### PR TITLE
[Enhancement] Adjust the default value of max_allowed_packet to 32MB

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -594,8 +594,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private long sqlSelectLimit = DEFAULT_SELECT_LIMIT;
 
     // this is used to make c3p0 library happy
+    // Max packet length to send to or receive from the server,
+    // try to set it to a higher value if `PacketTooBigException` is thrown at client
     @VariableMgr.VarAttr(name = MAX_ALLOWED_PACKET)
-    private int maxAllowedPacket = 1048576;
+    private int maxAllowedPacket = 33554432; // 32MB
     @VariableMgr.VarAttr(name = AUTO_INCREMENT_INCREMENT)
     private int autoIncrementIncrement = 1;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -274,7 +274,7 @@ public class ConstantExpressionTest extends PlanTestBase {
                         "  |  <slot 9> : '/starrocks/share/english/'\n" +
                         "  |  <slot 10> : 'Apache License 2.0'\n" +
                         "  |  <slot 11> : 0\n" +
-                        "  |  <slot 12> : 1048576\n" +
+                        "  |  <slot 12> : 33554432\n" +
                         "  |  <slot 13> : 16384\n" +
                         "  |  <slot 14> : 60\n" +
                         "  |  <slot 15> : 1048576\n" +


### PR DESCRIPTION
Fixes SR-10223
The default value is 1MB which is too small for long sql query.
