### PR TITLE
[Enhancement] Support olap scan prune complex type on BE

### DIFF
--- a/be/src/column/CMakeLists.txt
+++ b/be/src/column/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(Column STATIC
         chunk.cpp
         chunk_extra_data.cpp
         column.cpp
+        column_access_path.cpp
         column_helper.cpp
         column_viewer.cpp
         const_column.cpp

--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -76,7 +76,7 @@ StatusOr<ColumnAccessPathPtr> ColumnAccessPath::convert_by_index(const Field* fi
     if (!field->has_sub_fields()) {
         if (!this->_children.empty()) {
             return Status::InternalError(fmt::format(
-                    "impossable bad storage schema for access path, field: {}, path: {}", field, this->_path));
+                    "impossable bad storage schema for access path, field: {}, path: {}", field->name(), this->_path));
         }
         return path;
     }

--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -29,6 +29,7 @@ Status ColumnAccessPath::init(const TColumnAccessPath& column_path, RuntimeState
     _type = column_path.type;
 
     ExprContext* expr_ctx = nullptr;
+    // Todo: may support late materialization? to compute path by other column predicate
     RETURN_IF_ERROR(Expr::create_expr_tree(pool, column_path.path, &expr_ctx, state));
     if (!expr_ctx->root()->is_constant()) {
         return Status::InternalError("error column access constant path.");

--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -63,6 +63,8 @@ Status ColumnAccessPath::init(const TAccessPathType::type& type, const std::stri
     _type = type;
     _path = path;
     _column_index = index;
+
+    return Status::OK();
 }
 
 ColumnAccessPathPtr ColumnAccessPath::convert_by_index(const Field* filed, uint32_t index) {

--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -59,6 +59,12 @@ Status ColumnAccessPath::init(const TColumnAccessPath& column_path, RuntimeState
     return Status::OK();
 }
 
+Status ColumnAccessPath::init(const TAccessPathType::type& type, const std::string& path, uint32_t index) {
+    _type = type;
+    _path = path;
+    _column_index = index;
+}
+
 ColumnAccessPathPtr ColumnAccessPath::convert_by_index(const Field* filed, uint32_t index) {
     ColumnAccessPathPtr path = std::make_unique<ColumnAccessPath>();
     path->_type = this->_type;

--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "column/column_access_path.h"
+
+#include "column/column_helper.h"
+#include "column/field.h"
+#include "column/vectorized_fwd.h"
+#include "common/object_pool.h"
+#include "exprs/expr.h"
+#include "exprs/expr_context.h"
+#include "runtime/runtime_state.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+Status ColumnAccessPath::init(const TColumnAccessPath& column_path, RuntimeState* state, ObjectPool* pool) {
+    _type = column_path.type;
+
+    ExprContext* expr_ctx = nullptr;
+    RETURN_IF_ERROR(Expr::create_expr_tree(pool, column_path.path, &expr_ctx, state));
+    if (!expr_ctx->root()->is_constant()) {
+        return Status::InternalError("error column access constant path.");
+    }
+
+    RETURN_IF_ERROR(expr_ctx->prepare(state));
+    RETURN_IF_ERROR(expr_ctx->open(state));
+    ASSIGN_OR_RETURN(ColumnPtr column, expr_ctx->evaluate(nullptr));
+
+    if (column->is_null(0)) {
+        return Status::InternalError("error column access null path.");
+    }
+
+    Column* data = ColumnHelper::get_data_column(column.get());
+    if (!data->is_binary()) {
+        return Status::InternalError("error column access string path.");
+    }
+
+    Slice slice = ColumnHelper::as_raw_column<BinaryColumn>(data)->get_slice(0);
+    _path = slice.to_string();
+
+    for (const auto& child : column_path.children) {
+        ColumnAccessPathPtr child_path = std::make_unique<ColumnAccessPath>();
+        RETURN_IF_ERROR(child_path->init(child, state, pool));
+        _children.emplace_back(std::move(child_path));
+    }
+
+    return Status::OK();
+}
+
+ColumnAccessPathPtr ColumnAccessPath::convert_by_index(const Field* filed, uint32_t index) {
+    ColumnAccessPathPtr path = std::make_unique<ColumnAccessPath>();
+    path->_type = this->_type;
+    path->_path = this->_path;
+    path->_column_index = index;
+
+    auto all_filed = filed->sub_fields();
+
+    std::unordered_map<std::string_view, uint32_t> name_index;
+
+    for (uint32_t i = 0; i < all_filed.size(); i++) {
+        name_index[all_filed[i].name()] = i;
+    }
+
+    for (const auto& child : this->_children) {
+        uint32_t i = name_index[child->_path];
+        auto copy = child->convert_by_index(&all_filed[i], i);
+        path->_children.emplace_back(std::move(copy));
+    }
+
+    return path;
+}
+
+} // namespace starrocks

--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -65,6 +65,14 @@ ColumnAccessPathPtr ColumnAccessPath::convert_by_index(const Field* filed, uint3
     path->_path = this->_path;
     path->_column_index = index;
 
+    if (!filed->has_sub_fields()) {
+        if (!this->_children.empty()) {
+            LOG(WARNING) << "impossable bad storage schema for access path, filed: " << filed
+                         << ", path: " << this->_path;
+        }
+        return path;
+    }
+
     auto all_filed = filed->sub_fields();
 
     std::unordered_map<std::string_view, uint32_t> name_index;

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -26,6 +26,14 @@ class Field;
 class ObjectPool;
 class RuntimeState;
 
+/*
+ * Used to describe the access path of the subfield, it's like a file path.
+ * e.g. 
+ *  column: structA STRUCT<a STRCUT<a1 INT, b STRUCT<c INT>>>
+ *  path: /structA/a/b/c
+ *  type: /ROOT/FIELD/FIELD/FIELD
+ *  index: /7/0/1/0
+ */
 class ColumnAccessPath {
 public:
     Status init(const TColumnAccessPath& column_path, RuntimeState* state, ObjectPool* pool);
@@ -53,6 +61,10 @@ private:
 
     std::string _path;
 
+    // column index in storage
+    // the root index is the offset of table schema
+    // the FIELD index is the offset of struct schema
+    // it's unused for MAP/JSON now
     uint32_t _column_index;
 
     std::vector<std::unique_ptr<ColumnAccessPath>> _children;

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -36,9 +36,9 @@ public:
 
     const std::vector<std::unique_ptr<ColumnAccessPath>>& children() { return _children; }
 
-    bool is_root() { return _type == TAccessPathType::type::ROOT; }
+    bool is_key() { return _type == TAccessPathType::type::KEY; }
 
-    bool is_filed() { return _type == TAccessPathType::type::FIELD; }
+    bool is_offset() { return _type == TAccessPathType::type::OFFSET; }
 
     // copy and set index
     std::unique_ptr<ColumnAccessPath> convert_by_index(const Field* filed, uint32_t index);

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -32,7 +32,7 @@ class RuntimeState;
  *  column: structA STRUCT<a STRCUT<a1 INT, b STRUCT<c INT>>>
  *  path: /structA/a/b/c
  *  type: /ROOT/FIELD/FIELD/FIELD
- *  index: /7/0/1/0
+ *  index: /7/0/1/0, offset in storage
  */
 class ColumnAccessPath {
 public:
@@ -53,8 +53,9 @@ public:
 
     bool is_offset() { return _type == TAccessPathType::type::OFFSET; }
 
-    // copy and set index
-    std::unique_ptr<ColumnAccessPath> convert_by_index(const Field* filed, uint32_t index);
+    // segement may have different column schema(because schema change), 
+    // we need copy one and set the offset of schema, to help column reader find column access path
+    StatusOr<std::unique_ptr<ColumnAccessPath>> convert_by_index(const Field* filed, uint32_t index);
 
 private:
     TAccessPathType::type _type;

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -30,11 +30,16 @@ class ColumnAccessPath {
 public:
     Status init(const TColumnAccessPath& column_path, RuntimeState* state, ObjectPool* pool);
 
+    // for test
+    Status init(const TAccessPathType::type& type, const std::string& path, uint32_t index);
+
     const std::string& path() const { return _path; }
 
     uint32_t index() const { return _column_index; }
 
-    const std::vector<std::unique_ptr<ColumnAccessPath>>& children() { return _children; }
+    const std::vector<std::unique_ptr<ColumnAccessPath>>& children() const { return _children; }
+
+    std::vector<std::unique_ptr<ColumnAccessPath>>& children() { return _children; }
 
     bool is_key() { return _type == TAccessPathType::type::KEY; }
 

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -53,7 +53,7 @@ public:
 
     bool is_offset() { return _type == TAccessPathType::type::OFFSET; }
 
-    // segement may have different column schema(because schema change), 
+    // segement may have different column schema(because schema change),
     // we need copy one and set the offset of schema, to help column reader find column access path
     StatusOr<std::unique_ptr<ColumnAccessPath>> convert_by_index(const Field* filed, uint32_t index);
 

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "common/status.h"
+#include "gen_cpp/PlanNodes_types.h"
+
+namespace starrocks {
+
+class Field;
+class ObjectPool;
+class RuntimeState;
+
+class ColumnAccessPath {
+public:
+    Status init(const TColumnAccessPath& column_path, RuntimeState* state, ObjectPool* pool);
+
+    const std::string& path() const { return _path; }
+
+    uint32_t index() const { return _column_index; }
+
+    const std::vector<std::unique_ptr<ColumnAccessPath>>& children() { return _children; }
+
+    bool is_root() { return _type == TAccessPathType::type::ROOT; }
+
+    bool is_filed() { return _type == TAccessPathType::type::FIELD; }
+
+    // copy and set index
+    std::unique_ptr<ColumnAccessPath> convert_by_index(const Field* filed, uint32_t index);
+
+private:
+    TAccessPathType::type _type;
+
+    std::string _path;
+
+    uint32_t _column_index;
+
+    std::vector<std::unique_ptr<ColumnAccessPath>> _children;
+};
+
+using ColumnAccessPathPtr = std::unique_ptr<ColumnAccessPath>;
+
+} // namespace starrocks

--- a/be/src/column/field.h
+++ b/be/src/column/field.h
@@ -159,6 +159,8 @@ public:
 
     const std::vector<Field>& sub_fields() const { return *_sub_fields; }
 
+    bool has_sub_fields() const { return _sub_fields != nullptr; }
+
     ColumnPtr create_column() const;
 
     void set_uid(ColumnUID uid) { _uid = uid; }

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -77,6 +77,15 @@ Status OlapScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
                 std::min(_olap_scan_node.max_parallel_scan_instance_num, _io_tasks_per_scan_operator);
     }
 
+    if (_olap_scan_node.__isset.column_access_paths) {
+        for (int i = 0; i < _olap_scan_node.column_access_paths.size(); ++i) {
+            auto path = std::make_unique<ColumnAccessPath>();
+            if (path->init(_olap_scan_node.column_access_paths[i], state, _pool).ok()) {
+                _column_access_paths.emplace_back(std::move(path));
+            }
+        }
+    }
+
     _estimate_scan_and_output_row_bytes();
 
     return Status::OK();

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "column/chunk.h"
+#include "column/column_access_path.h"
 #include "exec/olap_common.h"
 #include "exec/olap_scan_prepare.h"
 #include "exec/scan_node.h"

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -270,7 +270,7 @@ Status OlapChunkSource::_init_column_access_paths(Schema* schema) {
             auto res = path->convert_by_index(filed.get(), index);
             // read whole data, doesn't effect query
             if (res.ok()) {
-                _column_access_paths[index] = res.value();
+                _column_access_paths[index] = std::move(res.value());
             }
         }
     }

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -267,7 +267,11 @@ Status OlapChunkSource::_init_column_access_paths(Schema* schema) {
         int32_t index = _tablet->field_index(root);
         auto filed = schema->get_field_by_name(root);
         if (index >= 0) {
-            _column_access_paths[index] = path->convert_by_index(filed.get(), index);
+            auto res = path->convert_by_index(filed.get(), index);
+            // read whole data, doesn't effect query
+            if (res.ok()) {
+                _column_access_paths[index] = res.value();
+            }
         }
     }
     _params.column_access_paths = &_column_access_paths;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -261,7 +261,7 @@ Status OlapChunkSource::_init_unused_output_columns(const std::vector<std::strin
 
 Status OlapChunkSource::_init_column_access_paths(Schema* schema) {
     // column access paths
-    auto paths = _scan_ctx->column_access_paths();
+    auto* paths = _scan_ctx->column_access_paths();
     for (const auto& path : *paths) {
         auto& root = path->path();
         int32_t index = _tablet->field_index(root);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -240,6 +240,7 @@ Status OlapChunkSource::_init_scanner_columns(std::vector<uint32_t>& scanner_col
     if (scanner_columns.empty()) {
         return Status::InternalError("failed to build storage scanner, no materialized slot!");
     }
+
     return Status::OK();
 }
 
@@ -258,6 +259,22 @@ Status OlapChunkSource::_init_unused_output_columns(const std::vector<std::strin
     return Status::OK();
 }
 
+Status OlapChunkSource::_init_column_access_paths(Schema* schema) {
+    // column access paths
+    auto paths = _scan_ctx->column_access_paths();
+    for (const auto& path : *paths) {
+        auto& root = path->path();
+        int32_t index = _tablet->field_index(root);
+        auto filed = schema->get_field_by_name(root);
+        if (index >= 0) {
+            _column_access_paths[index] = path->convert_by_index(filed.get(), index);
+        }
+    }
+    _params.column_access_paths = &_column_access_paths;
+
+    return Status::OK();
+}
+
 Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
     const TOlapScanNode& thrift_olap_scan_node = _scan_node->thrift_olap_scan_node();
     // output columns of `this` OlapScanner, i.e, the final output columns of `get_chunk`.
@@ -272,6 +289,7 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(_init_reader_params(_scan_ctx->key_ranges(), scanner_columns, reader_columns));
     const TabletSchema& tablet_schema = _tablet->tablet_schema();
     starrocks::Schema child_schema = ChunkHelper::convert_schema(tablet_schema, reader_columns);
+    RETURN_IF_ERROR(_init_column_access_paths(&child_schema));
 
     _reader = std::make_shared<TabletReader>(_tablet, Version(_morsel->from_version(), _version),
                                              std::move(child_schema), _morsel->rowsets());

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -65,6 +65,7 @@ private:
     void _update_counter();
     void _update_realtime_counter(Chunk* chunk);
     void _decide_chunk_size(bool has_predicate);
+    Status _init_column_access_paths(Schema* schema);
 
 private:
     TabletReaderParams _params{};
@@ -97,6 +98,8 @@ private:
 
     // slot descriptors for each one of |output_columns|.
     std::vector<SlotDescriptor*> _query_slots;
+
+    std::unordered_map<uint32_t, ColumnAccessPathPtr> _column_access_paths;
 
     // The following are profile meatures
     int64_t _num_rows_read = 0;

--- a/be/src/exec/pipeline/scan/olap_scan_context.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_context.cpp
@@ -21,6 +21,11 @@
 namespace starrocks::pipeline {
 
 /// OlapScanContext.
+
+const std::vector<ColumnAccessPathPtr>* OlapScanContext::column_access_paths() const {
+    return &_scan_node->column_access_paths();
+}
+
 void OlapScanContext::attach_shared_input(int32_t operator_seq, int32_t source_index) {
     auto key = std::make_pair(operator_seq, source_index);
     VLOG_ROW << fmt::format("attach_shared_input ({}, {}), active {}", operator_seq, source_index,

--- a/be/src/exec/pipeline/scan/olap_scan_context.h
+++ b/be/src/exec/pipeline/scan/olap_scan_context.h
@@ -16,6 +16,7 @@
 
 #include <mutex>
 
+#include "column/column_access_path.h"
 #include "exec/olap_scan_prepare.h"
 #include "exec/pipeline/context_with_dependency.h"
 #include "exec/pipeline/scan/balanced_chunk_buffer.h"
@@ -71,6 +72,8 @@ public:
     Status capture_tablet_rowsets(const std::vector<TInternalScanRange*>& olap_scan_ranges);
     const std::vector<TabletSharedPtr>& tablets() const { return _tablets; }
     const std::vector<std::vector<RowsetSharedPtr>>& tablet_rowsets() const { return _tablet_rowsets; };
+
+    const std::vector<ColumnAccessPathPtr>* column_access_paths() const;
 
 private:
     OlapScanNode* _scan_node;

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -36,6 +36,7 @@
 
 #include <string>
 
+#include "column/column_access_path.h"
 #include "exec/exec_node.h"
 #include "gen_cpp/InternalService_types.h"
 #include "util/runtime_profile.h"
@@ -123,6 +124,8 @@ public:
     void enable_shared_scan(bool enable);
     bool is_shared_scan_enabled() const;
 
+    const std::vector<ColumnAccessPathPtr>& column_access_paths() const { return _column_access_paths; }
+
 protected:
     RuntimeProfile::Counter* _bytes_read_counter = nullptr; // # bytes read from the scanner
     // # rows/tuples read from the scanner (including those discarded by eval_conjucts())
@@ -140,6 +143,8 @@ protected:
     bool _enable_shared_scan = false;
     int64_t _mem_limit = 0;
     int32_t _io_tasks_per_scan_operator = config::io_tasks_per_scan_operator;
+
+    std::vector<ColumnAccessPathPtr> _column_access_paths;
 };
 
 } // namespace starrocks

--- a/be/src/exec/tablet_scanner.h
+++ b/be/src/exec/tablet_scanner.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "column/chunk.h"
+#include "column/column_access_path.h"
 #include "common/status.h"
 #include "exec/olap_utils.h"
 #include "exprs/expr.h"
@@ -28,7 +29,6 @@
 #include "storage/conjunctive_predicates.h"
 #include "storage/tablet.h"
 #include "storage/tablet_reader.h"
-#include "column/column_access_path.h"
 
 namespace starrocks {
 

--- a/be/src/exec/tablet_scanner.h
+++ b/be/src/exec/tablet_scanner.h
@@ -28,6 +28,7 @@
 #include "storage/conjunctive_predicates.h"
 #include "storage/tablet.h"
 #include "storage/tablet_reader.h"
+#include "column/column_access_path.h"
 
 namespace starrocks {
 
@@ -39,6 +40,7 @@ struct TabletScannerParams {
     const std::vector<ExprContext*>* conjunct_ctxs = nullptr;
 
     const std::vector<std::string>* unused_output_columns = nullptr;
+    const std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
 
     bool skip_aggregation = false;
     bool need_agg_finalize = true;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -81,8 +81,7 @@ constexpr int64_t kRpcHttpMinSize = ((1L << 31) - (1L << 10));
 
 // A collection of items that are part of the global state of a
 // query and shared across all execution nodes of that query.
-class 
-RuntimeState {
+class RuntimeState {
 public:
     // for ut only
     RuntimeState() = default;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -81,7 +81,8 @@ constexpr int64_t kRpcHttpMinSize = ((1L << 31) - (1L << 10));
 
 // A collection of items that are part of the global state of a
 // query and shared across all execution nodes of that query.
-class RuntimeState {
+class 
+RuntimeState {
 public:
     // for ut only
     RuntimeState() = default;

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -40,6 +40,7 @@
 #include <utility>
 
 #include "column/column.h"
+#include "column/column_access_path.h"
 #include "column/column_helper.h"
 #include "column/datum_convert.h"
 #include "common/logging.h"
@@ -487,7 +488,7 @@ bool ColumnReader::segment_zone_map_filter(const std::vector<const ColumnPredica
     return std::all_of(predicates.begin(), predicates.end(), filter);
 }
 
-StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::new_iterator() {
+StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::new_iterator(ColumnAccessPath* path) {
     if (is_scalar_field_type(delegate_type(_column_type))) {
         return std::make_unique<ScalarColumnIterator>(this);
     } else if (_column_type == LogicalType::TYPE_ARRAY) {
@@ -521,12 +522,25 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::new_iterator() {
             num_fields -= 1;
             ASSIGN_OR_RETURN(null_iter, (*_sub_readers)[num_fields]->new_iterator());
         }
+
+        std::vector<uint8_t> access_flags;
+        std::vector<ColumnAccessPath*> child_paths(num_fields, nullptr);
+        if (path != nullptr && !path->children().empty()) {
+            access_flags.resize(num_fields, 0);
+            for (const auto& child : path->children()) {
+                child_paths[child->index()] = child.get();
+                access_flags[child->index()] = 1;
+            }
+        } else {
+            access_flags.resize(num_fields, 1);
+        }
+
         std::vector<std::unique_ptr<ColumnIterator>> field_iters;
         for (int i = 0; i < num_fields; ++i) {
-            ASSIGN_OR_RETURN(auto iter, (*_sub_readers)[i]->new_iterator());
+            ASSIGN_OR_RETURN(auto iter, (*_sub_readers)[i]->new_iterator(child_paths[i]));
             field_iters.emplace_back(std::move(iter));
         }
-        return create_struct_iter(std::move(null_iter), std::move(field_iters));
+        return create_struct_iter(std::move(null_iter), std::move(field_iters), access_flags);
     } else {
         return Status::NotSupported("unsupported type to create iterator: " + std::to_string(_column_type));
     }

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -512,7 +512,7 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::new_iterator(ColumnAcces
             for (const auto& child : path->children()) {
                 if (child->is_key()) {
                     key_path = child.get();
-                } 
+                }
                 child_paths.emplace_back(child.get());
             }
         }

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -102,7 +102,7 @@ public:
     void operator=(ColumnReader&&) = delete;
 
     // create a new column iterator. Caller should free the returned iterator after unused.
-    StatusOr<std::unique_ptr<ColumnIterator>> new_iterator();
+    StatusOr<std::unique_ptr<ColumnIterator>> new_iterator(ColumnAccessPath* path = nullptr);
 
     // Caller should free returned iterator after unused.
     // TODO: StatusOr<std::unique_ptr<ColumnIterator>> new_bitmap_index_iterator()

--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -77,8 +77,10 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
                 memory_copy(string_buffer, _default_value.c_str(), length);
                 (static_cast<Slice*>(_mem_value))->size = length;
                 (static_cast<Slice*>(_mem_value))->data = string_buffer;
-            } else if (_type_info->type() == TYPE_ARRAY) {
-                return Status::NotSupported("Array default type is unsupported");
+            } else if (_type_info->type() == TYPE_ARRAY || _type_info->type() == TYPE_MAP ||
+                       _type_info->type() == TYPE_STRUCT) {
+                // @todo: need support complex type literal
+                return Status::NotSupported("Array/Map/Struct default type is unsupported");
             } else {
                 RETURN_IF_ERROR(_type_info->from_string(_mem_value, _default_value));
             }

--- a/be/src/storage/rowset/map_column_iterator.h
+++ b/be/src/storage/rowset/map_column_iterator.h
@@ -17,13 +17,13 @@
 #include "storage/rowset/column_iterator.h"
 
 namespace starrocks {
+class ColumnAccessPath;
 
 class MapColumnIterator final : public ColumnIterator {
 public:
     MapColumnIterator(std::unique_ptr<ColumnIterator> nulls, std::unique_ptr<ColumnIterator> offsets,
-                      std::unique_ptr<ColumnIterator> keys, std::unique_ptr<ColumnIterator> values);
-    MapColumnIterator(ColumnIterator* null_iterator, ColumnIterator* offsets_iterator, ColumnIterator* keys_iterator,
-                      ColumnIterator* values_iterator);
+                      std::unique_ptr<ColumnIterator> keys, std::unique_ptr<ColumnIterator> values,
+                      std::vector<ColumnAccessPath*> paths);
 
     ~MapColumnIterator() override = default;
 
@@ -53,6 +53,10 @@ private:
     std::unique_ptr<ColumnIterator> _offsets;
     std::unique_ptr<ColumnIterator> _keys;
     std::unique_ptr<ColumnIterator> _values;
+    std::vector<ColumnAccessPath*> _paths;
+
+    bool _access_keys;
+    bool _access_values;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/map_column_writer.cpp
+++ b/be/src/storage/rowset/map_column_writer.cpp
@@ -64,7 +64,7 @@ StatusOr<std::unique_ptr<ColumnWriter>> create_map_column_writer(const ColumnWri
                                                                  const TabletColumn* column, WritableFile* wfile) {
     DCHECK(column->subcolumn_count() == 2);
 
-    // crete key columns writer
+    // create key columns writer
     std::unique_ptr<ColumnWriter> keys_writer;
     {
         const TabletColumn& key_column = column->subcolumn(0);
@@ -84,7 +84,7 @@ StatusOr<std::unique_ptr<ColumnWriter>> create_map_column_writer(const ColumnWri
         ASSIGN_OR_RETURN(keys_writer, ColumnWriter::create(key_options, &key_column, wfile));
     }
 
-    // crete key columns writer
+    // create value columns writer
     std::unique_ptr<ColumnWriter> values_writer;
     {
         const TabletColumn& value_column = column->subcolumn(1);

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -493,6 +493,7 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
     seg_options.global_dictmaps = options.global_dictmaps;
     seg_options.unused_output_column_ids = options.unused_output_column_ids;
     seg_options.runtime_range_pruner = options.runtime_range_pruner;
+    seg_options.column_access_paths = options.column_access_paths;
     if (options.delete_predicates != nullptr) {
         seg_options.delete_predicates = options.delete_predicates->get_predicates(end_version());
     }

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -76,7 +76,7 @@ public:
 
     OlapRuntimeScanRangePruner runtime_range_pruner;
 
-    std::unordered_map<uint32_t, ColumnAccessPathPtr>* column_access_paths;
+    std::unordered_map<uint32_t, ColumnAccessPathPtr>* column_access_paths = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -18,6 +18,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "column/column_access_path.h"
 #include "runtime/global_dict/types.h"
 #include "storage/olap_common.h"
 #include "storage/olap_runtime_range_pruner.h"
@@ -74,6 +75,8 @@ public:
     std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
 
     OlapRuntimeScanRangePruner runtime_range_pruner;
+
+    std::unordered_map<uint32_t, ColumnAccessPathPtr>* column_access_paths;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -40,8 +40,8 @@
 
 #include <memory>
 
-#include "column/schema.h"
 #include "column/column_access_path.h"
+#include "column/schema.h"
 #include "common/logging.h"
 #include "gutil/strings/substitute.h"
 #include "segment_chunk_iterator_adapter.h"

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -41,6 +41,7 @@
 #include <memory>
 
 #include "column/schema.h"
+#include "column/column_access_path.h"
 #include "common/logging.h"
 #include "gutil/strings/substitute.h"
 #include "segment_chunk_iterator_adapter.h"
@@ -369,7 +370,7 @@ void Segment::_prepare_adapter_info() {
     }
 }
 
-StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator(uint32_t cid) {
+StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator(uint32_t cid, ColumnAccessPath* path) {
     if (_column_readers[cid] == nullptr) {
         const TabletColumn& tablet_column = _tablet_schema->column(cid);
         if (!tablet_column.has_default_value() && !tablet_column.is_nullable()) {
@@ -384,7 +385,7 @@ StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator(uint32_t 
         RETURN_IF_ERROR(default_value_iter->init(iter_opts));
         return default_value_iter;
     }
-    return _column_readers[cid]->new_iterator();
+    return _column_readers[cid]->new_iterator(path);
 }
 
 Status Segment::new_bitmap_index_iterator(uint32_t cid, BitmapIndexIterator** iter, bool skip_fill_local_cache) {

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -54,6 +54,7 @@
 
 namespace starrocks {
 
+class ColumnAccessPath;
 class TabletSchema;
 class ShortKeyIndexDecoder;
 
@@ -116,7 +117,7 @@ public:
     uint64_t id() const { return _segment_id; }
 
     // TODO: remove this method, create `ColumnIterator` via `ColumnReader`.
-    StatusOr<std::unique_ptr<ColumnIterator>> new_column_iterator(uint32_t cid);
+    StatusOr<std::unique_ptr<ColumnIterator>> new_column_iterator(uint32_t cid, ColumnAccessPath* path = nullptr);
 
     Status new_bitmap_index_iterator(uint32_t cid, BitmapIndexIterator** iter, bool skip_fill_local_cache);
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -246,7 +246,8 @@ private:
     // search delta column group by column uniqueid, if this column exist in delta column group,
     // then return column iterator and delta column's fillname.
     // Or just return null
-    StatusOr<std::unique_ptr<ColumnIterator>> _new_dcg_column_iterator(uint32_t ucid, std::string* filename);
+    StatusOr<std::unique_ptr<ColumnIterator>> _new_dcg_column_iterator(uint32_t ucid, std::string* filename,
+                                                                       ColumnAccessPath* path);
 
     // This function is a unified entry for creating column iterators.
     // `ucid` means unique column id, use it for searching delta column group.
@@ -468,9 +469,10 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
     iter_opts.reader_type = _opts.reader_type;
 
     ColumnAccessPath* access_path = nullptr;
-    if (_opts.column_access_paths != nullptr &&
-        _opts.column_access_paths->find(cid) != _opts.column_access_paths->end()) {
-        access_path = (*_opts.column_access_paths)[cid].get();
+    if (_opts.column_access_paths != nullptr && !_opts.column_access_paths->empty()) {
+        if (_opts.column_access_paths->find(cid) != _opts.column_access_paths->end()) {
+            access_path = (*_opts.column_access_paths)[cid].get();
+        }
     }
 
     std::string dcg_filename;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -445,7 +445,8 @@ StatusOr<std::shared_ptr<Segment>> SegmentIterator::_get_dcg_segment(uint32_t uc
 }
 
 StatusOr<std::unique_ptr<ColumnIterator>> SegmentIterator::_new_dcg_column_iterator(uint32_t ucid,
-                                                                                    std::string* filename) {
+                                                                                    std::string* filename,
+                                                                                    ColumnAccessPath* path) {
     // build column iter from delta column group
     int32_t col_index = 0;
     ASSIGN_OR_RETURN(auto dcg_segment, _get_dcg_segment(ucid, &col_index));
@@ -453,7 +454,7 @@ StatusOr<std::unique_ptr<ColumnIterator>> SegmentIterator::_new_dcg_column_itera
         if (filename != nullptr) {
             *filename = dcg_segment->file_name();
         }
-        return dcg_segment->new_column_iterator(col_index);
+        return dcg_segment->new_column_iterator(col_index, path);
     }
     return nullptr;
 }
@@ -465,15 +466,22 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
     RandomAccessFileOptions opts{.skip_fill_local_cache = _skip_fill_local_cache()};
     iter_opts.check_dict_encoding = check_dict_enc;
     iter_opts.reader_type = _opts.reader_type;
+
+    ColumnAccessPath* access_path = nullptr;
+    if (_opts.column_access_paths != nullptr &&
+        _opts.column_access_paths->find(cid) != _opts.column_access_paths->end()) {
+        access_path = (*_opts.column_access_paths)[cid].get();
+    }
+
     std::string dcg_filename;
     if (ucid < 0) {
         LOG(ERROR) << "invalid unique columnid in segment iterator, ucid: " << ucid
                    << ", segment: " << _segment->file_name();
     }
-    ASSIGN_OR_RETURN(auto col_iter, _new_dcg_column_iterator((uint32_t)ucid, &dcg_filename));
+    ASSIGN_OR_RETURN(auto col_iter, _new_dcg_column_iterator((uint32_t)ucid, &dcg_filename, access_path));
     if (col_iter == nullptr) {
         // not found in delta column group, create normal column iterator
-        ASSIGN_OR_RETURN(_column_iterators[cid], _segment->new_column_iterator(cid));
+        ASSIGN_OR_RETURN(_column_iterators[cid], _segment->new_column_iterator(cid, access_path));
         ASSIGN_OR_RETURN(auto rfile, _opts.fs->new_random_access_file(opts, _segment->file_name()));
         iter_opts.read_file = rfile.get();
         _column_files[cid] = std::move(rfile);

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "column/datum.h"
+#include "column/column_access_path.h"
 #include "fs/fs.h"
 #include "runtime/global_dict/types.h"
 #include "storage/del_vector.h"
@@ -35,6 +36,7 @@ class DeltaColumnGroupLoader;
 
 namespace starrocks {
 
+class ColumnAccessPath;
 class ColumnPredicate;
 struct RowidRangeOption;
 using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
@@ -85,6 +87,7 @@ public:
 
     const std::atomic<bool>* is_cancelled = nullptr;
 
+    std::unordered_map<uint32_t, ColumnAccessPathPtr>* column_access_paths = nullptr;
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<LogicalType>& new_types, ObjectPool* obj_pool) const;
 

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -17,8 +17,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include "column/datum.h"
 #include "column/column_access_path.h"
+#include "column/datum.h"
 #include "fs/fs.h"
 #include "runtime/global_dict/types.h"
 #include "storage/del_vector.h"
@@ -88,6 +88,7 @@ public:
     const std::atomic<bool>* is_cancelled = nullptr;
 
     std::unordered_map<uint32_t, ColumnAccessPathPtr>* column_access_paths = nullptr;
+
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<LogicalType>& new_types, ObjectPool* obj_pool) const;
 

--- a/be/src/storage/rowset/struct_column_iterator.cpp
+++ b/be/src/storage/rowset/struct_column_iterator.cpp
@@ -73,9 +73,10 @@ Status StructColumnIterator::init(const ColumnIteratorOptions& opts) {
         RETURN_IF_ERROR(_null_iter->init(opts));
     }
 
-    for (int i = 0; i < _field_iters.size(); ++i) {
-        RETURN_IF_ERROR(_field_iters[i]->init(opts));
+    for (auto& iter : _field_iters) {
+        RETURN_IF_ERROR(iter->init(opts));
     }
+
     return Status::OK();
 }
 
@@ -186,8 +187,8 @@ Status StructColumnIterator::seek_to_first() {
     if (_null_iter != nullptr) {
         RETURN_IF_ERROR(_null_iter->seek_to_first());
     }
-    for (int i = 0; i < _field_iters.size(); ++i) {
-        RETURN_IF_ERROR(_field_iters[i]->seek_to_first());
+    for (auto& iter : _field_iters) {
+        RETURN_IF_ERROR(iter->seek_to_first());
     }
     return Status::OK();
 }
@@ -196,8 +197,8 @@ Status StructColumnIterator::seek_to_ordinal(ordinal_t ord) {
     if (_null_iter != nullptr) {
         RETURN_IF_ERROR(_null_iter->seek_to_ordinal(ord));
     }
-    for (int i = 0; i < _field_iters.size(); ++i) {
-        RETURN_IF_ERROR(_field_iters[i]->seek_to_ordinal(ord));
+    for (auto& iter : _field_iters) {
+        RETURN_IF_ERROR(iter->seek_to_ordinal(ord));
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/struct_column_iterator.h
+++ b/be/src/storage/rowset/struct_column_iterator.h
@@ -19,5 +19,6 @@
 namespace starrocks {
 
 StatusOr<std::unique_ptr<ColumnIterator>> create_struct_iter(std::unique_ptr<ColumnIterator> null_iter,
-                                                             std::vector<std::unique_ptr<ColumnIterator>> field_iters);
+                                                             std::vector<std::unique_ptr<ColumnIterator>> field_iters,
+                                                             std::vector<uint8_t> access_flags);
 }

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -142,6 +142,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.global_dictmaps = params.global_dictmaps;
     rs_opts.unused_output_column_ids = params.unused_output_column_ids;
     rs_opts.runtime_range_pruner = params.runtime_range_pruner;
+    rs_opts.column_access_paths = params.column_access_paths;
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
         rs_opts.version = _version.second;

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -18,6 +18,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "column/column_access_path.h"
 #include "runtime/global_dict/types.h"
 #include "storage/chunk_iterator.h"
 #include "storage/olap_common.h"
@@ -77,6 +78,7 @@ struct TabletReaderParams {
     bool sorted_by_keys_per_tablet = false;
     OlapRuntimeScanRangePruner runtime_range_pruner;
 
+    std::unordered_map<uint32_t, ColumnAccessPathPtr>* column_access_paths;
 public:
     std::string to_string() const;
 };

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -78,7 +78,8 @@ struct TabletReaderParams {
     bool sorted_by_keys_per_tablet = false;
     OlapRuntimeScanRangePruner runtime_range_pruner;
 
-    std::unordered_map<uint32_t, ColumnAccessPathPtr>* column_access_paths;
+    std::unordered_map<uint32_t, ColumnAccessPathPtr>* column_access_paths = nullptr;
+
 public:
     std::string to_string() const;
 };

--- a/be/test/storage/rowset/map_column_rw_test.cpp
+++ b/be/test/storage/rowset/map_column_rw_test.cpp
@@ -177,6 +177,96 @@ protected:
                 ASSERT_EQ("{4:-1,5:-2,6:-3}", dst_column->debug_item(3));
             }
         }
+
+        // read and check
+        {
+            auto res = ColumnReader::create(&meta, segment.get());
+            ASSERT_TRUE(res.ok());
+            auto reader = std::move(res).value();
+
+
+            ColumnAccessPath child_path;
+            child_path.init(TAccessPathType::type::OFFSET, "offsets", 1);
+            
+            ColumnAccessPath path;
+            path.init(TAccessPathType::type::ROOT, "root", 0);
+            path.children().emplace_back(child_path);
+
+
+            ASSIGN_OR_ABORT(auto iter, reader->new_iterator());
+            ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(fname));
+
+            ColumnIteratorOptions iter_opts;
+            OlapReaderStatistics stats;
+            iter_opts.stats = &stats;
+            iter_opts.read_file = read_file.get();
+            ASSERT_TRUE(iter->init(iter_opts).ok());
+
+            // sequence read
+            {
+                auto st = iter->seek_to_first();
+                ASSERT_TRUE(st.ok()) << st.to_string();
+
+                auto dst_offsets = UInt32Column::create();
+                auto dst_keys = NullableColumn::create(Int32Column::create(), NullColumn::create());
+                auto dst_values = NullableColumn::create(Int32Column::create(), NullColumn::create());
+                auto dst_column = MapColumn::create(dst_keys, dst_values, dst_offsets);
+                size_t rows_read = src_column->size();
+                st = iter->next_batch(&rows_read, dst_column.get());
+                ASSERT_TRUE(st.ok());
+                ASSERT_EQ(src_column->size(), rows_read);
+
+                ASSERT_EQ("{0:0}", dst_column->debug_item(0));
+                ASSERT_EQ("{}", dst_column->debug_item(1));
+                ASSERT_EQ("{0:0,0:0}", dst_column->debug_item(2));
+                ASSERT_EQ("{0:0,0:0,0:0}", dst_column->debug_item(3));
+            }
+        }
+
+        // read and check
+        {
+            auto res = ColumnReader::create(&meta, segment.get());
+            ASSERT_TRUE(res.ok());
+            auto reader = std::move(res).value();
+
+
+            ColumnAccessPath child_path;
+            child_path.init(TAccessPathType::type::KEY, "key", 1);
+            
+            ColumnAccessPath path;
+            path.init(TAccessPathType::type::ROOT, "root", 0);
+            path.children().emplace_back(child_path);
+
+
+            ASSIGN_OR_ABORT(auto iter, reader->new_iterator());
+            ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(fname));
+
+            ColumnIteratorOptions iter_opts;
+            OlapReaderStatistics stats;
+            iter_opts.stats = &stats;
+            iter_opts.read_file = read_file.get();
+            ASSERT_TRUE(iter->init(iter_opts).ok());
+
+            // sequence read
+            {
+                auto st = iter->seek_to_first();
+                ASSERT_TRUE(st.ok()) << st.to_string();
+
+                auto dst_offsets = UInt32Column::create();
+                auto dst_keys = NullableColumn::create(Int32Column::create(), NullColumn::create());
+                auto dst_values = NullableColumn::create(Int32Column::create(), NullColumn::create());
+                auto dst_column = MapColumn::create(dst_keys, dst_values, dst_offsets);
+                size_t rows_read = src_column->size();
+                st = iter->next_batch(&rows_read, dst_column.get());
+                ASSERT_TRUE(st.ok());
+                ASSERT_EQ(src_column->size(), rows_read);
+
+                ASSERT_EQ("{1:0}", dst_column->debug_item(0));
+                ASSERT_EQ("{}", dst_column->debug_item(1));
+                ASSERT_EQ("{2:0,3:0}", dst_column->debug_item(2));
+                ASSERT_EQ("{4:0,5:0,6:0}", dst_column->debug_item(3));
+            }
+        }
     }
 
 private:

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -17,6 +17,7 @@
 #include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/column.h"
+#include "column/column_access_path.h"
 #include "column/datum_convert.h"
 #include "column/fixed_length_column.h"
 #include "column/map_column.h"
@@ -131,11 +132,11 @@ protected:
 
         LOG(INFO) << "Finish writing";
         // read and check
-        {
-            auto res = ColumnReader::create(&meta, segment.get());
-            ASSERT_TRUE(res.ok());
-            auto reader = std::move(res).value();
+        auto res = ColumnReader::create(&meta, segment.get());
+        ASSERT_TRUE(res.ok());
+        auto reader = std::move(res).value();
 
+        {
             ASSIGN_OR_ABORT(auto iter, reader->new_iterator());
             ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(fname));
 
@@ -146,38 +147,31 @@ protected:
             ASSERT_TRUE(iter->init(iter_opts).ok());
 
             // sequence read
-            {
-                auto st = iter->seek_to_first();
-                ASSERT_TRUE(st.ok()) << st.to_string();
+            auto st = iter->seek_to_first();
+            ASSERT_TRUE(st.ok()) << st.to_string();
 
-                auto dst_f1_column = Int32Column::create();
-                auto dst_f2_column = BinaryColumn::create();
-                Columns dst_columns;
-                dst_columns.emplace_back(std::move(dst_f1_column));
-                dst_columns.emplace_back(std::move(dst_f2_column));
+            auto dst_f1_column = Int32Column::create();
+            auto dst_f2_column = BinaryColumn::create();
+            Columns dst_columns;
+            dst_columns.emplace_back(std::move(dst_f1_column));
+            dst_columns.emplace_back(std::move(dst_f2_column));
 
-                ColumnPtr dst_column = StructColumn::create(dst_columns, names);
-                size_t rows_read = src_column->size();
-                st = iter->next_batch(&rows_read, dst_column.get());
-                ASSERT_TRUE(st.ok());
-                ASSERT_EQ(src_column->size(), rows_read);
+            ColumnPtr dst_column = StructColumn::create(dst_columns, names);
+            size_t rows_read = src_column->size();
+            st = iter->next_batch(&rows_read, dst_column.get());
+            ASSERT_TRUE(st.ok());
+            ASSERT_EQ(src_column->size(), rows_read);
 
-                ASSERT_EQ("{f1:1,f2:'Column2'}", dst_column->debug_item(0));
-            }
+            ASSERT_EQ("{f1:1,f2:'Column2'}", dst_column->debug_item(0));
         }
 
-        // read and check
         {
-            auto res = ColumnReader::create(&meta, segment.get());
-            ASSERT_TRUE(res.ok());
-            auto reader = std::move(res).value();
+            auto child_path = std::make_unique<ColumnAccessPath>();
+            child_path->init(TAccessPathType::type::FIELD, "f1", 0);
 
-            ColumnAccessPath child_path;
-            child_path.init(TAccessPathType::type::FIELD, "f1", 0);
-            
             ColumnAccessPath path;
             path.init(TAccessPathType::type::ROOT, "root", 0);
-            path.children().emplace_back(child_path);
+            path.children().emplace_back(std::move(child_path));
 
             ASSIGN_OR_ABORT(auto iter, reader->new_iterator(&path));
             ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(fname));
@@ -211,16 +205,12 @@ protected:
 
         // read and check
         {
-            auto res = ColumnReader::create(&meta, segment.get());
-            ASSERT_TRUE(res.ok());
-            auto reader = std::move(res).value();
+            auto child_path = std::make_unique<ColumnAccessPath>();
+            child_path->init(TAccessPathType::type::FIELD, "f2", 1);
 
-            ColumnAccessPath child_path;
-            child_path.init(TAccessPathType::type::FIELD, "f2", 1);
-            
             ColumnAccessPath path;
             path.init(TAccessPathType::type::ROOT, "root", 0);
-            path.children().emplace_back(child_path);
+            path.children().emplace_back(std::move(child_path));
 
             ASSIGN_OR_ABORT(auto iter, reader->new_iterator(&path));
             ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(fname));
@@ -258,7 +248,7 @@ private:
 };
 
 // test map<int, int>, and nullable
-TEST_F(StructColumnRWTest, test_array_int) {
+TEST_F(StructColumnRWTest, test_struct_int) {
     test_int_struct();
 }
 


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

Follow:
https://github.com/StarRocks/starrocks/pull/23451

eg. `select st5.ss4.s52.s421, st5.ss3.s32 from sc0`
```
PLAN FRAGMENT 0(F00)
  Output Exprs:7: st5.ss4.s52.s421 | 8: st5.ss3.s32
  Input Partition: RANDOM
  RESULT SINK

  1:Project
  |  output columns:
  |  7 <-> 6: st5.ss4.s52.s421
  |  8 <-> 6: st5.ss3.s32
  |  cardinality: 1
  |  
  0:OlapScanNode
     table: sc0, rollup: sc0
     preAggregation: on
     partitionsRatio=0/1, tabletsRatio=0/0
     tabletList=
     actualRows=0, avgRowSize=3.0
     ColumnAccessPath: [/st5/ss4/s52/s421, /st5/ss3/s32]
     cardinality: 1
```

FE send column access paths `/st5/ss4/s52/s421`, `/st5/ss3/s32` to BE, it's like a path tree:
```
../
├── st5
│   ├── ss3
│   │   └── s32
│   └── ss4
│       └── s52
│           └── s421
```

Then, BE will read sub-fields according to ColumnAccessPath when read collection column `st5`.

1. Will put default values in un-read sub-fields now, because execute-node depend on collection column type, we can't prune sub-fields directly. It's meanings, we only reduced IO operations for INT sub-fields, but for Array/Map/String sub-fields, the optimization is obvious

2. We can unpack the collection column after scan node (next PR later)


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
