### PR TITLE
[Refactor] Refactor schema change log

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -72,9 +72,11 @@ static void alter_tablet(const TAlterTabletReqV2& agent_task_req, int64_t signat
         status = STARROCKS_SUCCESS;
     }
 
+    std::string alter_msg_head =
+            strings::Substitute("[Alter Job:$0, tablet:$1]: ", agent_task_req.job_id, agent_task_req.base_tablet_id);
     if (status == STARROCKS_SUCCESS) {
         g_report_version.fetch_add(1, std::memory_order_relaxed);
-        LOG(INFO) << "alter finished. signature: " << signature;
+        LOG(INFO) << alter_msg_head << "alter finished. signature: " << signature;
     }
 
     // Return result to fe
@@ -99,7 +101,7 @@ static void alter_tablet(const TAlterTabletReqV2& agent_task_req, int64_t signat
         }
 
         LOG_IF(WARNING, status != STARROCKS_SUCCESS)
-                << "alter success, but get new tablet info failed."
+                << alter_msg_head << "alter success, but get new tablet info failed."
                 << "tablet_id: " << new_tablet_id << ", schema_hash: " << new_schema_hash
                 << ", signature: " << signature;
     }
@@ -107,16 +109,16 @@ static void alter_tablet(const TAlterTabletReqV2& agent_task_req, int64_t signat
     if (status == STARROCKS_SUCCESS) {
         swap(finish_tablet_infos, finish_task_request->finish_tablet_infos);
         finish_task_request->__isset.finish_tablet_infos = true;
-        LOG(INFO) << "alter success. signature: " << signature;
+        LOG(INFO) << alter_msg_head << "alter success. signature: " << signature;
         error_msgs.push_back("alter success");
         task_status.__set_status_code(TStatusCode::OK);
     } else if (status == STARROCKS_TASK_REQUEST_ERROR) {
-        LOG(WARNING) << "alter table request task type invalid. "
+        LOG(WARNING) << alter_msg_head << "alter table request task type invalid. "
                      << "signature:" << signature;
         error_msgs.emplace_back("alter table request new tablet id or schema count invalid.");
         task_status.__set_status_code(TStatusCode::ANALYSIS_ERROR);
     } else {
-        LOG(WARNING) << "alter failed. signature: " << signature;
+        LOG(WARNING) << alter_msg_head << "alter failed. signature: " << signature;
         error_msgs.push_back("alter failed");
         error_msgs.push_back("status: " + print_agent_status(status));
         task_status.__set_status_code(TStatusCode::RUNTIME_ERROR);
@@ -215,7 +217,9 @@ void run_create_tablet_task(const std::shared_ptr<CreateTabletAgentTaskRequest>&
 
 void run_alter_tablet_task(const std::shared_ptr<AlterTabletAgentTaskRequest>& agent_task_req, ExecEnv* exec_env) {
     int64_t signatrue = agent_task_req->signature;
-    LOG(INFO) << "get alter table task, signature: " << agent_task_req->signature;
+    std::string alter_msg_head = strings::Substitute("[Alter Job:$0, tablet:$1]: ", agent_task_req->task_req.job_id,
+                                                     agent_task_req->task_req.base_tablet_id);
+    LOG(INFO) << alter_msg_head << "get alter table task, signature: " << agent_task_req->signature;
     bool is_task_timeout = false;
     if (agent_task_req->isset.recv_time) {
         int64_t time_elapsed = time(nullptr) - agent_task_req->recv_time;

--- a/be/src/storage/schema_change.h
+++ b/be/src/storage/schema_change.h
@@ -73,6 +73,10 @@ public:
 
     virtual Status process(TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr tablet,
                            TabletSharedPtr base_tablet, RowsetSharedPtr rowset) = 0;
+    void set_alter_msg_header(std::string msg) { _alter_msg_header = msg; }
+    std::string alter_msg_header() { return _alter_msg_header; }
+
+    std::string _alter_msg_header;
 };
 
 class LinkedSchemaChange : public SchemaChange {
@@ -111,7 +115,7 @@ public:
     Status process(TabletReader* reader, RowsetWriter* new_rowset_writer, TabletSharedPtr new_tablet,
                    TabletSharedPtr base_tablet, RowsetSharedPtr rowset) override;
 
-    static bool _internal_sorting(std::vector<ChunkPtr>& chunk_arr, RowsetWriter* new_rowset_writer,
+    static Status _internal_sorting(std::vector<ChunkPtr>& chunk_arr, RowsetWriter* new_rowset_writer,
                                   TabletSharedPtr tablet);
 
 private:
@@ -143,8 +147,8 @@ private:
         std::unique_ptr<ChunkChanger> chunk_changer = nullptr;
     };
 
-    static Status _get_versions_to_be_changed(const TabletSharedPtr& base_tablet,
-                                              std::vector<Version>* versions_to_be_changed);
+    Status _get_versions_to_be_changed(const TabletSharedPtr& base_tablet,
+                                       std::vector<Version>* versions_to_be_changed);
 
     Status _do_process_alter_tablet_v2(const TAlterTabletReqV2& request);
 
@@ -153,7 +157,7 @@ private:
 
     Status _validate_alter_result(const TabletSharedPtr& new_tablet, const TAlterTabletReqV2& request);
 
-    static Status _convert_historical_rowsets(SchemaChangeParams& sc_params);
+    Status _convert_historical_rowsets(SchemaChangeParams& sc_params);
 
     DISALLOW_COPY(SchemaChangeHandler);
     std::string _alter_msg_header;

--- a/be/src/storage/schema_change.h
+++ b/be/src/storage/schema_change.h
@@ -116,7 +116,7 @@ public:
                    TabletSharedPtr base_tablet, RowsetSharedPtr rowset) override;
 
     static Status _internal_sorting(std::vector<ChunkPtr>& chunk_arr, RowsetWriter* new_rowset_writer,
-                                  TabletSharedPtr tablet);
+                                    TabletSharedPtr tablet);
 
 private:
     ChunkChanger* _chunk_changer = nullptr;

--- a/be/src/storage/schema_change.h
+++ b/be/src/storage/schema_change.h
@@ -128,6 +128,8 @@ public:
     // schema change v2, it will not set alter task in base tablet
     Status process_alter_tablet_v2(const TAlterTabletReqV2& request);
 
+    void set_alter_msg_header(std::string msg) { _alter_msg_header = msg; }
+
 private:
     struct SchemaChangeParams {
         TabletSharedPtr base_tablet;
@@ -154,6 +156,7 @@ private:
     static Status _convert_historical_rowsets(SchemaChangeParams& sc_params);
 
     DISALLOW_COPY(SchemaChangeHandler);
+    std::string _alter_msg_header;
 };
 
 } // namespace starrocks

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -202,13 +202,13 @@ public:
     void to_updates_pb(TabletUpdatesPB* updates_pb) const;
 
     // Used for schema change, migrate another tablet's version&rowsets to this tablet
-    Status link_from(Tablet* base_tablet, int64_t request_version);
+    Status link_from(Tablet* base_tablet, int64_t request_version, std::string err_msg_header = "");
 
     Status convert_from(const std::shared_ptr<Tablet>& base_tablet, int64_t request_version,
-                        ChunkChanger* chunk_changer);
+                        ChunkChanger* chunk_changer, std::string err_msg_header = "");
 
     Status reorder_from(const std::shared_ptr<Tablet>& base_tablet, int64_t request_version,
-                        ChunkChanger* chunk_changer);
+                        ChunkChanger* chunk_changer, std::string err_msg_header = "");
 
     Status load_snapshot(const SnapshotMeta& snapshot_meta, bool restore_from_backup = false);
 

