### PR TITLE
[Enhancement] Add retry operation when getting kafka info time out

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -195,7 +195,7 @@ public class KafkaUtil {
                     if (code != TStatusCode.OK) {
                         LOG.warn("failed to send proxy request to " + address + " err " + result.status.errorMsgs);
                         // When getting kafka info timed out, we tried again three times.
-                        if (++retryTimes > 3 || retryTimes * Config.routine_load_kafka_timeout_second >
+                        if (++retryTimes > 3 || (retryTimes + 1) * Config.routine_load_kafka_timeout_second >
                                                                         Config.routine_load_task_timeout_second) {
                             throw new UserException(
                                     "failed to send proxy request to " + address + " err " + result.status.errorMsgs);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -204,17 +204,6 @@ public class KafkaUtil {
                         return result;
                     }
                 }
-                request.timeout = Config.routine_load_kafka_timeout_second;
-                Future<PProxyResult> future = BackendServiceClient.getInstance().getInfo(address, request);
-                PProxyResult result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
-                TStatusCode code = TStatusCode.findByValue(result.status.statusCode);
-                if (code != TStatusCode.OK) {
-                    LOG.warn("failed to send proxy request to " + address + " err " + result.status.errorMsgs);
-                    throw new UserException(
-                            "failed to send proxy request to " + address + " err " + result.status.errorMsgs);
-                } else {
-                    return result;
-                }
             } catch (InterruptedException ie) {
                 LOG.warn("got interrupted exception when sending proxy request to " + address);
                 Thread.currentThread().interrupt();


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)
Add retry operation to avoid the routine load job be paused when getting kafka info timeout.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
