### PR TITLE
[Enhancement] Refactor parquet schema parse logic

### DIFF
--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -483,8 +483,20 @@ private:
     const ColumnReaderOptions& _opts;
 };
 
+Status ColumnReader::_check_type_matched(const starrocks::TypeDescriptor& parquet_field_type, const starrocks::TypeDescriptor& column_type) {
+    // We only checked about complex types, because we will not set primitive type in ParquetField after parse schema
+    if (parquet_field_type.is_complex_type() || column_type.is_complex_type()) {
+        if (parquet_field_type.type != column_type.type) {
+            return Status::InternalError(fmt::format("Parquet parsed type {} is not matched the column type {}", parquet_field_type.debug_string(), column_type.debug_string()));
+        }
+    }
+    return Status::OK();
+}
+
 Status ColumnReader::create(const ColumnReaderOptions& opts, const ParquetField* field, const TypeDescriptor& col_type,
                             std::unique_ptr<ColumnReader>* output) {
+    RETURN_IF_ERROR(_check_type_matched(field->type, col_type));
+
     if (field->type.type == LogicalType::TYPE_ARRAY) {
         std::unique_ptr<ColumnReader> child_reader;
         RETURN_IF_ERROR(ColumnReader::create(opts, &field->children[0], col_type.children[0], &child_reader));
@@ -551,6 +563,8 @@ Status ColumnReader::create(const ColumnReaderOptions& opts, const ParquetField*
 
 Status ColumnReader::create(const ColumnReaderOptions& opts, const ParquetField* field, const TypeDescriptor& col_type,
                             const TIcebergSchemaField* iceberg_schema_field, std::unique_ptr<ColumnReader>* output) {
+    RETURN_IF_ERROR(_check_type_matched(field->type, col_type));
+
     DCHECK(iceberg_schema_field != nullptr);
     if (field->type.type == LogicalType::TYPE_ARRAY) {
         std::unique_ptr<ColumnReader> child_reader;

--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -499,12 +499,10 @@ Status ColumnReader::create(const ColumnReaderOptions& opts, const ParquetField*
         DCHECK(field->children[0].children.size() == 2);
 
         if (!col_type.children[0].is_unknown_type()) {
-            RETURN_IF_ERROR(
-                    ColumnReader::create(opts, &(field->children[0].children[0]), col_type.children[0], &key_reader));
+            RETURN_IF_ERROR(ColumnReader::create(opts, &(field->children[0]), col_type.children[0], &key_reader));
         }
         if (!col_type.children[1].is_unknown_type()) {
-            RETURN_IF_ERROR(
-                    ColumnReader::create(opts, &(field->children[0].children[1]), col_type.children[1], &value_reader));
+            RETURN_IF_ERROR(ColumnReader::create(opts, &(field->children[1]), col_type.children[1], &value_reader));
         }
 
         std::unique_ptr<MapColumnReader> reader(new MapColumnReader(opts));
@@ -576,11 +574,11 @@ Status ColumnReader::create(const ColumnReaderOptions& opts, const ParquetField*
         const TIcebergSchemaField* value_iceberg_schema = &iceberg_schema_field->children[1];
 
         if (!col_type.children[0].is_unknown_type()) {
-            RETURN_IF_ERROR(ColumnReader::create(opts, &(field->children[0].children[0]), col_type.children[0],
-                                                 key_iceberg_schema, &key_reader));
+            RETURN_IF_ERROR(ColumnReader::create(opts, &(field->children[0]), col_type.children[0], key_iceberg_schema,
+                                                 &key_reader));
         }
         if (!col_type.children[1].is_unknown_type()) {
-            RETURN_IF_ERROR(ColumnReader::create(opts, &(field->children[0].children[1]), col_type.children[1],
+            RETURN_IF_ERROR(ColumnReader::create(opts, &(field->children[1]), col_type.children[1],
                                                  value_iceberg_schema, &value_reader));
         }
 

--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -494,9 +494,6 @@ Status ColumnReader::create(const ColumnReaderOptions& opts, const ParquetField*
     } else if (field->type.type == LogicalType::TYPE_MAP) {
         std::unique_ptr<ColumnReader> key_reader = nullptr;
         std::unique_ptr<ColumnReader> value_reader = nullptr;
-        // ParquetFiled Map -> Map<Struct<key,value>>
-        DCHECK(field->children[0].type.is_struct_type());
-        DCHECK(field->children[0].children.size() == 2);
 
         if (!col_type.children[0].is_unknown_type()) {
             RETURN_IF_ERROR(ColumnReader::create(opts, &(field->children[0]), col_type.children[0], &key_reader));
@@ -566,9 +563,6 @@ Status ColumnReader::create(const ColumnReaderOptions& opts, const ParquetField*
     } else if (field->type.type == LogicalType::TYPE_MAP) {
         std::unique_ptr<ColumnReader> key_reader = nullptr;
         std::unique_ptr<ColumnReader> value_reader = nullptr;
-        // ParquetFiled Map -> Map<Struct<key,value>>
-        DCHECK(field->children[0].type.is_struct_type());
-        DCHECK(field->children[0].children.size() == 2);
 
         const TIcebergSchemaField* key_iceberg_schema = &iceberg_schema_field->children[0];
         const TIcebergSchemaField* value_iceberg_schema = &iceberg_schema_field->children[1];

--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -78,6 +78,8 @@ public:
     }
 
     std::unique_ptr<ColumnConverter> converter;
+private:
+    static Status _check_type_matched(const TypeDescriptor& parquet_field_type, const TypeDescriptor& column_type);
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -273,14 +273,8 @@ void GroupReader::_collect_field_io_range(const ParquetField& field,
     // and it may not be equal to col_idx_in_chunk.
     // 3. For array type, the physical_column_index is 0, we need to iterate the children and
     // collect their io ranges.
-    if (field.type.type == LogicalType::TYPE_ARRAY || field.type.type == LogicalType::TYPE_STRUCT) {
+    if (field.type.is_complex_type()) {
         for (auto& child : field.children) {
-            _collect_field_io_range(child, ranges, end_offset);
-        }
-    } else if (field.type.type == LogicalType::TYPE_MAP) {
-        // ParquetFiled Map -> Map<Struct<key,value>>
-        DCHECK(field.children[0].type.type == TYPE_STRUCT);
-        for (auto& child : field.children[0].children) {
             _collect_field_io_range(child, ranges, end_offset);
         }
     } else {

--- a/be/src/formats/parquet/schema.cpp
+++ b/be/src/formats/parquet/schema.cpp
@@ -476,6 +476,9 @@ Status SchemaDescriptor::new_group_to_struct_field(const std::vector<tparquet::S
     for (size_t i = 0; i < num_children; i++) {
         field->type.children.emplace_back(field->children[i].type);
     }
+    for (size_t i = 0; i < num_children; i++) {
+        field->type.field_names.emplace_back(field->children[i].name);
+    }
     field->field_id = group_schema->field_id;
     return Status::OK();
 }

--- a/be/src/formats/parquet/schema.cpp
+++ b/be/src/formats/parquet/schema.cpp
@@ -338,7 +338,7 @@ Status SchemaDescriptor::new_map_to_field(const std::vector<tparquet::SchemaElem
     // SR doesn't support 1 column maps (i.e. Sets).  The options are to either
     // make the values column nullable, or process the map as a list.  We choose the latter
     // as it is simpler.
-    if (key_schema->num_children == 1) {
+    if (key_value_schema->num_children == 1) {
         return new_list_to_field(t_schemas, pos, cur_level_info, field, next_pos);
     }
 
@@ -631,6 +631,7 @@ Status SchemaDescriptor::node_to_field(const std::vector<tparquet::SchemaElement
     return Status::OK();
 }
 
+// The schema resolve logic is copied from https://github.com/apache/arrow/blob/main/cpp/src/parquet/arrow/schema.cc
 Status SchemaDescriptor::from_thrift(const std::vector<tparquet::SchemaElement>& t_schemas, bool case_sensitive) {
     if (t_schemas.size() == 0) {
         return Status::InvalidArgument("Empty parquet Schema");
@@ -673,14 +674,14 @@ Status SchemaDescriptor::from_thrift(const std::vector<tparquet::SchemaElement>&
 
 std::string SchemaDescriptor::debug_string() const {
     std::stringstream ss;
-    ss << "fields=[";
+    ss << "fields=[\n";
     for (int i = 0; i < _fields.size(); ++i) {
         if (i != 0) {
-            ss << ",";
+            ss << ",\n";
         }
         ss << _fields[i].debug_string();
     }
-    ss << "]";
+    ss << "\n]";
     return ss.str();
 }
 

--- a/be/src/formats/parquet/schema.cpp
+++ b/be/src/formats/parquet/schema.cpp
@@ -50,13 +50,38 @@ static bool is_group(const tparquet::SchemaElement& schema) {
     return schema.num_children > 0;
 }
 
+static bool is_group(const tparquet::SchemaElement* schema) {
+    return schema->num_children > 0;
+}
+
+static bool is_repeated(const tparquet::SchemaElement* schema) {
+    return schema->__isset.repetition_type && schema->repetition_type == tparquet::FieldRepetitionType::REPEATED;
+}
+
+static bool is_required(const tparquet::SchemaElement* schema) {
+    return schema->__isset.repetition_type && schema->repetition_type == tparquet::FieldRepetitionType::REQUIRED;
+}
+
+static bool is_optional(const tparquet::SchemaElement* schema) {
+    return schema->__isset.repetition_type && schema->repetition_type == tparquet::FieldRepetitionType::OPTIONAL;
+}
+
 static bool is_list(const tparquet::SchemaElement& schema) {
     return schema.__isset.converted_type && schema.converted_type == tparquet::ConvertedType::LIST;
+}
+
+static bool is_list(const tparquet::SchemaElement* schema) {
+    return schema->__isset.converted_type && schema->converted_type == tparquet::ConvertedType::LIST;
 }
 
 static bool is_map(const tparquet::SchemaElement& schema) {
     return schema.__isset.converted_type && (schema.converted_type == tparquet::ConvertedType::MAP ||
                                              schema.converted_type == tparquet::ConvertedType::MAP_KEY_VALUE);
+}
+
+static bool is_map(const tparquet::SchemaElement* schema) {
+    return schema->__isset.converted_type && (schema->converted_type == tparquet::ConvertedType::MAP ||
+                                              schema->converted_type == tparquet::ConvertedType::MAP_KEY_VALUE);
 }
 
 static bool is_repeated(const tparquet::SchemaElement& schema) {
@@ -89,6 +114,23 @@ void SchemaDescriptor::leaf_to_field(const tparquet::SchemaElement& t_schema, co
 
     _physical_fields.push_back(field);
     field->physical_column_index = _physical_fields.size() - 1;
+}
+
+Status SchemaDescriptor::new_leaf_to_field(const tparquet::SchemaElement* t_schema, const LevelInfo& cur_level_info,
+                                           bool is_nullable, ParquetField* field) {
+    field->name = t_schema->name;
+    field->schema_element = *t_schema;
+    field->is_nullable = is_nullable;
+    field->physical_type = t_schema->type;
+    field->type_length = t_schema->type_length;
+    field->scale = t_schema->scale;
+    field->precision = t_schema->precision;
+    field->field_id = t_schema->field_id;
+    field->level_info = cur_level_info;
+
+    _physical_fields.push_back(field);
+    field->physical_column_index = _physical_fields.size() - 1;
+    return Status::OK();
 }
 
 // Special case mentioned in the format spec:
@@ -197,6 +239,140 @@ Status SchemaDescriptor::list_to_field(const std::vector<tparquet::SchemaElement
     return Status::OK();
 }
 
+Status SchemaDescriptor::new_list_to_field(const std::vector<tparquet::SchemaElement>& t_schemas, size_t pos,
+                                           LevelInfo cur_level_info, ParquetField* field, size_t* next_pos) {
+    ASSIGN_OR_RETURN(const auto* group_schema, _get_schema_element(t_schemas, pos));
+    if (group_schema->num_children != 1) {
+        return Status::InvalidArgument("LIST-annotated groups must have a single child.");
+    }
+    if (is_repeated(group_schema)) {
+        return Status::InvalidArgument("LIST-annotated groups must not be repeated.");
+    }
+    _increment(group_schema, &cur_level_info);
+
+    field->children.resize(1);
+    auto child_field = &field->children[0];
+
+    ASSIGN_OR_RETURN(const auto* list_node_schema, _get_schema_element(t_schemas, pos + 1));
+    if (!is_repeated(list_node_schema)) {
+        return Status::InvalidArgument("Non-repeated nodes in a LIST-annotated group are not supported.");
+    }
+
+    int16_t last_immediate_repeated_ancestor_def_level = cur_level_info.increment_repeated();
+    if (is_group(list_node_schema)) {
+        // Resolve 3-level encoding
+        //
+        // required/optional group name=whatever {
+        //   repeated group name=list {
+        //     required/optional TYPE item;
+        //   }
+        // }
+        //
+        // yields list<item: TYPE ?nullable> ?nullable
+        //
+        // We distinguish the special case that we have
+        //
+        // required/optional group name=whatever {
+        //   repeated group name=array or $SOMETHING_tuple {
+        //     required/optional TYPE item;
+        //   }
+        // }
+        //
+        // In this latter case, the inner type of the list should be a struct
+        // rather than a primitive value
+        //
+        // yields list<item: struct<item: TYPE ?nullable> not null> ?nullable
+        if (list_node_schema->num_children == 1 && !has_struct_list_name(list_node_schema->name)) {
+            RETURN_IF_ERROR(new_node_to_field(t_schemas, pos + 2, cur_level_info, child_field, next_pos));
+        } else {
+            RETURN_IF_ERROR(group_to_struct_field(t_schemas, pos + 1, cur_level_info, child_field, next_pos));
+        }
+    } else {
+        // Two-level list encoding
+        //
+        // required/optional group LIST {
+        //   repeated TYPE;
+        // }
+        RETURN_IF_ERROR(new_leaf_to_field(list_node_schema, cur_level_info, false, child_field));
+        *next_pos = pos + 2;
+    }
+
+    field->name = group_schema->name;
+    field->field_id = group_schema->field_id;
+    field->type.type = TYPE_ARRAY;
+    field->type.children.push_back(field->children[0].type);
+    field->is_nullable = is_optional(group_schema);
+    field->level_info = cur_level_info;
+    field->level_info.immediate_repeated_ancestor_def_level = last_immediate_repeated_ancestor_def_level;
+    return Status::OK();
+}
+
+Status SchemaDescriptor::new_map_to_field(const std::vector<tparquet::SchemaElement>& t_schemas, size_t pos,
+                                          LevelInfo cur_level_info, ParquetField* field, size_t* next_pos) {
+    ASSIGN_OR_RETURN(const auto* group_schema, _get_schema_element(t_schemas, pos));
+    if (group_schema->num_children != 1) {
+        return Status::InvalidArgument("MAP-annotated group must have a single child.");
+    }
+    if (is_repeated(group_schema)) {
+        return Status::InvalidArgument("MAP-annotated group must not be repeated.");
+    }
+
+    ASSIGN_OR_RETURN(const auto* key_value_schema, _get_schema_element(t_schemas, pos + 1));
+
+    if (!is_repeated(key_value_schema)) {
+        return Status::InvalidArgument("Non-repeated key value in a MAP-annotated group are not supported.");
+    }
+    if (!is_group(key_value_schema)) {
+        return Status::InvalidArgument("Key-value node must be a group.");
+    }
+
+    if (key_value_schema->num_children != 1 && key_value_schema->num_children != 2) {
+        return Status::InvalidArgument(strings::Substitute(
+                "Key-value map node must have 1 or 2 child elements. Found: $0", key_value_schema->num_children));
+    }
+
+    ASSIGN_OR_RETURN(const auto* key_schema, _get_schema_element(t_schemas, pos + 2));
+    if (!is_required(key_schema)) {
+        return Status::InvalidArgument("Map keys must be annotated as required.");
+    }
+    // SR doesn't support 1 column maps (i.e. Sets).  The options are to either
+    // make the values column nullable, or process the map as a list.  We choose the latter
+    // as it is simpler.
+    if (key_schema->num_children == 1) {
+        return new_list_to_field(t_schemas, pos, cur_level_info, field, next_pos);
+    }
+
+    _increment(group_schema, &cur_level_info);
+    // Increment rep levels for key_value_schema
+    int16_t last_immediate_repeated_ancestor_def_level = cur_level_info.increment_repeated();
+
+    field->children.resize(2);
+    auto key_field = &field->children[0];
+    auto value_field = &field->children[1];
+
+    // required/optional group name=whatever {
+    //   repeated group name=key_values{
+    //     required TYPE key;
+    //     required/optional TYPE value;
+    //   }
+    // }
+    //
+    RETURN_IF_ERROR(new_node_to_field(t_schemas, pos + 2, cur_level_info, key_field, next_pos));
+    RETURN_IF_ERROR(new_node_to_field(t_schemas, pos + 3, cur_level_info, value_field, next_pos));
+
+
+    field->name = group_schema->name;
+    // Actually, we don't need to put field_id here
+    field->field_id = group_schema->field_id;
+    field->type.type = TYPE_MAP;
+    field->type.children.emplace_back(key_field->type);
+    field->type.children.emplace_back(value_field->type);
+    field->is_nullable = is_optional(group_schema);
+    field->level_info = cur_level_info;
+    field->level_info.immediate_repeated_ancestor_def_level = last_immediate_repeated_ancestor_def_level;
+    return Status::OK();
+}
+
 Status SchemaDescriptor::map_to_field(const std::vector<tparquet::SchemaElement>& t_schemas, size_t pos,
                                       LevelInfo cur_level_info, ParquetField* field, size_t* next_pos) {
     // <map-repetition> group <name> (MAP) {
@@ -280,6 +456,30 @@ Status SchemaDescriptor::group_to_struct_field(const std::vector<tparquet::Schem
     return Status::OK();
 }
 
+Status SchemaDescriptor::new_group_to_struct_field(const std::vector<tparquet::SchemaElement>& t_schemas, size_t pos,
+                                                   LevelInfo cur_level_info, ParquetField* field, size_t* next_pos) {
+    ASSIGN_OR_RETURN(const auto* group_schema, _get_schema_element(t_schemas, pos));
+    int32_t num_children = group_schema->num_children;
+    field->children.resize(num_children);
+    *next_pos = pos + 1;
+
+    // All level increments for the node are expected to happen by callers.
+    // This is required because repeated elements need to have their own ParquetField.
+    for (size_t i = 0; i < num_children; ++i) {
+        RETURN_IF_ERROR(new_node_to_field(t_schemas, *next_pos, cur_level_info, &field->children[i], next_pos));
+    }
+
+    field->name = group_schema->name;
+    field->is_nullable = is_optional(group_schema);
+    field->level_info = cur_level_info;
+    field->type.type = TYPE_STRUCT;
+    for (size_t i = 0; i < num_children; i++) {
+        field->type.children.emplace_back(field->children[i].type);
+    }
+    field->field_id = group_schema->field_id;
+    return Status::OK();
+}
+
 Status SchemaDescriptor::group_to_field(const std::vector<tparquet::SchemaElement>& t_schemas, size_t pos,
                                         LevelInfo cur_level_info, ParquetField* field, size_t* next_pos) {
     auto& group_schema = t_schemas[pos];
@@ -313,6 +513,82 @@ Status SchemaDescriptor::group_to_field(const std::vector<tparquet::SchemaElemen
     }
 
     return Status::OK();
+}
+
+Status SchemaDescriptor::new_group_to_field(const std::vector<tparquet::SchemaElement>& t_schemas, size_t pos,
+                                            LevelInfo cur_level_info, ParquetField* field, size_t* next_pos) {
+    ASSIGN_OR_RETURN(const auto* group_schema, _get_schema_element(t_schemas, pos));
+    if (is_list(group_schema)) {
+        return new_list_to_field(t_schemas, pos, cur_level_info, field, next_pos);
+    } else if (is_map(group_schema)) {
+        return new_map_to_field(t_schemas, pos, cur_level_info, field, next_pos);
+    }
+
+    if (is_repeated(group_schema)) {
+        // Simple repeated struct
+        //
+        // repeated group $NAME {
+        //   r/o TYPE[0] f0
+        //   r/o TYPE[1] f1
+        // }
+        field->children.resize(1);
+
+        int16_t last_immediate_repeated_ancestor_def_level = cur_level_info.increment_repeated();
+        RETURN_IF_ERROR(new_group_to_struct_field(t_schemas, pos, cur_level_info, &field->children[0], next_pos));
+
+        field->name = group_schema->name;
+        field->type.type = TYPE_ARRAY;
+        field->is_nullable = false;
+        field->level_info = cur_level_info;
+        field->level_info.immediate_repeated_ancestor_def_level = last_immediate_repeated_ancestor_def_level;
+        return Status::OK();
+    } else {
+        _increment(group_schema, &cur_level_info);
+        return new_group_to_struct_field(t_schemas, pos, cur_level_info, field, next_pos);
+    }
+}
+
+Status SchemaDescriptor::new_node_to_field(const std::vector<tparquet::SchemaElement>& t_schemas, size_t pos,
+                                           LevelInfo cur_level_info, ParquetField* field, size_t* next_pos) {
+    ASSIGN_OR_RETURN(const auto* node_schema, _get_schema_element(t_schemas, pos));
+
+    if (is_group(node_schema)) {
+        // A nested field, but we don't know what kind yet
+        return new_group_to_field(t_schemas, pos, cur_level_info, field, next_pos);
+    } else {
+        // Either a normal flat primitive type, or a list type encoded with 1-level
+        // list encoding. Note that the 3-level encoding is the form recommended by
+        // the parquet specification, but technically we can have either
+        //
+        // required/optional $TYPE $FIELD_NAME
+        //
+        // or
+        //
+        // repeated $TYPE $FIELD_NAME
+        if (is_repeated(node_schema)) {
+            // One-level list encoding, e.g.
+            // a: repeated int32;
+            // This will generate a required list<element> which element is non-null
+            int16_t last_immediate_repeated_ancestor_def_level = cur_level_info.increment_repeated();
+
+            field->children.resize(1);
+            auto child = &field->children[0];
+            RETURN_IF_ERROR(new_leaf_to_field(node_schema, cur_level_info, false, child));
+
+            field->name = node_schema->name;
+            field->type.type = TYPE_ARRAY;
+            field->is_nullable = false;
+            field->field_id = node_schema->field_id;
+            field->level_info = cur_level_info;
+            field->level_info.immediate_repeated_ancestor_def_level = last_immediate_repeated_ancestor_def_level;
+            *next_pos = pos + 1;
+        } else {
+            _increment(node_schema, &cur_level_info);
+            RETURN_IF_ERROR(new_leaf_to_field(node_schema, cur_level_info, is_optional(node_schema), field));
+            *next_pos = pos + 1;
+        }
+        return Status::OK();
+    }
 }
 
 Status SchemaDescriptor::node_to_field(const std::vector<tparquet::SchemaElement>& t_schemas, size_t pos,
@@ -372,9 +648,10 @@ Status SchemaDescriptor::from_thrift(const std::vector<tparquet::SchemaElement>&
     }
     _fields.resize(root_schema.num_children);
     // skip root SchemaElement
+    // next_pos is the index in t_schemas, t_schemas is a flatten structure
     size_t next_pos = 1;
     for (size_t i = 0; i < root_schema.num_children; ++i) {
-        RETURN_IF_ERROR(node_to_field(t_schemas, next_pos, LevelInfo(), &_fields[i], &next_pos));
+        RETURN_IF_ERROR(new_node_to_field(t_schemas, next_pos, LevelInfo(), &_fields[i], &next_pos));
         if (!case_sensitive) {
             _fields[i].name = boost::algorithm::to_lower_copy(_fields[i].name);
         }
@@ -432,5 +709,17 @@ const ParquetField* SchemaDescriptor::get_stored_column_by_column_name(const std
     int idx = get_field_idx_by_column_name(column_name);
     if (idx == -1) return nullptr;
     return &(_fields[idx]);
+}
+
+// Increments levels according to the cardinality of node.
+void SchemaDescriptor::_increment(const tparquet::SchemaElement* t_schema, LevelInfo* level_info) {
+    if (is_repeated(t_schema)) {
+        level_info->increment_repeated();
+        return;
+    }
+    if (is_optional(t_schema)) {
+        level_info->increment_optional();
+        return;
+    }
 }
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/schema.cpp
+++ b/be/src/formats/parquet/schema.cpp
@@ -122,6 +122,7 @@ Status SchemaDescriptor::new_leaf_to_field(const tparquet::SchemaElement* t_sche
     field->schema_element = *t_schema;
     field->is_nullable = is_nullable;
     field->physical_type = t_schema->type;
+    field->converted_type = t_schema->converted_type;
     field->type_length = t_schema->type_length;
     field->scale = t_schema->scale;
     field->precision = t_schema->precision;
@@ -677,14 +678,14 @@ Status SchemaDescriptor::from_thrift(const std::vector<tparquet::SchemaElement>&
 
 std::string SchemaDescriptor::debug_string() const {
     std::stringstream ss;
-    ss << "fields=[\n";
+    ss << "fields=[";
     for (int i = 0; i < _fields.size(); ++i) {
         if (i != 0) {
-            ss << ",\n";
+            ss << ",";
         }
         ss << _fields[i].debug_string();
     }
-    ss << "\n]";
+    ss << "]";
     return ss.str();
 }
 

--- a/be/src/formats/parquet/schema.h
+++ b/be/src/formats/parquet/schema.h
@@ -97,6 +97,8 @@ struct ParquetField {
 
     // Only valid when this field is a leaf node
     tparquet::Type::type physical_type;
+    // Only valid when this field is a leaf node
+    tparquet::ConvertedType::type converted_type;
     // If type is FIXED_LEN_BYTE_ARRAY, this is the byte length of the vales.
     int32_t type_length;
 

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -1095,48 +1095,48 @@ TEST_F(FileReaderTest, TestReadRequiredArrayColumns) {
 
 // when key type is char or varchar, not string
 // the real type is BYTE_ARRAY which is OPTIONAL
-TEST_F(FileReaderTest, TestReadMapCharKeyColumn) {
-    auto file = _create_file(_file_map_char_key_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file_map_char_key_path));
-
-    //init
-    auto* ctx = _create_file_map_char_key_context();
-    Status status = file_reader->init(ctx);
-    ASSERT_TRUE(status.ok());
-
-    EXPECT_EQ(file_reader->_row_group_readers.size(), 1);
-    std::vector<io::SharedBufferedInputStream::IORange> ranges;
-    int64_t end_offset = 0;
-    file_reader->_row_group_readers[0]->collect_io_ranges(&ranges, &end_offset);
-
-    // c1, c2.key, c2.value, c3.key, c3.value
-    EXPECT_EQ(ranges.size(), 5);
-
-    EXPECT_EQ(file_reader->_file_metadata->num_rows(), 1);
-    TypeDescriptor type_map_char(LogicalType::TYPE_MAP);
-    type_map_char.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_CHAR));
-    type_map_char.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
-
-    TypeDescriptor type_map_varchar(LogicalType::TYPE_MAP);
-    type_map_varchar.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR));
-    type_map_varchar.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
-
-    ChunkPtr chunk = std::make_shared<Chunk>();
-    _append_column_for_chunk(LogicalType::TYPE_INT, &chunk);
-    auto c = ColumnHelper::create_column(type_map_char, true);
-    chunk->append_column(c, chunk->num_columns());
-    auto c_map1 = ColumnHelper::create_column(type_map_varchar, true);
-    chunk->append_column(c_map1, chunk->num_columns());
-
-    status = file_reader->get_next(&chunk);
-    ASSERT_TRUE(status.ok());
-    EXPECT_EQ(chunk->num_rows(), 1);
-    for (int i = 0; i < chunk->num_rows(); ++i) {
-        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
-    }
-    EXPECT_EQ(chunk->debug_row(0), "[0, {'abc':123}, {'def':456}]");
-}
+//TEST_F(FileReaderTest, TestReadMapCharKeyColumn) {
+//    auto file = _create_file(_file_map_char_key_path);
+//    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+//                                                    std::filesystem::file_size(_file_map_char_key_path));
+//
+//    //init
+//    auto* ctx = _create_file_map_char_key_context();
+//    Status status = file_reader->init(ctx);
+//    ASSERT_TRUE(status.ok());
+//
+//    EXPECT_EQ(file_reader->_row_group_readers.size(), 1);
+//    std::vector<io::SharedBufferedInputStream::IORange> ranges;
+//    int64_t end_offset = 0;
+//    file_reader->_row_group_readers[0]->collect_io_ranges(&ranges, &end_offset);
+//
+//    // c1, c2.key, c2.value, c3.key, c3.value
+//    EXPECT_EQ(ranges.size(), 5);
+//
+//    EXPECT_EQ(file_reader->_file_metadata->num_rows(), 1);
+//    TypeDescriptor type_map_char(LogicalType::TYPE_MAP);
+//    type_map_char.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_CHAR));
+//    type_map_char.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+//
+//    TypeDescriptor type_map_varchar(LogicalType::TYPE_MAP);
+//    type_map_varchar.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR));
+//    type_map_varchar.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+//
+//    ChunkPtr chunk = std::make_shared<Chunk>();
+//    _append_column_for_chunk(LogicalType::TYPE_INT, &chunk);
+//    auto c = ColumnHelper::create_column(type_map_char, true);
+//    chunk->append_column(c, chunk->num_columns());
+//    auto c_map1 = ColumnHelper::create_column(type_map_varchar, true);
+//    chunk->append_column(c_map1, chunk->num_columns());
+//
+//    status = file_reader->get_next(&chunk);
+//    ASSERT_TRUE(status.ok());
+//    EXPECT_EQ(chunk->num_rows(), 1);
+//    for (int i = 0; i < chunk->num_rows(); ++i) {
+//        std::cout << "row" << i << ": " << chunk->debug_row(i) << std::endl;
+//    }
+//    EXPECT_EQ(chunk->debug_row(0), "[0, {'abc':123}, {'def':456}]");
+//}
 
 TEST_F(FileReaderTest, TestReadMapColumn) {
     auto file = _create_file(_file_map_path);

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -741,12 +741,11 @@ TEST_F(FileReaderTest, TestGetNext) {
 }
 
 TEST_F(FileReaderTest, TestGetNextWithSkipID) {
-    int64_t ids[]= {1};
+    int64_t ids[] = {1};
     std::set<std::int64_t> need_skip_rowids(ids, ids + 1);
     auto file = _create_file(_file1_path);
-    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(_file1_path),
-                                                    nullptr, &need_skip_rowids);
+    auto file_reader = std::make_shared<FileReader>(
+            config::vector_chunk_size, file.get(), std::filesystem::file_size(_file1_path), nullptr, &need_skip_rowids);
     // init
     auto* ctx = _create_file1_base_context();
     Status status = file_reader->init(ctx);
@@ -1858,20 +1857,20 @@ TEST_F(FileReaderTest, TestReadArrayMap) {
     // --------------finish init context---------------
 
     Status status = file_reader->init(ctx);
-    ASSERT_TRUE(status.ok());
-
-    EXPECT_EQ(file_reader->_row_group_readers.size(), 1);
-
-    auto chunk = std::make_shared<Chunk>();
-    chunk->append_column(ColumnHelper::create_column(type_string, true), chunk->num_columns());
-    chunk->append_column(ColumnHelper::create_column(type_array_map, true), chunk->num_columns());
-
-    status = file_reader->get_next(&chunk);
-    ASSERT_TRUE(status.ok());
-    ASSERT_EQ(2, chunk->num_rows());
-
-    EXPECT_EQ("['0', [{'def':11,'abc':10},{'ghi':12},{'jkl':13}]]", chunk->debug_row(0));
-    EXPECT_EQ("['1', [{'happy new year':11,'hello world':10},{'vary happy':12},{'ok':13}]]", chunk->debug_row(1));
+    //    ASSERT_TRUE(status.ok()) << status.get_error_msg();
+    ASSERT_FALSE(status.ok());
+    //    EXPECT_EQ(file_reader->_row_group_readers.size(), 1);
+    //
+    //    auto chunk = std::make_shared<Chunk>();
+    //    chunk->append_column(ColumnHelper::create_column(type_string, true), chunk->num_columns());
+    //    chunk->append_column(ColumnHelper::create_column(type_array_map, true), chunk->num_columns());
+    //
+    //    status = file_reader->get_next(&chunk);
+    //    ASSERT_TRUE(status.ok());
+    //    ASSERT_EQ(2, chunk->num_rows());
+    //
+    //    EXPECT_EQ("['0', [{'def':11,'abc':10},{'ghi':12},{'jkl':13}]]", chunk->debug_row(0));
+    //    EXPECT_EQ("['1', [{'happy new year':11,'hello world':10},{'vary happy':12},{'ok':13}]]", chunk->debug_row(1));
 }
 
 TEST_F(FileReaderTest, TestStructArrayNull) {
@@ -2128,69 +2127,69 @@ TEST_F(FileReaderTest, TestComplexTypeNotNull) {
     EXPECT_EQ(262144, total_row_nums);
 }
 
-TEST_F(FileReaderTest, TestHudiMORTwoNestedLevelArray) {
-    // format:
-    // b: varchar
-    // c: ARRAY<ARRAY<INT>>
-    const std::string filepath = "./be/test/exec/test_data/parquet_data/hudi_mor_two_level_nested_array.parquet";
-    auto file = _create_file(filepath);
-    auto file_reader =
-            std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(filepath));
-
-    // --------------init context---------------
-    auto ctx = _create_scan_context();
-
-    TypeDescriptor type_string = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
-
-    TypeDescriptor type_array = TypeDescriptor::from_logical_type(LogicalType::TYPE_ARRAY);
-    TypeDescriptor type_array_array = TypeDescriptor::from_logical_type(LogicalType::TYPE_ARRAY);
-    type_array_array.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
-
-    type_array.children.emplace_back(type_array_array);
-
-    Utils::SlotDesc slot_descs[] = {
-            {"b", type_string},
-            {"c", type_array},
-            {""},
-    };
-
-    ctx->tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
-    Utils::make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);
-    ctx->scan_ranges.emplace_back(_create_scan_range(_file_col_not_null_path));
-    // --------------finish init context---------------
-
-    Status status = file_reader->init(ctx);
-    ASSERT_TRUE(status.ok());
-
-    EXPECT_EQ(file_reader->_row_group_readers.size(), 1);
-
-    auto chunk = std::make_shared<Chunk>();
-    chunk->append_column(ColumnHelper::create_column(type_string, true), chunk->num_columns());
-    chunk->append_column(ColumnHelper::create_column(type_array, true), chunk->num_columns());
-
-    status = file_reader->get_next(&chunk);
-    ASSERT_TRUE(status.ok());
-
-    chunk->check_or_die();
-
-    EXPECT_EQ("['hello', [[10,20,30],[40,50,60,70]]]", chunk->debug_row(0));
-    EXPECT_EQ("[NULL, [[30,40],[10,20,30]]]", chunk->debug_row(1));
-    EXPECT_EQ("['hello', NULL]", chunk->debug_row(2));
-
-    size_t total_row_nums = 0;
-    total_row_nums += chunk->num_rows();
-
-    {
-        while (!status.is_end_of_file()) {
-            chunk->reset();
-            status = file_reader->get_next(&chunk);
-            chunk->check_or_die();
-            total_row_nums += chunk->num_rows();
-        }
-    }
-
-    EXPECT_EQ(3, total_row_nums);
-}
+//TEST_F(FileReaderTest, TestHudiMORTwoNestedLevelArray) {
+//    // format:
+//    // b: varchar
+//    // c: ARRAY<ARRAY<INT>>
+//    const std::string filepath = "./be/test/exec/test_data/parquet_data/hudi_mor_two_level_nested_array.parquet";
+//    auto file = _create_file(filepath);
+//    auto file_reader =
+//            std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(filepath));
+//
+//    // --------------init context---------------
+//    auto ctx = _create_scan_context();
+//
+//    TypeDescriptor type_string = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+//
+//    TypeDescriptor type_array = TypeDescriptor::from_logical_type(LogicalType::TYPE_ARRAY);
+//    TypeDescriptor type_array_array = TypeDescriptor::from_logical_type(LogicalType::TYPE_ARRAY);
+//    type_array_array.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+//
+//    type_array.children.emplace_back(type_array_array);
+//
+//    Utils::SlotDesc slot_descs[] = {
+//            {"b", type_string},
+//            {"c", type_array},
+//            {""},
+//    };
+//
+//    ctx->tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
+//    Utils::make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);
+//    ctx->scan_ranges.emplace_back(_create_scan_range(_file_col_not_null_path));
+//    // --------------finish init context---------------
+//
+//    Status status = file_reader->init(ctx);
+//    ASSERT_TRUE(status.ok()) << status.get_error_msg();
+//
+//    EXPECT_EQ(file_reader->_row_group_readers.size(), 1);
+//
+//    auto chunk = std::make_shared<Chunk>();
+//    chunk->append_column(ColumnHelper::create_column(type_string, true), chunk->num_columns());
+//    chunk->append_column(ColumnHelper::create_column(type_array, true), chunk->num_columns());
+//
+//    status = file_reader->get_next(&chunk);
+//    ASSERT_TRUE(status.ok());
+//
+//    chunk->check_or_die();
+//
+//    EXPECT_EQ("['hello', [[10,20,30],[40,50,60,70]]]", chunk->debug_row(0));
+//    EXPECT_EQ("[NULL, [[30,40],[10,20,30]]]", chunk->debug_row(1));
+//    EXPECT_EQ("['hello', NULL]", chunk->debug_row(2));
+//
+//    size_t total_row_nums = 0;
+//    total_row_nums += chunk->num_rows();
+//
+//    {
+//        while (!status.is_end_of_file()) {
+//            chunk->reset();
+//            status = file_reader->get_next(&chunk);
+//            chunk->check_or_die();
+//            total_row_nums += chunk->num_rows();
+//        }
+//    }
+//
+//    EXPECT_EQ(3, total_row_nums);
+//}
 
 TEST_F(FileReaderTest, TestLateMaterializationAboutRequiredComplexType) {
     // Schema:

--- a/be/test/formats/parquet/parquet_schema_test.cpp
+++ b/be/test/formats/parquet/parquet_schema_test.cpp
@@ -15,27 +15,160 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <utility>
 #include <vector>
 
 #include "formats/parquet/schema.h"
 
 namespace starrocks::parquet {
 
+using namespace tparquet;
+
+class PrimitiveNode {
+public:
+    static SchemaElement make(const std::string& name, FieldRepetitionType::type repetition, Type::type type,
+                              ConvertedType::type converted_type) {
+        SchemaElement element;
+        element.__set_name(name);
+        element.__set_repetition_type(repetition);
+        element.__set_type(type);
+        element.__set_converted_type(converted_type);
+        return element;
+    }
+    static SchemaElement make(const std::string& name, FieldRepetitionType::type repetition, Type::type type) {
+        SchemaElement element;
+        element.__set_name(name);
+        element.__set_repetition_type(repetition);
+        element.__set_type(type);
+        return element;
+    }
+    static ParquetField make_field(const std::string& name, bool is_nullable, Type::type type) {
+        ParquetField field;
+        field.name = name;
+        field.physical_type = type;
+        field.is_nullable = is_nullable;
+        return field;
+    }
+};
+
+class GroupNode {
+public:
+    static SchemaElement make_root(int32_t num_children) {
+        SchemaElement element;
+        element.__set_name("root_node");
+        element.__set_num_children(num_children);
+        return element;
+    }
+    static SchemaElement make(const std::string& name, FieldRepetitionType::type repetition,
+                              ConvertedType::type converted_type, int32_t num_children) {
+        SchemaElement element;
+        element.__set_name(name);
+        element.__set_repetition_type(repetition);
+        element.__set_converted_type(converted_type);
+        element.__set_num_children(num_children);
+        return element;
+    }
+    static SchemaElement make(const std::string& name, FieldRepetitionType::type repetition, int32_t num_children) {
+        SchemaElement element;
+        element.__set_name(name);
+        element.__set_repetition_type(repetition);
+        element.__set_num_children(num_children);
+        return element;
+    }
+    static ParquetField make_field(const std::string& name, bool is_nullable, LogicalType type,
+                                   std::vector<ParquetField> children) {
+        ParquetField field;
+        field.name = name;
+        field.is_nullable = is_nullable;
+        field.type.type = type;
+        field.children = std::move(children);
+        return field;
+    }
+};
+
+class ParquetLevelsTest : public testing::Test {
+public:
+    ParquetLevelsTest() = default;
+    ~ParquetLevelsTest() override = default;
+protected:
+    LevelInfo make(int16_t def_level, int16_t rep_level, int16_t ancestor_def_level) {
+        LevelInfo level;
+        level.immediate_repeated_ancestor_def_level = ancestor_def_level;
+        level.max_def_level = def_level;
+        level.max_rep_level = rep_level;
+        return level;
+    }
+
+    void do_check(const std::vector<SchemaElement>& t_schemas, const std::vector<LevelInfo>& expected_levels) {
+        SchemaDescriptor desc;
+        auto st = desc.from_thrift(t_schemas, true);
+        ASSERT_TRUE(st.ok()) << st.get_error_msg();
+        const auto& actual = _collect_flatten_levels(desc.get_parquet_fields());
+        _check_flatten_levels(expected_levels, actual);
+    }
+
+private:
+    const std::vector<LevelInfo> _collect_flatten_levels(const std::vector<ParquetField>& fields) {
+        std::vector<LevelInfo> vec;
+        for (const auto& field : fields) {
+            vec.emplace_back(field.level_info);
+            if (field.children.size() > 0) {
+                const auto& child = _collect_flatten_levels(field.children);
+                vec.insert(vec.end(), child.begin(), child.end());
+            }
+        }
+        return vec;
+    }
+
+    void _check_flatten_levels(const std::vector<LevelInfo>& expected, const std::vector<LevelInfo>& actual) {
+        ASSERT_EQ(expected.size(), actual.size());
+        for (size_t i = 0; i < expected.size(); i++) {
+            ASSERT_EQ(expected[i].immediate_repeated_ancestor_def_level, actual[i].immediate_repeated_ancestor_def_level);
+            ASSERT_EQ(expected[i].max_def_level, actual[i].max_def_level);
+            ASSERT_EQ(expected[i].max_rep_level, actual[i].max_rep_level);
+        }
+    }
+};
+
 class ParquetSchemaTest : public testing::Test {
 public:
     ParquetSchemaTest() = default;
     ~ParquetSchemaTest() override = default;
+
+protected:
+    void check_flat_parquet_field(const std::vector<ParquetField>& expected, const std::vector<ParquetField>& actual) {
+        ASSERT_EQ(expected.size(), actual.size());
+        if (expected.size() > 1) {
+            // is group node, need to check TypeDescriptor
+            for (size_t i = 0; i < expected.size(); i++) {
+                ASSERT_EQ(expected[i].name, actual[i].name);
+                ASSERT_EQ(expected[i].is_nullable, actual[i].is_nullable);
+                ASSERT_EQ(expected[0].type.type, actual[0].type.type);
+            }
+        } else if (expected.size() == 1) {
+            // is primitive node
+            ASSERT_EQ(expected[0].name, actual[0].name);
+            ASSERT_EQ(expected[0].is_nullable, actual[0].is_nullable);
+            ASSERT_EQ(expected[0].physical_type, actual[0].physical_type);
+        } else {
+            return;
+        }
+        // recursive about children
+        for (size_t i = 0; i < expected.size(); i++) {
+            check_flat_parquet_field(expected[i].children, actual[i].children);
+        }
+    }
 };
 
 TEST_F(ParquetSchemaTest, EmptySchema) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
     SchemaDescriptor desc;
     auto st = desc.from_thrift(t_schemas, true);
     ASSERT_FALSE(st.ok());
 }
 
 TEST_F(ParquetSchemaTest, OnlyRoot) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(1);
     {
@@ -49,7 +182,7 @@ TEST_F(ParquetSchemaTest, OnlyRoot) {
 }
 
 TEST_F(ParquetSchemaTest, OnlyLeafType) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(3);
     // Root
@@ -61,18 +194,18 @@ TEST_F(ParquetSchemaTest, OnlyLeafType) {
     // INT32
     {
         auto& t_schema = t_schemas[1];
-        t_schema.__set_type(tparquet::Type::INT32);
+        t_schema.__set_type(Type::INT32);
         t_schema.name = "col1";
         t_schema.__set_num_children(0);
-        t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+        t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
     }
     // BYTE_ARRAY
     {
         auto& t_schema = t_schemas[2];
-        t_schema.__set_type(tparquet::Type::BYTE_ARRAY);
+        t_schema.__set_type(Type::BYTE_ARRAY);
         t_schema.name = "col2";
         t_schema.__set_num_children(0);
-        t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REQUIRED);
+        t_schema.__set_repetition_type(FieldRepetitionType::REQUIRED);
     }
 
     SchemaDescriptor desc;
@@ -104,7 +237,7 @@ TEST_F(ParquetSchemaTest, OnlyLeafType) {
 }
 
 TEST_F(ParquetSchemaTest, NestedType) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(8);
     // Root
@@ -116,10 +249,10 @@ TEST_F(ParquetSchemaTest, NestedType) {
     // col1: INT32
     {
         auto& t_schema = t_schemas[1];
-        t_schema.__set_type(tparquet::Type::INT32);
+        t_schema.__set_type(Type::INT32);
         t_schema.name = "col1";
         t_schema.__set_num_children(0);
-        t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+        t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
     }
 
     // col2: LIST(BYTE_ARRAY)
@@ -131,8 +264,8 @@ TEST_F(ParquetSchemaTest, NestedType) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(1);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
-            t_schema.__set_converted_type(tparquet::ConvertedType::LIST);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
+            t_schema.__set_converted_type(ConvertedType::LIST);
         }
 
         // level-2
@@ -140,16 +273,16 @@ TEST_F(ParquetSchemaTest, NestedType) {
             auto& t_schema = t_schemas[idx_base + 1];
             t_schema.name = "list";
             t_schema.__set_num_children(1);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REPEATED);
+            t_schema.__set_repetition_type(FieldRepetitionType::REPEATED);
         }
 
         // level-3
         {
             auto& t_schema = t_schemas[idx_base + 2];
-            t_schema.__set_type(tparquet::Type::BYTE_ARRAY);
+            t_schema.__set_type(Type::BYTE_ARRAY);
             t_schema.name = "element";
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
     }
 
@@ -161,25 +294,25 @@ TEST_F(ParquetSchemaTest, NestedType) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col3";
             t_schema.__set_num_children(2);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
 
         // field-a
         {
             auto& t_schema = t_schemas[idx_base + 1];
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.name = "a";
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
 
         // field-b
         {
             auto& t_schema = t_schemas[idx_base + 2];
-            t_schema.__set_type(tparquet::Type::BYTE_ARRAY);
+            t_schema.__set_type(Type::BYTE_ARRAY);
             t_schema.name = "b";
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REQUIRED);
+            t_schema.__set_repetition_type(FieldRepetitionType::REQUIRED);
         }
     }
 
@@ -229,7 +362,7 @@ TEST_F(ParquetSchemaTest, NestedType) {
 }
 
 TEST_F(ParquetSchemaTest, InvalidCase1) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(3);
     // Root
@@ -241,18 +374,18 @@ TEST_F(ParquetSchemaTest, InvalidCase1) {
     // INT32
     {
         auto& t_schema = t_schemas[1];
-        t_schema.__set_type(tparquet::Type::INT32);
+        t_schema.__set_type(Type::INT32);
         t_schema.name = "col1";
         t_schema.__set_num_children(0);
-        t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+        t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
     }
     // BYTE_ARRAY
     {
         auto& t_schema = t_schemas[2];
-        t_schema.__set_type(tparquet::Type::BYTE_ARRAY);
+        t_schema.__set_type(Type::BYTE_ARRAY);
         t_schema.name = "col2";
         t_schema.__set_num_children(0);
-        t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REQUIRED);
+        t_schema.__set_repetition_type(FieldRepetitionType::REQUIRED);
     }
 
     SchemaDescriptor desc;
@@ -261,7 +394,7 @@ TEST_F(ParquetSchemaTest, InvalidCase1) {
 }
 
 TEST_F(ParquetSchemaTest, InvalidCase2) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(3);
     // Root
@@ -273,18 +406,18 @@ TEST_F(ParquetSchemaTest, InvalidCase2) {
     // INT32
     {
         auto& t_schema = t_schemas[1];
-        t_schema.__set_type(tparquet::Type::INT32);
+        t_schema.__set_type(Type::INT32);
         t_schema.name = "col1";
         t_schema.__set_num_children(0);
-        t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+        t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
     }
     // BYTE_ARRAY
     {
         auto& t_schema = t_schemas[2];
-        t_schema.__set_type(tparquet::Type::BYTE_ARRAY);
+        t_schema.__set_type(Type::BYTE_ARRAY);
         t_schema.name = "col2";
         t_schema.__set_num_children(0);
-        t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REQUIRED);
+        t_schema.__set_repetition_type(FieldRepetitionType::REQUIRED);
     }
 
     SchemaDescriptor desc;
@@ -293,7 +426,7 @@ TEST_F(ParquetSchemaTest, InvalidCase2) {
 }
 
 TEST_F(ParquetSchemaTest, InvalidList1) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(2);
     // Root
@@ -311,8 +444,8 @@ TEST_F(ParquetSchemaTest, InvalidList1) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(1);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REPEATED);
-            t_schema.__set_converted_type(tparquet::ConvertedType::LIST);
+            t_schema.__set_repetition_type(FieldRepetitionType::REPEATED);
+            t_schema.__set_converted_type(ConvertedType::LIST);
         }
     }
 
@@ -322,7 +455,7 @@ TEST_F(ParquetSchemaTest, InvalidList1) {
 }
 
 TEST_F(ParquetSchemaTest, InvalidList2) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(2);
     // Root
@@ -340,8 +473,8 @@ TEST_F(ParquetSchemaTest, InvalidList2) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(2);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
-            t_schema.__set_converted_type(tparquet::ConvertedType::LIST);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
+            t_schema.__set_converted_type(ConvertedType::LIST);
         }
     }
 
@@ -351,7 +484,7 @@ TEST_F(ParquetSchemaTest, InvalidList2) {
 }
 
 TEST_F(ParquetSchemaTest, InvalidList3) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(2);
     // Root
@@ -369,8 +502,8 @@ TEST_F(ParquetSchemaTest, InvalidList3) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(1);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
-            t_schema.__set_converted_type(tparquet::ConvertedType::LIST);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
+            t_schema.__set_converted_type(ConvertedType::LIST);
         }
     }
 
@@ -380,7 +513,7 @@ TEST_F(ParquetSchemaTest, InvalidList3) {
 }
 
 TEST_F(ParquetSchemaTest, InvalidList4) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(3);
     // Root
@@ -398,8 +531,8 @@ TEST_F(ParquetSchemaTest, InvalidList4) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(1);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
-            t_schema.__set_converted_type(tparquet::ConvertedType::LIST);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
+            t_schema.__set_converted_type(ConvertedType::LIST);
         }
 
         // level-2
@@ -407,7 +540,7 @@ TEST_F(ParquetSchemaTest, InvalidList4) {
             auto& t_schema = t_schemas[idx_base + 1];
             t_schema.name = "list";
             t_schema.__set_num_children(1);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
     }
 
@@ -417,7 +550,7 @@ TEST_F(ParquetSchemaTest, InvalidList4) {
 }
 
 TEST_F(ParquetSchemaTest, SimpleArray) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(2);
     // Root
@@ -434,9 +567,9 @@ TEST_F(ParquetSchemaTest, SimpleArray) {
         {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REPEATED);
+            t_schema.__set_repetition_type(FieldRepetitionType::REPEATED);
         }
     }
 
@@ -461,7 +594,7 @@ TEST_F(ParquetSchemaTest, SimpleArray) {
 }
 
 TEST_F(ParquetSchemaTest, TwoLevelArray) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(3);
     // Root
@@ -479,17 +612,17 @@ TEST_F(ParquetSchemaTest, TwoLevelArray) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(1);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
-            t_schema.__set_converted_type(tparquet::ConvertedType::LIST);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
+            t_schema.__set_converted_type(ConvertedType::LIST);
         }
 
         // level-2
         {
             auto& t_schema = t_schemas[idx_base + 1];
             t_schema.name = "field";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REPEATED);
+            t_schema.__set_repetition_type(FieldRepetitionType::REPEATED);
         }
     }
 
@@ -514,7 +647,7 @@ TEST_F(ParquetSchemaTest, TwoLevelArray) {
 }
 
 TEST_F(ParquetSchemaTest, MapNormal) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(5);
     // Root
@@ -532,33 +665,33 @@ TEST_F(ParquetSchemaTest, MapNormal) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(1);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
-            t_schema.__set_converted_type(tparquet::ConvertedType::MAP);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
+            t_schema.__set_converted_type(ConvertedType::MAP);
         }
 
         // level-2
         {
             auto& t_schema = t_schemas[idx_base + 1];
             t_schema.name = "key_value";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(2);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REPEATED);
+            t_schema.__set_repetition_type(FieldRepetitionType::REPEATED);
         }
         // key
         {
             auto& t_schema = t_schemas[idx_base + 2];
             t_schema.name = "key";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REQUIRED);
+            t_schema.__set_repetition_type(FieldRepetitionType::REQUIRED);
         }
         // value
         {
             auto& t_schema = t_schemas[idx_base + 3];
             t_schema.name = "value";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
     }
 
@@ -582,7 +715,7 @@ TEST_F(ParquetSchemaTest, MapNormal) {
 }
 
 TEST_F(ParquetSchemaTest, InvalidMap1) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(3);
     // Root
@@ -600,17 +733,17 @@ TEST_F(ParquetSchemaTest, InvalidMap1) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(1);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
-            t_schema.__set_converted_type(tparquet::ConvertedType::MAP);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
+            t_schema.__set_converted_type(ConvertedType::MAP);
         }
 
         // level-2
         {
             auto& t_schema = t_schemas[idx_base + 1];
             t_schema.name = "key_value";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(2);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REPEATED);
+            t_schema.__set_repetition_type(FieldRepetitionType::REPEATED);
         }
     }
 
@@ -620,7 +753,7 @@ TEST_F(ParquetSchemaTest, InvalidMap1) {
 }
 
 TEST_F(ParquetSchemaTest, InvalidMap2) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(4);
     // Root
@@ -638,25 +771,25 @@ TEST_F(ParquetSchemaTest, InvalidMap2) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(2);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
-            t_schema.__set_converted_type(tparquet::ConvertedType::MAP);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
+            t_schema.__set_converted_type(ConvertedType::MAP);
         }
 
         // key
         {
             auto& t_schema = t_schemas[idx_base + 1];
             t_schema.name = "key";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REQUIRED);
+            t_schema.__set_repetition_type(FieldRepetitionType::REQUIRED);
         }
         // value
         {
             auto& t_schema = t_schemas[idx_base + 2];
             t_schema.name = "value";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
     }
 
@@ -666,7 +799,7 @@ TEST_F(ParquetSchemaTest, InvalidMap2) {
 }
 
 TEST_F(ParquetSchemaTest, InvalidMap3) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(4);
     // Root
@@ -684,25 +817,25 @@ TEST_F(ParquetSchemaTest, InvalidMap3) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(2);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REPEATED);
-            t_schema.__set_converted_type(tparquet::ConvertedType::MAP);
+            t_schema.__set_repetition_type(FieldRepetitionType::REPEATED);
+            t_schema.__set_converted_type(ConvertedType::MAP);
         }
 
         // key
         {
             auto& t_schema = t_schemas[idx_base + 1];
             t_schema.name = "key";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REQUIRED);
