### PR TITLE
[BugFix] Fix GroupByCountDistinctDataSkewEliminateRule will throw npe when count distinct column with type which not supported by multi_count_distinct

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorUtil.java
@@ -32,6 +32,9 @@ public class ScalarOperatorUtil {
         Function searchDesc = new Function(new FunctionName(FunctionSet.MULTI_DISTINCT_COUNT),
                 oldFunctionCall.getFunction().getArgs(), Type.INVALID, false);
         Function fn = GlobalStateMgr.getCurrentState().getFunction(searchDesc, IS_NONSTRICT_SUPERTYPE_OF);
+        if (fn == null) {
+            return null;
+        }
 
         ScalarOperatorRewriter scalarOpRewriter = new ScalarOperatorRewriter();
         return (CallOperator) scalarOpRewriter.rewrite(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctDataSkewEliminateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/GroupByCountDistinctDataSkewEliminateRule.java
@@ -146,6 +146,9 @@ public class GroupByCountDistinctDataSkewEliminateRule extends TransformationRul
         secondGroupBy.add(bucketColRef);
         Map<ColumnRefOperator, CallOperator> secondStageAggregations = Maps.newHashMap();
         CallOperator multiDistinctCountAgg = ScalarOperatorUtil.buildMultiCountDistinct(aggCall);
+        if (multiDistinctCountAgg == null) {
+            return Lists.newArrayList(input);
+        }
         secondStageAggregations.put(aggColRef, multiDistinctCountAgg);
 
         LogicalAggregationOperator secondAggOp =


### PR DESCRIPTION
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->
When enable_distinct_column_bucketization is true, sql below will execute with failure
```
SELECT
b1
, count(distinct a1) as cnt
from (
SELECT split('a,b,c', ',') as a1, 'aaa' as b1
) t1
group by b1
;  
```
From the log of FE, we can see exception below:
```
2023-05-16 18:33:30,575 WARN (starrocks-mysql-nio-pool-2|250) [StmtExecutor.execute():534] execute Exception, sql SELECT b1 , count(distinct a1) as cnt from ( SELECT split('a,b,c', ',') as a1, 'aaa' as b1 ) t1 group by b1
java.lang.NullPointerException: null
        at com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil.buildMultiCountDistinct(ScalarOperatorUtil.java:38) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.rule.transformation.GroupByCountDistinctDataSkewEliminateRule.transform(GroupByCountDistinctDataSkewEliminateRule.java:148) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.task.ApplyRuleTask.execute(ApplyRuleTask.java:70) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.task.SeriallyTaskScheduler.executeTasks(SeriallyTaskScheduler.java:56) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.Optimizer.memoOptimize(Optimizer.java:429) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:151) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:93) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.createQueryPlan(StatementPlanner.java:95) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:66) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:37) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:379) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:333) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:450) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:708) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:55) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_362]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_362]
        at java.lang.Thread.run(Thread.java:750) [?:1.8.0_362]
```
The error is caused by column a1 is not supported by multi_count_distinct
```
MySQL [(none)]> SELECT split('a,b,c', ',') as a1, 'aaa' as b1;
+---------------+------+
| a1            | b1   |
+---------------+------+
| ["a","b","c"] | aaa  |
+---------------+------+
1 row in set (0.010 sec)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
