### PR TITLE
[Enhancement] upgrade roaring bitmap lib to v1.1.3

### DIFF
--- a/be/src/storage/del_vector.cpp
+++ b/be/src/storage/del_vector.cpp
@@ -109,7 +109,7 @@ string DelVector::to_string() const {
 void DelVector::_update_stats() {
     // TODO(cbl): optimization
     if (_roaring) {
-        roaring_statistics_t st;
+        roaring::api::roaring_statistics_t st;
         roaring_bitmap_statistics(&_roaring->roaring, &st);
         _memory_usage = st.n_bytes_array_containers + st.n_bytes_bitset_containers + st.n_bytes_run_containers;
         //_memory_usage = _roaring->getSizeInBytes(false);

--- a/be/src/storage/del_vector.h
+++ b/be/src/storage/del_vector.h
@@ -21,6 +21,8 @@
 
 namespace starrocks {
 
+using Roaring = roaring::Roaring;
+
 // A bitmap(uint32_t set) to store all the deleted rows' ids of a segment.
 // Each DelVector is associated with a version, which is EditVersion's majar version.
 // Serialization format:

--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -46,6 +46,8 @@
 
 namespace starrocks {
 
+using Roaring = roaring::Roaring;
+
 BitmapIndexReader::BitmapIndexReader() {
     MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->bitmap_index_mem_tracker(), sizeof(BitmapIndexReader));
 }

--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -52,6 +52,8 @@ class BitmapIndexIterator;
 class IndexedColumnReader;
 class IndexedColumnIterator;
 
+using Roaring = roaring::Roaring;
+
 class BitmapIndexReader {
 public:
     BitmapIndexReader();

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -52,7 +52,7 @@
 
 namespace starrocks {
 
-namespace {
+using Roaring = roaring::Roaring;
 
 class BitmapUpdateContext {
     static const size_t estimate_size_threshold = 1024;
@@ -268,8 +268,6 @@ private:
     mutable uint64_t _reverted_index_size = 0;
     mutable std::vector<BitmapUpdateContext*> _late_update_context_vector;
 };
-
-} // namespace
 
 struct BitmapIndexWriterBuilder {
     template <LogicalType ftype>

--- a/be/src/storage/rowset/bitmap_range_iterator.h
+++ b/be/src/storage/rowset/bitmap_range_iterator.h
@@ -76,7 +76,7 @@ public:
 
 private:
     void _read_next_batch() {
-        uint32_t n = roaring_read_uint32_iterator(&_iter, _buf, kBatchSize);
+        uint32_t n = roaring::api::roaring_read_uint32_iterator(&_iter, _buf, kBatchSize);
         _buf_pos = 0;
         _buf_size = n;
         _eof = n == 0;
@@ -84,7 +84,7 @@ private:
 
     static const uint32_t kBatchSize = 256;
 
-    roaring_uint32_iterator_t _iter{};
+    roaring::api::roaring_uint32_iterator_t _iter{};
     uint32_t _last_val{0};
     uint32_t _buf_pos{0};
     uint32_t _buf_size{0};

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -274,7 +274,7 @@ private:
     Status _get_dcg_st;
     DelVectorPtr _del_vec;
     DeltaColumnGroupList _dcgs;
-    roaring_uint32_iterator_t _roaring_iter;
+    roaring::api::roaring_uint32_iterator_t _roaring_iter;
 
     std::unordered_map<ColumnId, std::unique_ptr<RandomAccessFile>> _column_files;
 

--- a/be/src/types/bitmap_value_detail.h
+++ b/be/src/types/bitmap_value_detail.h
@@ -90,6 +90,13 @@ struct BitmapTypeCode {
 
 namespace detail {
 
+// https://github.com/RoaringBitmap/CRoaring/blob/5d6dd2342d9e3ffaf481aa5ebe344e19984faa4a/src/roaring.c#L21
+// The tow macro is not in .h file, so copy to here.
+#define SERIALIZATION_ARRAY_UINT32 1
+#define SERIALIZATION_CONTAINER 2
+
+using Roaring = roaring::Roaring;
+
 class Roaring64MapSetBitForwardIterator;
 
 // Forked from https://github.com/RoaringBitmap/CRoaring/blob/v0.2.60/cpp/roaring64map.hh

--- a/be/test/types/bitmap_value_test.cpp
+++ b/be/test/types/bitmap_value_test.cpp
@@ -180,7 +180,7 @@ TEST(BitmapValueTest, bitmap_serde) {
         BitmapValue bitmap32(std::vector<uint64_t>{0, UINT32_MAX});
         std::string buffer = convert_bitmap_to_string(bitmap32);
 
-        Roaring roaring;
+        roaring::Roaring roaring;
         roaring.add(0);
         roaring.add(UINT32_MAX);
         std::string expect_buffer(1, type_bitmap32);
@@ -209,7 +209,7 @@ TEST(BitmapValueTest, bitmap_serde) {
         BitmapValue bitmap64(std::vector<uint64_t>{0, static_cast<uint64_t>(UINT32_MAX) + 1});
         std::string buffer = convert_bitmap_to_string(bitmap64);
 
-        Roaring roaring;
+        roaring::Roaring roaring;
         roaring.add(0);
         std::string expect_buffer(1, type_bitmap64);
         put_varint64(&expect_buffer, 2); // map size

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -685,6 +685,8 @@ build_bitshuffle() {
 }
 
 # croaring bitmap
+# If open AVX512 default, current version will be compiled failed on some machine, so close AVX512 default,
+# When this problem is solved, a switch will be added to control.
 build_croaringbitmap() {
     FORCE_AVX=ON
     # avx2 is not supported by aarch64.
@@ -705,6 +707,8 @@ build_croaringbitmap() {
     -DENABLE_ROARING_TESTS=OFF \
     -DROARING_DISABLE_NATIVE=ON \
     -DFORCE_AVX=$FORCE_AVX \
+    -DROARING_DISABLE_AVX512=ON \
+    -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_LIBRARY_PATH="$TP_INSTALL_DIR/lib;$TP_INSTALL_DIR/lib64" ..
     ${BUILD_SYSTEM} -j$PARALLEL
     ${BUILD_SYSTEM} install

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -252,10 +252,10 @@ BITSHUFFLE_SOURCE=bitshuffle-0.5.1
 BITSHUFFLE_MD5SUM="b3bf6a9838927f7eb62214981c138e2f"
 
 # CROARINGBITMAP
-CROARINGBITMAP_DOWNLOAD="https://github.com/RoaringBitmap/CRoaring/archive/v0.2.60.tar.gz"
-CROARINGBITMAP_NAME=CRoaring-0.2.60.tar.gz
-CROARINGBITMAP_SOURCE=CRoaring-0.2.60
-CROARINGBITMAP_MD5SUM="29602918e6890ffdeed84cb171857046"
+CROARINGBITMAP_DOWNLOAD="https://github.com/RoaringBitmap/CRoaring/archive/refs/tags/v1.1.3.tar.gz"
+CROARINGBITMAP_NAME=CRoaring-1.1.3.tar.gz
+CROARINGBITMAP_SOURCE=CRoaring-1.1.3
+CROARINGBITMAP_MD5SUM="605924d21c14c760e66466799215868f"
 
 # jemalloc
 JEMALLOC_DOWNLOAD="https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2"


### PR DESCRIPTION
## Problem Summary:
The related pr of RoaringBitmap: https://github.com/RoaringBitmap/CRoaring/pull/246/files
This bug will cause queries based on BitmapIndex to return wrong data, so upgrade roaring bitmap lib

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
