### PR TITLE
[BugFix] adapt hive metastore version with alter_table_with_environmentContext

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1377,8 +1377,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             hook.preAlterTable(table, environmentContext);
         }
 
-        client.alter_table_with_environment_context(prependCatalogToDbName(databaseName, conf),
-                tblName, table, environmentContext);
+        client.alter_table_with_environment_context(databaseName, tblName, table, environmentContext);
     }
 
     @Override


### PR DESCRIPTION

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
If I use hive metastore of version 2.3.9 to execute `insert into iceberg_table select ` in the starrocks; it will throw exception in the hive metastore side. stack as follows:
![image](https://github.com/StarRocks/starrocks/assets/91597003/9c2fed44-dd53-4288-989e-026102cca078)

the root cause is hms version incompatible with `alter_table_with_environment_context` interface.

hive metastore of 3.1.2 version. 
https://github.com/apache/hive/blob/rel/release-3.1.2/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java#L4990

hive metastore of 2.3.9 version.
https://github.com/apache/hive/blob/rel/release-2.3.9/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java#L3980

we need to pass the origin dbName to hms service and judge whether to use catalogName on the server side instead of prepend CatalogName in the fe.


## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
