### PR TITLE
[BugFix] should return early if submit completed/aborted transaction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -159,8 +159,8 @@ public class TransactionLoadAction extends RestBaseAction {
             }
             TransactionStatus txnStatus = GlobalStateMgr.getCurrentGlobalTransactionMgr().getLabelState(db.getId(),
                     label);
+            Long txnID = GlobalStateMgr.getCurrentGlobalTransactionMgr().getLabelTxnID(db.getId(), label);
             if (txnStatus == TransactionStatus.PREPARED) {
-                Long txnID = GlobalStateMgr.getCurrentGlobalTransactionMgr().getLabelTxnID(db.getId(), label);
                 if (txnID == -1) {
                     throw new UserException("label " + label + " txn not exist");
                 }
@@ -175,6 +175,26 @@ public class TransactionLoadAction extends RestBaseAction {
                     GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(db.getId(), txnID,
                             "User Aborted");
                 }
+                resp.addResultEntry("Label", label);
+                sendResult(request, response, resp);
+                return;
+            } else if (txnStatus == TransactionStatus.COMMITTED || txnStatus == TransactionStatus.VISIBLE) {
+                // whether txnId is valid or not is not important
+                if (op.equalsIgnoreCase(TXN_ROLLBACK)) {
+                    throw new UserException(String.format(
+                        "cannot abort committed transaction %s, label %s ", Long.toString(txnID), label));
+                }
+                resp.setOKMsg("label " + label + " transaction " + txnID + " has already committed");
+                resp.addResultEntry("Label", label);
+                sendResult(request, response, resp);
+                return;
+            } else if (txnStatus == TransactionStatus.ABORTED) {
+                // whether txnId is valid or not is not important
+                if (op.equalsIgnoreCase(TXN_COMMIT)) {
+                    throw new UserException(String.format(
+                        "cannot commit aborted transaction %s, label %s ", Long.toString(txnID), label));
+                }
+                resp.setOKMsg("label " + label + " transaction " + txnID + " has already aborted");
                 resp.addResultEntry("Label", label);
                 sendResult(request, response, resp);
                 return;


### PR DESCRIPTION
Fixes #issue

this problem frequently occur in Flink scenarios. Flink process the data source and then sink to multiple StarRocks table, for some reason，the job is interrupted and restart to recover, some completed transaction will be committed again. If the fe restart will discard the transaction info,  will cause some exception. we should better process this case in FE side.

