### PR TITLE
[BugFix] Fix percentile_approx cast const arg compatibility issue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -371,15 +371,9 @@ public class FunctionAnalyzer {
                         "percentile_approx requires the first parameter's type is numeric type");
             }
             if (!functionCallExpr.getChild(1).getType().isNumericType() ||
-                    !functionCallExpr.getChild(1).isLiteral()) {
+                    !functionCallExpr.getChild(1).isConstant()) {
                 throw new SemanticException(
                         "percentile_approx requires the second parameter's type is numeric constant type");
-            }
-
-            double rate = ((LiteralExpr) functionCallExpr.getChild(1)).getDoubleValue();
-            if (rate < 0 || rate > 1) {
-                throw new SemanticException(
-                        fnName + " second parameter'value must be between 0 and 1");
             }
 
             if (functionCallExpr.getChildren().size() == 3) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -227,10 +227,10 @@ public class AnalyzeAggregateTest {
         analyzeFail("select percentile_approx(0.5) from tall group by tb");
         analyzeFail("select percentile_approx('c',0.5) from tall group by tb");
         analyzeFail("select percentile_approx(1,'c') from tall group by tb");
-        analyzeFail("select percentile_approx(1,5) from tall group by tb");
         analyzeFail("select percentile_approx(1,1,'c') from tall group by tb");
         analyzeFail("select percentile_approx(1,1,tc) from tall group by tb");
         analyzeFail("select percentile_approx(1,1,0.5,tc) from tall group by tb");
+        analyzeSuccess("select percentile_approx(1,5) from tall group by tb");
         analyzeSuccess("select percentile_approx(1,0.5,1047) from tall group by tb");
         analyzeSuccess("select percentile_disc(tj,0.5) from tall group by tb");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2282,4 +2282,33 @@ public class AggregateTest extends PlanTestBase {
                 "  |  <slot 10> : 61\n" +
                 "  |  limit: 1");
     }
+
+    @Test
+    public void testPercentileFunctionConst() throws Exception {
+        // For compatibility
+        String sql = "select percentile_approx(1, cast(0.4 as DOUBLE));";
+        String plan = getCostExplain(sql);
+        assertContains(plan, "percentile_approx[(1.0, 0.4); args: DOUBLE,DOUBLE");
+
+        sql = "select percentile_approx(1, cast(1.3 as DOUBLE));";
+        expectedException.expect(SemanticException.class);
+        expectedException.expectMessage("Getting analyzing error. " +
+                "Detail message: percentile_approx second parameter'value must be between 0 and 1.");
+        getCostExplain(sql);
+        plan = getCostExplain(sql);
+
+
+        sql = "select percentile_cont(1, cast(0.4 as DOUBLE));";
+        expectedException.expect(SemanticException.class);
+        expectedException.expectMessage("Getting analyzing error. " +
+                "Detail message: percentile_cont 's second parameter's data type is wrong .");
+        getCostExplain(sql);
+
+
+        sql = "select PERCENTILE_DISC(1, cast(0.4 as DOUBLE));";
+        expectedException.expect(SemanticException.class);
+        expectedException.expectMessage("Getting analyzing error. " +
+                "Detail message: percentile_disc 's second parameter's data type is wrong .");
+        getCostExplain(sql);
+    }
 }


### PR DESCRIPTION
## Problem Summary:

```
MySQL [acdcf794f_3388_4b2b_a8a9_09a41e2558ed_21f01c43_3228_4650_b68e_b42e6fd86942_e671bcf0_2b4e_46f4_9f1c_19df25408b77]> select percentile_approx(1, cast(0.4 as DOUBLE));
ERROR 1064 (HY000): percentile_approx requires the second parameter's type is numeric constant type
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
