### PR TITLE
[Enhancement] conditional expressions support array/map/struct/json types

### DIFF
--- a/be/src/exprs/case_expr.cpp
+++ b/be/src/exprs/case_expr.cpp
@@ -117,12 +117,6 @@ private:
         Columns then_columns;
         then_columns.reserve(loop_end);
 
-        std::vector<ColumnViewer<WhenType>> when_viewers;
-        when_viewers.reserve(loop_end);
-
-        std::vector<ColumnViewer<ResultType>> then_viewers;
-        then_viewers.reserve(loop_end);
-
         for (int i = 1; i < loop_end; i += 2) {
             ASSIGN_OR_RETURN(ColumnPtr when_column, _children[i]->evaluate_checked(context, chunk));
 
@@ -133,62 +127,109 @@ private:
 
             ASSIGN_OR_RETURN(ColumnPtr then_column, _children[i + 1]->evaluate_checked(context, chunk));
 
-            when_viewers.emplace_back(when_column);
-            then_viewers.emplace_back(then_column);
-
             when_columns.emplace_back(when_column);
             then_columns.emplace_back(then_column);
         }
 
-        if (when_viewers.empty()) {
+        if (when_columns.empty()) {
             return else_column->clone();
         }
-        when_columns.emplace_back(case_column);
         then_columns.emplace_back(else_column);
-
-        ColumnViewer<WhenType> case_viewer(case_column);
-        then_viewers.emplace_back(else_column);
-
         size_t size = when_columns[0]->size();
-        ColumnBuilder<ResultType> builder(size, this->type().precision, this->type().scale);
-
-        bool columns_has_null = false;
-        for (ColumnPtr& column : when_columns) {
-            columns_has_null |= column->has_null();
-        }
-
-        size_t view_size = when_viewers.size();
-        if (!columns_has_null) {
-            for (int row = 0; row < size; ++row) {
-                int i = 0;
-                while ((i < view_size) && (when_viewers[i].value(row) != case_viewer.value(row))) {
-                    i += 1;
-                }
-                if (!then_viewers[i].is_null(row)) {
-                    builder.append(then_viewers[i].value(row));
-                } else {
-                    builder.append_null();
+        if constexpr (lt_is_collection<ResultType> || lt_is_collection<WhenType>) {
+            // construct nullable result column
+            ColumnPtr res = nullptr;
+            for (const auto col : then_columns) {
+                if (!col->only_null()) {
+                    res = col->clone_empty();
+                    break;
                 }
             }
+            if (res == nullptr) {
+                res = else_column->clone_empty();
+            }
+            res = ColumnHelper::cast_to_nullable_column(res);
+
+            // case_column equals to when_columns[i] or not?
+            auto when_num = when_columns.size();
+            if (!case_column->is_nullable()) {
+                for (auto row = 0; row < size; ++row) {
+                    int i = 0;
+                    while ((i < when_num) && !when_columns[i]->equals(row, *case_column, row)) {
+                        ++i;
+                    }
+                    res->append(*then_columns[i], row, 1);
+                }
+            } else {
+                NullColumnPtr case_nulls = down_cast<NullableColumn*>(case_column.get())->null_column();
+                auto case_data = down_cast<NullableColumn*>(case_column.get())->data_column();
+
+                for (auto row = 0; row < size; ++row) {
+                    int i = 0;
+                    while ((i < when_num) && (case_nulls != nullptr && case_nulls->get_data()[row] ||
+                                              !when_columns[i]->equals(row, *case_data, row))) {
+                        ++i;
+                    }
+                    res->append(*then_columns[i], row, 1);
+                }
+            }
+            return res;
         } else {
-            for (int row = 0; row < size; ++row) {
-                int i = view_size;
-                if (!case_viewer.is_null(row)) {
-                    i = 0;
-                    while ((i < view_size) &&
-                           (when_viewers[i].is_null(row) || when_viewers[i].value(row) != case_viewer.value(row))) {
+            std::vector<ColumnViewer<WhenType>> when_viewers;
+            when_viewers.reserve(loop_end);
+
+            std::vector<ColumnViewer<ResultType>> then_viewers;
+            then_viewers.reserve(loop_end);
+            for (auto col : when_columns) {
+                when_viewers.emplace_back(col);
+            }
+            for (auto col : then_columns) {
+                then_viewers.emplace_back(col);
+            }
+            when_columns.emplace_back(case_column);
+
+            bool when_columns_has_null = false;
+            for (ColumnPtr& column : when_columns) {
+                when_columns_has_null |= column->has_null();
+            }
+            ColumnViewer<WhenType> case_viewer(case_column);
+            then_viewers.emplace_back(else_column);
+
+            ColumnBuilder<ResultType> builder(size, this->type().precision, this->type().scale);
+
+            size_t view_size = when_viewers.size();
+            if (!when_columns_has_null) {
+                for (int row = 0; row < size; ++row) {
+                    int i = 0;
+                    while ((i < view_size) && (when_viewers[i].value(row) != case_viewer.value(row))) {
                         i += 1;
                     }
+                    if (!then_viewers[i].is_null(row)) {
+                        builder.append(then_viewers[i].value(row));
+                    } else {
+                        builder.append_null();
+                    }
                 }
-                if (!then_viewers[i].is_null(row)) {
-                    builder.append(then_viewers[i].value(row));
-                } else {
-                    builder.append_null();
+            } else {
+                for (int row = 0; row < size; ++row) {
+                    int i = view_size;
+                    if (!case_viewer.is_null(row)) {
+                        i = 0;
+                        while ((i < view_size) &&
+                               (when_viewers[i].is_null(row) || when_viewers[i].value(row) != case_viewer.value(row))) {
+                            i += 1;
+                        }
+                    }
+                    if (!then_viewers[i].is_null(row)) {
+                        builder.append(then_viewers[i].value(row));
+                    } else {
+                        builder.append_null();
+                    }
                 }
             }
-        }
 
-        return builder.build(ColumnHelper::is_all_const(when_columns) && ColumnHelper::is_all_const(then_columns));
+            return builder.build(ColumnHelper::is_all_const(when_columns) && ColumnHelper::is_all_const(then_columns));
+        }
     }
 
     // CASE 1:
@@ -196,7 +237,7 @@ private:
     //         WHEN sex = '2' THEN 'woman'
     //    ELSE 'other' END
     //
-    //  Special CASE-WHEN statment, and `WHEN` clause must be boolean.
+    //  Special CASE-WHEN statement, and `WHEN` clause must be boolean.
     //  If all `WHEN` is null/false, return `ELSE`
     //  If `WHEN` is not null and true, return `THEN`
     //
@@ -204,7 +245,7 @@ private:
     //    CASE WHEN sex = '1' THEN 'man'
     //         WHEN sex = '2' THEN 'woman'
     //
-    //  Special CASE-WHEN statment, and `WHEN` clause must be boolean.
+    //  Special CASE-WHEN statement, and `WHEN` clause must be boolean.
     //  If all `WHEN` is null/false, return NULL
     //  If `WHEN` is not null and true, return `THEN`
     StatusOr<ColumnPtr> evaluate_no_case(ExprContext* context, Chunk* chunk) {
@@ -226,9 +267,6 @@ private:
         std::vector<ColumnViewer<TYPE_BOOLEAN>> when_viewers;
         when_viewers.reserve(loop_end);
 
-        std::vector<ColumnViewer<ResultType>> then_viewers;
-        then_viewers.reserve(loop_end);
-
         for (int i = 0; i < loop_end; i += 2) {
             ASSIGN_OR_RETURN(ColumnPtr when_column, _children[i]->evaluate_checked(context, chunk));
 
@@ -248,110 +286,149 @@ private:
 
             when_columns.emplace_back(when_column);
             then_columns.emplace_back(then_column);
-
             when_viewers.emplace_back(when_column);
-            then_viewers.emplace_back(then_column);
         }
 
         if (when_viewers.empty()) {
             return else_column->clone();
         }
         then_columns.emplace_back(else_column);
-        then_viewers.emplace_back(else_column);
 
         size_t size = when_columns[0]->size();
-        ColumnBuilder<ResultType> builder(size, this->type().precision, this->type().scale);
 
         bool when_columns_has_null = false;
         for (ColumnPtr& column : when_columns) {
             when_columns_has_null |= column->has_null();
         }
 
-        // max case size in use SIMD CASE WHEN implements
-        constexpr int max_simd_case_when_size = 8;
-
-        // optimization for no-nullable Arithmetic Type
-        if constexpr (isArithmeticLT<ResultType>) {
-            bool then_columns_has_null = false;
-            for (const auto& column : then_columns) {
-                then_columns_has_null |= column->has_null();
-            }
-
-            bool check_could_use_multi_simd_selector =
-                    !when_columns_has_null && when_columns.size() <= max_simd_case_when_size && !then_columns_has_null;
-
-            if (check_could_use_multi_simd_selector) {
-                int then_column_size = then_columns.size();
-                int when_column_size = when_columns.size();
-                // TODO: avoid unpack const column
-                for (int i = 0; i < then_column_size; ++i) {
-                    then_columns[i] = ColumnHelper::unpack_and_duplicate_const_column(size, then_columns[i]);
-                }
-                for (int i = 0; i < when_column_size; ++i) {
-                    when_columns[i] = ColumnHelper::unpack_and_duplicate_const_column(size, when_columns[i]);
-                }
-                for (int i = 0; i < when_column_size; ++i) {
-                    ColumnHelper::merge_nullable_filter(when_columns[i].get());
-                }
-
-                using ResultContainer = typename RunTimeColumnType<ResultType>::Container;
-
-                ResultContainer* select_list[then_column_size];
-                for (int i = 0; i < then_column_size; ++i) {
-                    auto* data_column = ColumnHelper::get_data_column(then_columns[i].get());
-                    select_list[i] = &down_cast<RunTimeColumnType<ResultType>*>(data_column)->get_data();
-                }
-
-                uint8_t* select_vec[when_column_size];
-                for (int i = 0; i < when_column_size; ++i) {
-                    auto* data_column = ColumnHelper::get_data_column(when_columns[i].get());
-                    select_vec[i] = down_cast<BooleanColumn*>(data_column)->get_data().data();
-                }
-
-                auto res = RunTimeColumnType<ResultType>::create();
-
-                if constexpr (lt_is_decimal<ResultType>) {
-                    res->set_scale(this->type().scale);
-                    res->set_precision(this->type().precision);
-                }
-
-                auto& container = res->get_data();
-                container.resize(size);
-                SIMD_muti_selector<ResultType>::multi_select_if(select_vec, when_column_size, container, select_list,
-                                                                then_column_size);
-                return res;
-            }
-        }
-
-        size_t view_size = when_viewers.size();
-        if (!when_columns_has_null) {
-            for (int row = 0; row < size; ++row) {
-                int i = 0;
-                while (i < view_size && !(when_viewers[i].value(row))) {
-                    i += 1;
-                }
-                if (!then_viewers[i].is_null(row)) {
-                    builder.append(then_viewers[i].value(row));
-                } else {
-                    builder.append_null();
+        if constexpr (lt_is_collection<ResultType>) {
+            // construct nullable result column
+            ColumnPtr res = nullptr;
+            for (const auto col : then_columns) {
+                if (!col->only_null()) {
+                    res = col->clone_empty();
+                    break;
                 }
             }
+            if (res == nullptr) {
+                res = else_column->clone_empty();
+            }
+            res = ColumnHelper::cast_to_nullable_column(res);
+
+            // when_columns[i] is true or not
+            auto when_num = when_columns.size();
+            if (!when_columns_has_null) {
+                for (auto row = 0; row < size; ++row) {
+                    int i = 0;
+                    while (i < when_num && !(when_viewers[i].value(row))) {
+                        ++i;
+                    }
+                    res->append(*then_columns[i], row, 1);
+                }
+            } else {
+                for (auto row = 0; row < size; ++row) {
+                    int i = 0;
+                    while ((i < when_num) && (when_viewers[i].is_null(row) || !when_viewers[i].value(row))) {
+                        ++i;
+                    }
+                    res->append(*then_columns[i], row, 1);
+                }
+            }
+            return res;
         } else {
-            for (int row = 0; row < size; ++row) {
-                int i = 0;
-                while ((i < view_size) && (when_viewers[i].is_null(row) || !when_viewers[i].value(row))) {
-                    i += 1;
+            std::vector<ColumnViewer<ResultType>> then_viewers;
+            then_viewers.reserve(loop_end);
+            for (auto col : then_columns) {
+                then_viewers.emplace_back(col);
+            }
+            ColumnBuilder<ResultType> builder(size, this->type().precision, this->type().scale);
+            // max case size in use SIMD CASE WHEN implements
+            constexpr int max_simd_case_when_size = 8;
+
+            // optimization for no-nullable Arithmetic Type
+            if constexpr (isArithmeticLT<ResultType>) {
+                bool then_columns_has_null = false;
+                for (const auto& column : then_columns) {
+                    then_columns_has_null |= column->has_null();
                 }
 
-                if (!then_viewers[i].is_null(row)) {
-                    builder.append(then_viewers[i].value(row));
-                } else {
-                    builder.append_null();
+                bool check_could_use_multi_simd_selector = !when_columns_has_null &&
+                                                           when_columns.size() <= max_simd_case_when_size &&
+                                                           !then_columns_has_null;
+
+                if (check_could_use_multi_simd_selector) {
+                    int then_column_size = then_columns.size();
+                    int when_column_size = when_columns.size();
+                    // TODO: avoid unpack const column
+                    for (int i = 0; i < then_column_size; ++i) {
+                        then_columns[i] = ColumnHelper::unpack_and_duplicate_const_column(size, then_columns[i]);
+                    }
+                    for (int i = 0; i < when_column_size; ++i) {
+                        when_columns[i] = ColumnHelper::unpack_and_duplicate_const_column(size, when_columns[i]);
+                    }
+                    for (int i = 0; i < when_column_size; ++i) {
+                        ColumnHelper::merge_nullable_filter(when_columns[i].get());
+                    }
+
+                    using ResultContainer = typename RunTimeColumnType<ResultType>::Container;
+
+                    ResultContainer* select_list[then_column_size];
+                    for (int i = 0; i < then_column_size; ++i) {
+                        auto* data_column = ColumnHelper::get_data_column(then_columns[i].get());
+                        select_list[i] = &down_cast<RunTimeColumnType<ResultType>*>(data_column)->get_data();
+                    }
+
+                    uint8_t* select_vec[when_column_size];
+                    for (int i = 0; i < when_column_size; ++i) {
+                        auto* data_column = ColumnHelper::get_data_column(when_columns[i].get());
+                        select_vec[i] = down_cast<BooleanColumn*>(data_column)->get_data().data();
+                    }
+
+                    auto res = RunTimeColumnType<ResultType>::create();
+
+                    if constexpr (lt_is_decimal<ResultType>) {
+                        res->set_scale(this->type().scale);
+                        res->set_precision(this->type().precision);
+                    }
+
+                    auto& container = res->get_data();
+                    container.resize(size);
+                    SIMD_muti_selector<ResultType>::multi_select_if(select_vec, when_column_size, container,
+                                                                    select_list, then_column_size);
+                    return res;
                 }
             }
-        }
 
-        return builder.build(ColumnHelper::is_all_const(when_columns) && ColumnHelper::is_all_const(then_columns));
+            size_t view_size = when_viewers.size();
+            if (!when_columns_has_null) {
+                for (int row = 0; row < size; ++row) {
+                    int i = 0;
+                    while (i < view_size && !(when_viewers[i].value(row))) {
+                        i += 1;
+                    }
+                    if (!then_viewers[i].is_null(row)) {
+                        builder.append(then_viewers[i].value(row));
+                    } else {
+                        builder.append_null();
+                    }
+                }
+            } else {
+                for (int row = 0; row < size; ++row) {
+                    int i = 0;
+                    while ((i < view_size) && (when_viewers[i].is_null(row) || !when_viewers[i].value(row))) {
+                        i += 1;
+                    }
+
+                    if (!then_viewers[i].is_null(row)) {
+                        builder.append(then_viewers[i].value(row));
+                    } else {
+                        builder.append_null();
+                    }
+                }
+            }
+
+            return builder.build(ColumnHelper::is_all_const(when_columns) && ColumnHelper::is_all_const(then_columns));
+        }
     }
 
 private:
@@ -384,6 +461,9 @@ private:
         CASE_WHEN_RESULT_TYPE(TYPE_DECIMAL64, RESULT_TYPE);                               \
         CASE_WHEN_RESULT_TYPE(TYPE_DECIMAL128, RESULT_TYPE);                              \
         CASE_WHEN_RESULT_TYPE(TYPE_JSON, RESULT_TYPE);                                    \
+        CASE_WHEN_RESULT_TYPE(TYPE_ARRAY, RESULT_TYPE);                                   \
+        CASE_WHEN_RESULT_TYPE(TYPE_MAP, RESULT_TYPE);                                     \
+        CASE_WHEN_RESULT_TYPE(TYPE_STRUCT, RESULT_TYPE);                                  \
     default: {                                                                            \
         LOG(WARNING) << "vectorized engine case expr no support when type: " << whenType; \
         return nullptr;                                                                   \
@@ -405,6 +485,7 @@ Expr* VectorizedCaseExprFactory::from_thrift(const starrocks::TExprNode& node) {
 
     switch (resultType) {
         APPLY_FOR_ALL_SCALAR_TYPE(CASE_RESULT_TYPE)
+        APPLY_FOR_COMPLEX_TYPE(CASE_RESULT_TYPE)
         CASE_RESULT_TYPE(TYPE_OBJECT)
         CASE_RESULT_TYPE(TYPE_HLL)
         CASE_RESULT_TYPE(TYPE_PERCENTILE)

--- a/be/src/exprs/case_expr.h
+++ b/be/src/exprs/case_expr.h
@@ -21,5 +21,7 @@ namespace starrocks {
 class VectorizedCaseExprFactory {
 public:
     static Expr* from_thrift(const TExprNode& node);
+    // for tests
+    static Expr* from_thrift(const starrocks::TExprNode& node, LogicalType resultType, LogicalType whenType);
 };
 } // namespace starrocks

--- a/be/src/exprs/condition_expr.cpp
+++ b/be/src/exprs/condition_expr.cpp
@@ -69,7 +69,7 @@ struct SelectIfOP {
                                                 \
     ~NAME() {}                                  \
                                                 \
-   virtual Expr* clone(ObjectPool* pool) const override { return pool->add(new NAME(*this)); }
+    virtual Expr* clone(ObjectPool* pool) const override { return pool->add(new NAME(*this)); }
 
 template <LogicalType Type>
 class VectorizedIfNullExpr : public Expr {

--- a/be/src/exprs/condition_expr.cpp
+++ b/be/src/exprs/condition_expr.cpp
@@ -64,14 +64,12 @@ struct SelectIfOP {
     }
 };
 
-#define DEFINE_CLASS_CONSTRUCT_FN(NAME)                    \
-    NAME(const TExprNode& node) : Expr(node) {}            \
-                                                           \
-    ~NAME() {}                                             \
-                                                           \
-    virtual Expr* clone(ObjectPool* pool) const override { \
-        return pool->add(new NAME(*this));                 \
-    }
+#define DEFINE_CLASS_CONSTRUCT_FN(NAME)         \
+    NAME(const TExprNode& node) : Expr(node) {} \
+                                                \
+    ~NAME() {}                                  \
+                                                \
+   virtual Expr* clone(ObjectPool* pool) const override { return pool->add(new NAME(*this)); }
 
 template <LogicalType Type>
 class VectorizedIfNullExpr : public Expr {

--- a/be/src/exprs/function_context.cpp
+++ b/be/src/exprs/function_context.cpp
@@ -200,7 +200,7 @@ struct ColumnBuilder {
     ColumnPtr operator()(const FunctionContext::TypeDesc& type_desc) {
         if constexpr (lt_is_decimal<Type>) {
             return RunTimeColumnType<Type>::create(type_desc.precision, type_desc.scale);
-        } else if constexpr (lt_is_conllection<Type>) {
+        } else if constexpr (lt_is_collection<Type>) {
             throw std::runtime_error(fmt::format("Unsupported collection type {}", Type));
             return nullptr;
         } else if constexpr (Type == TYPE_UNKNOWN || Type == TYPE_BINARY || Type == TYPE_DECIMAL) {

--- a/be/src/types/logical_type.h
+++ b/be/src/types/logical_type.h
@@ -280,7 +280,7 @@ VALUE_GUARD(LogicalType, DecimalV2LTGuard, lt_is_decimalv2, TYPE_DECIMALV2)
 VALUE_GUARD(LogicalType, DecimalOfAnyVersionLTGuard, lt_is_decimal_of_any_version, TYPE_DECIMALV2, TYPE_DECIMAL32,
             TYPE_DECIMAL64, TYPE_DECIMAL128)
 VALUE_GUARD(LogicalType, DateOrDateTimeLTGuard, lt_is_date_or_datetime, TYPE_DATE, TYPE_DATETIME)
-VALUE_GUARD(LogicalType, CollectionLTGuard, lt_is_conllection, TYPE_ARRAY, TYPE_MAP, TYPE_STRUCT)
+VALUE_GUARD(LogicalType, CollectionLTGuard, lt_is_collection, TYPE_ARRAY, TYPE_MAP, TYPE_STRUCT)
 
 UNION_VALUE_GUARD(LogicalType, IntegralLTGuard, lt_is_integral, lt_is_boolean_struct, lt_is_integer_struct)
 

--- a/be/src/types/logical_type_infra.h
+++ b/be/src/types/logical_type_infra.h
@@ -47,6 +47,11 @@ namespace starrocks {
     M(TYPE_VARBINARY)                \
     M(TYPE_BOOLEAN)
 
+#define APPLY_FOR_COMPLEX_TYPE(M) \
+    M(TYPE_STRUCT)                \
+    M(TYPE_MAP)                   \
+    M(TYPE_ARRAY)
+
 #define APPLY_FOR_ALL_SCALAR_TYPE_WITH_NULL(M) \
     APPLY_FOR_ALL_SCALAR_TYPE(M)               \
     M(TYPE_NULL)

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -20,10 +20,10 @@
 #include <unordered_set>
 
 #include "column/const_column.h"
+#include "exprs/mock_vectorized_expr.h"
 
 namespace starrocks {
 
-namespace {
 TypeDescriptor array_type(const TypeDescriptor& child_type) {
     TypeDescriptor t;
     t.type = TYPE_ARRAY;
@@ -39,7 +39,6 @@ TypeDescriptor array_type(const LogicalType& child_type) {
     t.children[0].len = child_type == TYPE_VARCHAR ? 10 : child_type == TYPE_CHAR ? 10 : -1;
     return t;
 }
-} // namespace
 
 class ArrayFunctionsTest : public ::testing::Test {
 protected:

--- a/be/test/exprs/case_expr_test.cpp
+++ b/be/test/exprs/case_expr_test.cpp
@@ -114,42 +114,111 @@ public:
     TExprNode expr_node;
 };
 
+TEST_F(VectorizedCaseExprTest, whenArrayMapCase) {
+    expr_node.case_expr.has_case_expr = true;
+    expr_node.case_expr.has_else_expr = false;
+
+    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_ARRAY, TYPE_MAP));
+
+    TypeDescriptor type_arr_int = array_type(TYPE_INT);
+
+    auto array0 = ColumnHelper::create_column(type_arr_int, true);
+    array0->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
+    array0->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
+    array0->append_datum(DatumArray{Datum(), Datum((int32_t)12)});          // [NULL, 12]
+    auto array_expr0 = MockExpr(type_arr_int, array0);
+
+    auto array1 = ColumnHelper::create_column(type_arr_int, false);
+    array1->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)41)}); // [11,41]
+    array1->append_datum(DatumArray{Datum(), Datum()});                       // [NULL, NULL]
+    array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});             // [NULL, 1]
+    auto array_expr1 = MockExpr(type_arr_int, array1);
+
+    TypeDescriptor type_map_int_int = map_type(TYPE_INT, TYPE_INT);
+
+    auto map_column_not_nullable = ColumnHelper::create_column(type_map_int_int, false);
+    {
+        DatumMap map1;
+        map1[(int32_t)1] = (int32_t)44;
+        map1[(int32_t)2] = (int32_t)55;
+        map1[(int32_t)4] = (int32_t)66;
+        map_column_not_nullable->append_datum(map1);
+
+        DatumMap map2;
+        map2[(int32_t)2] = (int32_t)77;
+        map2[(int32_t)3] = (int32_t)88;
+        map_column_not_nullable->append_datum(map2);
+
+        // {} empty
+        map_column_not_nullable->append_datum(DatumMap());
+    }
+    auto map_expr = MockExpr(type_map_int_int, map_column_not_nullable);
+
+    expr->_children.push_back(&array_expr0); // case
+    expr->_children.push_back(&array_expr1); // when1
+    expr->_children.push_back(&map_expr);    // then1
+    expr->_children.push_back(&array_expr0); // when2
+    expr->_children.push_back(&map_expr);    // then2
+
+    {
+        Chunk chunk;
+        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+        if (ptr->is_nullable()) {
+            ptr = down_cast<NullableColumn*>(ptr.get())->data_column();
+        }
+        ASSERT_TRUE(ptr->is_map());
+        ASSERT_EQ(ptr->size(), 3);
+
+        for (int j = 0; j < ptr->size(); ++j) {
+            ASSERT_TRUE(ptr->equals(j, *map_column_not_nullable, j));
+        }
+    }
+}
+
+// old tests also test _evaluate_complex()
 TEST_F(VectorizedCaseExprTest, whenSliceCase) {
     expr_node.child_type = TPrimitiveType::VARCHAR;
     expr_node.type = gen_type_desc(TPrimitiveType::DATETIME);
     expr_node.case_expr.has_case_expr = true;
     expr_node.case_expr.has_else_expr = false;
 
-    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node));
+    std::vector<std::unique_ptr<Expr>> exprs;
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node));
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_ARRAY, TYPE_ARRAY));
 
-    std::string v1("test1");
-    std::string v2("test2");
-    std::string v3("test3");
+    for (auto& expr : exprs) {
+        std::string v1("test1");
+        std::string v2("test2");
+        std::string v3("test3");
 
-    Slice s1(v1);
-    Slice s2(v2);
-    Slice s3(v3);
+        Slice s1(v1);
+        Slice s2(v2);
+        Slice s3(v3);
 
-    MockVectorizedExpr<TYPE_VARCHAR> case1(expr_node, 10, s1);
-    MockVectorizedExpr<TYPE_VARCHAR> when2(expr_node, 10, s2);
-    MockVectorizedExpr<TYPE_DATETIME> then2(expr_node, 10, TimestampValue::create(2000, 12, 2, 12, 12, 30));
-    MockVectorizedExpr<TYPE_VARCHAR> when3(expr_node, 10, s1);
-    MockVectorizedExpr<TYPE_DATETIME> then3(expr_node, 10, TimestampValue::create(2002, 12, 2, 12, 12, 30));
+        MockVectorizedExpr<TYPE_VARCHAR> case1(expr_node, 10, s1);
+        MockVectorizedExpr<TYPE_VARCHAR> when2(expr_node, 10, s2);
+        MockVectorizedExpr<TYPE_DATETIME> then2(expr_node, 10, TimestampValue::create(2000, 12, 2, 12, 12, 30));
+        MockVectorizedExpr<TYPE_VARCHAR> when3(expr_node, 10, s1);
+        MockVectorizedExpr<TYPE_DATETIME> then3(expr_node, 10, TimestampValue::create(2002, 12, 2, 12, 12, 30));
 
-    expr->_children.push_back(&case1);
-    expr->_children.push_back(&when2);
-    expr->_children.push_back(&then2);
-    expr->_children.push_back(&when3);
-    expr->_children.push_back(&then3);
+        expr->_children.push_back(&case1);
+        expr->_children.push_back(&when2);
+        expr->_children.push_back(&then2);
+        expr->_children.push_back(&when3);
+        expr->_children.push_back(&then3);
 
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_timestamp());
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            if (ptr->is_nullable()) {
+                ptr = down_cast<NullableColumn*>(ptr.get())->data_column();
+            }
+            ASSERT_TRUE(ptr->is_timestamp());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_DATETIME>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            ASSERT_EQ(TimestampValue::create(2002, 12, 2, 12, 12, 30), v->get_data()[j]);
+            auto v = ColumnHelper::cast_to_raw<TYPE_DATETIME>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                ASSERT_EQ(TimestampValue::create(2002, 12, 2, 12, 12, 30), v->get_data()[j]);
+            }
         }
     }
 }
@@ -161,44 +230,51 @@ TEST_F(VectorizedCaseExprTest, whenDecimalCase) {
     expr_node.case_expr.has_case_expr = true;
     expr_node.case_expr.has_else_expr = false;
 
-    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node));
+    std::vector<std::unique_ptr<Expr>> exprs;
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node));
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_ARRAY, TYPE_ARRAY));
 
