### PR TITLE
[BugFix] Disable shortcut compaction after link schema change

### DIFF
--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -156,6 +156,7 @@ Status CompactionAction::do_compaction(uint64_t tablet_id, const string& compact
                 if (compaction_task != nullptr) {
                     compaction_task->set_task_id(
                             StorageEngine::instance()->compaction_manager()->next_compaction_task_id());
+                    compaction_task->set_is_manual_compaction(true);
                     compaction_task->start();
                     if (compaction_task->compaction_task_state() != COMPACTION_SUCCESS) {
                         return Status::InternalError(fmt::format("Failed to base compaction tablet={} err={}",
@@ -189,6 +190,7 @@ Status CompactionAction::do_compaction(uint64_t tablet_id, const string& compact
                 if (compaction_task != nullptr) {
                     compaction_task->set_task_id(
                             StorageEngine::instance()->compaction_manager()->next_compaction_task_id());
+                    compaction_task->set_is_manual_compaction(true);
                     compaction_task->start();
                     if (compaction_task->compaction_task_state() != COMPACTION_SUCCESS) {
                         return Status::InternalError(fmt::format("Failed to base compaction tablet={} task_id={}",

--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -197,7 +197,8 @@ Status CompactionTask::_shortcut_compact(Statistics* statistics) {
         }
     }
 
-    if (data_rowsets.size() == 1 && !data_rowsets.back()->rowset_meta()->is_segments_overlapping()) {
+    if (data_rowsets.size() == 1 && !data_rowsets.back()->rowset_meta()->is_segments_overlapping() &&
+        _tablet->enable_shortcut_compaction()) {
         TRACE("[Compaction] start shortcut comapction data");
         int64_t max_rows_per_segment = CompactionUtils::get_segment_max_rows(
                 config::max_segment_file_size, _task_info.input_rows_num, _task_info.input_rowsets_size);

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -69,6 +69,7 @@ struct CompactionTaskInfo {
     size_t output_num_rows{0};
     CompactionType compaction_type{CompactionType::INVALID_COMPACTION};
     bool is_shortcut_compaction{false};
+    bool is_manual_compaction{false};
 
     // for vertical compaction
     size_t column_group_size{0};
@@ -119,6 +120,7 @@ struct CompactionTaskInfo {
         ss << ", total_merged_rows:" << total_merged_rows;
         ss << ", total_del_filtered_rows:" << total_del_filtered_rows;
         ss << ", is_shortcut_compaction:" << is_shortcut_compaction;
+        ss << ", is_manual_compaction:" << is_manual_compaction;
         ss << ", progress:" << get_progress();
         return ss.str();
     }
@@ -214,6 +216,10 @@ public:
 
     bool is_shortcut_compaction() const { return _task_info.is_shortcut_compaction; }
 
+    bool is_manual_compaction() const { return _task_info.is_manual_compaction; }
+
+    void set_is_manual_compaction(bool is_manual_compaction) { _task_info.is_manual_compaction = is_manual_compaction; }
+
 protected:
     virtual Status run_impl() = 0;
 
@@ -246,6 +252,10 @@ protected:
         std::stringstream input_stream_info;
         {
             std::unique_lock wrlock(_tablet->get_header_lock());
+            // after one success compaction, low cardinality dict will be generated.
+            // so we can enable shortcut compaction.
+            _tablet->tablet_meta()->set_enable_shortcut_compaction(true);
+
             for (int i = 0; i < 5 && i < _input_rowsets.size(); ++i) {
                 input_stream_info << _input_rowsets[i]->version() << ";";
             }

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -745,6 +745,11 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTable
             // do not drop the new tablet and its data. GC thread will
             return res;
         }
+        // link schema change will not generate low cardinality dict for new column
+        // so that we need disable shortchut compaction make sure dict will generate by further compaction
+        if (!sc_params.sc_directly && !sc_params.sc_sorting) {
+            new_tablet->tablet_meta()->set_enable_shortcut_compaction(false);
+        }
         new_tablet->save_meta();
     }
 

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1138,7 +1138,7 @@ void Tablet::get_compaction_status(std::string* json_result) {
     double compaction_score;
     std::string compaction_type;
     vector<RowsetSharedPtr> compaction_rowsets;
-    int64_t compaction_start_time;
+    int64_t compaction_start_time = 0;
 
     {
         std::shared_lock rdlock(_meta_lock);

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -119,6 +119,7 @@ public:
     size_t field_index(const string& field_name) const;
     std::string schema_debug_string() const;
     std::string debug_string() const;
+    bool enable_shortcut_compaction() const;
 
     // Load incremental rowsets to the tablet in DataDir#load.
     Status load_rowset(const RowsetSharedPtr& rowset);
@@ -434,6 +435,11 @@ inline size_t Tablet::next_unique_id() const {
 
 inline size_t Tablet::field_index(const string& field_name) const {
     return _tablet_meta->tablet_schema().field_index(field_name);
+}
+
+inline bool Tablet::enable_shortcut_compaction() const {
+    std::shared_lock rdlock(_meta_lock);
+    return _tablet_meta->enable_shortcut_compaction();
 }
 
 } // namespace starrocks

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -280,6 +280,8 @@ void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb) {
         auto& lsnPb = tablet_meta_pb.binlog_min_lsn();
         _binlog_min_lsn = BinlogLsn(lsnPb.version(), lsnPb.seq_id());
     }
+
+    _enable_shortcut_compaction = tablet_meta_pb.enable_shortcut_compaction();
 }
 
 void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
@@ -336,6 +338,8 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
         lsn->set_version(_binlog_min_lsn.version());
         lsn->set_seq_id(_binlog_min_lsn.seq_id());
     }
+
+    tablet_meta_pb->set_enable_shortcut_compaction(_enable_shortcut_compaction);
 }
 
 void TabletMeta::to_json(string* json_string, json2pb::Pb2JsonOptions& options) {

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -205,6 +205,12 @@ public:
 
     void set_binlog_min_lsn(BinlogLsn& binlog_lsn) { _binlog_min_lsn = binlog_lsn; }
 
+    bool enable_shortcut_compaction() const { return _enable_shortcut_compaction; }
+
+    void set_enable_shortcut_compaction(bool enable_shortcut_compaction) {
+        _enable_shortcut_compaction = enable_shortcut_compaction;
+    }
+
 private:
     int64_t _mem_usage() const { return sizeof(TabletMeta); }
 
@@ -260,6 +266,8 @@ private:
     // 2. config::inc_rowset_expired_sec is larger than the expired time of binlog, so
     //    a rowset will not be removed from _inc_rs_metas if only the binlog is expired
     BinlogLsn _binlog_min_lsn;
+
+    bool _enable_shortcut_compaction = true;
 
     std::shared_mutex _meta_lock;
 };

--- a/be/src/storage/task/engine_manual_compaction_task.cpp
+++ b/be/src/storage/task/engine_manual_compaction_task.cpp
@@ -86,6 +86,7 @@ Status EngineManualCompactionTask::_manual_compaction() {
                 if (compaction_task != nullptr) {
                     compaction_task->set_task_id(
                             StorageEngine::instance()->compaction_manager()->next_compaction_task_id());
+                    compaction_task->set_is_manual_compaction(true);
                     compaction_task->start();
                     if (compaction_task->compaction_task_state() != COMPACTION_SUCCESS) {
                         return Status::InternalError(fmt::format("Failed to base compaction tablet={} task_id={}",
@@ -119,6 +120,7 @@ Status EngineManualCompactionTask::_manual_compaction() {
                 if (compaction_task != nullptr) {
                     compaction_task->set_task_id(
                             StorageEngine::instance()->compaction_manager()->next_compaction_task_id());
+                    compaction_task->set_is_manual_compaction(true);
                     compaction_task->start();
                     if (compaction_task->compaction_task_state() != COMPACTION_SUCCESS) {
                         return Status::InternalError(fmt::format("Failed to cumulative compaction tablet={} err={}",

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -281,6 +281,7 @@ message TabletMetaPB {
     optional bool enable_persistent_index = 51 [default = false]; // used for persistent index in primary index
     optional BinlogConfigPB binlog_config = 52;
     optional BinlogLsnPB binlog_min_lsn = 53;
+    optional bool enable_shortcut_compaction = 60 [default = true];
 }
 
 message OLAPIndexHeaderMessage {


### PR DESCRIPTION
link schema change will not generate low cardinality dict so that we need disable shortcut compaction make sure dict will generate by normal compaction

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/StarRocks/StarRocksTest/issues/2488

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
