### PR TITLE
[BugFix] Fix RuntimeFilter wrong result in aarch64

### DIFF
--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -132,11 +132,13 @@ public:
         return _mm256_testc_si256(bucket, mask);
 #elif defined(__ARM_NEON)
         uint32x4_t masks[2];
-        uint32x4_t directory_1 = vdupq_n_u32(_directory[bucket_idx][0]);
-        uint32x4_t directory_2 = vdupq_n_u32(_directory[bucket_idx][4]);
+
+        uint32x4_t directory_1 = vld1q_u32(&_directory[bucket_idx][0]);
+        uint32x4_t directory_2 = vld1q_u32(&_directory[bucket_idx][4]);
+
         make_mask(hash >> _log_num_buckets, masks);
-        uint32x4_t out_1 = vbicq_u32(directory_1, masks[0]);
-        uint32x4_t out_2 = vbicq_u32(directory_2, masks[1]);
+        uint32x4_t out_1 = vbicq_u32(masks[0], directory_1);
+        uint32x4_t out_2 = vbicq_u32(masks[1], directory_2);
         out_1 = vorrq_u32(out_1, out_2);
         uint32x2_t low_1 = vget_low_u32(out_1);
         uint32x2_t high_1 = vget_high_u32(out_1);


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)
1. vld1q_u32 load all masks 
2. swap argument for vbicq_s32 https://github.com/DLTcollab/sse2neon/blob/master/sse2neon.h#L2957
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
