### PR TITLE
[BugFix] Split not-equal binary predicates as other predicates to support rewrte mv when exactly match

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -121,8 +121,12 @@ public class BinaryPredicateOperator extends PredicateOperator {
                     || type.equals(GE.type);
         }
 
-        public boolean isRangeOrNe() {
-            return isRange() || type.equals(NE.type);
+        public boolean isEqualOrRange() {
+            return isEqual() || isRange();
+        }
+
+        public boolean isNotEqualOrRange() {
+            return isRange() || isNotEqual();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateSplit.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateSplit.java
@@ -78,25 +78,23 @@ public class PredicateSplit {
         List<ScalarOperator> columnEqualityPredicates = Lists.newArrayList();
         List<ScalarOperator> rangePredicates = Lists.newArrayList();
         List<ScalarOperator> residualPredicates = Lists.newArrayList();
+        // Split predicates into three kinds:
+        //  - Equal Predicates:  col1 = col2 (both col1 and col2 are ColumnRefs)
+        //  - Range Predicates:  col1 >/>=/=/</<= 2 (col1 is ColumnRef and right is ConstantRef)
+        // TODO: support NotEqual/Or Range as range predicates
+        //  - Other Predicates:  others(eg: NonEqual BinaryPredicateOperator or others)
         for (ScalarOperator scalarOperator : predicateConjuncts) {
             if (scalarOperator instanceof BinaryPredicateOperator) {
                 BinaryPredicateOperator binary = (BinaryPredicateOperator) scalarOperator;
                 ScalarOperator leftChild = scalarOperator.getChild(0);
                 ScalarOperator rightChild = scalarOperator.getChild(1);
-                if (binary.getBinaryType().isEqual()) {
-                    if (leftChild.isColumnRef() && rightChild.isColumnRef()) {
-                        columnEqualityPredicates.add(scalarOperator);
-                    } else if (leftChild.isColumnRef() && rightChild.isConstantRef()) {
-                        rangePredicates.add(scalarOperator);
-                    } else {
-                        residualPredicates.add(scalarOperator);
-                    }
-                } else if (binary.getBinaryType().isRangeOrNe()) {
-                    if (leftChild.isColumnRef() && rightChild.isConstantRef()) {
-                        rangePredicates.add(scalarOperator);
-                    } else {
-                        residualPredicates.add(scalarOperator);
-                    }
+                BinaryPredicateOperator.BinaryType binaryType = binary.getBinaryType();
+                if (binaryType.isEqual() && leftChild.isColumnRef() && rightChild.isColumnRef()) {
+                    columnEqualityPredicates.add(scalarOperator);
+                } else if (binaryType.isEqualOrRange() && leftChild.isColumnRef() && rightChild.isConstantRef()) {
+                    rangePredicates.add(scalarOperator);
+                } else {
+                    residualPredicates.add(scalarOperator);
                 }
             } else {
                 residualPredicates.add(scalarOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RangeSimplifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RangeSimplifier.java
@@ -25,12 +25,16 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 public class RangeSimplifier {
+    protected static final Logger LOG = LogManager.getLogger(RangeSimplifier.class);
+
     private final List<ScalarOperator> srcPredicates;
 
     public RangeSimplifier(List<ScalarOperator> srcPredicates) {
@@ -103,6 +107,7 @@ public class RangeSimplifier {
                 return Utils.compoundAnd(rewrittenRangePredicates);
             }
         } catch (Exception e) {
+            LOG.warn("Simplify scalar operator {} failed:", Utils.compoundAnd(targets), e);
             return null;
         }
     }
@@ -114,7 +119,7 @@ public class RangeSimplifier {
             Preconditions.checkState(rangePredicate.getChild(0) instanceof ColumnRefOperator);
             Preconditions.checkState(rangePredicate.getChild(1) instanceof ConstantOperator);
             BinaryPredicateOperator srcBinary = (BinaryPredicateOperator) rangePredicate;
-            Preconditions.checkState(srcBinary.getBinaryType().isRange() || srcBinary.getBinaryType().isEqual());
+            Preconditions.checkState(srcBinary.getBinaryType().isEqualOrRange());
             ColumnRefOperator srcColumn = (ColumnRefOperator) srcBinary.getChild(0);
             ConstantOperator srcConstant = (ConstantOperator) srcBinary.getChild(1);
             if (!columnIdToRange.containsKey(srcColumn.getId())) {
@@ -134,7 +139,7 @@ public class RangeSimplifier {
     private List<ScalarOperator> filterScalarOperators(
             List<ScalarOperator> columnScalars, Range<ConstantOperator> validRange) {
         List<ScalarOperator> results = Lists.newArrayList();
-        ;
+
         for (ScalarOperator candidate : columnScalars) {
             if (isRedundantPredicate(candidate, validRange)) {
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RangeSimplifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RangeSimplifier.java
@@ -107,7 +107,7 @@ public class RangeSimplifier {
                 return Utils.compoundAnd(rewrittenRangePredicates);
             }
         } catch (Exception e) {
-            LOG.warn("Simplify scalar operator {} failed:", Utils.compoundAnd(targets), e);
+            LOG.debug("Simplify scalar operator {} failed:", Utils.compoundAnd(targets), e);
             return null;
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -2562,4 +2562,101 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             testRewriteOK(mv, query);
         }
     }
+
+    // Single Predicates
+    @Test
+    public void testRangePredicates1() {
+        // =
+        {
+            String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
+                    " left join locations on emps.locationid = locations.locationid where emps.deptno = 10";
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno = 10");
+            testRewriteFail(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno = 20");
+        }
+
+        // >
+        {
+            String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
+                    " left join locations on emps.locationid = locations.locationid where emps.deptno > 10";
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno > 10");
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno > 20");
+            testRewriteFail(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno < 10");
+        }
+
+        // >=
+        {
+            String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
+                    " left join locations on emps.locationid = locations.locationid where emps.deptno >= 10";
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno >= 10");
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno = 10");
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno >= 20");
+            testRewriteFail(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno <= 10");
+        }
+
+        // <
+        {
+            String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
+                    " left join locations on emps.locationid = locations.locationid where emps.deptno < 10";
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno < 10");
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno < 5");
+            testRewriteFail(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno > 10");
+        }
+
+        // <=
+        {
+            String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
+                    " left join locations on emps.locationid = locations.locationid where emps.deptno <= 10";
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno <= 10");
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno = 10");
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno <= 5");
+            testRewriteFail(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno >= 10");
+        }
+
+        // !=
+        {
+            String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
+                    " left join locations on emps.locationid = locations.locationid where emps.deptno != 10";
+            testRewriteOK(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno != 10");
+            testRewriteFail(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno = 10");
+            // TODO: Support != as Range Predicates
+            testRewriteFail(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno > 10");
+            // TODO: Support != as Range Predicates
+            testRewriteFail(mv, "select count(*) from " +
+                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno < 10");
+        }
+    }
+
+    // Multi Predicates
+    @Test
+    public void testRangePredicates2() {
+        // !=
+        {
+            String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
+                    " left join locations on emps.locationid = locations.locationid where emps.deptno < 10 or emps.deptno > 10";
+            testRewriteOK(mv, "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
+                    " left join locations on emps.locationid = locations.locationid where emps.deptno < 10 or emps.deptno > 10");
+            // TODO: support OrPredicates as Range Predicates.
+            testRewriteFail(mv, "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
+                    " left join locations on emps.locationid = locations.locationid where emps.deptno < 5 or emps.deptno > 20");
+        }
+    }
 }


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool


## Problem Summary(Required):
- Split not-equal binary predicates as other predicates to support rewrte mv when exactly match;

TODO: 
- Support  not-equal binary predicates as range predicates
```
   String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
                    " left join locations on emps.locationid = locations.locationid where emps.deptno != 10";
            testRewriteOK(mv, "select count(*) from " +
                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno != 10");
            // TODO: Support != as Range Predicates
            testRewriteFail(mv, "select count(*) from " +
                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno > 10");
            // TODO: Support != as Range Predicates
            testRewriteFail(mv, "select count(*) from " +
                    "emps  left join locations on emps.locationid = locations.locationid where emps.deptno < 10");
```
## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
