### PR TITLE
[BugFix] add pushdown predicate process when join reorder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderHelper.java
@@ -14,14 +14,12 @@
 
 package com.starrocks.sql.optimizer.rule.join;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
@@ -73,13 +71,6 @@ public class JoinReorderHelper {
         return Lists.newArrayList(leftCols, rightCols, refBothChildCols);
     }
 
-
-    // TODO(packy) obtain the output info of tableFunction is not as easy as other op. Forbid it now.
-    public static boolean existTableFunc(OptExpression input) {
-        List<OptExpression> flattenExprs = ImmutableList.of(input.inputAt(0).inputAt(0),
-                input.inputAt(0).inputAt(1), input.inputAt(1));
-        return flattenExprs.stream().anyMatch(e -> e.getOp() instanceof LogicalTableFunctionOperator);
-    }
 
     public static boolean isAssoc(OptExpression bottomJoinExpr, OptExpression topJoinExpr) {
         LogicalJoinOperator topJoin = (LogicalJoinOperator) topJoinExpr.getOp();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociativityRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociativityRule.java
@@ -77,9 +77,6 @@ public class JoinAssociativityRule extends JoinAssociateBaseRule {
 
     @Override
     public boolean check(final OptExpression input, OptimizerContext context) {
-        if (JoinReorderHelper.existTableFunc(input)) {
-            return false;
-        }
         LogicalJoinOperator topJoin = (LogicalJoinOperator) input.getOp();
         LogicalJoinOperator bottomJoin = (LogicalJoinOperator) input.inputAt(0).getOp();
         if (StringUtils.isNotEmpty(topJoin.getJoinHint()) || StringUtils.isNotEmpty(bottomJoin.getJoinHint())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.JoinOperator;
@@ -88,10 +87,10 @@ public class SemiReorderRule extends TransformationRule {
         LogicalJoinOperator topJoin = (LogicalJoinOperator) input.getOp();
         LogicalJoinOperator leftChildJoin = (LogicalJoinOperator) input.inputAt(0).getOp();
 
-        Preconditions.checkState(topJoin.getPredicate() == null);
 
         LogicalJoinOperator newTopJoin = new LogicalJoinOperator.Builder().withOperator(leftChildJoin)
                 .setProjection(topJoin.getProjection())
+                .setPredicate(Utils.compoundAnd(leftChildJoin.getPredicate(), topJoin.getPredicate()))
                 .setLimit(topJoin.getLimit())
                 .build();
 
@@ -157,11 +156,13 @@ public class SemiReorderRule extends TransformationRule {
         // build new semi join projection
         if (semiExpression.isEmpty()) {
             newSemiJoin = new LogicalJoinOperator.Builder().withOperator(topJoin)
+                    .setPredicate(null)
                     .setLimit(Operator.DEFAULT_LIMIT)
                     .setProjection(new Projection(projectMap)).build();
         } else {
             semiExpression.putAll(projectMap);
             newSemiJoin = new LogicalJoinOperator.Builder().withOperator(topJoin)
+                    .setPredicate(null)
                     .setLimit(Operator.DEFAULT_LIMIT)
                     .setProjection(new Projection(semiExpression)).build();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OuterJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OuterJoinReorderTest.java
@@ -106,6 +106,40 @@ public class OuterJoinReorderTest extends PlanTestBase {
                 "  |  <slot 3> : 3: v3\n" +
                 "  |  \n" +
                 "  3:HASH JOIN");
+        sqlList.add("select t0.* from t0 left join t1 on t0.v1 = t1.v4 join t2 on t0.v1 = t2.v7 " +
+                "where t0.v2 in (select max(v10) from t3) and t1.v5 is null;");
+        planList.add("14:HASH JOIN\n" +
+                "  |  join op: LEFT SEMI JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 2: v2 = 13: max\n" +
+                "  |  \n" +
+                "  |----13:EXCHANGE\n" +
+                "  |    \n" +
+                "  8:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 3> : 3: v3\n" +
+                "  |  \n" +
+                "  7:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (BUCKET_SHUFFLE)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 = 4: v4\n" +
+                "  |  other predicates: 5: v5 IS NULL");
+        sqlList.add("select t0.*, t1.v5 from t0 join t1 on t0.v1 = t1.v4 left join t2 on t1.v5 = t2.v7 " +
+                "where t2.v8 <=> t0.v2 and t0.v3 in (select max(v10) from t3) and t1.v5 is null");
+        planList.add("15:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 3> : 3: v3\n" +
+                "  |  <slot 5> : 5: v5\n" +
+                "  |  \n" +
+                "  14:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 5: v5 = 7: v7\n" +
+                "  |  other predicates: 8: v8 <=> 2: v2\n" +
+                "  |  \n" +
+                "  |----13:EXCHANGE");
         List<Pair<String, String>> zips = zipSqlAndPlan(sqlList, planList);
         return zips.stream().map(e -> Arguments.of(e));
     }


### PR DESCRIPTION
## Problem Summary:
Fixes #23896

When we supported outer join reorder, `(a semi join b ) left join c where c.col is null` will reorder to `(a left join c)  semi join b where c.col is null. (a left join c)`, then `(a left join c)`  may generate some new plan when `a` contins inner join which leads to a optExpression match the pattern in SemiJoinReorderRule but predicate in the topJoin is not null which makes        `Preconditions.checkState(topJoin.getPredicate() == null);` failed.

This pr firstly add pushdown predicate process in `JoinAssociateBaseRule` to generate more optimzied plan and secondly remove the `Preconditions.checkState(topJoin.getPredicate() == null);` to avoid unnecessary check.

Actually, the `SemiJoinReorderRule` can be removed in the future because  the new  `JoinAssociateBaseRule` has the ability to do the same thing when doing some necessary change. I think when the `JoinAssociateBaseRule` had been tested in more clients, we can comebine these two rules.


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto backported to target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
