### PR TITLE
[Enhancement] Add agg func bitmap_agg (#23641)

### DIFF
--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -55,6 +55,12 @@ void ObjectColumn<T>::append(T&& object) {
 }
 
 template <typename T>
+void ObjectColumn<T>::append(const T& object) {
+    _pool.emplace_back(object);
+    _cache_ok = false;
+}
+
+template <typename T>
 void ObjectColumn<T>::remove_first_n_values(size_t count) {
     size_t remain_size = _pool.size() - count;
     for (size_t i = 0; i < remain_size; ++i) {

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -80,6 +80,8 @@ public:
 
     void append(T&& object);
 
+    void append(const T& object);
+
     void append_datum(const Datum& datum) override { append(datum.get<T*>()); }
 
     void remove_first_n_values(size_t count) override;

--- a/be/src/exprs/agg/aggregate_factory.cpp
+++ b/be/src/exprs/agg/aggregate_factory.cpp
@@ -10,6 +10,7 @@
 #include "exprs/agg/any_value.h"
 #include "exprs/agg/array_agg.h"
 #include "exprs/agg/avg.h"
+#include "exprs/agg/bitmap_agg.h"
 #include "exprs/agg/bitmap_intersect.h"
 #include "exprs/agg/bitmap_union.h"
 #include "exprs/agg/bitmap_union_count.h"
@@ -35,7 +36,6 @@
 #include "udf/java/java_function_fwd.h"
 
 namespace starrocks::vectorized {
-
 // The function should be placed by alphabetical order
 
 template <PrimitiveType PT>
@@ -45,6 +45,11 @@ AggregateFunctionPtr AggregateFactory::MakeAvgAggregateFunction() {
 template <PrimitiveType PT>
 AggregateFunctionPtr AggregateFactory::MakeDecimalAvgAggregateFunction() {
     return std::make_shared<DecimalAvgAggregateFunction<PT>>();
+}
+
+template <PrimitiveType LT>
+AggregateFunctionPtr AggregateFactory::MakeBitmapAggAggregateFunction() {
+    return std::make_shared<BitmapAggAggregateFunction<LT>>();
 }
 
 template <PrimitiveType PT>
@@ -267,6 +272,14 @@ public:
     }
 
     template <PrimitiveType arg_type, PrimitiveType return_type>
+    void add_bitmap_mapping(std::string&& name) {
+        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false),
+                               create_bitmap_function<arg_type, return_type, false>(name));
+        _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, true),
+                               create_bitmap_function<arg_type, return_type, true>(name));
+    }
+
+    template <PrimitiveType arg_type, PrimitiveType return_type>
     void add_object_mapping(std::string&& name) {
         _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, false),
                                create_object_function<arg_type, return_type, false>(name));
@@ -288,6 +301,21 @@ public:
                                create_decimal_function<arg_type, return_type, false>(name));
         _infos_mapping.emplace(std::make_tuple(name, arg_type, return_type, true),
                                create_decimal_function<arg_type, return_type, true>(name));
+    }
+
+    template <PrimitiveType arg_type, PrimitiveType return_type, bool is_null>
+    AggregateFunctionPtr create_bitmap_function(std::string& name) {
+        if constexpr (is_null) {
+            if (name == "bitmap_agg") {
+                auto bitmap = AggregateFactory::MakeBitmapAggAggregateFunction<arg_type>();
+                return AggregateFactory::MakeNullableAggregateFunctionUnary<BitmapValue>(bitmap);
+            }
+        } else {
+            if (name == "bitmap_agg") {
+                return AggregateFactory::MakeBitmapAggAggregateFunction<arg_type>();
+            }
+        }
+        return nullptr;
     }
 
     template <PrimitiveType arg_type, PrimitiveType return_type, bool is_null>
