### PR TITLE
[BugFix] Fix the type output of show create table statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ArrayType.java
@@ -56,9 +56,9 @@ public class ArrayType extends Type {
     @Override
     public String toSql(int depth) {
         if (depth >= MAX_NESTING_DEPTH) {
-            return "ARRAY<...>";
+            return "array<...>";
         }
-        return String.format("ARRAY<%s>", itemType.toSql(depth + 1));
+        return String.format("array<%s>", itemType.toSql(depth + 1));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
@@ -135,9 +135,9 @@ public class MapType extends Type {
     @Override
     public String toSql(int depth) {
         if (depth >= MAX_NESTING_DEPTH) {
-            return "MAP<...>";
+            return "map<...>";
         }
-        return String.format("MAP<%s,%s>",
+        return String.format("map<%s,%s>",
                 keyType.toSql(depth + 1), valueType.toSql(depth + 1));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -564,11 +564,8 @@ public class ScalarType extends Type implements Cloneable {
             case FUNCTION:
                 stringBuilder.append(type.toString().toLowerCase());
                 break;
-            case NULL_TYPE:
-                stringBuilder.append(type);
-                break;
             default:
-                stringBuilder.append("unknown type: ").append(type);
+                stringBuilder.append(type);
                 break;
         }
         return stringBuilder.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
@@ -122,13 +122,13 @@ public class StructType extends Type {
     @Override
     public String toSql(int depth) {
         if (depth >= MAX_NESTING_DEPTH) {
-            return "STRUCT<...>";
+            return "struct<...>";
         }
         ArrayList<String> fieldsSql = Lists.newArrayList();
         for (StructField f : fields) {
             fieldsSql.add(f.toSql(depth + 1));
         }
-        return String.format("STRUCT<%s>", Joiner.on(", ").join(fieldsSql));
+        return String.format("struct<%s>", Joiner.on(", ").join(fieldsSql));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1040,41 +1040,7 @@ public class ShowExecutor {
     private String toMysqlDDL(Column column) {
         StringBuilder sb = new StringBuilder();
         sb.append("  `").append(column.getName()).append("` ");
-        switch (column.getType().getPrimitiveType()) {
-            case TINYINT:
-                sb.append("tinyint(4)");
-                break;
-            case SMALLINT:
-                sb.append("smallint(6)");
-                break;
-            case INT:
-                sb.append("int(11)");
-                break;
-            case BIGINT:
-                sb.append("bigint(20)");
-                break;
-            case FLOAT:
-                sb.append("float");
-                break;
-            case DOUBLE:
-                sb.append("double");
-            case DECIMAL32:
-            case DECIMAL64:
-            case DECIMAL128:
-            case DECIMALV2:
-                sb.append("decimal");
-                break;
-            case DATE:
-            case DATETIME:
-                sb.append("datetime");
-                break;
-            case CHAR:
-            case VARCHAR:
-                sb.append("varchar(1048576)");
-                break;
-            default:
-                sb.append("binary(1048576)");
-        }
+        sb.append(column.getType().toSql());
         sb.append(" DEFAULT NULL");
 
         if (!Strings.isNullOrEmpty(column.getComment())) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -367,7 +367,7 @@ public class SelectStmtTest {
             Assert.fail("Must throw an exception");
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage(),
-                    e.getMessage().contains("NOT support scalar correlated sub-query of type ARRAY<varchar(32)>"));
+                    e.getMessage().contains("NOT support scalar correlated sub-query of type array<varchar(32)>"));
         }
 
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StructTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StructTypeTest.java
@@ -30,7 +30,7 @@ public class StructTypeTest {
     @Test
     public void testUnnamedStruct() {
         StructType type = new StructType(Lists.newArrayList(Type.INT, Type.DATETIME));
-        Assert.assertEquals("STRUCT<col0 int(11), col1 datetime>", type.toSql());
+        Assert.assertEquals("struct<col0 int(11), col1 datetime>", type.toSql());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -208,7 +208,7 @@ public class TypeTest {
         String json = GsonUtils.GSON.toJson(mapType);
         Type deType = GsonUtils.GSON.fromJson(json, Type.class);
         Assert.assertTrue(deType.isMapType());
-        Assert.assertEquals("MAP<INT,STRUCT<c1 int(11), cc1 varchar(1048576)>>", deType.toString());
+        Assert.assertEquals("MAP<INT,struct<c1 int(11), cc1 varchar(1048576)>>", deType.toString());
         // Make sure select fields are false when initialized
         Assert.assertFalse(deType.selectedFields[0]);
         Assert.assertFalse(deType.selectedFields[1]);
@@ -228,7 +228,7 @@ public class TypeTest {
         String json = GsonUtils.GSON.toJson(root);
         Type deType = GsonUtils.GSON.fromJson(json, Type.class);
         Assert.assertTrue(deType.isStructType());
-        Assert.assertEquals("STRUCT<struct_test int(11) COMMENT 'comment test', c1 STRUCT<c1 int(11), cc1 varchar(1048576)>>",
+        Assert.assertEquals("struct<struct_test int(11) COMMENT 'comment test', c1 struct<c1 int(11), cc1 varchar(1048576)>>",
                 deType.toString());
         // test initialed fieldMap by ctor in deserializer.
         Assert.assertEquals(1, ((StructType) deType).getFieldPos("c1"));

--- a/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/delete/DeleteTest.java
@@ -341,7 +341,7 @@ public class DeleteTest {
         try {
             deleteHandler.process(deleteStmt);
         } catch (DdlException e) {
-            Assert.assertTrue(e.getMessage().contains("Type[ARRAY<bigint(20)>] not supported"));
+            Assert.assertTrue(e.getMessage().contains("Type[array<bigint(20)>] not supported"));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -1102,7 +1102,7 @@ public class ShowExecutorTest {
         Assert.assertEquals("test_table", resultSet.getResultRows().get(0).get(0));
         Assert.assertEquals("CREATE TABLE `test_table` (\n" +
                 "  `id` int(11) DEFAULT NULL COMMENT \"id\",\n" +
-                "  `name` varchar(1048576) DEFAULT NULL,\n" +
+                "  `name` varchar DEFAULT NULL,\n" +
                 "  `year` int(11) DEFAULT NULL,\n" +
                 "  `dt` int(11) DEFAULT NULL\n" +
                 ")\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -175,7 +175,7 @@ public class AnalyzeInsertTest {
                 "Expected: p1, but actual: p2");
 
         analyzeFail("insert into iceberg_catalog.db.tbl partition(p1=1, p2=\"aaffsssaa\") values (1)",
-                "Type[ARRAY<date>] not supported.");
+                "Type[array<date>] not supported.");
 
         new Expectations() {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStructTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStructTest.java
@@ -115,8 +115,8 @@ public class AnalyzeStructTest {
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
         String res = resultSet.getResultRows().get(0).get(1);
-        Assert.assertTrue(res.contains("`b` STRUCT<b STRUCT<c STRUCT<d STRUCT<e int(11)>>>> NULL COMMENT \"\""));
+        Assert.assertTrue(res.contains("`b` struct<b struct<c struct<d struct<e int(11)>>>> NULL COMMENT \"\""));
         Assert.assertTrue(
-                res.contains("`struct_a` STRUCT<struct_a STRUCT<struct_a int(11)>, other int(11)> NULL COMMENT \"\""));
+                res.contains("`struct_a` struct<struct_a struct<struct_a int(11)>, other int(11)> NULL COMMENT \"\""));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -257,7 +257,7 @@ public class ArrayTypeTest extends PlanTestBase {
         String sql = "select array_difference(c1, 3) from test_array";
         expectedEx.expect(SemanticException.class);
         expectedEx.expectMessage(
-                "No matching function with signature: array_difference(ARRAY<varchar(65533)>, tinyint(4)).");
+                "No matching function with signature: array_difference(array<varchar(65533)>, tinyint(4)).");
         getFragmentPlan(sql);
     }
 
@@ -289,7 +289,7 @@ public class ArrayTypeTest extends PlanTestBase {
             String sql = String.format("select %s(v3) over() from tarray", fnName.toLowerCase());
             expectedEx.expect(SemanticException.class);
             expectedEx.expectMessage(
-                    String.format("No matching function with signature: %s(ARRAY<bigint(20)>)", fnName.toLowerCase()));
+                    String.format("No matching function with signature: %s(array<bigint(20)>)", fnName.toLowerCase()));
             getFragmentPlan(sql);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -193,10 +193,10 @@ public class DecimalTypeTest extends PlanTestBase {
         try {
             String sql = "select array_agg(c_0_0) from tab0";
             String plan = getVerboseExplain(sql);
-            assertContains(plan, "array_agg[([16: array_agg, STRUCT<col0 ARRAY<decimal128(26, 2)>>, true]); " +
+            assertContains(plan, "array_agg[([16: array_agg, struct<col0 array<decimal128(26, 2)>>, true]); " +
                     "args: DECIMAL128; result: ARRAY<DECIMAL128(26,2)>;");
             assertContains(plan, "array_agg[([1: c_0_0, DECIMAL128(26,2), false]); " +
-                    "args: DECIMAL128; result: STRUCT<col0 ARRAY<decimal128(26, 2)>>;");
+                    "args: DECIMAL128; result: struct<col0 array<decimal128(26, 2)>>;");
         } finally {
             connectContext.getSessionVariable().setNewPlanerAggStage(stage);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
@@ -233,6 +233,6 @@ public class JsonTypeTest extends PlanTestBase {
         // Multi-dimension array casting is not supported
         assertExceptionMessage("select cast(json_array(1,2,3) as array<array<int>>)",
                 "Getting analyzing error from line 1, column 7 to line 1, column 50. Detail message: " +
-                        "Invalid type cast from json to ARRAY<ARRAY<int(11)>> in sql `json_array(1, 2, 3)`.");
+                        "Invalid type cast from json to array<array<int(11)>> in sql `json_array(1, 2, 3)`.");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
@@ -61,7 +61,7 @@ public class StructTypePlanTest extends PlanTestBase {
         sql = "select c2 from test1 union all select c2_0 from test1";
         plan = getFragmentPlan(sql);
         assertContains(plan, "2:Project\n" +
-                "  |  <slot 6> : CAST(3: c2 AS STRUCT<col0 int(11), col1 varchar(10)>)\n" +
+                "  |  <slot 6> : CAST(3: c2 AS struct<col0 int(11), col1 varchar(10)>)\n" +
                 "  |  \n" +
                 "  1:OlapScanNode", "0:UNION\n" +
                 "  |  \n" +


### PR DESCRIPTION
## Problem Summary:

Fix the wrong type output of show create table statement

expect: double, actual: doubledecimal
expect: struct<...>, actual: binary
expect: array<...>, actual: binary
expect: map<...>, actual: binary


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
