### PR TITLE
[BugFix] Fix NPE of there's no PullRowNum or PushRowNum when set pipeline_profile_level to 0

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1807,8 +1807,9 @@ public class Coordinator {
                 Preconditions.checkNotNull(commonMetrics);
                 Counter pullRowNum = commonMetrics.getCounter("PullRowNum");
                 Counter pushRowNum = commonMetrics.getCounter("PushRowNum");
-                Preconditions.checkNotNull(pullRowNum);
-                Preconditions.checkNotNull(pushRowNum);
+                if (pullRowNum == null || pushRowNum == null) {
+                    continue;
+                }
                 if (Objects.equals(pullRowNum.getValue(), pushRowNum.getValue())) {
                     foldNames.add(operatorProfile.getName());
                 }


### PR DESCRIPTION
## Problem Summary:
Fixes # (issue)

For `pipeline_profile_level = 0`, be will filter all the metrics except `OperatorTotalTime`. 

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
