### PR TITLE
[BugFix] avoid partition version change when building plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -235,8 +235,8 @@ public class StatementPlanner {
                 isSchemaValid = olapTables.stream().noneMatch(t ->
                         t.lastSchemaUpdateTime.get() > planStartTime);
                 isPartitionVersionConsistent = olapTables.stream().allMatch(t ->
-                        t.lastVersionUpdateEndTime.get() < buildFragmentStartTime &&
-                                t.lastVersionUpdateEndTime.get() >= t.lastVersionUpdateStartTime.get());
+                        t.lastVersionUpdateEndTime.get() >= t.lastVersionUpdateStartTime.get() &&
+                                t.lastVersionUpdateEndTime.get() < buildFragmentStartTime);
                 if (isSchemaValid && isPartitionVersionConsistent) {
                     return plan;
                 }


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

![img_v2_22f32254-14ba-4c3e-90bf-96ceae67e7dg](https://github.com/StarRocks/starrocks/assets/110370499/ffd481ee-f934-4359-acf9-4e4eb904204c)
A possible scenario is as follows:
The `lastVersionUpdateEndTime` may update when this step `t.lastVersionUpdateEndTime.get() >= t.lastVersionUpdateStartTime.get()` which may lead to use a new version data after query begin. Change the order to ensure the `lastVersionUpdateEndTime` is small than `buildFragmentStartTime`.



## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