-    std::string case_v1("1234567890.1234");
-    std::string case_v2("1234567890.1230");
-    std::string then_v1("123456.9999");
-    std::string then_v2("123456.8888");
+    for (auto& expr : exprs) {
+        std::string case_v1("1234567890.1234");
+        std::string case_v2("1234567890.1230");
+        std::string then_v1("123456.9999");
+        std::string then_v2("123456.8888");
 
-    int128_t case_decimal1;
-    int128_t case_decimal2;
-    int64_t then_decimal1;
-    int64_t then_decimal2;
-    DecimalV3Cast::from_string<int128_t>(&case_decimal1, 33, 11, case_v1.c_str(), case_v1.size());
-    DecimalV3Cast::from_string<int128_t>(&case_decimal2, 33, 11, case_v2.c_str(), case_v2.size());
-    DecimalV3Cast::from_string<int64_t>(&then_decimal1, 15, 4, then_v1.c_str(), then_v1.size());
-    DecimalV3Cast::from_string<int64_t>(&then_decimal2, 15, 4, then_v2.c_str(), then_v2.size());
+        int128_t case_decimal1;
+        int128_t case_decimal2;
+        int64_t then_decimal1;
+        int64_t then_decimal2;
+        DecimalV3Cast::from_string<int128_t>(&case_decimal1, 33, 11, case_v1.c_str(), case_v1.size());
+        DecimalV3Cast::from_string<int128_t>(&case_decimal2, 33, 11, case_v2.c_str(), case_v2.size());
+        DecimalV3Cast::from_string<int64_t>(&then_decimal1, 15, 4, then_v1.c_str(), then_v1.size());
+        DecimalV3Cast::from_string<int64_t>(&then_decimal2, 15, 4, then_v2.c_str(), then_v2.size());
 
-    MockVectorizedExpr<TYPE_DECIMAL128> case_expr(expr_node, 10, case_decimal1);
-    MockVectorizedExpr<TYPE_DECIMAL128> when2_expr(expr_node, 10, case_decimal2);
-    MockVectorizedExpr<TYPE_DECIMAL64> then2_expr(expr_node, 10, then_decimal2);
-    MockVectorizedExpr<TYPE_DECIMAL128> when1_expr(expr_node, 10, case_decimal1);
-    MockVectorizedExpr<TYPE_DECIMAL64> then1_expr(expr_node, 10, then_decimal1);
+        MockVectorizedExpr<TYPE_DECIMAL128> case_expr(expr_node, 10, case_decimal1);
+        MockVectorizedExpr<TYPE_DECIMAL128> when2_expr(expr_node, 10, case_decimal2);
+        MockVectorizedExpr<TYPE_DECIMAL64> then2_expr(expr_node, 10, then_decimal2);
+        MockVectorizedExpr<TYPE_DECIMAL128> when1_expr(expr_node, 10, case_decimal1);
+        MockVectorizedExpr<TYPE_DECIMAL64> then1_expr(expr_node, 10, then_decimal1);
 
-    expr->_children.push_back(&case_expr);
-    expr->_children.push_back(&when2_expr);
-    expr->_children.push_back(&then2_expr);
-    expr->_children.push_back(&when1_expr);
-    expr->_children.push_back(&then1_expr);
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_decimal());
+        expr->_children.push_back(&case_expr);
+        expr->_children.push_back(&when2_expr);
+        expr->_children.push_back(&then2_expr);
+        expr->_children.push_back(&when1_expr);
+        expr->_children.push_back(&then1_expr);
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            if (ptr->is_nullable()) {
+                ptr = down_cast<NullableColumn*>(ptr.get())->data_column();
+            }
+            ASSERT_TRUE(ptr->is_decimal());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_DECIMAL64>(ptr);
-        ASSERT_EQ(v->precision(), type_desc.precision);
-        ASSERT_EQ(v->scale(), type_desc.scale);
+            auto v = ColumnHelper::cast_to_raw<TYPE_DECIMAL64>(ptr);
+            ASSERT_EQ(v->precision(), type_desc.precision);
+            ASSERT_EQ(v->scale(), type_desc.scale);
 