--- a/be/src/storage/task/engine_alter_tablet_task.cpp
+++ b/be/src/storage/task/engine_alter_tablet_task.cpp
@@ -57,15 +57,18 @@ Status EngineAlterTabletTask::execute() {
     StarRocksMetrics::instance()->create_rollup_requests_total.increment(1);
 
     Status res;
+    std::string alter_msg_header = strings::Substitute("[Alter Job:$0, tablet:$1]: ", _alter_tablet_req.job_id,
+                                                       _alter_tablet_req.base_tablet_id);
     if (_alter_tablet_req.tablet_type == TTabletType::TABLET_TYPE_LAKE) {
         lake::SchemaChangeHandler handler(ExecEnv::GetInstance()->lake_tablet_manager());
         res = handler.process_alter_tablet(_alter_tablet_req);
     } else {
         SchemaChangeHandler handler;
+        handler.set_alter_msg_header(alter_msg_header);
         res = handler.process_alter_tablet_v2(_alter_tablet_req);
     }
     if (!res.ok()) {
-        LOG(WARNING) << "failed to do alter task. status=" << res.to_string()
+        LOG(WARNING) << alter_msg_header << "failed to do alter task. status=" << res.to_string()
                      << " base_tablet_id=" << _alter_tablet_req.base_tablet_id
                      << ", base_schema_hash=" << _alter_tablet_req.base_schema_hash
                      << ", new_tablet_id=" << _alter_tablet_req.new_tablet_id
@@ -74,7 +77,7 @@ Status EngineAlterTabletTask::execute() {
         return res;
     }
 
-    LOG(INFO) << "success to do alter task. base_tablet_id=" << _alter_tablet_req.base_tablet_id;
+    LOG(INFO) << alter_msg_header << "success to do alter task. base_tablet_id=" << _alter_tablet_req.base_tablet_id;
     return Status::OK();
 } // execute
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -174,6 +174,7 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
         req.setMaterialized_column_req(materializedColumnReq);
         req.setTablet_type(tabletType);
         req.setTxn_id(txnId);
+        req.setJob_id(jobId);
         return req;
     }
 

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -135,6 +135,7 @@ struct TAlterTabletReqV2 {
     8: optional TTabletType tablet_type
     9: optional i64 txn_id
     10: optional TAlterTabletMaterializedColumnReq materialized_column_req
+    11: optional i64 job_id
 }
 
 struct TAlterMaterializedViewParam {


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)
It is hard to trace the alter job and we need to use multiple key words to trace the complete execution path in BE. This causes a lot of difficulties for the user when troubleshooting the reason for the failure of the alter job. This pr refactor the log of alter job and we can use `[Alter Job:$job_id]` as key word to trace the complete execution log of the alter job. If you only want to trace one tablet, you can use `[Alter Job:$job_id, tablet:$tablet_id]` as the key word.

