### PR TITLE
[BugFix] adapt hive metastore version on dropping database and table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -178,7 +178,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getDefaultCatalog;
-import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.prependCatalogToDbName;
 
 /**
  * Modified from apache hive  org.apache.hadoop.hive.metastore.HiveMetaStoreClient.java
@@ -951,7 +950,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
         }
         boolean success = false;
         try {
-            drop_table_with_environment_context(catName, dbname, name, deleteData, envContext);
+            drop_table_with_environment_context(dbname, name, deleteData, envContext);
             if (hook != null) {
                 hook.commitDropTable(tbl, deleteData || (envContext != null && "TRUE".equals(envContext.getProperties().get("ifPurge"))));
             }
@@ -1336,9 +1335,9 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
         client.create_table_with_environment_context(tbl, envContext);
     }
 
-    protected void drop_table_with_environment_context(String catName, String dbname, String name,
+    protected void drop_table_with_environment_context(String dbname, String name,
                                                        boolean deleteData, EnvironmentContext envContext) throws TException {
-        client.drop_table_with_environment_context(prependCatalogToDbName(catName, dbname, conf),
+        client.drop_table_with_environment_context(dbname,
                 name, deleteData, envContext);
     }
 
@@ -1448,7 +1447,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
                 }
             }
         }
-        client.drop_database(prependCatalogToDbName(catalogName, dbName, conf), deleteData, cascade);
+        client.drop_database(dbName, deleteData, cascade);
     }
 
     @Override


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)

To tackle a hive metastore of version 2.3.9, we should not prepend the database name with its catalog name.

See also #23457 

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
