### PR TITLE
[Enhancement] primary key table's version count should contains pending rowsets

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2451,6 +2451,7 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
     int64_t min_readable_version = 0;
     int64_t version = 0;
     bool has_pending = false;
+    int64_t version_count = 0;
     vector<uint32_t> rowsets;
     {
         std::lock_guard rl(_lock);
@@ -2462,6 +2463,9 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
             version = last->version.major();
             rowsets = last->rowsets;
             has_pending = _pending_commits.size() > 0;
+            // version count in primary key table contains two parts:
+            // 1. rowsets in newest version. 2. pending rowsets.
+            version_count = rowsets.size() + _pending_commits.size();
         }
     }
     string err_rowsets;
@@ -2487,7 +2491,7 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
     info->__set_version(version);
     info->__set_min_readable_version(min_readable_version);
     info->__set_version_miss(has_pending);
-    info->__set_version_count(rowsets.size());
+    info->__set_version_count(version_count);
     info->__set_row_count(total_row);
     info->__set_data_size(total_size);
     info->__set_is_error_state(_error);


### PR DESCRIPTION

## Problem Summary:
Fixes #23846

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