@@ -889,6 +917,13 @@ AggregateFuncResolver::AggregateFuncResolver() {
 
     add_object_mapping<TYPE_OBJECT, TYPE_OBJECT>("bitmap_union");
     add_object_mapping<TYPE_OBJECT, TYPE_BIGINT>("bitmap_union_count");
+
+    add_bitmap_mapping<TYPE_BOOLEAN, TYPE_OBJECT>("bitmap_agg");
+    add_bitmap_mapping<TYPE_TINYINT, TYPE_OBJECT>("bitmap_agg");
+    add_bitmap_mapping<TYPE_SMALLINT, TYPE_OBJECT>("bitmap_agg");
+    add_bitmap_mapping<TYPE_INT, TYPE_OBJECT>("bitmap_agg");
+    add_bitmap_mapping<TYPE_BIGINT, TYPE_OBJECT>("bitmap_agg");
+    add_bitmap_mapping<TYPE_LARGEINT, TYPE_OBJECT>("bitmap_agg");
 
     // This first type is the second type input of intersect_count.
     // And the first type is Bitmap.

--- a/be/src/exprs/agg/aggregate_factory.h
+++ b/be/src/exprs/agg/aggregate_factory.h
@@ -20,6 +20,9 @@ public:
     template <PrimitiveType PT>
     static AggregateFunctionPtr MakeBitmapUnionIntAggregateFunction();
 
+    template <PrimitiveType LT>
+    static AggregateFunctionPtr MakeBitmapAggAggregateFunction();
+
     static AggregateFunctionPtr MakeBitmapUnionAggregateFunction();
 
     static AggregateFunctionPtr MakeBitmapIntersectAggregateFunction();

--- a/be/src/exprs/agg/bitmap_agg.h
+++ b/be/src/exprs/agg/bitmap_agg.h
@@ -21,9 +21,9 @@
 #include "gutil/casts.h"
 #include "types/bitmap_value.h"
 
-namespace starrocks {
+namespace starrocks::vectorized {
 
-template <LogicalType LT>
+template <PrimitiveType LT>
 class BitmapAggAggregateFunction final
         : public AggregateFunctionBatchHelper<BitmapValue, BitmapAggAggregateFunction<LT>> {
 public:
@@ -71,4 +71,4 @@ public:
 
     std::string get_name() const override { return "bitmap_agg"; }
 };
-} // namespace starrocks
+} // namespace starrocks::vectorized

--- a/be/src/exprs/agg/bitmap_agg.h
+++ b/be/src/exprs/agg/bitmap_agg.h
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "column/object_column.h"
+#include "column/type_traits.h"
+#include "column/vectorized_fwd.h"
+#include "exprs/agg/aggregate.h"
+#include "gutil/casts.h"
+#include "types/bitmap_value.h"
+
+namespace starrocks {
+
+template <LogicalType LT>
+class BitmapAggAggregateFunction final
+        : public AggregateFunctionBatchHelper<BitmapValue, BitmapAggAggregateFunction<LT>> {
+public:
+    using InputColumnType = RunTimeColumnType<LT>;
+    using InputCppType = RunTimeCppType<LT>;
+
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+        const auto* col = down_cast<const InputColumnType*>(columns[0]);
+        auto value = col->get_data()[row_num];
+        if (value >= 0 && value <= std::numeric_limits<uint64_t>::max()) {
+            this->data(state).add(value);
+        }
+    }
+
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        const auto& col = down_cast<const BitmapColumn&>(*column);
+        this->data(state) |= *(col.get_object(row_num));
+    }
+
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        auto* col = down_cast<BitmapColumn*>(to);
+        auto& bitmap = this->data(state);
+        col->append(bitmap);
+    }
+
+    void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
+                                     ColumnPtr* dst) const override {
+        auto& src_column = down_cast<InputColumnType&>(*src[0].get());
+        auto* dest_column = down_cast<BitmapColumn*>(dst->get());
+        for (size_t i = 0; i < chunk_size; i++) {
+            BitmapValue bitmap;
+            auto v = src_column.get_data()[i];
+            if (v >= 0 && v <= std::numeric_limits<uint64_t>::max()) {
+                bitmap.add(v);
+            }
+            dest_column->append(std::move(bitmap));
+        }
+    }
+
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        auto* col = down_cast<BitmapColumn*>(to);
+        auto& bitmap = const_cast<BitmapValue&>(this->data(state));
+        col->append(std::move(bitmap));
+    }
+
+    std::string get_name() const override { return "bitmap_agg"; }
+};
+} // namespace starrocks

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -1,0 +1,370 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <tuple>
+#include <unordered_map>
+
+#include "column/type_traits.h"
+#include "exprs/agg/aggregate.h"
+#include "exprs/agg/aggregate_factory.h"
+#include "exprs/agg/any_value.h"
+#include "exprs/agg/array_agg.h"
+#include "exprs/agg/avg.h"
+#include "exprs/agg/bitmap_agg.h"
+#include "exprs/agg/bitmap_intersect.h"
+#include "exprs/agg/bitmap_union.h"
+#include "exprs/agg/bitmap_union_count.h"
+#include "exprs/agg/bitmap_union_int.h"
+#include "exprs/agg/count.h"
+#include "exprs/agg/distinct.h"
+#include "exprs/agg/exchange_perf.h"
+#include "exprs/agg/group_concat.h"
+#include "exprs/agg/histogram.h"
+#include "exprs/agg/hll_ndv.h"
+#include "exprs/agg/hll_union.h"
+#include "exprs/agg/hll_union_count.h"
+#include "exprs/agg/intersect_count.h"
+#include "exprs/agg/maxmin.h"
+#include "exprs/agg/maxmin_by.h"
+#include "exprs/agg/nullable_aggregate.h"
+#include "exprs/agg/percentile_approx.h"
+#include "exprs/agg/percentile_cont.h"
+#include "exprs/agg/percentile_union.h"
+#include "exprs/agg/retention.h"
+#include "exprs/agg/stream/retract_maxmin.h"
+#include "exprs/agg/sum.h"
+#include "exprs/agg/variance.h"
+#include "exprs/agg/window.h"
+#include "exprs/agg/window_funnel.h"
+#include "types/logical_type.h"
+#include "types/logical_type_infra.h"
+#include "udf/java/java_function_fwd.h"
+
+namespace starrocks {
+
+// TODO(murphy) refactor the factory into a shim style
+class AggregateFactory {
+public:
+    // The function should be placed by alphabetical order
+    template <LogicalType LT>
+    static auto MakeAvgAggregateFunction() {
+        return std::make_shared<AvgAggregateFunction<LT>>();
+    }
+
+    template <LogicalType LT>
+    static auto MakeDecimalAvgAggregateFunction() {
+        return std::make_shared<DecimalAvgAggregateFunction<LT>>();
+    }
+
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakeBitmapUnionIntAggregateFunction() {
+        return std::make_shared<BitmapUnionIntAggregateFunction<LT>>();
+    }
+
+    static AggregateFunctionPtr MakeBitmapUnionAggregateFunction();
+
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakeBitmapAggAggregateFunction();
+
+    static AggregateFunctionPtr MakeBitmapIntersectAggregateFunction();
+
+    static AggregateFunctionPtr MakeBitmapUnionCountAggregateFunction();
+
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakeWindowfunnelAggregateFunction();
+
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakeIntersectCountAggregateFunction();
+
+    template <bool IsWindowFunc>
+    static AggregateFunctionPtr MakeCountAggregateFunction();
+
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakeCountDistinctAggregateFunction();
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakeCountDistinctAggregateFunctionV2();
+
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakeGroupConcatAggregateFunction();
+
+    template <bool IsWindowFunc>
+    static AggregateFunctionPtr MakeCountNullableAggregateFunction();
+
+    template <AggExchangePerfType PerfType>
+    static AggregateFunctionPtr MakeExchangePerfAggregateFunction() {
+        return std::make_shared<ExchangePerfAggregateFunction<PerfType>>();
+    }
+
+    static AggregateFunctionPtr MakeArrayAggAggregateFunctionV2() {
+        return std::make_shared<ArrayAggAggregateFunctionV2>();
+    }
+
+    template <LogicalType LT>
+    static auto MakeMaxAggregateFunction();
+
+    template <LogicalType LT>
+    static auto MakeMaxByAggregateFunction();
+
+    template <LogicalType LT>
+    static auto MakeMinByAggregateFunction();
+
+    template <LogicalType LT>
+    static auto MakeMinAggregateFunction();
+
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakeAnyValueAggregateFunction();
+
+    template <typename NestedState, bool IsWindowFunc, bool IgnoreNull = true,
+              typename NestedFunctionPtr = AggregateFunctionPtr>
+    static AggregateFunctionPtr MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function);
+
+    template <typename NestedState>
+    static AggregateFunctionPtr MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function);
+
+    template <LogicalType LT>
+    static auto MakeSumAggregateFunction();
+
+    template <LogicalType LT>
+    static auto MakeDecimalSumAggregateFunction();
+
+    template <LogicalType LT, bool is_sample>
+    static AggregateFunctionPtr MakeVarianceAggregateFunction();
+
+    template <LogicalType LT, bool is_sample>
+    static AggregateFunctionPtr MakeStddevAggregateFunction();
+
+    template <LogicalType LT>
+    static auto MakeSumDistinctAggregateFunction();
+    template <LogicalType LT>
+    static auto MakeSumDistinctAggregateFunctionV2();
+    template <LogicalType LT>
+    static auto MakeDecimalSumDistinctAggregateFunction();
+
+    static AggregateFunctionPtr MakeDictMergeAggregateFunction();
+    static AggregateFunctionPtr MakeRetentionAggregateFunction();
+
+    // Hyperloglog functions:
+    static AggregateFunctionPtr MakeHllUnionAggregateFunction();
+
+    static AggregateFunctionPtr MakeHllUnionCountAggregateFunction();
+
+    template <LogicalType T>
+    static AggregateFunctionPtr MakeHllNdvAggregateFunction();
+
+    template <LogicalType T>
+    static AggregateFunctionPtr MakeHllRawAggregateFunction();
+
+    static AggregateFunctionPtr MakePercentileApproxAggregateFunction();
+
+    static AggregateFunctionPtr MakePercentileUnionAggregateFunction();
+
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakePercentileContAggregateFunction();
+
+    template <LogicalType PT>
+    static AggregateFunctionPtr MakePercentileDiscAggregateFunction();
+
+    // Windows functions:
+    static AggregateFunctionPtr MakeDenseRankWindowFunction();
+
+    static AggregateFunctionPtr MakeRankWindowFunction();
+
+    static AggregateFunctionPtr MakeRowNumberWindowFunction();
+
+    static AggregateFunctionPtr MakeNtileWindowFunction();
+
+    template <LogicalType LT, bool ignoreNulls>
+    static AggregateFunctionPtr MakeFirstValueWindowFunction() {
+        return std::make_shared<FirstValueWindowFunction<LT, ignoreNulls>>();
+    }
+
+    template <LogicalType LT, bool ignoreNulls>
+    static AggregateFunctionPtr MakeLastValueWindowFunction() {
+        return std::make_shared<LastValueWindowFunction<LT, ignoreNulls>>();
+    }
+
+    template <LogicalType LT, bool ignoreNulls, bool isLag>
+    static AggregateFunctionPtr MakeLeadLagWindowFunction() {
+        return std::make_shared<LeadLagWindowFunction<LT, ignoreNulls, isLag>>();
+    }
+
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakeHistogramAggregationFunction() {
+        return std::make_shared<HistogramAggregationFunction<LT>>();
+    }
+
+    // Stream MV Retractable Agg Functions
+    template <LogicalType LT>
+    static auto MakeRetractMinAggregateFunction();
+
+    template <LogicalType LT>
+    static auto MakeRetractMaxAggregateFunction();
+};
+
+// The function should be placed by alphabetical order
+
+template <LogicalType LT>
+AggregateFunctionPtr AggregateFactory::MakeIntersectCountAggregateFunction() {
+    return std::make_shared<IntersectCountAggregateFunction<LT>>();
+}
+
+template <bool IsWindowFunc>
+AggregateFunctionPtr AggregateFactory::MakeCountAggregateFunction() {
+    return std::make_shared<CountAggregateFunction<IsWindowFunc>>();
+}
+
+template <LogicalType LT>
+AggregateFunctionPtr AggregateFactory::MakeWindowfunnelAggregateFunction() {
+    return std::make_shared<WindowFunnelAggregateFunction<LT>>();
+}
+
+template <LogicalType LT>
+AggregateFunctionPtr AggregateFactory::MakeCountDistinctAggregateFunction() {
+    return std::make_shared<DistinctAggregateFunction<LT, AggDistinctType::COUNT>>();
+}
+
+template <LogicalType LT>
+AggregateFunctionPtr AggregateFactory::MakeCountDistinctAggregateFunctionV2() {
+    return std::make_shared<DistinctAggregateFunctionV2<LT, AggDistinctType::COUNT>>();
+}
+
+template <LogicalType LT>
+AggregateFunctionPtr AggregateFactory::MakeGroupConcatAggregateFunction() {
+    return std::make_shared<GroupConcatAggregateFunction<LT>>();
+}
+
+template <bool IsWindowFunc>
+AggregateFunctionPtr AggregateFactory::MakeCountNullableAggregateFunction() {
+    return std::make_shared<CountNullableAggregateFunction<IsWindowFunc>>();
+}
+
+template <LogicalType LT>
+auto AggregateFactory::MakeMaxAggregateFunction() {
+    return std::make_shared<MaxMinAggregateFunction<LT, MaxAggregateData<LT>, MaxElement<LT, MaxAggregateData<LT>>>>();
+}
+
+template <LogicalType LT>
+auto AggregateFactory::MakeMaxByAggregateFunction() {
+    return std::make_shared<
+            MaxMinByAggregateFunction<LT, MaxByAggregateData<LT>, MaxByElement<LT, MaxByAggregateData<LT>>>>();
+}
+
+template <LogicalType LT>
+auto AggregateFactory::MakeMinByAggregateFunction() {
+    return std::make_shared<
+            MaxMinByAggregateFunction<LT, MinByAggregateData<LT>, MinByElement<LT, MinByAggregateData<LT>>>>();
+}
+
+template <LogicalType LT>
+auto AggregateFactory::MakeMinAggregateFunction() {
+    return std::make_shared<MaxMinAggregateFunction<LT, MinAggregateData<LT>, MinElement<LT, MinAggregateData<LT>>>>();
+}
+
+template <LogicalType LT>
+AggregateFunctionPtr AggregateFactory::MakeAnyValueAggregateFunction() {
+    return std::make_shared<
+            AnyValueAggregateFunction<LT, AnyValueAggregateData<LT>, AnyValueElement<LT, AnyValueAggregateData<LT>>>>();
+}
+
+template <typename NestedState, bool IsWindowFunc, bool IgnoreNull, typename NestedFunctionPtr>
+AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function) {
+    using AggregateDataType = NullableAggregateFunctionState<NestedState, IsWindowFunc>;
+    return std::make_shared<
+            NullableAggregateFunctionUnary<NestedFunctionPtr, AggregateDataType, IsWindowFunc, IgnoreNull>>(
+            nested_function);
+}
+
+template <typename NestedState>
+AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function) {
+    using AggregateDataType = NullableAggregateFunctionState<NestedState, false>;
+    return std::make_shared<NullableAggregateFunctionVariadic<AggregateDataType>>(nested_function);
+}
+
+template <LogicalType LT>
+auto AggregateFactory::MakeSumAggregateFunction() {
+    return std::make_shared<SumAggregateFunction<LT>>();
+}
+
+template <LogicalType LT>
+auto AggregateFactory::MakeDecimalSumAggregateFunction() {
+    return std::make_shared<DecimalSumAggregateFunction<LT>>();
+}
+
+template <LogicalType LT, bool is_sample>
+AggregateFunctionPtr AggregateFactory::MakeVarianceAggregateFunction() {
+    return std::make_shared<VarianceAggregateFunction<LT, is_sample>>();
+}
+
+template <LogicalType LT, bool is_sample>
+AggregateFunctionPtr AggregateFactory::MakeStddevAggregateFunction() {
+    return std::make_shared<StddevAggregateFunction<LT, is_sample>>();
+}
+
+template <LogicalType LT>
+auto AggregateFactory::MakeSumDistinctAggregateFunction() {
+    return std::make_shared<DistinctAggregateFunction<LT, AggDistinctType::SUM>>();
+}
+
+template <LogicalType LT>
+auto AggregateFactory::MakeSumDistinctAggregateFunctionV2() {
+    return std::make_shared<DistinctAggregateFunctionV2<LT, AggDistinctType::SUM>>();
+}
+
+template <LogicalType LT>
+auto AggregateFactory::MakeDecimalSumDistinctAggregateFunction() {
+    return std::make_shared<DecimalDistinctAggregateFunction<LT, AggDistinctType::SUM>>();
+}
+
+template <LogicalType LT>
+AggregateFunctionPtr AggregateFactory::MakeHllNdvAggregateFunction() {
+    return std::make_shared<HllNdvAggregateFunction<LT, false>>();
+}
+
+template <LogicalType LT>
+AggregateFunctionPtr AggregateFactory::MakeHllRawAggregateFunction() {
+    return std::make_shared<HllNdvAggregateFunction<LT, true>>();
+}
+
+template <LogicalType LT>
+AggregateFunctionPtr AggregateFactory::MakePercentileContAggregateFunction() {
+    return std::make_shared<PercentileContAggregateFunction<LT>>();
+}
+
+template <LogicalType PT>
+AggregateFunctionPtr AggregateFactory::MakePercentileDiscAggregateFunction() {
+    return std::make_shared<PercentileDiscAggregateFunction<PT>>();
+}
+
+template <LogicalType LT>
+AggregateFunctionPtr AggregateFactory::MakeBitmapAggAggregateFunction() {
+    return std::make_shared<BitmapAggAggregateFunction<LT>>();
+}
+
+// Stream MV Retractable Aggregate Functions
+template <LogicalType LT>
+auto AggregateFactory::MakeRetractMinAggregateFunction() {
+    return std::make_shared<MaxMinAggregateFunctionRetractable<LT, MinAggregateDataRetractable<LT>,
+                                                               MinElement<LT, MinAggregateDataRetractable<LT>>>>();
+}
+
+template <LogicalType LT>
+auto AggregateFactory::MakeRetractMaxAggregateFunction() {
+    return std::make_shared<MaxMinAggregateFunctionRetractable<LT, MaxAggregateDataRetractable<LT>,
+                                                               MaxElement<LT, MaxAggregateDataRetractable<LT>>>>();
+}
+
+} // namespace starrocks

