### PR TITLE
[BugFix] Be crash when restore primary key table cause by col unique id (#23383)

### DIFF
--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -548,6 +548,19 @@ Status SnapshotLoader::primary_key_move(const std::string& snapshot_path, const 
         LOG(FATAL) << "only support overwrite now";
     }
 
+    // We just replace the table_schema in tabletMeta using the schema
+    // in snapshot_meta.
+    TabletMetaSharedPtr new_tablet_meta = std::make_shared<TabletMeta>();
+    std::shared_lock rdlock(tablet->get_header_lock());
+    tablet->generate_tablet_meta_copy_unlocked(new_tablet_meta);
+    rdlock.unlock();
+
+    TabletMetaPB metapb;
+    new_tablet_meta->to_meta_pb(&metapb);
+    new_tablet_meta->init_from_pb(&metapb, &snapshot_meta.tablet_meta().schema());
+    tablet->set_tablet_meta(new_tablet_meta);
+    tablet->save_meta();
+
     RETURN_IF_ERROR(tablet->updates()->load_snapshot(snapshot_meta, true));
     tablet->updates()->remove_expired_versions(time(nullptr));
     LOG(INFO) << "Loaded snapshot of tablet " << tablet->tablet_id() << ", removing directory " << snapshot_path;

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -118,7 +118,7 @@ public:
 
     Status serialize(std::string* meta_binary);
     Status deserialize(std::string_view data);
-    void init_from_pb(TabletMetaPB* ptablet_meta_pb);
+    void init_from_pb(TabletMetaPB* ptablet_meta_pb, const TabletSchemaPB* ptablet_schema_pb = nullptr);
 
     void to_meta_pb(TabletMetaPB* tablet_meta_pb);
     void to_json(std::string* json_string, json2pb::Pb2JsonOptions& options);


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #23383

## Problem Summary(Required):
Problem:
For a primary key table, if the table's col unique id is not not consecutive, be will crash when restore this table cause by the difference between segment file and tablet schema.

Solution:
reset tablet schema using schema in snapshot data

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
