### PR TITLE
[Enhancement] Add type check for parquet/csv outfile at FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
@@ -329,12 +329,12 @@ public class OutFileClause implements ParseNode {
 
         if (type.isArrayType()) {
             ArrayType arrayType = (ArrayType) type;
-            return isSupportedTypeForParquetOutFile(arrayType.getItemType());
+            return isSupportedTypeForCSVOutFile(arrayType.getItemType());
         }
 
         if (type.isMapType()) {
             MapType mapType = (MapType) type;
-            return isSupportedTypeForParquetOutFile(mapType.getKeyType()) && isSupportedTypeForParquetOutFile(mapType.getValueType());
+            return isSupportedTypeForCSVOutFile(mapType.getKeyType()) && isSupportedTypeForCSVOutFile(mapType.getValueType());
         }
 
         // unreachable

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -111,14 +111,22 @@ public class QueryAnalyzer {
 
         @Override
         public Scope visitQueryStatement(QueryStatement node, Scope parent) {
+            Scope scope = visitQueryRelation(node.getQueryRelation(), parent);
             if (node.hasOutFileClause()) {
                 try {
                     node.getOutFileClause().analyze();
                 } catch (AnalysisException e) {
                     throw new SemanticException(e.getMessage());
                 }
+                SelectRelation selectRelation = (SelectRelation) node.getQueryRelation();
+                List<Expr> outputExprs = selectRelation.getOutputExpression();
+                for (Expr expr : outputExprs) {
+                    if (expr.getType().getPrimitiveType() == Type.BITMAP.getPrimitiveType()) {
+                        throw new SemanticException("bitmap not supported");
+                    }
+                }
             }
-            return visitQueryRelation(node.getQueryRelation(), parent);
+            return scope;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -113,18 +113,7 @@ public class QueryAnalyzer {
         public Scope visitQueryStatement(QueryStatement node, Scope parent) {
             Scope scope = visitQueryRelation(node.getQueryRelation(), parent);
             if (node.hasOutFileClause()) {
-                try {
-                    node.getOutFileClause().analyze();
-                } catch (AnalysisException e) {
-                    throw new SemanticException(e.getMessage());
-                }
-                SelectRelation selectRelation = (SelectRelation) node.getQueryRelation();
-                List<Expr> outputExprs = selectRelation.getOutputExpression();
-                for (Expr expr : outputExprs) {
-                    if (expr.getType().getPrimitiveType() == Type.BITMAP.getPrimitiveType()) {
-                        throw new SemanticException("bitmap not supported");
-                    }
-                }
+                node.getOutFileClause().analyze(scope);
             }
             return scope;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -149,21 +149,21 @@ public class IcebergApiConverterTest {
     @Test
     public void testToIcebergApiSchema() {
         List<Column> columns = Lists.newArrayList();
-        columns.add(new Column(new Column("c1", Type.BOOLEAN)));
-        columns.add(new Column(new Column("c2", Type.INT)));
-        columns.add(new Column(new Column("c3", Type.BIGINT)));
-        columns.add(new Column(new Column("c4", Type.FLOAT)));
-        columns.add(new Column(new Column("c5", Type.DOUBLE)));
-        columns.add(new Column(new Column("c6", Type.DATE)));
-        columns.add(new Column(new Column("c7", Type.DATETIME)));
-        columns.add(new Column(new Column("c8", Type.VARCHAR)));
-        columns.add(new Column(new Column("c9", Type.CHAR)));
-        columns.add(new Column(new Column("c10", Type.DECIMAL32)));
-        columns.add(new Column(new Column("c11", Type.DECIMAL64)));
-        columns.add(new Column(new Column("c12", Type.DECIMAL128)));
-        columns.add(new Column(new Column("c13", new ArrayType(Type.INT))));
-        columns.add(new Column(new Column("c14", new MapType(Type.INT, Type.INT))));
-        columns.add(new Column(new Column("c15", new StructType(ImmutableList.of(Type.INT)))));
+        columns.add(new Column("c1", Type.BOOLEAN));
+        columns.add(new Column("c2", Type.INT));
+        columns.add(new Column("c3", Type.BIGINT));
+        columns.add(new Column("c4", Type.FLOAT));
+        columns.add(new Column("c5", Type.DOUBLE));
+        columns.add(new Column("c6", Type.DATE));
+        columns.add(new Column("c7", Type.DATETIME));
+        columns.add(new Column("c8", Type.VARCHAR));
+        columns.add(new Column("c9", Type.CHAR));
+        columns.add(new Column("c10", Type.DECIMAL32));
+        columns.add(new Column("c11", Type.DECIMAL64));
+        columns.add(new Column("c12", Type.DECIMAL128));
+        columns.add(new Column("c13", new ArrayType(Type.INT)));
+        columns.add(new Column("c14", new MapType(Type.INT, Type.INT)));
+        columns.add(new Column("c15", new StructType(ImmutableList.of(Type.INT))));
 
         Schema schema = IcebergApiConverter.toIcebergApiSchema(columns);
         Assert.assertEquals("table {\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -83,6 +83,10 @@ public class AnalyzeSingleTest {
 
         analyzeSuccess("SELECT v1,v2,v3 FROM t0  INTO OUTFILE \"hdfs://path/to/result_\" FORMAT AS CSV");
 
+        analyzeFail("SELECT b1 FROM test_object INTO OUTFILE \"hdfs://path/to/result_\" FORMAT AS PARQUET");
+
+        analyzeFail("SELECT b1 FROM test_object INTO OUTFILE \"hdfs://path/to/result_\" FORMAT AS CSV");
+
         analyzeSuccess("select v1 as location from t0");
 
         analyzeSuccess("select v1 as rank from t0");


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

For query `select into outfile`, this PR add supported types check for both parquet/csv outfile. 
If not supported, throws exception at analyze stage.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
