### PR TITLE
[Enhancement] Reduce listObjects requests when obtaining tablet schema

### DIFF
--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -100,7 +100,7 @@ StatusOr<std::shared_ptr<TabletReader>> Tablet::new_reader(int64_t version, Sche
 }
 
 StatusOr<std::shared_ptr<const TabletSchema>> Tablet::get_schema() {
-    return _mgr->get_tablet_schema(_id);
+    return _mgr->get_tablet_schema(_id, &_version_hint);
 }
 
 StatusOr<std::vector<RowsetPtr>> Tablet::get_rowsets(int64_t version) {

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -89,10 +89,12 @@ public:
     Status delete_tablet_metadata_lock(int64_t version, int64_t expire_time);
 
     // `segment_max_rows` is used in vertical writer
+    // NOTE: This method may update the version hint
     StatusOr<std::unique_ptr<TabletWriter>> new_writer(WriterType type, uint32_t max_rows_per_segment = 0);
 
     StatusOr<std::shared_ptr<TabletReader>> new_reader(int64_t version, Schema schema);
 
+    // NOTE: This method may update the version hint
     StatusOr<std::shared_ptr<const TabletSchema>> get_schema();
 
     StatusOr<std::vector<RowsetPtr>> get_rowsets(int64_t version);
@@ -124,9 +126,22 @@ public:
 
     TabletManager* tablet_mgr() { return _mgr; }
 
+    // Many tablet operations need to fetch the tablet schema information
+    // stored in the object storage, if the cache does not hit. In order to
+    // reduce the costly listDirectory/listObject operations, you can specify
+    // an existing tablet metadata version, so you can directly obtain the schema
+    // information by reading the metadata of that version, without listObject.
+    //
+    // NOTE: set this value to a non-positive value means clear the version hint.
+    // NOTE: Some methods of Tablet will internally update this value automatically.
+    void set_version_hint(int64_t version_hint) { _version_hint = version_hint; }
+
+    int64_t version_hint() const { return _version_hint; }
+
 private:
     TabletManager* _mgr;
     int64_t _id;
+    int64_t _version_hint = 0;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -150,11 +150,9 @@ TabletMetadataPtr TabletManager::lookup_tablet_latest_metadata(std::string_view 
 }
 
 void TabletManager::cache_tablet_latest_metadata(TabletMetadataPtr metadata) {
-    if (is_primary_key(metadata.get())) {
-        auto value_ptr = std::make_unique<CacheValue>(metadata);
-        fill_metacache(tablet_latest_metadata_key(metadata->id()), value_ptr.release(),
-                       static_cast<int>(metadata->SpaceUsedLong()));
-    }
+    auto value_ptr = std::make_unique<CacheValue>(metadata);
+    fill_metacache(tablet_latest_metadata_key(metadata->id()), value_ptr.release(),
+                   static_cast<int>(metadata->SpaceUsedLong()));
 }
 
 TabletSchemaPtr TabletManager::lookup_tablet_schema(std::string_view key) {
@@ -273,7 +271,11 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
 }
 
 StatusOr<Tablet> TabletManager::get_tablet(int64_t tablet_id) {
-    return Tablet(this, tablet_id);
+    Tablet tablet(this, tablet_id);
+    if (auto metadata = get_latest_cached_tablet_metadata(tablet_id); metadata != nullptr) {
+        tablet.set_version_hint(metadata->version());
+    }
+    return tablet;
 }
 
 Status TabletManager::delete_tablet(int64_t tablet_id) {
@@ -489,20 +491,40 @@ StatusOr<TxnLogIter> TabletManager::list_txn_log(int64_t tablet_id, bool filter_
     return TxnLogIter{this, std::move(objects)};
 }
 
-StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema(int64_t tablet_id) {
+StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema(int64_t tablet_id, int64_t* version_hint) {
+    // Check in-memory cache first
     auto cache_key = tablet_schema_cache_key(tablet_id);
     auto ptr = lookup_tablet_schema(cache_key);
     RETURN_IF(ptr != nullptr, ptr);
-    // TODO: limit the list size
-    ASSIGN_OR_RETURN(TabletMetadataIter metadata_iter, list_tablet_metadata(tablet_id, true));
-    if (!metadata_iter.has_next()) {
-        return Status::NotFound(fmt::format("tablet {} metadata not found", tablet_id));
+
+    TabletMetadataPtr metadata;
+
+    // Cache miss, load tablet metadata from remote storage use the hint version
+    if (version_hint != nullptr && *version_hint > 0) {
+        if (auto res = get_tablet_metadata(tablet_id, *version_hint); res.ok()) {
+            metadata = std::move(res).value();
+        }
     }
-    ASSIGN_OR_RETURN(auto metadata, metadata_iter.next());
+
+    // version hint not works, get tablet metadata by list directory
+    if (metadata == nullptr) {
+        // TODO: limit the list size
+        ASSIGN_OR_RETURN(TabletMetadataIter metadata_iter, list_tablet_metadata(tablet_id, true));
+        if (!metadata_iter.has_next()) {
+            return Status::NotFound(fmt::format("tablet {} metadata not found", tablet_id));
+        }
+        ASSIGN_OR_RETURN(metadata, metadata_iter.next());
+        if (version_hint != nullptr) {
+            *version_hint = metadata->version();
+        }
+    }
+
     auto [schema, inserted] = GlobalTabletSchemaMap::Instance()->emplace(metadata->schema());
     if (UNLIKELY(schema == nullptr)) {
         return Status::InternalError(fmt::format("tablet schema {} failed to emplace in TabletSchemaMap", tablet_id));
     }
+
+    // Save the schema into the in-memory cache
     auto cache_value = std::make_unique<CacheValue>(schema);
     auto cache_size = inserted ? (int)schema->mem_usage() : 0;
     (void)fill_metacache(cache_key, cache_value.release(), cache_size);
@@ -643,6 +665,7 @@ StatusOr<double> publish(Tablet* tablet, int64_t base_version, int64_t new_versi
 StatusOr<CompactionTaskPtr> TabletManager::compact(int64_t tablet_id, int64_t version, int64_t txn_id) {
     ASSIGN_OR_RETURN(auto tablet, get_tablet(tablet_id));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
+    tablet_ptr->set_version_hint(version);
     ASSIGN_OR_RETURN(auto compaction_policy, CompactionPolicy::create_compaction_policy(tablet_ptr));
     ASSIGN_OR_RETURN(auto input_rowsets, compaction_policy->pick_rowsets(version));
     ASSIGN_OR_RETURN(auto algorithm, compaction_policy->choose_compaction_algorithm(input_rowsets));

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -160,7 +160,7 @@ private:
     static std::string tablet_latest_metadata_key(int64_t tablet_id);
     static void cache_value_deleter(const CacheKey& /*key*/, void* value) { delete static_cast<CacheValue*>(value); }
 
-    StatusOr<TabletSchemaPtr> get_tablet_schema(int64_t tablet_id);
+    StatusOr<TabletSchemaPtr> get_tablet_schema(int64_t tablet_id, int64_t* version_hint = nullptr);
 
     StatusOr<TabletMetadataPtr> load_tablet_metadata(const std::string& metadata_location, bool fill_cache);
     StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location, bool fill_cache);


### PR DESCRIPTION
Use a version hint to get tablet metadata directory without list objects

## Problem Summary:
Fixes # (issue)

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
