### PR TITLE
[BugFix] Fix hour partitioned mv refresh range error.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -47,7 +47,6 @@ import com.starrocks.alter.AlterJobV2Builder;
 import com.starrocks.alter.OlapTableAlterJobV2Builder;
 import com.starrocks.analysis.DescriptorTable.ReferencedPartitionInfo;
 import com.starrocks.analysis.Expr;
-import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
@@ -1149,11 +1148,10 @@ public class OlapTable extends Table {
             throw new AnalysisException("Unsupported partition type: " + partitionType);
         }
 
-        LiteralExpr startExpr = sortedRange.get(startIndex).lowerEndpoint().
-                getKeys().get(0);
-        LiteralExpr endExpr = sortedRange.get(partitionNum - 1).upperEndpoint().getKeys().get(0);
-        String start = AnalyzerUtils.parseLiteralExprToDateString(startExpr, 0);
-        String end = AnalyzerUtils.parseLiteralExprToDateString(endExpr, 0);
+        PartitionKey lowerEndpoint = sortedRange.get(startIndex).lowerEndpoint();
+        PartitionKey upperEndpoint = sortedRange.get(partitionNum - 1).upperEndpoint();
+        String start = AnalyzerUtils.parseLiteralExprToDateString(lowerEndpoint, 0);
+        String end = AnalyzerUtils.parseLiteralExprToDateString(upperEndpoint, 0);
 
         Map<String, Range<PartitionKey>> result = Maps.newHashMap();
         Range<PartitionKey> rangeToInclude = SyncPartitionUtils.createRange(start, end, partitionColumn);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.IsNullPredicate;
-import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.BaseTableInfo;
@@ -256,8 +255,7 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         if (partitionNameIter.hasNext()) {
             String startPartitionName = partitionNameIter.next();
             Range<PartitionKey> partitionKeyRange = mappedPartitionsToRefresh.get(startPartitionName);
-            LiteralExpr lowerExpr = partitionKeyRange.lowerEndpoint().getKeys().get(0);
-            nextPartitionStart = AnalyzerUtils.parseLiteralExprToDateString(lowerExpr, 0);
+            nextPartitionStart = AnalyzerUtils.parseLiteralExprToDateString(partitionKeyRange.lowerEndpoint(), 0);
             endPartitionName = startPartitionName;
             partitionsToRefresh.remove(endPartitionName);
         }
