### PR TITLE
[Feature]Support analyze external table [iceberg]

### DIFF
--- a/be/src/runtime/statistic_result_writer.cpp
+++ b/be/src/runtime/statistic_result_writer.cpp
@@ -29,6 +29,7 @@ const int STATISTIC_HISTOGRAM_VERSION = 2;
 const int DICT_STATISTIC_DATA_VERSION = 101;
 const int STATISTIC_TABLE_VERSION = 3;
 const int STATISTIC_BATCH_VERSION = 4;
+const int STATISTIC_EXTERNAL_VERSION = 5;
 
 StatisticResultWriter::StatisticResultWriter(BufferControlBlock* sinker,
                                              const std::vector<ExprContext*>& output_expr_ctxs,
@@ -147,6 +148,9 @@ StatusOr<TFetchDataResultPtr> StatisticResultWriter::_process_chunk(Chunk* chunk
                                   "Fill table statistic data failed");
     } else if (version == STATISTIC_BATCH_VERSION) {
         RETURN_IF_ERROR_WITH_WARN(_fill_full_statistic_data_v4(version, result_columns, chunk, result.get()),
+                                  "Fill table statistic data failed");
+    } else if (version == STATISTIC_EXTERNAL_VERSION) {
+        RETURN_IF_ERROR_WITH_WARN(_fill_full_statistic_data_external(version, result_columns, chunk, result.get()),
                                   "Fill table statistic data failed");
     }
     return result;
