### PR TITLE
[BugFix] Fix rename update compaction thread as manual_compact

### DIFF
--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -199,7 +199,7 @@ Status StorageEngine::start_bg_threads() {
 
     for (uint32_t i = 0; i < config::manual_compaction_threads; i++) {
         _manual_compaction_threads.emplace_back([this] { _manual_compaction_thread_callback(nullptr); });
-        Thread::set_thread_name(_update_compaction_threads.back(), "manual_compact");
+        Thread::set_thread_name(_manual_compaction_threads.back(), "manual_compact");
     }
 
     // tablet checkpoint thread


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)
We add a manual compaction thread pool to support manual compact, but change the thread name of update compaction pool to manual_compact accidentally.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
