### PR TITLE
[Enhancement] Add agg func bitmap_agg (#23641)

### DIFF
--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -56,6 +56,12 @@ void ObjectColumn<T>::append(T&& object) {
 }
 
 template <typename T>
+void ObjectColumn<T>::append(const T& object) {
+    _pool.emplace_back(object);
+    _cache_ok = false;
+}
+
+template <typename T>
 void ObjectColumn<T>::remove_first_n_values(size_t count) {
     size_t remain_size = _pool.size() - count;
     for (size_t i = 0; i < remain_size; ++i) {

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -81,6 +81,8 @@ public:
 
     void append(T&& object);
 
+    void append(const T& object);
+
     void append_datum(const Datum& datum) override { append(datum.get<T*>()); }
 
     void remove_first_n_values(size_t count) override;

--- a/be/src/exprs/agg/bitmap_agg.h
+++ b/be/src/exprs/agg/bitmap_agg.h
@@ -21,9 +21,9 @@
 #include "gutil/casts.h"
 #include "types/bitmap_value.h"
 
-namespace starrocks {
+namespace starrocks::vectorized {
 
-template <LogicalType LT>
+template <PrimitiveType LT>
 class BitmapAggAggregateFunction final
         : public AggregateFunctionBatchHelper<BitmapValue, BitmapAggAggregateFunction<LT>> {
 public:
@@ -71,4 +71,4 @@ public:
 
     std::string get_name() const override { return "bitmap_agg"; }
 };
-} // namespace starrocks
+} // namespace starrocks::vectorized

--- a/be/src/exprs/agg/bitmap_agg.h
+++ b/be/src/exprs/agg/bitmap_agg.h
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "column/object_column.h"
+#include "column/type_traits.h"
+#include "column/vectorized_fwd.h"
+#include "exprs/agg/aggregate.h"
+#include "gutil/casts.h"
+#include "types/bitmap_value.h"
+
+namespace starrocks {
+
+template <LogicalType LT>
+class BitmapAggAggregateFunction final
+        : public AggregateFunctionBatchHelper<BitmapValue, BitmapAggAggregateFunction<LT>> {
+public:
+    using InputColumnType = RunTimeColumnType<LT>;
+    using InputCppType = RunTimeCppType<LT>;
+
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+        const auto* col = down_cast<const InputColumnType*>(columns[0]);
+        auto value = col->get_data()[row_num];
+        if (value >= 0 && value <= std::numeric_limits<uint64_t>::max()) {
+            this->data(state).add(value);
+        }
+    }
+
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        const auto& col = down_cast<const BitmapColumn&>(*column);
+        this->data(state) |= *(col.get_object(row_num));
+    }
+
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        auto* col = down_cast<BitmapColumn*>(to);
+        auto& bitmap = this->data(state);
+        col->append(bitmap);
+    }
+
+    void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
+                                     ColumnPtr* dst) const override {
+        auto& src_column = down_cast<InputColumnType&>(*src[0].get());
+        auto* dest_column = down_cast<BitmapColumn*>(dst->get());
+        for (size_t i = 0; i < chunk_size; i++) {
+            BitmapValue bitmap;
+            auto v = src_column.get_data()[i];
+            if (v >= 0 && v <= std::numeric_limits<uint64_t>::max()) {
+                bitmap.add(v);
+            }
+            dest_column->append(std::move(bitmap));
+        }
+    }
+
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        auto* col = down_cast<BitmapColumn*>(to);
+        auto& bitmap = const_cast<BitmapValue&>(this->data(state));
+        col->append(std::move(bitmap));
+    }
+
+    std::string get_name() const override { return "bitmap_agg"; }
+};
+} // namespace starrocks

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -63,7 +63,7 @@ public:
 
     static AggregateFunctionPtr MakeBitmapUnionAggregateFunction();
 
-    template <LogicalType LT>
+    template <PrimitiveType LT>
     static AggregateFunctionPtr MakeBitmapAggAggregateFunction();
 
     static AggregateFunctionPtr MakeBitmapIntersectAggregateFunction();
@@ -315,7 +315,7 @@ AggregateFunctionPtr AggregateFactory::MakePercentileDiscAggregateFunction() {
     return std::make_shared<PercentileDiscAggregateFunction<PT>>();
 }
 
-template <LogicalType LT>
+template <PrimitiveType LT>
 AggregateFunctionPtr AggregateFactory::MakeBitmapAggAggregateFunction() {
     return std::make_shared<BitmapAggAggregateFunction<LT>>();
 }

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -319,3 +319,5 @@ template <PrimitiveType LT>
 AggregateFunctionPtr AggregateFactory::MakeBitmapAggAggregateFunction() {
     return std::make_shared<BitmapAggAggregateFunction<LT>>();
 }