-        for (int i = 0; i < ptr->size(); ++i) {
-            ASSERT_EQ(v->get_data()[i], then_decimal1);
+            for (int i = 0; i < ptr->size(); ++i) {
+                ASSERT_EQ(v->get_data()[i], then_decimal1);
+            }
         }
     }
 }
@@ -208,29 +284,32 @@ TEST_F(VectorizedCaseExprTest, whenIntCaseAllNull) {
     expr_node.type = gen_type_desc(TPrimitiveType::INT);
     expr_node.case_expr.has_case_expr = true;
     expr_node.case_expr.has_else_expr = false;
+    std::vector<std::unique_ptr<Expr>> exprs;
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node));
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_ARRAY, TYPE_ARRAY));
 
-    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node));
+    for (auto& expr : exprs) {
+        MockVectorizedExpr<TYPE_INT> case1(expr_node, 10, 1);
+        MockNullVectorizedExpr<TYPE_INT> when2(expr_node, 10, 2);
+        MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
+        MockNullVectorizedExpr<TYPE_INT> when3(expr_node, 10, 1);
+        MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 20);
 
-    MockVectorizedExpr<TYPE_INT> case1(expr_node, 10, 1);
-    MockNullVectorizedExpr<TYPE_INT> when2(expr_node, 10, 2);
-    MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
-    MockNullVectorizedExpr<TYPE_INT> when3(expr_node, 10, 1);
-    MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 20);
+        when2.only_null = true;
+        when3.only_null = true;
 
-    when2.only_null = true;
-    when3.only_null = true;
+        expr->_children.push_back(&case1);
+        expr->_children.push_back(&when2);
+        expr->_children.push_back(&then2);
+        expr->_children.push_back(&when3);
+        expr->_children.push_back(&then3);
 
-    expr->_children.push_back(&case1);
-    expr->_children.push_back(&when2);
-    expr->_children.push_back(&then2);
-    expr->_children.push_back(&when3);
-    expr->_children.push_back(&then3);
-
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_nullable());
-        ASSERT_TRUE(ptr->only_null());
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_nullable());
+            ASSERT_TRUE(ptr->only_null());
+        }
     }
 }
 
@@ -240,30 +319,34 @@ TEST_F(VectorizedCaseExprTest, whenTimestampCaseElse) {
     expr_node.case_expr.has_case_expr = true;
     expr_node.case_expr.has_else_expr = true;
 
-    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node));
+    std::vector<std::unique_ptr<Expr>> exprs;
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node));
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_ARRAY, TYPE_ARRAY));
 
