### PR TITLE
[Enhancement] Support show sync stream load

### DIFF
--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -342,6 +342,7 @@ bool StreamLoadExecutor::collect_load_stat(StreamLoadContext* ctx, TTxnCommitAtt
         manual_load_attach.__set_filteredRows(ctx->number_filtered_rows);
         manual_load_attach.__set_receivedBytes(ctx->receive_bytes);
         manual_load_attach.__set_loadedBytes(ctx->loaded_bytes);
+        manual_load_attach.__set_unselectedRows(ctx->number_unselected_rows);
         if (!ctx->error_url.empty()) {
             manual_load_attach.__set_errorLogUrl(ctx->error_url);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/ManualLoadTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/ManualLoadTxnCommitAttachment.java
@@ -30,6 +30,8 @@ public class ManualLoadTxnCommitAttachment extends TxnCommitAttachment {
     private long loadedRows;
     @SerializedName("filteredRows")
     private long filteredRows;
+
+    private long unselectedRows;
     private long receivedBytes;
     private long loadedBytes;
     // optional
@@ -46,6 +48,7 @@ public class ManualLoadTxnCommitAttachment extends TxnCommitAttachment {
         this.loadedBytes = tManualLoadTxnCommitAttachment.getLoadedBytes();
         this.receivedBytes = tManualLoadTxnCommitAttachment.getReceivedBytes();
         this.filteredRows = tManualLoadTxnCommitAttachment.getFilteredRows();
+        this.unselectedRows = tManualLoadTxnCommitAttachment.getUnselectedRows();
         if (tManualLoadTxnCommitAttachment.isSetErrorLogUrl()) {
             this.errorLogUrl = tManualLoadTxnCommitAttachment.getErrorLogUrl();
         }
@@ -65,6 +68,10 @@ public class ManualLoadTxnCommitAttachment extends TxnCommitAttachment {
 
     public long getFilteredRows() {
         return filteredRows;
+    }
+
+    public long getUnselectedRows() {
+        return unselectedRows;
     }
 
     public String getErrorLogUrl() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -197,7 +197,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         TExecPlanFragmentParams tExecPlanFragmentParams = routineLoadJob.plan(loadId, txnId, label);
         if (tExecPlanFragmentParams.query_options.enable_profile) {
             StreamLoadTask streamLoadTask = GlobalStateMgr.getCurrentState().
-                    getStreamLoadManager().getSyncSteamLoadTaskByLabel(label);
+                    getStreamLoadManager().getTaskByLabel(label);
             setStreamLoadTask(streamLoadTask);
         }
         TPlanFragment tPlanFragment = tExecPlanFragmentParams.getFragment();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RLTaskTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RLTaskTxnCommitAttachment.java
@@ -63,6 +63,7 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
     @SerializedName("progress")
     private RoutineLoadProgress progress;
     private String errorLogUrl;
+    private long loadedBytes;
 
     public RLTaskTxnCommitAttachment() {
         super(TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK);
@@ -76,6 +77,7 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
         this.loadedRows = rlTaskTxnCommitAttachment.getLoadedRows();
         this.unselectedRows = rlTaskTxnCommitAttachment.getUnselectedRows();
         this.receivedBytes = rlTaskTxnCommitAttachment.getReceivedBytes();
+        this.loadedBytes = rlTaskTxnCommitAttachment.getLoadedBytes();
         this.taskExecutionTimeMs = rlTaskTxnCommitAttachment.getLoadCostMs();
 
         switch (rlTaskTxnCommitAttachment.getLoadSourceType()) {
@@ -120,6 +122,10 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
 
     public long getReceivedBytes() {
         return receivedBytes;
+    }
+
+    public long getLoadedBytes() {
+        return loadedBytes;
     }
 
     public long getTaskExecutionTimeMs() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -788,7 +788,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
                 StreamLoadManager streamLoadManager = GlobalStateMgr.getCurrentState().getStreamLoadManager();
 
                 StreamLoadTask streamLoadTask = streamLoadManager.createLoadTask(db, table.getName(), label,
-                        Config.routine_load_task_timeout_second);
+                        Config.routine_load_task_timeout_second, true);
                 streamLoadTask.setTxnId(txnId);
                 streamLoadTask.setLabel(label);
                 streamLoadTask.setTUniqueId(loadId);
@@ -804,9 +804,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
                         add("label", label).
                         add("streamLoadTaskId", streamLoadTask.getId()));
 
-            } else {
-                planParams.query_options.setEnable_profile(false);
             }
+
             // add table indexes to transaction state
             TransactionState txnState =
                     GlobalStateMgr.getCurrentGlobalTransactionMgr().getTransactionState(db.getId(), txnId);
@@ -986,6 +985,13 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
                     LOG.warn("failed to pause the job {}. this should not happen", id, e);
                 }
                 return;
+            }
+
+            try {
+                routineLoadTaskInfo.afterVisible(txnState, txnOperated);
+            } catch (UserException e) {
+                LOG.warn("failed to execute 'routineLoadTaskInfo.afterVisible', txnId {}, label {}. " +
+                        "this should not happen", txnState.getTransactionId(), routineLoadTaskInfo.getLabel());
             }
 
             // create new task

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
@@ -147,6 +147,10 @@ public abstract class RoutineLoadTaskInfo {
         return txnId;
     }
 
+    public String getLabel() {
+        return label;
+    }
+
     public boolean isRunning() {
         return executeStartTimeMs > 0;
     }
@@ -220,14 +224,21 @@ public abstract class RoutineLoadTaskInfo {
     }
 
     public void afterCommitted(TransactionState txnState, boolean txnOperated) throws UserException {
-        //StreamLoadTask is null, if not specify session variable `enable_profile = true`
+        // StreamLoadTask is null, if not specify session variable `enable_profile = true`
         if (streamLoadTask != null) {
             streamLoadTask.afterCommitted(txnState, txnOperated);
         }
     }
 
+    public void afterVisible(TransactionState txnState, boolean txnOperated) throws UserException {
+        // StreamLoadTask is null, if not specify session variable `enable_profile = true`
+        if (streamLoadTask != null) {
+            streamLoadTask.afterVisible(txnState, txnOperated);
+        }
+    }
+
     public void afterAborted(TransactionState txnState, boolean txnOperated, String txnStatusChangeReason) throws UserException {
-        //StreamLoadTask is null, if not specify `enable_profile = true` when creating the routine load job
+        // StreamLoadTask is null, if not specify session variable `enable_profile = true`
         if (streamLoadTask != null) {
             streamLoadTask.afterAborted(txnState, txnOperated, txnStatusChangeReason);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadFunctionalExprProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadFunctionalExprProvider.java
@@ -142,6 +142,25 @@ public class StreamLoadFunctionalExprProvider extends FunctionalExprProvider<Str
                 }
             };
 
+    private static final ColumnValueSupplier<StreamLoadTask> TASK_TYPE_SUPPLIER =
+            new ColumnValueSupplier<StreamLoadTask>() {
+                @Override
+                public String getColumnName() {
+                    return "Type";
+                }
+
+                @Override
+                public PrimitiveType getColumnType() {
+                    return PrimitiveType.VARCHAR;
+                }
+
+                @Override
+                @SuppressWarnings("unchecked")
+                public String getColumnValue(StreamLoadTask task) {
+                    return task.getStringByType();
+                }
+            };
+
     @Override
     protected ImmutableList<ColumnValueSupplier<StreamLoadTask>> delegateWhereSuppliers() {
         // return a group of ColumnValueSuppliers which are abled to be filtered and ordered.
@@ -152,6 +171,7 @@ public class StreamLoadFunctionalExprProvider extends FunctionalExprProvider<Str
                 .add(TASK_DB_NAME_SUPPLIER)
                 .add(TASK_TABLE_NAME_SUPPLIER)
                 .add(TASK_STATE_SUPPLIER)
+                .add(TASK_TYPE_SUPPLIER)
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -85,9 +85,9 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback implements Wr
     }
 
     public enum Type {
-        SYNC,
+        STREAM_LOAD,
         ROUTINE_LOAD,
-        PARALLEL     // default
+        PARALLEL_STREAM_LOAD     // default
     }
 
     @SerializedName(value = "id")
@@ -141,7 +141,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback implements Wr
     // used for sync stream load and routine load
     private boolean isSyncStreamLoad = false;
 
-    private Type type = Type.PARALLEL;
+    private Type type = Type.PARALLEL_STREAM_LOAD;
 
     private List<State> channels;
     private StreamLoadParam streamLoadParam;
@@ -178,7 +178,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback implements Wr
         if (isRoutineLoad) {
             type = Type.ROUTINE_LOAD;
         } else {
-            type = Type.SYNC;
+            type = Type.STREAM_LOAD;
         }
     }
     public StreamLoadTask(long id, Database db, OlapTable table, String label,
@@ -1300,12 +1300,12 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback implements Wr
         switch (this.type) {
             case ROUTINE_LOAD:
                 return "ROUTINE_LOAD";
-            case SYNC:
-                return "SYNC";
-            case PARALLEL:
-                return "PARALLEL";
+            case STREAM_LOAD:
+                return "STREAM_LOAD";
+            case PARALLEL_STREAM_LOAD:
+                return "PARALLEL_STREAM_LOAD";
             default:
-                return "UNKOWN TYPE";
+                return "UNKOWN";
         }
     }
 
@@ -1385,7 +1385,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback implements Wr
         task.setTUniqueId(loadId);
         // Only task which type is PARALLEL will be persisted
         // just set type to PARALLEL
-        task.setType(Type.PARALLEL);
+        task.setType(Type.PARALLEL_STREAM_LOAD);
         return task;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1305,7 +1305,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback implements Wr
             case PARALLEL_STREAM_LOAD:
                 return "PARALLEL_STREAM_LOAD";
             default:
-                return "UNKOWN";
+                return "UNKNOWN";
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1087,9 +1087,13 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (connectContext.getSessionVariable().isEnableLoadProfile()) {
             TransactionResult resp = new TransactionResult();
             StreamLoadManager streamLoadManager = GlobalStateMgr.getCurrentState().getStreamLoadManager();
-            streamLoadManager.beginLoadTask(dbName, table.getName(), request.getLabel(), timeoutSecond, resp);
+            streamLoadManager.beginLoadTask(dbName, table.getName(), request.getLabel(), timeoutSecond, resp, false);
+            if (!resp.stateOK()) {
+                LOG.warn("Load label: {} begin transacton failed, reason: {}", request.getLabel(), resp.msg);
+            }
 
-            StreamLoadTask task = streamLoadManager.getSyncSteamLoadTaskByLabel(request.getLabel());
+            StreamLoadTask task = streamLoadManager.getTaskByLabel(request.getLabel());
+            // this should't open
             if (task == null || task.getTxnId() == -1) {
                 throw new UserException(String.format("Load label: {} begin transacton failed", request.getLabel()));
             }
@@ -1186,6 +1190,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             return;
         }
         TableMetricsEntity entity = TableMetricsRegistry.getInstance().getMetricsEntity(tbl.getId());
+        StreamLoadTask streamLoadtask = GlobalStateMgr.getCurrentState().getStreamLoadManager().
+                getSyncSteamLoadTaskByTxnId(request.getTxnId());
+
         switch (request.txnCommitAttachment.getLoadType()) {
             case ROUTINE_LOAD:
                 if (!(attachment instanceof RLTaskTxnCommitAttachment)) {
@@ -1197,6 +1204,15 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 entity.counterRoutineLoadRowsTotal.increase(routineAttachment.getLoadedRows());
                 entity.counterRoutineLoadErrorRowsTotal.increase(routineAttachment.getFilteredRows());
                 entity.counterRoutineLoadUnselectedRowsTotal.increase(routineAttachment.getUnselectedRows());
+
+                if (streamLoadtask != null) {
+                    streamLoadtask.setLoadState(routineAttachment.getLoadedBytes(),
+                            routineAttachment.getLoadedRows(),
+                            routineAttachment.getFilteredRows(),
+                            routineAttachment.getUnselectedRows(),
+                            routineAttachment.getErrorLogUrl(), "");
+                }
+
                 break;
             case MANUAL_LOAD:
                 if (!(attachment instanceof ManualLoadTxnCommitAttachment)) {
@@ -1206,6 +1222,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 entity.counterStreamLoadFinishedTotal.increase(1L);
                 entity.counterStreamLoadBytesTotal.increase(streamAttachment.getReceivedBytes());
                 entity.counterStreamLoadRowsTotal.increase(streamAttachment.getLoadedRows());
+
+                if (streamLoadtask != null) {
+                    streamLoadtask.setLoadState(streamAttachment.getLoadedBytes(),
+                            streamAttachment.getLoadedRows(),
+                            streamAttachment.getFilteredRows(),
+                            streamAttachment.getUnselectedRows(),
+                            streamAttachment.getErrorLogUrl(), "");
+                }
 
                 break;
             default:
@@ -1268,6 +1292,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 TabletCommitInfo.fromThrift(request.getCommitInfos()),
                 TabletFailInfo.fromThrift(request.getFailInfos()),
                 attachment);
+
     }
 
     @Override
@@ -1324,6 +1349,46 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(dbId, request.getTxnId(),
                 request.isSetReason() ? request.getReason() : "system cancel",
                 TxnCommitAttachment.fromThrift(request.getTxnCommitAttachment()));
+
+        TxnCommitAttachment attachment = TxnCommitAttachment.fromThrift(request.txnCommitAttachment);
+        StreamLoadTask streamLoadtask = GlobalStateMgr.getCurrentState().getStreamLoadManager().
+                getSyncSteamLoadTaskByTxnId(request.getTxnId());
+
+        switch (request.txnCommitAttachment.getLoadType()) {
+            case ROUTINE_LOAD:
+                if (!(attachment instanceof RLTaskTxnCommitAttachment)) {
+                    break;
+                }
+                RLTaskTxnCommitAttachment routineAttachment = (RLTaskTxnCommitAttachment) attachment;
+
+                if (streamLoadtask != null) {
+                    streamLoadtask.setLoadState(routineAttachment.getLoadedBytes(),
+                            routineAttachment.getLoadedRows(),
+                            routineAttachment.getFilteredRows(),
+                            routineAttachment.getUnselectedRows(),
+                            routineAttachment.getErrorLogUrl(), request.getReason());
+
+                }
+
+                break;
+            case MANUAL_LOAD:
+                if (!(attachment instanceof ManualLoadTxnCommitAttachment)) {
+                    break;
+                }
+                ManualLoadTxnCommitAttachment streamAttachment = (ManualLoadTxnCommitAttachment) attachment;
+
+                if (streamLoadtask != null) {
+                    streamLoadtask.setLoadState(streamAttachment.getLoadedBytes(),
+                            streamAttachment.getLoadedRows(),
+                            streamAttachment.getFilteredRows(),
+                            streamAttachment.getUnselectedRows(),
+                            streamAttachment.getErrorLogUrl(), request.getReason());
+                }
+
+                break;
+            default:
+                break;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1089,7 +1089,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             StreamLoadManager streamLoadManager = GlobalStateMgr.getCurrentState().getStreamLoadManager();
             streamLoadManager.beginLoadTask(dbName, table.getName(), request.getLabel(), timeoutSecond, resp, false);
             if (!resp.stateOK()) {
-                LOG.warn("Load label: {} begin transacton failed, reason: {}", request.getLabel(), resp.msg);
+                LOG.warn(resp.msg);
+                throw new UserException(resp.msg);
             }
 
             StreamLoadTask task = streamLoadManager.getTaskByLabel(request.getLabel());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowStreamLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowStreamLoadStmt.java
@@ -88,6 +88,7 @@ public class ShowStreamLoadStmt extends ShowStmt {
                     .add("FinishPreparingTimeMs")
                     .add("EndTimeMs")
                     .add("ChannelState")
+                    .add("Type")
                     .build();
 
     private final LabelName labelName;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowStreamLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowStreamLoadStmtTest.java
@@ -46,7 +46,7 @@ public class ShowStreamLoadStmtTest {
         Assert.assertEquals("label", stmt.getName());
         Assert.assertEquals("testDb", stmt.getDbFullName());
         Assert.assertFalse(stmt.isIncludeHistory());
-        Assert.assertEquals(23, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals(24, stmt.getMetaData().getColumnCount());
         Assert.assertEquals("Label", stmt.getMetaData().getColumn(0).getName());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/ShowStreamLoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/ShowStreamLoadTest.java
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.streamload;
+
+import com.starrocks.common.Config;
+import com.starrocks.http.rest.TransactionResult;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.ShowStreamLoadStmt;
+import com.starrocks.system.Backend;
+import com.starrocks.utframe.UtFrameUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class ShowStreamLoadTest {
+    private static final Logger LOG = LogManager.getLogger(ShowStreamLoadTest.class);
+    private static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        Backend be = UtFrameUtils.addMockBackend(10002);
+        be.setIsDecommissioned(true);
+        UtFrameUtils.addMockBackend(10003);
+        UtFrameUtils.addMockBackend(10004);
+        Config.enable_strict_storage_medium_check = true;
+        Config.enable_auto_tablet_distribution = true;
+
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setDatabase("test_db");
+        connectContext.setQueryId(UUID.randomUUID());
+
+        // create database
+        String createDbStmtStr = "create database test_db;";
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
+        // create table
+        String createTableStmtStr = "CREATE TABLE test_db.test_tbl (c0 int, c1 string, c2 int, c3 bigint) " +
+                "DUPLICATE KEY (c0) DISTRIBUTED BY HASH (c0) BUCKETS 3 properties(\"replication_num\"=\"1\") ;;";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.
+                parseStmtWithNewParser(createTableStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createTable(createTableStmt);
+    }
+
+    @Test
+    public void testShowStreamLoad() throws Exception {
+        StreamLoadManager streamLoadManager = GlobalStateMgr.getCurrentState().getStreamLoadManager();
+
+        String dbName = "test_db";
+        String tableName = "test_tbl";
+        long timeoutMillis = 100000;
+
+        String labelName = "label_stream_load";
+        TransactionResult resp = new TransactionResult();
+        streamLoadManager.beginLoadTask(dbName, tableName, labelName, timeoutMillis, resp, false);
+        labelName = "label_routine_load";
+        streamLoadManager.beginLoadTask(dbName, tableName, labelName, timeoutMillis, resp, true);
+
+        String sql = "show all stream load";
+        ShowStreamLoadStmt showStreamLoadStmt = (ShowStreamLoadStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        ShowExecutor executor = new ShowExecutor(connectContext, showStreamLoadStmt);
+        ShowResultSet resultSet = executor.execute();
+        Assert.assertEquals(resultSet.getResultRows().size(), 2);
+
+        String sqlWithWhere = "show all stream load where Type = \"ROUTINE_LOAD\"";
+        ShowStreamLoadStmt showStreamLoadStmtWithWhere = (ShowStreamLoadStmt) UtFrameUtils.
+                parseStmtWithNewParser(sqlWithWhere, connectContext);
+        executor = new ShowExecutor(connectContext, showStreamLoadStmtWithWhere);
+        ShowResultSet resultSetWithWhere = executor.execute();
+        Assert.assertEquals(resultSetWithWhere.getResultRows().size(), 1);
+    }
+}

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -759,6 +759,7 @@ struct TManualLoadTxnCommitAttachment {
     3: optional string errorLogUrl
     4: optional i64 receivedBytes
     5: optional i64 loadedBytes
+    6: optional i64 unselectedRows
 }
 
 struct TTxnCommitAttachment {


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When the session variable `enable_load_profile ` is set to true #21441, the stream load will be recorded. Then we can see stream load through `show stream load` and distinguish them by `type` including `STREAM_LOAD`, `ROUTINE_LOAD`, and `PARALLEL_STREAM_LOAD`.
Type `STREAM_LOAD` indicates the load is created by `/api/dateabase/table/_stream_load`, `ROUTINE_LOAD` indicates  the load corresponds to a routine load task as well as `PARALLEL_STREAM_LOAD` indicates the load is created with the way of 
pr #12182

![image](https://github.com/StarRocks/starrocks/assets/13373748/c91b19e8-47e6-4050-9d06-2fb5d138b1df)


Support filter stream load by type through condition

![image](https://github.com/StarRocks/starrocks/assets/13373748/4845068d-14da-4ed2-bce4-04a010db43d7)


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