+
+} // namespace starrocks::vectorized

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -11,6 +11,7 @@
 #include "exprs/agg/aggregate_factory.h"
 #include "exprs/agg/any_value.h"
 #include "exprs/agg/avg.h"
+#include "exprs/agg/bitmap_agg.h"
 #include "exprs/agg/bitmap_intersect.h"
 #include "exprs/agg/bitmap_union.h"
 #include "exprs/agg/bitmap_union_count.h"
@@ -61,6 +62,9 @@ public:
     }
 
     static AggregateFunctionPtr MakeBitmapUnionAggregateFunction();
+
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakeBitmapAggAggregateFunction();
 
     static AggregateFunctionPtr MakeBitmapIntersectAggregateFunction();
 
@@ -311,4 +315,7 @@ AggregateFunctionPtr AggregateFactory::MakePercentileDiscAggregateFunction() {
     return std::make_shared<PercentileDiscAggregateFunction<PT>>();
 }
 
-} // namespace starrocks::vectorized
+template <LogicalType LT>
+AggregateFunctionPtr AggregateFactory::MakeBitmapAggAggregateFunction() {
+    return std::make_shared<BitmapAggAggregateFunction<LT>>();
+}

--- a/be/src/exprs/agg/factory/aggregate_resolver_minmaxany.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_minmaxany.cpp
@@ -25,6 +25,20 @@ void AggregateFuncResolver::register_bitmap() {
             "bitmap_union_int", false, AggregateFactory::MakeBitmapUnionIntAggregateFunction<TYPE_BIGINT>());
     add_aggregate_mapping<TYPE_OBJECT, TYPE_OBJECT, BitmapValue>("bitmap_union", false,
                                                                  AggregateFactory::MakeBitmapUnionAggregateFunction());
+
+    add_aggregate_mapping<TYPE_BOOLEAN, TYPE_OBJECT, BitmapValue>(
+            "bitmap_agg", false, AggregateFactory::MakeBitmapAggAggregateFunction<TYPE_BOOLEAN>());
+    add_aggregate_mapping<TYPE_TINYINT, TYPE_OBJECT, BitmapValue>(
+            "bitmap_agg", false, AggregateFactory::MakeBitmapAggAggregateFunction<TYPE_TINYINT>());
+    add_aggregate_mapping<TYPE_SMALLINT, TYPE_OBJECT, BitmapValue>(
+            "bitmap_agg", false, AggregateFactory::MakeBitmapAggAggregateFunction<TYPE_SMALLINT>());
+    add_aggregate_mapping<TYPE_INT, TYPE_OBJECT, BitmapValue>(
+            "bitmap_agg", false, AggregateFactory::MakeBitmapAggAggregateFunction<TYPE_INT>());
+    add_aggregate_mapping<TYPE_BIGINT, TYPE_OBJECT, BitmapValue>(
+            "bitmap_agg", false, AggregateFactory::MakeBitmapAggAggregateFunction<TYPE_BIGINT>());
+    add_aggregate_mapping<TYPE_LARGEINT, TYPE_OBJECT, BitmapValue>(
+            "bitmap_agg", false, AggregateFactory::MakeBitmapAggAggregateFunction<TYPE_LARGEINT>());
+
     add_aggregate_mapping<TYPE_OBJECT, TYPE_OBJECT, BitmapValuePacked>(
             "bitmap_intersect", false, AggregateFactory::MakeBitmapIntersectAggregateFunction());
     add_aggregate_mapping<TYPE_OBJECT, TYPE_BIGINT, BitmapValue>(

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -258,6 +258,7 @@ public class FunctionSet {
     public static final String BITMAP_TO_STRING = "bitmap_to_string";
     public static final String BITMAP_TO_ARRAY = "bitmap_to_array";
     public static final String BITMAP_UNION = "bitmap_union";
+    public static final String BITMAP_AGG = "bitmap_agg";
     public static final String BITMAP_XOR = "bitmap_xor";
     public static final String TO_BITMAP = "to_bitmap";
     public static final String BITMAP_COUNT = "bitmap_count";
@@ -390,7 +391,7 @@ public class FunctionSet {
 
     // JSON functions
     public static final Function JSON_QUERY_FUNC = new Function(
-            new FunctionName(JSON_QUERY), new Type[] {Type.JSON, Type.VARCHAR}, Type.JSON, false);
+            new FunctionName(JSON_QUERY), new Type[]{Type.JSON, Type.VARCHAR}, Type.JSON, false);
 
     private static final Logger LOGGER = LogManager.getLogger(FunctionSet.class);
 
@@ -922,6 +923,11 @@ public class FunctionSet {
                 Type.BITMAP,
                 Type.BITMAP,
                 true, false, true));
+
+        for (Type t : Type.getIntegerTypes()) {
+            addBuiltin(AggregateFunction.createBuiltin(BITMAP_AGG, Lists.newArrayList(t),
+                    Type.BITMAP, Type.BITMAP, true, false, true));
+        }
 
         addBuiltin(AggregateFunction.createBuiltin(BITMAP_UNION_COUNT, Lists.newArrayList(Type.BITMAP),
                 Type.BIGINT,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -292,6 +292,19 @@ public class FunctionAnalyzer {
             return;
         }
 
+        if (fnName.getFunction().equals(FunctionSet.BITMAP_AGG)) {
+            if (functionCallExpr.getChildren().size() != 1) {
+                throw new SemanticException(fnName + " function could only have one child", functionCallExpr.getPos());
+            }
+            Type inputType = functionCallExpr.getChild(0).getType();
+            if (!inputType.isIntegerType() && !inputType.isBoolean() && !inputType.isLargeIntType()) {
+                throw new SemanticException(
+                        fnName + " function's argument should be of int type or bool type, but was " + inputType,
+                        functionCallExpr.getChild(0).getPos());
+            }
+            return;
+        }
+
         if (fnName.getFunction().equals(FunctionSet.BITMAP_COUNT)
                 || fnName.getFunction().equals(FunctionSet.BITMAP_UNION)
                 || fnName.getFunction().equals(FunctionSet.BITMAP_UNION_COUNT)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -294,13 +294,12 @@ public class FunctionAnalyzer {
 
         if (fnName.getFunction().equals(FunctionSet.BITMAP_AGG)) {
             if (functionCallExpr.getChildren().size() != 1) {
-                throw new SemanticException(fnName + " function could only have one child", functionCallExpr.getPos());
+                throw new SemanticException(fnName + " function could only have one child");
             }
             Type inputType = functionCallExpr.getChild(0).getType();
             if (!inputType.isIntegerType() && !inputType.isBoolean() && !inputType.isLargeIntType()) {
                 throw new SemanticException(
-                        fnName + " function's argument should be of int type or bool type, but was " + inputType,
-                        functionCallExpr.getChild(0).getPos());
+                        fnName + " function's argument should be of int type or bool type, but was " + inputType);
             }
             return;
         }

--- a/test/sql/test_agg_function/R/test_bitmap_agg
+++ b/test/sql/test_agg_function/R/test_bitmap_agg
@@ -1,0 +1,44 @@
+-- name: test_bitmap_agg
+CREATE TABLE t1 (
+    c1 int,
+    c2 boolean,
+    c3 tinyint,
+    c4 int,
+    c5 bigint,
+    c6 largeint
+    )
+DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t1 values
+    (1, true, 11, 111, 1111, 11111),
+    (2, false, 22, 222, 2222, 22222),
+    (3, true, 33, 333, 3333, 33333),
+    (4, null, null, null, null, null),
+    (5, -1, -11, -111, -1111, -11111),
+    (6, null, null, null, null, "36893488147419103232");
+-- result:
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c2)) FROM t1;
+-- result:
+0,1
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c3)) FROM t1;
+-- result:
+11,22,33
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c4)) FROM t1;
+-- result:
+111,222,333
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c5)) FROM t1;
+-- result:
+1111,2222,3333
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c6)) FROM t1;
+-- result:
+11111,22222,33333
+-- !result

