### PR TITLE
[Enhancement] Log on process exit caused by signal

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -246,7 +246,7 @@ static void init_starrocks_metrics(const std::vector<StorePath>& store_paths) {
 }
 
 void sigterm_handler(int signo, siginfo_t* info, void* context) {
-    LOG(INFO) << "got signal: " << strsignal(signo) << " from pid: " << info->si_pid << ", is going to exit";
+    LOG(ERROR) << "got signal: " << strsignal(signo) << " from pid: " << info->si_pid << ", is going to exit";
     k_starrocks_exit.store(true);
 }
 

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -246,6 +246,7 @@ static void init_starrocks_metrics(const std::vector<StorePath>& store_paths) {
 }
 
 void sigterm_handler(int signo) {
+    LOG(INFO) << "got signal" << strsignal(signo) << ", is going to exit";
     k_starrocks_exit.store(true);
 }
 

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -245,15 +245,15 @@ static void init_starrocks_metrics(const std::vector<StorePath>& store_paths) {
     StarRocksMetrics::instance()->initialize(paths, init_system_metrics, disk_devices, network_interfaces);
 }
 
-void sigterm_handler(int signo) {
-    LOG(INFO) << "got signal" << strsignal(signo) << ", is going to exit";
+void sigterm_handler(int signo, siginfo_t* info, void* context) {
+    LOG(INFO) << "got signal: " << strsignal(signo) << " from pid: " << info->si_pid << ", is going to exit";
     k_starrocks_exit.store(true);
 }
 
-int install_signal(int signo, void (*handler)(int)) {
+int install_signal(int signo, void (*handler)(int sig, siginfo_t* info, void* context)) {
     struct sigaction sa;
     memset(&sa, 0, sizeof(struct sigaction));
-    sa.sa_handler = handler;
+    sa.sa_sigaction = handler;
     sigemptyset(&sa.sa_mask);
     auto ret = sigaction(signo, &sa, nullptr);
     if (ret != 0) {


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)
When the BE gets the signal SIGTERM/SIGINT, the process will exit soon without any log.
It's hard to distinguish it from an abnormal exit.
This PR adds log to indicate exit lead by the signal handler.
```
I0517 22:19:45.260324 723345 daemon.cpp:249] got signal: Terminated from pid: 994050320, is going to exit
```
```
I0517 22:21:36.337054 733289 daemon.cpp:249] got signal: Interrupt from pid: 1105230360, is going to exit
```
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