e.g.
```
trace the alter job of all tablet:

[root@sandbox-dw be]$ grep "Alter Job:202060" log/be.INFO
I0517 16:49:36.403213 10585 agent_task.cpp:222] [Alter Job:202060, tablet:201465]: get alter table task, signature: 202064
I0517 16:49:36.403216 10584 agent_task.cpp:222] [Alter Job:202060, tablet:201463]: get alter table task, signature: 202062
I0517 16:49:36.403225 10583 agent_task.cpp:222] [Alter Job:202060, tablet:201467]: get alter table task, signature: 202066
I0517 16:49:36.403257 10583 schema_change.cpp:475] [Alter Job:202060, tablet:201467]: begin to do request alter tablet: base_tablet_id=201467, base_schema_hash=798652608, new_tablet_id=202066, new_schema_hash=314096200, alter_version=3
I0517 16:49:36.403254 10585 schema_change.cpp:475] [Alter Job:202060, tablet:201465]: begin to do request alter tablet: base_tablet_id=201465, base_schema_hash=798652608, new_tablet_id=202064, new_schema_hash=314096200, alter_version=3
I0517 16:49:36.403254 10584 schema_change.cpp:475] [Alter Job:202060, tablet:201463]: begin to do request alter tablet: base_tablet_id=201463, base_schema_hash=798652608, new_tablet_id=202062, new_schema_hash=314096200, alter_version=3
I0517 16:49:36.403278 10584 schema_change.cpp:525] [Alter Job:202060, tablet:201463]: finish to validate alter tablet request. begin to convert data from base tablet to new tablet base_tablet=201463.798652608.574b3dc5250698a1-a92a115685e9f7a1 new_tablet=202062.314096200.f946f3889dd0b805-6cb46cd4643a4aad
I0517 16:49:36.403271 10583 schema_change.cpp:525] [Alter Job:202060, tablet:201467]: finish to validate alter tablet request. begin to convert data from base tablet to new tablet base_tablet=201467.798652608.e3492e80d7829593-9db02c527e48e2a6 new_tablet=202066.314096200.e54b617b53c7ea5c-e9fca093a2d3dd90
I0517 16:49:36.403271 10585 schema_change.cpp:525] [Alter Job:202060, tablet:201465]: finish to validate alter tablet request. begin to convert data from base tablet to new tablet base_tablet=201465.798652608.e444d26cf774abda-b7529497af9ba3bc new_tablet=202064.314096200.244a63626031463b-77974af120c8b4b3
I0517 16:49:36.403656 10583 schema_change.cpp:493] [Alter Job:202060, tablet:201467]: finished alter tablet process, status=OK duration: 0ms, peak_mem_usage: 0 bytes
I0517 16:49:36.403659 10583 engine_alter_tablet_task.cpp:80] [Alter Job:202060, tablet:201467]: success to do alter task. base_tablet_id=201467
I0517 16:49:36.403662 10583 agent_task.cpp:79] [Alter Job:202060, tablet:201467]: alter finished. signature: 202066
I0517 16:49:36.403683 10583 agent_task.cpp:112] [Alter Job:202060, tablet:201467]: alter success. signature: 202066
I0517 16:49:36.405265 10585 schema_change.cpp:493] [Alter Job:202060, tablet:201465]: finished alter tablet process, status=OK duration: 2ms, peak_mem_usage: 0 bytes
I0517 16:49:36.405268 10585 engine_alter_tablet_task.cpp:80] [Alter Job:202060, tablet:201465]: success to do alter task. base_tablet_id=201465
I0517 16:49:36.405272 10585 agent_task.cpp:79] [Alter Job:202060, tablet:201465]: alter finished. signature: 202064
I0517 16:49:36.405274 10584 schema_change.cpp:493] [Alter Job:202060, tablet:201463]: finished alter tablet process, status=OK duration: 2ms, peak_mem_usage: 0 bytes
I0517 16:49:36.405277 10584 engine_alter_tablet_task.cpp:80] [Alter Job:202060, tablet:201463]: success to do alter task. base_tablet_id=201463
I0517 16:49:36.405278 10585 agent_task.cpp:112] [Alter Job:202060, tablet:201465]: alter success. signature: 202064
I0517 16:49:36.405282 10584 agent_task.cpp:79] [Alter Job:202060, tablet:201463]: alter finished. signature: 202062
I0517 16:49:36.405287 10584 agent_task.cpp:112] [Alter Job:202060, tablet:201463]: alter success. signature: 202062
```

