### PR TITLE
[BugFix] Fix left outer broadcast join return empty result in spill mode

### DIFF
--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -310,6 +310,7 @@ Status HashJoiner::create_runtime_filters(RuntimeState* state) {
 void HashJoiner::reference_hash_table(HashJoiner* src_join_builder) {
     auto& hash_table = _hash_join_builder->hash_table();
 
+    _hash_table_param = src_join_builder->hash_table_param();
     hash_table = src_join_builder->_hash_join_builder->hash_table().clone_readable_table();
     hash_table.set_probe_profile(probe_metrics().search_ht_timer, probe_metrics().output_probe_column_timer,
                                  probe_metrics().output_tuple_column_timer);

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -248,6 +248,7 @@ public:
     }
 
     // hash table param.
+    // this function only valid in hash_joiner_builder
     const HashTableParam& hash_table_param() const { return _hash_table_param; }
 
     void set_spiller(std::shared_ptr<spill::Spiller> spiller) { _spiller = std::move(spiller); }
@@ -299,6 +300,8 @@ public:
         }
         return Status::OK();
     }
+
+    const TJoinOp::type& join_type() const { return _join_type; }
 
 private:
     static bool _has_null(const ColumnPtr& column);

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -99,23 +99,13 @@ Status SpillableHashJoinBuildOperator::publish_runtime_filters(RuntimeState* sta
     // It usually involves re-reading all the data that has been spilled
     // which cannot be streamed process in the spill scenario when build phase is finished
     // (unless FE can give an estimate of the hash table size), so we currently empty all the hash tables first
+    // we could build global runtime filter for this case later.
+    auto merged = _partial_rf_merger->set_always_true();
 
-    size_t merger_index = _driver_sequence;
-    // make sure ht_row_count exceed max runtime filters
-    auto ht_row_count = _partial_rf_merger->limit() + 1;
-    RuntimeInFilters partial_in_filters;
-    RuntimeBloomFilters partial_bloom_filters;
-    auto& partial_bloom_filter_build_params = _join_builder->get_runtime_bloom_filter_build_params();
-
-    ASSIGN_OR_RETURN(auto merged,
-                     _partial_rf_merger->add_partial_filters(merger_index, ht_row_count, std::move(partial_in_filters),
-                                                             std::move(partial_bloom_filter_build_params),
-                                                             std::move(partial_bloom_filters)));
     if (merged) {
         RuntimeInFilterList in_filters;
         RuntimeBloomFilterList bloom_filters;
-
-        // publish runtime bloom-filters
+        // publish empty runtime bloom-filters
         state->runtime_filter_port()->publish_runtime_filters(bloom_filters);
         // move runtime filters into RuntimeFilterHub.
         runtime_filter_hub()->set_collector(_plan_node_id, std::make_unique<RuntimeFilterCollector>(

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -39,7 +39,7 @@
 namespace starrocks::pipeline {
 Status SpillableHashJoinProbeOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(HashJoinProbeOperator::prepare(state));
-    _need_post_probe = has_post_probe(_join_prober->hash_table_param().join_type);
+    _need_post_probe = has_post_probe(_join_prober->join_type());
     _probe_spiller->set_metrics(spill::SpillProcessMetrics(_unique_metrics.get()));
     metrics.hash_partitions = ADD_COUNTER(_unique_metrics.get(), "SpillPartitions", TUnit::UNIT);
     RETURN_IF_ERROR(_probe_spiller->prepare(state));
@@ -197,7 +197,7 @@ Status SpillableHashJoinProbeOperator::_push_probe_chunk(RuntimeState* state, co
                                                                    const std::vector<uint32_t>& selection, int32_t from,
                                                                    int32_t size) {
         // nothing to do for empty partition
-        if (could_short_circuit(_join_prober->hash_table_param().join_type)) {
+        if (could_short_circuit(_join_prober->join_type())) {
             // For left semi join and inner join we can just skip the empty partition
             auto build_partition_iter = _pid_to_build_partition.find(probe_partition->partition_id);
             if (build_partition_iter != _pid_to_build_partition.end()) {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
@@ -1,3 +1,17 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <atomic>

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -217,6 +217,12 @@ public:
         _num_active_builders++;
     }
 
+    // mark runtime_filter as always true.
+    bool set_always_true() {
+        _always_true = true;
+        return _try_do_merge({});
+    }
+
     // HashJoinBuildOperator call add_partial_filters to gather partial runtime filters. the last HashJoinBuildOperator
     // will merge partial runtime filters into total one finally.
     StatusOr<bool> add_partial_filters(size_t idx, size_t ht_row_count, RuntimeInFilters&& partial_in_filters,
@@ -229,14 +235,8 @@ public:
         _ht_row_counts[idx] = ht_row_count;
         _partial_in_filters[idx] = std::move(partial_in_filters);
         _partial_bloom_filter_build_params[idx] = std::move(partial_bloom_filter_build_params);
-        // merge
-        if (1 == _num_active_builders--) {
-            _bloom_filter_descriptors = std::move(bloom_filter_descriptors);
-            merge_local_in_filters();
-            merge_local_bloom_filters();
-            return true;
-        }
-        return false;
+
+        return _try_do_merge(std::move(bloom_filter_descriptors));
     }
 
     RuntimeInFilterList get_total_in_filters() {
@@ -384,8 +384,25 @@ public:
     size_t limit() const { return _limit; }
 
 private:
+    bool _try_do_merge(RuntimeBloomFilters&& bloom_filter_descriptors) {
+        if (1 == _num_active_builders--) {
+            if (_always_true) {
+                _partial_in_filters.clear();
+                _bloom_filter_descriptors.clear();
+                return true;
+            }
+            _bloom_filter_descriptors = std::move(bloom_filter_descriptors);
+            merge_local_in_filters();
+            merge_local_bloom_filters();
+            return true;
+        }
+        return false;
+    }
+
+private:
     ObjectPool* _pool;
     const size_t _limit;
+    bool _always_true = false;
     std::atomic<size_t> _num_active_builders{0};
     std::vector<size_t> _ht_row_counts;
     std::vector<RuntimeInFilters> _partial_in_filters;

--- a/test/sql/test_spill/R/test_spill_hash_join
+++ b/test/sql/test_spill/R/test_spill_hash_join
@@ -73,11 +73,35 @@ select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left semi jo
 -- result:
 0	0	None	0
 -- !result
-select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left semi join [broadcast] t1 r on l.c0 = r.c0;
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left outer join [broadcast] t1 r on l.c0 = r.c0;
 -- result:
 0	0	None	0
 -- !result
 select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left anti join [broadcast] t1 r on l.c0 = r.c0;
+-- result:
+0	0	None	0
+-- !result
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left semi join [shuffle] t1 r on l.c0 = r.c0;
+-- result:
+0	0	None	0
+-- !result
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left outer join [shuffle] t1 r on l.c0 = r.c0;
+-- result:
+0	0	None	0
+-- !result
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left anti join [shuffle] t1 r on l.c0 = r.c0;
+-- result:
+0	0	None	0
+-- !result
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left semi join [bucket] t1 r on l.c0 = r.c0;
+-- result:
+0	0	None	0
+-- !result
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left outer join [bucket] t1 r on l.c0 = r.c0;
+-- result:
+0	0	None	0
+-- !result
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left anti join [bucket] t1 r on l.c0 = r.c0;
 -- result:
 0	0	None	0
 -- !result
@@ -101,11 +125,23 @@ select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left semi join [b
 -- result:
 0	0	None	0
 -- !result
-select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left semi join [broadcast] empty_t r on l.c0 = r.c0;
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left outer join [broadcast] empty_t r on l.c0 = r.c0;
+-- result:
+4097	4097	6144.0	4097
+-- !result
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left anti join [broadcast] empty_t r on l.c0 = r.c0;
+-- result:
+4097	4097	6144.0	4097
+-- !result
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left semi join [shuffle] empty_t r on l.c0 = r.c0;
 -- result:
 0	0	None	0
 -- !result
-select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left anti join [broadcast] empty_t r on l.c0 = r.c0;
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left outer join [shuffle] empty_t r on l.c0 = r.c0;
+-- result:
+4097	4097	6144.0	4097
+-- !result
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left anti join [shuffle] empty_t r on l.c0 = r.c0;
 -- result:
 4097	4097	6144.0	4097
 -- !result

--- a/test/sql/test_spill/T/test_spill_hash_join
+++ b/test/sql/test_spill/T/test_spill_hash_join
@@ -28,20 +28,35 @@ create table empty_t like t0;
 
 -- probe side empty.
 select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left semi join [broadcast] t1 r on l.c0 = r.c0;
-select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left semi join [broadcast] t1 r on l.c0 = r.c0;
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left outer join [broadcast] t1 r on l.c0 = r.c0;
 select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left anti join [broadcast] t1 r on l.c0 = r.c0;
+
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left semi join [shuffle] t1 r on l.c0 = r.c0;
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left outer join [shuffle] t1 r on l.c0 = r.c0;
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left anti join [shuffle] t1 r on l.c0 = r.c0;
+
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left semi join [bucket] t1 r on l.c0 = r.c0;
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left outer join [bucket] t1 r on l.c0 = r.c0;
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from empty_t l left anti join [bucket] t1 r on l.c0 = r.c0;
 
 select count(*), count(r.c0), avg(r.c0), count(r.c1) from empty_t l right semi join [bucket] t1 r on l.c0 = r.c0;
 select count(*), count(r.c0), avg(r.c0), count(r.c1) from empty_t l right anti join [bucket] t1 r on l.c0 = r.c0;
 select count(*), count(r.c0), avg(r.c0), count(r.c1) from empty_t l right outer join [bucket] t1 r on l.c0 = r.c0;
+
 select count(*), count(r.c0), avg(r.c0), count(r.c1) from empty_t l full outer join [bucket] t1 r on l.c0 = r.c0;
+
 -- build side empty. 
 select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left semi join [broadcast] empty_t r on l.c0 = r.c0;
-select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left semi join [broadcast] empty_t r on l.c0 = r.c0;
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left outer join [broadcast] empty_t r on l.c0 = r.c0;
 select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left anti join [broadcast] empty_t r on l.c0 = r.c0;
+
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left semi join [shuffle] empty_t r on l.c0 = r.c0;
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left outer join [shuffle] empty_t r on l.c0 = r.c0;
+select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l left anti join [shuffle] empty_t r on l.c0 = r.c0;
 
 select count(*), count(r.c0), avg(r.c0), count(r.c1) from t1 l right semi join [bucket] empty_t r on l.c0 = r.c0;
 select count(*), count(r.c0), avg(r.c0), count(r.c1) from t1 l right anti join [bucket] empty_t r on l.c0 = r.c0;
 select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l right outer join [bucket] empty_t r on l.c0 = r.c0;
+
 select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l full outer join [bucket] empty_t r on l.c0 = r.c0;
 


### PR DESCRIPTION
## Problem Summary:

Fix https://github.com/StarRocks/starrocks/issues/23839
Fix https://github.com/StarRocks/starrocks/issues/23838

1. hash_table_param only init in hash_joiner_builder side. we should call join_type() in hash_joiner_probe side.
2. if some hash_builder has spilled data. but other has no data. we shouldn't generate any runtime filter for them

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
