### PR TITLE
[BugFix] Protect parquet reader from dict code out of range

### DIFF
--- a/be/src/formats/parquet/encoding.h
+++ b/be/src/formats/parquet/encoding.h
@@ -80,6 +80,14 @@ public:
     virtual Status next_batch(size_t count, uint8_t* dst) {
         return Status::NotSupported("next_batch is not supported");
     }
+
+protected:
+    Status check_dict_index_in_bounds(size_t index, size_t dict_size) {
+        if (LIKELY(0 <= index && index < dict_size)) {
+            return Status::OK();
+        }
+        return Status::InternalError("Index not in dictionary bounds");
+    }
 };
 
 class EncodingInfo {

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -133,6 +133,7 @@ public:
         data_column->resize_uninitialized(cur_size + count);
         T* __restrict__ data = data_column->get_data().data() + cur_size;
         for (int i = 0; i < count; i++) {
+            RETURN_IF_ERROR(check_dict_index_in_bounds(_indexes[i], _dict.size()));
             data[i] = _dict[_indexes[i]];
         }
         return Status::OK();
@@ -247,6 +248,7 @@ public:
         case VALUE: {
             raw::stl_vector_resize_uninitialized(&_slices, count);
             for (int i = 0; i < count; ++i) {
+                RETURN_IF_ERROR(check_dict_index_in_bounds(_indexes[i], _dict.size()));
                 _slices[i] = _dict[_indexes[i]];
             }
             auto ret = dst->append_strings_overflow(_slices, _max_value_length);

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -2350,4 +2350,93 @@ TEST_F(FileReaderTest, TestLateMaterializationAboutOptionalComplexType) {
     EXPECT_EQ(1, total_row_nums);
 }
 
+TEST_F(FileReaderTest, CheckDictOutofBouds) {
+    const std::string filepath = "./be/test/exec/test_data/parquet_scanner/type_mismatch_decode_min_max.parquet";
+    auto file = _create_file(filepath);
+    auto file_reader =
+            std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(filepath));
+
+    // --------------init context---------------
+    auto ctx = _create_scan_context();
+
+    TypeDescriptor type_vin = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_log_domain = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_file_name = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_is_collection = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
+    TypeDescriptor type_is_center = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
+    TypeDescriptor type_is_cloud = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
+    TypeDescriptor type_collection_time = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_center_time = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_cloud_time = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_error_collection_tips = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_error_center_tips = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_error_cloud_tips = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_error_collection_time = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_error_center_time = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_error_cloud_time = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_original_time = TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR);
+    TypeDescriptor type_is_original = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
+
+    Utils::SlotDesc slot_descs[] = {
+            {"vin", type_vin},
+            {"type_log_domain", type_log_domain},
+            {"file_name", type_file_name},
+            {"is_collection", type_is_collection},
+            {"is_center", type_is_center},
+            {"is_cloud", type_is_cloud},
+            {"collection_time", type_collection_time},
+            {"center_time", type_center_time},
+            {"cloud_time", type_cloud_time},
+            {"error_collection_tips", type_error_collection_tips},
+            {"error_center_tips", type_error_center_tips},
+            {"error_cloud_tips", type_error_cloud_tips},
+            {"error_collection_time", type_error_collection_time},
+            {"error_center_time", type_error_center_time},
+            {"error_cloud_time", type_error_cloud_time},
+            {"original_time", type_original_time},
+            {"is_original", type_is_original},
+            {""},
+    };
+
+    ctx->tuple_desc = Utils::create_tuple_descriptor(_runtime_state, &_pool, slot_descs);
+    Utils::make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);
+    ctx->scan_ranges.emplace_back(_create_scan_range(filepath));
+
+    // --------------finish init context---------------
+
+    Status status = file_reader->init(ctx);
+    ASSERT_TRUE(status.ok());
+
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(ColumnHelper::create_column(type_vin, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_log_domain, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_file_name, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_is_collection, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_is_center, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_is_cloud, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_collection_time, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_center_time, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_cloud_time, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_error_collection_tips, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_error_center_tips, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_error_cloud_tips, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_error_collection_time, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_error_center_time, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_error_cloud_time, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_original_time, true), chunk->num_columns());
+    chunk->append_column(ColumnHelper::create_column(type_is_original, true), chunk->num_columns());
+
+    size_t total_row_nums = 0;
+    while (!status.is_end_of_file()) {
+        chunk->reset();
+        status = file_reader->get_next(&chunk);
+        if (!status.ok()) {
+            break;
+        }
+        chunk->check_or_die();
+        total_row_nums += chunk->num_rows();
+    }
+    EXPECT_EQ(0, total_row_nums);
+}
+
 } // namespace starrocks::parquet


### PR DESCRIPTION
## Problem Summary:
Previous has a pr #14798 about this problem, but it will occur performance degradation (Make tpcds-1T slower 3x). So it has been reverted.

But this check is necessary for the parquet reader, so here written in another version. Already tested, no performance degradation.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