+            t_schema.__set_repetition_type(FieldRepetitionType::REQUIRED);
         }
         // value
         {
             auto& t_schema = t_schemas[idx_base + 2];
             t_schema.name = "value";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
     }
 
@@ -712,7 +845,7 @@ TEST_F(ParquetSchemaTest, InvalidMap3) {
 }
 
 TEST_F(ParquetSchemaTest, InvalidMap4) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(5);
     // Root
@@ -730,33 +863,33 @@ TEST_F(ParquetSchemaTest, InvalidMap4) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(1);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
-            t_schema.__set_converted_type(tparquet::ConvertedType::MAP);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
+            t_schema.__set_converted_type(ConvertedType::MAP);
         }
 
         // level-2
         {
             auto& t_schema = t_schemas[idx_base + 1];
             t_schema.name = "key_value";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(2);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
         // key
         {
             auto& t_schema = t_schemas[idx_base + 2];
             t_schema.name = "key";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REQUIRED);
+            t_schema.__set_repetition_type(FieldRepetitionType::REQUIRED);
         }
         // value
         {
             auto& t_schema = t_schemas[idx_base + 3];
             t_schema.name = "value";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
     }
 
@@ -766,7 +899,7 @@ TEST_F(ParquetSchemaTest, InvalidMap4) {
 }
 
 TEST_F(ParquetSchemaTest, InvalidMap5) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(5);
     // Root
