### PR TITLE
[BugFix][Cherry-Pick][Branch-2.5] check if tablet delete after get tabletupdates' lock (#19653)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3471,6 +3471,13 @@ Status TabletUpdates::get_column_values(std::vector<uint32_t>& column_ids, bool 
             rssid_to_rowsets.insert(rowset);
         }
     }
+
+    if (rssid_to_rowsets.empty()) {
+        std::string msg =
+                strings::Substitute("tablet deleted when call get_column_values() tablet:", _tablet.tablet_id());
+        LOG(WARNING) << msg;
+        return Status::InternalError(msg);
+    }
     if (with_default) {
         for (auto i = 0; i < column_ids.size(); ++i) {
             const TabletColumn& tablet_column = _tablet.tablet_schema().column(column_ids[i]);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3467,17 +3467,17 @@ Status TabletUpdates::get_column_values(std::vector<uint32_t>& column_ids, bool 
     std::map<uint32_t, RowsetSharedPtr> rssid_to_rowsets;
     {
         std::lock_guard<std::mutex> l(_rowsets_lock);
+        if (_edit_version_infos.empty()) {
+            std::string msg =
+                    strings::Substitute("tablet deleted when call get_column_values() tablet:", _tablet.tablet_id());
+            LOG(WARNING) << msg;
+            return Status::InternalError(msg);
+        }
         for (const auto& rowset : _rowsets) {
             rssid_to_rowsets.insert(rowset);
         }
     }
 
-    if (rssid_to_rowsets.empty()) {
-        std::string msg =
-                strings::Substitute("tablet deleted when call get_column_values() tablet:", _tablet.tablet_id());
-        LOG(WARNING) << msg;
-        return Status::InternalError(msg);
-    }
     if (with_default) {
         for (auto i = 0; i < column_ids.size(); ++i) {
             const TabletColumn& tablet_column = _tablet.tablet_schema().column(column_ids[i]);


### PR DESCRIPTION
When deleting a primary key tablet, clear_meta will be called and _rowsets will be cleared, this makes all other concurrent operations invalid, so these operations running in other threads should check state validity after acquiring lock.