@@ -321,6 +325,61 @@ Status StatisticResultWriter::_fill_full_statistic_data_v4(int version, const Co
     data_list.resize(num_rows);
     for (int i = 0; i < num_rows; ++i) {
         data_list[i].__set_partitionId(pid.value(i));
+        data_list[i].__set_columnName(name.value(i).to_string());
+        data_list[i].__set_rowCount(rowCounts.value(i));
+        data_list[i].__set_dataSize(dataSizes.value(i));
+        data_list[i].__set_hll(hll.value(i).to_string());
+        data_list[i].__set_nullCount(nullCounts.value(i));
+        data_list[i].__set_max(max.value(i).to_string());
+        data_list[i].__set_min(min.value(i).to_string());
+    }
+
+    result->result_batch.rows.resize(num_rows);
+    result->result_batch.__set_statistic_version(version);
+
+    ThriftSerializer serializer(true, chunk->memory_usage());
+    for (int i = 0; i < num_rows; ++i) {
+        RETURN_IF_ERROR(serializer.serialize(&data_list[i], &result->result_batch.rows[i]));
+    }
+    return Status::OK();
+}
+
+/*
+FE SQL:
+    SELECT cast(5 as INT),
+        'partitionName',
+        'columnName',
+        cast(COUNT(1) as BIGINT),
+        cast($dataSize as BIGINT),
+        $hllFunction,
+        cast($countNullFunction as BIGINT),
+        $maxFunction,
+        $minFunction
+    FROM xxx
+*/
+Status StatisticResultWriter::_fill_full_statistic_data_external(int version, const Columns& columns,
+                                                                 const Chunk* chunk, TFetchDataResult* result) {
+    SCOPED_TIMER(_serialize_timer);
+
+    // mapping with Data.thrift.TStatisticData
+    DCHECK(columns.size() == 9);
+
+    // skip read version
+    auto partitionName = ColumnViewer<TYPE_VARCHAR>(columns[1]);
+    auto name = ColumnViewer<TYPE_VARCHAR>(columns[2]);
+    auto rowCounts = ColumnViewer<TYPE_BIGINT>(columns[3]);
+    auto dataSizes = ColumnViewer<TYPE_BIGINT>(columns[4]);
+    auto hll = ColumnViewer<TYPE_VARCHAR>(columns[5]);
+    auto nullCounts = ColumnViewer<TYPE_BIGINT>(columns[6]);
+    auto max = ColumnViewer<TYPE_VARCHAR>(columns[7]);
+    auto min = ColumnViewer<TYPE_VARCHAR>(columns[8]);
+
+    std::vector<TStatisticData> data_list;
+    int num_rows = chunk->num_rows();
+
+    data_list.resize(num_rows);
+    for (int i = 0; i < num_rows; ++i) {
+        data_list[i].__set_partitionName(partitionName.value(i).to_string());
         data_list[i].__set_columnName(name.value(i).to_string());
         data_list[i].__set_rowCount(rowCounts.value(i));
         data_list[i].__set_dataSize(dataSizes.value(i));

--- a/be/src/runtime/statistic_result_writer.h
+++ b/be/src/runtime/statistic_result_writer.h
@@ -57,6 +57,9 @@ private:
     Status _fill_full_statistic_data_v4(int version, const Columns& columns, const Chunk* chunk,
                                         TFetchDataResult* result);
 
+    Status _fill_full_statistic_data_external(int version, const Columns& columns, const Chunk* chunk,
+                                              TFetchDataResult* result);
+
 private:
     BufferControlBlock* _sinker;
     const std::vector<ExprContext*>& _output_expr_ctxs;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -906,8 +906,6 @@ public class StmtExecutor {
         } catch (RejectedExecutionException e) {
             analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
             analyzeStatus.setReason("The statistics tasks running concurrently exceed the upper limit");
-            analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
-            analyzeStatus.setReason("The statistics tasks running concurrently exceed the upper limit");
             if (analyzeStmt.isExternal()) {
                 GlobalStateMgr.getCurrentAnalyzeMgr().addOrUpdateAnalyzeStatus(analyzeStatus);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -140,6 +140,7 @@ import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.statistic.AnalyzeManager;
 import com.starrocks.statistic.AnalyzeStatus;
+import com.starrocks.statistic.ExternalAnalyzeStatus;
 import com.starrocks.statistic.HistogramStatisticsCollectJob;
 import com.starrocks.statistic.NativeAnalyzeStatus;
 import com.starrocks.statistic.StatisticExecutor;
@@ -874,18 +875,26 @@ public class StmtExecutor {
             }
         }
 
+        AnalyzeStatus analyzeStatus;
         if (analyzeStmt.isExternal()) {
-            // deal later
-            return;
+            String catalogName = analyzeStmt.getTableName().getCatalog();
+            analyzeStatus = new ExternalAnalyzeStatus(GlobalStateMgr.getCurrentState().getNextId(),
+                    catalogName, db.getOriginName(), table.getName(),
+                    table.getUUID(),
+                    analyzeStmt.getColumnNames(),
+                    analyzeType, StatsConstants.ScheduleType.ONCE, analyzeStmt.getProperties(), LocalDateTime.now());
+            analyzeStatus.setStatus(StatsConstants.ScheduleStatus.PENDING);
+            GlobalStateMgr.getCurrentAnalyzeMgr().addOrUpdateAnalyzeStatus(analyzeStatus);
+        } else {
+            //Only for send sync command to client
+            analyzeStatus = new NativeAnalyzeStatus(GlobalStateMgr.getCurrentState().getNextId(),
+                    db.getId(), table.getId(), analyzeStmt.getColumnNames(),
+                    analyzeType, StatsConstants.ScheduleType.ONCE, analyzeStmt.getProperties(), LocalDateTime.now());
+            analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
+            GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
+            analyzeStatus.setStatus(StatsConstants.ScheduleStatus.PENDING);
+            GlobalStateMgr.getCurrentAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
         }
-        //Only for send sync command to client
-        AnalyzeStatus analyzeStatus = new NativeAnalyzeStatus(GlobalStateMgr.getCurrentState().getNextId(),
-                db.getId(), table.getId(), analyzeStmt.getColumnNames(),
-                analyzeType, StatsConstants.ScheduleType.ONCE, analyzeStmt.getProperties(), LocalDateTime.now());
-        analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
-        GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
-        analyzeStatus.setStatus(StatsConstants.ScheduleStatus.PENDING);
-        GlobalStateMgr.getCurrentAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
 
         try {
             Future<?> future = GlobalStateMgr.getCurrentAnalyzeMgr().getAnalyzeTaskThreadPool()
@@ -897,11 +906,21 @@ public class StmtExecutor {
         } catch (RejectedExecutionException e) {
             analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
             analyzeStatus.setReason("The statistics tasks running concurrently exceed the upper limit");
-            GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
+            analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
+            analyzeStatus.setReason("The statistics tasks running concurrently exceed the upper limit");
+            if (analyzeStmt.isExternal()) {
+                GlobalStateMgr.getCurrentAnalyzeMgr().addOrUpdateAnalyzeStatus(analyzeStatus);
+            } else {
+                GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
+            }
         } catch (ExecutionException | InterruptedException e) {
             analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
             analyzeStatus.setReason("The statistics tasks running failed");
-            GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
+            if (analyzeStmt.isExternal()) {
+                GlobalStateMgr.getCurrentAnalyzeMgr().addOrUpdateAnalyzeStatus(analyzeStatus);
+            } else {
+                GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
+            }
         }
 
         ShowResultSet resultSet = analyzeStatus.toShowResult();
@@ -927,7 +946,18 @@ public class StmtExecutor {
                                 Database db, Table table) {
         StatisticExecutor statisticExecutor = new StatisticExecutor();
         if (analyzeStmt.isExternal()) {
-            // deal later
+            StatsConstants.AnalyzeType analyzeType = analyzeStmt.isSample() ? StatsConstants.AnalyzeType.SAMPLE :
+                    StatsConstants.AnalyzeType.FULL;
+            // TODO: we should check old statistic and confirm paritionlist
+            statisticExecutor.collectStatistics(statsConnectCtx,
+                    StatisticsCollectJobFactory.buildExternalStatisticsCollectJob(
+                            analyzeStmt.getTableName().getCatalog(),
+                            db, table,
+                            analyzeStmt.getColumnNames(),
+                            analyzeType,
+                            StatsConstants.ScheduleType.ONCE, analyzeStmt.getProperties()),
+                    analyzeStatus,
+                    false);
         } else {
             if (analyzeStmt.getAnalyzeTypeDesc() instanceof AnalyzeHistogramDesc) {
                 statisticExecutor.collectStatistics(statsConnectCtx,
@@ -956,7 +986,7 @@ public class StmtExecutor {
         DropStatsStmt dropStatsStmt = (DropStatsStmt) parsedStmt;
         Table table = MetaUtils.getTable(context, dropStatsStmt.getTableName());
         if (dropStatsStmt.isExternal()) {
-            // deal later
+            GlobalStateMgr.getCurrentAnalyzeMgr().dropExternalStats(table.getUUID());
         } else {
             List<String> columns = table.getBaseSchema().stream().filter(d -> !d.isAggregated()).map(Column::getName)
                     .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeManager.java
@@ -173,6 +173,17 @@ public class AnalyzeManager implements Writable {
         }
     }
 
+    public void dropExternalStats(String tableUUID) {
+        List<AnalyzeStatus> expireList = analyzeStatusMap.values().stream().
+                filter(status -> status instanceof ExternalAnalyzeStatus).
+                filter(status -> ((ExternalAnalyzeStatus) status).getTableUUID().equals(tableUUID)).
+                collect(Collectors.toList());
+
+        expireList.forEach(status -> analyzeStatusMap.remove(status.getId()));
+        StatisticExecutor statisticExecutor = new StatisticExecutor();
+        statisticExecutor.dropTableStatistics(StatisticUtils.buildConnectContext(), tableUUID);
+    }
+
     public void addBasicStatsMeta(BasicStatsMeta basicStatsMeta) {
         basicStatsMetaMap.put(basicStatsMeta.getTableId(), basicStatsMeta);
         GlobalStateMgr.getCurrentState().getEditLog().logAddBasicStatsMeta(basicStatsMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalAnalyzeStatus.java
@@ -1,0 +1,191 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.statistic;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.qe.ShowResultSet;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ExternalAnalyzeStatus implements AnalyzeStatus {
+
+    private long id;
+    private String catalogName;
+    private String dbName;
+    private String tableName;
+    private String tableUUID;
+
+    private List<String> columns;
+
+    private StatsConstants.AnalyzeType type;
+
+    private StatsConstants.ScheduleType scheduleType;
+
+    private Map<String, String> properties;
+
+    private StatsConstants.ScheduleStatus status;
+
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
+
+    private String reason;
+
+    private long progress;
+
+    public ExternalAnalyzeStatus(long id, String catalogName, String dbName, String tableName,
+                                 String tableUUID,
+                                 List<String> columns,
+                                 StatsConstants.AnalyzeType type,
+                                 StatsConstants.ScheduleType scheduleType,
+                                 Map<String, String> properties,
+                                 LocalDateTime startTime) {
+        this.id = id;
+        this.catalogName = catalogName;
+        this.dbName = dbName;
+        this.tableName = tableName;
+        this.tableUUID = tableUUID;
+        this.columns = columns;
+        this.type = type;
+        this.scheduleType = scheduleType;
+        this.properties = properties;
+        this.startTime = startTime;
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isNative() {
+        return false;
+    }
+
+    public String getTableUUID() {
+        return tableUUID;
+    }
+
+    @Override
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    @Override
+    public String getDbName() throws MetaNotFoundException {
+        return dbName;
+    }
+
+    @Override
+    public String getTableName() throws MetaNotFoundException {
+        return tableName;
+    }
+
+    @Override
+    public List<String> getColumns() {
+        return columns;
+    }
+
+    @Override
+    public StatsConstants.AnalyzeType getType() {
+        return type;
+    }
+
+    @Override
+    public StatsConstants.ScheduleType getScheduleType() {
+        return scheduleType;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    @Override
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    @Override
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    @Override
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    @Override
+    public void setStatus(StatsConstants.ScheduleStatus status) {
+        this.status = status;
+    }
+
+    @Override
+    public StatsConstants.ScheduleStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    @Override
+    public long getProgress() {
+        return progress;
+    }
+
+    @Override
+    public void setProgress(long progress) {
+        this.progress = progress;
+    }
+
+    @Override
+    public ShowResultSet toShowResult() {
+        String op = "unknown";
+        if (type.equals(StatsConstants.AnalyzeType.HISTOGRAM)) {
+            op = "histogram";
+        } else if (type.equals(StatsConstants.AnalyzeType.FULL)) {
+            op = "analyze";
+        } else if (type.equals(StatsConstants.AnalyzeType.SAMPLE)) {
+            op = "sample";
+        }
+
+        String msgType;
+        String msgText;
+        if (status.equals(StatsConstants.ScheduleStatus.FAILED)) {
+            msgType = "error";
+            msgText = reason;
+        } else {
+            msgType = "status";
+            msgText = "OK";
+        }
+
+        List<List<String>> rows = new ArrayList<>();
+        rows.add(Lists.newArrayList(catalogName + "." + dbName + "." + tableName, op, msgType, msgText));
+        return new ShowResultSet(META_DATA, rows);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -1,0 +1,250 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.statistic;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.OriginStatement;
+import com.starrocks.qe.QueryState;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.ValuesRelation;
+import com.starrocks.thrift.TStatisticData;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.velocity.VelocityContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
+    private static final Logger LOG = LogManager.getLogger(ExternalFullStatisticsCollectJob.class);
+
+    private static final String BATCH_FULL_STATISTIC_TEMPLATE = "SELECT cast($version as INT)" +
+            ", '$partitionNameStr'" + // VARCHAR
+            ", '$columnNameStr'" + // VARCHAR
+            ", cast(COUNT(1) as BIGINT)" + // BIGINT
+            ", cast($dataSize as BIGINT)" + // BIGINT
+            ", $hllFunction" + // VARBINARY
+            ", cast($countNullFunction as BIGINT)" + // BIGINT
+            ", $maxFunction" + // VARCHAR
+            ", $minFunction " + // VARCHAR
+            " FROM `$catalogName`.`$dbName`.`$tableName`";
+
+    private final String catalogName;
+    private final List<String> sqlBuffer = Lists.newArrayList();
+    private final List<List<Expr>> rowsBuffer = Lists.newArrayList();
+
+    public ExternalFullStatisticsCollectJob(String catalogName, Database db, Table table, List<String> columns,
+                                    StatsConstants.AnalyzeType type, StatsConstants.ScheduleType scheduleType,
+                                    Map<String, String> properties) {
+        super(db, table, columns, type, scheduleType, properties);
+        this.catalogName = catalogName;
+    }
+
+    @Override
+    public void collect(ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
+        long finishedSQLNum = 0;
+        int parallelism = Math.max(1, context.getSessionVariable().getStatisticCollectParallelism());
+        List<List<String>> collectSQLList = buildCollectSQLList(parallelism);
+        long totalCollectSQL = collectSQLList.size();
+
+        // First, the collection task is divided into several small tasks according to the column name and partition,
+        // and then the multiple small tasks are aggregated into several tasks
+        // that will actually be run according to the configured parallelism, and are connected by union all
+        // Because each union will run independently, if the number of unions is greater than the degree of parallelism,
+        // dop will be set to 1 to meet the requirements of the degree of parallelism.
+        // If the number of unions is less than the degree of parallelism,
+        // dop should be adjusted appropriately to use enough cpu cores
+        for (List<String> sqlUnion : collectSQLList) {
+            if (sqlUnion.size() < parallelism) {
+                context.getSessionVariable().setPipelineDop(parallelism / sqlUnion.size());
+            } else {
+                context.getSessionVariable().setPipelineDop(1);
+            }
+
+            String sql = Joiner.on(" UNION ALL ").join(sqlUnion);
+
+            collectStatisticSync(sql, context);
+            finishedSQLNum++;
+            analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);
+            GlobalStateMgr.getCurrentAnalyzeMgr().replayAddAnalyzeStatus(analyzeStatus);
+        }
+
+        flushInsertStatisticsData(context, true);
+    }
+
+    private List<List<String>> buildCollectSQLList(int parallelism) {
+        List<String> totalQuerySQL = new ArrayList<>();
+        for (String columnName : columns) {
+            totalQuerySQL.add(buildBatchCollectFullStatisticSQL(table, columnName));
+        }
+
+        return Lists.partition(totalQuerySQL, parallelism);
+    }
+
+    private String buildBatchCollectFullStatisticSQL(Table table, String columnName) {
+        StringBuilder builder = new StringBuilder();
+        VelocityContext context = new VelocityContext();
+        Column column = table.getColumn(columnName);
+
+        String columnNameStr = StringEscapeUtils.escapeSql(columnName);
+        String quoteColumnName = StatisticUtils.quoting(columnName);
+
+        context.put("version", StatsConstants.STATISTIC_EXTERNAL_VERSION);
+        // all table now, partition later
+        context.put("partitionNameStr", "All");
+        context.put("columnNameStr", columnNameStr);
+        context.put("dataSize", fullAnalyzeGetDataSize(column));
+        context.put("dbName", db.getOriginName());
+        context.put("tableName", table.getName());
+        context.put("catalogName", this.catalogName);
+
+        if (!column.getType().canStatistic()) {
+            context.put("hllFunction", "hex(hll_serialize(hll_empty()))");
+            context.put("countNullFunction", "0");
+            context.put("maxFunction", "''");
+            context.put("minFunction", "''");
+        } else {
+            context.put("hllFunction", "hex(hll_serialize(IFNULL(hll_raw(" + quoteColumnName + "), hll_empty())))");
+            context.put("countNullFunction", "COUNT(1) - COUNT(" + quoteColumnName + ")");
+            context.put("maxFunction", getMinMaxFunction(column, quoteColumnName, true));
+            context.put("minFunction", getMinMaxFunction(column, quoteColumnName, false));
+        }
+
+        builder.append(build(context, BATCH_FULL_STATISTIC_TEMPLATE));
+        return builder.toString();
+    }
+
+    @Override
+    public void collectStatisticSync(String sql, ConnectContext context) throws Exception {
+        LOG.debug("statistics collect sql : " + sql);
+        StatisticExecutor executor = new StatisticExecutor();
+        SessionVariable sessionVariable = context.getSessionVariable();
+        // Full table scan is performed for full statistics collecting. In this case,
+        // we do not need to use pagecache.
+        sessionVariable.setUsePageCache(false);
+        List<TStatisticData> dataList = executor.executeStatisticDQL(context, sql);
+
+        for (TStatisticData data : dataList) {
+            List<String> params = Lists.newArrayList();
+            List<Expr> row = Lists.newArrayList();
+
+            params.add(table.getUUID());
+            params.add("'" + StringEscapeUtils.escapeSql(data.getPartitionName()) + "'");
+            params.add("'" + StringEscapeUtils.escapeSql(data.getColumnName()) + "'");
+            params.add(catalogName);
+            params.add(db.getOriginName());
+            params.add(table.getName());
+            params.add(String.valueOf(data.getRowCount()));
+            params.add(String.valueOf(data.getDataSize()));
+            params.add("hll_deserialize(unhex('mockData'))");
+            params.add(String.valueOf(data.getNullCount()));
+            params.add("'" + data.getMax() + "'");
+            params.add("'" + data.getMin() + "'");
+            params.add("now()");
+            // int
+            row.add(new StringLiteral(table.getUUID())); // table id, wait to byte
+            row.add(new StringLiteral(data.getPartitionName()));
+            row.add(new StringLiteral(data.getColumnName())); // column name, 20 byte
+            row.add(new StringLiteral(catalogName));
+            row.add(new StringLiteral(db.getOriginName()));
+            row.add(new StringLiteral(table.getName()));
+            row.add(new IntLiteral(data.getRowCount(), Type.BIGINT)); // row count, 8 byte
+            row.add(new IntLiteral((long) data.getDataSize(), Type.BIGINT)); // data size, 8 byte
+            row.add(hllDeserialize(data.getHll())); // hll, 32 kB
+            row.add(new IntLiteral(data.getNullCount(), Type.BIGINT)); // null count, 8 byte
+            row.add(new StringLiteral(data.getMax())); // max, 200 byte
+            row.add(new StringLiteral(data.getMin())); // min, 200 byte
+            row.add(nowFn()); // update time, 8 byte
+
+            rowsBuffer.add(row);
+            sqlBuffer.add("(" + String.join(", ", params) + ")");
+        }
+        flushInsertStatisticsData(context, false);
+    }
+
+    private void flushInsertStatisticsData(ConnectContext context, boolean force) throws Exception {
+        // hll serialize to hex, about 32kb
+        long bufferSize = 33L * 1024 * rowsBuffer.size();
+        if (bufferSize < Config.statistic_full_collect_buffer && !force) {
+            return;
+        }
+        if (rowsBuffer.isEmpty()) {
+            return;
+        }
+
+        int count = 0;
+        int maxRetryTimes = 5;
+        StatementBase insertStmt = createInsertStmt();
+        do {
+            LOG.debug("statistics insert sql size:" + rowsBuffer.size());
+            StmtExecutor executor = new StmtExecutor(context, insertStmt);
+            context.setExecutor(executor);
+            context.setQueryId(UUIDUtil.genUUID());
+            context.setStartTime();
+            executor.execute();
+
+            if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {
+                LOG.warn("Statistics collect fail | {} | Error Message [{}]", DebugUtil.printId(context.getQueryId()),
+                        context.getState().getErrorMessage());
+                if (StringUtils.contains(context.getState().getErrorMessage(), "Too many versions")) {
+                    Thread.sleep(Config.statistic_collect_too_many_version_sleep);
+                    count++;
+                } else {
+                    throw new DdlException(context.getState().getErrorMessage());
+                }
+            } else {
+                sqlBuffer.clear();
+                rowsBuffer.clear();
+                return;
+            }
+        } while (count < maxRetryTimes);
+
+        throw new DdlException(context.getState().getErrorMessage());
+    }
+
+    private StatementBase createInsertStmt() {
+        String sql = "INSERT INTO external_column_statistics values " + String.join(", ", sqlBuffer) + ";";
+        List<String> names = Lists.newArrayList("column_0", "column_1", "column_2", "column_3",
+                "column_4", "column_5", "column_6", "column_7", "column_8", "column_9", "column_10",
+                "column_11", "column_12");
+        QueryStatement qs = new QueryStatement(new ValuesRelation(rowsBuffer, names));
+        InsertStmt insert = new InsertStmt(new TableName("_statistics_", "external_column_statistics"), qs);
+        insert.setOrigStmt(new OriginStatement(sql, 0));
+        return insert;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -110,6 +110,16 @@ public class StatisticExecutor {
         }
     }
 
+    public void dropTableStatistics(ConnectContext statsConnectCtx, String tableUUID) {
+        String sql = StatisticSQLBuilder.buildDropExternalStatSQL(tableUUID);
+        LOG.debug("Expire statistic SQL: {}", sql);
+
+        boolean result = executeDML(statsConnectCtx, sql);
+        if (!result) {
+            LOG.warn("Execute statistic table expire fail.");
+        }
+    }
+
     public boolean dropPartitionStatistics(ConnectContext statsConnectCtx, List<Long> pids) {
         String sql = StatisticSQLBuilder.buildDropPartitionSQL(pids);
         LOG.debug("Expire partition statistic SQL: {}", sql);
@@ -203,7 +213,8 @@ public class StatisticExecutor {
                 || version == StatsConstants.STATISTIC_DICT_VERSION
                 || version == StatsConstants.STATISTIC_HISTOGRAM_VERSION
                 || version == StatsConstants.STATISTIC_TABLE_VERSION
-                || version == StatsConstants.STATISTIC_BATCH_VERSION) {
+                || version == StatsConstants.STATISTIC_BATCH_VERSION
+                || version == StatsConstants.STATISTIC_EXTERNAL_VERSION) {
             TDeserializer deserializer = new TDeserializer(new TCompactProtocol.Factory());
             for (TResultBatch resultBatch : sqlResult) {
                 for (ByteBuffer bb : resultBatch.rows) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.starrocks.statistic.StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.FULL_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.SAMPLE_STATISTICS_TABLE_NAME;
 import static com.starrocks.statistic.StatsConstants.STATISTIC_DATA_VERSION;
@@ -131,6 +132,10 @@ public class StatisticSQLBuilder {
         }
 
         return "DELETE FROM " + tableName + " WHERE TABLE_ID = " + tableId;
+    }
+
+    public static String buildDropExternalStatSQL(String tableUUID) {
+        return "DELETE FROM " + EXTERNAL_FULL_STATISTICS_TABLE_NAME + " WHERE TABLE_UUID = '" + tableUUID + "'";
     }
 
     public static String buildDropPartitionSQL(List<Long> pids) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -106,6 +106,18 @@ public class StatisticsCollectJobFactory {
         }
     }
 
+    public static StatisticsCollectJob buildExternalStatisticsCollectJob(String catalogName, Database db, Table table,
+                                                                         List<String> columns,
+                                                                         StatsConstants.AnalyzeType analyzeType,
+                                                                         StatsConstants.ScheduleType scheduleType,
+                                                                         Map<String, String> properties) {
+        if (columns == null || columns.isEmpty()) {
+            columns = StatisticUtils.getCollectibleColumns(table);
+        }
+        return new ExternalFullStatisticsCollectJob(catalogName, db, table, columns,
+                analyzeType, scheduleType, properties);
+    }
+
     private static void createJob(List<StatisticsCollectJob> allTableJobMap, AnalyzeJob job,
                                   Database db, Table table, List<String> columns) {
         if (table == null || !(table.isOlapOrCloudNativeTable() || table.isMaterializedView())) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -129,6 +129,10 @@ public class StatisticsMetaManager extends FrontendDaemon {
             "table_id", "column_name"
     );
 
+    private static final List<String> EXTERNAL_FULL_STATISTICS_KEY_COLUMNS = ImmutableList.of(
+            "table_uuid", "partition_name", "column_name"
+    );
+
     private boolean createSampleStatisticsTable(ConnectContext context) {
         LOG.info("create sample statistics table start");
         TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
@@ -228,6 +232,36 @@ public class StatisticsMetaManager extends FrontendDaemon {
         return checkTableExist(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME);
     }
 
+    private boolean createExternalFullStatisticsTable(ConnectContext context) {
+        LOG.info("create external full statistics table start");
+        TableName tableName = new TableName(StatsConstants.STATISTICS_DB_NAME,
+                StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME);
+        KeysType keysType = RunMode.allowCreateLakeTable() ? KeysType.UNIQUE_KEYS : KeysType.PRIMARY_KEYS;
+        Map<String, String> properties = Maps.newHashMap();
+        int defaultReplicationNum = Math.min(3, GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber());
+        properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, Integer.toString(defaultReplicationNum));
+        CreateTableStmt stmt = new CreateTableStmt(false, false,
+                tableName,
+                StatisticUtils.buildStatsColumnDef(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME),
+                EngineType.defaultEngine().name(),
+                new KeysDesc(keysType, EXTERNAL_FULL_STATISTICS_KEY_COLUMNS),
+                null,
+                new HashDistributionDesc(10, EXTERNAL_FULL_STATISTICS_KEY_COLUMNS),
+                properties,
+                null,
+                "");
+
+        Analyzer.analyze(stmt, context);
+        try {
+            GlobalStateMgr.getCurrentState().createTable(stmt);
+        } catch (DdlException e) {
+            LOG.warn("Failed to create full statistics table" + e.getMessage());
+            return false;
+        }
+        LOG.info("create external full statistics table done");
+        return checkTableExist(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME);
+    }
+
     private void refreshAnalyzeJob() {
         for (Map.Entry<Long, BasicStatsMeta> entry :
                 GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().entrySet()) {
@@ -276,6 +310,8 @@ public class StatisticsMetaManager extends FrontendDaemon {
             return createFullStatisticsTable(context);
         } else if (tableName.equals(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME)) {
             return createHistogramStatisticsTable(context);
+        } else if (tableName.equals(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME)) {
+            return createExternalFullStatisticsTable(context);
         } else {
             throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
         }
@@ -314,6 +350,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
         refreshStatisticsTable(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME);
         refreshStatisticsTable(StatsConstants.FULL_STATISTICS_TABLE_NAME);
         refreshStatisticsTable(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME);
+        refreshStatisticsTable(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME);
 
         GlobalStateMgr.getCurrentAnalyzeMgr().clearStatisticFromDroppedPartition();
         GlobalStateMgr.getCurrentAnalyzeMgr().clearStatisticFromDroppedTable();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -23,12 +23,14 @@ public class StatsConstants {
     public static final int STATISTIC_HISTOGRAM_VERSION = 2;
     public static final int STATISTIC_TABLE_VERSION = 3;
     public static final int STATISTIC_BATCH_VERSION = 4;
+    public static final int STATISTIC_EXTERNAL_VERSION = 5;
 
 
     public static final int STATISTICS_PARTITION_UPDATED_THRESHOLD = 10;
     public static final String STATISTICS_DB_NAME = "_statistics_";
     public static final String SAMPLE_STATISTICS_TABLE_NAME = "table_statistic_v1";
     public static final String FULL_STATISTICS_TABLE_NAME = "column_statistics";
+    public static final String EXTERNAL_FULL_STATISTICS_TABLE_NAME = "external_column_statistics";
     public static final String HISTOGRAM_STATISTICS_TABLE_NAME = "histogram_statistics";
 
     public static final String INFORMATION_SCHEMA = "information_schema";

--- a/gensrc/thrift/Data.thrift
+++ b/gensrc/thrift/Data.thrift
@@ -118,6 +118,7 @@ struct TStatisticData {
     14: optional i64 partitionId
     // the batch load version
     15: optional binary hll
+    16: optional string partitionName
 }
 
 // Result data for user variable


### PR DESCRIPTION
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Which issues of this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
split from https://github.com/StarRocks/starrocks/pull/22899


## Problem Summary(Required):
<!-- (Please describe the changes you have made. In which scenarios will this bug be triggered and what measures have you taken to fix the bug?) -->

1. Create table "_statistics_.external_column_statistics" to save column statistics. Table type is UniqueKey or PrimaryKey depending on cloud native or not. Key Columns are "table_uuid"、"partition_name"、 "column_name", so that only one result of the same table, partition and column. Other columns are "catalog_name"、"db_name"、"table_name"、"row_count"、"data_size"、"ndv"、"null_count"、 "max"、"min"、"update_time".
2. ExternalAnalyzeStatus is used to record analyze status. We don't use NativeAnalyzeStatus because external table id and db id are not static, it changes across different query. It's not persistent by Bdb log, because persistence may involve compatibility issues. We are going to bypass persistence by statistics data caught from be, and consider persistence later. Same as NativeAnalyzeStatus, ExternalAnalyzeStatus will be deleted after 3 days.
3. We collect statistics of External tables just like Native tables but with different SQL. We now only support FULL analyze(not SAMPLE and Histogram). We now only support analyzing the integrity table not incremental data(will be support later). ExternalFullStatisticsCollectJob works on this. FE sends SQL to BE and BE returns result by 'statistics_result_writer'.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
