### PR TITLE
[Enhancement] Add a lru insertion point option to block cache to support inserting the new cache item to a custom position of the lru list. (backport #23267)

### DIFF
--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -33,9 +33,11 @@ struct CacheOptions {
     // advanced
     size_t block_size;
     bool checksum;
-    size_t max_parcel_memory_mb;
-    size_t max_concurrent_inserts;
     std::string engine;
+    size_t max_concurrent_inserts;
+    // The following options are only valid for cachelib engine currently
+    size_t max_parcel_memory_mb;
+    uint8_t lru_insertion_point;
 };
 
 } // namespace starrocks

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -47,8 +47,10 @@ Status CacheLibWrapper::init(const CacheOptions& options) {
         config.enableNvmCache(nvmConfig);
     }
 
+    Cache::MMConfig mm_config;
+    mm_config.lruInsertionPointSpec = options.lru_insertion_point;
     _cache = std::make_unique<Cache>(config);
-    _default_pool = _cache->addPool("default pool", _cache->getCacheMemoryStats().cacheSize);
+    _default_pool = _cache->addPool("default pool", _cache->getCacheMemoryStats().cacheSize, {}, mm_config);
     _meta_path = options.meta_path;
     return Status::OK();
 }
@@ -104,11 +106,6 @@ std::unordered_map<std::string, double> CacheLibWrapper::cache_stats() {
 Status CacheLibWrapper::shutdown() {
     if (_cache) {
         _dump_cache_stats();
-        auto res = _cache->shutDown();
-        if (res != Cache::ShutDownStatus::kSuccess) {
-            LOG(WARNING) << "block cache shutdown failed";
-            return Status::InternalError("block cache shutdown failed");
-        }
     }
     return Status::OK();
 }

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -45,6 +45,7 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
     _load_starcache_conf();
     starcache::config::FLAGS_block_size = options.block_size;
     starcache::config::FLAGS_enable_disk_checksum = options.checksum;
+    starcache::config::FLAGS_max_concurrent_writes = options.max_concurrent_inserts;
 
     _cache = std::make_unique<starcache::StarCache>();
     return to_status(_cache->init(opt));

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -886,11 +886,15 @@ CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
 CONF_Bool(block_cache_checksum_enable, "true");
 // Maximum number of concurrent inserts we allow globally for block cache.
 // 0 means unlimited.
-CONF_Int64(block_cache_max_concurrent_inserts, "1000000");
+CONF_Int64(block_cache_max_concurrent_inserts, "1500000");
 // Total memory limit for in-flight parcels.
 // Once this is reached, requests will be rejected until the parcel memory usage gets under the limit.
 CONF_Int64(block_cache_max_parcel_memory_mb, "256");
 CONF_Bool(block_cache_report_stats, "false");
+// This essentially turns the LRU into a two-segmented LRU. Setting this to 1 means every new insertion
+// will be inserted 1/2 from the end of the LRU, 2 means 1/4 from the end of the LRU, and so on.
+// It is only useful for the cachelib engine currently.
+CONF_Int64(block_cache_lru_insertion_point, "1");
 // cachelib, starcache
 CONF_String(block_cache_engine, "starcache");
 

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -228,6 +228,7 @@ int main(int argc, char** argv) {
         cache_options.checksum = starrocks::config::block_cache_checksum_enable;
         cache_options.max_parcel_memory_mb = starrocks::config::block_cache_max_parcel_memory_mb;
         cache_options.max_concurrent_inserts = starrocks::config::block_cache_max_concurrent_inserts;
+        cache_options.lru_insertion_point = starrocks::config::block_cache_lru_insertion_point;
         cache_options.engine = starrocks::config::block_cache_engine;
         EXIT_IF_ERROR(cache->init(cache_options));
     }

--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -54,13 +54,14 @@ protected:
 
 TEST_F(BlockCacheTest, hybrid_cache) {
     std::unique_ptr<BlockCache> cache(new BlockCache);
-    const size_t block_size = 1 * 1024 * 1024;
+    const size_t block_size = 1024 * 1024;
 
     CacheOptions options;
     options.mem_space_size = 20 * 1024 * 1024;
     size_t quota = 500 * 1024 * 1024;
     options.disk_spaces.push_back({.path = "./ut_dir/block_disk_cache", .size = quota});
     options.block_size = block_size;
+    options.max_concurrent_inserts = 100000;
     options.engine = "starcache";
     Status status = cache->init(options);
     ASSERT_TRUE(status.ok());
@@ -102,10 +103,21 @@ TEST_F(BlockCacheTest, hybrid_cache) {
     // not found
     res = cache->read_cache(cache_key, block_size * 1000, batch_size, value);
     ASSERT_TRUE(res.status().is_not_found());
+
+    cache->shutdown();
 }
 
 TEST_F(BlockCacheTest, write_with_overwrite_option) {
-    BlockCache* cache = BlockCache::instance();
+    std::unique_ptr<BlockCache> cache(new BlockCache);
+    const size_t block_size = 1024 * 1024;
+
+    CacheOptions options;
+    options.mem_space_size = 20 * 1024 * 1024;
+    options.block_size = block_size;
+    options.max_concurrent_inserts = 100000;
+    options.engine = "starcache";
+    Status status = cache->init(options);
+    ASSERT_TRUE(status.ok());
 
     const size_t cache_size = 1024;
     const std::string cache_key = "test_file";
@@ -127,17 +139,20 @@ TEST_F(BlockCacheTest, write_with_overwrite_option) {
     std::string value3(cache_size, 'c');
     st = cache->write_cache(cache_key, 0, cache_size, value3.c_str(), 0, false);
     ASSERT_TRUE(st.is_already_exist());
+
+    cache->shutdown();
 }
 
 TEST_F(BlockCacheTest, auto_create_disk_cache_path) {
     std::unique_ptr<BlockCache> cache(new BlockCache);
-    const size_t block_size = 1 * 1024 * 1024;
+    const size_t block_size = 1024 * 1024;
 
     CacheOptions options;
     options.mem_space_size = 20 * 1024 * 1024;
     size_t quota = 500 * 1024 * 1024;
     options.disk_spaces.push_back({.path = "./ut_dir/final_entry_not_exist", .size = quota});
     options.block_size = block_size;
+    options.max_concurrent_inserts = 100000;
     options.engine = "starcache";
     Status status = cache->init(options);
     ASSERT_TRUE(status.ok());
@@ -170,5 +185,42 @@ TEST_F(BlockCacheTest, auto_create_disk_cache_path) {
 
     cache->shutdown();
 }
+
+#ifdef WITH_CACHELIB
+TEST_F(BlockCacheTest, custom_lru_insertion_point) {
+    std::unique_ptr<BlockCache> cache(new BlockCache);
+    const size_t block_size = 1024 * 1024;
+
+    CacheOptions options;
+    options.mem_space_size = 20 * 1024 * 1024;
+    options.block_size = block_size;
+    options.max_concurrent_inserts = 100000;
+    options.engine = "cachelib";
+    // insert in the 1/2 of the lru list
+    options.lru_insertion_point = 1;
+    Status status = cache->init(options);
+    ASSERT_TRUE(status.ok());
+
+    const size_t rounds = 20;
+    const size_t batch_size = block_size;
+    const std::string cache_key = "test_file";
+    // write cache
+    // only 12 blocks can be cached
+    for (size_t i = 0; i < rounds; ++i) {
+        char ch = 'a' + i % 26;
+        std::string value(batch_size, ch);
+        Status st = cache->write_cache(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+        ASSERT_TRUE(st.ok());
+    }
+
+    // read cache
+    // with the 1/2 lru insertion point, the test_file1 items will not be evicted
+    char value[batch_size] = {0};
+    auto res = cache->read_cache(cache_key + std::to_string(1), 0, batch_size, value);
+    ASSERT_TRUE(res.status().ok());
+
+    cache->shutdown();
+}
+#endif
 
 } // namespace starrocks


### PR DESCRIPTION

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
In this PR, we add an option to support cachelib lru insertion point, which is a custom postion and not at the head of the list. New items will be inserted at the position ipos(p) = size(LRU) * p from the tail, where p ∈ [0,1] is a ratio parameter. For example, suppose the regular LRU tail age be 600s, but you want to cache only items that were accessed during the 200s after insertion. Inserting new items at position ipos(1/3) from the tail may help you to achieve this. Not that custom IP affects only items that're inserted into the cache the first time; it doesn't affect items that on access are moved to the head of the list.

![image](https://github.com/StarRocks/starrocks/assets/13727748/7166d799-0d69-44ac-9cf4-cb7637a53088)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
