### PR TITLE
[Enhancement][Cherry-pick][Branch-2.3] Backport remove rssid file in update compaction pr to branch-2.3

### DIFF
--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -159,7 +159,7 @@ Status StorageEngine::start_bg_threads() {
     }
 
     int32_t update_compaction_num_threads_per_disk =
-            std::max<int32_t>(1, config::update_compaction_num_threads_per_disk);
+            config::update_compaction_num_threads_per_disk >= 0 ? config::update_compaction_num_threads_per_disk : 1;
     int32_t update_compaction_num_threads = update_compaction_num_threads_per_disk * data_dir_num;
     _update_compaction_threads.reserve(update_compaction_num_threads);
     for (uint32_t i = 0; i < update_compaction_num_threads; ++i) {

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -308,13 +308,23 @@ public:
     // |old_values|: return old values if key exist, or set to NullValue if not
     Status erase(size_t n, const void* keys, IndexValue* old_values);
 
+    // TODO(qzc): maybe unused, remove it or refactor it with the methods in use by template after a period of time
     // batch replace
     // |n|: size of key/value array
     // |keys|: key array as raw buffer
     // |values|: value array
     // |src_rssid|: rssid array
     // |failed|: return not match rowid
-    Status try_replace(size_t n, const void* keys, const IndexValue* values, const std::vector<uint32_t>& src_rssid,
+    [[maybe_unused]] Status try_replace(size_t n, const void* keys, const IndexValue* values,
+                                        const std::vector<uint32_t>& src_rssid, std::vector<uint32_t>* failed);
+
+    // batch replace
+    // |n|: size of key/value array
+    // |keys|: key array as raw buffer
+    // |values|: value array
+    // |max_src_rssid|: maximum of rssid array
+    // |failed|: return not match rowid
+    Status try_replace(size_t n, const void* keys, const IndexValue* values, const uint32_t max_src_rssid,
                        std::vector<uint32_t>* failed);
 
     size_t mutable_index_size();

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -152,17 +152,6 @@ StatusOr<RowsetSharedPtr> BetaRowsetWriter::build() {
     return rowset;
 }
 
-Status BetaRowsetWriter::flush_src_rssids(uint32_t segment_id) {
-    auto path = BetaRowset::segment_srcrssid_file_path(_context.rowset_path_prefix, _context.rowset_id,
-                                                       static_cast<int>(segment_id));
-    ASSIGN_OR_RETURN(auto wfile, _fs->new_writable_file(path));
-    RETURN_IF_ERROR(wfile->append(Slice((const char*)(_src_rssids->data()), _src_rssids->size() * sizeof(uint32_t))));
-    RETURN_IF_ERROR(wfile->close());
-    _src_rssids->clear();
-    _src_rssids.reset();
-    return Status::OK();
-}
-
 HorizontalBetaRowsetWriter::HorizontalBetaRowsetWriter(const RowsetWriterContext& context)
         : BetaRowsetWriter(context), _segment_writer(nullptr) {}
 
@@ -258,25 +247,6 @@ Status HorizontalBetaRowsetWriter::add_chunk(const vectorized::Chunk& chunk) {
     }
 
     RETURN_IF_ERROR(_segment_writer->append_chunk(chunk));
-    _num_rows_written += static_cast<int64_t>(chunk.num_rows());
-    _total_row_size += static_cast<int64_t>(chunk.bytes_usage());
-    return Status::OK();
-}
-
-Status HorizontalBetaRowsetWriter::add_chunk_with_rssid(const vectorized::Chunk& chunk, const vector<uint32_t>& rssid) {
-    if (_segment_writer == nullptr) {
-        ASSIGN_OR_RETURN(_segment_writer, _create_segment_writer());
-    } else if (_segment_writer->estimate_segment_size() >= config::max_segment_file_size ||
-               _segment_writer->num_rows_written() + chunk.num_rows() >= _context.max_rows_per_segment) {
-        RETURN_IF_ERROR(_flush_segment_writer(&_segment_writer));
-        ASSIGN_OR_RETURN(_segment_writer, _create_segment_writer());
-    }
-
-    RETURN_IF_ERROR(_segment_writer->append_chunk(chunk));
-    if (!_src_rssids) {
-        _src_rssids = std::make_unique<vector<uint32_t>>();
-    }
-    _src_rssids->insert(_src_rssids->end(), rssid.begin(), rssid.end());
     _num_rows_written += static_cast<int64_t>(chunk.num_rows());
     _total_row_size += static_cast<int64_t>(chunk.bytes_usage());
     return Status::OK();
@@ -758,9 +728,6 @@ Status HorizontalBetaRowsetWriter::_flush_segment_writer(std::unique_ptr<Segment
         _total_data_size += static_cast<int64_t>(segment_size);
         _total_index_size += static_cast<int64_t>(index_size);
     }
-    if (_src_rssids) {
-        RETURN_IF_ERROR(flush_src_rssids(_segment_writer->segment_id()));
-    }
 
     // check global_dict efficacy
     const auto& seg_global_dict_columns_valid_info = (*segment_writer)->global_dict_columns_valid_info();
@@ -869,17 +836,6 @@ Status VerticalBetaRowsetWriter::add_columns(const vectorized::Chunk& chunk,
     return Status::OK();
 }
 
-Status VerticalBetaRowsetWriter::add_columns_with_rssid(const vectorized::Chunk& chunk,
-                                                        const std::vector<uint32_t>& column_indexes,
-                                                        const std::vector<uint32_t>& rssid) {
-    RETURN_IF_ERROR(add_columns(chunk, column_indexes, true));
-    if (!_src_rssids) {
-        _src_rssids = std::make_unique<std::vector<uint32_t>>();
-    }
-    _src_rssids->insert(_src_rssids->end(), rssid.begin(), rssid.end());
-    return Status::OK();
-}
-
 Status VerticalBetaRowsetWriter::flush_columns() {
     if (_segment_writers.empty()) {
         return Status::OK();
@@ -948,9 +904,6 @@ Status VerticalBetaRowsetWriter::_flush_columns(std::unique_ptr<SegmentWriter>* 
     {
         std::lock_guard<std::mutex> l(_lock);
         _total_index_size += static_cast<int64_t>(index_size);
-    }
-    if (_src_rssids) {
-        return flush_src_rssids((*segment_writer)->segment_id());
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/beta_rowset_writer.h
+++ b/be/src/storage/rowset/beta_rowset_writer.h
@@ -52,8 +52,6 @@ public:
     RowsetId rowset_id() override { return _context.rowset_id; }
 
 protected:
-    Status flush_src_rssids(uint32_t segment_id);
-
     RowsetWriterContext _context;
     std::shared_ptr<FileSystem> _fs;
     std::unique_ptr<RowsetMetaPB> _rowset_meta_pb;
@@ -76,9 +74,6 @@ protected:
     int64_t _total_data_size;
     int64_t _total_index_size;
 
-    // used for updatable tablet's compaction
-    std::unique_ptr<vector<uint32_t>> _src_rssids;
-
     bool _is_pending = false;
     bool _already_built = false;
 
@@ -94,7 +89,6 @@ public:
     ~HorizontalBetaRowsetWriter() override;
 
     Status add_chunk(const vectorized::Chunk& chunk) override;
-    Status add_chunk_with_rssid(const vectorized::Chunk& chunk, const vector<uint32_t>& rssid) override;
 
     Status flush_chunk(const vectorized::Chunk& chunk) override;
     Status flush_chunk_with_deletes(const vectorized::Chunk& upserts, const vectorized::Column& deletes) override;
@@ -130,9 +124,6 @@ public:
 
     Status add_columns(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes,
                        bool is_key) override;
-
-    Status add_columns_with_rssid(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes,
-                                  const std::vector<uint32_t>& rssid) override;
 
     Status flush_columns() override;
 

--- a/be/src/storage/rowset/rowset_writer.h
+++ b/be/src/storage/rowset/rowset_writer.h
@@ -80,21 +80,11 @@ public:
 
     virtual Status add_chunk(const vectorized::Chunk& chunk) { return Status::NotSupported("RowsetWriter::add_chunk"); }
 
-    // Used for updatable tablet compaction (BetaRowsetWriter), need to write src rssid with segment
-    virtual Status add_chunk_with_rssid(const vectorized::Chunk& chunk, const vector<uint32_t>& rssid) {
-        return Status::NotSupported("RowsetWriter::add_chunk_with_rssid");
-    }
-
     // Used for vertical compaction
     // |Chunk| contains partial columns data corresponding to |column_indexes|.
     virtual Status add_columns(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes,
                                bool is_key) {
         return Status::NotSupported("RowsetWriter::add_columns");
-    }
-
-    virtual Status add_columns_with_rssid(const vectorized::Chunk& chunk, const std::vector<uint32_t>& column_indexes,
-                                          const std::vector<uint32_t>& rssid) {
-        return Status::NotSupported("RowsetWriter::add_columns_with_rssid");
     }
 
     virtual Status flush_chunk(const vectorized::Chunk& chunk) {

--- a/be/src/storage/rowset/rowset_writer_adapter.h
+++ b/be/src/storage/rowset/rowset_writer_adapter.h
@@ -25,10 +25,6 @@ public:
 
     Status add_chunk(const vectorized::Chunk& chunk) override;
 
-    Status add_chunk_with_rssid(const vectorized::Chunk& chunk, const vector<uint32_t>& rssid) override {
-        return _writer->add_chunk_with_rssid(chunk, rssid);
-    }
-
     Status flush_chunk(const vectorized::Chunk& chunk) override;
 
     Status flush_chunk_with_deletes(const vectorized::Chunk& upserts, const vectorized::Column& deletes) override;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1308,14 +1308,13 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     size_t total_rows = 0;
     vector<std::pair<uint32_t, DelVectorPtr>> delvecs;
     vector<uint32_t> tmp_deletes;
-    for (size_t i = 0; i < _compaction_state->segment_states.size(); i++) {
-        auto& sstate = _compaction_state->segment_states[i];
-        total_rows += sstate.src_rssids.size();
+    for (size_t i = 0; i < _compaction_state->pk_cols.size(); i++) {
+        auto& pk_col = _compaction_state->pk_cols[i];
+        total_rows += pk_col->size();
         uint32_t rssid = rowset_id + i;
         tmp_deletes.clear();
         // replace will not grow hashtable, so don't need to check memory limit
-        index.try_replace(rssid, 0, *sstate.pkeys, *std::max_element(info->inputs.begin(), info->inputs.end()),
-                          &tmp_deletes);
+        index.try_replace(rssid, 0, *pk_col, *std::max_element(info->inputs.begin(), info->inputs.end()), &tmp_deletes);
         DelVectorPtr dv = std::make_shared<DelVector>();
         if (tmp_deletes.empty()) {
             dv->init(version.major(), nullptr, 0);
@@ -1325,8 +1324,7 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
         }
         delvecs.emplace_back(rssid, dv);
         // release memory early
-        sstate.pkeys.reset();
-        sstate.src_rssids.clear();
+        pk_col.reset();
     }
     // release memory
     _compaction_state.reset();

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1308,13 +1308,27 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     size_t total_rows = 0;
     vector<std::pair<uint32_t, DelVectorPtr>> delvecs;
     vector<uint32_t> tmp_deletes;
+
+    // Since value stored in info->inputs of CompactInfo is rowset id
+    // we should get the real max rssid here by segment number
+    uint32_t max_rowset_id = *std::max_element(info->inputs.begin(), info->inputs.end());
+    Rowset* rowset = _get_rowset(max_rowset_id).get();
+    if (rowset == nullptr) {
+        string msg = Substitute("_apply_compaction_commit rowset not found tablet=$0 rowset=$1", _tablet.tablet_id(),
+                                max_rowset_id);
+        LOG(ERROR) << msg;
+        _set_error(msg);
+        return;
+    }
+    uint32_t max_src_rssid = max_rowset_id + rowset->num_segments() - 1;
+
     for (size_t i = 0; i < _compaction_state->pk_cols.size(); i++) {
         auto& pk_col = _compaction_state->pk_cols[i];
         total_rows += pk_col->size();
         uint32_t rssid = rowset_id + i;
         tmp_deletes.clear();
         // replace will not grow hashtable, so don't need to check memory limit
-        index.try_replace(rssid, 0, *pk_col, *std::max_element(info->inputs.begin(), info->inputs.end()), &tmp_deletes);
+        index.try_replace(rssid, 0, *pk_col, max_src_rssid, &tmp_deletes);
         DelVectorPtr dv = std::make_shared<DelVector>();
         if (tmp_deletes.empty()) {
             dv->init(version.major(), nullptr, 0);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1314,7 +1314,8 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
         uint32_t rssid = rowset_id + i;
         tmp_deletes.clear();
         // replace will not grow hashtable, so don't need to check memory limit
-        index.try_replace(rssid, 0, *sstate.pkeys, sstate.src_rssids, &tmp_deletes);
+        index.try_replace(rssid, 0, *sstate.pkeys, *std::max_element(info->inputs.begin(), info->inputs.end()),
+                          &tmp_deletes);
         DelVectorPtr dv = std::make_shared<DelVector>();
         if (tmp_deletes.empty()) {
             dv->init(version.major(), nullptr, 0);

--- a/be/src/storage/update_compaction_state.h
+++ b/be/src/storage/update_compaction_state.h
@@ -12,14 +12,8 @@
 namespace starrocks {
 
 class Rowset;
-using RowsetSharedPtr = std::shared_ptr<Rowset>;
 
 namespace vectorized {
-
-struct CompactionSemgentState {
-    ColumnPtr pkeys;
-    std::vector<uint32_t> src_rssids;
-};
 
 class CompactionState {
 public:
@@ -33,7 +27,7 @@ public:
 
     size_t memory_usage() const { return _memory_usage; }
 
-    std::vector<CompactionSemgentState> segment_states;
+    std::vector<ColumnPtr> pk_cols;
 
 private:
     Status _do_load(Rowset* rowset);


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)
This pr backport the following prs to branch-2.3
+ https://github.com/StarRocks/starrocks/pull/8468
+ https://github.com/StarRocks/starrocks/pull/8542
+ https://github.com/StarRocks/starrocks/pull/9492

These prs are aim to remove the rssid file during update compaction. If we upgrade to branch-2.4 but meet some errors and degrade to branch-2.3 finally, we may get error which can not find the specified rssid file,  that is because we don't generate rssid file in branch-2.4 anymore but we need it in branch-2.3 to do update compaction. So we backport the above prs to branch-2.3 to resolve the degrade issue.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
