### PR TITLE
[Enhancement] Using timeout instead of a switch to tolerate dead backend

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -491,21 +491,6 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         return Pair.create(status, prio);
     }
 
-    private boolean isReplicaBackendDead(Backend backend) {
-        return backend != null && !backend.isAlive();
-    }
-
-    private boolean isReplicaBackendDropped(Backend backend) {
-        return backend == null;
-    }
-
-    private boolean isReplicaStateAbnormal(Replica replica, Backend backend, Set<String> replicaHostSet) {
-        return replica.getState() == ReplicaState.CLONE
-                || replica.getState() == ReplicaState.DECOMMISSION
-                || replica.isBad()
-                || !replicaHostSet.add(backend.getHost());
-    }
-
     /**
      * For certain deployment, like k8s pods + pvc, the replica is not lost even the
      * corresponding backend is detected as dead, because the replica data is persisted
@@ -518,23 +503,27 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
      * to delete the redundant healthy replica which cause resource waste and may also affect
      * the loading process.
      *
-     * <p> This method checks the necessity of a {@link TabletStatus#REPLICA_MISSING} task without
-     * considering the corresponding backends of tablet replicas are alive or not.
-     *
-     * @param systemInfoService {@link SystemInfoService}
-     * @return {@code true} means that we still need to schedule a {@link TabletStatus#REPLICA_MISSING} task
-     * even though we have ignored the aliveness of corresponding backend
+     * <p>This method checks whether the corresponding backend of tablet replica is dead or not.
+     * Only when the backend has been dead for {@link Config#tablet_sched_be_down_tolerate_time_s}
+     * seconds, will this method returns true.
      */
-    public boolean checkReplicaMissingIgnoreDeadBackend(SystemInfoService systemInfoService) {
-        Set<String> hosts = Sets.newHashSet();
-        for (Replica replica : replicas) {
-            Backend backend = systemInfoService.getBackend(replica.getBackendId());
-            if (isReplicaBackendDropped(backend) || isReplicaStateAbnormal(replica, backend, hosts)) {
-                return true;
-            }
-        }
+    private boolean isReplicaBackendDead(Backend backend) {
+        long currentTimeMs = System.currentTimeMillis();
+        assert backend != null;
+        return !backend.isAlive() &&
+                (currentTimeMs - backend.getLastUpdateMs() > Config.tablet_sched_be_down_tolerate_time_s * 1000);
+    }
 
-        return false;
+    private boolean isReplicaBackendDropped(Backend backend) {
+        return backend == null;
+    }
+
+    private boolean isReplicaStateAbnormal(Replica replica, Backend backend, Set<String> replicaHostSet) {
+        assert backend != null && replica != null;
+        return replica.getState() == ReplicaState.CLONE
+                || replica.getState() == ReplicaState.DECOMMISSION
+                || replica.isBad()
+                || !replicaHostSet.add(backend.getHost());
     }
 
     /**
@@ -580,7 +569,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
             }
             aliveAndVersionComplete++;
 
-            if (!backend.isAvailable()) {
+            if (backend.isDecommissioned()) {
                 // this replica is alive, version complete, but backend is not available
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -342,14 +342,6 @@ public class TabletChecker extends FrontendDaemon {
                                                 replicaNum,
                                                 aliveBeIdsInCluster);
 
-                                if (Config.tablet_sched_ignore_dead_backend &&
-                                        statusWithPrio.first == TabletStatus.REPLICA_MISSING &&
-                                        !localTablet.checkReplicaMissingIgnoreDeadBackend(infoService)) {
-                                    // Deem this tablet healthy in this situation, see comments for
-                                    // `Config.tablet_sched_ignore_dead_backend` for more details.
-                                    statusWithPrio.first = TabletStatus.HEALTHY;
-                                }
-
                                 if (statusWithPrio.first == TabletStatus.HEALTHY) {
                                     // Only set last status check time when status is healthy.
                                     localTablet.setLastStatusCheckTime(System.currentTimeMillis());

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1190,18 +1190,24 @@ public class Config extends ConfigBase {
      * to delete the redundant healthy replica which cause resource waste and may also affect
      * the loading process.
      *
-     * <p>When setting this configuration to true, we won't schedule any
-     * {@link LocalTablet.TabletStatus#REPLICA_MISSING} task because of dead backends
-     * (but may still schedule {@link LocalTablet.TabletStatus#REPLICA_MISSING} tasks because of
-     * other reasons, like manually setting a replica as bad, actively decommission a backend etc.)
-     * and let the resource manager like k8s handle the repair process.
+     * <p>When a backend is considered to be dead, this configuration specifies how long the
+     * {@link com.starrocks.clone.TabletScheduler} should wait before starting to schedule
+     * {@link LocalTablet.TabletStatus#REPLICA_MISSING} tasks. It is intended to leave some time for
+     * the external scheduler like k8s to handle the repair process before internal scheduler kicks in
+     * or for the system administrator to restart and put the backend online in time.
+     * To be noticed, it only affects the dead backend situation, the scheduler
+     * may still schedule {@link LocalTablet.TabletStatus#REPLICA_MISSING} tasks because of
+     * other reasons, like manually setting a replica as bad, actively decommission a backend etc.
+     *
+     * <p>Currently this configuration only works for non-colocate tables, for colocate tables,
+     * refer to {@link Config#tablet_sched_colocate_be_down_tolerate_time_s}.
      *
      * <p>For more discussion on this issue, see
      * <a href="https://github.com/StarRocks/starrocks-kubernetes-operator/issues/49">issue49</a>
      *
      */
     @ConfField(mutable = true)
-    public static boolean tablet_sched_ignore_dead_backend = false;
+    public static long tablet_sched_be_down_tolerate_time_s = 900; // 15 min
 
     /**
      * If BE is down beyond this time, tablets on that BE of colocate table will be migrated to other available BEs


### PR DESCRIPTION
## Problem Summary:
This is a fix to previous pr: https://github.com/StarRocks/starrocks/pull/23654

It's better to use a timeout mechanism instead of a single switch
to control whether we should tolerate dead backend for a period
time, so that if the external repair process doesn't work in time, the
internal tablet scheduler still got a chance to repair the tablet for
dead backend automatically.


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
