### PR TITLE
[BugFix] Fix parsing max rowgroup size of parquet outfile

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
@@ -263,14 +263,19 @@ public class OutFileClause implements ParseNode {
             if (!isParquetFormat()) {
                 throw new SemanticException(PARQUET_USE_DICT + " is only for PARQUET format");
             }
-            useDict = Boolean.getBoolean(properties.get(PARQUET_USE_DICT));
+            useDict = Boolean.parseBoolean(properties.get(PARQUET_USE_DICT));
         }
 
         if (properties.containsKey(PARQUET_MAX_ROW_GROUP_SIZE)) {
             if (!isParquetFormat()) {
                 throw new SemanticException(PARQUET_MAX_ROW_GROUP_SIZE + " is only for PARQUET format");
             }
-            maxParquetRowGroupBytes = Long.getLong(properties.get(PARQUET_MAX_ROW_GROUP_SIZE));
+            try {
+                maxParquetRowGroupBytes = Long.parseLong(properties.get(PARQUET_MAX_ROW_GROUP_SIZE));
+            } catch (NumberFormatException e) {
+                throw new SemanticException(
+                        PARQUET_MAX_ROW_GROUP_SIZE + " should be a number of bytes (e.g. 134217728)");
+            }
         }
 
         if (properties.containsKey(PROP_MAX_FILE_SIZE)) {


### PR DESCRIPTION
## Problem Summary:
Use `Long.parseLong` to parse row group size as a number of bytes.

Successful case:
```
MySQL [dla_ice.jlt_ice_oss]>  select * from sc into outfile "oss://xxx" format as parquet properties ("max_row_group_bytes"="1000"); 
```

Failed case:
```
MySQL [dla_ice.jlt_ice_oss]>  select * from sc into outfile "oss://xxx" format as parquet properties ("max_row_group_bytes"="1000MB");
ERROR 1064 (HY000): Getting analyzing error. Detail message: max_row_group_bytes should be a number of bytes (e.g. 134217728).
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
