### PR TITLE
[BugFix] Fix ElasticSearch predicate timezone problem

### DIFF
--- a/be/src/connector/es_connector.cpp
+++ b/be/src/connector/es_connector.cpp
@@ -118,8 +118,7 @@ Status ESDataSource::_build_conjuncts() {
     _predicate_idx.reserve(conjunct_sz);
 
     for (int i = 0; i < _conjunct_ctxs.size(); ++i) {
-        EsPredicate* predicate =
-                _pool->add(new EsPredicate(_conjunct_ctxs[i], _tuple_desc, _timezone, _pool));
+        EsPredicate* predicate = _pool->add(new EsPredicate(_conjunct_ctxs[i], _tuple_desc, _timezone, _pool));
         predicate->set_field_context(_fields_context);
         status = predicate->build_disjuncts_list();
         if (status.ok()) {

--- a/be/src/connector/es_connector.cpp
+++ b/be/src/connector/es_connector.cpp
@@ -63,6 +63,17 @@ Status ESDataSource::open(RuntimeState* state) {
         _fields_context = es_scan_node.fields_context;
     }
 
+    {
+        const auto& it = _properties.find(ESScanReader::KEY_TIME_ZONE);
+        if (it != _properties.end()) {
+            // Use user customer timezone
+            _timezone = it->second;
+        } else {
+            // Use default timezone in StarRocks
+            _timezone = _runtime_state->timezone();
+        }
+    }
+
     _tuple_desc = state->desc_tbl().get_tuple_descriptor(es_scan_node.tuple_id);
     DCHECK(_tuple_desc != nullptr);
 
@@ -108,7 +119,7 @@ Status ESDataSource::_build_conjuncts() {
 
     for (int i = 0; i < _conjunct_ctxs.size(); ++i) {
         EsPredicate* predicate =
-                _pool->add(new EsPredicate(_conjunct_ctxs[i], _tuple_desc, _runtime_state->timezone(), _pool));
+                _pool->add(new EsPredicate(_conjunct_ctxs[i], _tuple_desc, _timezone, _pool));
         predicate->set_field_context(_fields_context);
         status = predicate->build_disjuncts_list();
         if (status.ok()) {
@@ -229,7 +240,7 @@ Status ESDataSource::get_next(RuntimeState* state, ChunkPtr* chunk) {
         COUNTER_UPDATE(_read_counter, 1);
         if (_line_eof || _es_scroll_parser == nullptr) {
             RETURN_IF_ERROR(_es_reader->get_next(&_batch_eof, _es_scroll_parser));
-            _es_scroll_parser->set_params(_tuple_desc, &_docvalue_context);
+            _es_scroll_parser->set_params(_tuple_desc, &_docvalue_context, _timezone);
             if (_batch_eof) {
                 return Status::EndOfFile("");
             }

--- a/be/src/connector/es_connector.h
+++ b/be/src/connector/es_connector.h
@@ -79,6 +79,7 @@ private:
     std::map<std::string, std::string> _docvalue_context;
     std::map<std::string, std::string> _fields_context;
     std::vector<std::string> _column_names;
+    std::string _timezone;
 
     // predicate index in the conjuncts
     std::vector<int> _predicate_idx;

--- a/be/src/exec/es/es_scan_reader.cpp
+++ b/be/src/exec/es/es_scan_reader.cpp
@@ -92,7 +92,7 @@ ESScanReader::ESScanReader(const std::string& target, const std::map<std::string
 
     if (props.find(KEY_TERMINATE_AFTER) != props.end()) {
         _exactly_once = true;
-        // just send a normal search  against the elasticsearch with additional terminate_after param to achieve terminate early effect when limit take effect
+        // just send a normal search against the elasticsearch with additional terminate_after param to achieve terminate early effect when limit take effect
         if (_type.empty()) {
             _search_url = fmt::format("{}/{}/_search?terminate_after={}&preference=_shards:{}&{}", _target, _index,
                                       props.at(KEY_TERMINATE_AFTER), _shards, filter_path);

--- a/be/src/exec/es/es_scan_reader.h
+++ b/be/src/exec/es/es_scan_reader.h
@@ -57,6 +57,7 @@ public:
     static constexpr const char* KEY_TERMINATE_AFTER = "limit";
     static constexpr const char* KEY_DOC_VALUES_MODE = "doc_values_mode";
     static constexpr const char* KEY_ES_NET_SSL = "es.net.ssl";
+    static constexpr const char* KEY_TIME_ZONE = "time_zone";
     ESScanReader(const std::string& target, const std::map<std::string, std::string>& props, bool doc_value_mode);
     ~ESScanReader();
 

--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -276,8 +276,7 @@ Status ScrollParser::fill_chunk(RuntimeState* state, ChunkPtr* chunk, bool* line
     return Status::OK();
 }
 
-void ScrollParser::set_params(const TupleDescriptor* descs,
-                              const std::map<std::string, std::string>* docvalue_context,
+void ScrollParser::set_params(const TupleDescriptor* descs, const std::map<std::string, std::string>* docvalue_context,
                               std::string& timezone) {
     _tuple_desc = descs;
     _doc_value_context = docvalue_context;
@@ -618,7 +617,8 @@ Status ScrollParser::_append_array_val_from_source(const rapidjson::Value& val, 
 
 // TODO: test here
 template <LogicalType type, typename T>
-Status ScrollParser::_append_date_val(const rapidjson::Value& col, Column* column, bool pure_doc_value, const std::string& timezone) {
+Status ScrollParser::_append_date_val(const rapidjson::Value& col, Column* column, bool pure_doc_value,
+                                      const std::string& timezone) {
     auto append_timestamp = [](auto& col, Column* column, const std::string& timezone) {
         TimestampValue value;
         value.from_unixtime(col.GetInt64() / 1000, timezone);

--- a/be/src/exec/es/es_scroll_parser.h
+++ b/be/src/exec/es/es_scroll_parser.h
@@ -40,7 +40,8 @@ public:
     int get_size() { return _size; }
     bool current_eos() { return _cur_line == _size; }
 
-    void set_params(const TupleDescriptor* descs, const std::map<std::string, std::string>* docvalue_context, std::string& timezone);
+    void set_params(const TupleDescriptor* descs, const std::map<std::string, std::string>* docvalue_context,
+                    std::string& timezone);
 
 private:
     static bool _is_pure_doc_value(const rapidjson::Value& obj);
@@ -64,7 +65,8 @@ private:
     static Status _append_bool_val(const rapidjson::Value& col, Column* column, bool pure_doc_value);
 
     template <LogicalType type, typename T = RunTimeCppType<type>>
-    static Status _append_date_val(const rapidjson::Value& col, Column* column, bool pure_doc_value, const std::string& timezone);
+    static Status _append_date_val(const rapidjson::Value& col, Column* column, bool pure_doc_value,
+                                   const std::string& timezone);
 
     // The representation of array value in _source and doc_value (column storage) is inconsistent
     // in Elasticsearch, we need to do different processing to show consistent behavior.

--- a/be/src/exec/es/es_scroll_parser.h
+++ b/be/src/exec/es/es_scroll_parser.h
@@ -40,7 +40,7 @@ public:
     int get_size() { return _size; }
     bool current_eos() { return _cur_line == _size; }
 
-    void set_params(const TupleDescriptor* descs, const std::map<std::string, std::string>* docvalue_context);
+    void set_params(const TupleDescriptor* descs, const std::map<std::string, std::string>* docvalue_context, std::string& timezone);
 
 private:
     static bool _is_pure_doc_value(const rapidjson::Value& obj);
@@ -64,7 +64,7 @@ private:
     static Status _append_bool_val(const rapidjson::Value& col, Column* column, bool pure_doc_value);
 
     template <LogicalType type, typename T = RunTimeCppType<type>>
-    static Status _append_date_val(const rapidjson::Value& col, Column* column, bool pure_doc_value);
+    static Status _append_date_val(const rapidjson::Value& col, Column* column, bool pure_doc_value, const std::string& timezone);
 
     // The representation of array value in _source and doc_value (column storage) is inconsistent
     // in Elasticsearch, we need to do different processing to show consistent behavior.
@@ -88,6 +88,7 @@ private:
 
     const TupleDescriptor* _tuple_desc;
     const std::map<std::string, std::string>* _doc_value_context;
+    std::string _timezone;
 
     std::string _scroll_id;
     size_t _size;

--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -102,6 +102,13 @@ Status HttpClient::init(const std::string& url) {
         return Status::InternalError("fail to set CURLOPT_URL");
     }
 
+    // set NoProxy, otherwise elasticsearch may hang when the host enables HTTP_PROXY/HTTPS_PROXY
+    code = curl_easy_setopt(_curl, CURLOPT_NOPROXY, "*");
+    if (code != CURLE_OK) {
+        LOG(WARNING) << "failed to set CURLOPT_NOPROXY, errmsg=" << _to_errmsg(code);
+        return Status::InternalError("fail to set CURLOPT_NOPROXY");
+    }
+
     return Status::OK();
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/EsTable.java
@@ -66,24 +66,25 @@ public class EsTable extends Table {
 
     public static final Set<String> DEFAULT_DOCVALUE_DISABLED_FIELDS = new HashSet<>(Arrays.asList("text"));
 
-    public static final String HOSTS = "hosts";
-    public static final String USER = "user";
-    public static final String PASSWORD = "password";
-    public static final String INDEX = "index";
-    public static final String TYPE = "type";
-    public static final String CATALOG_TYPE = "es.type";
-    public static final String TRANSPORT = "transport";
-    public static final String VERSION = "version";
-    public static final String DOC_VALUES_MODE = "doc_values_mode";
+    public static final String KEY_HOSTS = "hosts";
+    public static final String KEY_USER = "user";
+    public static final String KEY_PASSWORD = "password";
+    public static final String KEY_INDEX = "index";
+    public static final String KEY_TYPE = "type";
+    public static final String KEY_CATALOG_TYPE = "es.type";
+    public static final String KEY_TRANSPORT = "transport";
+    public static final String KEY_VERSION = "version";
+    public static final String KEY_DOC_VALUES_MODE = "doc_values_mode";
 
-    public static final String TRANSPORT_HTTP = "http";
-    public static final String TRANSPORT_THRIFT = "thrift";
-    public static final String DOC_VALUE_SCAN = "enable_docvalue_scan";
-    public static final String KEYWORD_SNIFF = "enable_keyword_sniff";
-    public static final String MAX_DOCVALUE_FIELDS = "max_docvalue_fields";
+    public static final String KEY_TRANSPORT_HTTP = "http";
+    public static final String KEY_TRANSPORT_THRIFT = "thrift";
+    public static final String KEY_DOC_VALUE_SCAN = "enable_docvalue_scan";
+    public static final String KEY_KEYWORD_SNIFF = "enable_keyword_sniff";
+    public static final String KEY_MAX_DOCVALUE_FIELDS = "max_docvalue_fields";
 
-    public static final String WAN_ONLY = "es.nodes.wan.only";
-    public static final String ES_NET_SSL = "es.net.ssl";
+    public static final String KEY_WAN_ONLY = "es.nodes.wan.only";
+    public static final String KEY_ES_NET_SSL = "es.net.ssl";
+    public static final String KEY_TIME_ZONE = "time_zone";
 
     private String hosts;
     private String[] seeds;
@@ -120,6 +121,7 @@ public class EsTable extends Table {
 
     private boolean wanOnly = false;
     private boolean sslEnabled = false;
+    private String timeZone = null;
 
     // version would be used to be compatible with different ES Cluster
     public EsMajorVersion majorVersion = null;
@@ -187,94 +189,94 @@ public class EsTable extends Table {
                     + "they are: hosts, user, password, index");
         }
 
-        if (Strings.isNullOrEmpty(properties.get(HOSTS))
-                || Strings.isNullOrEmpty(properties.get(HOSTS).trim())) {
+        if (Strings.isNullOrEmpty(properties.get(KEY_HOSTS))
+                || Strings.isNullOrEmpty(properties.get(KEY_HOSTS).trim())) {
             throw new DdlException("Hosts of ES table is null. "
                     + "Please add properties('hosts'='xxx.xxx.xxx.xxx,xxx.xxx.xxx.xxx') when create table");
         }
-        hosts = properties.get(HOSTS).trim();
+        hosts = properties.get(KEY_HOSTS).trim();
         seeds = hosts.split(",");
 
-        if (!Strings.isNullOrEmpty(properties.get(USER))
-                && !Strings.isNullOrEmpty(properties.get(USER).trim())) {
-            userName = properties.get(USER).trim();
+        if (!Strings.isNullOrEmpty(properties.get(KEY_USER))
+                && !Strings.isNullOrEmpty(properties.get(KEY_USER).trim())) {
+            userName = properties.get(KEY_USER).trim();
         }
 
-        if (!Strings.isNullOrEmpty(properties.get(PASSWORD))
-                && !Strings.isNullOrEmpty(properties.get(PASSWORD).trim())) {
-            passwd = properties.get(PASSWORD).trim();
+        if (!Strings.isNullOrEmpty(properties.get(KEY_PASSWORD))
+                && !Strings.isNullOrEmpty(properties.get(KEY_PASSWORD).trim())) {
+            passwd = properties.get(KEY_PASSWORD).trim();
         }
 
-        if (Strings.isNullOrEmpty(properties.get(INDEX))
-                || Strings.isNullOrEmpty(properties.get(INDEX).trim())) {
+        if (Strings.isNullOrEmpty(properties.get(KEY_INDEX))
+                || Strings.isNullOrEmpty(properties.get(KEY_INDEX).trim())) {
             throw new DdlException("Index of ES table is null. "
                     + "Please add properties('index'='xxxx') when create table");
         }
-        indexName = properties.get(INDEX).trim();
+        indexName = properties.get(KEY_INDEX).trim();
 
         // Explicit setting for cluster version to avoid detecting version failure
-        if (properties.containsKey(VERSION)) {
+        if (properties.containsKey(KEY_VERSION)) {
             try {
-                majorVersion = EsMajorVersion.parse(properties.get(VERSION).trim());
+                majorVersion = EsMajorVersion.parse(properties.get(KEY_VERSION).trim());
                 if (majorVersion.before(EsMajorVersion.V_5_X)) {
-                    throw new DdlException("Unsupported/Unknown ES Cluster version [" + properties.get(VERSION) + "] ");
+                    throw new DdlException("Unsupported/Unknown ES Cluster version [" + properties.get(KEY_VERSION) + "] ");
                 }
             } catch (Exception e) {
                 throw new DdlException("fail to parse ES major version, version= "
-                        + properties.get(VERSION).trim() + ", should be like '6.5.3' ");
+                        + properties.get(KEY_VERSION).trim() + ", should be like '6.5.3' ");
             }
         }
 
         // enable doc value scan for Elasticsearch
-        if (properties.containsKey(DOC_VALUE_SCAN)) {
+        if (properties.containsKey(KEY_DOC_VALUE_SCAN)) {
             try {
-                enableDocValueScan = Boolean.parseBoolean(properties.get(DOC_VALUE_SCAN).trim());
+                enableDocValueScan = Boolean.parseBoolean(properties.get(KEY_DOC_VALUE_SCAN).trim());
             } catch (Exception e) {
                 throw new DdlException("fail to parse enable_docvalue_scan, enable_docvalue_scan= "
-                        + properties.get(VERSION).trim() + " ,`enable_docvalue_scan`"
+                        + properties.get(KEY_VERSION).trim() + " ,`enable_docvalue_scan`"
                         + " shoud be like 'true' or 'false', value should be double quotation marks");
             }
         }
 
-        if (properties.containsKey(KEYWORD_SNIFF)) {
+        if (properties.containsKey(KEY_KEYWORD_SNIFF)) {
             try {
-                enableKeywordSniff = Boolean.parseBoolean(properties.get(KEYWORD_SNIFF).trim());
+                enableKeywordSniff = Boolean.parseBoolean(properties.get(KEY_KEYWORD_SNIFF).trim());
             } catch (Exception e) {
                 throw new DdlException("fail to parse enable_keyword_sniff, enable_keyword_sniff= "
-                        + properties.get(VERSION).trim() + " ,`enable_keyword_sniff`"
+                        + properties.get(KEY_VERSION).trim() + " ,`enable_keyword_sniff`"
                         + " shoud be like 'true' or 'false', value should be double quotation marks");
             }
         } else {
             enableKeywordSniff = true;
         }
 
-        if (!Strings.isNullOrEmpty(properties.get(TYPE))
-                && !Strings.isNullOrEmpty(properties.get(TYPE).trim())) {
+        if (!Strings.isNullOrEmpty(properties.get(KEY_TYPE))
+                && !Strings.isNullOrEmpty(properties.get(KEY_TYPE).trim())) {
             // just for compatible external es table definition
             // type in catalog means that such as es/hive/iceberg, but type in table properties also can be defined.
-            if (!"es".equalsIgnoreCase(properties.get(TYPE).trim())) {
-                mappingType = properties.get(TYPE).trim();
+            if (!"es".equalsIgnoreCase(properties.get(KEY_TYPE).trim())) {
+                mappingType = properties.get(KEY_TYPE).trim();
             } else {
-                if (!Strings.isNullOrEmpty(properties.get(CATALOG_TYPE))
-                        && !Strings.isNullOrEmpty(properties.get(CATALOG_TYPE).trim())) {
-                    mappingType = properties.get(CATALOG_TYPE).trim();
+                if (!Strings.isNullOrEmpty(properties.get(KEY_CATALOG_TYPE))
+                        && !Strings.isNullOrEmpty(properties.get(KEY_CATALOG_TYPE).trim())) {
+                    mappingType = properties.get(KEY_CATALOG_TYPE).trim();
                 }
             }
         } else {
             mappingType = null;
         }
-        if (!Strings.isNullOrEmpty(properties.get(TRANSPORT))
-                && !Strings.isNullOrEmpty(properties.get(TRANSPORT).trim())) {
-            transport = properties.get(TRANSPORT).trim();
-            if (!(TRANSPORT_HTTP.equals(transport) || TRANSPORT_THRIFT.equals(transport))) {
+        if (!Strings.isNullOrEmpty(properties.get(KEY_TRANSPORT))
+                && !Strings.isNullOrEmpty(properties.get(KEY_TRANSPORT).trim())) {
+            transport = properties.get(KEY_TRANSPORT).trim();
+            if (!(KEY_TRANSPORT_HTTP.equals(transport) || KEY_TRANSPORT_THRIFT.equals(transport))) {
                 throw new DdlException("transport of ES table must be http(recommend) or thrift(reserved inner usage),"
                         + " but value is " + transport);
             }
         }
 
-        if (properties.containsKey(MAX_DOCVALUE_FIELDS)) {
+        if (properties.containsKey(KEY_MAX_DOCVALUE_FIELDS)) {
             try {
-                maxDocValueFields = Integer.parseInt(properties.get(MAX_DOCVALUE_FIELDS).trim());
+                maxDocValueFields = Integer.parseInt(properties.get(KEY_MAX_DOCVALUE_FIELDS).trim());
                 if (maxDocValueFields < 0) {
                     maxDocValueFields = 0;
                 }
@@ -283,20 +285,24 @@ public class EsTable extends Table {
             }
         }
 
-        if (properties.containsKey(WAN_ONLY)) {
+        if (properties.containsKey(KEY_WAN_ONLY)) {
             try {
-                wanOnly = Boolean.parseBoolean(properties.get(WAN_ONLY).trim());
+                wanOnly = Boolean.parseBoolean(properties.get(KEY_WAN_ONLY).trim());
             } catch (Exception e) {
                 wanOnly = false;
             }
         }
-        if (properties.containsKey(ES_NET_SSL)) {
+        if (properties.containsKey(KEY_ES_NET_SSL)) {
             try {
-                sslEnabled = Boolean.parseBoolean(properties.get(ES_NET_SSL).trim());
+                sslEnabled = Boolean.parseBoolean(properties.get(KEY_ES_NET_SSL).trim());
             } catch (Exception e) {
                 sslEnabled = false;
             }
         }
+        if (properties.containsKey(KEY_TIME_ZONE)) {
+            timeZone = properties.get(KEY_TIME_ZONE).trim();
+        }
+
         Column idColumn = getColumn("_id");
         if (idColumn != null && !(idColumn.getPrimitiveType() == PrimitiveType.VARCHAR
                 || idColumn.getPrimitiveType() == PrimitiveType.CHAR)) {
@@ -317,7 +323,7 @@ public class EsTable extends Table {
         tableContext.put("enableKeywordSniff", String.valueOf(enableKeywordSniff));
         tableContext.put("maxDocValueFields", String.valueOf(maxDocValueFields));
         tableContext.put("es.nodes.wan.only", String.valueOf(wanOnly));
-        tableContext.put(ES_NET_SSL, String.valueOf(sslEnabled));
+        tableContext.put(KEY_ES_NET_SSL, String.valueOf(sslEnabled));
     }
 
     @Override
@@ -403,13 +409,13 @@ public class EsTable extends Table {
                 maxDocValueFields = DEFAULT_MAX_DOCVALUE_FIELDS;
             }
         }
-        if (tableContext.containsKey(WAN_ONLY)) {
-            wanOnly = Boolean.parseBoolean(tableContext.get(WAN_ONLY));
+        if (tableContext.containsKey(KEY_WAN_ONLY)) {
+            wanOnly = Boolean.parseBoolean(tableContext.get(KEY_WAN_ONLY));
         } else {
             wanOnly = false;
         }
-        if (tableContext.containsKey(ES_NET_SSL)) {
-            sslEnabled = Boolean.parseBoolean(tableContext.get(ES_NET_SSL));
+        if (tableContext.containsKey(KEY_ES_NET_SSL)) {
+            sslEnabled = Boolean.parseBoolean(tableContext.get(KEY_ES_NET_SSL));
         } else {
             sslEnabled = false;
         }
@@ -450,6 +456,10 @@ public class EsTable extends Table {
 
     public String getTransport() {
         return transport;
+    }
+
+    public String getTimeZone() {
+        return timeZone;
     }
 
     public PartitionInfo getPartitionInfo() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorFactory.java
@@ -21,7 +21,7 @@ import org.apache.logging.log4j.Logger;
 import java.lang.reflect.Constructor;
 
 public class ConnectorFactory {
-    private static Logger LOG = LogManager.getLogger(ConnectorFactory.class);
+    private static final Logger LOG = LogManager.getLogger(ConnectorFactory.class);
 
     /**
      * create a connector instance

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/ElasticsearchMetadata.java
@@ -76,7 +76,7 @@ public class ElasticsearchMetadata
                                     String tableName, String dbName, String catalogName) {
         try {
             List<Column> columns = EsUtil.convertColumnSchema(esRestClient, tableName);
-            properties.put(EsTable.INDEX, tableName);
+            properties.put(EsTable.KEY_INDEX, tableName);
             EsTable esTable = new EsTable(CONNECTOR_ID_GENERATOR.getNextId().asInt(),
                     catalogName, dbName, tableName, columns, properties, new SinglePartitionInfo());
             esTable.setComment("created by external es catalog");

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsConfig.java
@@ -17,43 +17,43 @@ package com.starrocks.connector.elasticsearch;
 import com.starrocks.connector.config.Config;
 import com.starrocks.connector.config.ConnectorConfig;
 
-import static com.starrocks.catalog.EsTable.DOC_VALUE_SCAN;
-import static com.starrocks.catalog.EsTable.ES_NET_SSL;
-import static com.starrocks.catalog.EsTable.HOSTS;
-import static com.starrocks.catalog.EsTable.KEYWORD_SNIFF;
-import static com.starrocks.catalog.EsTable.PASSWORD;
-import static com.starrocks.catalog.EsTable.USER;
-import static com.starrocks.catalog.EsTable.WAN_ONLY;
+import static com.starrocks.catalog.EsTable.KEY_DOC_VALUE_SCAN;
+import static com.starrocks.catalog.EsTable.KEY_ES_NET_SSL;
+import static com.starrocks.catalog.EsTable.KEY_HOSTS;
+import static com.starrocks.catalog.EsTable.KEY_KEYWORD_SNIFF;
+import static com.starrocks.catalog.EsTable.KEY_PASSWORD;
+import static com.starrocks.catalog.EsTable.KEY_USER;
+import static com.starrocks.catalog.EsTable.KEY_WAN_ONLY;
 
 public class EsConfig extends ConnectorConfig {
 
-    @Config(key = HOSTS, desc = "user when connecting es cluster", defaultValue = "", nullable = false)
+    @Config(key = KEY_HOSTS, desc = "user when connecting es cluster", defaultValue = "", nullable = false)
     private String[] nodes;
 
-    @Config(key = USER, desc = "user when connecting es cluster", defaultValue = "")
+    @Config(key = KEY_USER, desc = "user when connecting es cluster", defaultValue = "")
     private String userName = null;
 
-    @Config(key = PASSWORD, desc = "password when connecting es cluster", defaultValue = "")
+    @Config(key = KEY_PASSWORD, desc = "password when connecting es cluster", defaultValue = "")
     private String password = null;
 
-    @Config(key = ES_NET_SSL,
+    @Config(key = KEY_ES_NET_SSL,
             desc = " Whether the HTTPS protocol can be used to access your Elasticsearch cluster",
             defaultValue = "false")
     private boolean enableSsl;
 
-    @Config(key = WAN_ONLY,
+    @Config(key = KEY_WAN_ONLY,
             desc = "indicates whether StarRocks only uses the addresses specified by hosts to access the " +
                     "Elasticsearch cluster and fetch data",
             defaultValue = "true")
     private boolean enableWanOnly;
 
-    @Config(key = DOC_VALUE_SCAN,
+    @Config(key = KEY_DOC_VALUE_SCAN,
             desc = "Whether to enable docvalues scan optimization for fetching fields more fast",
             defaultValue = "true")
     private boolean enableDocValueScan;
     
-    @Config(key = KEYWORD_SNIFF,
-            desc = " Whether to enable sniffing keyword for filtering more reasonable",
+    @Config(key = KEY_KEYWORD_SNIFF,
+            desc = "Whether to enable sniffing keyword for filtering more reasonable",
             defaultValue = "true")
     private boolean enableKeywordSniff;
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/PartitionPhase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/PartitionPhase.java
@@ -54,7 +54,7 @@ public class PartitionPhase implements SearchPhase {
     @Override
     public void postProcess(SearchContext context) throws StarRocksConnectorException {
         context.partitions(shardPartitions);
-        if (EsTable.TRANSPORT_HTTP.equals(context.esTable().getTransport())) {
+        if (EsTable.KEY_TRANSPORT_HTTP.equals(context.esTable().getTransport())) {
             context.partitions().addHttpAddress(nodesInfo);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/EsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/EsScanNode.java
@@ -139,20 +139,25 @@ public class EsScanNode extends ScanNode {
 
     @Override
     protected void toThrift(TPlanNode msg) {
-        if (EsTable.TRANSPORT_HTTP.equals(table.getTransport())) {
+        if (EsTable.KEY_TRANSPORT_HTTP.equals(table.getTransport())) {
             msg.node_type = TPlanNodeType.ES_HTTP_SCAN_NODE;
         } else {
             msg.node_type = TPlanNodeType.ES_SCAN_NODE;
         }
         Map<String, String> properties = Maps.newHashMap();
-        properties.put(EsTable.USER, table.getUserName());
-        properties.put(EsTable.PASSWORD, table.getPasswd());
-        properties.put(EsTable.ES_NET_SSL, String.valueOf(table.sslEnabled()));
+        properties.put(EsTable.KEY_USER, table.getUserName());
+        properties.put(EsTable.KEY_PASSWORD, table.getPasswd());
+        properties.put(EsTable.KEY_ES_NET_SSL, String.valueOf(table.sslEnabled()));
+        String time_zone = table.getTimeZone();
+        if (time_zone != null) {
+            // If user has set timezone, we need to send it to BE
+            properties.put(EsTable.KEY_TIME_ZONE, time_zone);
+        }
         TEsScanNode esScanNode = new TEsScanNode(desc.getId().asInt());
         esScanNode.setProperties(properties);
         if (table.isDocValueScanEnable()) {
             esScanNode.setDocvalue_context(table.docValueContext());
-            properties.put(EsTable.DOC_VALUES_MODE, String.valueOf(useDocValueScan(desc, table.docValueContext())));
+            properties.put(EsTable.KEY_DOC_VALUES_MODE, String.valueOf(useDocValueScan(desc, table.docValueContext())));
         }
         if (table.isKeywordSniffEnable() && table.fieldsContext().size() > 0) {
             esScanNode.setFields_context(table.fieldsContext());
@@ -185,7 +190,7 @@ public class EsScanNode extends ScanNode {
                 int numBe = Math.min(3, size);
                 List<TNetworkAddress> shardAllocations = new ArrayList<>();
                 for (EsShardRouting item : shardRouting) {
-                    shardAllocations.add(EsTable.TRANSPORT_HTTP.equals(table.getTransport()) ? item.getHttpAddress() :
+                    shardAllocations.add(EsTable.KEY_TRANSPORT_HTTP.equals(table.getTransport()) ? item.getHttpAddress() :
                             item.getAddress());
                 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
@@ -246,13 +246,13 @@ public class GlobalStateMgrTestUtil {
 
         RangePartitionInfo partitionInfo = new RangePartitionInfo(partitionColumns);
         Map<String, String> properties = Maps.newHashMap();
-        properties.put(EsTable.HOSTS, "xxx");
-        properties.put(EsTable.INDEX, "doe");
-        properties.put(EsTable.TYPE, "doc");
-        properties.put(EsTable.PASSWORD, "");
-        properties.put(EsTable.USER, "root");
-        properties.put(EsTable.DOC_VALUE_SCAN, "true");
-        properties.put(EsTable.KEYWORD_SNIFF, "true");
+        properties.put(EsTable.KEY_HOSTS, "xxx");
+        properties.put(EsTable.KEY_INDEX, "doe");
+        properties.put(EsTable.KEY_TYPE, "doc");
+        properties.put(EsTable.KEY_PASSWORD, "");
+        properties.put(EsTable.KEY_USER, "root");
+        properties.put(EsTable.KEY_DOC_VALUE_SCAN, "true");
+        properties.put(EsTable.KEY_KEYWORD_SNIFF, "true");
         EsTable esTable = new EsTable(testEsTableId1, testEsTable1,
                 columns, properties, partitionInfo);
         db.createTable(esTable);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsTestCase.java
@@ -87,10 +87,10 @@ public class EsTestCase {
 
     public EsTable fakeEsTable(String table, String index, String type, List<Column> columns) throws DdlException {
         Map<String, String> props = new HashMap<>();
-        props.put(EsTable.HOSTS, "127.0.0.1:8200");
-        props.put(EsTable.INDEX, index);
-        props.put(EsTable.TYPE, type);
-        props.put(EsTable.VERSION, "6.5.3");
+        props.put(EsTable.KEY_HOSTS, "127.0.0.1:8200");
+        props.put(EsTable.KEY_INDEX, index);
+        props.put(EsTable.KEY_TYPE, type);
+        props.put(EsTable.KEY_VERSION, "6.5.3");
         return new EsTable(new Random().nextLong(), table, columns, props, null);
 
     }

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -191,11 +191,11 @@ public abstract class StarRocksHttpTestCase {
         partitionInfo.setReplicationNum(testPartitionId + 100, (short) 3);
         EsTable table = null;
         Map<String, String> props = new HashMap<>();
-        props.put(EsTable.HOSTS, "http://node-1:8080");
-        props.put(EsTable.USER, "root");
-        props.put(EsTable.PASSWORD, "root");
-        props.put(EsTable.INDEX, "test");
-        props.put(EsTable.TYPE, "doc");
+        props.put(EsTable.KEY_HOSTS, "http://node-1:8080");
+        props.put(EsTable.KEY_USER, "root");
+        props.put(EsTable.KEY_PASSWORD, "root");
+        props.put(EsTable.KEY_INDEX, "test");
+        props.put(EsTable.KEY_TYPE, "doc");
         try {
             table = new EsTable(testTableId + 1, name, columns, props, partitionInfo);
         } catch (DdlException e) {


### PR DESCRIPTION
## Problem Summary:

* Fix ES hang when BE enables HTTP_PROXY/HTTPS_PROXY
* Introduce timezone properties `time_zone` for ES table/catalog. Because many users will insert data into ES with UTC time, but SR query from ES will use +08:00 time, it will occur user's predicates will not be matched. If the user `SET time_zone=+00:00` in SR, the user will worry that may affect other SR query's correctness. So we introduce this property, it will only affect specific ES table/catalog.

Example:
```sql
CREATE EXTERNAL TABLE es_table_timezone
(
    id int,
    create_date datetime
)
ENGINE=ELASTICSEARCH
PROPERTIES 
(
    "hosts" = "http://127.0.0.1:9200",
    "index" = "bug",
    "time_zone" = "+00:00"
);
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
