### PR TITLE
[BugFix] fix estimated mem usage of chunk source

### DIFF
--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -94,6 +94,7 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
         }
         update_map(unmerge, small_ranges.size() - 1);
     }
+    _update_estimated_mem_usage();
     return Status::OK();
 }
 
@@ -170,7 +171,7 @@ StatusOr<std::string_view> SharedBufferedInputStream::peek(int64_t count) {
     return std::string_view((const char*)buf, count);
 }
 
-int64_t SharedBufferedInputStream::estimated_mem_usage() const {
+void SharedBufferedInputStream::_update_estimated_mem_usage() {
     int64_t mem_usage = 0;
     for (const auto& [_, sb] : _map) {
         mem_usage += sb.size;
@@ -178,7 +179,7 @@ int64_t SharedBufferedInputStream::estimated_mem_usage() const {
     // in most cases, those data are compressed.
     // to read it, we need to decompress it, and let's say to add 50% overhead.
     mem_usage += mem_usage / 2;
-    return mem_usage;
+    _estimated_mem_usage = std::max(mem_usage, _estimated_mem_usage);
 }
 
 } // namespace starrocks::io

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -65,7 +65,7 @@ public:
     int64_t direct_io_count() const { return _direct_io_count; }
     int64_t direct_io_bytes() const { return _direct_io_bytes; }
     int64_t direct_io_timer() const { return _direct_io_timer; }
-    int64_t estimated_mem_usage() const;
+    int64_t estimated_mem_usage() const { return _estimated_mem_usage; }
 
     StatusOr<std::string_view> peek(int64_t count) override;
 
@@ -82,6 +82,8 @@ private:
         std::vector<uint8_t> buffer;
         void align(int64_t align_size, int64_t file_size);
     };
+
+    void _update_estimated_mem_usage();
     Status _get_bytes(const uint8_t** buffer, size_t offset, size_t nbytes);
     StatusOr<SharedBuffer*> _find_shared_buffer(size_t offset, size_t count);
     Status _read_stream_buffer(SharedBuffer& sb, size_t offset, size_t count);
@@ -98,6 +100,7 @@ private:
     int64_t _direct_io_bytes = 0;
     int64_t _direct_io_timer = 0;
     int64_t _align_size = 0;
+    int64_t _estimated_mem_usage = 0;
 };
 
 } // namespace starrocks::io


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)

In previous implementation, `map` will be cleared when chunk source is closed, so `estimated_mem_usage` is 0 at that time.

The current impl is to compute `estimated_mem_usage` when calling `set_io_ranges`.



## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
