### PR TITLE
[Enhancement] Clean up table folders using FileIO on dropping iceberg table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/hive/IcebergHiveCatalog.java
@@ -58,7 +58,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -357,19 +356,8 @@ public class IcebergHiveCatalog extends BaseMetastoreCatalog implements IcebergC
 
     @Override
     public void deleteUncommittedDataFiles(List<String> fileLocations) {
-        fileLocations.forEach(this::deletePath);
-    }
-
-    // TODO(stephen): use CachingFileIO to access file system After adaptation
-    private void deletePath(String location) {
-        Path path = new Path(location);
-        URI uri = path.toUri();
-        try {
-            FileSystem fileSystem = FileSystem.get(uri, conf);
-            fileSystem.delete(path, true);
-        } catch (IOException e) {
-            LOG.error("Failed to delete location {}", location, e);
-            throw new StarRocksConnectorException("Failed to delete location %s. msg: %s", location, e.getMessage());
+        for (String location : fileLocations) {
+            fileIO.deleteFile(location);
         }
     }
 


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Dropping iceberg database/table requires us to clean up files/objects in the filesystem. 
This PR uses FileIO to handle clean-up uniformly.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
