### PR TITLE
[Enhancement] Trigger statistics collection after first load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
@@ -348,6 +348,10 @@ public class Partition extends MetaObject implements Writable {
                 || FeConstants.runningUnitTest);
     }
 
+    public boolean isFirstLoad() {
+        return visibleVersion == PARTITION_INIT_VERSION + 1;
+    }
+
     /*
      * Change the index' state from SHADOW to NORMAL
      * Also move it to idToVisibleRollupIndex if it is not the base index.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1537,6 +1537,12 @@ public class Config extends ConfigBase {
     public static boolean enable_statistic_collect = true;
 
     /**
+     * auto statistic collect on first load flag
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_statistic_collect_on_first_load = true;
+
+    /**
      * The start time of day when auto-updates are enabled
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/load/EtlStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/EtlStatus.java
@@ -46,6 +46,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.load.loadv2.dpp.DppResult;
+import com.starrocks.metric.TableMetricsEntity;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.thrift.TEtlState;
 import com.starrocks.thrift.TReportExecStatusParams;
@@ -149,6 +150,14 @@ public class EtlStatus implements Writable {
 
     public void setCounters(Map<String, String> counters) {
         this.counters = counters;
+    }
+
+    public Long getLoadedRows(long tableId) {
+        Map<String, Long> counters = tableCounters.get(tableId);
+        if (counters == null) {
+            return null;
+        }
+        return counters.get(TableMetricsEntity.TABLE_LOAD_ROWS);
     }
 
     public Map<String, Long> getFileMap() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -440,10 +440,10 @@ public class BrokerLoadJob extends BulkLoadJob {
     }
 
     @Override
-    public void updateProgess(TReportExecStatusParams params) {
+    public void updateProgress(TReportExecStatusParams params) {
         writeLock();
         try {
-            super.updateProgess(params);
+            super.updateProgress(params);
             if (!loadingStatus.getLoadStatistic().getLoadFinish()) {
                 if (jobType == EtlJobType.BROKER) {
                     progress = (int) ((double) loadingStatus.getLoadStatistic().sourceScanBytes() /

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/InsertLoadJob.java
@@ -145,10 +145,10 @@ public class InsertLoadJob extends LoadJob {
     }
 
     @Override
-    public void updateProgess(TReportExecStatusParams params) {
+    public void updateProgress(TReportExecStatusParams params) {
         writeLock();
         try {
-            super.updateProgess(params);
+            super.updateProgress(params);
             if (!loadingStatus.getLoadStatistic().getLoadFinish()) {
                 if (this.loadType == TLoadJobType.INSERT_QUERY) {
                     progress = (int) ((double) loadingStatus.getLoadStatistic().totalSourceLoadRows() 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -41,6 +41,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.AuthorizationInfo;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -70,6 +71,7 @@ import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterLoadStmt;
 import com.starrocks.sql.ast.LoadStmt;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.task.LeaderTaskExecutor;
 import com.starrocks.task.PriorityLeaderTask;
 import com.starrocks.task.PriorityLeaderTaskExecutor;
@@ -79,6 +81,7 @@ import com.starrocks.thrift.TReportExecStatusParams;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.AbstractTxnStateChangeCallback;
 import com.starrocks.transaction.BeginTransactionException;
+import com.starrocks.transaction.TableCommitInfo;
 import com.starrocks.transaction.TransactionException;
 import com.starrocks.transaction.TransactionState;
 import org.apache.logging.log4j.LogManager;
@@ -89,8 +92,10 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 public abstract class LoadJob extends AbstractTxnStateChangeCallback implements LoadTaskCallback, Writable {
 
@@ -277,7 +282,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         loadStartTimestamp = System.currentTimeMillis();
     }
 
-    public void updateProgess(TReportExecStatusParams params) {
+    public void updateProgress(TReportExecStatusParams params) {
         loadingStatus.getLoadStatistic().updateLoadProgress(params);
     }
 
@@ -1017,8 +1022,37 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         if (!txnOperated) {
             return;
         }
-        unprotectUpdateLoadingStatus(txnState);
-        updateState(JobState.FINISHED);
+        collectStatisticsOnFirstLoadAsync(txnState, () -> {
+            unprotectUpdateLoadingStatus(txnState);
+            updateState(JobState.FINISHED);
+        });
+    }
+
+    private void collectStatisticsOnFirstLoadAsync(TransactionState txnState, Runnable listener) {
+        Database db;
+        try {
+            db = getDb();
+        } catch (MetaNotFoundException e) {
+            listener.run();
+            return;
+        }
+
+        List<Table> tables = txnState.getIdToTableCommitInfos().values().stream()
+                .map(TableCommitInfo::getTableId)
+                .distinct()
+                .map(db::getTable)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        if (tables.isEmpty()) {
+            listener.run();
+            return;
+        }
+
+        StatisticUtils.CountedListener counteredListener =
+                StatisticUtils.createCounteredListener(tables.size(), listener);
+        for (Table table : tables) {
+            StatisticUtils.triggerCollectionOnFirstLoad(db, table, false, counteredListener);
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -1051,7 +1051,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         StatisticUtils.CountedListener counteredListener =
                 StatisticUtils.createCounteredListener(tables.size(), listener);
         for (Table table : tables) {
-            StatisticUtils.triggerCollectionOnFirstLoad(db, table, false, counteredListener);
+            StatisticUtils.triggerCollectionOnFirstLoad(txnState, db, table, false, counteredListener);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -691,7 +691,7 @@ public class LoadMgr implements Writable {
     public void updateJobPrgress(Long jobId, TReportExecStatusParams params) {
         LoadJob job = idToLoadJob.get(jobId);
         if (job != null) {
-            job.updateProgess(params);
+            job.updateProgress(params);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1375,6 +1375,7 @@ public class StmtExecutor {
         TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
         MetricRepo.COUNTER_LOAD_ADD.increase(1L);
         long transactionId = -1;
+        TransactionState txnState = null;
         if (targetTable instanceof ExternalOlapTable) {
             ExternalOlapTable externalTable = (ExternalOlapTable) targetTable;
             TAuthenticateParams authenticateParams = new TAuthenticateParams();
@@ -1407,9 +1408,8 @@ public class StmtExecutor {
                     context.getSessionVariable().getQueryTimeoutS());
 
             // add table indexes to transaction state
-            TransactionState txnState =
-                    GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                            .getTransactionState(database.getId(), transactionId);
+            txnState = GlobalStateMgr.getCurrentGlobalTransactionMgr()
+                    .getTransactionState(database.getId(), transactionId);
             if (txnState == null) {
                 throw new DdlException("txn does not exist: " + transactionId);
             }
@@ -1700,7 +1700,7 @@ public class StmtExecutor {
                     LOG.warn("errors when cancel insert load job {}", jobId);
                 }
             } else {
-                StatisticUtils.triggerCollectionOnFirstLoad(database, targetTable, true,
+                StatisticUtils.triggerCollectionOnFirstLoad(txnState, database, targetTable, true,
                         StatisticUtils.createCounteredListener(1, null));
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1699,6 +1699,9 @@ public class StmtExecutor {
                 } catch (Exception abortTxnException) {
                     LOG.warn("errors when cancel insert load job {}", jobId);
                 }
+            } else {
+                StatisticUtils.triggerCollectionOnFirstLoad(database, targetTable, true,
+                        StatisticUtils.createCounteredListener(1, null));
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -190,10 +190,6 @@ public class AnalyzeMgr implements Writable {
         statisticExecutor.dropTableStatistics(StatisticUtils.buildConnectContext(), tableUUID);
     }
 
-    public boolean hasBasicStatsMeta(long tableId) {
-        return basicStatsMetaMap.containsKey(tableId);
-    }
-
     public void addBasicStatsMeta(BasicStatsMeta basicStatsMeta) {
         basicStatsMetaMap.put(basicStatsMeta.getTableId(), basicStatsMeta);
         GlobalStateMgr.getCurrentState().getEditLog().logAddBasicStatsMeta(basicStatsMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -190,6 +190,10 @@ public class AnalyzeMgr implements Writable {
         statisticExecutor.dropTableStatistics(StatisticUtils.buildConnectContext(), tableUUID);
     }
 
+    public boolean hasBasicStatsMeta(long tableId) {
+        return basicStatsMetaMap.containsKey(tableId);
+    }
+
     public void addBasicStatsMeta(BasicStatsMeta basicStatsMeta) {
         basicStatsMetaMap.put(basicStatsMeta.getTableId(), basicStatsMeta);
         GlobalStateMgr.getCurrentState().getEditLog().logAddBasicStatsMeta(basicStatsMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1714,7 +1714,7 @@ public class DatabaseTransactionMgr {
         StatisticUtils.CountedListener counteredListener =
                 StatisticUtils.createCounteredListener(tables.size(), null);
         for (Table table : tables) {
-            StatisticUtils.triggerCollectionOnFirstLoad(db, table, false, counteredListener);
+            StatisticUtils.triggerCollectionOnFirstLoad(txnState, db, table, false, counteredListener);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -67,6 +67,7 @@ import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.FeNameFormat;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.thrift.TUniqueId;
 import io.opentelemetry.api.trace.Span;
 import org.apache.commons.collections4.CollectionUtils;
@@ -82,6 +83,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -1048,6 +1050,9 @@ public class DatabaseTransactionMgr {
             db.writeUnlock();
             finishSpan.end();
         }
+
+        collectStatisticsForStreamLoadOnFirstLoad(transactionState, db);
+
         LOG.info("finish transaction {} successfully", transactionState);
     }
 
@@ -1687,7 +1692,30 @@ public class DatabaseTransactionMgr {
             db.writeUnlock();
             finishSpan.end();
         }
+
+        collectStatisticsForStreamLoadOnFirstLoad(transactionState, db);
+
         LOG.info("finish transaction {} successfully", transactionState);
+    }
+
+    private void collectStatisticsForStreamLoadOnFirstLoad(TransactionState txnState, Database db) {
+        TransactionState.LoadJobSourceType sourceType = txnState.getSourceType();
+        if (!TransactionState.LoadJobSourceType.FRONTEND_STREAMING.equals(sourceType)
+                && !TransactionState.LoadJobSourceType.BACKEND_STREAMING.equals(sourceType)) {
+            return;
+        }
+        List<Table> tables = txnState.getIdToTableCommitInfos().values().stream()
+                .map(TableCommitInfo::getTableId)
+                .distinct()
+                .map(db::getTable)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        StatisticUtils.CountedListener counteredListener =
+                StatisticUtils.createCounteredListener(tables.size(), null);
+        for (Table table : tables) {
+            StatisticUtils.triggerCollectionOnFirstLoad(db, table, false, counteredListener);
+        }
     }
 
     public String getTxnPublishTimeoutDebugInfo(long txnId) {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ConcurrentTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ConcurrentTxnTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.transaction;
 
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.pseudocluster.PseudoBackend;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.pseudocluster.Tablet;
@@ -30,11 +31,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ConcurrentTxnTest {
     @BeforeClass
     public static void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
         PseudoCluster.getOrCreateWithRandomPort(true, 3);
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
+        FeConstants.runningUnitTest = false;
     }
 
     int runTime = 2;

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ConcurrentTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ConcurrentTxnTest.java
@@ -15,7 +15,6 @@
 package com.starrocks.transaction;
 
 import com.starrocks.common.Config;
-import com.starrocks.common.FeConstants;
 import com.starrocks.pseudocluster.PseudoBackend;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.pseudocluster.Tablet;
@@ -31,13 +30,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ConcurrentTxnTest {
     @BeforeClass
     public static void setUp() throws Exception {
-        FeConstants.runningUnitTest = true;
+        Config.enable_statistic_collect_on_first_load = false;
         PseudoCluster.getOrCreateWithRandomPort(true, 3);
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
-        FeConstants.runningUnitTest = false;
+        Config.enable_statistic_collect_on_first_load = true;
     }
 
     int runTime = 2;


### PR DESCRIPTION
## Problem Summary:

Currently, full statistics collection will be performed for all tables with an interval of 5min(defined by `Config::statistic_collect_interval_sec`). But in some scenerios, this timeliness is not enough. For example, a ETL process may contain multiply intermediate tables, which will be accessed right after load, and at this moment, statistics has not been generated, so it may produce terrible execution plan.

In order to solve this problem, we're trying to trigger a full/sample statistics collection right after the first loading process is finished. 
* If loaded data row count >= `statistic_sample_collect_rows`, a sample statistics collection will be triggered
* otherwise, a full statistics collection will be triggered.

There are 5 ways for loading data, which respectively are:
1. `insert into`
2. `stream load`
3. `broker load`
4. `spark load`
5. `routine load`

And the above 5 approaches can be categorized into 3 groups:
1. `insert into`
2. `stream load`
3. `broker load/spark load/routine load`

For `insert into`, we can add a sync process to trigger statistics collection process and hold execution until the collection is finished.

For `stream load`, this kind of load approach is totally controled by a coordinator be, and fe will finish this transaction aynscly. So the statistics collection process must be async if we don't want to change the whole stream load procedure.

For `broker load/spark load/routine load`, these three load approaches are async and are constraint by load task management, and we can check the loading status by the command `show load`. So we just need to make sure that the progress of the load task won't become 100 until the statistics collection is finished.

### Config

A configuration `enable_statistic_collect_on_first_load` has been added, with a default value true, to enable/disable this feature.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
