### PR TITLE
[BugFix] Fix Load plugin failed bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/plugin/DynamicPluginLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/DynamicPluginLoader.java
@@ -218,8 +218,9 @@ public class DynamicPluginLoader extends PluginLoader {
         // create a child to load the plugin in this bundle
         ClassLoader parentLoader = PluginClassLoader.createLoader(getClass().getClassLoader(), Collections.EMPTY_LIST);
 
+        URLClassLoader loader = URLClassLoader.newInstance(jarList.toArray(new URL[0]), parentLoader);
         Class<? extends Plugin> pluginClass;
-        try (URLClassLoader loader = URLClassLoader.newInstance(jarList.toArray(new URL[0]), parentLoader)) {
+        try  {
             pluginClass = loader.loadClass(pluginInfo.getClassName()).asSubclass(Plugin.class);
         } catch (ClassNotFoundException | NoClassDefFoundError t) {
             throw new UserException("Could not find plugin class [" + pluginInfo.getClassName() + "]", t);


### PR DESCRIPTION
## Problem Summary:
Fixes #23607
This PR #14401 put the class loader into `try()`, so it will be closed after the try block, and the classes which are loaded by this class loader will not be found when they are used in others code block.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
