### PR TITLE
[BugFix] Handle parquet exception caused by wrong s3 configuration

### DIFF
--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -450,9 +450,8 @@ Status AsyncFileWriter::_flush_row_group() {
         {
             auto lock = std::unique_lock(_m);
             _rg_writer_closing = false;
-            lock.unlock();
-            _cv.notify_one();
         }
+        _cv.notify_one();
         auto st = Status::ResourceBusy("submit flush row group task fails");
         LOG(WARNING) << st;
         return st;

--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -380,8 +380,7 @@ Status SyncFileWriter::_flush_row_group() {
             _closed = true;
             _writer.release();
 
-            auto st = Status::IOError(e.what());
-            st = st.clone_and_prepend("flush row group error");
+            auto st = Status::IOError(fmt::format("{}: {}", "flush rowgroup error", e.what()));
             LOG(WARNING) << st;
             return st;
         }
@@ -396,14 +395,12 @@ Status SyncFileWriter::close() {
         return Status::OK();
     }
 
-    auto st = _flush_row_group();
     RETURN_IF_ERROR(_flush_row_group());
     _writer->Close();
 
     auto arrow_st = _outstream->Close();
     if (!arrow_st.ok()) {
-        st = Status::IOError(arrow_st.message());
-        st = st.clone_and_prepend("close file error");
+        auto st = Status::IOError(fmt::format("{}: {}", "close file error", arrow_st.message()));
         LOG(WARNING) << st;
         return st;
     }

--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -376,7 +376,9 @@ Status SyncFileWriter::_flush_row_group() {
         try {
             _chunk_writer->close();
         } catch (const ::parquet::ParquetStatusException& e) {
-            // this is to avoid ParquetFileWriter.Close which cause segfaults
+            _chunk_writer.reset();
+
+            // this is to avoid calling ParquetFileWriter.Close which incurs segfault
             _closed = true;
             _writer.release();
 

--- a/be/src/formats/parquet/file_writer.h
+++ b/be/src/formats/parquet/file_writer.h
@@ -127,7 +127,7 @@ public:
 protected:
     void _generate_chunk_writer();
 
-    virtual void _flush_row_group() = 0;
+    virtual Status _flush_row_group() = 0;
 
 private:
     bool is_last_row_group() {
@@ -170,7 +170,7 @@ public:
     bool closed() const override { return _closed; }
 
 private:
-    void _flush_row_group() override;
+    Status _flush_row_group() override;
 
     bool _closed = false;
 };
@@ -200,7 +200,7 @@ public:
     std::string partition_location() const { return _partition_location; }
 
 private:
-    void _flush_row_group() override;
+    Status _flush_row_group() override;
 
     std::string _file_location;
     std::string _partition_location;


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)

Using a wrong s3 configuration (ak/sk/endpoint) will not be checked until the parquet writer tries to flush buffered data into the output stream. In this case, `BufferedPageWriter.Close()` throws an exception, which should be handled.

Moreover, the deconstructor of `ParquetFileWriter` causes SIGSEGV. We have to mark the file writer as closed and release its ownership to avoid calling its dtor.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
