### PR TITLE
[BugFix] Fix FE start failed when replaying TxnCommitAttachment log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -288,7 +288,7 @@ public class GsonUtils {
 
     public static final RuntimeTypeAdapterFactory<TxnCommitAttachment> TXN_COMMIT_ATTACHMENT_TYPE_RUNTIME_ADAPTER_FACTORY =
             RuntimeTypeAdapterFactory.of(TxnCommitAttachment.class, "clazz")
-                    .registerSubtype(InsertTxnCommitAttachment.class, InsertTxnCommitAttachment.class.getSimpleName())
+                    .registerSubtype(InsertTxnCommitAttachment.class, InsertTxnCommitAttachment.class.getSimpleName(), true)
                     .registerSubtype(LoadJobFinalOperation.class, LoadJobFinalOperation.class.getSimpleName())
                     .registerSubtype(ManualLoadTxnCommitAttachment.class, ManualLoadTxnCommitAttachment.class.getSimpleName())
                     .registerSubtype(MiniLoadTxnCommitAttachment.class, MiniLoadTxnCommitAttachment.class.getSimpleName())


### PR DESCRIPTION
## Problem Summary:
Fixes #23830

Introduced by #23712

The persist format of InsertTxnCommitAttachment is json before this PR #23712, but when InsertTxnCommitAttachment is added to RuntimeTypeAdapterFactory, there must be a "clazz" key in the json string when deserializing. 
To fix this bug
1. We can set  InsertTxnCommitAttachment to default type, and the check of "clazz" key existence will be unnecessary. 
2. We can also change the AdapterFactory logic to that: do not check the "clazz" key existence when the class specified is just the subClass, but there should be large number of test cases to cover the change, we choose method 1 to fix the problem ASAP.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
