### PR TITLE
[Enhancement] Optimization the performance of to_bitmap (#23824)

### DIFF
--- a/be/src/exprs/vectorized/bitmap_functions.cpp
+++ b/be/src/exprs/vectorized/bitmap_functions.cpp
@@ -56,8 +56,7 @@ ColumnPtr BitmapFunctions::to_bitmap(FunctionContext* context, const starrocks::
             }
         }
 
-        BitmapValue bitmap;
-        bitmap.add(value);
+        BitmapValue bitmap(value);
 
         builder.append(&bitmap);
     }


### PR DESCRIPTION
Fixes # (issue)

Before optimization

```
mysql> select count(to_bitmap(lo_orderkey)) from lineorder;
+-------------------------------+
| count(to_bitmap(lo_orderkey)) |
+-------------------------------+
|                     143999468 |
+-------------------------------+
1 row in set (2.38 sec)
```

after optimization

```
mysql> select count(to_bitmap(lo_orderkey)) from lineorder;
+-------------------------------+
| count(to_bitmap(lo_orderkey)) |
+-------------------------------+
|                     143999468 |
+-------------------------------+
1 row in set (2.02 sec)
```

Fixes #issue
