### PR TITLE
[BugFix] add sys_log_to_config to a new line in the fe.conf

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -83,7 +83,7 @@ if [ ! -f "$JAVA_HOME/bin/javac" ]; then
 fi
 
 JAVA=$JAVA_HOME/bin/java
- 
+
 # check java version and choose correct JAVA_OPTS
 JAVA_VERSION=$(jdk_version)
 final_java_opt=$JAVA_OPTS
@@ -91,7 +91,7 @@ if [[ "$JAVA_VERSION" -gt 8 ]]; then
     if [ -z "$JAVA_OPTS_FOR_JDK_9" ]; then
         echo "JAVA_OPTS_FOR_JDK_9 is not set in fe.conf"
         exit -1
-    fi 
+    fi
     final_java_opt=$JAVA_OPTS_FOR_JDK_9
 fi
 
@@ -150,7 +150,7 @@ if [ ${RUN_LOG_CONSOLE} -eq 1 ] ; then
         cp $STARROCKS_HOME/conf/fe.conf.readonly $STARROCKS_HOME/conf/fe.conf
     fi
     # force sys_log_to_console = true
-    echo "sys_log_to_console = true" >> $STARROCKS_HOME/conf/fe.conf
+    echo -e "\nsys_log_to_console = true" >> $STARROCKS_HOME/conf/fe.conf
 else
     # redirect all subsequent commands' stdout/stderr into $LOG_FILE
     exec &>> $LOG_FILE


### PR DESCRIPTION
## Problem Summary:
Helm chart strips off all the trailing empty lines when creating the `fe.conf` file from configmap.
As a result, when echoing a new line of config, it just appends it to the end of the last line in `fe.conf` instead of adding a new line of config. 

## What type of PR is this:
- [X] BugFix


## Checklist:
- [] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto backported to target branch
  - [X] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