--- a/be/src/exprs/agg/factory/aggregate_resolver_minmaxany.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_minmaxany.cpp
@@ -1,0 +1,111 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exprs/agg/any_value.h"
+#include "exprs/agg/bitmap_intersect.h"
+#include "exprs/agg/factory/aggregate_factory.hpp"
+#include "exprs/agg/factory/aggregate_resolver.hpp"
+#include "exprs/agg/maxmin.h"
+#include "types/bitmap_value.h"
+#include "types/logical_type.h"
+#include "types/logical_type_infra.h"
+
+namespace starrocks {
+
+void AggregateFuncResolver::register_bitmap() {
+    add_aggregate_mapping<TYPE_TINYINT, TYPE_BIGINT, BitmapValue>(
+            "bitmap_union_int", false, AggregateFactory::MakeBitmapUnionIntAggregateFunction<TYPE_TINYINT>());
+    add_aggregate_mapping<TYPE_SMALLINT, TYPE_BIGINT, BitmapValue>(
+            "bitmap_union_int", false, AggregateFactory::MakeBitmapUnionIntAggregateFunction<TYPE_SMALLINT>());
+    add_aggregate_mapping<TYPE_INT, TYPE_BIGINT, BitmapValue>(
+            "bitmap_union_int", false, AggregateFactory::MakeBitmapUnionIntAggregateFunction<TYPE_INT>());
+    add_aggregate_mapping<TYPE_BIGINT, TYPE_BIGINT, BitmapValue>(
+            "bitmap_union_int", false, AggregateFactory::MakeBitmapUnionIntAggregateFunction<TYPE_BIGINT>());
+    add_aggregate_mapping<TYPE_OBJECT, TYPE_OBJECT, BitmapValue>("bitmap_union", false,
+                                                                 AggregateFactory::MakeBitmapUnionAggregateFunction());
+
+    add_aggregate_mapping<TYPE_BOOLEAN, TYPE_OBJECT, BitmapValue>(
+            "bitmap_agg", false, AggregateFactory::MakeBitmapAggAggregateFunction<TYPE_BOOLEAN>());
+    add_aggregate_mapping<TYPE_TINYINT, TYPE_OBJECT, BitmapValue>(
+            "bitmap_agg", false, AggregateFactory::MakeBitmapAggAggregateFunction<TYPE_TINYINT>());
+    add_aggregate_mapping<TYPE_SMALLINT, TYPE_OBJECT, BitmapValue>(
+            "bitmap_agg", false, AggregateFactory::MakeBitmapAggAggregateFunction<TYPE_SMALLINT>());
+    add_aggregate_mapping<TYPE_INT, TYPE_OBJECT, BitmapValue>(
+            "bitmap_agg", false, AggregateFactory::MakeBitmapAggAggregateFunction<TYPE_INT>());
+    add_aggregate_mapping<TYPE_BIGINT, TYPE_OBJECT, BitmapValue>(
+            "bitmap_agg", false, AggregateFactory::MakeBitmapAggAggregateFunction<TYPE_BIGINT>());
+    add_aggregate_mapping<TYPE_LARGEINT, TYPE_OBJECT, BitmapValue>(
+            "bitmap_agg", false, AggregateFactory::MakeBitmapAggAggregateFunction<TYPE_LARGEINT>());
+
+    add_aggregate_mapping<TYPE_OBJECT, TYPE_OBJECT, BitmapValuePacked>(
+            "bitmap_intersect", false, AggregateFactory::MakeBitmapIntersectAggregateFunction());
+    add_aggregate_mapping<TYPE_OBJECT, TYPE_BIGINT, BitmapValue>(
+            "bitmap_union_count", true, AggregateFactory::MakeBitmapUnionCountAggregateFunction());
+}
+
+struct MinMaxAnyDispatcher {
+    template <LogicalType lt>
+    void operator()(AggregateFuncResolver* resolver) {
+        if constexpr (lt_is_aggregate<lt> || lt_is_json<lt>) {
+            resolver->add_aggregate_mapping<lt, lt, MinAggregateData<lt>>(
+                    "min", true, AggregateFactory::MakeMinAggregateFunction<lt>());
+            resolver->add_aggregate_mapping<lt, lt, MaxAggregateData<lt>>(
+                    "max", true, AggregateFactory::MakeMaxAggregateFunction<lt>());
+            resolver->add_aggregate_mapping<lt, lt, AnyValueAggregateData<lt>>(
+                    "any_value", true, AggregateFactory::MakeAnyValueAggregateFunction<lt>());
+        }
+    }
+};
+
+template <LogicalType ret_type, bool is_max_by>
+struct MaxMinByDispatcherInner {
+    template <LogicalType arg_type>
+    void operator()(AggregateFuncResolver* resolver) {
+        if constexpr ((lt_is_aggregate<arg_type> || lt_is_json<arg_type>)&&(lt_is_aggregate<ret_type> ||
+                                                                            lt_is_json<ret_type>)) {
+            if constexpr (is_max_by) {
+                resolver->add_aggregate_mapping_variadic<arg_type, ret_type, MaxByAggregateData<arg_type>>(
+                        "max_by", true, AggregateFactory::MakeMaxByAggregateFunction<arg_type>());
+            } else {
+                resolver->add_aggregate_mapping_variadic<arg_type, ret_type, MinByAggregateData<arg_type>>(
+                        "min_by", true, AggregateFactory::MakeMinByAggregateFunction<arg_type>());
+            }
+        }
+    }
+};
+
+template <bool is_max_by>
+struct MaxMinByDispatcher {
+    template <LogicalType lt>
+    void operator()(AggregateFuncResolver* resolver, LogicalType ret_type) {
+        type_dispatch_all(ret_type, MaxMinByDispatcherInner<lt, is_max_by>(), resolver);
+    }
+};
+
+void AggregateFuncResolver::register_minmaxany() {
+    auto minmax_types = aggregate_types();
+    minmax_types.push_back(TYPE_JSON);
+    for (auto ret_type : minmax_types) {
+        for (auto arg_type : minmax_types) {
+            type_dispatch_all(arg_type, MaxMinByDispatcher<true>(), this, ret_type);
+            type_dispatch_all(arg_type, MaxMinByDispatcher<false>(), this, ret_type);
+        }
+    }
+
+    for (auto type : minmax_types) {
+        type_dispatch_all(type, MinMaxAnyDispatcher(), this);
+    }
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -78,6 +78,7 @@ public class FunctionSet {
     public static final String PERCENTILE_UNION = "percentile_union";
     public static final String PERCENTILE_CONT = "percentile_cont";
     public static final String BITMAP_UNION = "bitmap_union";
+    public static final String BITMAP_AGG = "bitmap_agg";
     public static final String BITMAP_UNION_COUNT = "bitmap_union_count";
     public static final String BITMAP_UNION_INT = "bitmap_union_int";
     public static final String INTERSECT_COUNT = "intersect_count";
@@ -684,6 +685,11 @@ public class FunctionSet {
                 Type.BITMAP,
                 Type.BITMAP,
                 true, false, true));
+
+        for (Type t : Type.getIntegerTypes()) {
+            addBuiltin(AggregateFunction.createBuiltin(BITMAP_AGG, Lists.newArrayList(t),
+                    Type.BITMAP, Type.BITMAP, true, false, true));
+        }
 
         addBuiltin(AggregateFunction.createBuiltin(BITMAP_UNION_COUNT, Lists.newArrayList(Type.BITMAP),
                 Type.BIGINT,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -237,6 +237,18 @@ public class FunctionAnalyzer {
             return;
         }
 
+        if (fnName.getFunction().equals(FunctionSet.BITMAP_AGG)) {
+            if (functionCallExpr.getChildren().size() != 1) {
+                throw new SemanticException(fnName + " function could only have one child");
+            }
+            Type inputType = functionCallExpr.getChild(0).getType();
+            if (!inputType.isIntegerType() && !inputType.isBoolean() && !inputType.isLargeIntType()) {
+                throw new SemanticException(
+                        fnName + " function's argument should be of int type or bool type, but was " + inputType);
+            }
+            return;
+        }
+
         if (fnName.getFunction().equalsIgnoreCase(FunctionSet.BITMAP_COUNT)
                 || fnName.getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION)
                 || fnName.getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION_COUNT)

--- a/test/sql/test_agg_function/R/test_bitmap_agg
+++ b/test/sql/test_agg_function/R/test_bitmap_agg
@@ -1,0 +1,44 @@
+-- name: test_bitmap_agg
+CREATE TABLE t1 (
+    c1 int,
+    c2 boolean,
+    c3 tinyint,
+    c4 int,
+    c5 bigint,
+    c6 largeint
+    )
+DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t1 values
+    (1, true, 11, 111, 1111, 11111),
+    (2, false, 22, 222, 2222, 22222),
+    (3, true, 33, 333, 3333, 33333),
+    (4, null, null, null, null, null),
+    (5, -1, -11, -111, -1111, -11111),
+    (6, null, null, null, null, "36893488147419103232");
+-- result:
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c2)) FROM t1;
+-- result:
+0,1
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c3)) FROM t1;
+-- result:
+11,22,33
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c4)) FROM t1;
+-- result:
+111,222,333
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c5)) FROM t1;
+-- result:
+1111,2222,3333
+-- !result
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c6)) FROM t1;
+-- result:
+11111,22222,33333
+-- !result