@@ -784,33 +917,33 @@ TEST_F(ParquetSchemaTest, InvalidMap5) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(1);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
-            t_schema.__set_converted_type(tparquet::ConvertedType::MAP);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
+            t_schema.__set_converted_type(ConvertedType::MAP);
         }
 
         // level-2
         {
             auto& t_schema = t_schemas[idx_base + 1];
             t_schema.name = "key_value";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(2);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REPEATED);
+            t_schema.__set_repetition_type(FieldRepetitionType::REPEATED);
         }
         // key
         {
             auto& t_schema = t_schemas[idx_base + 2];
             t_schema.name = "key";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
         // value
         {
             auto& t_schema = t_schemas[idx_base + 3];
             t_schema.name = "value";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
     }
 
@@ -820,7 +953,7 @@ TEST_F(ParquetSchemaTest, InvalidMap5) {
 }
 
 TEST_F(ParquetSchemaTest, InvalidMap6) {
-    std::vector<tparquet::SchemaElement> t_schemas;
+    std::vector<SchemaElement> t_schemas;
 
     t_schemas.resize(6);
     // Root
@@ -838,47 +971,691 @@ TEST_F(ParquetSchemaTest, InvalidMap6) {
             auto& t_schema = t_schemas[idx_base + 0];
             t_schema.name = "col2";
             t_schema.__set_num_children(1);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
-            t_schema.__set_converted_type(tparquet::ConvertedType::MAP);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
+            t_schema.__set_converted_type(ConvertedType::MAP);
         }
 
         // level-2
         {
             auto& t_schema = t_schemas[idx_base + 1];
             t_schema.name = "key_value";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(3);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::REPEATED);
+            t_schema.__set_repetition_type(FieldRepetitionType::REPEATED);
         }
         // key
         {
             auto& t_schema = t_schemas[idx_base + 2];
             t_schema.name = "key";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
         // value
         {
             auto& t_schema = t_schemas[idx_base + 3];
             t_schema.name = "value";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
         // value3
         {
             auto& t_schema = t_schemas[idx_base + 4];
             t_schema.name = "value2";
-            t_schema.__set_type(tparquet::Type::INT32);
+            t_schema.__set_type(Type::INT32);
             t_schema.__set_num_children(0);
-            t_schema.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+            t_schema.__set_repetition_type(FieldRepetitionType::OPTIONAL);
         }
     }
 
     SchemaDescriptor desc;
     auto st = desc.from_thrift(t_schemas, true);
     ASSERT_FALSE(st.ok());
+}
+
+TEST_F(ParquetSchemaTest, DuplicateFieldNames) {
+    std::vector<SchemaElement> t_schemas;
+    t_schemas.emplace_back(GroupNode::make_root(2));
+    t_schemas.emplace_back(PrimitiveNode::make("xxx", FieldRepetitionType::type::REQUIRED, Type::type::BYTE_ARRAY,
+                                               ConvertedType::type::UTF8));
+    t_schemas.emplace_back(PrimitiveNode::make("xxx", FieldRepetitionType::type::REQUIRED, Type::type::BYTE_ARRAY,
+                                               ConvertedType::type::UTF8));
+
+    SchemaDescriptor desc;
+    auto st = desc.from_thrift(t_schemas, true);
+    ASSERT_FALSE(st.ok()) << st.get_error_msg();
+}
+
+// The UT logic is copied from https://github.com/apache/arrow/blob/main/cpp/src/parquet/arrow/arrow_schema_test.cc
+
+TEST_F(ParquetSchemaTest, ParquetMaps) {
+    std::vector<SchemaElement> t_schemas;
+    t_schemas.emplace_back(GroupNode::make_root(3));
+    std::vector<ParquetField> expected_fields;
+    // two column map
+    {
+        t_schemas.emplace_back(GroupNode::make("my_map", FieldRepetitionType::REQUIRED, ConvertedType::type::MAP, 1));
+        t_schemas.emplace_back(GroupNode::make("key_value", FieldRepetitionType::REPEATED, 2));
+        t_schemas.emplace_back(PrimitiveNode::make("key", FieldRepetitionType::type::REQUIRED, Type::type::BYTE_ARRAY,
+                                                   ConvertedType::type::UTF8));
+        t_schemas.emplace_back(PrimitiveNode::make("value", FieldRepetitionType::type::OPTIONAL, Type::type::BYTE_ARRAY,
+                                                   ConvertedType::type::UTF8));
+
+        expected_fields.emplace_back(
+                GroupNode::make_field("my_map", false, LogicalType::TYPE_MAP,
+                                      {PrimitiveNode::make_field("key", false, Type::type::BYTE_ARRAY),
+                                       PrimitiveNode::make_field("value", true, Type::type::BYTE_ARRAY)}));
+    }
+    // Single column map (i.e. set) gets converted to list of struct.
+    {
+        t_schemas.emplace_back(
+                GroupNode::make("my_set", FieldRepetitionType::type::REQUIRED, ConvertedType::type::MAP, 1));
+        t_schemas.emplace_back(GroupNode::make("key_value", FieldRepetitionType::type::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("key", FieldRepetitionType::type::REQUIRED, Type::type::BYTE_ARRAY,
+                                                   ConvertedType::type::UTF8));
+
+        expected_fields.emplace_back(
+                GroupNode::make_field("my_set", false, LogicalType::TYPE_ARRAY,
+                                      {PrimitiveNode::make_field("key", false, Type::type::BYTE_ARRAY)}));
+    }
+    // Two column map with non-standard field names.
+    {
+        t_schemas.emplace_back(
+                GroupNode::make("items", FieldRepetitionType::type::REQUIRED, ConvertedType::type::MAP, 1));
+        t_schemas.emplace_back(GroupNode::make("item2", FieldRepetitionType::type::REPEATED, 2));
+        t_schemas.emplace_back(PrimitiveNode::make("int_key", FieldRepetitionType::type::REQUIRED, Type::type::INT32,
+                                                   ConvertedType::type::INT_32));
+        t_schemas.emplace_back(PrimitiveNode::make("str_value", FieldRepetitionType::type::OPTIONAL,
+                                                   Type::type::BYTE_ARRAY, ConvertedType::type::UTF8));
+
+        expected_fields.emplace_back(
+                GroupNode::make_field("items", false, LogicalType::TYPE_MAP,
+                                      {PrimitiveNode::make_field("int_key", false, Type::type::INT32),
+                                       PrimitiveNode::make_field("str_value", true, Type::type::BYTE_ARRAY)}));
+    }
+
+    SchemaDescriptor desc;
+    auto st = desc.from_thrift(t_schemas, true);
+    ASSERT_TRUE(st.ok()) << st.get_error_msg();
+    check_flat_parquet_field(expected_fields, desc.get_parquet_fields());
+}
+
+TEST_F(ParquetSchemaTest, ParquetLists) {
+    std::vector<SchemaElement> t_schemas;
+    t_schemas.emplace_back(GroupNode::make_root(9));
+    std::vector<ParquetField> expected_fields;
+
+    // LIST encoding example taken from parquet-format/LogicalTypes.md
+
+    // // List<String> (list non-null, elements nullable)
+    // required group my_list (LIST) {
+    //   repeated group list {
+    //     optional binary element (UTF8);
+    //   }
+    // }
+    {
+        t_schemas.emplace_back(
+                GroupNode::make("my_list_1", FieldRepetitionType::REQUIRED, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("list", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("string", FieldRepetitionType::type::OPTIONAL,
+                                                   Type::type::BYTE_ARRAY, ConvertedType::type::UTF8));
+
+        expected_fields.emplace_back(
+                GroupNode::make_field("my_list_1", false, LogicalType::TYPE_ARRAY,
+                                      {PrimitiveNode::make_field("string", true, Type::type::BYTE_ARRAY)}));
+    }
+
+    // // List<String> (list nullable, elements non-null)
+    // optional group my_list (LIST) {
+    //   repeated group list {
+    //     required binary element (UTF8);
+    //   }
+    // }
+    {
+        t_schemas.emplace_back(
+                GroupNode::make("my_list_2", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("list", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("string", FieldRepetitionType::type::REQUIRED,
+                                                   Type::type::BYTE_ARRAY, ConvertedType::type::UTF8));
+
+        expected_fields.emplace_back(
+                GroupNode::make_field("my_list_2", true, LogicalType::TYPE_ARRAY,
+                                      {PrimitiveNode::make_field("string", false, Type::type::BYTE_ARRAY)}));
+    }
+
+    // Element types can be nested structures. For example, a list of lists:
+    //
+    // // List<List<Integer>>
+    // optional group array_of_arrays (LIST) {
+    //   repeated group list {
+    //     required group element (LIST) {
+    //       repeated group list {
+    //         required int32 element;
+    //       }
+    //     }
+    //   }
+    // }
+    {
+        t_schemas.emplace_back(
+                GroupNode::make("array_of_arrays", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("list", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(GroupNode::make("element", FieldRepetitionType::REQUIRED, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("list", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("int32", FieldRepetitionType::type::REQUIRED, Type::type::INT32,
+                                                   ConvertedType::type::INT_32));
+
+        expected_fields.emplace_back(GroupNode::make_field(
+                "array_of_arrays", true, LogicalType::TYPE_ARRAY,
+                {GroupNode::make_field("element", false, LogicalType::TYPE_ARRAY,
+                                       {PrimitiveNode::make_field("int32", false, Type::type::INT32)})}));
+    }
+
+    // // List<String> (list nullable, elements non-null)
+    // optional group my_list (LIST) {
+    //   repeated group element {
+    //     required binary str (UTF8);
+    //   };
+    // }
+    {
+        t_schemas.emplace_back(
+                GroupNode::make("my_list_3", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("element", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("str", FieldRepetitionType::type::REQUIRED, Type::type::BYTE_ARRAY,
+                                                   ConvertedType::type::UTF8));
+
+        expected_fields.emplace_back(
+                GroupNode::make_field("my_list_3", true, LogicalType::TYPE_ARRAY,
+                                      {PrimitiveNode::make_field("str", false, Type::type::BYTE_ARRAY)}));
+    }
+
+    // // List<Integer> (nullable list, non-null elements)
+    // optional group my_list (LIST) {
+    //   repeated int32 element;
+    // }
+    {
+        t_schemas.emplace_back(
+                GroupNode::make("my_list_4", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("element", FieldRepetitionType::type::REPEATED, Type::type::INT32,
+                                                   ConvertedType::type::INT_32));
+
+        expected_fields.emplace_back(
+                GroupNode::make_field("my_list_4", true, LogicalType::TYPE_ARRAY,
+                                      {PrimitiveNode::make_field("element", false, Type::type::INT32)}));
+    }
+
+    // // List<Tuple<String, Integer>> (nullable list, non-null elements)
+    // optional group my_list (LIST) {
+    //   repeated group element {
+    //     required binary str (UTF8);
+    //     required int32 num;
+    //   };
+    // }
+    {
+        t_schemas.emplace_back(
+                GroupNode::make("my_list_5", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("element", FieldRepetitionType::type::REPEATED, 2));
+        t_schemas.emplace_back(PrimitiveNode::make("str", FieldRepetitionType::type::REQUIRED, Type::type::BYTE_ARRAY,
+                                                   ConvertedType::type::UTF8));
+        t_schemas.emplace_back(PrimitiveNode::make("num", FieldRepetitionType::type::REQUIRED, Type::type::INT32,
+                                                   ConvertedType::type::INT_32));
+
+        expected_fields.emplace_back(GroupNode::make_field(
+                "my_list_5", true, LogicalType::TYPE_ARRAY,
+                {GroupNode::make_field("element", false, LogicalType::TYPE_STRUCT,
+                                       {PrimitiveNode::make_field("str", false, Type::type::BYTE_ARRAY),
+                                        PrimitiveNode::make_field("num", false, Type::type::INT32)})}));
+    }
+
+    // // List<OneTuple<String>> (nullable list, non-null elements)
+    // optional group my_list (LIST) {
+    //   repeated group array {
+    //     required binary str (UTF8);
+    //   };
+    // }
+    // Special case: group is named array
+    {
+        t_schemas.emplace_back(
+                GroupNode::make("my_list_6", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("array", FieldRepetitionType::type::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("str", FieldRepetitionType::type::REQUIRED, Type::type::BYTE_ARRAY,
+                                                   ConvertedType::type::UTF8));
+
+        expected_fields.emplace_back(GroupNode::make_field(
+                "my_list_6", true, LogicalType::TYPE_ARRAY,
+                {GroupNode::make_field("array", false, LogicalType::TYPE_STRUCT,
+                                       {PrimitiveNode::make_field("str", false, Type::type::BYTE_ARRAY)})}));
+    }
+
+    // // List<OneTuple<String>> (nullable list, non-null elements)
+    // optional group my_list (LIST) {
+    //   repeated group my_list_tuple {
+    //     required binary str (UTF8);
+    //   };
+    // }
+    // Special case: group named ends in _tuple
+    {
+        t_schemas.emplace_back(
+                GroupNode::make("my_list_7", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("my_list_tuple", FieldRepetitionType::type::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("str", FieldRepetitionType::type::REQUIRED, Type::type::BYTE_ARRAY,
+                                                   ConvertedType::type::UTF8));
+
+        expected_fields.emplace_back(GroupNode::make_field(
+                "my_list_7", true, LogicalType::TYPE_ARRAY,
+                {GroupNode::make_field("my_list_tuple", false, LogicalType::TYPE_STRUCT,
+                                       {PrimitiveNode::make_field("str", false, Type::type::BYTE_ARRAY)})}));
+    }
+
+    // One-level encoding: Only allows required lists with required cells
+    //   repeated value_type name
+    {
+        t_schemas.emplace_back(PrimitiveNode::make("name", FieldRepetitionType::REPEATED, Type::type::INT32));
+        expected_fields.emplace_back(GroupNode::make_field(
+                "name", false, LogicalType::TYPE_ARRAY, {PrimitiveNode::make_field("name", false, Type::type::INT32)}));
+    }
+
+    SchemaDescriptor desc;
+    auto st = desc.from_thrift(t_schemas, true);
+    ASSERT_TRUE(st.ok()) << st.get_error_msg();
+    check_flat_parquet_field(expected_fields, desc.get_parquet_fields());
+}
+
+TEST_F(ParquetSchemaTest, ParquetNestedSchema) {
+    std::vector<SchemaElement> t_schemas;
+    t_schemas.emplace_back(GroupNode::make_root(2));
+    std::vector<ParquetField> expected_fields;
+
+    // required group group1 {
+    //   required bool leaf1;
+    //   required int32 leaf2;
+    // }
+    // required int64 leaf3;
+    {
+        t_schemas.emplace_back(GroupNode::make("group1", FieldRepetitionType::REQUIRED, 2));
+        t_schemas.emplace_back(PrimitiveNode::make("leaf1", FieldRepetitionType::type::REQUIRED, Type::type::BOOLEAN));
+        t_schemas.emplace_back(PrimitiveNode::make("leaf2", FieldRepetitionType::type::REQUIRED, Type::type::INT32));
+
+        t_schemas.emplace_back(PrimitiveNode::make("leaf3", FieldRepetitionType::type::REQUIRED, Type::type::INT64));
+
+        expected_fields.emplace_back(
+                GroupNode::make_field("group1", false, LogicalType::TYPE_STRUCT,
+                                      {PrimitiveNode::make_field("leaf1", false, Type::type::BOOLEAN),
+                                       PrimitiveNode::make_field("leaf2", false, Type::type::INT32)}));
+        expected_fields.emplace_back(PrimitiveNode::make_field("leaf3", false, Type::type::INT64));
+    }
+
+    SchemaDescriptor desc;
+    auto st = desc.from_thrift(t_schemas, true);
+    ASSERT_TRUE(st.ok()) << st.get_error_msg();
+    check_flat_parquet_field(expected_fields, desc.get_parquet_fields());
+}
+
+TEST_F(ParquetSchemaTest, ParquetNestedSchema2) {
+    std::vector<SchemaElement> t_schemas;
+    t_schemas.emplace_back(GroupNode::make_root(3));
+    std::vector<ParquetField> expected_fields;
+
+    // Full Parquet Schema:
+    // required group group1 {
+    //   required int64 leaf1;
+    //   required int64 leaf2;
+    // }
+    // required group group2 {
+    //   required int64 leaf3;
+    //   required int64 leaf4;
+    // }
+    // required int64 leaf5;
+    {
+        t_schemas.emplace_back(GroupNode::make("group1", FieldRepetitionType::REQUIRED, 2));
+        t_schemas.emplace_back(PrimitiveNode::make("leaf1", FieldRepetitionType::type::REQUIRED, Type::type::INT64));
+        t_schemas.emplace_back(PrimitiveNode::make("leaf2", FieldRepetitionType::type::REQUIRED, Type::type::INT64));
+
+        t_schemas.emplace_back(GroupNode::make("group2", FieldRepetitionType::REQUIRED, 2));
+        t_schemas.emplace_back(PrimitiveNode::make("leaf3", FieldRepetitionType::type::REQUIRED, Type::type::INT64));
+        t_schemas.emplace_back(PrimitiveNode::make("leaf4", FieldRepetitionType::type::REQUIRED, Type::type::INT64));
+
+        t_schemas.emplace_back(PrimitiveNode::make("leaf5", FieldRepetitionType::type::REQUIRED, Type::type::INT64));
+
+        expected_fields.emplace_back(
+                GroupNode::make_field("group1", false, LogicalType::TYPE_STRUCT,
+                                      {PrimitiveNode::make_field("leaf1", false, Type::type::INT64),
+                                       PrimitiveNode::make_field("leaf2", false, Type::type::INT64)}));
+        expected_fields.emplace_back(
+                GroupNode::make_field("group2", false, LogicalType::TYPE_STRUCT,
+                                      {PrimitiveNode::make_field("leaf3", false, Type::type::INT64),
+                                       PrimitiveNode::make_field("leaf4", false, Type::type::INT64)}));
+        expected_fields.emplace_back(PrimitiveNode::make_field("leaf5", false, Type::type::INT64));
+    }
+
+    SchemaDescriptor desc;
+    auto st = desc.from_thrift(t_schemas, true);
+    ASSERT_TRUE(st.ok()) << st.get_error_msg();
+    check_flat_parquet_field(expected_fields, desc.get_parquet_fields());
+}
+
+TEST_F(ParquetSchemaTest, ParquetRepeatedNestedSchema) {
+    std::vector<SchemaElement> t_schemas;
+    t_schemas.emplace_back(GroupNode::make_root(2));
+    std::vector<ParquetField> expected_fields;
+
+    //   optional int32 leaf1;
+    //   repeated group outerGroup {
+    //     optional int32 leaf2;
+    //     repeated group innerGroup {
+    //       optional int32 leaf3;
+    //     }
+    //   }
+    {
+        t_schemas.emplace_back(PrimitiveNode::make("leaf1", FieldRepetitionType::OPTIONAL, Type::type::INT32));
+        t_schemas.emplace_back(GroupNode::make("outerGroup", FieldRepetitionType::REPEATED, 2));
+        t_schemas.emplace_back(PrimitiveNode::make("leaf2", FieldRepetitionType::type::OPTIONAL, Type::type::INT32));
+        t_schemas.emplace_back(GroupNode::make("innerGroup", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("leaf3", FieldRepetitionType::type::OPTIONAL, Type::type::INT32));
+
+        expected_fields.emplace_back(PrimitiveNode::make_field("leaf1", true, Type::type::INT32));
+
+        auto leaf2_field = PrimitiveNode::make_field("leaf2", true, Type::type::INT32);
+        auto leaf3_field = PrimitiveNode::make_field("leaf3", true, Type::type::INT32);
+        auto inner_group_struct = GroupNode::make_field("innerGroup", false, LogicalType::TYPE_STRUCT, {leaf3_field});
+        auto inner_group = GroupNode::make_field("innerGroup", false, LogicalType::TYPE_ARRAY, {inner_group_struct});
+        auto outer_group_struct = GroupNode::make_field("outerGroup", false, LogicalType::TYPE_STRUCT, {leaf2_field, inner_group});
+        auto outer_group = GroupNode::make_field("outerGroup", false, LogicalType::TYPE_ARRAY, {outer_group_struct});
+        expected_fields.emplace_back(outer_group);
+    }
+
+    SchemaDescriptor desc;
+    auto st = desc.from_thrift(t_schemas, true);
+    ASSERT_TRUE(st.ok()) << st.get_error_msg();
+    check_flat_parquet_field(expected_fields, desc.get_parquet_fields());
+}
+
+TEST_F(ParquetLevelsTest, TestPrimitive) {
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+        t_schemas.emplace_back(PrimitiveNode::make("node_name", FieldRepetitionType::REQUIRED, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(0, 0, 0));
+
+        do_check(t_schemas, expected);
+    }
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+        t_schemas.emplace_back(PrimitiveNode::make("node_name", FieldRepetitionType::OPTIONAL, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(1, 0, 0));
+        do_check(t_schemas, expected);
+    }
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+        t_schemas.emplace_back(PrimitiveNode::make("node_name", FieldRepetitionType::REPEATED, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(1, 1, 0));
+        expected.emplace_back(make(1, 1, 1));
+        do_check(t_schemas, expected);
+    }
+}
+
+TEST_F(ParquetLevelsTest, TestMaps) {
+    // two column map
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("my_map", FieldRepetitionType::OPTIONAL, ConvertedType::type::MAP, 1));
+        t_schemas.emplace_back(GroupNode::make("key_value", FieldRepetitionType::REPEATED, 2));
+        t_schemas.emplace_back(PrimitiveNode::make("key", FieldRepetitionType::type::REQUIRED, Type::type::BYTE_ARRAY,
+                                                   ConvertedType::type::UTF8));
+        t_schemas.emplace_back(PrimitiveNode::make("value", FieldRepetitionType::type::OPTIONAL, Type::type::BYTE_ARRAY,
+                                                   ConvertedType::type::UTF8));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(2, 1, 0));
+        expected.emplace_back(make(2, 1, 2));
+        expected.emplace_back(make(3, 1, 2));
+        do_check(t_schemas, expected);
+
+    }
+    // Single column map (i.e. set) gets converted to list of struct.
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(
+                GroupNode::make("my_set", FieldRepetitionType::type::REQUIRED, ConvertedType::type::MAP, 1));
+        t_schemas.emplace_back(GroupNode::make("key_value", FieldRepetitionType::type::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("key", FieldRepetitionType::type::REQUIRED, Type::type::BYTE_ARRAY,
+                                                   ConvertedType::type::UTF8));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(1, 1, 0));
+        expected.emplace_back(make(1, 1, 1));
+        do_check(t_schemas, expected);
+    }
+}
+
+TEST_F(ParquetLevelsTest, TestSimpleGroups) {
+    // schema: struct(child: struct(inner: boolean not null))
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("parent", FieldRepetitionType::OPTIONAL, 1));
+        t_schemas.emplace_back(GroupNode::make("child", FieldRepetitionType::OPTIONAL, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("inner", FieldRepetitionType::REQUIRED, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(1, 0, 0));
+        expected.emplace_back(make(2, 0, 0));
+        expected.emplace_back(make(2, 0, 0));
+        do_check(t_schemas, expected);
+    }
+    // schema: struct(child: struct(inner: boolean ))
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("parent", FieldRepetitionType::OPTIONAL, 1));
+        t_schemas.emplace_back(GroupNode::make("child", FieldRepetitionType::OPTIONAL, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("inner", FieldRepetitionType::OPTIONAL, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(1, 0, 0));
+        expected.emplace_back(make(2, 0, 0));
+        expected.emplace_back(make(3, 0, 0));
+        do_check(t_schemas, expected);
+    }
+    // schema: struct(child: struct(inner: boolean)) not null
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("parent", FieldRepetitionType::REQUIRED, 1));
+        t_schemas.emplace_back(GroupNode::make("child", FieldRepetitionType::OPTIONAL, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("inner", FieldRepetitionType::OPTIONAL, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(0, 0, 0));
+        expected.emplace_back(make(1, 0, 0));
+        expected.emplace_back(make(2, 0, 0));
+        do_check(t_schemas, expected);
+    }
+}
+
+TEST_F(ParquetLevelsTest, TestRepeatedGroups) {
+    // schema: list(bool)
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("child_list", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("list", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("element", FieldRepetitionType::OPTIONAL, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(2, 1, 0));
+        expected.emplace_back(make(3, 1, 2));
+        do_check(t_schemas, expected);
+    }
+    // schema: list(bool) not null
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("child_list", FieldRepetitionType::REQUIRED, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("list", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("element", FieldRepetitionType::OPTIONAL, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(1, 1, 0));
+        expected.emplace_back(make(2, 1, 1));
+        do_check(t_schemas, expected);
+    }
+    // schema: list(bool not null)
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("child_list", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("list", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("element", FieldRepetitionType::REQUIRED, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(2, 1, 0));
+        expected.emplace_back(make(2, 1, 2));
+        do_check(t_schemas, expected);
+    }
+    // schema: list(bool not null) not null
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("child_list", FieldRepetitionType::REQUIRED, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("list", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("element", FieldRepetitionType::REQUIRED, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(1, 1, 0));
+        expected.emplace_back(make(1, 1, 1));
+        do_check(t_schemas, expected);
+    }
+    // schema: list(struct(child: struct(list(bool not null) not null)) non null) not null
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("parent", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(GroupNode::make("child", FieldRepetitionType::OPTIONAL, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("inner", FieldRepetitionType::REPEATED, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(1, 1, 0));
+        expected.emplace_back(make(1, 1, 1));
+
+        expected.emplace_back(make(2, 1, 1)); // optional child struct
+
+        expected.emplace_back(make(3, 2, 1)); // repeated field
+        expected.emplace_back(make(3, 2, 3)); // inner field
+
+        do_check(t_schemas, expected);
+    }
+    // schema: list(struct(child_list: list(struct(f0: bool f1: bool))) not null) not null
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("parent", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(GroupNode::make("child_list", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(GroupNode::make("list", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(GroupNode::make("element", FieldRepetitionType::OPTIONAL, 2));
+        t_schemas.emplace_back(PrimitiveNode::make("f0", FieldRepetitionType::OPTIONAL, Type::type::BOOLEAN));
+        t_schemas.emplace_back(PrimitiveNode::make("f1", FieldRepetitionType::REQUIRED, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(1, 1, 0));
+        expected.emplace_back(make(1, 1, 1));
+
+        // Def_level=2 is handled together with def_level=3
+        // When decoding. Def_level=2 indicates present but empty
+        // list. def_level=3 indicates a present element in the
+        // list.
+        expected.emplace_back(make(3, 2, 1)); // list field
+        expected.emplace_back(make(4, 2, 3)); // inner struct field
+
+        expected.emplace_back(make(5, 2, 3)); // f0 bool field
+        expected.emplace_back(make(4, 2, 3)); // f1 bool field
+
+        do_check(t_schemas, expected);
+    }
+    // schema: list(struct(child_list: list(bool not null)) not null) not null
+    // Legacy 2-level encoding (required for backwards compatibility.  See
+    // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#nested-types
+    // for definitions).
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("parent", FieldRepetitionType::REPEATED, 1));
+        t_schemas.emplace_back(GroupNode::make("child_list", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("bool", FieldRepetitionType::REPEATED, Type::type::BOOLEAN));
+
+        std::vector<LevelInfo> expected;
+        expected.emplace_back(make(1, 1, 0)); // parent list
+        expected.emplace_back(make(1, 1, 1)); // parent struct
+
+        // Def_level=2 is handled together with def_level=3
+        // When decoding. Def_level=2 indicates present but empty
+        // list. def_level=3 indicates a present element in the
+        // list.
+        expected.emplace_back(make(3, 2, 1)); // list field
+        expected.emplace_back(make(3, 2, 3)); // inner bool
+    }
+}
+
+TEST_F(ParquetLevelsTest, ListErrors) {
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("child_list", FieldRepetitionType::REPEATED, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("bool", FieldRepetitionType::type::REPEATED, Type::type::BOOLEAN));
+
+        SchemaDescriptor desc;
+        auto st = desc.from_thrift(t_schemas, true);
+        ASSERT_FALSE(st.ok()) << st.get_error_msg();
+        ASSERT_EQ("LIST-annotated groups must not be repeated.", st.get_error_msg());
+    }
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("child_list", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 2));
+        t_schemas.emplace_back(PrimitiveNode::make("f1", FieldRepetitionType::type::REPEATED, Type::type::BOOLEAN));
+        t_schemas.emplace_back(PrimitiveNode::make("f2", FieldRepetitionType::type::REPEATED, Type::type::BOOLEAN));
+
+        SchemaDescriptor desc;
+        auto st = desc.from_thrift(t_schemas, true);
+        ASSERT_FALSE(st.ok()) << st.get_error_msg();
+        ASSERT_EQ("LIST-annotated groups must have a single child.", st.get_error_msg());
+    }
+    {
+        std::vector<SchemaElement> t_schemas;
+        t_schemas.emplace_back(GroupNode::make_root(1));
+
+        t_schemas.emplace_back(GroupNode::make("child_list", FieldRepetitionType::OPTIONAL, ConvertedType::type::LIST, 1));
+        t_schemas.emplace_back(PrimitiveNode::make("f1", FieldRepetitionType::type::OPTIONAL, Type::type::BOOLEAN));
+
+        SchemaDescriptor desc;
+        auto st = desc.from_thrift(t_schemas, true);
+        ASSERT_FALSE(st.ok()) << st.get_error_msg();
+        ASSERT_EQ("Non-repeated nodes in a LIST-annotated group are not supported.", st.get_error_msg());
+    }
 }
 
 } // namespace starrocks::parquet


### PR DESCRIPTION
## Problem Summary:
This this pr, we do the following things:
1. add more defensive code, to avoid be crashed
2. make the schema parse logic the same as ARROW: 
3. copy the schema ut logic from ARROW: https://github.com/apache/arrow/blob/main/cpp/src/parquet/arrow/arrow_schema_test.cc
Refactor parquet schema parse logic, the logic is the same as ARROW: https://github.com/apache/arrow/blob/main/cpp/src/parquet/arrow/schema.cc
4. In the previous version, we will parse `MAP<INT, INT>` into `MAP<STRUCT<KEY, VALUE>>`, now we fixed it.
5. **[Waiting for disscuss]**: Some illegal parquet files, we don't support it anymore, these files are reported by QA's HUDI cluster, and in the newest HUDI version, these bugs are already fixed. These bug parquet files can be read by Spark only.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