@@ -269,8 +267,8 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         mvContext.setNextPartitionStart(nextPartitionStart);
 
         if (endPartitionName != null) {
-            LiteralExpr upperExpr = mappedPartitionsToRefresh.get(endPartitionName).upperEndpoint().getKeys().get(0);
-            mvContext.setNextPartitionEnd(AnalyzerUtils.parseLiteralExprToDateString(upperExpr, 1));
+            PartitionKey upperEndpoint = mappedPartitionsToRefresh.get(endPartitionName).upperEndpoint();
+            mvContext.setNextPartitionEnd(AnalyzerUtils.parseLiteralExprToDateString(upperEndpoint, 0));
         } else {
             // partitionNameIter has just been traversed, and endPartitionName is not updated
             // will cause endPartitionName == null

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -16,26 +16,38 @@ package com.starrocks.analysis;
 
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
+import com.starrocks.sql.ast.DmlStmt;
+import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
+import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class RefreshMaterializedViewTest {
@@ -249,5 +261,108 @@ public class RefreshMaterializedViewTest {
             Assert.assertTrue(partitionsToRefresh.isEmpty());
             Assert.assertEquals(cachePartitionsToRefresh, partitionsToRefresh);
         }
+    }
+
+    @Test
+    public void testRefreshHourPartitionMv() throws Exception {
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+                if (stmt instanceof InsertStmt) {
+                    InsertStmt insertStmt = (InsertStmt) stmt;
+                    TableName tableName = insertStmt.getTableName();
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb(stmt.getTableName().getDb());
+                    OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
+                    for (Partition partition : tbl.getPartitions()) {
+                        if (insertStmt.getTargetPartitionIds().contains(partition.getId())) {
+                            long version = partition.getVisibleVersion() + 1;
+                            partition.setVisibleVersion(version, System.currentTimeMillis());
+                            MaterializedIndex baseIndex = partition.getBaseIndex();
+                            List<Tablet> tablets = baseIndex.getTablets();
+                            for (Tablet tablet : tablets) {
+                                List<Replica> replicas = ((LocalTablet) tablet).getImmutableReplicas();
+                                for (Replica replica : replicas) {
+                                    replica.updateVersionInfo(version, -1, version);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        starRocksAssert.useDatabase("test")
+                .withTable("CREATE TABLE `test`.`tbl_with_hour_partition` (\n" +
+                        "  `k1` datetime,\n" +
+                        "  `k2` int,\n" +
+                        "  `v1` string\n" +
+                        ") ENGINE=OLAP\n" +
+                        "DUPLICATE KEY(`k1`, `k2`)\n" +
+                        "PARTITION BY RANGE(`k1`)\n" +
+                        "(\n" +
+                        "PARTITION p2023041015 VALUES [(\"2023-04-10 15:00:00\"), (\"2023-04-10 16:00:00\")),\n" +
+                        "PARTITION p2023041016 VALUES [(\"2023-04-10 16:00:00\"), (\"2023-04-10 17:00:00\")),\n" +
+                        "PARTITION p2023041017 VALUES [(\"2023-04-10 17:00:00\"), (\"2023-04-10 18:00:00\")),\n" +
+                        "PARTITION p2023041018 VALUES [(\"2023-04-10 18:00:00\"), (\"2023-04-10 19:00:00\"))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                        "PROPERTIES (\"replication_num\" = \"1\");")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `mv_with_hour_partiton`\n" +
+                        "PARTITION BY (date_trunc('hour', `k1`))\n" +
+                        "REFRESH DEFERRED MANUAL \n" +
+                        "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                        "PROPERTIES (\"replication_num\" = \"1\", \"partition_refresh_number\"=\"1\")\n" +
+                        "AS\n" +
+                        "SELECT \n" +
+                        "k1,\n" +
+                        "count(DISTINCT `v1`) AS `v` \n" +
+                        "FROM `test`.`tbl_with_hour_partition`\n" +
+                        "group by k1;");
+        starRocksAssert.updateTablePartitionVersion("test", "tbl_with_hour_partition", 2);
+        starRocksAssert.refreshMvPartition("REFRESH MATERIALIZED VIEW test.mv_with_hour_partiton \n" +
+                "PARTITION START (\"2023-04-10 15:00:00\") END (\"2023-04-10 17:00:00\");");
+        MaterializedView mv1 = getMv("test", "mv_with_hour_partiton");
+        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> versionMap1 =
+                mv1.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+        Assert.assertEquals(1, versionMap1.size());
+        Set<String> partitions1 = versionMap1.values().iterator().next().keySet();
+        Assert.assertEquals(2, partitions1.size());
+
+        starRocksAssert.useDatabase("test")
+                .withTable("CREATE TABLE `test`.`tbl_with_day_partition` (\n" +
+                        "  `k1` date,\n" +
+                        "  `k2` int,\n" +
+                        "  `v1` string\n" +
+                        ") ENGINE=OLAP\n" +
+                        "DUPLICATE KEY(`k1`, `k2`)\n" +
+                        "PARTITION BY RANGE(`k1`)\n" +
+                        "(\n" +
+                        "PARTITION p20230410 VALUES [(\"2023-04-10\"), (\"2023-04-11\")),\n" +
+                        "PARTITION p20230411 VALUES [(\"2023-04-11\"), (\"2023-04-12\")),\n" +
+                        "PARTITION p20230412 VALUES [(\"2023-04-12\"), (\"2023-04-13\")),\n" +
+                        "PARTITION p20230413 VALUES [(\"2023-04-13\"), (\"2023-04-14\"))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                        "PROPERTIES (\"replication_num\" = \"1\");")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `mv_with_day_partiton`\n" +
+                        "PARTITION BY (date_trunc('day', `k1`))\n" +
+                        "REFRESH DEFERRED MANUAL \n" +
+                        "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                        "PROPERTIES (\"replication_num\" = \"1\", \"partition_refresh_number\"=\"1\")\n" +
+                        "AS\n" +
+                        "SELECT \n" +
+                        "k1,\n" +
+                        "count(DISTINCT `v1`) AS `v` \n" +
+                        "FROM `test`.`tbl_with_day_partition`\n" +
+                        "group by k1;");
+        starRocksAssert.updateTablePartitionVersion("test", "tbl_with_day_partition", 2);
+        starRocksAssert.refreshMvPartition("REFRESH MATERIALIZED VIEW test.mv_with_day_partiton \n" +
+                "PARTITION START (\"2023-04-10\") END (\"2023-04-13\");");
+        MaterializedView mv2 = getMv("test", "mv_with_day_partiton");
+        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> versionMap2 =
+                mv2.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+        Assert.assertEquals(1, versionMap2.size());
+        Set<String> partitions2 = versionMap2.values().iterator().next().keySet();
+        Assert.assertEquals(3, partitions2.size());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessorTest.java
@@ -1679,7 +1679,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
 
         mvContext = processor.getMvContext();
         Assert.assertEquals("2022-03-01", mvContext.getNextPartitionStart());
-        Assert.assertEquals("2022-05-02", mvContext.getNextPartitionEnd());
+        Assert.assertEquals("2022-05-01", mvContext.getNextPartitionEnd());
 
         taskRun.executeTaskRun();
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -38,8 +38,14 @@ import com.google.common.base.Preconditions;
 import com.starrocks.alter.AlterJobV2;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -53,6 +59,12 @@ import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.scheduler.MvTaskRunContext;
+import com.starrocks.scheduler.PartitionBasedMaterializedViewRefreshProcessor;
+import com.starrocks.scheduler.Task;
+import com.starrocks.scheduler.TaskBuilder;
+import com.starrocks.scheduler.TaskRun;
+import com.starrocks.scheduler.TaskRunBuilder;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.AlterTableStmt;
@@ -72,6 +84,8 @@ import com.starrocks.sql.ast.DropDbStmt;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.LoadStmt;
+import com.starrocks.sql.ast.PartitionRangeDesc;
+import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.sql.ast.ShowResourceGroupStmt;
 import com.starrocks.sql.ast.ShowTabletStmt;
 import com.starrocks.sql.ast.StatementBase;
@@ -79,9 +93,11 @@ import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.system.BackendCoreStat;
 import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.util.ThreadUtil;
 import org.junit.Assert;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -291,6 +307,61 @@ public class StarRocksAssert {
         }
         checkAlterJob();
         return this;
+    }
+
+    public StarRocksAssert refreshMvPartition(String sql) throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        if (stmt instanceof RefreshMaterializedViewStatement) {
+            RefreshMaterializedViewStatement refreshMaterializedViewStatement = (RefreshMaterializedViewStatement) stmt;
+
+            TableName mvName = refreshMaterializedViewStatement.getMvName();
+            Database db = GlobalStateMgr.getCurrentState().getDb(mvName.getDb());
+            Table table = db.getTable(mvName.getTbl());
+            Assert.assertNotNull(table);
+            Assert.assertTrue(table instanceof MaterializedView);
+            MaterializedView mv = (MaterializedView) table;
+
+            HashMap<String, String> taskRunProperties = new HashMap<>();
+            PartitionRangeDesc range = refreshMaterializedViewStatement.getPartitionRangeDesc();
+            taskRunProperties.put(TaskRun.PARTITION_START, range == null ? null : range.getPartitionStart());
+            taskRunProperties.put(TaskRun.PARTITION_END, range == null ? null : range.getPartitionEnd());
+            taskRunProperties.put(TaskRun.FORCE, "true");
+
+            Task task = TaskBuilder.rebuildMvTask(mv, "test", taskRunProperties);
+            TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(taskRunProperties).build();
+            taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+            taskRun.executeTaskRun();
+            waitingTaskFinish(taskRun);
+        }
+        return this;
+    }
+
+    private void waitingTaskFinish(TaskRun taskRun) {
+        MvTaskRunContext mvContext = ((PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor()).getMvContext();
+        int retryCount = 0;
+        int maxRetry = 5;
+        while (retryCount < maxRetry) {
+            ThreadUtil.sleepAtLeastIgnoreInterrupts(2000L);
+            if (mvContext.getNextPartitionStart() == null && mvContext.getNextPartitionEnd() == null) {
+                break;
+            }
+            retryCount++;
+        }
+    }
+
+    public void updateTablePartitionVersion(String dbName, String tableName, long version) {
+        Table table = GlobalStateMgr.getCurrentState().getDb(dbName).getTable(tableName);
+        for (Partition partition : table.getPartitions()) {
+            partition.setVisibleVersion(version, System.currentTimeMillis());
+            MaterializedIndex baseIndex = partition.getBaseIndex();
+            List<Tablet> tablets = baseIndex.getTablets();
+            for (Tablet tablet : tablets) {
+                List<Replica> replicas = ((LocalTablet) tablet).getImmutableReplicas();
+                for (Replica replica : replicas) {
+                    replica.updateVersionInfo(version, -1, version);
+                }
+            }
+        }
     }
     
     // Add rollup


### PR DESCRIPTION
## Problem Summary:
* change next partiton range format with partition key type.
* change mv next task upper endpoint with '0 offset', same behavior as `partition_refresh_number` not configured

Create mv with property `partition_refresh_number` will split to multi tasks, but next batch bound stash in mvContext format as DATE, cause problem when mv with hour partition. 


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
