### PR TITLE
[Enhancement] Optimization the performance of to_bitmap

### DIFF
--- a/be/src/exprs/bitmap_functions.cpp
+++ b/be/src/exprs/bitmap_functions.cpp
@@ -74,8 +74,7 @@ StatusOr<ColumnPtr> BitmapFunctions::to_bitmap(FunctionContext* context, const s
             }
         }
 
-        BitmapValue bitmap;
-        bitmap.add(value);
+        BitmapValue bitmap(value);
 
         builder.append(&bitmap);
     }


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)

Before optimization

```
mysql> select count(to_bitmap(lo_orderkey)) from lineorder;
+-------------------------------+
| count(to_bitmap(lo_orderkey)) |
+-------------------------------+
|                     143999468 |
+-------------------------------+
1 row in set (2.38 sec)
```

after optimization

```
mysql> select count(to_bitmap(lo_orderkey)) from lineorder;
+-------------------------------+
| count(to_bitmap(lo_orderkey)) |
+-------------------------------+
|                     143999468 |
+-------------------------------+
1 row in set (2.02 sec)
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
