### PR TITLE
[Enhancement] opt the performance of bitmap_agg<int>

### DIFF
--- a/be/src/exprs/agg/bitmap_agg.h
+++ b/be/src/exprs/agg/bitmap_agg.h
@@ -38,6 +38,32 @@ public:
         }
     }
 
+    bool check_valid(const std::vector<InputCppType>& values, size_t count) const {
+        for (size_t i = 0; i < count; i++) {
+            auto value = values[i];
+            if (!(value >= 0 && value <= std::numeric_limits<uint64_t>::max())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
+                                   AggDataPtr __restrict state) const override {
+        const auto& col = down_cast<const InputColumnType&>(*columns[0]);
+        const auto& values = col.get_data();
+        if (check_valid(values, chunk_size)) {
+            this->data(state).add_many(chunk_size, values.data());
+        } else {
+            for (size_t i = 0; i < chunk_size; i++) {
+                auto value = values[i];
+                if (value >= 0 && value <= std::numeric_limits<uint64_t>::max()) {
+                    this->data(state).add(value);
+                }
+            }
+        }
+    }
+
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         const auto& col = down_cast<const BitmapColumn&>(*column);
         this->data(state) |= *(col.get_object(row_num));

--- a/be/src/exprs/agg/bitmap_union.h
+++ b/be/src/exprs/agg/bitmap_union.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "column/object_column.h"
+#include "column/type_traits.h"
 #include "column/vectorized_fwd.h"
 #include "exprs/agg/aggregate.h"
 #include "gutil/casts.h"

--- a/be/src/exprs/agg/bitmap_union.h
+++ b/be/src/exprs/agg/bitmap_union.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include "column/object_column.h"
-#include "column/type_traits.h"
 #include "column/vectorized_fwd.h"
 #include "exprs/agg/aggregate.h"
 #include "gutil/casts.h"

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -131,36 +131,6 @@ BitmapValue::BitmapValue(const std::vector<uint64_t>& bits) {
     }
 }
 
-void BitmapValue::add(uint64_t value) {
-    switch (_type) {
-    case EMPTY:
-        _sv = value;
-        _type = SINGLE;
-        break;
-    case SINGLE:
-        //there is no need to convert the type if two variables are equal
-        if (_sv == value) {
-            break;
-        }
-
-        _set = std::make_unique<phmap::flat_hash_set<uint64_t>>();
-        _set->insert(_sv);
-        _set->insert(value);
-        _type = SET;
-        break;
-    case BITMAP:
-        _bitmap->add(value);
-        break;
-    case SET:
-        if (_set->size() < 32) {
-            _set->insert(value);
-        } else {
-            _from_set_to_bitmap();
-            _bitmap->add(value);
-        }
-    }
-}
-
 void BitmapValue::_from_set_to_bitmap() {
     _bitmap = std::make_shared<detail::Roaring64Map>();
     for (auto x : *_set) {

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -49,7 +49,9 @@
 
 #include "common/config.h"
 #include "common/logging.h"
+#include "types/bitmap_value_detail.h"
 #include "util/coding.h"
+#include "util/phmap/phmap.h"
 #include "util/phmap/phmap_fwd_decl.h"
 #include "util/slice.h"
 
@@ -84,7 +86,11 @@ public:
     // Construct a bitmap from given elements.
     explicit BitmapValue(const std::vector<uint64_t>& bits);
 
-    void add(uint64_t value);
+    template <typename T>
+    void add(T value);
+
+    template <typename T>
+    void add_many(size_t n_args, const T* vals);
 
     // Note: rhs BitmapValue is only readable after this method
     // Compute the union between the current bitmap and the provided bitmap.
@@ -171,5 +177,47 @@ private:
     uint64_t _sv = 0; // store the single value when _type == SINGLE
     BitmapDataType _type{EMPTY};
 };
+
+template <typename T>
+void BitmapValue::add_many(size_t n_args, const T* vals) {
+    if (_type != BITMAP) {
+        for (size_t i = 0; i < n_args; i++) {
+            add(vals[i]);
+        }
+    } else {
+        _bitmap->template addMany(n_args, vals);
+    }
+}
+
+template <typename T>
+void BitmapValue::add(T value) {
+    switch (_type) {
+    case EMPTY:
+        _sv = value;
+        _type = SINGLE;
+        break;
+    case SINGLE:
+        //there is no need to convert the type if two variables are equal
+        if (_sv == value) {
+            break;
+        }
+
+        _set = std::make_unique<phmap::flat_hash_set<uint64_t>>();
+        _set->insert(_sv);
+        _set->insert(value);
+        _type = SET;
+        break;
+    case BITMAP:
+        _bitmap->add(value);
+        break;
+    case SET:
+        if (_set->size() < 32) {
+            _set->insert(value);
+        } else {
+            _from_set_to_bitmap();
+            _bitmap->add(value);
+        }
+    }
+}
 
 } // namespace starrocks

--- a/be/src/types/bitmap_value_detail.h
+++ b/be/src/types/bitmap_value_detail.h
@@ -45,6 +45,7 @@
 #include "roaring/containers/containers.h"
 #include "roaring/roaring.h"
 #include "roaring/roaring_array.h"
+#include "util/coding.h"
 
 namespace starrocks {
 
@@ -160,24 +161,35 @@ public:
      * Add value x
      *
      */
-    void add(uint32_t x) { roarings[0].add(x); }
-
-    void add(uint64_t x) { roarings[highBytes(x)].add(lowBytes(x)); }
+    template <typename T>
+    void add(T x) {
+        if constexpr (sizeof(T) <= 4) {
+            roarings[0].add(x);
+        } else {
+            roarings[highBytes(x)].add(lowBytes(x));
+        }
+    }
 
     /**
      * Add value n_args from pointer vals
      *
      */
-    void addMany(size_t n_args, const uint32_t* vals) {
-        for (size_t lcv = 0; lcv < n_args; lcv++) {
-            roarings[0].add(vals[lcv]);
+    template <typename T>
+    void addMany(size_t n_args, const T* vals) {
+        if constexpr (std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t>) {
+            roarings[0].addMany(n_args, reinterpret_cast<const uint32_t*>(vals));
             roarings[0].setCopyOnWrite(copyOnWrite);
-        }
-    }
-    void addMany(size_t n_args, const uint64_t* vals) {
-        for (size_t lcv = 0; lcv < n_args; lcv++) {
-            roarings[highBytes(vals[lcv])].add(lowBytes(vals[lcv]));
-            roarings[highBytes(vals[lcv])].setCopyOnWrite(copyOnWrite);
+        } else if (sizeof(T) <= 4) {
+            for (size_t lcv = 0; lcv < n_args; lcv++) {
+                roarings[0].add(vals[lcv]);
+                roarings[0].setCopyOnWrite(copyOnWrite);
+            }
+        } else {
+            // TODO: optimize uint64_t*
+            for (size_t lcv = 0; lcv < n_args; lcv++) {
+                roarings[highBytes(vals[lcv])].add(lowBytes(vals[lcv]));
+                roarings[highBytes(vals[lcv])].setCopyOnWrite(copyOnWrite);
+            }
         }
     }
 


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)

Batch add value to bitmap to opt the performance ot bitmap_agg.

Before Optimization:

```
mysql> select bitmap_count(bitmap_agg(lo_orderkey)) from lineorder where lo_orderkey < 3000000;
+-----------------------------------------+
| bitmap_count(bitmap_agg(lo_orderkey)) |
+-----------------------------------------+
|                                  749999 |
+-----------------------------------------+
1 row in set (0.32 sec)
```

After Optimization

```
mysql> select bitmap_count(bitmap_agg(lo_orderkey)) from lineorder where lo_orderkey < 3000000;
+---------------------------------------+
| bitmap_count(bitmap_agg(lo_orderkey)) |
+---------------------------------------+
|                                749999 |
+---------------------------------------+
1 row in set (0.16 sec)
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
