### PR TITLE
[Enhancement] Optimize Gson subtype  deserialize

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -288,7 +288,7 @@ public class GsonUtils {
 
     public static final RuntimeTypeAdapterFactory<TxnCommitAttachment> TXN_COMMIT_ATTACHMENT_TYPE_RUNTIME_ADAPTER_FACTORY =
             RuntimeTypeAdapterFactory.of(TxnCommitAttachment.class, "clazz")
-                    .registerSubtype(InsertTxnCommitAttachment.class, InsertTxnCommitAttachment.class.getSimpleName(), true)
+                    .registerSubtype(InsertTxnCommitAttachment.class, InsertTxnCommitAttachment.class.getSimpleName())
                     .registerSubtype(LoadJobFinalOperation.class, LoadJobFinalOperation.class.getSimpleName())
                     .registerSubtype(ManualLoadTxnCommitAttachment.class, ManualLoadTxnCommitAttachment.class.getSimpleName())
                     .registerSubtype(MiniLoadTxnCommitAttachment.class, MiniLoadTxnCommitAttachment.class.getSimpleName())

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactory.java
@@ -366,8 +366,8 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
                     label = labelJsonElement.getAsString();
                 } else if (defaultLabel != null) {
                     label = defaultLabel;
-                } else if (labelToSubtype.containsKey(type.getRawType().getSimpleName())) {
-                    label = type.getRawType().getSimpleName();
+                } else if (subtypeToLabel.containsKey(type.getRawType())) {
+                    label = subtypeToLabel.get(type.getRawType());
                 } else {
                     throw new JsonParseException("cannot deserialize " + baseType
                             + " because it does not define a field named " + typeFieldName);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactory.java
@@ -361,6 +361,10 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
                     labelJsonElement = jsonElement.getAsJsonObject().remove(typeFieldName);
                 }
 
+                //1. if the typeFieldName is specified in the json string, then use this class.
+                //2. if default class if specified, then use the default class.
+                //3. if the type specified (the second param of GSON.fromJson) is in the register list,
+                //   then use this class.
                 String label;
                 if (labelJsonElement != null) {
                     label = labelJsonElement.getAsString();

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactory.java
@@ -366,6 +366,8 @@ public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
                     label = labelJsonElement.getAsString();
                 } else if (defaultLabel != null) {
                     label = defaultLabel;
+                } else if (labelToSubtype.containsKey(type.getRawType().getSimpleName())) {
+                    label = type.getRawType().getSimpleName();
                 } else {
                     throw new JsonParseException("cannot deserialize " + baseType
                             + " because it does not define a field named " + typeFieldName);

--- a/fe/fe-core/src/test/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactoryTest.java
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package com.starrocks.persist.gson;
 

--- a/fe/fe-core/src/test/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactoryTest.java
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package com.starrocks.persist.gson;
 
 import com.google.gson.Gson;

--- a/fe/fe-core/src/test/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactoryTest.java
@@ -1,0 +1,45 @@
+package com.starrocks.persist.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import org.junit.Test;
+
+public class RuntimeTypeAdapterFactoryTest {
+    @Test
+    public void test() {
+        GsonBuilder builder = new GsonBuilder();
+        builder.registerTypeAdapterFactory(RuntimeTypeAdapterFactory
+                .of(A.class, "clazz")
+                .registerSubtype(B.class, B.class.getSimpleName()));
+        Gson gson = builder.create();
+        B b = gson.fromJson("{\"a\":1,\"b\":2}", B.class);
+        System.out.println("a: " + b.getA() + ", b: " + b.getB());
+    }
+
+    public static class A {
+        @SerializedName("a")
+        private int a;
+
+        public int getA() {
+            return a;
+        }
+
+        public void setA(int a) {
+            this.a = a;
+        }
+    }
+
+    public static class B extends A {
+        @SerializedName("b")
+        private int b;
+
+        public int getB() {
+            return b;
+        }
+
+        public void setB(int b) {
+            this.b = b;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/gson/RuntimeTypeAdapterFactoryTest.java
@@ -20,6 +20,7 @@ package com.starrocks.persist.gson;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class RuntimeTypeAdapterFactoryTest {
@@ -31,7 +32,8 @@ public class RuntimeTypeAdapterFactoryTest {
                 .registerSubtype(B.class, B.class.getSimpleName()));
         Gson gson = builder.create();
         B b = gson.fromJson("{\"a\":1,\"b\":2}", B.class);
-        System.out.println("a: " + b.getA() + ", b: " + b.getB());
+        Assert.assertEquals(1, b.getA());
+        Assert.assertEquals(2, b.getB());
     }
 
     public static class A {


### PR DESCRIPTION
Currently, the search of subType in the gson util when deserializing is as follows:
1. if the typeFieldName(we use `clazz`) is specified in the json string, then use this class.
2. if default class if specified when register, then use the default class.
3. throw exception.

But we should support this case: there is no `clazz` field nor specified default class, but we use a subclass to deserialize the json string.
To support this case, we add another search logic:
 - if the class specified (the class is the second param of `fromJson`) is in the register list, then use this class.