### PR TITLE
[Enhancement][BugFix] fix spillable operator's name in profile

### DIFF
--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -267,7 +267,7 @@ pipeline::OpFactories AggregateBlockingNode::decompose_to_pipeline(pipeline::Pip
                 _decompose_to_pipeline<StreamingAggregatorFactory, SortedAggregateStreamingSourceOperatorFactory,
                                        SortedAggregateStreamingSinkOperatorFactory>(ops_with_sink, context);
     } else {
-        if (runtime_state()->enable_spill() && has_group_by_keys) {
+        if (runtime_state()->enable_spill() && runtime_state()->enable_agg_spill() && has_group_by_keys) {
             ops_with_source =
                     _decompose_to_pipeline<AggregatorFactory, SpillableAggregateBlockingSourceOperatorFactory,
                                            SpillableAggregateBlockingSinkOperatorFactory>(ops_with_sink, context);

--- a/be/src/exec/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/aggregate/distinct_blocking_node.cpp
@@ -206,7 +206,7 @@ pipeline::OpFactories DistinctBlockingNode::decompose_to_pipeline(pipeline::Pipe
                 _decompose_to_pipeline<StreamingAggregatorFactory, SortedAggregateStreamingSourceOperatorFactory,
                                        SortedAggregateStreamingSinkOperatorFactory>(ops_with_sink, context);
     } else {
-        if (runtime_state()->enable_spill()) {
+        if (runtime_state()->enable_spill() && runtime_state()->enable_agg_distinct_spill()) {
             ops_with_source =
                     _decompose_to_pipeline<AggregatorFactory, SpillableAggregateDistinctBlockingSourceOperatorFactory,
                                            SpillableAggregateDistinctBlockingSinkOperatorFactory>(ops_with_sink,

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -464,7 +464,7 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
     auto build_side_spill_channel_factory =
             std::make_shared<SpillProcessChannelFactory>(num_right_partitions, std::move(executor));
 
-    if (runtime_state()->enable_spill() &&
+    if (runtime_state()->enable_spill() && runtime_state()->enable_hash_join_spill() &&
         std::is_same_v<HashJoinBuilderFactory, SpillableHashJoinBuildOperatorFactory>) {
         context->interpolate_spill_process(id(), build_side_spill_channel_factory, num_right_partitions);
     }
@@ -536,7 +536,7 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
 pipeline::OpFactories HashJoinNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
     // now spill only support INNER_JOIN and LEFT-SEMI JOIN. we could implement LEFT_OUTER_JOIN later
-    if (runtime_state()->enable_spill() && is_spillable(_join_type)) {
+    if (runtime_state()->enable_spill() && runtime_state()->enable_hash_join_spill() && is_spillable(_join_type)) {
         return _decompose_to_pipeline<HashJoinerFactory, SpillableHashJoinBuildOperatorFactory,
                                       SpillableHashJoinProbeOperatorFactory>(context);
     } else {

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
@@ -28,7 +28,7 @@ public:
     template <class... Args>
     SpillableAggregateBlockingSinkOperator(AggregatorPtr aggregator, Args&&... args)
             : AggregateBlockingSinkOperator(aggregator, std::forward<Args>(args)...,
-                                            "spillable_aggregate_block_sink_operator") {}
+                                            "spillable_aggregate_blocking_sink") {}
 
     ~SpillableAggregateBlockingSinkOperator() override = default;
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.h
@@ -29,7 +29,7 @@ public:
     SpillableAggregateBlockingSourceOperator(const AggregatorPtr& aggregator,
                                              SortedStreamingAggregatorPtr stream_aggregator, Args&&... args)
             : AggregateBlockingSourceOperator(aggregator, std::forward<Args>(args)...,
-                                              "spillable_aggregate_source_operator"),
+                                              "spillable_aggregate_blocking_source"),
               _stream_aggregator(std::move(stream_aggregator)) {}
 
     ~SpillableAggregateBlockingSourceOperator() override = default;

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.h
@@ -30,7 +30,7 @@ public:
     template <class... Args>
     SpillableAggregateDistinctBlockingSinkOperator(AggregatorPtr aggregator, Args&&... args)
             : AggregateDistinctBlockingSinkOperator(aggregator, std::forward<Args>(args)...,
-                                                    "spillable_aggregate_distinct_block_sink_operator") {}
+                                                    "spillable_aggregate_distinct_blocking_sink") {}
     ~SpillableAggregateDistinctBlockingSinkOperator() override = default;
 
     bool need_input() const override;
@@ -91,7 +91,7 @@ public:
     SpillableAggregateDistinctBlockingSourceOperator(AggregatorPtr aggregator,
                                                      SortedStreamingAggregatorPtr stream_aggregator, Args&&... args)
             : AggregateDistinctBlockingSourceOperator(aggregator, std::forward<Args>(args)...,
-                                                      "spillable_aggregate_block_distinct_source_operator"),
+                                                      "spillable_aggregate_distinct_blocking_source"),
               _stream_aggregator(std::move(stream_aggregator)) {}
 
     ~SpillableAggregateDistinctBlockingSourceOperator() override = default;

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -241,8 +241,9 @@ OperatorPtr SpillableHashJoinBuildOperatorFactory::create(int32_t degree_of_para
     joiner->set_spill_channel(spill_channel);
     joiner->set_spiller(spiller);
 
-    return std::make_shared<SpillableHashJoinBuildOperator>(this, _id, _name, _plan_node_id, driver_sequence, joiner,
-                                                            _partial_rf_merger.get(), _distribution_mode);
+    return std::make_shared<SpillableHashJoinBuildOperator>(this, _id, "spillable_hash_join_build", _plan_node_id,
+                                                            driver_sequence, joiner, _partial_rf_merger.get(),
+                                                            _distribution_mode);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -493,7 +493,7 @@ OperatorPtr SpillableHashJoinProbeOperatorFactory::create(int32_t degree_of_para
     auto spiller = _spill_factory->create(*_spill_options);
 
     auto prober = std::make_shared<SpillableHashJoinProbeOperator>(
-            this, _id, _name, _plan_node_id, driver_sequence,
+            this, _id, "spillable_hash_join_probe", _plan_node_id, driver_sequence,
             _hash_joiner_factory->create_prober(degree_of_parallelism, driver_sequence),
             _hash_joiner_factory->get_builder(degree_of_parallelism, driver_sequence));
 

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -380,7 +380,7 @@ pipeline::OpFactories TopNNode::decompose_to_pipeline(pipeline::PipelineBuilderC
                                        LocalPartitionTopnSourceOperatorFactory>(context, is_partition_topn, need_merge,
                                                                                 enable_parallel_merge);
     } else {
-        if (runtime_state()->enable_spill() && _limit < 0) {
+        if (runtime_state()->enable_spill() && runtime_state()->enable_sort_spill() && _limit < 0) {
             if (enable_parallel_merge) {
                 operators_source_with_sort =
                         _decompose_to_pipeline<SortContextFactory, SpillablePartitionSortSinkOperatorFactory,

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -307,6 +307,12 @@ public:
 
     bool enable_spill() const { return _query_options.enable_spill; }
 
+    bool enable_hash_join_spill() const { return _query_options.enable_hash_join_spill; }
+
+    bool enable_agg_spill() const { return _query_options.enable_agg_spill; }
+    bool enable_agg_distinct_spill() const { return _query_options.enable_agg_distinct_spill; }
+    bool enable_sort_spill() const { return _query_options.enable_sort_spill; }
+
     int32_t spill_mem_table_size() const { return _query_options.spill_mem_table_size; }
 
     int32_t spill_mem_table_num() const { return _query_options.spill_mem_table_num; }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -307,11 +307,19 @@ public:
 
     bool enable_spill() const { return _query_options.enable_spill; }
 
-    bool enable_hash_join_spill() const { return _query_options.enable_hash_join_spill; }
+    bool enable_hash_join_spill() const {
+        return _query_options.spillable_operator_mask & (1LL << TSpillableOperatorType::HASH_JOIN);
+    }
 
-    bool enable_agg_spill() const { return _query_options.enable_agg_spill; }
-    bool enable_agg_distinct_spill() const { return _query_options.enable_agg_distinct_spill; }
-    bool enable_sort_spill() const { return _query_options.enable_sort_spill; }
+    bool enable_agg_spill() const {
+        return _query_options.spillable_operator_mask & (1LL << TSpillableOperatorType::AGG);
+    }
+    bool enable_agg_distinct_spill() const {
+        return _query_options.spillable_operator_mask & (1LL << TSpillableOperatorType::AGG_DISTINCT);
+    }
+    bool enable_sort_spill() const {
+        return _query_options.spillable_operator_mask & (1LL << TSpillableOperatorType::SORT);
+    }
 
     int32_t spill_mem_table_size() const { return _query_options.spill_mem_table_size; }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -144,6 +144,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String MAX_PARALLEL_SCAN_INSTANCE_NUM = "max_parallel_scan_instance_num";
     public static final String ENABLE_INSERT_STRICT = "enable_insert_strict";
     public static final String ENABLE_SPILL = "enable_spill";
+    public static final String ENABLE_HASH_JOIN_SPILL = "enable_hash_join_spill";
+    public static final String ENABLE_AGG_SPILL = "enable_agg_spill";
+    public static final String ENABLE_AGG_DISTINCT_SPILL = "enable_agg_distinct_spill";
+    public static final String ENABLE_SORT_SPILL = "enable_sort_spill";
     // spill mode: auto, force
     public static final String SPILL_MODE = "spill_mode";
     // if set to true, some of stmt will be forwarded to leader FE to get result
@@ -703,6 +707,18 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_SPILL)
     private boolean enableSpill = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_HASH_JOIN_SPILL, flag = VariableMgr.INVISIBLE)
+    private boolean enableHashJoinSpill = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_AGG_SPILL, flag = VariableMgr.INVISIBLE)
+    private boolean enableAggSpill = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_AGG_DISTINCT_SPILL, flag = VariableMgr.INVISIBLE)
+    private boolean enableAggDistinctSpill = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_SORT_SPILL, flag = VariableMgr.INVISIBLE)
+    private boolean enableSortSpill = true;
 
     @VariableMgr.VarAttr(name = SPILL_MODE)
     private String spillMode = "auto";
@@ -2135,6 +2151,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             tResult.setSpill_operator_min_bytes(spillOperatorMinBytes);
             tResult.setSpill_operator_max_bytes(spillOperatorMaxBytes);
             tResult.setSpill_encode_level(spillEncodeLevel);
+            tResult.setEnable_hash_join_spill(enableHashJoinSpill);
+            tResult.setEnable_agg_spill(enableAggSpill);
+            tResult.setEnable_agg_distinct_spill(enableAggDistinctSpill);
+            tResult.setEnable_sort_spill(enableSortSpill);
         }
 
         // Compression Type

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -715,9 +715,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // if spillable_operator_mask & 4 != 0, agg distinct operator can spill
     // if spillable_operator_mask & 8 != 0, sort operator can spill
     // ...
-    // default value is 15, means all operators can spill
+    // default value is -1, means all operators can spill
     @VariableMgr.VarAttr(name = SPILLABLE_OPERATOR_MASK, flag = VariableMgr.INVISIBLE)
-    private long spillableOperatorMask = 15;
+    private long spillableOperatorMask = -1;
 
     @VariableMgr.VarAttr(name = SPILL_MODE)
     private String spillMode = "auto";

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -45,6 +45,7 @@ import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TPipelineProfileLevel;
 import com.starrocks.thrift.TQueryOptions;
 import com.starrocks.thrift.TSpillMode;
+import com.starrocks.thrift.TSpillableOperatorType;
 import com.starrocks.thrift.TTabletInternalParallelMode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -2151,10 +2152,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             tResult.setSpill_operator_min_bytes(spillOperatorMinBytes);
             tResult.setSpill_operator_max_bytes(spillOperatorMaxBytes);
             tResult.setSpill_encode_level(spillEncodeLevel);
-            tResult.setEnable_hash_join_spill(enableHashJoinSpill);
-            tResult.setEnable_agg_spill(enableAggSpill);
-            tResult.setEnable_agg_distinct_spill(enableAggDistinctSpill);
-            tResult.setEnable_sort_spill(enableSortSpill);
+            long spillableOperatorMask = 0;
+            spillableOperatorMask |= enableHashJoinSpill ? (1L << TSpillableOperatorType.HASH_JOIN.getValue()) : 0;
+            spillableOperatorMask |= enableAggSpill ? (1L << TSpillableOperatorType.AGG.getValue()) : 0;
+            spillableOperatorMask |= enableAggDistinctSpill ? (1L << TSpillableOperatorType.AGG_DISTINCT.getValue()) : 0;
+            spillableOperatorMask |= enableSortSpill ? (1 << TSpillableOperatorType.SORT.getValue()) : 0;
+            tResult.setSpillable_operator_mask(spillableOperatorMask);
         }
 
         // Compression Type

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -712,7 +712,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // e.g.
     // if spillable_operator_mask & 1 != 0, hash join operator can spill
     // if spillable_operator_mask & 2 != 0, agg operator can spill
-    // if spillable_operator_mask & 2 != 0, agg operator can spill
+    // if spillable_operator_mask & 4 != 0, agg distinct operator can spill
+    // if spillable_operator_mask & 8 != 0, sort operator can spill
     // ...
     // default value is 15, means all operators can spill
     @VariableMgr.VarAttr(name = SPILLABLE_OPERATOR_MASK, flag = VariableMgr.INVISIBLE)

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -105,6 +105,13 @@ enum TSpillMode {
   FORCE
 }
 
+enum TSpillableOperatorType {
+  HASH_JOIN = 0;
+  AGG = 1;
+  AGG_DISTINCT = 2;
+  SORT = 3;
+}
+
 enum TTabletInternalParallelMode {
   AUTO,
   FORCE_SPLIT
@@ -200,11 +207,8 @@ struct TQueryOptions {
   93: optional i32 connector_io_tasks_slow_io_latency_ms = 50;
   94: optional double scan_use_query_mem_ratio = 0.25;
   95: optional double connector_scan_use_query_mem_ratio = 0.3;
-
-  96: optional bool enable_hash_join_spill = true;
-  97: optional bool enable_agg_spill = true;
-  98: optional bool enable_agg_distinct_spill = true;
-  99: optional bool enable_sort_spill = true;
+  // used to identify which operators allow spill, only meaningful when enable_spill=true
+  96: optional i64 spillable_operator_mask;
 }
 
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -200,6 +200,11 @@ struct TQueryOptions {
   93: optional i32 connector_io_tasks_slow_io_latency_ms = 50;
   94: optional double scan_use_query_mem_ratio = 0.25;
   95: optional double connector_scan_use_query_mem_ratio = 0.3;
+
+  96: optional bool enable_hash_join_spill = true;
+  97: optional bool enable_agg_spill = true;
+  98: optional bool enable_agg_distinct_spill = true;
+  99: optional bool enable_sort_spill = true;
 }
 
 


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)

1. fix some spillable operator's names so that our web ui can render the query profile
2. add some session variables to control whether each type of operator can spill, which can facilitate us to troubleshoot the implementation of spill operators in complex queries

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
