### PR TITLE
[Enhancement] Avoiding cache hot data being evicted due to a surge in cold data loading

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -382,6 +382,7 @@ Status LakeDataSource::init_reader_params(const std::vector<OlapScanRange*>& key
     _params.profile = _runtime_profile;
     _params.runtime_state = _runtime_state;
     _params.use_page_cache = !config::disable_storage_page_cache;
+    _params.fill_data_cache = _scan_range.fill_data_cache;
     _params.runtime_range_pruner = OlapRuntimeScanRangePruner(parser, _conjuncts_manager.unarrived_runtime_filters());
 
     std::vector<PredicatePtr> preds;

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -50,6 +50,7 @@ Status HorizontalCompactionTask::execute(Progress* progress, CancelFunc cancel_f
     reader_params.chunk_size = chunk_size;
     reader_params.profile = nullptr;
     reader_params.use_page_cache = false;
+    reader_params.fill_data_cache = false;
     RETURN_IF_ERROR(reader.open(reader_params));
 
     ASSIGN_OR_RETURN(auto writer, _tablet->new_writer(kHorizontal, _txn_id))

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -51,6 +51,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     seg_options.global_dictmaps = options.global_dictmaps;
     seg_options.unused_output_column_ids = options.unused_output_column_ids;
     seg_options.runtime_range_pruner = options.runtime_range_pruner;
+    seg_options.fill_data_cache = options.fill_data_cache;
     if (options.is_primary_keys) {
         seg_options.is_primary_keys = true;
         seg_options.delvec_loader = std::make_shared<LakeDelvecLoader>(_tablet->update_mgr(), nullptr);

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -134,6 +134,7 @@ Status ConvertedSchemaChange::init() {
     _read_params.skip_aggregation = false;
     _read_params.chunk_size = config::vector_chunk_size;
     _read_params.use_page_cache = false;
+    _read_params.fill_data_cache = false;
 
     ASSIGN_OR_RETURN(auto base_tablet_schema, _base_tablet->get_schema());
     _base_schema = ChunkHelper::convert_schema(*base_tablet_schema, _chunk_changer->get_selected_column_indexes());

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -135,6 +135,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.global_dictmaps = params.global_dictmaps;
     rs_opts.unused_output_column_ids = params.unused_output_column_ids;
     rs_opts.runtime_range_pruner = params.runtime_range_pruner;
+    rs_opts.fill_data_cache = params.fill_data_cache;
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
         rs_opts.version = _version;

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -138,6 +138,7 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
     reader_params.chunk_size = chunk_size;
     reader_params.profile = nullptr;
     reader_params.use_page_cache = false;
+    reader_params.fill_data_cache = false;
     RETURN_IF_ERROR(reader.open(reader_params));
 
     auto chunk = ChunkHelper::new_chunk(schema, chunk_size);

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -67,6 +67,7 @@ public:
     RuntimeState* runtime_state = nullptr;
     RuntimeProfile* profile = nullptr;
     bool use_page_cache = false;
+    bool fill_data_cache = true;
 
     ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
     const std::unordered_set<uint32_t>* unused_output_column_ids = nullptr;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -241,7 +241,7 @@ private:
 
     Status _read(Chunk* chunk, vector<rowid_t>* rowid, size_t n);
 
-    bool _skip_fill_local_cache() const { return _opts.reader_type != READER_QUERY; }
+    bool _skip_fill_data_cache() const { return !_opts.fill_data_cache; }
 
     // search delta column group by column uniqueid, if this column exist in delta column group,
     // then return column iterator and delta column's fillname.
@@ -464,7 +464,7 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
     ColumnIteratorOptions iter_opts;
     iter_opts.stats = _opts.stats;
     iter_opts.use_page_cache = _opts.use_page_cache;
-    RandomAccessFileOptions opts{.skip_fill_local_cache = _skip_fill_local_cache()};
+    RandomAccessFileOptions opts{.skip_fill_local_cache = _skip_fill_data_cache()};
     iter_opts.check_dict_encoding = check_dict_enc;
     iter_opts.reader_type = _opts.reader_type;
 
@@ -591,7 +591,7 @@ Status SegmentIterator::_get_row_ranges_by_key_ranges() {
         return Status::OK();
     }
 
-    RETURN_IF_ERROR(_segment->load_index(_skip_fill_local_cache()));
+    RETURN_IF_ERROR(_segment->load_index(_skip_fill_data_cache()));
     for (const SeekRange& range : _opts.ranges) {
         rowid_t lower_rowid = 0;
         rowid_t upper_rowid = num_rows();
@@ -622,7 +622,7 @@ Status SegmentIterator::_get_row_ranges_by_short_key_ranges() {
         return Status::OK();
     }
 
-    RETURN_IF_ERROR(_segment->load_index(_skip_fill_local_cache()));
+    RETURN_IF_ERROR(_segment->load_index(_skip_fill_data_cache()));
     for (const auto& short_key_range : _opts.short_key_ranges) {
         rowid_t lower_rowid = 0;
         rowid_t upper_rowid = num_rows();
@@ -1526,7 +1526,7 @@ Status SegmentIterator::_init_bitmap_index_iterators() {
             options.file_name = segment_ptr->file_name();
             options.use_page_cache = config::enable_bitmap_memory_page_cache || !config::disable_storage_page_cache;
             options.kept_in_memory = config::enable_bitmap_memory_page_cache;
-            options.skip_fill_local_cache = _skip_fill_local_cache();
+            options.skip_fill_local_cache = _skip_fill_data_cache();
             options.stats = _opts.stats;
 
             RETURN_IF_ERROR(segment_ptr->new_bitmap_index_iterator(col_index, options, &_bitmap_index_iterators[cid]));

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -71,6 +71,7 @@ public:
     RuntimeProfile* profile = nullptr;
 
     bool use_page_cache = false;
+    bool fill_data_cache = true;
 
     ReaderType reader_type = READER_QUERY;
     int chunk_size = DEFAULT_CHUNK_SIZE;

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -57,6 +57,10 @@ struct TabletReaderParams {
     //     if config::disable_storage_page_cache is false, we use page cache
     bool use_page_cache = false;
 
+    // Allow this query to cache remote data on local disk or not.
+    // Only work for cloud native tablet(LakeTablet) now.
+    bool fill_data_cache = true;
+
     RangeStartOperation range = RangeStartOperation::GT;
     RangeEndOperation end_range = RangeEndOperation::LT;
     std::vector<OlapTuple> start_key;

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -784,6 +784,12 @@ under the License.
             <artifactId>trino-parser</artifactId>
             <version>385</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.threeten</groupId>
+            <artifactId>threeten-extra</artifactId>
+            <version>1.7.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -72,6 +72,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.RangeUtils;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.Util;
 import com.starrocks.lake.StorageCacheInfo;
 import com.starrocks.persist.ColocatePersistInfo;
@@ -100,6 +101,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.threeten.extra.PeriodDuration;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -1969,6 +1971,15 @@ public class OlapTable extends Table {
             return;
         }
         tableProperty.setHasDelete(true);
+    }
+
+    public void setDataCachePartitionDuration(PeriodDuration duration) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION,
+                TimeUtils.toHumanReadableString(duration));
+        tableProperty.buildDataCachePartitionDuration();
     }
 
     public boolean hasForbitGlobalDict() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
@@ -54,6 +54,9 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Calendar;
 import java.util.List;
 
@@ -88,7 +91,7 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
         return partitionKey;
     }
 
-    public static PartitionKey createShadowPartitionKey(List<Column> columns) 
+    public static PartitionKey createShadowPartitionKey(List<Column> columns)
             throws AnalysisException {
         PartitionKey partitionKey = new PartitionKey();
         for (Column column : columns) {
@@ -129,6 +132,20 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
         }
 
         Preconditions.checkState(partitionKey.keys.size() == columns.size());
+        return partitionKey;
+    }
+
+    public static PartitionKey ofDateTime(LocalDateTime dateTime) throws AnalysisException {
+        PartitionKey partitionKey = new PartitionKey();
+        partitionKey.keys.add(new DateLiteral(dateTime, Type.DATETIME));
+        partitionKey.types.add(PrimitiveType.DATETIME);
+        return partitionKey;
+    }
+
+    public static PartitionKey ofDate(LocalDate date) throws AnalysisException {
+        PartitionKey partitionKey = new PartitionKey();
+        partitionKey.keys.add(new DateLiteral(LocalDateTime.of(date, LocalTime.MIN), Type.DATE));
+        partitionKey.types.add(PrimitiveType.DATE);
         return partitionKey;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -556,5 +556,9 @@ public class RangePartitionInfo extends PartitionInfo {
         sb.append(")");
         return sb.toString();
     }
+
+    public boolean isPartitionedBy(PrimitiveType type) {
+        return partitionColumns.size() == 1 && partitionColumns.get(0).getType().getPrimitiveType() == type;
+    }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -46,6 +46,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.WriteQuorum;
 import com.starrocks.lake.StorageInfo;
 import com.starrocks.persist.OperationType;
@@ -57,6 +58,7 @@ import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TWriteQuorumType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.threeten.extra.PeriodDuration;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -157,6 +159,8 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     // foreign key constraint for mv rewrite
     private List<ForeignKeyConstraint> foreignKeyConstraints;
+
+    private PeriodDuration dataCachePartitionDuration;
 
     public TableProperty(Map<String, String> properties) {
         this.properties = properties;
@@ -387,6 +391,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildDataCachePartitionDuration() {
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION)) {
+            dataCachePartitionDuration = TimeUtils.parseHumanReadablePeriodOrDuration(
+                    properties.get(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION));
+        }
+        return this;
+    }
+
     public void modifyTableProperties(Map<String, String> modifyProperties) {
         properties.putAll(modifyProperties);
     }
@@ -527,6 +539,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return binlogAvailabeVersions;
     }
 
+    public PeriodDuration getDataCachePartitionDuration() {
+        return dataCachePartitionDuration;
+    }
+
     public void clearBinlogAvailableVersion() {
         binlogAvailabeVersions.clear();
         for (Iterator<Map.Entry<String, String>> it = properties.entrySet().iterator(); it.hasNext();) {
@@ -565,5 +581,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildBinlogConfig();
         buildBinlogAvailableVersion();
         buildConstraint();
+        buildDataCachePartitionDuration();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -36,7 +36,6 @@ package com.starrocks.clone;
 
 import com.google.api.client.util.Preconditions;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
@@ -58,7 +57,6 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
-import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.DynamicPartitionUtil;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.RangeUtils;
@@ -75,6 +73,7 @@ import com.starrocks.statistic.StatsConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -515,10 +514,8 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
         List<Map.Entry<Long, Range<PartitionKey>>> candidatePartitionList = Lists.newArrayList();
 
         if (partitionType.isDateType()) {
-            LocalDateTime currentDateTime = LocalDateTime.now();
-            PartitionValue currentPartitionValue = new PartitionValue(currentDateTime.format(DateUtils.DATE_FORMATTER_UNIX));
-            PartitionKey currentPartitionKey = PartitionKey.createPartitionKey(
-                    ImmutableList.of(currentPartitionValue), partitionColumns);
+            PartitionKey currentPartitionKey = partitionType.isDatetime() ?
+                    PartitionKey.ofDateTime(LocalDateTime.now()) : PartitionKey.ofDate(LocalDate.now());
             PartitionKey shadowPartitionKey = PartitionKey.createShadowPartitionKey(partitionColumns);
 
             Map<Long, Range<PartitionKey>> idToRange = rangePartitionInfo.getIdToRange(false);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DurationStyle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DurationStyle.java
@@ -1,0 +1,109 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.Objects;
+
+import static org.joda.time.DateTimeConstants.SECONDS_PER_DAY;
+import static org.joda.time.DateTimeConstants.SECONDS_PER_HOUR;
+import static org.joda.time.DateTimeConstants.SECONDS_PER_MINUTE;
+
+public abstract class DurationStyle {
+    public static final DurationStyle LONG = new LongStyle();
+    public static final DurationStyle ISO8601 = new ISO8601Style();
+
+    public abstract Duration parse(String text);
+
+    public abstract String toString(Duration duration);
+
+    private static class ISO8601Style extends DurationStyle {
+
+        @Override
+        public Duration parse(String text) {
+            return Duration.parse(text);
+        }
+
+        @Override
+        public String toString(Duration duration) {
+            return duration.toString();
+        }
+    }
+
+    private static class LongStyle extends DurationStyle {
+
+        @Override
+        public Duration parse(String text) {
+            Objects.requireNonNull(text, "text is null");
+            String[] tokens = text.trim().split("\\s+");
+            if ((tokens.length == 0) || (tokens.length % 2 != 0)) {
+                throw new DateTimeParseException("Cannot parse text to Duration", text, 0);
+            }
+            long seconds = 0;
+            for (int i = 0; i < tokens.length; i += 2) {
+                try {
+                    long number = Long.parseLong(tokens[i]);
+                    String unit = tokens[i + 1].toLowerCase();
+                    switch (unit) {
+                        case "second":
+                        case "seconds":
+                            seconds += number;
+                            break;
+                        case "minute":
+                        case "minutes":
+                            seconds += number * SECONDS_PER_MINUTE;
+                            break;
+                        case "hour":
+                        case "hours":
+                            seconds += number * SECONDS_PER_HOUR;
+                            break;
+                        case "day":
+                        case "days":
+                            seconds += number * SECONDS_PER_DAY;
+                            break;
+                        default:
+                            throw new DateTimeParseException("Cannot parse text to Duration", text, 0);
+                    }
+                } catch (NumberFormatException ignored) {
+                    throw new DateTimeParseException("Cannot parse text to Duration", text, 0);
+                }
+            }
+            return Duration.ofSeconds(seconds);
+        }
+
+        @Override
+        public String toString(Duration duration) {
+            if (duration.isZero()) {
+                return "0 second";
+            }
+            long seconds = duration.getSeconds();
+            long hours = seconds / SECONDS_PER_HOUR;
+            int minutes = (int) ((seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
+            int secs = (int) (seconds % SECONDS_PER_MINUTE);
+            StringBuilder buf = new StringBuilder();
+            if (hours != 0) {
+                buf.append(hours).append(" hours ");
+            }
+            if (minutes != 0) {
+                buf.append(minutes).append(" minutes ");
+            }
+            if (secs != 0) {
+                buf.append(secs).append(" seconds");
+            }
+            return buf.toString().trim();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PeriodStyle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PeriodStyle.java
@@ -1,0 +1,124 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import java.time.Period;
+import java.time.format.DateTimeParseException;
+import java.util.Objects;
+
+public abstract class PeriodStyle {
+    public static final PeriodStyle ISO8601 = new ISO8601Style();
+    public static final PeriodStyle LONG = new LongStyle();
+
+    /**
+     * Obtains a Period from a text string.
+     *
+     * @param text the text to parse, not null
+     * @return the parsed period, not null
+     * @throws DateTimeParseException – if the text cannot be parsed to a period
+     */
+    public abstract Period parse(String text);
+
+    public abstract String toString(Period period);
+
+    public static PeriodStyle valueOf(String value) {
+        if ("ISO8601".equalsIgnoreCase(value)) {
+            return ISO8601;
+        }
+        if ("LONG".equalsIgnoreCase(value)) {
+            return LONG;
+        }
+        return null;
+    }
+
+    private static class ISO8601Style extends PeriodStyle {
+
+        @Override
+        public Period parse(String text) {
+            return Period.parse(text);
+        }
+
+        @Override
+        public String toString(Period period) {
+            return period.toString();
+        }
+    }
+
+    private static class LongStyle extends PeriodStyle {
+
+        @Override
+        public Period parse(String text) {
+            Objects.requireNonNull(text, "text is null");
+            String[] tokens = text.trim().split("\\s+");
+            if ((tokens.length == 0) || (tokens.length % 2 != 0)) {
+                throw new DateTimeParseException("Cannot parse text to Period", text, 0);
+            }
+            int years = 0;
+            int months = 0;
+            int days = 0;
+            for (int i = 0; i < tokens.length; i += 2) {
+                try {
+                    int number = Integer.parseInt(tokens[i]);
+                    String unit = tokens[i + 1].toLowerCase();
+                    switch (unit) {
+                        case "day":
+                        case "days":
+                            days += number;
+                            break;
+                        case "week":
+                        case "weeks":
+                            days += 7 * number;
+                            break;
+                        case "month":
+                        case "months":
+                            months += number;
+                            break;
+                        case "year":
+                        case "years":
+                            years += number;
+                            break;
+                        default:
+                            throw new DateTimeParseException("Cannot parse text to Period", text, 0);
+                    }
+                } catch (NumberFormatException ignored) {
+                    throw new DateTimeParseException("Cannot parse text to Period", text, 0);
+                }
+            }
+            return Period.of(years, months, days);
+        }
+
+        @Override
+        public String toString(Period period) {
+            if (period.isZero()) {
+                return "0 day";
+            } else {
+                int years = period.getYears();
+                int months = period.getMonths();
+                int days = period.getDays();
+                StringBuilder buf = new StringBuilder();
+                if (years != 0) {
+                    buf.append(years).append(" years ");
+                }
+                if (months != 0) {
+                    buf.append(months).append(" months ");
+                }
+                if (days != 0) {
+                    buf.append(days).append(" days");
+                }
+                return buf.toString().trim();
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -71,6 +71,7 @@ import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.threeten.extra.PeriodDuration;
 
 import java.util.Arrays;
 import java.util.List;
@@ -159,6 +160,7 @@ public class PropertyAnalyzer {
     // constraint for rewrite
     public static final String PROPERTIES_FOREIGN_KEY_CONSTRAINT = "foreign_key_constraints";
     public static final String PROPERTIES_UNIQUE_CONSTRAINT = "unique_constraints";
+    public static final String PROPERTIES_DATACACHE_PARTITION_DURATION = "datacache.partition_duration";
 
     public static final String PROPERTIES_MV_REWRITE_STALENESS_SECOND = "mv_rewrite_staleness_second";
 
@@ -909,7 +911,7 @@ public class PropertyAnalyzer {
                 }
 
                 analyzeForeignKeyUniqueConstraint(parentTable, parentColumns, analyzedTable);
-                
+
                 List<Pair<String, String>> columnRefPairs = Streams.zip(childColumns.stream(),
                         parentColumns.stream(), Pair::create).collect(Collectors.toList());
                 for (Pair<String, String> pair : columnRefPairs) {
@@ -965,5 +967,14 @@ public class PropertyAnalyzer {
         }
 
         return new StorageCacheInfo(enableStorageCache, storageCacheTtlS, enableAsyncWriteBack);
+    }
+
+    public static PeriodDuration analyzeDataCachePartitionDuration(Map<String, String> properties) throws AnalysisException {
+        String text = properties.get(PROPERTIES_DATACACHE_PARTITION_DURATION);
+        if (text == null) {
+            return null;
+        }
+        properties.remove(PROPERTIES_DATACACHE_PARTITION_DURATION);
+        return TimeUtils.parseHumanReadablePeriodOrDuration(text);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
@@ -47,12 +47,14 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.VariableMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.threeten.extra.PeriodDuration;
 
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.time.DateTimeException;
 import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
 import java.util.Date;
 import java.util.SimpleTimeZone;
 import java.util.TimeZone;
@@ -334,5 +336,24 @@ public class TimeUtils {
         long difference = targetTimeSecond - startTimeSecond;
         long step = difference / intervalSecond + 1;
         return startTimeSecond + step * intervalSecond;
+    }
+
+    public static PeriodDuration parseHumanReadablePeriodOrDuration(String text) {
+        try {
+            return PeriodDuration.of(PeriodStyle.LONG.parse(text));
+        } catch (DateTimeParseException ignored) {
+            return PeriodDuration.of(DurationStyle.LONG.parse(text));
+        }
+    }
+
+    public static String toHumanReadableString(PeriodDuration periodDuration) {
+        if (periodDuration.getPeriod().isZero()) {
+            return DurationStyle.LONG.toString(periodDuration.getDuration());
+        } else if (periodDuration.getDuration().isZero()) {
+            return PeriodStyle.LONG.toString(periodDuration.getPeriod());
+        } else {
+            return PeriodStyle.LONG.toString(periodDuration.getPeriod()) + " "
+                    + DurationStyle.LONG.toString(periodDuration.getDuration());
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -16,6 +16,7 @@ package com.starrocks.lake;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
 import com.staros.proto.FileCacheInfo;
 import com.staros.proto.FilePathInfo;
 import com.starrocks.alter.AlterJobV2Builder;
@@ -29,8 +30,12 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.TableIndexes;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.io.Text;
@@ -39,15 +44,19 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.threeten.extra.PeriodDuration;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Metadata for StarRocks lake table
@@ -211,5 +220,49 @@ public class LakeTable extends OlapTable {
             return CatalogUtils.addEscapeCharacter(comment);
         }
         return TableType.OLAP.name();
+    }
+
+    /**
+     * Check if data cache is allowed for the specified partition's data:
+     *  - If the partition is NOT partitioned by DATE or DATETIME, data cache is allowed
+     *  - If the partition is partitioned by DATE or DATETIME:
+     *    - if the partition's end value (of type DATE/DATETIME) is within the last "datacache.partition_duration"
+     *      duration, allow data cache for the partition.
+     *    - otherwise, disallow the data cache for the partition
+     *
+     * @param partition the partition to check. the partition must belong to this table.
+     * @return true if the partition is enabled for the data cache, false otherwise
+     */
+    public boolean isEnableFillDataCache(Partition partition) {
+        try {
+            return isEnableFillDataCacheImpl(Objects.requireNonNull(partition, "partition is null"));
+        } catch (AnalysisException ignored) {
+            return true;
+        }
+    }
+
+    private boolean isEnableFillDataCacheImpl(Partition partition) throws AnalysisException {
+        PeriodDuration cacheDuration = getTableProperty().getDataCachePartitionDuration();
+        if (cacheDuration != null && getPartitionInfo().isRangePartition()) {
+            RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) getPartitionInfo();
+            Range<PartitionKey> partitionRange = rangePartitionInfo.getRange(partition.getId());
+            Range<PartitionKey> dataCacheRange;
+            if (rangePartitionInfo.isPartitionedBy(PrimitiveType.DATETIME)) {
+                LocalDateTime upper = LocalDateTime.now();
+                LocalDateTime lower = upper.minus(cacheDuration);
+                dataCacheRange = Range.closed(PartitionKey.ofDateTime(lower), PartitionKey.ofDateTime(upper));
+                return partitionRange.isConnected(dataCacheRange);
+            } else if (rangePartitionInfo.isPartitionedBy(PrimitiveType.DATE)) {
+                LocalDate upper = LocalDate.now();
+                LocalDate lower = upper.minus(cacheDuration);
+                dataCacheRange = Range.closed(PartitionKey.ofDate(lower), PartitionKey.ofDate(upper));
+                return partitionRange.isConnected(dataCacheRange);
+            } else {
+                // If the table was not partitioned by DATE/DATETIME, ignore the property "datacache.partition_duration" and
+                // enable data cache by default.
+                return true;
+            }
+        }
+        return true;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -70,6 +70,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
+import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -110,6 +111,16 @@ public class OlapScanNode extends ScanNode {
     private static final Logger LOG = LogManager.getLogger(OlapScanNode.class);
 
     private final List<TScanRangeLocations> result = new ArrayList<>();
+    private final List<String> selectedPartitionNames = Lists.newArrayList();
+    private final List<Long> selectedPartitionVersions = Lists.newArrayList();
+    private final HashSet<Long> scanBackendIds = new HashSet<>();
+    // The column names applied dict optimization
+    // used for explain
+    private final List<String> appliedDictStringColumns = new ArrayList<>();
+    private final List<String> unUsedOutputStringColumns = new ArrayList<>();
+    // a bucket seq may map to many tablets, and each tablet has a TScanRangeLocations.
+    public ArrayListMultimap<Integer, TScanRangeLocations> bucketSeq2locations = ArrayListMultimap.create();
+    public List<Expr> prunedPartitionPredicates = Lists.newArrayList();
     /*
      * When the field value is ON, the storage engine can return the data directly without pre-aggregation.
      * When the field value is OFF, the storage engine needs to aggregate the data before returning to scan node.
@@ -135,28 +146,18 @@ public class OlapScanNode extends ScanNode {
     private long selectedIndexId = -1;
     private int selectedPartitionNum = 0;
     private List<Long> selectedPartitionIds = Lists.newArrayList();
-    private final List<String> selectedPartitionNames = Lists.newArrayList();
-    private final List<Long> selectedPartitionVersions = Lists.newArrayList();
     private long actualRows = 0;
-
     // List of tablets will be scanned by current olap_scan_node
     private ArrayList<Long> scanTabletIds = Lists.newArrayList();
     private boolean isFinalized = false;
-
     private boolean isSortedByKeyPerTablet = false;
-
-    private final HashSet<Long> scanBackendIds = new HashSet<>();
-
     private Map<Long, Integer> tabletId2BucketSeq = Maps.newHashMap();
-    // a bucket seq may map to many tablets, and each tablet has a TScanRangeLocations.
-    public ArrayListMultimap<Integer, TScanRangeLocations> bucketSeq2locations = ArrayListMultimap.create();
-
     private List<Expr> bucketExprs = Lists.newArrayList();
     private List<ColumnRefOperator> bucketColumns = Lists.newArrayList();
-    public List<Expr> prunedPartitionPredicates = Lists.newArrayList();
-
     // record the selected partition with the selected tablets belong to it
     private Map<Long, List<Long>> partitionToScanTabletMap;
+    // The dict id int column ids to dict string column ids
+    private Map<Integer, Integer> dictStringIdToIntIds = Maps.newHashMap();
 
     // Constructs node to scan given data files of table 'tbl'.
     public OlapScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
@@ -188,6 +189,10 @@ public class OlapScanNode extends ScanNode {
         return selectedPartitionIds;
     }
 
+    public void setSelectedPartitionIds(List<Long> selectedPartitionIds) {
+        this.selectedPartitionIds = selectedPartitionIds;
+    }
+
     public List<String> getSelectedPartitionNames() {
         return selectedPartitionNames;
     }
@@ -195,9 +200,6 @@ public class OlapScanNode extends ScanNode {
     public List<Long> getSelectedPartitionVersions() {
         return selectedPartitionVersions;
     }
-
-    // The dict id int column ids to dict string column ids
-    private Map<Integer, Integer> dictStringIdToIntIds = Maps.newHashMap();
 
     public List<Expr> getPrunedPartitionPredicates() {
         return prunedPartitionPredicates;
@@ -228,10 +230,6 @@ public class OlapScanNode extends ScanNode {
         this.bucketExprs = bucketExprs;
     }
 
-    // The column names applied dict optimization
-    // used for explain
-    private final List<String> appliedDictStringColumns = new ArrayList<>();
-
     public void updateAppliedDictStringColumns(Set<Integer> appliedColumnIds) {
         for (SlotDescriptor slot : desc.getSlots()) {
             if (appliedColumnIds.contains(slot.getId().asInt())) {
@@ -239,8 +237,6 @@ public class OlapScanNode extends ScanNode {
             }
         }
     }
-
-    private final List<String> unUsedOutputStringColumns = new ArrayList<>();
 
     public void setUnUsedOutputStringColumns(Set<Integer> unUsedOutputColumnIds,
                                              Set<String> aggOrPrimaryKeyTableValueColumnNames) {
@@ -342,7 +338,7 @@ public class OlapScanNode extends ScanNode {
         }
     }
 
-    // update TScanRangeLocations based on the latest olapTable tablet distributions, 
+    // update TScanRangeLocations based on the latest olapTable tablet distributions,
     // this function will make sure the version of each TScanRangeLocations doesn't change.
     public List<TScanRangeLocations> updateScanRangeLocations(List<TScanRangeLocations> locations)
             throws UserException {
@@ -435,8 +431,10 @@ public class OlapScanNode extends ScanNode {
         String schemaHashStr = String.valueOf(schemaHash);
         long visibleVersion = partition.getVisibleVersion();
         String visibleVersionStr = String.valueOf(visibleVersion);
+        boolean fillDataCache = olapTable.isCloudNativeTable() && ((LakeTable) olapTable).isEnableFillDataCache(partition);
         selectedPartitionNames.add(partition.getName());
         selectedPartitionVersions.add(visibleVersion);
+
         for (Tablet tablet : tablets) {
             long tabletId = tablet.getId();
             LOG.debug("{} tabletId={}", (logNum++), tabletId);
@@ -502,6 +500,7 @@ public class OlapScanNode extends ScanNode {
                 scanRangeLocation.setBackend_id(replica.getBackendId());
                 scanRangeLocations.addToLocations(scanRangeLocation);
                 internalRange.addToHosts(new TNetworkAddress(ip, port));
+                internalRange.setFill_data_cache(fillDataCache);
                 tabletIsNull = false;
 
                 // for CBO
@@ -875,10 +874,6 @@ public class OlapScanNode extends ScanNode {
 
         // FixMe(kks): For DUPLICATE table, isPreAggregation could always true
         this.isPreAggregation = true;
-    }
-
-    public void setSelectedPartitionIds(List<Long> selectedPartitionIds) {
-        this.selectedPartitionIds = selectedPartitionIds;
     }
 
     public void setTabletId2BucketSeq(Map<Long, Integer> tabletId2BucketSeq) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2559,7 +2559,16 @@ public class GlobalStateMgr {
                 sb.append(olapTable.getTableProperty().getDynamicPartitionProperty().toString());
             }
 
-            // enable storage cache && cache ttl & storage volume
+            String partitionDuration =
+                    olapTable.getTableProperty().getProperties().get(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION);
+            if (partitionDuration != null) {
+                sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR)
+                        .append(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION)
+                        .append("\" = \"")
+                        .append(partitionDuration).append("\"");
+            }
+
+            // enable storage cache && cache ttl
             if (table.isCloudNativeTable()) {
                 Map<String, String> storageProperties = olapTable.getProperties();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionValue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionValue.java
@@ -19,7 +19,12 @@ import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.DateUtils;
 import com.starrocks.sql.parser.NodePosition;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public class PartitionValue implements ParseNode {
     public static final PartitionValue MAX_VALUE = new PartitionValue();
@@ -39,6 +44,14 @@ public class PartitionValue implements ParseNode {
     public PartitionValue(String value, NodePosition pos) {
         this.pos = pos;
         this.value = value;
+    }
+
+    public static PartitionValue ofDateTime(LocalDateTime dateTime) {
+        return new PartitionValue(dateTime.format(DateUtils.DATE_FORMATTER_UNIX));
+    }
+
+    public static PartitionValue ofDate(LocalDate date) {
+        return ofDateTime(LocalDateTime.of(date, LocalTime.MIN));
     }
 
     public LiteralExpr getValue(Type type) throws AnalysisException {

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/DurationStyleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/DurationStyleTest.java
@@ -1,0 +1,92 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.DateTimeException;
+import java.time.Duration;
+
+public class DurationStyleTest {
+    @Test
+    public void testLongHours() {
+        Assert.assertEquals(Duration.ofHours(1), DurationStyle.LONG.parse("1 hour"));
+        Assert.assertEquals(Duration.ofHours(1), DurationStyle.LONG.parse("1 hours"));
+        Assert.assertEquals(Duration.ofHours(1), DurationStyle.LONG.parse(" 1 hours"));
+        Assert.assertEquals(Duration.ofHours(1), DurationStyle.LONG.parse("1 hours "));
+        Assert.assertEquals(Duration.ofHours(1), DurationStyle.LONG.parse(" 1 hours "));
+        Assert.assertEquals(Duration.ofHours(1), DurationStyle.LONG.parse(" 1  hours "));
+        Assert.assertEquals(Duration.ofHours(1), DurationStyle.LONG.parse(" 1\thours "));
+
+        Assert.assertEquals(Duration.ofHours(3), DurationStyle.LONG.parse("3 hour"));
+        Assert.assertEquals(Duration.ofHours(3), DurationStyle.LONG.parse("3 hours"));
+        Assert.assertEquals(Duration.ofHours(3), DurationStyle.LONG.parse("3 HOURS"));
+
+        Assert.assertEquals("0 second", DurationStyle.LONG.toString(Duration.ofHours(0)));
+        Assert.assertEquals("1 hours", DurationStyle.LONG.toString(Duration.ofHours(1)));
+        Assert.assertEquals("3 hours", DurationStyle.LONG.toString(Duration.ofHours(3)));
+
+        Assert.assertThrows(DateTimeException.class, () -> DurationStyle.LONG.parse("a hour"));
+        Assert.assertThrows(DateTimeException.class, () -> DurationStyle.LONG.parse("3 hur"));
+        Assert.assertThrows(DateTimeException.class, () -> DurationStyle.LONG.parse("3h"));
+        Assert.assertThrows(DateTimeException.class, () -> DurationStyle.LONG.parse("3H"));
+    }
+
+    @Test
+    public void testLongMinutes() {
+        Assert.assertEquals(Duration.ofMinutes(1), DurationStyle.LONG.parse("1 minute"));
+        Assert.assertEquals(Duration.ofMinutes(1), DurationStyle.LONG.parse("1 minutes"));
+        Assert.assertEquals(Duration.ofMinutes(1), DurationStyle.LONG.parse(" 1 minutes"));
+        Assert.assertEquals(Duration.ofMinutes(1), DurationStyle.LONG.parse("1 minutes "));
+        Assert.assertEquals(Duration.ofMinutes(1), DurationStyle.LONG.parse(" 1 minutes "));
+        Assert.assertEquals(Duration.ofMinutes(1), DurationStyle.LONG.parse(" 1  minutes "));
+        Assert.assertEquals(Duration.ofMinutes(1), DurationStyle.LONG.parse(" 1\tMINUTES "));
+
+        Assert.assertEquals(Duration.ofMinutes(3), DurationStyle.LONG.parse("3 minute"));
+        Assert.assertEquals(Duration.ofMinutes(3), DurationStyle.LONG.parse("3 minutes"));
+        Assert.assertEquals(Duration.ofMinutes(3), DurationStyle.LONG.parse("3 MINUTES"));
+
+        Assert.assertEquals("0 second", DurationStyle.LONG.toString(Duration.ofMinutes(0)));
+        Assert.assertEquals("1 minutes", DurationStyle.LONG.toString(Duration.ofMinutes(1)));
+        Assert.assertEquals("3 minutes", DurationStyle.LONG.toString(Duration.ofMinutes(3)));
+
+        Assert.assertThrows(DateTimeException.class, () -> DurationStyle.LONG.parse("a minute"));
+        Assert.assertThrows(DateTimeException.class, () -> DurationStyle.LONG.parse("3 min"));
+        Assert.assertThrows(DateTimeException.class, () -> DurationStyle.LONG.parse("3m"));
+        Assert.assertThrows(DateTimeException.class, () -> DurationStyle.LONG.parse("3M"));
+    }
+
+    @Test
+    public void testLongSeconds() {
+        Assert.assertEquals(Duration.ofSeconds(1), DurationStyle.LONG.parse("1 seconds"));
+        Assert.assertEquals(Duration.ofSeconds(10), DurationStyle.LONG.parse("10 seconds"));
+        Assert.assertThrows(DateTimeException.class, () -> DurationStyle.LONG.parse("a seconds"));
+        Assert.assertThrows(DateTimeException.class, () -> DurationStyle.LONG.parse("3 scond"));
+        Assert.assertThrows(DateTimeException.class, () -> DurationStyle.LONG.parse("3s"));
+        Assert.assertThrows(DateTimeException.class, () -> DurationStyle.LONG.parse("3S"));
+    }
+
+    @Test
+    public void testLongDays() {
+        Assert.assertEquals(Duration.ofDays(1), DurationStyle.LONG.parse("1 days"));
+        Assert.assertEquals(Duration.ofDays(2), DurationStyle.LONG.parse("2 days"));
+    }
+
+    @Test
+    public void testLongCombined() {
+        Assert.assertEquals(Duration.parse("P2DT3H4M5S"), DurationStyle.LONG.parse("2 days 3 Hours\t 4 minute 5 seconds"));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/PeriodStyleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/PeriodStyleTest.java
@@ -1,0 +1,125 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.DateTimeException;
+import java.time.Period;
+
+public class PeriodStyleTest {
+
+    @Test
+    public void testLongYears() {
+        Assert.assertEquals(Period.ofYears(1), PeriodStyle.LONG.parse("1 year"));
+        Assert.assertEquals(Period.ofYears(1), PeriodStyle.LONG.parse("1 years"));
+        Assert.assertEquals(Period.ofYears(1), PeriodStyle.LONG.parse(" 1 years"));
+        Assert.assertEquals(Period.ofYears(1), PeriodStyle.LONG.parse("1 years "));
+        Assert.assertEquals(Period.ofYears(1), PeriodStyle.LONG.parse(" 1 years "));
+        Assert.assertEquals(Period.ofYears(1), PeriodStyle.LONG.parse(" 1  years "));
+        Assert.assertEquals(Period.ofYears(1), PeriodStyle.LONG.parse(" 1\tyears "));
+
+        Assert.assertEquals(Period.ofYears(3), PeriodStyle.LONG.parse("3 year"));
+        Assert.assertEquals(Period.ofYears(3), PeriodStyle.LONG.parse("3 years"));
+        Assert.assertEquals(Period.ofYears(3), PeriodStyle.LONG.parse("3 YEARS"));
+
+        Assert.assertEquals("0 day", PeriodStyle.LONG.toString(Period.ofYears(0)));
+        Assert.assertEquals("1 years", PeriodStyle.LONG.toString(Period.ofYears(1)));
+        Assert.assertEquals("3 years", PeriodStyle.LONG.toString(Period.ofYears(3)));
+
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("a year"));
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("3 yer"));
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("3y"));
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("3Y"));
+    }
+
+    @Test
+    public void testLongMonths() {
+        Assert.assertEquals(Period.ofMonths(1), PeriodStyle.LONG.parse("1 month"));
+        Assert.assertEquals(Period.ofMonths(1), PeriodStyle.LONG.parse("1 months"));
+        Assert.assertEquals(Period.ofMonths(1), PeriodStyle.LONG.parse(" 1 months"));
+        Assert.assertEquals(Period.ofMonths(1), PeriodStyle.LONG.parse("1 months "));
+        Assert.assertEquals(Period.ofMonths(1), PeriodStyle.LONG.parse(" 1 months "));
+        Assert.assertEquals(Period.ofMonths(1), PeriodStyle.LONG.parse(" 1  months "));
+        Assert.assertEquals(Period.ofMonths(1), PeriodStyle.LONG.parse(" 1\tmonths "));
+
+        Assert.assertEquals(Period.ofMonths(3), PeriodStyle.LONG.parse("3 month"));
+        Assert.assertEquals(Period.ofMonths(3), PeriodStyle.LONG.parse("3 months"));
+        Assert.assertEquals(Period.ofMonths(3), PeriodStyle.LONG.parse("3 MONTHS"));
+
+        Assert.assertEquals("0 day", PeriodStyle.LONG.toString(Period.ofMonths(0)));
+        Assert.assertEquals("1 months", PeriodStyle.LONG.toString(Period.ofMonths(1)));
+        Assert.assertEquals("3 months", PeriodStyle.LONG.toString(Period.ofMonths(3)));
+
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("a month"));
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("3 mont"));
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("3M"));
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("3m"));
+    }
+
+    @Test
+    public void testLongWeeks() {
+        Assert.assertEquals(Period.ofWeeks(1), PeriodStyle.LONG.parse("1 week"));
+        Assert.assertEquals(Period.ofWeeks(1), PeriodStyle.LONG.parse("1 weeks"));
+        Assert.assertEquals(Period.ofWeeks(1), PeriodStyle.LONG.parse(" 1 weeks"));
+        Assert.assertEquals(Period.ofWeeks(1), PeriodStyle.LONG.parse("1 weeks "));
+        Assert.assertEquals(Period.ofWeeks(1), PeriodStyle.LONG.parse(" 1 weeks "));
+        Assert.assertEquals(Period.ofWeeks(1), PeriodStyle.LONG.parse(" 1  weeks "));
+        Assert.assertEquals(Period.ofWeeks(1), PeriodStyle.LONG.parse(" 1\tweeks "));
+
+        Assert.assertEquals(Period.ofWeeks(3), PeriodStyle.LONG.parse("3 week"));
+        Assert.assertEquals(Period.ofWeeks(3), PeriodStyle.LONG.parse("3 weeks"));
+        Assert.assertEquals(Period.ofWeeks(3), PeriodStyle.LONG.parse("3 WEEKS"));
+
+        Assert.assertEquals("0 day", PeriodStyle.LONG.toString(Period.ofWeeks(0)));
+        Assert.assertEquals("7 days", PeriodStyle.LONG.toString(Period.ofWeeks(1)));
+        Assert.assertEquals("21 days", PeriodStyle.LONG.toString(Period.ofWeeks(3)));
+
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("a weeks"));
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("3 we"));
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("3w"));
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("3W"));
+    }
+
+    @Test
+    public void testLongDays() {
+        Assert.assertEquals(Period.ofDays(3), PeriodStyle.LONG.parse("3 days"));
+        Assert.assertEquals(Period.ofDays(3), PeriodStyle.LONG.parse("3  days"));
+        Assert.assertEquals(Period.ofDays(3), PeriodStyle.LONG.parse(" 3 DAYS"));
+        Assert.assertEquals(Period.ofDays(3), PeriodStyle.LONG.parse(" 3 DAYS "));
+
+        Assert.assertEquals("0 day", PeriodStyle.LONG.toString(Period.ZERO));
+        Assert.assertEquals("1 days", PeriodStyle.LONG.toString(Period.ofDays(1)));
+        Assert.assertEquals("3 days", PeriodStyle.LONG.toString(Period.ofDays(3)));
+        Assert.assertEquals("7 days", PeriodStyle.LONG.toString(Period.ofWeeks(1)));
+
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("a days"));
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("3 dya"));
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("3d"));
+        Assert.assertThrows(DateTimeException.class, () -> PeriodStyle.LONG.parse("3D"));
+    }
+
+    @Test
+    public void testLongCombined() {
+        Assert.assertEquals(Period.of(2, 3, 12), PeriodStyle.LONG.parse("2 years 3 months 12 days"));
+        Assert.assertEquals(Period.of(2, 3, 12), PeriodStyle.LONG.parse(" 2 YEARS 3 Months 12  Days "));
+        Assert.assertEquals(Period.of(0, 3, 12), PeriodStyle.LONG.parse("  3 Months 12  Days "));
+        Assert.assertEquals(Period.of(0, 0, 26), PeriodStyle.LONG.parse("\t2 WeeKs 12  Days "));
+
+        Assert.assertEquals("2 years 3 months 4 days", PeriodStyle.LONG.toString(Period.of(2, 3, 4)));
+        Assert.assertEquals("3 months 4 days", PeriodStyle.LONG.toString(Period.of(0, 3, 4)));
+    }
+}

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -126,6 +126,9 @@ struct TInternalScanRange {
   9: optional string table_name 
   10: optional i64 partition_id
   11: optional i64 row_count
+  // Allow this query to cache remote data on local disks or not.
+  // Only the cloud native tablet will respect this field.
+  12: optional bool fill_data_cache = true;
 }
 
 enum TFileFormatType {


### PR DESCRIPTION
Add property "datacache.partition_duration" for cloud native table. If a table is partitioned by DATE or DATETIME, and a partition range is within the last "datacache.partition_duration", it is a hot partition, queries on that partition will trigger cache population, otherwise will not.
"datacache.partition_duration" unit can be "second", "minute", "hour", "day", "week", "month", "year".

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