-    MockVectorizedExpr<TYPE_DATETIME> case1(expr_node, 10, TimestampValue::create(2000, 12, 2, 12, 12, 30));
-    MockVectorizedExpr<TYPE_DATETIME> when2(expr_node, 10, TimestampValue::create(2001, 12, 2, 12, 12, 30));
-    MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 1);
-    MockVectorizedExpr<TYPE_DATETIME> when3(expr_node, 10, TimestampValue::create(2002, 12, 2, 12, 12, 30));
-    MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 2);
-    MockVectorizedExpr<TYPE_INT> else1(expr_node, 10, 3);
+    for (auto& expr : exprs) {
+        MockVectorizedExpr<TYPE_DATETIME> case1(expr_node, 10, TimestampValue::create(2000, 12, 2, 12, 12, 30));
+        MockVectorizedExpr<TYPE_DATETIME> when2(expr_node, 10, TimestampValue::create(2001, 12, 2, 12, 12, 30));
+        MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 1);
+        MockVectorizedExpr<TYPE_DATETIME> when3(expr_node, 10, TimestampValue::create(2002, 12, 2, 12, 12, 30));
+        MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 2);
+        MockVectorizedExpr<TYPE_INT> else1(expr_node, 10, 3);
 
-    expr->_children.push_back(&case1);
-    expr->_children.push_back(&when2);
-    expr->_children.push_back(&then2);
-    expr->_children.push_back(&when3);
-    expr->_children.push_back(&then3);
-    expr->_children.push_back(&else1);
+        expr->_children.push_back(&case1);
+        expr->_children.push_back(&when2);
+        expr->_children.push_back(&then2);
+        expr->_children.push_back(&when3);
+        expr->_children.push_back(&then3);
+        expr->_children.push_back(&else1);
 
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_numeric());
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_numeric());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_INT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            ASSERT_EQ(3, v->get_data()[j]);
+            auto v = ColumnHelper::cast_to_raw<TYPE_INT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                ASSERT_EQ(3, v->get_data()[j]);
+            }
         }
     }
 }
@@ -274,43 +357,47 @@ TEST_F(VectorizedCaseExprTest, whenNullIntCaseElse) {
     expr_node.case_expr.has_case_expr = true;
     expr_node.case_expr.has_else_expr = true;
 
-    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node));
+    std::vector<std::unique_ptr<Expr>> exprs;
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node));
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_ARRAY, TYPE_ARRAY));
 
-    std::string v1("test1");
-    std::string v2("test2");
-    std::string v3("test3");
+    for (auto& expr : exprs) {
+        std::string v1("test1");
+        std::string v2("test2");
+        std::string v3("test3");
 
-    Slice s1(v1);
-    Slice s2(v2);
-    Slice s3(v3);
+        Slice s1(v1);
+        Slice s2(v2);
+        Slice s3(v3);
 
-    MockNullVectorizedExpr<TYPE_INT> case1(expr_node, 10, 1);
-    MockVectorizedExpr<TYPE_INT> when2(expr_node, 10, 2);
-    MockVectorizedExpr<TYPE_VARCHAR> then2(expr_node, 10, s1);
-    MockVectorizedExpr<TYPE_INT> when3(expr_node, 10, 1);
-    MockVectorizedExpr<TYPE_VARCHAR> then3(expr_node, 10, s2);
-    MockVectorizedExpr<TYPE_VARCHAR> else1(expr_node, 10, s3);
+        MockNullVectorizedExpr<TYPE_INT> case1(expr_node, 10, 1);
+        MockVectorizedExpr<TYPE_INT> when2(expr_node, 10, 2);
+        MockVectorizedExpr<TYPE_VARCHAR> then2(expr_node, 10, s1);
+        MockVectorizedExpr<TYPE_INT> when3(expr_node, 10, 1);
+        MockVectorizedExpr<TYPE_VARCHAR> then3(expr_node, 10, s2);
+        MockVectorizedExpr<TYPE_VARCHAR> else1(expr_node, 10, s3);
 
-    expr->_children.push_back(&case1);
-    expr->_children.push_back(&when2);
-    expr->_children.push_back(&then2);
-    expr->_children.push_back(&when3);
-    expr->_children.push_back(&then3);
-    expr->_children.push_back(&else1);
+        expr->_children.push_back(&case1);
+        expr->_children.push_back(&when2);
+        expr->_children.push_back(&then2);
+        expr->_children.push_back(&when3);
+        expr->_children.push_back(&then3);
+        expr->_children.push_back(&else1);
 
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_binary());
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_binary());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            if (j % 2) {
-                ASSERT_FALSE(ptr->is_null(j));
-                ASSERT_EQ(s3, v->get_data()[j]);
-            } else {
-                ASSERT_FALSE(ptr->is_null(j));
-                ASSERT_EQ(s2, v->get_data()[j]);
+            auto v = ColumnHelper::cast_to_raw<TYPE_VARCHAR>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                if (j % 2) {
+                    ASSERT_FALSE(ptr->is_null(j));
+                    ASSERT_EQ(s3, v->get_data()[j]);
+                } else {
+                    ASSERT_FALSE(ptr->is_null(j));
+                    ASSERT_EQ(s2, v->get_data()[j]);
+                }
             }
         }
     }
@@ -322,35 +409,39 @@ TEST_F(VectorizedCaseExprTest, whenIntCaseNullElse) {
     expr_node.case_expr.has_case_expr = true;
     expr_node.case_expr.has_else_expr = true;
 
-    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node));
+    std::vector<std::unique_ptr<Expr>> exprs;
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node));
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_ARRAY, TYPE_ARRAY));
 
-    MockVectorizedExpr<TYPE_INT> case1(expr_node, 10, 1);
-    MockNullVectorizedExpr<TYPE_INT> when2(expr_node, 10, 2);
-    MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
-    MockNullVectorizedExpr<TYPE_INT> when3(expr_node, 10, 1);
-    MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 20);
-    MockVectorizedExpr<TYPE_INT> else1(expr_node, 10, 30);
+    for (auto& expr : exprs) {
+        MockVectorizedExpr<TYPE_INT> case1(expr_node, 10, 1);
+        MockNullVectorizedExpr<TYPE_INT> when2(expr_node, 10, 2);
+        MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
+        MockNullVectorizedExpr<TYPE_INT> when3(expr_node, 10, 1);
+        MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 20);
+        MockVectorizedExpr<TYPE_INT> else1(expr_node, 10, 30);
 
-    when2.only_null = true;
+        when2.only_null = true;
 
-    expr->_children.push_back(&case1);
-    expr->_children.push_back(&when2);
-    expr->_children.push_back(&then2);
-    expr->_children.push_back(&when3);
-    expr->_children.push_back(&then3);
-    expr->_children.push_back(&else1);
+        expr->_children.push_back(&case1);
+        expr->_children.push_back(&when2);
+        expr->_children.push_back(&then2);
+        expr->_children.push_back(&when3);
+        expr->_children.push_back(&then3);
+        expr->_children.push_back(&else1);
 
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_numeric());
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_numeric());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_INT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            if (j % 2) {
-                ASSERT_EQ(30, v->get_data()[j]);
-            } else {
-                ASSERT_EQ(20, v->get_data()[j]);
+            auto v = ColumnHelper::cast_to_raw<TYPE_INT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                if (j % 2) {
+                    ASSERT_EQ(30, v->get_data()[j]);
+                } else {
+                    ASSERT_EQ(20, v->get_data()[j]);
+                }
             }
         }
     }
@@ -410,26 +501,30 @@ TEST_F(VectorizedCaseExprTest, whenConstantAndElseVariable) {
     expr_node.case_expr.has_case_expr = true;
     expr_node.case_expr.has_else_expr = true;
 
-    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node));
+    std::vector<std::unique_ptr<Expr>> exprs;
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node));
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_ARRAY, TYPE_ARRAY));
 
-    MockConstVectorizedExpr<TYPE_INT> case1(expr_node, 1);
-    MockConstVectorizedExpr<TYPE_INT> when2(expr_node, 2);
-    MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
-    MockVectorizedExpr<TYPE_INT> else1(expr_node, 10, 20);
+    for (auto& expr : exprs) {
+        MockConstVectorizedExpr<TYPE_INT> case1(expr_node, 1);
+        MockConstVectorizedExpr<TYPE_INT> when2(expr_node, 2);
+        MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
+        MockVectorizedExpr<TYPE_INT> else1(expr_node, 10, 20);
 
-    expr->_children.push_back(&case1);
-    expr->_children.push_back(&when2);
-    expr->_children.push_back(&then2);
-    expr->_children.push_back(&else1);
+        expr->_children.push_back(&case1);
+        expr->_children.push_back(&when2);
+        expr->_children.push_back(&then2);
+        expr->_children.push_back(&else1);
 
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_numeric());
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_numeric());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_INT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            ASSERT_EQ(20, v->get_data()[j]);
+            auto v = ColumnHelper::cast_to_raw<TYPE_INT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                ASSERT_EQ(20, v->get_data()[j]);
+            }
         }
     }
 }
@@ -440,33 +535,37 @@ TEST_F(VectorizedCaseExprTest, whenIntCaseAllNullElse) {
     expr_node.case_expr.has_case_expr = true;
     expr_node.case_expr.has_else_expr = true;
 
-    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node));
+    std::vector<std::unique_ptr<Expr>> exprs;
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node));
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_ARRAY, TYPE_ARRAY));
 
-    MockVectorizedExpr<TYPE_INT> case1(expr_node, 10, 1);
-    MockNullVectorizedExpr<TYPE_INT> when2(expr_node, 10, 2);
-    MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
-    MockNullVectorizedExpr<TYPE_INT> when3(expr_node, 10, 1);
-    MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 20);
-    MockVectorizedExpr<TYPE_INT> else1(expr_node, 10, 30);
+    for (auto& expr : exprs) {
+        MockVectorizedExpr<TYPE_INT> case1(expr_node, 10, 1);
+        MockNullVectorizedExpr<TYPE_INT> when2(expr_node, 10, 2);
+        MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
+        MockNullVectorizedExpr<TYPE_INT> when3(expr_node, 10, 1);
+        MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 20);
+        MockVectorizedExpr<TYPE_INT> else1(expr_node, 10, 30);
 
-    when2.only_null = true;
-    when3.only_null = true;
+        when2.only_null = true;
+        when3.only_null = true;
 
-    expr->_children.push_back(&case1);
-    expr->_children.push_back(&when2);
-    expr->_children.push_back(&then2);
-    expr->_children.push_back(&when3);
-    expr->_children.push_back(&then3);
-    expr->_children.push_back(&else1);
+        expr->_children.push_back(&case1);
+        expr->_children.push_back(&when2);
+        expr->_children.push_back(&then2);
+        expr->_children.push_back(&when3);
+        expr->_children.push_back(&then3);
+        expr->_children.push_back(&else1);
 
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_numeric());
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_numeric());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_INT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            ASSERT_EQ(30, v->get_data()[j]);
+            auto v = ColumnHelper::cast_to_raw<TYPE_INT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                ASSERT_EQ(30, v->get_data()[j]);
+            }
         }
     }
 }
@@ -477,26 +576,30 @@ TEST_F(VectorizedCaseExprTest, NoCaseReturnInt) {
     expr_node.case_expr.has_case_expr = false;
     expr_node.case_expr.has_else_expr = false;
 
-    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node));
+    std::vector<std::unique_ptr<Expr>> exprs;
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node));
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_ARRAY, TYPE_ARRAY));
 
-    MockVectorizedExpr<TYPE_BOOLEAN> when2(expr_node, 10, true);
-    MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
-    MockVectorizedExpr<TYPE_BOOLEAN> when3(expr_node, 10, false);
-    MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 20);
+    for (auto& expr : exprs) {
+        MockVectorizedExpr<TYPE_BOOLEAN> when2(expr_node, 10, true);
+        MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
+        MockVectorizedExpr<TYPE_BOOLEAN> when3(expr_node, 10, false);
+        MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 20);
 
