### PR TITLE
[BugFix] Fix fs options use-after-free 

### DIFF
--- a/be/src/exec/parquet_writer.h
+++ b/be/src/exec/parquet_writer.h
@@ -47,7 +47,7 @@ struct TableInfo {
 
 class RollingAsyncParquetWriter {
 public:
-    RollingAsyncParquetWriter(const TableInfo& tableInfo, const std::vector<ExprContext*>& output_expr_ctxs,
+    RollingAsyncParquetWriter(TableInfo tableInfo, const std::vector<ExprContext*>& output_expr_ctxs,
                               RuntimeProfile* parent_profile,
                               std::function<void(starrocks::parquet::AsyncFileWriter*, RuntimeState*)> _commit_func,
                               RuntimeState* state, int32_t driver_id);
@@ -55,7 +55,7 @@ public:
     ~RollingAsyncParquetWriter() = default;
 
     Status append_chunk(Chunk* chunk, RuntimeState* state);
-    Status init_rolling_writer(const TableInfo& tableInfo);
+    Status init_rolling_writer();
     Status close(RuntimeState* state);
     bool writable() const { return _writer == nullptr || _writer->writable(); }
     bool closed();
@@ -72,6 +72,7 @@ private:
     std::shared_ptr<::parquet::WriterProperties> _properties;
     std::shared_ptr<::parquet::schema::GroupNode> _schema;
     std::string _partition_location;
+    TableInfo _table_info;
     int32_t _file_cnt = 0;
     std::string _outfile_location;
     std::vector<std::shared_ptr<starrocks::parquet::AsyncFileWriter>> _pending_commits;


### PR DESCRIPTION
## Problem Summary:
`RollingAsyncParquetWriter` owns a copy of fs options to avoid use-after-free.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
