### PR TITLE
[Enhancement] Make pk table compaction's rowset size threshold large and configurable

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -291,6 +291,7 @@ CONF_mInt32(update_compaction_check_interval_seconds, "60");
 CONF_mInt32(update_compaction_num_threads_per_disk, "1");
 CONF_Int32(update_compaction_per_tablet_min_interval_seconds, "120"); // 2min
 CONF_mInt64(max_update_compaction_num_singleton_deltas, "1000");
+CONF_mInt64(update_compaction_size_threshold, "277872640");
 
 CONF_mInt32(repair_compaction_interval_seconds, "600"); // 10 min
 CONF_Int32(manual_compaction_threads, "4");

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1739,7 +1739,7 @@ int64_t TabletUpdates::get_compaction_score() {
         }
         rowsets = _edit_version_infos[_apply_version_idx]->rowsets;
     }
-    int64_t total_score = -_compaction_cost_seek;
+    int64_t total_score = -config::update_compaction_size_threshold;
     bool has_error = false;
     {
         std::lock_guard lg(_rowset_stats_lock);
@@ -1786,7 +1786,6 @@ static string int_list_to_string(const vector<uint32_t>& l) {
     return ret;
 }
 
-static const size_t compaction_result_bytes_threashold = 1000000000;
 static const size_t compaction_result_rows_threashold = 10000000;
 
 Status TabletUpdates::compaction(MemTracker* mem_tracker) {
@@ -1816,7 +1815,7 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
     size_t total_bytes = 0;
     size_t total_rows_after_compaction = 0;
     size_t total_bytes_after_compaction = 0;
-    int64_t total_score = -_compaction_cost_seek;
+    int64_t total_score = -config::update_compaction_size_threshold;
     vector<CompactionEntry> candidates;
     {
         std::lock_guard lg(_rowset_stats_lock);
@@ -1854,7 +1853,7 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
         size_t new_rows = total_rows_after_compaction + e.num_rows - e.num_dels;
         size_t new_bytes = total_bytes_after_compaction + e.bytes * (e.num_rows - e.num_dels) / e.num_rows;
         if (info->inputs.size() > 0 && (new_rows > compaction_result_rows_threashold * 3 / 2 ||
-                                        new_bytes > compaction_result_bytes_threashold * 3 / 2)) {
+                                        new_bytes > config::update_compaction_size_threshold * 3 / 2)) {
             break;
         }
         info->inputs.push_back(e.rowsetid);
@@ -1863,7 +1862,7 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
         total_bytes += e.bytes;
         total_rows_after_compaction = new_rows;
         total_bytes_after_compaction = new_bytes;
-        if (total_bytes_after_compaction > compaction_result_bytes_threashold ||
+        if (total_bytes_after_compaction > config::update_compaction_size_threshold ||
             total_rows_after_compaction > compaction_result_rows_threashold ||
             info->inputs.size() >= config::max_update_compaction_num_singleton_deltas) {
             break;
@@ -2131,8 +2130,8 @@ void TabletUpdates::get_compaction_status(std::string* json_result) {
 }
 
 void TabletUpdates::_calc_compaction_score(RowsetStats* stats) {
-    if (stats->num_rows < 10) {
-        stats->compaction_score = _compaction_cost_seek;
+    if (stats->num_rows == 0) {
+        stats->compaction_score = config::update_compaction_size_threshold;
         return;
     }
     // TODO(cbl): estimate read/write cost, currently just use fixed value
@@ -2140,7 +2139,8 @@ void TabletUpdates::_calc_compaction_score(RowsetStats* stats) {
     const int64_t cost_record_read = 4;
     // use double to prevent overflow
     auto delete_bytes = (int64_t)(stats->byte_size * (double)stats->num_dels / stats->num_rows);
-    stats->compaction_score = _compaction_cost_seek + (cost_record_read + cost_record_write) * delete_bytes -
+    stats->compaction_score = config::update_compaction_size_threshold +
+                              (cost_record_read + cost_record_write) * delete_bytes -
                               cost_record_write * stats->byte_size;
 }
 

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -420,7 +420,6 @@ private:
     int64_t _last_compaction_time_ms = 0;
     std::atomic<int64_t> _last_compaction_success_millis{0};
     std::atomic<int64_t> _last_compaction_failure_millis{0};
-    int64_t _compaction_cost_seek = 32 * 1024 * 1024; // 32MB
 
     mutable std::mutex _rowset_stats_lock;
     // maintain current version(applied version) rowsets' stats


### PR DESCRIPTION
## Problem Summary:
If size of PK tablets' rowset is greater than 32M(currently fixed value) and there are no deletes on the rowsets, these rowsets won't selected for compaction, for table's with very large rows(some column is very large while most columns are small), a rowset may contain very few rows(e.g 32M bytes, each row 16K, so only 2000 row per file), this is inefficient for scan of small columns.

This PR makes the rowset selection threshold configurable, by adding a new config `update_compaction_size_threshold`(default now 256M vs original 32M), rowsets whose size below this size will be selected for compaction.

Note this PR changes compaction behavior, after this PR, some previously uncompacted rowsets will be compacted, which may increase compaction load.

Fixes #23841
Backport #23843