### PR TITLE
[BugFix] Fix Iceberg RestCatalog FileIO NPE problem

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -123,6 +123,8 @@ public class IcebergCachingFileIO implements FileIO, Configurable {
                     break;
                 case "glue":
                     wrappedIO = new S3FileIO();
+                case "rest":
+                    wrappedIO = new HadoopFileIO(conf);
                     break;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/io/IcebergCachingFileIO.java
@@ -119,12 +119,11 @@ public class IcebergCachingFileIO implements FileIO, Configurable {
         if (wrappedIO == null) {
             switch (properties.get(ICEBERG_CATALOG_TYPE)) {
                 case "hive":
+                case "rest":
                     wrappedIO = new HadoopFileIO(conf);
                     break;
                 case "glue":
                     wrappedIO = new S3FileIO();
-                case "rest":
-                    wrappedIO = new HadoopFileIO(conf);
                     break;
             }
 


### PR DESCRIPTION
Fixes #23432

Now we can use Tabular via Iceberg RestCatalog smoothly.

```sql
create external catalog tabular properties (
	"type"="iceberg",
	"iceberg.catalog.type"="rest",
	"uri"="https://api.tabular.io/ws",
	"credential"="t-5Ii8T9m0",
	"warehouse"="smith",
	"aws.s3.region"="us-west-2",
	"aws.s3.access_key"="AKIAMST",
	"aws.s3.secret_key"="LJUchAtmacTuf+"
);
```

```sql
set catalog tabular;
```

```sql
mysql> show databases;
+----------+
| Database |
+----------+
| default  |
| examples |
| hello    |
| sr       |
| system   |
+----------+
```

```sql
use sr;

create table hello_smith (id int, name string);

mysql> insert into hello_smith values (1, "smith"), (2, "cruise");
Query OK, 2 rows affected (8.99 sec)
{'label':'FAKE_ICEBERG_SINK_LABEL', 'status':'VISIBLE', 'txnId':'-1'}

mysql> select * from hello_smith;
+------+--------+
| id   | name   |
+------+--------+
|    1 | smith  |
|    2 | cruise |
+------+--------+
2 rows in set (1.66 sec)
```
