### PR TITLE
[BugFix] Fix short-circuited logic of nljoin

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_context.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.cpp
@@ -130,4 +130,12 @@ Status NLJoinContext::finish_one_right_sinker(RuntimeState* state) {
     return Status::OK();
 }
 
+Status NLJoinContext::finish_one_left_prober(RuntimeState* state) {
+    if (_num_left_probers == _num_finished_left_probers.fetch_add(1) + 1) {
+        // All the probers have finished, so the builders can be short-circuited.
+        set_finished();
+    }
+    return Status::OK();
+}
+
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/nljoin/nljoin_context.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.h
@@ -65,6 +65,7 @@ public:
     void append_build_chunk(int32_t sinker_id, const ChunkPtr& build_chunk);
 
     Status finish_one_right_sinker(RuntimeState* state);
+    Status finish_one_left_prober(RuntimeState* state);
 
     bool is_right_finished() const { return _all_right_finished.load(std::memory_order_acquire); }
 
@@ -81,6 +82,7 @@ private:
     const int32_t _plan_node_id;
 
     std::atomic<int32_t> _num_finished_right_sinkers = 0;
+    std::atomic<int32_t> _num_finished_left_probers = 0;
     std::atomic<int32_t> _num_closed_left_probers = 0;
     std::atomic_bool _all_right_finished = false;
     std::atomic_int64_t _num_build_rows = 0;

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -158,8 +158,7 @@ Status NLJoinProbeOperator::set_finishing(RuntimeState* state) {
 }
 
 Status NLJoinProbeOperator::set_finished(RuntimeState* state) {
-    _cross_join_context->set_finished();
-    return Status::OK();
+    return _cross_join_context->finish_one_left_prober(state);
 }
 
 bool NLJoinProbeOperator::_is_left_join() const {


### PR DESCRIPTION
## Problem Summary:
Fixes #23878

When one instance of the nestloop join is short-circuited by hash join, `NLJoinProbeOperator::set_finished` calls `_cross_join_context->set_finished()`, which makes all the instances of the nestloop join finished. 



## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