```
trace the alter job of one tablet:

[root@sandbox-dw be]$ grep "Alter Job:202060, tablet:201465" log/be.INFO
I0517 16:49:36.403213 10585 agent_task.cpp:222] [Alter Job:202060, tablet:201465]: get alter table task, signature: 202064
I0517 16:49:36.403254 10585 schema_change.cpp:475] [Alter Job:202060, tablet:201465]: begin to do request alter tablet: base_tablet_id=201465, base_schema_hash=798652608, new_tablet_id=202064, new_schema_hash=314096200, alter_version=3
I0517 16:49:36.403271 10585 schema_change.cpp:525] [Alter Job:202060, tablet:201465]: finish to validate alter tablet request. begin to convert data from base tablet to new tablet base_tablet=201465.798652608.e444d26cf774abda-b7529497af9ba3bc new_tablet=202064.314096200.244a63626031463b-77974af120c8b4b3
I0517 16:49:36.405265 10585 schema_change.cpp:493] [Alter Job:202060, tablet:201465]: finished alter tablet process, status=OK duration: 2ms, peak_mem_usage: 0 bytes
I0517 16:49:36.405268 10585 engine_alter_tablet_task.cpp:80] [Alter Job:202060, tablet:201465]: success to do alter task. base_tablet_id=201465
I0517 16:49:36.405272 10585 agent_task.cpp:79] [Alter Job:202060, tablet:201465]: alter finished. signature: 202064
I0517 16:49:36.405278 10585 agent_task.cpp:112] [Alter Job:202060, tablet:201465]: alter success. signature: 202064
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