-    expr->_children.push_back(&when2);
-    expr->_children.push_back(&then2);
-    expr->_children.push_back(&when3);
-    expr->_children.push_back(&then3);
+        expr->_children.push_back(&when2);
+        expr->_children.push_back(&then2);
+        expr->_children.push_back(&when3);
+        expr->_children.push_back(&then3);
 
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_numeric());
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_numeric());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_INT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            ASSERT_EQ(10, v->get_data()[j]);
+            auto v = ColumnHelper::cast_to_raw<TYPE_INT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                ASSERT_EQ(10, v->get_data()[j]);
+            }
         }
     }
 }
@@ -507,25 +610,29 @@ TEST_F(VectorizedCaseExprTest, NoCaseAllNull) {
     expr_node.case_expr.has_case_expr = false;
     expr_node.case_expr.has_else_expr = false;
 
-    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node));
+    std::vector<std::unique_ptr<Expr>> exprs;
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node));
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_ARRAY, TYPE_ARRAY));
 
-    MockNullVectorizedExpr<TYPE_BOOLEAN> when2(expr_node, 10, true);
-    MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
-    MockNullVectorizedExpr<TYPE_BOOLEAN> when3(expr_node, 10, false);
-    MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 20);
+    for (auto& expr : exprs) {
+        MockNullVectorizedExpr<TYPE_BOOLEAN> when2(expr_node, 10, true);
+        MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
+        MockNullVectorizedExpr<TYPE_BOOLEAN> when3(expr_node, 10, false);
+        MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 20);
 
-    when2.only_null = true;
-    when3.only_null = true;
+        when2.only_null = true;
+        when3.only_null = true;
 
-    expr->_children.push_back(&when2);
-    expr->_children.push_back(&then2);
-    expr->_children.push_back(&when3);
-    expr->_children.push_back(&then3);
+        expr->_children.push_back(&when2);
+        expr->_children.push_back(&then2);
+        expr->_children.push_back(&when3);
+        expr->_children.push_back(&then3);
 
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->only_null());
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->only_null());
+        }
     }
 }
 
@@ -535,31 +642,35 @@ TEST_F(VectorizedCaseExprTest, NoCaseWhenNullReturnIntElse) {
     expr_node.case_expr.has_case_expr = false;
     expr_node.case_expr.has_else_expr = true;
 
-    std::unique_ptr<Expr> expr(VectorizedCaseExprFactory::from_thrift(expr_node));
+    std::vector<std::unique_ptr<Expr>> exprs;
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node));
+    exprs.emplace_back(VectorizedCaseExprFactory::from_thrift(expr_node, TYPE_ARRAY, TYPE_ARRAY));
 
-    MockNullVectorizedExpr<TYPE_BOOLEAN> when2(expr_node, 10, true);
-    MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
-    MockVectorizedExpr<TYPE_BOOLEAN> when3(expr_node, 10, false);
-    MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 20);
-    MockVectorizedExpr<TYPE_INT> else1(expr_node, 10, 30);
+    for (auto& expr : exprs) {
+        MockNullVectorizedExpr<TYPE_BOOLEAN> when2(expr_node, 10, true);
+        MockVectorizedExpr<TYPE_INT> then2(expr_node, 10, 10);
+        MockVectorizedExpr<TYPE_BOOLEAN> when3(expr_node, 10, false);
+        MockVectorizedExpr<TYPE_INT> then3(expr_node, 10, 20);
+        MockVectorizedExpr<TYPE_INT> else1(expr_node, 10, 30);
 
-    expr->_children.push_back(&when2);
-    expr->_children.push_back(&then2);
-    expr->_children.push_back(&when3);
-    expr->_children.push_back(&then3);
-    expr->_children.push_back(&else1);
+        expr->_children.push_back(&when2);
+        expr->_children.push_back(&then2);
+        expr->_children.push_back(&when3);
+        expr->_children.push_back(&then3);
+        expr->_children.push_back(&else1);
 
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_numeric());
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_numeric());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_INT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            if (j % 2) {
-                ASSERT_EQ(30, v->get_data()[j]);
-            } else {
-                ASSERT_EQ(10, v->get_data()[j]);
+            auto v = ColumnHelper::cast_to_raw<TYPE_INT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                if (j % 2) {
+                    ASSERT_EQ(30, v->get_data()[j]);
+                } else {
+                    ASSERT_EQ(10, v->get_data()[j]);
+                }
             }
         }
     }

--- a/be/test/exprs/coalesce_expr_test.cpp
+++ b/be/test/exprs/coalesce_expr_test.cpp
@@ -33,95 +33,155 @@ public:
         expr_node.__isset.opcode = true;
         expr_node.__isset.child_type = true;
         expr_node.type = gen_type_desc(TPrimitiveType::BIGINT);
+        tttype_desc.push_back(expr_node.type);
+
+        TTypeDesc ttype_desc;
+        ttype_desc.__isset.types = true;
+        ttype_desc.types.emplace_back();
+        ttype_desc.types.back().__set_type(TTypeNodeType::ARRAY);
+        ttype_desc.types.emplace_back();
+        ttype_desc.types.back().__set_type(TTypeNodeType::SCALAR);
+        ttype_desc.types.back().__set_scalar_type(TScalarType());
+        ttype_desc.types.back().scalar_type.__set_type(TPrimitiveType::VARCHAR);
+        ttype_desc.types.back().scalar_type.__set_len(10);
+        tttype_desc.push_back(ttype_desc);
     }
 
-public:
+private:
+    std::vector<TTypeDesc> tttype_desc;
     TExprNode expr_node;
 };
 
-TEST_F(VectorizedCoalesceExprTest, coalesceAllNotNull) {
+TEST_F(VectorizedCoalesceExprTest, coalesceArray) {
+    expr_node.type = tttype_desc[1];
     auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_coalesce_expr(expr_node));
 
-    MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+    TypeDescriptor type_arr_int = array_type(TYPE_INT);
+    auto array0 = ColumnHelper::create_column(type_arr_int, true);
+    array0->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
+    array0->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
+    array0->append_datum(Datum{});                                          // NULL
+    auto array_expr0 = MockExpr(type_arr_int, array0);
 
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
+    auto array1 = ColumnHelper::create_column(type_arr_int, false);
+    array1->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)41)}); // [11,41]
+    array1->append_datum(DatumArray{Datum(), Datum()});                       // [NULL, NULL]
+    array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});             // [NULL, 1]
+    auto array_expr1 = MockExpr(type_arr_int, array1);
+
+    expr->_children.push_back(&array_expr0);
+    expr->_children.push_back(&array_expr1);
+
     {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_numeric());
+        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+        if (ptr->is_nullable()) {
+            ptr = down_cast<NullableColumn*>(ptr.get())->data_column();
+        }
+        ASSERT_TRUE(ptr->is_array());
+        ASSERT_TRUE(array0->equals(0, *ptr, 0));
+        ASSERT_TRUE(array0->equals(1, *ptr, 1));
+        ASSERT_TRUE(array1->equals(2, *ptr, 2));
+    }
+}
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            ASSERT_EQ(10, v->get_data()[j]);
+TEST_F(VectorizedCoalesceExprTest, coalesceAllNotNull) {
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_coalesce_expr(expr_node));
+
+        MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_numeric());
+
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                ASSERT_EQ(10, v->get_data()[j]);
+            }
         }
     }
 }
 
 TEST_F(VectorizedCoalesceExprTest, coalesceAllNull) {
-    auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_coalesce_expr(expr_node));
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_coalesce_expr(expr_node));
 
-    MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+        MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
 
-    col1.all_null = true;
-    col2.all_null = true;
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->only_null());
+        col1.all_null = true;
+        col2.all_null = true;
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->only_null());
+        }
     }
 }
 
 TEST_F(VectorizedCoalesceExprTest, coalesceNull) {
-    auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_coalesce_expr(expr_node));
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_coalesce_expr(expr_node));
 
-    MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+        MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
 
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_numeric());
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            if(ptr->is_nullable()) {
+                ptr = down_cast<NullableColumn*>(ptr.get())->data_column();
+            }
+            ASSERT_TRUE(ptr->is_numeric());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            if (j % 2 == 0) {
-                ASSERT_EQ(10, v->get_data()[j]);
-            } else {
-                ASSERT_EQ(20, v->get_data()[j]);
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                if (j % 2 == 0) {
+                    ASSERT_EQ(10, v->get_data()[j]);
+                } else {
+                    ASSERT_EQ(20, v->get_data()[j]);
+                }
             }
         }
     }
 }
 
 TEST_F(VectorizedCoalesceExprTest, coalesceSameNull) {
-    auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_coalesce_expr(expr_node));
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_coalesce_expr(expr_node));
 
-    MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+        MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
 
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_nullable());
-        ASSERT_FALSE(ptr->is_numeric());
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_nullable());
+            ASSERT_FALSE(ptr->is_numeric());
 
-        auto v =
-                ColumnHelper::cast_to_raw<TYPE_BIGINT>(ColumnHelper::as_raw_column<NullableColumn>(ptr)->data_column());
-        for (int j = 0; j < ptr->size(); ++j) {
-            if (j % 2 == 0) {
-                ASSERT_FALSE(ptr->is_null(j));
-                ASSERT_EQ(10, v->get_data()[j]);
-            } else {
-                ASSERT_TRUE(ptr->is_null(j));
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(
+                    ColumnHelper::as_raw_column<NullableColumn>(ptr)->data_column());
+            for (int j = 0; j < ptr->size(); ++j) {
+                if (j % 2 == 0) {
+                    ASSERT_FALSE(ptr->is_null(j));
+                    ASSERT_EQ(10, v->get_data()[j]);
+                } else {
+                    ASSERT_TRUE(ptr->is_null(j));
+                }
             }
         }
     }

--- a/be/test/exprs/condition_expr_test.cpp
+++ b/be/test/exprs/condition_expr_test.cpp
@@ -41,95 +41,155 @@ public:
         expr_node.__isset.opcode = true;
         expr_node.__isset.child_type = true;
         expr_node.type = gen_type_desc(TPrimitiveType::BIGINT);
+        tttype_desc.push_back(expr_node.type);
+
+        TTypeDesc ttype_desc;
+        ttype_desc.__isset.types = true;
+        ttype_desc.types.emplace_back();
+        ttype_desc.types.back().__set_type(TTypeNodeType::ARRAY);
+        ttype_desc.types.emplace_back();
+        ttype_desc.types.back().__set_type(TTypeNodeType::SCALAR);
+        ttype_desc.types.back().__set_scalar_type(TScalarType());
+        ttype_desc.types.back().scalar_type.__set_type(TPrimitiveType::VARCHAR);
+        ttype_desc.types.back().scalar_type.__set_len(10);
+        tttype_desc.push_back(ttype_desc);
     }
 
-public:
+private:
+    std::vector<TTypeDesc> tttype_desc;
     TExprNode expr_node;
 };
 
-TEST_F(VectorizedConditionExprTest, ifNullLNotNull) {
+TEST_F(VectorizedConditionExprTest, ifNullLArray) {
+    expr_node.type = tttype_desc[1];
     auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_null_expr(expr_node));
+    TypeDescriptor type_arr_int = array_type(TYPE_INT);
 
-    MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+    auto array0 = ColumnHelper::create_column(type_arr_int, true);
+    array0->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
+    array0->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
+    array0->append_datum(Datum{});                                          // NULL
+    auto array_expr0 = MockExpr(type_arr_int, array0);
 
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
+    auto array1 = ColumnHelper::create_column(type_arr_int, false);
+    array1->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)41)}); // [11,41]
+    array1->append_datum(DatumArray{Datum(), Datum()});                       // [NULL, NULL]
+    array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});             // [NULL, 1]
+    auto array_expr1 = MockExpr(type_arr_int, array1);
+
+    expr->_children.push_back(&array_expr0);
+    expr->_children.push_back(&array_expr1);
+
     {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
-        ASSERT_TRUE(ptr->is_numeric());
+        if (ptr->is_nullable()) {
+            ptr = down_cast<NullableColumn*>(ptr.get())->data_column();
+        }
+        ASSERT_TRUE(ptr->is_array());
+        ASSERT_TRUE(array0->equals(0, *ptr, 0));
+        ASSERT_TRUE(array0->equals(1, *ptr, 1));
+        ASSERT_TRUE(array1->equals(2, *ptr, 2));
+    }
+}
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            ASSERT_EQ(10, v->get_data()[j]);
+TEST_F(VectorizedConditionExprTest, ifNullLNotNull) {
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_null_expr(expr_node));
+
+        MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+            ASSERT_TRUE(ptr->is_numeric());
+
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                ASSERT_EQ(10, v->get_data()[j]);
+            }
         }
     }
 }
 
 TEST_F(VectorizedConditionExprTest, ifNullLAllNull) {
-    auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_null_expr(expr_node));
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_null_expr(expr_node));
 
