### PR TITLE
[BugFix] fix schema change hang when data loading concurrent with schema change

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -194,6 +194,9 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
      *      There are new load jobs after alter task, and at least one of them is succeed on this replica.
      *      So the replica's version should be larger than X. So we don't need to modify the replica version
      *      because its already looks like normal.
+     * Case 3:
+     *      There are new load jobs after alter task, and their version and LFV is smaller or equal to X. 
+     *      And because alter request report success, it means that we can increase replica's version to X.
      */
     public void handleFinishAlterTask() throws Exception {
         Database db = GlobalStateMgr.getCurrentState().getDb(getDbId());
@@ -227,18 +230,10 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
                         getVersion());
                 boolean versionChanged = false;
                 if (replica.getVersion() <= getVersion()) {
-                    if (replica.getLastFailedVersion() > getVersion()) {
-                        // Case 2.1
-                        replica.updateRowCount(getVersion(), replica.getDataSize(),
-                                replica.getRowCount());
-                        versionChanged = true;
-                    } else {
-                        // Case 1
-                        Preconditions.checkState(replica.getLastFailedVersion() == -1, replica.getLastFailedVersion());
-                        replica.updateRowCount(getVersion(), replica.getDataSize(),
-                                replica.getRowCount());
-                        versionChanged = true;
-                    }
+                    // Case 1, Case 2.1 or Case 3
+                    replica.updateRowCount(getVersion(), replica.getDataSize(),
+                            replica.getRowCount());
+                    versionChanged = true;
                 }
 
                 if (versionChanged) {


### PR DESCRIPTION
## What type of PR is this:
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #23452

## Problem Summary(Required):
1. Assume there is a partition, current visible version is 13378, and all loading task is finished.
2. Trigger schema change, it will create new replica, and at the same time, one loading task is trigger and finished, and it's version is 13379.
3. Before send alter replica request, FE check that all loading task is finished, but loading task on new create replica haven't finish yet and V=1, LFV=13379. 
4. Alter replica finish on BE, and BE send finish alter replica request back to FE. When call `handleFinishAlterTask`, `checkState` fail because LFV != -1.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
