### PR TITLE
[BugFix] Fix spill may use-after-free when cancel

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -269,7 +269,7 @@ Status SpillableHashJoinProbeOperator::_load_all_partition_build_side(RuntimeSta
     for (size_t i = 0; i < _processing_partitions.size(); ++i) {
         std::shared_ptr<spill::SpillerReader> reader = std::move(spill_readers[i]);
         auto task = [this, state, reader, i, query_ctx]() {
-            if (query_ctx.lock()) {
+            if (auto acquired = query_ctx.lock()) {
                 _update_status(_load_partition_build_side(state, reader, i));
                 _latch.count_down();
             }


### PR DESCRIPTION
## Problem Summary:
```
==3247495==ERROR: AddressSanitizer: heap-use-after-free on address 0x6040029dd090 at pc 0x00000e1296bf bp 0x7f5ef72f60c0 sp 0x7f5ef72f60b0
READ of size 8 at 0x6040029dd090 thread T415
    #0 0xe1296be in starrocks::ScopedTimer<starrocks::MonotonicStopWatch>::UpdateCounter() /root/starrocks/be/src/util/runtime_profile.h:658
    #1 0xe125dfd in starrocks::ScopedTimer<starrocks::MonotonicStopWatch>::~ScopedTimer() /root/starrocks/be/src/util/runtime_profile.h:665
    #2 0xe7156a6 in starrocks::HashJoinBuilder::append_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&) /root/starrocks/be/src/exec/hash_join_components.cpp:86
    #3 0xecc1382 in starrocks::pipeline::SpillableHashJoinProbeOperator::_load_partition_build_side(starrocks::RuntimeState*, std::shared_ptr<starrocks::spill::SpillerReader> const&, unsigned long) /root/starrocks/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp:258
    #4 0xecc2982 in operator() /root/starrocks/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp:281
    #5 0xeccb32f in __invoke_impl<void, starrocks::pipeline::SpillableHashJoinProbeOperator::_load_all_partition_build_side(starrocks::RuntimeState*)::<lambda()>&> /usr/include/c++/11/bits/invoke.h:61
    #6 0xeccacc2 in __invoke_r<void, starrocks::pipeline::SpillableHashJoinProbeOperator::_load_all_partition_build_side(starrocks::RuntimeState*)::<lambda()>&> /usr/include/c++/11/bits/invoke.h:111
```

https://stackoverflow.com/questions/25292580/why-am-i-getting-an-access-violation-when-locking-a-weak-ptr
weak_ptr.lock() should capture the resource
```
#include <unistd.h>

#include <iostream>
#include <memory>
#include <thread>

struct LongDesc : public std::enable_shared_from_this<LongDesc> {
    LongDesc() = default;
    ~LongDesc() { std::cout << "desc finish" << std::endl; }

private:
    long epoh{};
};
int main() {
    auto desc = std::make_shared<LongDesc>();
    std::weak_ptr<LongDesc> weak = desc;
    std::thread t([&]() {
        std::cout << "start thread" << std::endl;
        if (weak.lock()) {
            std::cout << "hold resource" << std::endl;
            sleep(5);
            std::cout << "call in thread" << std::endl;
        }
    });
    sleep(1);
    std::cout << "reset" << std::endl;
    desc.reset();
    t.join();

    return 0;
}
```
output:
```
start thread
hold resource
reset
desc finish
call in thread
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