-    MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+        MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
 
-    col1.all_null = true;
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
-    {
-        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
-        ASSERT_TRUE(ptr->is_numeric());
+        col1.all_null = true;
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+            ASSERT_TRUE(ptr->is_numeric());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            ASSERT_EQ(20, v->get_data()[j]);
-        }
-    }
-}
-
-TEST_F(VectorizedConditionExprTest, ifNull) {
-    auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_null_expr(expr_node));
-
-    MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
-
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
-    {
-        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
-        ASSERT_TRUE(ptr->is_numeric());
-
-        auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            if (j % 2 == 0) {
-                ASSERT_EQ(10, v->get_data()[j]);
-            } else {
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
                 ASSERT_EQ(20, v->get_data()[j]);
             }
         }
     }
 }
 
+TEST_F(VectorizedConditionExprTest, ifNull) {
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_null_expr(expr_node));
+
+        MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+            if (ptr->is_nullable()) {
+                ptr = down_cast<NullableColumn*>(ptr.get())->data_column();
+            }
+            ASSERT_TRUE(ptr->is_numeric());
+
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                if (j % 2 == 0) {
+                    ASSERT_EQ(10, v->get_data()[j]);
+                } else {
+                    ASSERT_EQ(20, v->get_data()[j]);
+                }
+            }
+        }
+    }
+}
+
 TEST_F(VectorizedConditionExprTest, ifNullNull) {
-    auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_null_expr(expr_node));
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_null_expr(expr_node));
 
-    MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+        MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
 
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
-    {
-        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
-        ASSERT_TRUE(ptr->is_nullable());
-        ASSERT_FALSE(ptr->is_numeric());
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+            ASSERT_TRUE(ptr->is_nullable());
+            ASSERT_FALSE(ptr->is_numeric());
 
-        auto v =
-                ColumnHelper::cast_to_raw<TYPE_BIGINT>(ColumnHelper::as_raw_column<NullableColumn>(ptr)->data_column());
-        for (int j = 0; j < ptr->size(); ++j) {
-            if (j % 2 == 0) {
-                ASSERT_EQ(10, v->get_data()[j]);
-            } else {
-                ASSERT_TRUE(ptr->is_null(j));
-                ASSERT_EQ(20, v->get_data()[j]);
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(
+                    ColumnHelper::as_raw_column<NullableColumn>(ptr)->data_column());
+            for (int j = 0; j < ptr->size(); ++j) {
+                if (j % 2 == 0) {
+                    ASSERT_EQ(10, v->get_data()[j]);
+                } else {
+                    ASSERT_TRUE(ptr->is_null(j));
+                    ASSERT_EQ(20, v->get_data()[j]);
+                }
             }
         }
     }
@@ -209,6 +269,28 @@ TEST_F(VectorizedConditionExprTest, ifExpr) {
     for (int i = 0; i < res_col0->size(); ++i) {
         auto result = select_col.get_data()[i] ? col1.get_data()[i] : col2.get_data()[i];
         ASSERT_EQ(result, res_col0->get_data()[i]);
+    }
+
+    // Test fake Array works
+    {
+        expr_node.type = tttype_desc[1];
+        auto expr0 = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
+        RandomValueExpr<TYPE_INT> col1(expr_node, chunk_size, e);
+        RandomValueExpr<TYPE_INT> col2(expr_node, chunk_size, e);
+
+        expr0->_children.push_back(&select_col);
+        expr0->_children.push_back(&col1);
+        expr0->_children.push_back(&col2);
+
+        ColumnPtr ptr = expr0->evaluate(nullptr, nullptr);
+        if(ptr->is_nullable()) {
+            ptr = down_cast<NullableColumn*>(ptr.get())->data_column();
+        }
+        auto* res_col0 = down_cast<Int32Column*>(ptr.get());
+        for (int i = 0; i < res_col0->size(); ++i) {
+            auto result = select_col.get_data()[i] ? col1.get_data()[i] : col2.get_data()[i];
+            ASSERT_EQ(result, res_col0->get_data()[i]);
+        }
     }
 
     // Test FLOAT

--- a/be/test/exprs/if_expr_test.cpp
+++ b/be/test/exprs/if_expr_test.cpp
@@ -32,80 +32,143 @@ public:
         expr_node.__isset.opcode = true;
         expr_node.__isset.child_type = true;
         expr_node.type = gen_type_desc(TPrimitiveType::BIGINT);
+        tttype_desc.push_back(expr_node.type);
+
+        TTypeDesc ttype_desc;
+        ttype_desc.__isset.types = true;
+        ttype_desc.types.emplace_back();
+        ttype_desc.types.back().__set_type(TTypeNodeType::ARRAY);
+        ttype_desc.types.emplace_back();
+        ttype_desc.types.back().__set_type(TTypeNodeType::SCALAR);
+        ttype_desc.types.back().__set_scalar_type(TScalarType());
+        ttype_desc.types.back().scalar_type.__set_type(TPrimitiveType::VARCHAR);
+        ttype_desc.types.back().scalar_type.__set_len(10);
+        tttype_desc.push_back(ttype_desc);
     }
 
-public:
+private:
+    std::vector<TTypeDesc> tttype_desc;
     TExprNode expr_node;
 };
 
