### PR TITLE
[Enhancement] Adapt tablet repair process to k8s+pvc recovery mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -491,6 +491,52 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         return Pair.create(status, prio);
     }
 
+    private boolean isReplicaBackendDead(Backend backend) {
+        return backend != null && !backend.isAlive();
+    }
+
+    private boolean isReplicaBackendDropped(Backend backend) {
+        return backend == null;
+    }
+
+    private boolean isReplicaStateAbnormal(Replica replica, Backend backend, Set<String> replicaHostSet) {
+        return replica.getState() == ReplicaState.CLONE
+                || replica.getState() == ReplicaState.DECOMMISSION
+                || replica.isBad()
+                || !replicaHostSet.add(backend.getHost());
+    }
+
+    /**
+     * For certain deployment, like k8s pods + pvc, the replica is not lost even the
+     * corresponding backend is detected as dead, because the replica data is persisted
+     * on a pvc which is backed by a remote storage service, such as AWS EBS. And later,
+     * k8s control place will schedule a new pod and attach the pvc to it which will
+     * restore the replica to a {@link ReplicaState#NORMAL} state immediately. But normally
+     * the {@link com.starrocks.clone.TabletScheduler} of Starrocks will start to schedule
+     * {@link TabletStatus#REPLICA_MISSING} tasks and create new replicas in a short time.
+     * After new pod scheduling is completed, {@link com.starrocks.clone.TabletScheduler} has
+     * to delete the redundant healthy replica which cause resource waste and may also affect
+     * the loading process.
+     *
+     * <p> This method checks the necessity of a {@link TabletStatus#REPLICA_MISSING} task without
+     * considering the corresponding backends of tablet replicas are alive or not.
+     *
+     * @param systemInfoService {@link SystemInfoService}
+     * @return {@code true} means that we still need to schedule a {@link TabletStatus#REPLICA_MISSING} task
+     * even though we have ignored the aliveness of corresponding backend
+     */
+    public boolean checkReplicaMissingIgnoreDeadBackend(SystemInfoService systemInfoService) {
+        Set<String> hosts = Sets.newHashSet();
+        for (Replica replica : replicas) {
+            Backend backend = systemInfoService.getBackend(replica.getBackendId());
+            if (isReplicaBackendDropped(backend) || isReplicaStateAbnormal(replica, backend, hosts)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * A replica is healthy only if
      * 1. the backend is available
@@ -508,15 +554,14 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         int alive = 0;
         int aliveAndVersionComplete = 0;
         int stable = 0;
-        int availableInCluster = 0;
 
         Replica needFurtherRepairReplica = null;
         Set<String> hosts = Sets.newHashSet();
         for (Replica replica : replicas) {
             Backend backend = systemInfoService.getBackend(replica.getBackendId());
-            if (backend == null || !backend.isAlive() || replica.getState() == ReplicaState.CLONE
-                    || replica.getState() == ReplicaState.DECOMMISSION
-                    || replica.isBad() || !hosts.add(backend.getHost())) {
+            if (isReplicaBackendDropped(backend)
+                    || isReplicaBackendDead(backend)
+                    || isReplicaStateAbnormal(replica, backend, hosts)) {
                 // this replica is not alive,
                 // or if this replica is on same host with another replica, we also treat it as 'dead',
                 // so that Tablet Scheduler will create a new replica on different host.
@@ -540,8 +585,6 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
                 continue;
             }
             stable++;
-
-            availableInCluster++;
         }
 
         // 1. alive replicas are not enough

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -342,6 +342,14 @@ public class TabletChecker extends FrontendDaemon {
                                                 replicaNum,
                                                 aliveBeIdsInCluster);
 
+                                if (Config.tablet_sched_ignore_dead_backend &&
+                                        statusWithPrio.first == TabletStatus.REPLICA_MISSING &&
+                                        !localTablet.checkReplicaMissingIgnoreDeadBackend(infoService)) {
+                                    // Deem this tablet healthy in this situation, see comments for
+                                    // `Config.tablet_sched_ignore_dead_backend` for more details.
+                                    statusWithPrio.first = TabletStatus.HEALTHY;
+                                }
+
                                 if (statusWithPrio.first == TabletStatus.HEALTHY) {
                                     // Only set last status check time when status is healthy.
                                     localTablet.setLastStatusCheckTime(System.currentTimeMillis());

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -35,6 +35,8 @@
 package com.starrocks.common;
 
 import com.starrocks.StarRocksFE;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.Replica;
 
 public class Config extends ConfigBase {
 
@@ -1175,6 +1177,31 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static boolean tablet_sched_always_force_decommission_replica = false;
+
+    /**
+     * For certain deployment, like k8s pods + pvc, the replica is not lost even the
+     * corresponding backend is detected as dead, because the replica data is persisted
+     * on a pvc which is backed by a remote storage service, such as AWS EBS. And later,
+     * k8s control place will schedule a new pod and attach the pvc to it which will
+     * restore the replica to a {@link Replica.ReplicaState#NORMAL} state immediately. But normally
+     * the {@link com.starrocks.clone.TabletScheduler} of Starrocks will start to schedule
+     * {@link LocalTablet.TabletStatus#REPLICA_MISSING} tasks and create new replicas in a short time.
+     * After new pod scheduling is completed, {@link com.starrocks.clone.TabletScheduler} has
+     * to delete the redundant healthy replica which cause resource waste and may also affect
+     * the loading process.
+     *
+     * <p>When setting this configuration to true, we won't schedule any
+     * {@link LocalTablet.TabletStatus#REPLICA_MISSING} task because of dead backends
+     * (but may still schedule {@link LocalTablet.TabletStatus#REPLICA_MISSING} tasks because of
+     * other reasons, like manually setting a replica as bad, actively decommission a backend etc.)
+     * and let the resource manager like k8s handle the repair process.
+     *
+     * <p>For more discussion on this issue, see
+     * <a href="https://github.com/StarRocks/starrocks-kubernetes-operator/issues/49">issue49</a>
+     *
+     */
+    @ConfField(mutable = true)
+    public static boolean tablet_sched_ignore_dead_backend = false;
 
     /**
      * If BE is down beyond this time, tablets on that BE of colocate table will be migrated to other available BEs


### PR DESCRIPTION
## Problem Summary:
Fixes https://github.com/StarRocks/starrocks-kubernetes-operator/issues/49

For certain deployment, like k8s pods + pvc, the replica is not lost even the
corresponding backend is detected as dead, because the replica data is persisted
on a pvc which is backed by a remote storage service, such as AWS EBS. And later,
k8s control place will schedule a new pod and attach the pvc to it which will
restore the replica to a normal state immediately. But normally the tablet scheduler
of Starrocks will start to schedule REPLICA_MISSING type tasks and create new
replicas in a short time. After new pod scheduling is completed, tablet scheduler has
to delete the redundant healthy replica which cause resource waste and may also affect
the loading process.

We add a new configuration `tablet_sched_ignore_dead_backend` to adapt to this recovery
mode, when setting it to true, StarRocks won't schedule any REPLICA_MISSING type task
because of dead backends (but may still schedule REPLICA_MISSING type tasks because of
other reasons, like manually setting a replica as bad, actively decommission a backend etc.)
and leave the resource manager like k8s to handle the repair process.

Signed-off-by: Dejun Xia <xiadejun@starrocks.com>

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
