### PR TITLE
[BugFix] Remove the tailing row delimeter for csv files which contain windows line break.

### DIFF
--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -54,6 +54,8 @@ public:
 protected:
     Status _fill_buffer() override;
 
+    void _trim_row_delimeter(Record* record);
+
 private:
     RandomAccessFile* _file;
     size_t _offset = 0;
@@ -87,6 +89,7 @@ Status HdfsScannerCSVReader::next_record(Record* record) {
     } else {
         _remain_length -= consume;
     }
+    _trim_row_delimeter(record);
     return Status::OK();
 }
 
@@ -129,6 +132,16 @@ Status HdfsScannerCSVReader::_fill_buffer() {
     }
 
     return Status::OK();
+}
+
+void HdfsScannerCSVReader::_trim_row_delimeter(Record* record) {
+    // For default row delemiter which is line break, we need to trim the windows line break
+    // if the file was written in windows platfom.
+    if (_parse_options.row_delimiter == "\n") {
+        while (record->size > 0 && record->data[record->size - 1] == '\r') {
+            record->size--;
+        }
+    }
 }
 
 Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {

--- a/be/test/exec/test_data/csv_scanner/windows.csv
+++ b/be/test/exec/test_data/csv_scanner/windows.csv
@@ -1,0 +1,3 @@
+hello
+world
+starrocks


### PR DESCRIPTION

Fixes #issue

If the csv file was written in windows platform, it may contain the windows CR LF line break types. When parsing the record by default row delimiter ("\n"), the record data may contain the '\r' tail, which cause the unexpected query result with the text comparision.