-TEST_F(VectorizedIfExprTest, ifConstTrue) {
+TEST_F(VectorizedIfExprTest, ifArray) {
+    expr_node.type = tttype_desc[1];
     auto expr = VectorizedConditionExprFactory::create_if_expr(expr_node);
     std::unique_ptr<Expr> expr_ptr(expr);
 
-    MockConstVectorizedExpr<TYPE_BOOLEAN> bol(expr_node, true);
-    MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+    auto target = ColumnHelper::create_column(TypeDescriptor(TYPE_BOOLEAN), false);
+    target->append_datum(Datum{(int8_t)0});
+    target->append_datum(Datum{(int8_t)1});
+    target->append_datum(Datum{(int8_t)0});
+    auto cond = MockExpr(TypeDescriptor(TYPE_BOOLEAN), target);
 
-    expr->_children.push_back(&bol);
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
+    TypeDescriptor type_arr_int = array_type(TYPE_INT);
+
+    auto array0 = ColumnHelper::create_column(type_arr_int, true);
+    array0->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
+    array0->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
+    array0->append_datum(DatumArray{Datum(), Datum((int32_t)12)});          // [NULL, 12]
+    auto array_expr0 = MockExpr(type_arr_int, array0);
+
+    auto array1 = ColumnHelper::create_column(type_arr_int, false);
+    array1->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)41)}); // [11,41]
+    array1->append_datum(DatumArray{Datum(), Datum()});                       // [NULL, NULL]
+    array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});             // [NULL, 1]
+    auto array_expr1 = MockExpr(type_arr_int, array1);
+
+    expr->_children.push_back(&cond);
+    expr->_children.push_back(&array_expr0);
+    expr->_children.push_back(&array_expr1);
+
     {
         ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
-        ASSERT_TRUE(ptr->is_numeric());
+        if(ptr->is_nullable()) {
+            ptr = down_cast<NullableColumn*>(ptr.get())->data_column();
+        }
+        ASSERT_TRUE(ptr->is_array());
+        ASSERT_TRUE(array1->equals(0, *ptr, 0));
+        ASSERT_TRUE(array0->equals(1, *ptr, 1));
+        ASSERT_TRUE(array1->equals(2, *ptr, 2));
+    }
+}
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            ASSERT_EQ(10, v->get_data()[j]);
+TEST_F(VectorizedIfExprTest, ifConstTrue) {
+    for(auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = VectorizedConditionExprFactory::create_if_expr(expr_node);
+        std::unique_ptr<Expr> expr_ptr(expr);
+
+        MockConstVectorizedExpr<TYPE_BOOLEAN> bol(expr_node, true);
+        MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+
+        expr->_children.push_back(&bol);
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+            ASSERT_TRUE(ptr->is_numeric());
+
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                ASSERT_EQ(10, v->get_data()[j]);
+            }
         }
     }
 }
 
 TEST_F(VectorizedIfExprTest, ifAllFalse) {
-    auto expr = VectorizedConditionExprFactory::create_if_expr(expr_node);
-    std::unique_ptr<Expr> expr_ptr(expr);
+    for(auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = VectorizedConditionExprFactory::create_if_expr(expr_node);
+        std::unique_ptr<Expr> expr_ptr(expr);
 
-    MockVectorizedExpr<TYPE_BOOLEAN> bol(expr_node, 10, false);
-    MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+        MockVectorizedExpr<TYPE_BOOLEAN> bol(expr_node, 10, false);
+        MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
 
-    expr->_children.push_back(&bol);
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
-    {
-        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
-        ASSERT_TRUE(ptr->is_numeric());
+        expr->_children.push_back(&bol);
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+            ASSERT_TRUE(ptr->is_numeric());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            ASSERT_EQ(20, v->get_data()[j]);
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                ASSERT_EQ(20, v->get_data()[j]);
+            }
         }
     }
 }
 
 TEST_F(VectorizedIfExprTest, ifNull) {
-    auto expr = VectorizedConditionExprFactory::create_if_expr(expr_node);
-    std::unique_ptr<Expr> expr_ptr(expr);
+    for(auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = VectorizedConditionExprFactory::create_if_expr(expr_node);
+        std::unique_ptr<Expr> expr_ptr(expr);
 
-    MockMultiVectorizedExpr<TYPE_BOOLEAN> bol(expr_node, 10, true, false);
-    MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+        MockMultiVectorizedExpr<TYPE_BOOLEAN> bol(expr_node, 10, true, false);
+        MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
 
-    expr->_children.push_back(&bol);
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
-    {
-        ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
-        ASSERT_TRUE(ptr->is_nullable());
-        ASSERT_FALSE(ptr->is_numeric());
+        expr->_children.push_back(&bol);
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+            ASSERT_TRUE(ptr->is_nullable());
+            ASSERT_FALSE(ptr->is_numeric());
 
-        auto v =
-                ColumnHelper::cast_to_raw<TYPE_BIGINT>(ColumnHelper::as_raw_column<NullableColumn>(ptr)->data_column());
-        for (int j = 0; j < ptr->size(); ++j) {
-            if (j % 2 == 0) {
-                ASSERT_FALSE(ptr->is_null(j));
-                ASSERT_EQ(10, v->get_data()[j]);
-            } else {
-                ASSERT_TRUE(ptr->is_null(j));
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(
+                    ColumnHelper::as_raw_column<NullableColumn>(ptr)->data_column());
+            for (int j = 0; j < ptr->size(); ++j) {
+                if (j % 2 == 0) {
+                    ASSERT_FALSE(ptr->is_null(j));
+                    ASSERT_EQ(10, v->get_data()[j]);
+                } else {
+                    ASSERT_TRUE(ptr->is_null(j));
+                }
             }
         }
     }

--- a/be/test/exprs/lambda_array_expr_test.cpp
+++ b/be/test/exprs/lambda_array_expr_test.cpp
@@ -245,15 +245,6 @@ std::vector<Expr*> VectorizedLambdaFunctionExprTest::create_lambda_expr(ObjectPo
     return lambda_funcs;
 }
 
-TypeDescriptor array_type(const LogicalType& child_type) {
-    TypeDescriptor t;
-    t.type = TYPE_ARRAY;
-    t.children.resize(1);
-    t.children[0].type = child_type;
-    t.children[0].len = child_type == TYPE_VARCHAR ? 10 : child_type == TYPE_CHAR ? 10 : -1;
-    return t;
-}
-
 // just consider one level, not nested
 // array_map(lambdaFunction(x<type>, lambdaExpr),array<type>)
 TEST_F(VectorizedLambdaFunctionExprTest, array_map_lambda_test_normal_array) {

--- a/be/test/exprs/map_functions_test.cpp
+++ b/be/test/exprs/map_functions_test.cpp
@@ -18,17 +18,17 @@
 
 #include "column/column_helper.h"
 #include "column/map_column.h"
+#include "exprs/mock_vectorized_expr.h"
 #include "testutil/parallel_test.h"
 
 namespace starrocks {
 
-TypeDescriptor create_array_type(const LogicalType& child_type) {
-    TypeDescriptor t;
-    t.type = TYPE_ARRAY;
-    t.children.resize(1);
-    t.children[0].type = child_type;
-    t.children[0].len = child_type == TYPE_VARCHAR ? 10 : child_type == TYPE_CHAR ? 10 : -1;
-    return t;
+TypeDescriptor map_type(LogicalType key, LogicalType value) {
+    TypeDescriptor type_creator;
+    type_creator.type = LogicalType::TYPE_MAP;
+    type_creator.children.emplace_back(TypeDescriptor(key));
+    type_creator.children.emplace_back(TypeDescriptor(value));
+    return type_creator;
 }
 
 PARALLEL_TEST(MapFunctionsTest, test_map) {
@@ -189,10 +189,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_mismatch2) {
 }
 
 PARALLEL_TEST(MapFunctionsTest, test_map_function) {
-    TypeDescriptor type_map_int_int;
-    type_map_int_int.type = LogicalType::TYPE_MAP;
-    type_map_int_int.children.emplace_back(TypeDescriptor(LogicalType::TYPE_INT));
-    type_map_int_int.children.emplace_back(TypeDescriptor(LogicalType::TYPE_INT));
+    TypeDescriptor type_map_int_int = map_type(TYPE_INT, TYPE_INT);
 
     auto column = ColumnHelper::create_column(type_map_int_int, true);
 
@@ -329,10 +326,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_function) {
 }
 
 PARALLEL_TEST(MapFunctionsTest, test_map_filter_int_nullable) {
-    TypeDescriptor type_map_int_int;
-    type_map_int_int.type = LogicalType::TYPE_MAP;
-    type_map_int_int.children.emplace_back(TypeDescriptor(LogicalType::TYPE_INT));
-    type_map_int_int.children.emplace_back(TypeDescriptor(LogicalType::TYPE_INT));
+    TypeDescriptor type_map_int_int = map_type(TYPE_INT, TYPE_INT);
 
     auto map_column_nullable = ColumnHelper::create_column(type_map_int_int, true);
     {
@@ -389,7 +383,7 @@ PARALLEL_TEST(MapFunctionsTest, test_map_filter_int_nullable) {
         map_column_not_nullable->append_datum(DatumMap());
     }
 
-    TypeDescriptor TYPE_ARRAY_BOOLEAN = create_array_type(TYPE_BOOLEAN);
+    TypeDescriptor TYPE_ARRAY_BOOLEAN = array_type(TYPE_BOOLEAN);
 
     // [null, true, false]
     // []
@@ -565,10 +559,7 @@ PARALLEL_TEST(MapFunctionsTest, test_distinct_map_keys) {
 }
 
 PARALLEL_TEST(MapFunctionsTest, test_map_concat) {
-    TypeDescriptor type_map_int_int;
-    type_map_int_int.type = LogicalType::TYPE_MAP;
-    type_map_int_int.children.emplace_back(TypeDescriptor(LogicalType::TYPE_INT));
-    type_map_int_int.children.emplace_back(TypeDescriptor(LogicalType::TYPE_INT));
+    TypeDescriptor type_map_int_int = map_type(TYPE_INT, TYPE_INT);
 
     auto map_column_nullable = ColumnHelper::create_column(type_map_int_int, true);
     {

--- a/be/test/exprs/mock_vectorized_expr.h
+++ b/be/test/exprs/mock_vectorized_expr.h
@@ -26,9 +26,18 @@
 #include "glog/logging.h"
 
 namespace starrocks {
+
+
+TypeDescriptor array_type(const TypeDescriptor& child_type);
+
+TypeDescriptor array_type(const LogicalType& child_type);
+
+TypeDescriptor map_type(LogicalType key, LogicalType value);
+
 class MockExpr : public starrocks::Expr {
 public:
     explicit MockExpr(const TExprNode& dummy, ColumnPtr result) : Expr(dummy), _column(std::move(result)) {}
+    explicit MockExpr(TypeDescriptor type, ColumnPtr col): Expr(std::move(type), false), _column(std::move(col)) {}
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext*, Chunk*) override { return _column; }
 

--- a/be/test/exprs/null_if_expr_test.cpp
+++ b/be/test/exprs/null_if_expr_test.cpp
@@ -33,95 +33,156 @@ public:
         expr_node.__isset.opcode = true;
         expr_node.__isset.child_type = true;
         expr_node.type = gen_type_desc(TPrimitiveType::BIGINT);
+        tttype_desc.push_back(expr_node.type);
+
+        TTypeDesc ttype_desc;
+        ttype_desc.__isset.types = true;
+        ttype_desc.types.emplace_back();
+        ttype_desc.types.back().__set_type(TTypeNodeType::ARRAY);
+        ttype_desc.types.emplace_back();
+        ttype_desc.types.back().__set_type(TTypeNodeType::SCALAR);
+        ttype_desc.types.back().__set_scalar_type(TScalarType());
+        ttype_desc.types.back().scalar_type.__set_type(TPrimitiveType::VARCHAR);
+        ttype_desc.types.back().scalar_type.__set_len(10);
+        tttype_desc.push_back(ttype_desc);
     }
 
-public:
+private:
+    std::vector<TTypeDesc> tttype_desc;
     TExprNode expr_node;
 };
 
-TEST_F(VectorizedNullIfExprTest, nullIfEquals) {
+TEST_F(VectorizedNullIfExprTest, nullIfArray) {
+    expr_node.type = tttype_desc[1];
     auto expr = VectorizedConditionExprFactory::create_null_if_expr(expr_node);
     std::unique_ptr<Expr> expr_ptr(expr);
 
-    MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 10);
+    TypeDescriptor type_arr_int = array_type(TYPE_INT);
 
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
+    auto array0 = ColumnHelper::create_column(type_arr_int, true);
+    array0->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
+    array0->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
+    array0->append_datum(DatumArray{Datum(), Datum((int32_t)12)});          // [NULL, 12]
+    auto array_expr0 = MockExpr(type_arr_int, array0);
+
+    auto array1 = ColumnHelper::create_column(type_arr_int, false);
+    array1->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)41)}); // [11,41]
+    array1->append_datum(DatumArray{Datum(), Datum()});                       // [NULL, NULL]
+    array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});             // [NULL, 1]
+    auto array_expr1 = MockExpr(type_arr_int, array1);
+
+    expr->_children.push_back(&array_expr0);
+    expr->_children.push_back(&array_expr1);
+
     {
         Chunk chunk;
         ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
         ASSERT_TRUE(ptr->is_nullable());
 
-        for (int j = 0; j < ptr->size(); ++j) {
-            ASSERT_TRUE(ptr->is_null(j));
+        ASSERT_TRUE(!ptr->is_null(0));
+        ASSERT_TRUE(ptr->is_null(1));
+        ASSERT_TRUE(!ptr->is_null(2));
+    }
+}
+
+TEST_F(VectorizedNullIfExprTest, nullIfEquals) {
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = VectorizedConditionExprFactory::create_null_if_expr(expr_node);
+        std::unique_ptr<Expr> expr_ptr(expr);
+
+        MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 10);
+
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_nullable());
+
+            for (int j = 0; j < ptr->size(); ++j) {
+                ASSERT_TRUE(ptr->is_null(j));
+            }
         }
     }
 }
 
 TEST_F(VectorizedNullIfExprTest, nullIfAllFalse) {
-    auto expr = VectorizedConditionExprFactory::create_null_if_expr(expr_node);
-    std::unique_ptr<Expr> expr_ptr(expr);
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = VectorizedConditionExprFactory::create_null_if_expr(expr_node);
+        std::unique_ptr<Expr> expr_ptr(expr);
 
-    MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+        MockVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
 
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_numeric());
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            if (ptr->is_nullable()) {
+                ptr = down_cast<NullableColumn*>(ptr.get())->data_column();
+            }
+            ASSERT_TRUE(ptr->is_numeric());
 
