### PR TITLE
[Doc] Fix typo of `Aggregate table` in docs TOC

### DIFF
--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -18,7 +18,7 @@
   + Table types
     + [Overview of table types](./table_design/table_types/table_types.md)
     + [Duplicate Key table](./table_design/table_types/duplicate_key_table.md)
-    + [Aggragete table](./table_design/table_types/aggregate_table.md)
+    + [Aggregate table](./table_design/table_types/aggregate_table.md)
     + [Unique Key table](./table_design/table_types/unique_key_table.md)
     + [Primary Key table](./table_design/table_types/primary_key_table.md)
   + Data distribution


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
- fix the typo in docs TOC, `Aggragete table` should be `Aggregate table`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
