### PR TITLE
[BugFix] Fix runtime filter value escape problem in mysql external table

### DIFF
--- a/be/src/connector/mysql_connector.cpp
+++ b/be/src/connector/mysql_connector.cpp
@@ -154,15 +154,7 @@ Status MySQLDataSource::open(RuntimeState* state) {
 #undef APPLY_FOR_NUMERICAL_TYPE
 #undef DIRECT_APPEND_TO_SQL
 
-#define CONVERT_APPEND_TO_SQL          \
-    std::stringstream ss;              \
-    for (char c : value.to_string()) { \
-        if (c == '"') {                \
-            ss << '\\';                \
-        }                              \
-        ss << c;                       \
-    }                                  \
-    vector_values.emplace_back(fmt::format("'{}'", ss.str()));
+#define CONVERT_APPEND_TO_SQL vector_values.emplace_back(_mysql_scanner->escape(value.to_string()).to_string());
                 APPLY_FOR_VARCHAR_DATE_TYPE(READ_CONST_PREDICATE, CONVERT_APPEND_TO_SQL)
 #undef APPLY_FOR_VARCHAR_DATE_TYPE
 #undef CONVERT_APPEND_TO_SQL

--- a/be/src/exec/mysql_scanner.cpp
+++ b/be/src/exec/mysql_scanner.cpp
@@ -208,6 +208,14 @@ Status MysqlScanner::query(const std::string& table, const std::vector<std::stri
     return query(_sql_str);
 }
 
+Slice MysqlScanner::escape(const std::string& value) {
+    _escape_buffer.resize(value.size() * 2 + 1 + 2);
+    _escape_buffer[0] = '\'';
+    auto sz = mysql_real_escape_string(_my_conn, _escape_buffer.data() + 1, value.data(), value.size());
+    _escape_buffer[sz + 1] = '\'';
+    return {_escape_buffer.data(), sz + 2};
+}
+
 Status MysqlScanner::get_next_row(char*** buf, unsigned long** lengths, bool* eos) {
     if (!_opened) {
         return Status::InternalError("GetNextRow before open.");

--- a/be/src/exec/mysql_scanner.h
+++ b/be/src/exec/mysql_scanner.h
@@ -79,9 +79,11 @@ public:
 
     int field_num() const { return _field_num; }
 
+    Slice escape(const std::string& value);
+
 private:
     Status _error_status(const std::string& prefix);
-
+    std::string _escape_buffer;
     const MysqlScannerParam& _my_param;
     __StarRocksMysql* _my_conn;
     __StarRocksMysqlRes* _my_result;


### PR DESCRIPTION
## Problem Summary:

for the value 'raw' we should convert to '\'raw\''

Fixes # https://github.com/StarRocks/starrocks/issues/23554

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