-        auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
-        for (int j = 0; j < ptr->size(); ++j) {
-            ASSERT_EQ(10, v->get_data()[j]);
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                ASSERT_EQ(10, v->get_data()[j]);
+            }
         }
     }
 }
 
 TEST_F(VectorizedNullIfExprTest, nullIfLeftAllNull) {
-    auto expr = VectorizedConditionExprFactory::create_null_if_expr(expr_node);
-    std::unique_ptr<Expr> expr_ptr(expr);
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = VectorizedConditionExprFactory::create_null_if_expr(expr_node);
+        std::unique_ptr<Expr> expr_ptr(expr);
 
-    MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+        MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
 
-    col1.all_null = true;
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_nullable());
-        ASSERT_TRUE(ptr->only_null());
-        ASSERT_FALSE(ptr->is_numeric());
+        col1.all_null = true;
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_nullable());
+            ASSERT_TRUE(ptr->only_null());
+            ASSERT_FALSE(ptr->is_numeric());
+        }
     }
 }
 
 TEST_F(VectorizedNullIfExprTest, nullIfLeftNullRightNull) {
-    auto expr = VectorizedConditionExprFactory::create_null_if_expr(expr_node);
-    std::unique_ptr<Expr> expr_ptr(expr);
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = VectorizedConditionExprFactory::create_null_if_expr(expr_node);
+        std::unique_ptr<Expr> expr_ptr(expr);
 
-    MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
-    MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+        MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
 
-    expr->_children.push_back(&col1);
-    expr->_children.push_back(&col2);
-    {
-        Chunk chunk;
-        ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
-        ASSERT_TRUE(ptr->is_nullable());
-        ASSERT_FALSE(ptr->is_numeric());
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_nullable());
+            ASSERT_FALSE(ptr->is_numeric());
 
-        auto v =
-                ColumnHelper::cast_to_raw<TYPE_BIGINT>(ColumnHelper::as_raw_column<NullableColumn>(ptr)->data_column());
-        for (int j = 0; j < ptr->size(); ++j) {
-            if (j % 2 == 0) {
-                ASSERT_FALSE(ptr->is_null(j));
-                ASSERT_EQ(10, v->get_data()[j]);
-            } else {
-                ASSERT_TRUE(ptr->is_null(j));
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(
+                    ColumnHelper::as_raw_column<NullableColumn>(ptr)->data_column());
+            for (int j = 0; j < ptr->size(); ++j) {
+                if (j % 2 == 0) {
+                    ASSERT_FALSE(ptr->is_null(j));
+                    ASSERT_EQ(10, v->get_data()[j]);
+                } else {
+                    ASSERT_TRUE(ptr->is_null(j));
+                }
             }
         }
     }

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -441,6 +441,7 @@
       + [to_binary](/sql-reference/sql-functions/binary-functions/to_binary.md)
       + [from_binary](/sql-reference/sql-functions/binary-functions/from_binary.md)
     + Conditional Functions
+      + [case_when](./sql-reference/sql-functions/condition-functions/case_when.md)
       + [coalesce](./sql-reference/sql-functions/condition-functions/coalesce.md)
       + [if](./sql-reference/sql-functions/condition-functions/if.md)
       + [ifnull](./sql-reference/sql-functions/condition-functions/ifnull.md)

--- a/docs/sql-reference/sql-functions/condition-functions/case_when.md
+++ b/docs/sql-reference/sql-functions/condition-functions/case_when.md
@@ -1,0 +1,71 @@
+# case_when
+
+## Description
+
+Return results from `then-clause` when the condition returns true in `when-clause`, otherwise from optional `else-clause` or NULL.
+
+## Syntax
+
+```SQL
+CASE WHEN condition1 THEN result1
+    [WHEN condition2 THEN result2]
+    ...
+    [WHEN conditionN THEN resultN]
+    [ELSE result]
+END
+```
+or
+```SQL
+CASE expression
+    WHEN expression1 THEN result1
+    [WHEN expression2 THEN result2]
+    ...
+    [WHEN expressionN THEN resultN]
+    [ELSE result]
+END
+```
+the second case equals to the first format as follows:
+
+```SQL
+CASE WHEN expression = expression1 THEN result1
+    [WHEN expression = expression2 THEN result2]
+    ...
+    [WHEN expression = expressionN THEN resultN]
+    [ELSE result]
+END
+```
+
+
+## Parameters
+
+`conditionN` should be compatible with bool type.
+
+`expressionN` are compatible in data type.
+
+`resultN` are compatible in data type.
+
+## Return value
+
+The return value is of the common type of all types from `then-clause`.
+
+## Examples
+
+```SQL
+mysql> select gender, case gender when 1 then 'male' when 0 then 'female' else 'error' end gender_str from test;
++---------+-------------+
+| gender  | gender_str  |
++---------+-------------+
+| 1       | male        |
+| 0       | female      |
+| -1      | error       |
++---------+-------------+
+ 
+mysql> select gender, case when gender = 1 then 'male' when gender = 0 then 'female' end gender_str from test;
++---------+-------------+
+| gender  | gender_str  |
++---------+-------------+
+| 1       | male        |
+| 0       | female      |
+| -1      | NULL        |
++---------+-------------+
+```

--- a/docs/sql-reference/sql-functions/condition-functions/coalesce.md
+++ b/docs/sql-reference/sql-functions/condition-functions/coalesce.md
@@ -12,9 +12,7 @@ coalesce(expr1,...);
 
 ## Parameters
 
-`expr1`: This expression must evaluate to any of the following data types: BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, LARGEINT, FLOAT, DOUBLE, DATETIME, DATE, DECIMALV2, DECIMAL32, DECIMAL64, DECIMAL128, VARCHAR, BITMAP, PERCENTILE, HLL, TIME.
-
-We recommend that you pass in expressions of the same type.
+input expressions must be compatible in data type.
 
 ## Return value
 

--- a/docs/sql-reference/sql-functions/condition-functions/if.md
+++ b/docs/sql-reference/sql-functions/condition-functions/if.md
@@ -14,11 +14,7 @@ if(expr1,expr2,expr3);
 
 `expr1`: the condition. It must be a BOOLEAN value.
 
-`expr2`: This value is returned if the condition is true. This expression must evaluate to any of the following data types: BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, LARGEINT, FLOAT, DOUBLE, DATETIME, DATE, DECIMALV2, DECIMAL32, DECIMAL64, DECIMAL128, VARCHAR, BITMAP, PERCENTILE, HLL, TIME.
-
-`expr3`: This value is returned if the condition is false. The data type is the same as `expr2`.
-
-> `expr2` and `expr3` must agree in data type.
+`expr2` and `expr3` must be compatible in data type.
 
 ## Return value
 

--- a/docs/sql-reference/sql-functions/condition-functions/ifnull.md
+++ b/docs/sql-reference/sql-functions/condition-functions/ifnull.md
@@ -12,11 +12,7 @@ ifnull(expr1,expr2);
 
 ## Parameters
 
-`expr1`: This expression must evaluate to any of the following data types: BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, LARGEINT, FLOAT, DOUBLE, DATETIME, DATE, DECIMALV2, DECIMAL32, DECIMAL64, DECIMAL128, VARCHAR, BITMAP, PERCENTILE, HLL, TIME.
-
-`expr2`: This expression must evaluate to any of the following data types: BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, LARGEINT, FLOAT, DOUBLE, DATETIME, DATE, DECIMALV2, DECIMAL32, DECIMAL64, DECIMAL128, VARCHAR, BITMAP, PERCENTILE, HLL, TIME.
-
-> `expr1` and `expr2` must agree in data type.
+`expr1` and `expr2` must be compatible in data type.
 
 ## Return value
 

--- a/docs/sql-reference/sql-functions/condition-functions/nullif.md
+++ b/docs/sql-reference/sql-functions/condition-functions/nullif.md
@@ -12,11 +12,7 @@ nullif(expr1,expr2);
 
 ## Parameters
 
-`expr1`: This expression must evaluate to any of the following data types: BOOLEAN, TINYINT, SMALLINT, INT, BIGINT, LARGEINT, FLOAT, DOUBLE, DATETIME, DATE, DECIMALV2, DECIMAL32, DECIMAL64, DECIMAL128, VARCHAR, BITMAP, PERCENTILE, HLL, TIME.
-
-`expr2`: An expression that evaluates to the same data type as `expr1`.
-
-> `expr1` and `expr2` must agree in data type.
+`expr1` and `expr2` must be compatible in data type.
 
 ## Return value
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1263,11 +1263,6 @@ public class ExpressionAnalyzer {
                 end--;
             }
 
-            // check is scalar type
-            if (node.getChildren().stream().anyMatch(d -> !d.getType().isScalarType())) {
-                throw new SemanticException("case-when only support scalar type", node.getPos());
-            }
-
             // check when type
             List<Type> whenTypes = Lists.newArrayList();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
@@ -179,11 +179,21 @@ public class PolymorphicFunctionAnalyzer {
         }
     }
 
-    private static class MapConcatDeduce implements java.util.function.Function<Type[], Type> {
+    private static class CommonDeduce implements java.util.function.Function<Type[], Type> {
         @Override
         public Type apply(Type[] types) {
             Type commonType = TypeManager.getCommonSuperType(Arrays.asList(types));
             Arrays.fill(types, commonType);
+            return commonType;
+        }
+    }
+
+    private static class IfDeduce implements java.util.function.Function<Type[], Type> {
+        @Override
+        public Type apply(Type[] types) {
+            Type commonType = TypeManager.getCommonSuperType(types[1], types[2]);
+            types[1] = commonType;
+            types[2] = commonType;
             return commonType;
         }
     }
@@ -204,7 +214,11 @@ public class PolymorphicFunctionAnalyzer {
             .put("map_apply", new MapApplyDeduce())
             .put("map_filter", new MapFilterDeduce())
             .put("distinct_map_keys", new DistinctMapKeysDeduce())
-            .put("map_concat", new MapConcatDeduce())
+            .put("map_concat", new CommonDeduce())
+            .put("if", new IfDeduce())
+            .put("ifnull", new CommonDeduce())
+            .put("nullif", new CommonDeduce())
+            .put("coalesce", new CommonDeduce())
             .build();
 
     private static Function resolveByDeducingReturnType(Function fn, Type[] inputArgTypes) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -197,7 +197,7 @@ public class TypeManager {
     public static Type getCompatibleType(List<Type> types, String kind) {
         Type compatibleType = types.get(0);
         for (int i = 1; i < types.size(); i++) {
-            compatibleType = Type.getAssignmentCompatibleType(compatibleType, types.get(i), false);
+            compatibleType = getCommonSuperType(compatibleType, types.get(i));
             if (!compatibleType.isValid()) {
                 throw new SemanticException("Failed to get compatible type for %s with %s and %s",
                         kind, types.get(i), types.get(i - 1));

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -475,6 +475,11 @@ vectorized_functions = [
     [70113, 'if', 'PERCENTILE', ['BOOLEAN', 'PERCENTILE', 'PERCENTILE'], 'nullptr'],
     [70114, 'if', 'HLL', ['BOOLEAN', 'HLL', 'HLL'], 'nullptr'],
     [70115, 'if', 'TIME', ['BOOLEAN', 'TIME', 'TIME'], 'nullptr'],
+    [70116, 'if', 'ANY_ARRAY', ['BOOLEAN', 'ANY_ARRAY', 'ANY_ARRAY'], 'nullptr'],
+    [70117, 'if', 'ANY_MAP', ['BOOLEAN', 'ANY_MAP', 'ANY_MAP'], 'nullptr'],
+    [70118, 'if', 'ANY_STRUCT', ['BOOLEAN', 'ANY_STRUCT', 'ANY_STRUCT'], 'nullptr'],
+    [70119, 'if', 'JSON', ['BOOLEAN', 'JSON', 'JSON'], 'nullptr'],
+
 
     [70200, 'ifnull', 'BOOLEAN', ['BOOLEAN', 'BOOLEAN'], 'nullptr'],
     [70201, 'ifnull', 'TINYINT', ['TINYINT', 'TINYINT'], 'nullptr'],
@@ -495,6 +500,10 @@ vectorized_functions = [
     [70213, 'ifnull', 'PERCENTILE', ['PERCENTILE', 'PERCENTILE'], 'nullptr'],
     [70214, 'ifnull', 'HLL', ['HLL', 'HLL'], 'nullptr'],
     [70215, 'ifnull', 'TIME', ['TIME', 'TIME'], 'nullptr'],
+    [70216, 'ifnull', 'ANY_ARRAY', ['ANY_ARRAY', 'ANY_ARRAY'], 'nullptr'],
+    [70217, 'ifnull', 'ANY_MAP', ['ANY_MAP', 'ANY_MAP'], 'nullptr'],
+    [70218, 'ifnull', 'ANY_STRUCT', ['ANY_STRUCT', 'ANY_STRUCT'], 'nullptr'],
+    [70219, 'ifnull', 'JSON', ['JSON', 'JSON'], 'nullptr'],
 
     [70300, 'nullif', 'BOOLEAN', ['BOOLEAN', 'BOOLEAN'], 'nullptr'],
     [70301, 'nullif', 'TINYINT', ['TINYINT', 'TINYINT'], 'nullptr'],
@@ -515,6 +524,10 @@ vectorized_functions = [
     [70313, 'nullif', 'PERCENTILE', ['PERCENTILE', 'PERCENTILE'], 'nullptr'],
     [70314, 'nullif', 'HLL', ['HLL', 'HLL'], 'nullptr'],
     [70315, 'nullif', 'TIME', ['TIME', 'TIME'], 'nullptr'],
+    [70316, 'nullif', 'ANY_ARRAY', ['ANY_ARRAY', 'ANY_ARRAY'], 'nullptr'],
+    [70317, 'nullif', 'ANY_MAP', ['ANY_MAP', 'ANY_MAP'], 'nullptr'],
+    [70318, 'nullif', 'ANY_STRUCT', ['ANY_STRUCT', 'ANY_STRUCT'], 'nullptr'],
+    [70319, 'nullif', 'JSON', ['JSON', 'JSON'], 'nullptr'],
 
     [70400, 'coalesce', 'BOOLEAN', ['BOOLEAN', '...'], 'nullptr'],
     [70401, 'coalesce', 'TINYINT', ['TINYINT', '...'], 'nullptr'],
@@ -535,6 +548,10 @@ vectorized_functions = [
     [70413, 'coalesce', 'PERCENTILE', ['PERCENTILE', '...'], 'nullptr'],
     [70414, 'coalesce', 'HLL', ['HLL', '...'], 'nullptr'],
     [70416, 'coalesce', 'TIME', ['TIME', '...'], 'nullptr'],
+    [70417, 'coalesce', 'ANY_ARRAY', ['ANY_ARRAY', '...'], 'nullptr'],
+    [70418, 'coalesce', 'ANY_MAP', ['ANY_MAP', '...'], 'nullptr'],
+    [70419, 'coalesce', 'ANY_STRUCT', ['ANY_STRUCT', '...'], 'nullptr'],
+    [70420, 'coalesce', 'JSON', ['JSON', '...'], 'nullptr'],
 
     [70415, 'esquery', 'BOOLEAN', ['VARCHAR', 'VARCHAR'], 'ESFunctions::match'],
 


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)

conditional expressions support array/map/struct/json types, including `if`, `ifnull`, `nullif`, `coalesc`, `case... when...`


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