--- a/test/sql/test_agg_function/T/test_bitmap_agg
+++ b/test/sql/test_agg_function/T/test_bitmap_agg
@@ -1,0 +1,27 @@
+-- name: test_bitmap_agg
+CREATE TABLE t1 (
+    c1 int,
+    c2 boolean,
+    c3 tinyint,
+    c4 int,
+    c5 bigint,
+    c6 largeint
+    )
+DUPLICATE KEY(c1)
+DISTRIBUTED BY HASH(c1)
+BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t1 values
+    (1, true, 11, 111, 1111, 11111),
+    (2, false, 22, 222, 2222, 22222),
+    (3, true, 33, 333, 3333, 33333),
+    (4, null, null, null, null, null),
+    (5, -1, -11, -111, -1111, -11111),
+    (6, null, null, null, null, "36893488147419103232");
+
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c2)) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c3)) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c4)) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c5)) FROM t1;
+SELECT BITMAP_TO_STRING(BITMAP_AGG(c6)) FROM t1;


### PR DESCRIPTION
Add agg func bitmap_agg

Current, bitmap_union only support Bitmap as param, the performance is poor because we should first covert int to bitmap , and then union all the bitmap.

```
mysql> select bitmap_count(bitmap_union(to_bitmap(lo_orderkey))) from lineorder where lo_orderkey < 3000000;
+----------------------------------------------------+
| bitmap_count(bitmap_union(to_bitmap(lo_orderkey))) |
+----------------------------------------------------+
|                                             749999 |
+----------------------------------------------------+
1 row in set (0.90 sec)

mysql> select bitmap_count(bitmap_agg(lo_orderkey)) from lineorder where lo_orderkey < 3000000;
+-----------------------------------------+
| bitmap_count(bitmap_agg(lo_orderkey)) |
+-----------------------------------------+
|                                  749999 |
+-----------------------------------------+
1 row in set (0.32 sec)
```

