### PR TITLE
[Enhancement] Change Xmx in start_fe to 8G

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -60,7 +60,7 @@ source $STARROCKS_HOME/bin/common.sh
 # JAVA_OPTS
 # LOG_DIR
 # PID_DIR
-export JAVA_OPTS="-Xmx1024m"
+export JAVA_OPTS="-Xmx8G"
 export LOG_DIR="$STARROCKS_HOME/log"
 export PID_DIR=`cd "$curdir"; pwd`
 

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -60,7 +60,7 @@ source $STARROCKS_HOME/bin/common.sh
 # JAVA_OPTS
 # LOG_DIR
 # PID_DIR
-export JAVA_OPTS="-Xmx8G"
+export JAVA_OPTS="-Xmx8g"
 export LOG_DIR="$STARROCKS_HOME/log"
 export PID_DIR=`cd "$curdir"; pwd`
 


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)
If there are some Illegal characters in the fe.conf, the JAVA_OPTS will be read in the start_fe.sh, but the Xmx in start_fe.sh is 1G, which will cause OOM.
Set Xmx in start_fe.sh to 8G.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