--- a/test/sql/test_agg_function/T/test_bitmap_agg
+++ b/test/sql/test_agg_function/T/test_bitmap_agg
@@ -1,0 +1,27 @@
+-- name: test_bitmap_agg
+CREATE TABLE t1 (
+    c1 int,
+    c2 boolean,
+    c3 tinyint,
+    c4 int,
+    c5 bigint,
+    c6 largeint
+    )
+DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t1 values
+    (1, true, 11, 111, 1111, 11111),
+    (2, false, 22, 222, 2222, 22222),
+    (3, true, 33, 333, 3333, 33333),
+    (4, null, null, null, null, null),
+    (5, -1, -11, -111, -1111, -11111),
+    (6, null, null, null, null, "36893488147419103232");
+
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c2)) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c3)) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c4)) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c5)) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c6)) FROM t1;


### PR DESCRIPTION
Add agg func bitmap_agg

Current, bitmap_union only support Bitmap as param, the performance is poor because we should first covert int to bitmap , and then union all the bitmap.

```
mysql> select bitmap_count(bitmap_union(to_bitmap(lo_orderkey))) from lineorder where lo_orderkey < 3000000;
+----------------------------------------------------+
| bitmap_count(bitmap_union(to_bitmap(lo_orderkey))) |
+----------------------------------------------------+
|                                             749999 |
+----------------------------------------------------+
1 row in set (0.90 sec)

mysql> select bitmap_count(bitmap_agg(lo_orderkey)) from lineorder where lo_orderkey < 3000000;
+-----------------------------------------+
| bitmap_count(bitmap_agg(lo_orderkey)) |
+-----------------------------------------+
|                                  749999 |
+-----------------------------------------+
1 row in set (0.32 sec)
```