### PR TITLE
[Enhancement] Convert bitmap_union(to_bitmap(int type) to bitmap_agg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -537,6 +537,10 @@ public class FunctionSet {
                     .addAll(Type.FLOAT_TYPES)
                     .build();
 
+    public static final Set<Type> BITMAP_AGG_TYPE =
+            ImmutableSet.<Type>builder()
+                    .addAll(Type.INTEGER_TYPES)
+                    .build();
     /**
      * Use for vectorized engine, but we can't use vectorized function directly, because we
      * need to check whether the expression tree can use vectorized function from bottom to

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -594,6 +594,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_HYPERSCAN_VEC = "enable_hyperscan_vec";
 
+    // whether rewrite bitmap_union(to_bitmap(x)) to bitmap_agg(x) directly.
+    public static final String ENABLE_REWRITE_BITMAP_UNION_TO_BITMAP_AGG = "enable_rewrite_bitmap_union_to_bitamp_agg";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1220,6 +1223,17 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_HYPERSCAN_VEC)
     private boolean enableHyperscanVec = true;
+
+    @VarAttr(name = ENABLE_REWRITE_BITMAP_UNION_TO_BITMAP_AGG)
+    private boolean enableRewriteBitmapUnionToBitmapAgg = true;
+
+    public boolean isEnableRewriteBitmapUnionToBitmapAgg() {
+        return enableRewriteBitmapUnionToBitmapAgg;
+    }
+
+    public void setEnableRewriteBitmapUnionToBitmapAgg(boolean enableRewriteBitmapUnionToBitmapAgg) {
+        this.enableRewriteBitmapUnionToBitmapAgg = enableRewriteBitmapUnionToBitmapAgg;
+    }
 
     public long getCboPushDownTopNLimit() {
         return cboPushDownTopNLimit;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1131,6 +1131,23 @@ public class ExpressionAnalyzer {
                 argumentTypes = node.getChildren().stream().map(Expr::getType).toArray(Type[]::new);
             } else if (DecimalV3FunctionAnalyzer.argumentTypeContainDecimalV2(fnName, argumentTypes)) {
                 fn = DecimalV3FunctionAnalyzer.getDecimalV2Function(node, argumentTypes);
+            } else if (FunctionSet.BITMAP_UNION.equals(fnName)) {
+                fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_IDENTICAL);
+                if (session.getSessionVariable().isEnableRewriteBitmapUnionToBitmapAgg() &&
+                        node.getChild(0) instanceof FunctionCallExpr) {
+                    FunctionCallExpr arg0Func = (FunctionCallExpr) node.getChild(0);
+                    // Convert bitmap_union(to_bitmap(v1)) to bitmap_agg(v1) when v1's type
+                    // is a numeric type.
+                    if (FunctionSet.TO_BITMAP.equals(arg0Func.getFnName().getFunction())) {
+                        Expr toBitmapArg0 = arg0Func.getChild(0);
+                        Type toBitmapArg0Type = toBitmapArg0.getType();
+                        if (toBitmapArg0Type.isIntegerType() || toBitmapArg0Type.isBoolean()
+                                || toBitmapArg0Type.isLargeIntType()) {
+                            node.setChild(0, toBitmapArg0);
+                            node.resetFnName("", FunctionSet.BITMAP_AGG);
+                        }
+                    }
+                }
             } else {
                 fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mvpattern/MVColumnBitmapAggPattern.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mvpattern/MVColumnBitmapAggPattern.java
@@ -1,0 +1,54 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer.mvpattern;
+
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Type;
+
+import static com.starrocks.catalog.FunctionSet.BITMAP_AGG_TYPE;
+
+public class MVColumnBitmapAggPattern implements MVColumnPattern {
+
+    @Override
+    public boolean match(Expr expr) {
+        if (!(expr instanceof FunctionCallExpr)) {
+            return false;
+        }
+        FunctionCallExpr fnExpr = (FunctionCallExpr) expr;
+        String fnNameString = fnExpr.getFnName().getFunction();
+        if (!fnNameString.equalsIgnoreCase(FunctionSet.BITMAP_AGG)) {
+            return false;
+        }
+        if (fnExpr.getChild(0) instanceof SlotRef) {
+            SlotRef slotRef = (SlotRef) fnExpr.getChild(0);
+            Type slotRefType = slotRef.getType();
+            return BITMAP_AGG_TYPE.contains(slotRefType);
+        } else if (fnExpr.getChild(0) instanceof Expr) {
+            Expr child0FnExpr = (Expr) fnExpr.getChild(0);
+            Type childType = child0FnExpr.getType();
+            return BITMAP_AGG_TYPE.contains(childType);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return FunctionSet.BITMAP_AGG + "(column), type of column only support integer. ";
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
@@ -50,6 +50,7 @@ import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
@@ -67,6 +68,7 @@ import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.UnsupportedMVException;
+import com.starrocks.sql.analyzer.mvpattern.MVColumnBitmapAggPattern;
 import com.starrocks.sql.analyzer.mvpattern.MVColumnBitmapUnionPattern;
 import com.starrocks.sql.analyzer.mvpattern.MVColumnHLLUnionPattern;
 import com.starrocks.sql.analyzer.mvpattern.MVColumnOneChildPattern;
@@ -114,6 +116,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 new MVColumnOneChildPattern(AggregateType.MAX.name().toLowerCase()));
         FN_NAME_TO_PATTERN.put(FunctionSet.COUNT, new MVColumnOneChildPattern(FunctionSet.COUNT));
         FN_NAME_TO_PATTERN.put(FunctionSet.BITMAP_UNION, new MVColumnBitmapUnionPattern());
+        FN_NAME_TO_PATTERN.put(FunctionSet.BITMAP_AGG, new MVColumnBitmapAggPattern());
         FN_NAME_TO_PATTERN.put(FunctionSet.HLL_UNION, new MVColumnHLLUnionPattern());
         FN_NAME_TO_PATTERN.put(FunctionSet.PERCENTILE_UNION, new MVColumnPercentileUnionPattern());
     }
@@ -491,7 +494,11 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         String mvColumnName = null;
         if (defineExpr instanceof SlotRef) {
             String baseColumName = baseSlotRefs.get(0).getColumnName();
-            mvColumnName = MVUtils.getMVAggColumnName(functionName, baseColumName);
+            if (functionName.equals(FunctionSet.BITMAP_AGG)) {
+                mvColumnName = MVUtils.getMVAggColumnName(FunctionSet.BITMAP_UNION, baseColumName);
+            } else {
+                mvColumnName = MVUtils.getMVAggColumnName(functionName, baseColumName);
+            }
         } else {
             if (defineExpr instanceof FunctionCallExpr) {
                 FunctionCallExpr argFunc = (FunctionCallExpr) defineExpr;
@@ -506,6 +513,12 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                         }
                         break;
                     }
+                    case FunctionSet.BITMAP_AGG:
+                        if (argFunc.getChild(0) instanceof SlotRef) {
+                            String baseColumName = baseSlotRefs.get(0).getColumnName();
+                            mvColumnName = MVUtils.getMVAggColumnName(FunctionSet.BITMAP_UNION, baseColumName);
+                        }
+                        break;
                     default:
                 }
             }
@@ -534,6 +547,20 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 type = baseType;
                 break;
             case FunctionSet.BITMAP_UNION:
+                type = Type.BITMAP;
+                break;
+            case FunctionSet.BITMAP_AGG:
+                // Compatible aggregation models
+                if (FunctionSet.BITMAP_AGG_TYPE.contains(baseType)) {
+                    Function fn = Expr.getBuiltinFunction(FunctionSet.TO_BITMAP, new Type[] {baseType},
+                            Function.CompareMode.IS_IDENTICAL);
+                    defineExpr = new FunctionCallExpr(FunctionSet.TO_BITMAP, Lists.newArrayList(defineExpr));
+                    defineExpr.setFn(fn);
+                    defineExpr.setType(Type.BITMAP);
+                } else {
+                    throw new SemanticException("Unsupported bitmap_agg type:" + baseType);
+                }
+                functionName = FunctionSet.BITMAP_UNION;
                 type = Type.BITMAP;
                 break;
             case FunctionSet.HLL_UNION:

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
@@ -132,6 +132,14 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
                     Expr.getBuiltinFunction(FunctionSet.BITMAP_UNION_COUNT, new Type[] {Type.BITMAP},
                             IS_IDENTICAL));
             return (CallOperator) replaceColumnRefRewriter.rewrite(callOperator);
+        } else if (functionName.equals(FunctionSet.BITMAP_AGG) &&
+                mvColumn.getAggregationType() == AggregateType.BITMAP_UNION) {
+            CallOperator callOperator = new CallOperator(FunctionSet.BITMAP_UNION,
+                    queryAggFunc.getType(),
+                    queryAggFunc.getChildren(),
+                    Expr.getBuiltinFunction(FunctionSet.BITMAP_UNION, new Type[] {Type.BITMAP},
+                            IS_IDENTICAL));
+            return (CallOperator) replaceColumnRefRewriter.rewrite(callOperator);
         } else if (
                 (functionName.equals(FunctionSet.NDV) || functionName.equals(FunctionSet.APPROX_COUNT_DISTINCT))
                         && mvColumn.getAggregationType() == AggregateType.HLL_UNION) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRule.java
@@ -799,6 +799,10 @@ public class MaterializedViewRule extends Rule {
         builder.put(FunctionSet.MAX, FunctionSet.MAX);
         builder.put(FunctionSet.MIN, FunctionSet.MIN);
         builder.put(FunctionSet.SUM, FunctionSet.COUNT);
+        builder.put(FunctionSet.BITMAP_AGG, FunctionSet.BITMAP_UNION);
+        builder.put(FunctionSet.BITMAP_AGG, FunctionSet.BITMAP_UNION_COUNT);
+        builder.put(FunctionSet.BITMAP_AGG, FunctionSet.MULTI_DISTINCT_COUNT);
+        builder.put(FunctionSet.BITMAP_UNION, FunctionSet.BITMAP_AGG);
         builder.put(FunctionSet.BITMAP_UNION, FunctionSet.BITMAP_UNION);
         builder.put(FunctionSet.BITMAP_UNION, FunctionSet.BITMAP_UNION_COUNT);
         builder.put(FunctionSet.BITMAP_UNION, FunctionSet.MULTI_DISTINCT_COUNT);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -72,8 +72,10 @@ import static com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil.fin
 public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter {
     private static final Logger LOG = LogManager.getLogger(AggregatedMaterializedViewRewriter.class);
 
-    private static final Map<String, String> ROLLUP_FUNCTION_MAP = ImmutableMap.<String, String>builder()
+    // Functions that rollup function name is different from original function name.
+    private static final Map<String, String> REWRITE_ROLLUP_FUNCTION_MAP = ImmutableMap.<String, String>builder()
             .put(FunctionSet.COUNT, FunctionSet.SUM)
+            .put(FunctionSet.BITMAP_AGG, FunctionSet.BITMAP_UNION)
             .build();
 
     private static final Set<String> SUPPORTED_ROLLUP_FUNCTIONS = ImmutableSet.<String>builder()
@@ -83,6 +85,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             .add(FunctionSet.MIN)
             .add(FunctionSet.APPROX_COUNT_DISTINCT)
             .add(FunctionSet.BITMAP_UNION)
+            .add(FunctionSet.BITMAP_AGG)
             .add(FunctionSet.HLL_UNION)
             .add(FunctionSet.PERCENTILE_UNION)
             .build();
@@ -715,17 +718,13 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         if (!SUPPORTED_ROLLUP_FUNCTIONS.contains(aggCall.getFnName())) {
             return null;
         }
-        if (ROLLUP_FUNCTION_MAP.containsKey(aggCall.getFnName())) {
-            if (aggCall.getFnName().equals(FunctionSet.COUNT)) {
-                Type[] argTypes = {targetColumn.getType()};
-                Function sumFn = findArithmeticFunction(argTypes, FunctionSet.SUM);
-                return new CallOperator(FunctionSet.SUM, aggCall.getFunction().getReturnType(),
-                        Lists.newArrayList(targetColumn), sumFn);
-            } else {
-                // impossible to reach here
-                LOG.warn("unsupported rollup function:{}", aggCall.getFnName());
-                return null;
-            }
+        String aggFuncName = aggCall.getFnName();
+        if (REWRITE_ROLLUP_FUNCTION_MAP.containsKey(aggFuncName)) {
+            String rollupFuncName = REWRITE_ROLLUP_FUNCTION_MAP.get(aggFuncName);
+            Type[] argTypes = {targetColumn.getType()};
+            Function rollupFn = findArithmeticFunction(argTypes, rollupFuncName);
+            return new CallOperator(rollupFuncName, aggCall.getFunction().getReturnType(),
+                    Lists.newArrayList(targetColumn), rollupFn);
         } else {
             // NOTE:
             // 1. Change fn's type  as 1th child has change, otherwise physical plan

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -2767,6 +2767,28 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     }
 
     @Test
+    public void testCountDistinctToBitmapCount7() {
+        String mv = "select user_id, time, bitmap_agg(tag_id) from user_tags group by user_id, time;";
+        testRewriteOK(mv, "select user_id, bitmap_count(bitmap_union(to_bitmap(tag_id))) x from user_tags group by user_id;");
+        // rewrite count distinct to bitmap_count(bitmap_union(to_bitmap(x)));
+        testRewriteOK(mv, "select user_id, count(distinct tag_id) x from user_tags group by user_id;");
+        testRewriteOK(mv, "select user_id, bitmap_count(bitmap_agg(tag_id)) x from user_tags group by user_id;");
+        testRewriteOK(mv, "select user_id, bitmap_agg(tag_id) x from user_tags group by user_id, time;");
+    }
+
+    @Test
+    public void testCountDistinctToBitmapCount8() {
+        String mv = "select user_id, time, bitmap_agg(tag_id % 10) from user_tags group by user_id, time;";
+        testRewriteOK(mv, "select user_id, bitmap_union(to_bitmap(tag_id % 10)) x from user_tags group by user_id;");
+        testRewriteOK(mv, "select user_id, bitmap_count(bitmap_union(to_bitmap(tag_id % 10))) x from user_tags group by user_id;");
+        // rewrite count distinct to bitmap_count(bitmap_union(to_bitmap(x)));
+        testRewriteOK(mv, "select user_id, count(distinct tag_id % 10) x from user_tags group by user_id;");
+        // bitmap_agg
+        testRewriteOK(mv, "select user_id, bitmap_agg(tag_id % 10) x from user_tags group by user_id;");
+        testRewriteOK(mv, "select user_id, bitmap_agg(tag_id % 10) x from user_tags group by user_id;");
+    }
+
+    @Test
     public void testStrColumnCountDistinctToBitmapCount1() {
         {
             String mv = "select user_id, bitmap_union(bitmap_hash(user_name)) from user_tags group by user_id;";
@@ -3010,7 +3032,6 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         }
 
         {
-            this.setTracLogModule("MV");
             String mv = "SELECT count(lo_linenumber)\n" +
                     "FROM lineorder inner join customer on lo_custkey = c_custkey\n" +
                     "WHERE `c_name` != 'name'; ";
@@ -5232,7 +5253,6 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         connectContext.getSessionVariable()
                 .setMaterializedViewRewriteMode(SessionVariable.MaterializedViewRewriteMode.FORCE.toString());
         {
-            this.setTracLogModule("MV");
             MVRewriteChecker checker = testRewriteOK(mv, query);
             checker.contains("UNION");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -174,15 +174,12 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     PREDICATES: 9: c2 >= 2000\n" +
                         "     partitions=5/5");
 
-        setTracLogModule("MV");
         sql("select c1, c3, c2 from test_base_part where c2 < 3000 and c3 < 3000")
                 .contains("partial_mv_6")
                 .contains("TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
                         "     PREDICATES: 9: c2 < 3000, 9: c2 >= 2000\n" +
                         "     partitions=5/5");
-        setTracLogModule("");
-
         // test query delta
         sql("select c1, c3, c2 from test_base_part where c2 < 1000 and c3 < 1000")
                 .contains("partial_mv_6")

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -299,5 +299,4 @@ public class AnalyzeAggregateTest {
         analyzeSuccess("SELECT window_funnel(1, ta, 0, [ta='a', ta='b']) FROM tall");
         analyzeSuccess("SELECT window_funnel(1, ta, 0, [true, true, false]) FROM tall");
     }
-
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1876,6 +1876,38 @@ public class AggregateTest extends PlanTestBase {
     }
 
     @Test
+    public void testBitmapUnionAggRewrite() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(true);
+        // normal case
+        String sql = "select " +
+                "bitmap_union(to_bitmap(t1a))," + // varchar
+                "bitmap_union(to_bitmap(t1b))," + // smallint
+                "bitmap_union(to_bitmap(t1c))," + // int
+                "bitmap_union(to_bitmap(t1d))," + // bigint
+                "bitmap_union(to_bitmap(t1e))," + // float
+                "bitmap_union(to_bitmap(t1f))," + //double
+                "bitmap_union(to_bitmap(t1g))," + // bigint
+                "bitmap_union(to_bitmap(id_datetime))," + // datetime
+                "bitmap_union(to_bitmap(id_date))," + // date
+                "bitmap_union(to_bitmap(id_decimal))" + //decimal
+                "from test_all_type_not_null";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "2:AGGREGATE (update finalize)\n" +
+                "  |  output: bitmap_union(to_bitmap(1: t1a)), " +
+                "bitmap_agg(2: t1b), " +
+                "bitmap_agg(3: t1c), " +
+                "bitmap_agg(4: t1d), " +
+                "bitmap_union(to_bitmap(CAST(5: t1e AS VARCHAR))), " +
+                "bitmap_union(to_bitmap(CAST(6: t1f AS VARCHAR))), " +
+                "bitmap_agg(7: t1g), " +
+                "bitmap_union(to_bitmap(CAST(8: id_datetime AS VARCHAR))), " +
+                "bitmap_union(to_bitmap(CAST(9: id_date AS VARCHAR))), " +
+                "bitmap_union(to_bitmap(CAST(10: id_decimal AS VARCHAR)))\n" +
+                "  |  group by: ");
+
+    }
+
+    @Test
     public void testGroupByLiteral() throws Exception {
         String sql = "select -9223372036854775808 group by TRUE;";
         String plan = getFragmentPlan(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -374,8 +374,8 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/select_sbuquery_with_multi_join"), null,
                         TExplainLevel.NORMAL);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("  20:Project\n" +
-                "  |  <slot 33> : bitmap_and(21: bitmap_union, 29: bitmap_union)\n" +
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("20:Project\n" +
+                "  |  <slot 31> : bitmap_and(20: bitmap_agg, 27: bitmap_agg)\n" +
                 "  |  \n" +
                 "  19:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
@@ -384,7 +384,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
                 "  |----18:EXCHANGE\n" +
                 "  |    \n" +
                 "  11:Project\n" +
-                "  |  <slot 21> : 18: bitmap_union"));
+                "  |  <slot 20> : 17: bitmap_agg"));
     }
 
     @Test

--- a/test/sql/test_agg_function/R/test_bitmap_agg
+++ b/test/sql/test_agg_function/R/test_bitmap_agg
@@ -9,8 +9,7 @@ CREATE TABLE t1 (
     c7 string
     )
 DUPLICATE KEY(c1)
-DISTRIBUTED BY HASH(c1)
-BUCKETS 1
+DISTRIBUTED BY HASH(c1) BUCKETS 3
 PROPERTIES ("replication_num" = "1");
 -- result:
 -- !result
@@ -46,4 +45,218 @@ SELECT BITMAP_TO_STRING(BITMAP_AGG(c6)) FROM t1;
 SELECT BITMAP_TO_STRING(BITMAP_AGG(c7)) FROM t1;
 -- result:
 111111,222222,333333
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c2))) FROM t1;
+-- result:
+0,1
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c3))) FROM t1;
+-- result:
+11,22,33
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c4))) FROM t1;
+-- result:
+111,222,333
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c5))) FROM t1;
+-- result:
+1111,2222,3333
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c6))) FROM t1;
+-- result:
+11111,22222,33333
+-- !result
+create materialized view mv1 as select c1, bitmap_agg(c2), bitmap_agg(c3), bitmap_agg(c4) from t1 group by c1;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select bitmap_agg(c2), bitmap_agg(c3), bitmap_agg(c4) from t1 group by c1", "mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select bitmap_union(to_bitmap(c2)), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1", "mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select bitmap_union(to_bitmap(c2)), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1", "mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select count(distinct c2), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1", "mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c2))) FROM t1", "mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select bitmap_union_count(to_bitmap(c4)), bitmap_agg(c4) from t1 group by c1", "mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select c1, count(distinct c2), count(distinct c3), count(distinct c4) from t1 group by c1", "mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select c1, multi_distinct_count(c3), multi_distinct_count(c4) from t1 group by c1", "mv1")
+-- result:
+None
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c2))) FROM t1;
+-- result:
+0,1
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c3))) FROM t1;
+-- result:
+11,22,33
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c4))) FROM t1;
+-- result:
+111,222,333
+-- !result
+select c1, BITMAP_TO_STRING(bitmap_union(to_bitmap(c2))), BITMAP_TO_STRING(bitmap_union(to_bitmap(c3))), BITMAP_TO_STRING(bitmap_agg(c4)) from t1 group by c1 order by c1;
+-- result:
+1	1	11	111
+2	0	22	222
+3	1	33	333
+4	None	None	None
+5	1	None	None
+6	None	None	None
+-- !result
+select c1, count(distinct c2), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1 order by c1;
+-- result:
+1	1	None	None
+2	1	None	None
+3	1	None	None
+4	0	None	None
+5	1	None	None
+6	0	None	None
+-- !result
+select c1, bitmap_union_count(to_bitmap(c4)), BITMAP_TO_STRING(bitmap_agg(c4)) from t1 group by c1 order by c1;
+-- result:
+1	1	111
+2	1	222
+3	1	333
+4	0	None
+5	0	None
+6	0	None
+-- !result
+select c1, multi_distinct_count(c2), multi_distinct_count(c3), multi_distinct_count(c4) from t1 group by c1 order by c1;
+-- result:
+1	1	1	1
+2	1	1	1
+3	1	1	1
+4	0	0	0
+5	1	0	0
+6	0	0	0
+-- !result
+select c1, count(distinct c2), count(distinct c3), count(distinct c4) from t1 group by c1 order by c1;
+-- result:
+1	1	1	1
+2	1	1	1
+3	1	1	1
+4	0	0	0
+5	1	0	0
+6	0	0	0
+-- !result
+drop materialized view mv1;
+-- result:
+-- !result
+create materialized view mv2
+distributed by random
+refresh deferred manual
+as select c1, bitmap_agg(c2), bitmap_agg(c3), bitmap_agg(c4) from t1 group by c1;
+-- result:
+-- !result
+refresh materialized view mv2 with sync mode;
+function: check_hit_materialized_view("select bitmap_agg(c2), bitmap_agg(c3), bitmap_agg(c4) from t1 group by c1", "mv2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select bitmap_union(to_bitmap(c2)), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1", "mv2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select bitmap_union(to_bitmap(c2)), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1", "mv2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select count(distinct c2), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1", "mv2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c2))) FROM t1", "mv2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select bitmap_union_count(to_bitmap(c4)), bitmap_agg(c4) from t1 group by c1", "mv2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select c1, multi_distinct_count(c3), multi_distinct_count(c4) from t1 group by c1", "mv2")
+-- result:
+None
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c2))) FROM t1;
+-- result:
+0,1
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c3))) FROM t1;
+-- result:
+11,22,33
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c4))) FROM t1;
+-- result:
+111,222,333
+-- !result
+select BITMAP_TO_STRING(bitmap_union(to_bitmap(c2))), BITMAP_TO_STRING(bitmap_union(to_bitmap(c3))), BITMAP_TO_STRING(bitmap_agg(c4)) from t1 group by c1 order by c1;
+-- result:
+1	11	111
+0	22	222
+1	33	333
+None	None	None
+1		
+None	None	None
+-- !result
+select c1, count(distinct c2), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1 order by c1;
+-- result:
+1	1	None	None
+2	1	None	None
+3	1	None	None
+4	0	None	None
+5	1	None	None
+6	0	None	None
+-- !result
+select c1, bitmap_union_count(to_bitmap(c4)), BITMAP_TO_STRING(bitmap_agg(c4)) from t1 group by c1 order by c1;
+-- result:
+1	1	111
+2	1	222
+3	1	333
+4	0	None
+5	0	
+6	0	None
+-- !result
+select c1, count(distinct c2), count(distinct c3), count(distinct c4) from t1 group by c1 order by c1;
+-- result:
+1	1	1	1
+2	1	1	1
+3	1	1	1
+4	0	0	0
+5	1	1	1
+6	0	0	0
+-- !result
+select c1, multi_distinct_count(c2), multi_distinct_count(c3), multi_distinct_count(c4) from t1 group by c1 order by c1;
+-- result:
+1	1	1	1
+2	1	1	1
+3	1	1	1
+4	0	0	0
+5	1	0	0
+6	0	0	0
+-- !result
+drop materialized view mv2;
+-- result:
 -- !result

--- a/test/sql/test_agg_function/T/test_bitmap_agg
+++ b/test/sql/test_agg_function/T/test_bitmap_agg
@@ -9,8 +9,7 @@ CREATE TABLE t1 (
     c7 string
     )
 DUPLICATE KEY(c1)
-DISTRIBUTED BY HASH(c1)
-BUCKETS 1
+DISTRIBUTED BY HASH(c1) BUCKETS 3
 PROPERTIES ("replication_num" = "1");
 
 INSERT INTO t1 values
@@ -27,3 +26,53 @@ SELECT BITMAP_TO_STRING(BITMAP_AGG(c4)) FROM t1;
 SELECT BITMAP_TO_STRING(BITMAP_AGG(c5)) FROM t1;
 SELECT BITMAP_TO_STRING(BITMAP_AGG(c6)) FROM t1;
 SELECT BITMAP_TO_STRING(BITMAP_AGG(c7)) FROM t1;
+
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c2))) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c3))) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c4))) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c5))) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c6))) FROM t1;
+
+create materialized view mv1 as select c1, bitmap_agg(c2), bitmap_agg(c3), bitmap_agg(c4) from t1 group by c1;
+function: wait_materialized_view_finish()
+function: check_hit_materialized_view("select bitmap_agg(c2), bitmap_agg(c3), bitmap_agg(c4) from t1 group by c1", "mv1")
+function: check_hit_materialized_view("select bitmap_union(to_bitmap(c2)), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1", "mv1")
+function: check_hit_materialized_view("select bitmap_union(to_bitmap(c2)), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1", "mv1")
+function: check_hit_materialized_view("select count(distinct c2), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1", "mv1")
+function: check_hit_materialized_view("SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c2))) FROM t1", "mv1")
+function: check_hit_materialized_view("select bitmap_union_count(to_bitmap(c4)), bitmap_agg(c4) from t1 group by c1", "mv1")
+function: check_hit_materialized_view("select c1, count(distinct c2), count(distinct c3), count(distinct c4) from t1 group by c1", "mv1")
+function: check_hit_materialized_view("select c1, multi_distinct_count(c3), multi_distinct_count(c4) from t1 group by c1", "mv1")
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c2))) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c3))) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c4))) FROM t1;
+select c1, BITMAP_TO_STRING(bitmap_union(to_bitmap(c2))), BITMAP_TO_STRING(bitmap_union(to_bitmap(c3))), BITMAP_TO_STRING(bitmap_agg(c4)) from t1 group by c1 order by c1;
+select c1, count(distinct c2), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1 order by c1;
+select c1, bitmap_union_count(to_bitmap(c4)), BITMAP_TO_STRING(bitmap_agg(c4)) from t1 group by c1 order by c1;
+select c1, multi_distinct_count(c2), multi_distinct_count(c3), multi_distinct_count(c4) from t1 group by c1 order by c1;
+select c1, count(distinct c2), count(distinct c3), count(distinct c4) from t1 group by c1 order by c1;
+drop materialized view mv1;
+
+create materialized view mv2
+distributed by random
+refresh deferred manual
+as select c1, bitmap_agg(c2), bitmap_agg(c3), bitmap_agg(c4) from t1 group by c1;
+refresh materialized view mv2 with sync mode;
+function: check_hit_materialized_view("select bitmap_agg(c2), bitmap_agg(c3), bitmap_agg(c4) from t1 group by c1", "mv2")
+function: check_hit_materialized_view("select bitmap_union(to_bitmap(c2)), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1", "mv2")
+function: check_hit_materialized_view("select bitmap_union(to_bitmap(c2)), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1", "mv2")
+function: check_hit_materialized_view("select count(distinct c2), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1", "mv2")
+function: check_hit_materialized_view("SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c2))) FROM t1", "mv2")
+function: check_hit_materialized_view("select bitmap_union_count(to_bitmap(c4)), bitmap_agg(c4) from t1 group by c1", "mv2")
+--function: check_hit_materialized_view("select c1, count(distinct c2), count(distinct c3), count(distinct c4) from t1 group by c1", "mv2")
+function: check_hit_materialized_view("select c1, multi_distinct_count(c3), multi_distinct_count(c4) from t1 group by c1", "mv2")
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c2))) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c3))) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_UNION(TO_BITMAP(c4))) FROM t1;
+select BITMAP_TO_STRING(bitmap_union(to_bitmap(c2))), BITMAP_TO_STRING(bitmap_union(to_bitmap(c3))), BITMAP_TO_STRING(bitmap_agg(c4)) from t1 group by c1 order by c1;
+select c1, count(distinct c2), bitmap_union(to_bitmap(c3)), bitmap_agg(c4) from t1 group by c1 order by c1;
+select c1, bitmap_union_count(to_bitmap(c4)), BITMAP_TO_STRING(bitmap_agg(c4)) from t1 group by c1 order by c1;
+select c1, count(distinct c2), count(distinct c3), count(distinct c4) from t1 group by c1 order by c1;
+select c1, multi_distinct_count(c2), multi_distinct_count(c3), multi_distinct_count(c4) from t1 group by c1 order by c1;
+
+drop materialized view mv2;

--- a/test/sql/test_materialized_view/R/test_show_materialized_view
+++ b/test/sql/test_materialized_view/R/test_show_materialized_view
@@ -1,4 +1,7 @@
 -- name: test_show_materialized_view
+set enable_rewrite_bitmap_union_to_bitamp_agg = false;
+-- result:
+-- !result
 create database test_show_materialized_view;
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/T/test_show_materialized_view
+++ b/test/sql/test_materialized_view/T/test_show_materialized_view
@@ -1,4 +1,5 @@
 -- name: test_show_materialized_view
+set enable_rewrite_bitmap_union_to_bitamp_agg = false;
 create database test_show_materialized_view;
 use test_show_materialized_view;
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');


### PR DESCRIPTION
Why I'm doing:
After pr(https://github.com/StarRocks/starrocks/pull/23641),  bitmap_agg can support boolean and int types.
so convert bitmap_union(to_bitmap(int type) to bitmap_agg directly to avoid redundant expression evaluations.

What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/5178

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5

