### PR TITLE
[Enhancement] support session var partial_update_mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -424,6 +424,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_STRICT_TYPE = "enable_strict_type";
 
+    public static final String PARTIAL_UPDATE_MODE = "partial_update_mode";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -930,6 +932,18 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_REWRITE_SIMPLE_AGG_TO_META_SCAN)
     private boolean enableRewriteSimpleAggToMetaScan = false;
+
+    // support auto|row|column
+    @VariableMgr.VarAttr(name = PARTIAL_UPDATE_MODE)
+    private String partialUpdateMode = "auto";
+
+    public void setPartialUpdateMode(String mode) {
+        this.partialUpdateMode = mode;
+    }
+
+    public String getPartialUpdateMode() {
+        return this.partialUpdateMode;
+    }
 
     public boolean isEnableSortAggregate() {
         return enableSortAggregate;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableVarConverters.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableVarConverters.java
@@ -33,6 +33,8 @@ public class VariableVarConverters {
     static {
         SqlModeConverter sqlModeConverter = new SqlModeConverter();
         CONVERTERS.put(SessionVariable.SQL_MODE, sqlModeConverter);
+        PartialUpdateModeConverter partialUpdateModeConverter = new PartialUpdateModeConverter();
+        CONVERTERS.put(SessionVariable.PARTIAL_UPDATE_MODE, partialUpdateModeConverter);
     }
 
     public static String convert(String varName, String value) throws DdlException {
@@ -49,6 +51,18 @@ public class VariableVarConverters {
         @Override
         public String convert(String value) throws DdlException {
             return SqlModeHelper.encode(value).toString();
+        }
+    }
+
+    // Converter to convert and check var `partial_update_mode`
+    public static class PartialUpdateModeConverter implements VariableVarConverterI {
+        @Override
+        public String convert(String value) throws DdlException {
+            if (value.equals("auto") || value.equals("row") || value.equals("column")) {
+                return value;
+            } else {
+                throw new DdlException("partial_update_mode only support auto|row|column");
+            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/UpdateAnalyzer.java
@@ -87,14 +87,25 @@ public class UpdateAnalyzer {
             }
         }
 
-        if (updateStmt.getWherePredicate() == null) {
-            if (checkIfUsePartialUpdate(assignmentList.size(), table.getBaseSchema().size())) {
-                // use partial update if:
-                // 1. Columns updated are less than 4
-                // 2. The proportion of columns updated is less than 30%
-                // 3. No where predicate in update stmt
-                updateStmt.setUsePartialUpdate();
-            } else {
+        if (session.getSessionVariable().getPartialUpdateMode().equals("column")) {
+            // use partial update by column
+            updateStmt.setUsePartialUpdate();
+        } else if (session.getSessionVariable().getPartialUpdateMode().equals("auto")) {
+            // decide by default rules
+            if (updateStmt.getWherePredicate() == null) {
+                if (checkIfUsePartialUpdate(assignmentList.size(), table.getBaseSchema().size())) {
+                    // use partial update if:
+                    // 1. Columns updated are less than 4
+                    // 2. The proportion of columns updated is less than 30%
+                    // 3. No where predicate in update stmt
+                    updateStmt.setUsePartialUpdate();
+                } else {
+                    throw new SemanticException("must specify where clause to prevent full table update");
+                }
+            }
+        } else {
+            // when var `partial_update_mode` == row, use full columns update instead of partial update
+            if (updateStmt.getWherePredicate() == null) {
                 throw new SemanticException("must specify where clause to prevent full table update");
             }
         }

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update_session_var
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update_session_var
@@ -1,0 +1,119 @@
+-- name: test_partial_update_session_var
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "100", 100, "100", "100");
+-- result:
+-- !result
+insert into tab1 values (200, "100", 100, "100", "100");
+-- result:
+-- !result
+insert into tab1 values (300, "100", 100, "100", "100");
+-- result:
+-- !result
+insert into tab1 values (400, "100", 100, "100", "100");
+-- result:
+-- !result
+insert into tab1 values (500, "100", 100, "100", "100");
+-- result:
+-- !result
+select * from tab1;
+-- result:
+300	100	100	100	100
+200	100	100	100	100
+500	100	100	100	100
+400	100	100	100	100
+100	100	100	100	100
+-- !result
+set partial_update_mode = "auto";
+-- result:
+-- !result
+update tab1 set v1 = 1000;
+-- result:
+-- !result
+update tab1 set v1 = 2000, v2 = 2000;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: must specify where clause to prevent full table update.')
+-- !result
+update tab1 set v1 = 2000, v2 = 2000 where k1 = 200;
+-- result:
+-- !result
+select * from tab1;
+-- result:
+400	100	1000	100	100
+100	100	1000	100	100
+200	100	2000	2000	100
+300	100	1000	100	100
+500	100	1000	100	100
+-- !result
+set partial_update_mode = "column";
+-- result:
+-- !result
+update tab1 set v1 = 10000;
+-- result:
+-- !result
+update tab1 set v1 = 20000, v2 = 20000;
+-- result:
+-- !result
+update tab1 set v1 = 20000, v2 = 20000 where k1 = 200;
+-- result:
+-- !result
+select * from tab1;
+-- result:
+300	100	20000	20000	100
+200	100	20000	20000	100
+100	100	20000	20000	100
+500	100	20000	20000	100
+400	100	20000	20000	100
+-- !result
+set partial_update_mode = "row";
+-- result:
+-- !result
+update tab1 set v1 = 100000;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: must specify where clause to prevent full table update.')
+-- !result
+update tab1 set v1 = 200000, v2 = 200000;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: must specify where clause to prevent full table update.')
+-- !result
+update tab1 set v1 = 200000, v2 = 200000 where k1 = 200;
+-- result:
+-- !result
+select * from tab1;
+-- result:
+400	100	20000	20000	100
+200	100	200000	200000	100
+100	100	20000	20000	100
+300	100	20000	20000	100
+500	100	20000	20000	100
+-- !result
+set partial_update_mode = "row111";
+-- result:
+E: (1064, 'partial_update_mode only support auto|row|column')
+-- !result
+set partial_update_mode = "ros";
+-- result:
+E: (1064, 'partial_update_mode only support auto|row|column')
+-- !result
+set partial_update_mode = "columns";
+-- result:
+E: (1064, 'partial_update_mode only support auto|row|column')
+-- !result
+set partial_update_mode = "auto11";
+-- result:
+E: (1064, 'partial_update_mode only support auto|row|column')
+-- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update_session_var
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update_session_var
@@ -1,0 +1,48 @@
+-- name: test_partial_update_session_var
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into tab1 values (100, "100", 100, "100", "100");
+insert into tab1 values (200, "100", 100, "100", "100");
+insert into tab1 values (300, "100", 100, "100", "100");
+insert into tab1 values (400, "100", 100, "100", "100");
+insert into tab1 values (500, "100", 100, "100", "100");
+select * from tab1;
+
+set partial_update_mode = "auto";
+update tab1 set v1 = 1000;
+update tab1 set v1 = 2000, v2 = 2000;
+update tab1 set v1 = 2000, v2 = 2000 where k1 = 200;
+
+select * from tab1;
+
+set partial_update_mode = "column";
+update tab1 set v1 = 10000;
+update tab1 set v1 = 20000, v2 = 20000;
+update tab1 set v1 = 20000, v2 = 20000 where k1 = 200;
+
+select * from tab1;
+
+set partial_update_mode = "row";
+update tab1 set v1 = 100000;
+update tab1 set v1 = 200000, v2 = 200000;
+update tab1 set v1 = 200000, v2 = 200000 where k1 = 200;
+
+select * from tab1;
+
+set partial_update_mode = "row111";
+set partial_update_mode = "ros";
+set partial_update_mode = "columns";
+set partial_update_mode = "auto11";


### PR DESCRIPTION
## Problem Summary:
Fixes #20436
Support session var `partial_update_mode`. `partial_update_mode` support three types now:
1. `auto`. It means that `UPDATE` syntax will use the default strategy to decide whether to perform partial column update:
* No WHERE condition is used.
* The percentage of updated columns to all columns is less than 30% and the number of updated columns is less than 4.
2. `column`.  It means that `UPDATE` syntax will use partial update by column.
3. `row`. It means that `UPDATE` syntax will use full columns update.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
