### PR TITLE
[Enhancement] Jsonpaths does not needed for avro union data

### DIFF
--- a/be/src/exec/avro_scanner.cpp
+++ b/be/src/exec/avro_scanner.cpp
@@ -215,7 +215,7 @@ Status AvroScanner::_construct_row(const avro_value_t& avro_value, Chunk* chunk)
             column->append_nulls(1);
             continue;
         }
-        avro_value_t output_value;
+        const avro_value_t output_value;
         auto st = _extract_field(avro_value, _json_paths[i], &output_value);
         if (LIKELY(st.ok())) {
             RETURN_IF_ERROR(_construct_column(output_value, column, _src_slot_descriptors[i]->type(),
@@ -586,7 +586,7 @@ bool construct_path_from_str(std::string path_str, std::vector<AvroPath>& paths)
 //         ]
 //     ]
 // The whole logic is to return the deepest data, which could be null or some other data type.
-Status AvroScanner::_handle_union(const avro_value_t* input_value, const avro_value_t* branch) {
+Status AvroScanner::_handle_union(const avro_value_t* input_value, avro_value_t* branch) {
     while (avro_value_get_type(input_value) == AVRO_UNION) {
         int disc;
         if (avro_value_get_discriminant(input_value, &disc) != 0) {
@@ -611,7 +611,7 @@ Status AvroScanner::_handle_union(const avro_value_t* input_value, const avro_va
 // paths: input param
 // output_value: output param
 Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::vector<AvroPath>& paths,
-                                   avro_value_t* output_value) {
+                                   const avro_value_t* output_value) {
     const avro_value_t* cur_value = &input_value;
 
     // Select the entire data
@@ -620,7 +620,7 @@ Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::v
         if (avro_value_get_type(cur_value) == AVRO_UNION) {
             avro_value_t branch;
             RETURN_IF_ERROR(_handle_union(cur_value, &branch));
-            *cur_value = branch;
+            cur_value = &branch;
         }
         output_value = cur_value;
         return Status::OK();
@@ -639,7 +639,7 @@ Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::v
         }
         avro_value_t element;
         RETURN_IF_ERROR(_get_array_element(cur_value, paths[0].idx, &element));
-        *cur_value = element;
+        cur_value = &element;
     }
 
     // paths[0] should be $, skip it
@@ -656,7 +656,7 @@ Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::v
         if (UNLIKELY(avro_value_get_type(cur_value) == AVRO_UNION)) {
             avro_value_t branch;
             RETURN_IF_ERROR(_handle_union(cur_value, &branch));
-            *cur_value = branch;
+            cur_value = &branch;
             if (avro_value_get_type(&branch) == AVRO_NULL) {
                 output_value = cur_value;
                 return Status::OK();
@@ -674,7 +674,7 @@ Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::v
         avro_value_t next_value;
         if (LIKELY(avro_value_get_by_name(cur_value, paths[i].key.c_str(), &next_value, nullptr) == 0)) {
             // For each path, we first need to determine whether the path has an array element operation
-            *cur_value = next_value;
+            cur_value = &next_value;
             if (UNLIKELY(paths[i].idx != -1)) {
                 // In this case, you need to remove the union:
                 // $.event_params[2]
@@ -688,21 +688,21 @@ Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::v
                 if (avro_value_get_type(cur_value) == AVRO_UNION) {
                     avro_value_t branch;
                     RETURN_IF_ERROR(_handle_union(cur_value, &branch));
-                    *cur_value = branch;
+                    cur_value = &branch;
                     if (avro_value_get_type(&branch) == AVRO_NULL) {
                         output_value = cur_value;
                         return Status::OK();
                     }
                 }
                 // cur_value must be an array type, otherwise it is invalid
-                if (avro_value_get_type(&cur_value) != AVRO_ARRAY) {
+                if (avro_value_get_type(cur_value) != AVRO_ARRAY) {
                     auto err_msg =
                             "A non-array type was found during avro parsing. Please check the path you specified";
                     return Status::InternalError(err_msg);
                 }
                 avro_value_t element;
                 RETURN_IF_ERROR(_get_array_element(cur_value, paths[0].idx, &element));
-                *cur_value = element;
+                cur_value = &element;
             }
         } else {
             // If no field can be found, end the parsing of the row and return not found.
@@ -711,10 +711,10 @@ Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::v
         }
     }
     // Remove union
-    if (UNLIKELY(avro_value_get_type(&cur_value) == AVRO_UNION)) {
+    if (UNLIKELY(avro_value_get_type(cur_value) == AVRO_UNION)) {
         avro_value_t branch;
         RETURN_IF_ERROR(_handle_union(cur_value, &branch));
-        *cur_value = branch;
+        cur_value = &branch;
     }
     output_value = cur_value;
     return Status::OK();

--- a/be/src/exec/avro_scanner.cpp
+++ b/be/src/exec/avro_scanner.cpp
@@ -216,7 +216,7 @@ Status AvroScanner::_construct_row(const avro_value_t& avro_value, Chunk* chunk)
             continue;
         }
         avro_value_t output_value;
-        auto st = _extract_field(avro_value, _json_paths[i], output_value);
+        auto st = _extract_field(avro_value, _json_paths[i], &output_value);
         if (LIKELY(st.ok())) {
             RETURN_IF_ERROR(_construct_column(output_value, column, _src_slot_descriptors[i]->type(),
                                               _src_slot_descriptors[i]->col_name()));
@@ -363,14 +363,14 @@ Status AvroScanner::_construct_row_without_jsonpath(const avro_value_t& avro_val
 
         auto& column = chunk->get_column_by_slot_id(slot_info.id_);
         // We should expand the union type.
-        avro_value_t& cur_value = element_value;
-        if (UNLIKELY(avro_value_get_type(&cur_value) == AVRO_UNION)) {
+        avro_value_t* cur_value = &element_value;
+        if (UNLIKELY(avro_value_get_type(cur_value) == AVRO_UNION)) {
             avro_value_t branch;
-            RETURN_IF_ERROR(_handle_union(cur_value, branch));
-            cur_value = branch;
+            RETURN_IF_ERROR(_handle_union(cur_value, &branch));
+            *cur_value = branch;
         }
         // construct column with value.
-        RETURN_IF_ERROR(_construct_column(cur_value, column.get(), slot_info.type_, slot_info.key_));
+        RETURN_IF_ERROR(_construct_column(*cur_value, column.get(), slot_info.type_, slot_info.key_));
     }
 
     for (int i = 0; i < _found_columns.size(); i++) {
@@ -553,7 +553,7 @@ void AvroScanner::close() {
     FileScanner::close();
 }
 
-Status AvroScanner::_get_array_element(avro_value_t* cur_value, size_t idx, avro_value_t* element) {
+Status AvroScanner::_get_array_element(const avro_value_t* cur_value, size_t idx, avro_value_t* element) {
     size_t element_count;
     if (avro_value_get_size(cur_value, &element_count) != 0) {
         auto err_msg = "Cannot get avro array size: " + std::string(avro_strerror());
@@ -586,18 +586,18 @@ bool construct_path_from_str(std::string path_str, std::vector<AvroPath>& paths)
 //         ]
 //     ]
 // The whole logic is to return the deepest data, which could be null or some other data type.
-Status AvroScanner::_handle_union(avro_value_t input_value, avro_value_t& branch) {
-    while (avro_value_get_type(&input_value) == AVRO_UNION) {
+Status AvroScanner::_handle_union(const avro_value_t* input_value, const avro_value_t* branch) {
+    while (avro_value_get_type(input_value) == AVRO_UNION) {
         int disc;
-        if (avro_value_get_discriminant(&input_value, &disc) != 0) {
+        if (avro_value_get_discriminant(input_value, &disc) != 0) {
             auto err_msg = "Cannot get union discriminan: " + std::string(avro_strerror());
             return Status::InternalError(err_msg);
         }
-        if (avro_value_set_branch(&input_value, disc, &branch) != 0) {
+        if (avro_value_set_branch(input_value, disc, branch) != 0) {
             auto err_msg = "Cannot set union branch: " + std::string(avro_strerror());
             return Status::InternalError(err_msg);
         }
-        if (avro_value_get_type(&branch) == AVRO_NULL) {
+        if (avro_value_get_type(branch) == AVRO_NULL) {
             return Status::OK();
         }
         input_value = branch;
@@ -611,16 +611,16 @@ Status AvroScanner::_handle_union(avro_value_t input_value, avro_value_t& branch
 // paths: input param
 // output_value: output param
 Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::vector<AvroPath>& paths,
-                                   avro_value_t& output_value) {
-    avro_value_t cur_value = input_value;
+                                   avro_value_t* output_value) {
+    const avro_value_t* cur_value = &input_value;
 
     // Select the entire data
     if (UNLIKELY(paths.size() == 1 && paths[0].key == "$" && paths[0].idx == -1)) {
         // Remove union
-        if (avro_value_get_type(&cur_value) == AVRO_UNION) {
+        if (avro_value_get_type(cur_value) == AVRO_UNION) {
             avro_value_t branch;
-            RETURN_IF_ERROR(_handle_union(cur_value, branch));
-            cur_value = branch;
+            RETURN_IF_ERROR(_handle_union(cur_value, &branch));
+            *cur_value = branch;
         }
         output_value = cur_value;
         return Status::OK();
@@ -632,14 +632,14 @@ Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::v
     //     key == "$"
     //     idx = 0,1,2,3....
     // }
-    if (UNLIKELY(avro_value_get_type(&cur_value) == AVRO_ARRAY)) {
+    if (UNLIKELY(avro_value_get_type(cur_value) == AVRO_ARRAY)) {
         if (paths[0].key != "$" || paths[0].idx < 0) {
             auto err_msg = "The avro root type is an array, and you should select a specific array element.";
             return Status::InternalError(err_msg);
         }
         avro_value_t element;
-        RETURN_IF_ERROR(_get_array_element(&cur_value, paths[0].idx, &element));
-        cur_value = element;
+        RETURN_IF_ERROR(_get_array_element(cur_value, paths[0].idx, &element));
+        *cur_value = element;
     }
 
     // paths[0] should be $, skip it
@@ -653,17 +653,17 @@ Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::v
         // For each iteration, we first determine if the current avro type is union. If it is union,
         // we continue to determine if it is null. If so, we stop the progression and return.
         // If it is not null, the corresponding value is extracted and the progress continues.
-        if (UNLIKELY(avro_value_get_type(&cur_value) == AVRO_UNION)) {
+        if (UNLIKELY(avro_value_get_type(cur_value) == AVRO_UNION)) {
             avro_value_t branch;
-            RETURN_IF_ERROR(_handle_union(cur_value, branch));
-            cur_value = branch;
+            RETURN_IF_ERROR(_handle_union(cur_value, &branch));
+            *cur_value = branch;
             if (avro_value_get_type(&branch) == AVRO_NULL) {
                 output_value = cur_value;
                 return Status::OK();
             }
         }
 
-        if (UNLIKELY(avro_value_get_type(&cur_value) != AVRO_RECORD)) {
+        if (UNLIKELY(avro_value_get_type(cur_value) != AVRO_RECORD)) {
             if (i == paths.size() - 1) {
                 break;
             } else {
@@ -672,9 +672,9 @@ Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::v
             }
         }
         avro_value_t next_value;
-        if (LIKELY(avro_value_get_by_name(&cur_value, paths[i].key.c_str(), &next_value, nullptr) == 0)) {
+        if (LIKELY(avro_value_get_by_name(cur_value, paths[i].key.c_str(), &next_value, nullptr) == 0)) {
             // For each path, we first need to determine whether the path has an array element operation
-            cur_value = next_value;
+            *cur_value = next_value;
             if (UNLIKELY(paths[i].idx != -1)) {
                 // In this case, you need to remove the union:
                 // $.event_params[2]
@@ -685,10 +685,10 @@ Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::v
                 //      "type": "array"
                 //    }]
                 // }
-                if (avro_value_get_type(&cur_value) == AVRO_UNION) {
+                if (avro_value_get_type(cur_value) == AVRO_UNION) {
                     avro_value_t branch;
-                    RETURN_IF_ERROR(_handle_union(cur_value, branch));
-                    cur_value = branch;
+                    RETURN_IF_ERROR(_handle_union(cur_value, &branch));
+                    *cur_value = branch;
                     if (avro_value_get_type(&branch) == AVRO_NULL) {
                         output_value = cur_value;
                         return Status::OK();
@@ -701,8 +701,8 @@ Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::v
                     return Status::InternalError(err_msg);
                 }
                 avro_value_t element;
-                RETURN_IF_ERROR(_get_array_element(&cur_value, paths[0].idx, &element));
-                cur_value = element;
+                RETURN_IF_ERROR(_get_array_element(cur_value, paths[0].idx, &element));
+                *cur_value = element;
             }
         } else {
             // If no field can be found, end the parsing of the row and return not found.
@@ -713,8 +713,8 @@ Status AvroScanner::_extract_field(const avro_value_t& input_value, const std::v
     // Remove union
     if (UNLIKELY(avro_value_get_type(&cur_value) == AVRO_UNION)) {
         avro_value_t branch;
-        RETURN_IF_ERROR(_handle_union(cur_value, branch));
-        cur_value = branch;
+        RETURN_IF_ERROR(_handle_union(cur_value, &branch));
+        *cur_value = branch;
     }
     output_value = cur_value;
     return Status::OK();

--- a/be/src/exec/avro_scanner.h
+++ b/be/src/exec/avro_scanner.h
@@ -78,9 +78,9 @@ private:
     Status _construct_column(const avro_value_t& input_value, Column* column, const TypeDescriptor& type_desc,
                              const std::string& col_name);
     Status _extract_field(const avro_value_t& input_value, const std::vector<AvroPath>& paths,
-                          avro_value_t& output_value);
-    Status _handle_union(avro_value_t input_value, avro_value_t& branch);
-    Status _get_array_element(avro_value_t* cur_value, size_t idx, avro_value_t* element);
+                          avro_value_t* output_value);
+    Status _handle_union(const avro_value_t* input_value, const avro_value_t* branch);
+    Status _get_array_element(const avro_value_t* cur_value, size_t idx, avro_value_t* element);
     std::string _preprocess_jsonpaths(std::string jsonpath);
     Status _construct_row_without_jsonpath(const avro_value_t& avro_value, Chunk* chunk);
 

--- a/be/src/exec/avro_scanner.h
+++ b/be/src/exec/avro_scanner.h
@@ -78,7 +78,7 @@ private:
     Status _construct_column(const avro_value_t& input_value, Column* column, const TypeDescriptor& type_desc,
                              const std::string& col_name);
     Status _extract_field(const avro_value_t& input_value, const std::vector<AvroPath>& paths,
-                          const avro_value_t* output_value);
+                          avro_value_t* output_value);
     Status _handle_union(const avro_value_t* input_value, avro_value_t* branch);
     Status _get_array_element(const avro_value_t* cur_value, size_t idx, avro_value_t* element);
     std::string _preprocess_jsonpaths(std::string jsonpath);

--- a/be/src/exec/avro_scanner.h
+++ b/be/src/exec/avro_scanner.h
@@ -78,8 +78,8 @@ private:
     Status _construct_column(const avro_value_t& input_value, Column* column, const TypeDescriptor& type_desc,
                              const std::string& col_name);
     Status _extract_field(const avro_value_t& input_value, const std::vector<AvroPath>& paths,
-                          avro_value_t* output_value);
-    Status _handle_union(const avro_value_t* input_value, const avro_value_t* branch);
+                          const avro_value_t* output_value);
+    Status _handle_union(const avro_value_t* input_value, avro_value_t* branch);
     Status _get_array_element(const avro_value_t* cur_value, size_t idx, avro_value_t* element);
     std::string _preprocess_jsonpaths(std::string jsonpath);
     Status _construct_row_without_jsonpath(const avro_value_t& avro_value, Chunk* chunk);


### PR DESCRIPTION
## Problem Summary:
For avro data that does not have nested data, the user must specify the jsonpaths when parsing union data. If you're loading a table with hundreds or thousands of columns, you need to write jsonpath for each column, which is  tedious. This PR fixes this issue.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
