### PR TITLE
[BugFix] remove useless hard link for file in clone and restore (#23588)

### DIFF
--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -657,16 +657,19 @@ Status SnapshotManager::assign_new_rowset_id(SnapshotMeta* snapshot_meta, const 
             auto old_path = Rowset::segment_file_path(clone_dir, old_rowset_id, seg_id);
             auto new_path = Rowset::segment_file_path(clone_dir, new_rowset_id, seg_id);
             RETURN_IF_ERROR(FileSystem::Default()->link_file(old_path, new_path));
+            FileSystem::Default()->delete_file(old_path);
         }
         for (int del_id = 0; del_id < rowset_meta_pb.num_delete_files(); del_id++) {
             auto old_path = Rowset::segment_del_file_path(clone_dir, old_rowset_id, del_id);
             auto new_path = Rowset::segment_del_file_path(clone_dir, new_rowset_id, del_id);
             RETURN_IF_ERROR(FileSystem::Default()->link_file(old_path, new_path));
+            FileSystem::Default()->delete_file(old_path);
         }
         for (int upt_id = 0; upt_id < rowset_meta_pb.num_update_files(); upt_id++) {
             auto old_path = Rowset::segment_upt_file_path(clone_dir, old_rowset_id, upt_id);
             auto new_path = Rowset::segment_upt_file_path(clone_dir, new_rowset_id, upt_id);
             RETURN_IF_ERROR(FileSystem::Default()->link_file(old_path, new_path));
+            FileSystem::Default()->delete_file(old_path);
         }
         rowset_meta_pb.set_rowset_id(new_rowset_id.to_string());
     }


### PR DESCRIPTION
## Problem Summary:
Fixes #23588

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
