### PR TITLE
[BugFix][CherryPick] Ignore sql select limit during creating rollup mv for 3.0(#21872)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
@@ -62,6 +62,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.mvpattern.MVColumnBitmapUnionPattern;
@@ -292,7 +293,11 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         public Void visitCreateMaterializedViewStmt(CreateMaterializedViewStmt statement,
                                                     ConnectContext context) {
             QueryStatement queryStatement = statement.getQueryStatement();
+            long originSelectLimit = context.getSessionVariable().getSqlSelectLimit();
+            // ignore limit in creating mv
+            context.getSessionVariable().setSqlSelectLimit(SessionVariable.DEFAULT_SELECT_LIMIT);
             com.starrocks.sql.analyzer.Analyzer.analyze(statement.getQueryStatement(), context);
+            context.getSessionVariable().setSqlSelectLimit(originSelectLimit);
 
             // forbid explain query
             if (queryStatement.isExplain()) {


### PR DESCRIPTION
Fixes #21365 
