### PR TITLE
[BugFix] Fix delete version can not compact when skip large base rowset

### DIFF
--- a/be/src/storage/size_tiered_compaction_policy.cpp
+++ b/be/src/storage/size_tiered_compaction_policy.cpp
@@ -183,7 +183,8 @@ Status SizeTieredCompactionPolicy::_pick_rowsets_to_size_tiered_compact(bool for
     bool skip_dup_large_base_rowset = true;
     for (auto rowset : candidate_rowsets) {
         // when duplicate key's base rowset larger than 0.8 * max_segment_file_size, we don't need compact it
-        if (keys_type == KeysType::DUP_KEYS && skip_dup_large_base_rowset &&
+        // if set force_base_compaction, we will compact it to make sure delete version can be compacted
+        if (keys_type == KeysType::DUP_KEYS && skip_dup_large_base_rowset && !force_base_compaction &&
             !rowset->rowset_meta()->is_segments_overlapping() &&
             rowset->data_disk_size() > config::max_segment_file_size * 0.8) {
             continue;

--- a/be/test/storage/size_tiered_compaction_policy_test.cpp
+++ b/be/test/storage/size_tiered_compaction_policy_test.cpp
@@ -1427,4 +1427,57 @@ TEST_F(SizeTieredCompactionPolicyTest, test_large_dup_base_rowset) {
     }
 }
 
+TEST_F(SizeTieredCompactionPolicyTest, test_large_dup_base_rowset_force_compact) {
+    LOG(INFO) << "test_large_dup_base_rowset_force_compact";
+    create_tablet_schema(DUP_KEYS);
+
+    TabletMetaSharedPtr tablet_meta = std::make_shared<TabletMeta>();
+    create_tablet_meta(tablet_meta.get());
+
+    write_new_version(tablet_meta, 2);
+    write_new_version(tablet_meta, 1);
+    write_new_version(tablet_meta, 1);
+    write_new_version(tablet_meta, 1);
+
+    TabletSharedPtr tablet =
+            Tablet::create_tablet_from_meta(tablet_meta, starrocks::StorageEngine::instance()->get_stores()[0]);
+    tablet->init();
+    init_compaction_context(tablet);
+
+    ASSERT_EQ(4, tablet->version_count());
+
+    config::max_segment_file_size = 1024 * 128;
+    DeferOp defer([&]() {
+        config::max_segment_file_size = 1073741824;
+    });
+
+    {
+        auto res = compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(2, tablet->version_count());
+        std::vector<Version> versions;
+        tablet->list_versions(&versions);
+        ASSERT_EQ(2, versions.size());
+        ASSERT_EQ(0, versions[0].first);
+        ASSERT_EQ(0, versions[0].second);
+        ASSERT_EQ(1, versions[1].first);
+        ASSERT_EQ(3, versions[1].second);
+    }
+
+    {
+        auto res = compact(tablet);
+        ASSERT_FALSE(res.ok());
+
+        ASSERT_EQ(2, tablet->version_count());
+    }
+
+    {
+        auto res = base_compact(tablet);
+        ASSERT_TRUE(res.ok());
+
+        ASSERT_EQ(1, tablet->version_count());
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Problem Summary:
Fixes delete version can not compact when skip large base rowset

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
