### PR TITLE
[Enhancement] skip text file desc part when file is not text format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -28,6 +28,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
+import com.starrocks.thrift.THdfsFileFormat;
 import com.starrocks.thrift.THdfsScanRange;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TScanRange;
@@ -104,7 +105,9 @@ public class RemoteScanRangeLocations {
         hdfsScanRange.setPartition_id(partitionId);
         hdfsScanRange.setFile_length(fileDesc.getLength());
         hdfsScanRange.setFile_format(partition.getFormat().toThrift());
-        hdfsScanRange.setText_file_desc(fileDesc.getTextFileFormatDesc().toThrift());
+        if (isTextFormat(hdfsScanRange.getFile_format())) {
+            hdfsScanRange.setText_file_desc(fileDesc.getTextFileFormatDesc().toThrift());
+        }
         TScanRange scanRange = new TScanRange();
         scanRange.setHdfs_scan_range(hdfsScanRange);
         scanRangeLocations.setScan_range(scanRange);
@@ -124,6 +127,10 @@ public class RemoteScanRangeLocations {
         result.add(scanRangeLocations);
     }
 
+    private boolean isTextFormat(THdfsFileFormat format) {
+        return format == THdfsFileFormat.TEXT || format == THdfsFileFormat.LZO_TEXT;
+    }
+
     private void createHudiScanRangeLocations(long partitionId,
                                               RemoteFileInfo partition,
                                               RemoteFileDesc fileDesc,
@@ -137,7 +144,9 @@ public class RemoteScanRangeLocations {
         hdfsScanRange.setPartition_id(partitionId);
         hdfsScanRange.setFile_length(fileDesc.getLength());
         hdfsScanRange.setFile_format(partition.getFormat().toThrift());
-        hdfsScanRange.setText_file_desc(fileDesc.getTextFileFormatDesc().toThrift());
+        if (isTextFormat(hdfsScanRange.getFile_format())) {
+            hdfsScanRange.setText_file_desc(fileDesc.getTextFileFormatDesc().toThrift());
+        }
         for (String log : fileDesc.getHudiDeltaLogs()) {
             hdfsScanRange.addToHudi_logs(log);
         }


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

This PR is trying to reduce plan size(in thrift format). 

I was tring to setup a table with 600K small files, then it took about 3262ms seconds on `CoordDeliverExec` stage.

<img width="384" alt="Collect Profile Time 26ms" src="https://github.com/StarRocks/starrocks/assets/1081215/71566c09-67af-41ae-b88f-7aae2dbdf731">

and from profile, we can see a lot of time is on thrift serialization

<img width="2289" alt="Pasted Graphic 2" src="https://github.com/StarRocks/starrocks/assets/1081215/f19c1b6d-9163-48f4-a3a3-bb0e6993f27b">

---

but from the profile, we can `TextFileDesc` part takes a lot of time, but that part is necessary only for text format.

so with this pr, the `CoordDeliverExec` can be reduced to 2664ms(whch is slightly improved)

<img width="499" alt="image" src="https://github.com/StarRocks/starrocks/assets/1081215/01ba409c-8a36-4da4-aea5-022f9cf608e6">

<img width="2128" alt="image" src="https://github.com/StarRocks/starrocks/assets/1081215/ed40a431-61fd-4798-a99c-f5e06485458f">


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
