### PR TITLE
[BugFix] iceberg catalog adapt deprecated config 'starrocks.catalog-type' in the IcebergCachingFileIO.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -43,7 +43,6 @@ public class IcebergConnector implements Connector {
     @Deprecated
     public static final String ICEBERG_METASTORE_URIS = "iceberg.catalog.hive.metastore.uris";
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
-    public static final String ICEBERG_IMPL = "iceberg.catalog-impl";
 
     private final Map<String, String> properties;
     private final CloudConfiguration cloudConfiguration;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -52,6 +52,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Weigher;
 import com.starrocks.common.Config;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -85,6 +86,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import static com.starrocks.connector.iceberg.IcebergConnector.ICEBERG_CATALOG_LEGACY;
 import static com.starrocks.connector.iceberg.IcebergConnector.ICEBERG_CATALOG_TYPE;
 
 /**
@@ -116,14 +118,25 @@ public class IcebergCachingFileIO implements FileIO, Configurable {
 
     @Override
     public void initialize(Map<String, String> properties) {
+        String type = properties.get(ICEBERG_CATALOG_TYPE);
+        if (type == null) {
+            type = properties.get(ICEBERG_CATALOG_LEGACY);
+        }
+
+        if (type == null) {
+            throw new StarRocksConnectorException("iceberg catalog type can't be null");
+        }
+
         if (wrappedIO == null) {
-            switch (properties.get(ICEBERG_CATALOG_TYPE)) {
+            switch (type) {
                 case "hive":
                     wrappedIO = new HadoopFileIO(conf);
                     break;
                 case "glue":
                     wrappedIO = new S3FileIO();
                     break;
+                default:
+                    throw new StarRocksConnectorException("Unknown type %s", type);
             }
 
             wrappedIO.initialize(properties);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIOTest.java
@@ -50,6 +50,7 @@ public class IcebergCachingFileIOTest {
         // create iceberg cachingFileIO
         IcebergCachingFileIO cachingFileIO = new IcebergCachingFileIO(hadoopFileIO);
         Map<String, String> icebergProperties = new HashMap<>();
+        icebergProperties.put("iceberg.catalog.type", "hive");
         cachingFileIO.initialize(icebergProperties);
 
         // get input file by hadoopFileIO and cachingFileIO


### PR DESCRIPTION
Fix NPE:
```
java.lang.NullPointerException: null
	at com.starrocks.connector.iceberg.io.IcebergCachingFileIO.initialize(IcebergCachingFileIO.java:120) ~[starrocks-fe.jar:?]
	at org.apache.iceberg.CatalogUtil.loadFileIO(CatalogUtil.java:325) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.hive.HiveCatalog.initialize(HiveCatalog.java:108) ~[iceberg-hive-metastore-1.2.1.jar:?]
	at org.apache.iceberg.CatalogUtil.loadCatalog(CatalogUtil.java:239) ~[iceberg-core-1.2.1.jar:?]
	at com.starrocks.connector.iceberg.hive.IcebergHiveCatalog.<init>(IcebergHiveCatalog.java:87) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.iceberg.IcebergConnector.buildIcebergNativeCatalog(IcebergConnector.java:73) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.iceberg.IcebergConnector.getNativeCatalog(IcebergConnector.java:103) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.iceberg.IcebergConnector.getMetadata(IcebergConnector.java:96) ~[starrocks-fe.jar:?]
	at com.starrocks.server.MetadataMgr$QueryMetadatas.getConnectorMetadata(MetadataMgr.java:319) ~[starrocks-fe.jar:?]
	at com.starrocks.server.MetadataMgr.getOptionalMetadata(MetadataMgr.java:81) ~[starrocks-fe.jar:?]
	at com.starrocks.server.MetadataMgr.getTable(MetadataMgr.java:211) ~[starrocks-fe.jar:?]
	at com.starrocks.server.ExternalTableFactory.getTableFromResourceMappingCatalog(ExternalTableFactory.java:64) ~[starrocks-fe.jar:?]
	at com.starrocks.server.IcebergTableFactory.createTable(IcebergTableFactory.java:52) ~[starrocks-fe.jar:?]
```