### PR TITLE
[Enhancement] Optimize automatic partition incremental open timeout

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -247,7 +247,7 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
 
     // This ref is for RPC's reference
     open_closure->ref();
-    open_closure->cntl.set_timeout_ms(config::tablet_writer_open_rpc_timeout_sec * 1000);
+    open_closure->cntl.set_timeout_ms(_rpc_timeout_ms);
     if (request.ByteSizeLong() > _parent->_rpc_http_min_size) {
         TNetworkAddress brpc_addr;
         brpc_addr.hostname = _node_info->host;

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -130,7 +130,7 @@ void LoadChannel::open(brpc::Controller* cntl, const PTabletWriterOpenRequest& r
                         break;
                     }
 
-                    if (++i % 60000 == 0) {
+                    if (++i % 3000 == 0) {
                         LOG(INFO) << "LoadChannel txn_id: " << request.txn_id()
                                   << " load_id: " << print_id(request.id())
                                   << " wait other sender finish write already "

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -703,17 +703,20 @@ Status LocalTabletsChannel::incremental_open(const PTabletWriterOpenRequest& par
         _delta_writers.emplace(tablet.tablet_id(), std::move(writer));
         tablet_ids.emplace_back(tablet.tablet_id());
     }
-    _s_tablet_writer_count += incremental_tablet_num;
 
-    auto it = _tablet_id_to_sorted_indexes.begin();
-    while (it != _tablet_id_to_sorted_indexes.end()) {
-        tablet_ids.emplace_back(it->first);
-        it++;
-    }
-    DCHECK_EQ(_delta_writers.size(), tablet_ids.size());
-    std::sort(tablet_ids.begin(), tablet_ids.end());
-    for (size_t i = 0; i < tablet_ids.size(); ++i) {
-        _tablet_id_to_sorted_indexes.emplace(tablet_ids[i], i);
+    if (incremental_tablet_num > 0) {
+        _s_tablet_writer_count += incremental_tablet_num;
+
+        auto it = _tablet_id_to_sorted_indexes.begin();
+        while (it != _tablet_id_to_sorted_indexes.end()) {
+            tablet_ids.emplace_back(it->first);
+            it++;
+        }
+        DCHECK_EQ(_delta_writers.size(), tablet_ids.size());
+        std::sort(tablet_ids.begin(), tablet_ids.end());
+        for (size_t i = 0; i < tablet_ids.size(); ++i) {
+            _tablet_id_to_sorted_indexes.emplace(tablet_ids[i], i);
+        }
     }
 
     if (_is_incremental_channel && !_senders[params.sender_id()].has_incremental_open) {


### PR DESCRIPTION
## Problem Summary:
Fixes https://github.com/StarRocks/StarRocksBenchmark/issues/396

When load pressure is heavy, the incremental open may be very slow, so that we need use query timeout to avoid unnecessary fail

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
