### PR TITLE
[Enhancement] Eliminate list objects operations when obtaining tablet schemas (#23821)

### DIFF
--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -85,6 +85,10 @@ inline std::string random_segment_filename() {
     return name;
 }
 
+inline std::string schema_filename(int64_t schema_id) {
+    return fmt::format("SCHEMA_{:016X}", schema_id);
+}
+
 // Return value: <tablet id, tablet version>
 inline std::pair<int64_t, int64_t> parse_tablet_metadata_filename(std::string_view file_name) {
     constexpr static int kBase = 16;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -47,6 +47,11 @@
 #include "util/lru_cache.h"
 #include "util/raw_container.h"
 
+// TODO: Eliminate the explicit dependency on staros worker
+#ifdef USE_STAROS
+#include "service/staros_worker.h"
+#endif
+
 namespace starrocks::lake {
 
 static void* gc_checker(void* arg);
@@ -108,12 +113,16 @@ std::string TabletManager::tablet_metadata_lock_location(int64_t tablet_id, int6
     return _location_provider->tablet_metadata_lock_location(tablet_id, version, expire_time);
 }
 
-std::string TabletManager::tablet_schema_cache_key(int64_t tablet_id) {
-    return fmt::format("schema_{}", tablet_id);
+std::string TabletManager::global_schema_cache_key(int64_t schema_id) {
+    return fmt::format("GS{}", schema_id);
 }
 
-std::string TabletManager::tablet_latest_metadata_key(int64_t tablet_id) {
-    return fmt::format("meta_latest_{}", tablet_id);
+std::string TabletManager::tablet_schema_cache_key(int64_t tablet_id) {
+    return fmt::format("TS{}", tablet_id);
+}
+
+std::string TabletManager::tablet_latest_metadata_cache_key(int64_t tablet_id) {
+    return fmt::format("TL{}", tablet_id);
 }
 
 bool TabletManager::fill_metacache(std::string_view key, CacheValue* ptr, int size) {
@@ -151,7 +160,7 @@ TabletMetadataPtr TabletManager::lookup_tablet_latest_metadata(std::string_view 
 
 void TabletManager::cache_tablet_latest_metadata(TabletMetadataPtr metadata) {
     auto value_ptr = std::make_unique<CacheValue>(metadata);
-    fill_metacache(tablet_latest_metadata_key(metadata->id()), value_ptr.release(),
+    fill_metacache(tablet_latest_metadata_cache_key(metadata->id()), value_ptr.release(),
                    static_cast<int>(metadata->SpaceUsedLong()));
 }
 
@@ -267,6 +276,7 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
                 req.tablet_schema, next_unique_id, col_idx_to_unique_id, tablet_metadata_pb->mutable_schema(),
                 req.__isset.compression_type ? req.compression_type : TCompressionType::LZ4_FRAME));
     }
+    RETURN_IF_ERROR(create_schema_file(req.tablet_id, tablet_metadata_pb->schema()));
     return put_tablet_metadata(std::move(tablet_metadata_pb));
 }
 
@@ -338,7 +348,7 @@ StatusOr<TabletMetadataPtr> TabletManager::load_tablet_metadata(const string& me
 }
 
 TabletMetadataPtr TabletManager::get_latest_cached_tablet_metadata(int64_t tablet_id) {
-    return lookup_tablet_latest_metadata(tablet_latest_metadata_key(tablet_id));
+    return lookup_tablet_latest_metadata(tablet_latest_metadata_cache_key(tablet_id));
 }
 
 StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id, int64_t version) {
@@ -492,6 +502,42 @@ StatusOr<TxnLogIter> TabletManager::list_txn_log(int64_t tablet_id, bool filter_
 }
 
 StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema(int64_t tablet_id, int64_t* version_hint) {
+// TODO: Eliminate the explicit dependency on staros worker
+#ifdef USE_STAROS
+    auto shard_info_or = g_worker->get_shard_info(tablet_id);
+    if (shard_info_or.ok()) {
+        const auto& shard_info = shard_info_or.value();
+        const auto& properties = shard_info.properties;
+        auto index_id_iter = properties.find("indexId");
+        if (index_id_iter != properties.end()) {
+            auto schema_id = std::atol(index_id_iter->second.data());
+            auto cache_key = global_schema_cache_key(schema_id);
+            auto schema = lookup_tablet_schema(cache_key);
+            if (schema != nullptr) {
+                return schema;
+            }
+            // else: Cache miss, read the schema file
+            auto schema_file_path = join_path(tablet_root_location(tablet_id), schema_filename(schema_id));
+            auto schema_or = load_and_parse_schema_file(schema_file_path);
+            if (schema_or.ok()) {
+                VLOG(3) << "Got tablet schema of id " << schema_id << " for tablet " << tablet_id;
+                schema = std::move(schema_or).value();
+                // Save the schema into the in-memory cache, use the schema id as the cache key
+                auto cache_value = std::make_unique<CacheValue>(schema);
+                (void)fill_metacache(cache_key, cache_value.release(), 0);
+                return std::move(schema);
+            } else if (schema_or.status().is_not_found()) {
+                // version 3.0 will not generate the tablet schema file, ignore the not found error and
+                // try to extract the tablet schema from the tablet metadata.
+            } else {
+                return schema_or.status();
+            }
+        } else {
+            // no "indexId" property, will extract the tablet schema from the tablet metadata.
+        }
+    }
+#endif // USE_STAROS
+
     // Check in-memory cache first
     auto cache_key = tablet_schema_cache_key(tablet_id);
     auto ptr = lookup_tablet_schema(cache_key);
@@ -755,6 +801,57 @@ Status TabletManager::delete_tablet_metadata_lock(int64_t tablet_id, int64_t ver
     auto location = tablet_metadata_lock_location(tablet_id, version, expire_time);
     auto st = fs::delete_file(location);
     return st.is_not_found() ? Status::OK() : st;
+}
+
+Status TabletManager::create_schema_file(int64_t tablet_id, const TabletSchemaPB& schema_pb) {
+    auto cache_key = global_schema_cache_key(schema_pb.id());
+    auto handle = _metacache->lookup(CacheKey(cache_key));
+    if (handle != nullptr) {
+        // If there is a cache entry, it means that the current process has successfully
+        // created the file already, and there is no need to create it again.
+        _metacache->release(handle);
+        VLOG(3) << "Skipped creating schema file of id " << schema_pb.id() << " for tablet " << tablet_id;
+    } else {
+        VLOG(3) << "Creating schema file of id " << schema_pb.id() << " for tablet " << tablet_id;
+        // The absence of a cache entry does not necessarily mean that the schema file does
+        // not exist. It may also be that the cache has been evicted. In addition, other
+        // processes may have already created or are creating the schema file. It is allowed
+        // for this to happen, because the schema files created by all processes are the
+        // same, as long as the final file exists, it is fine.
+        auto options = WritableFileOptions{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        auto schema_file_path = join_path(tablet_root_location(tablet_id), schema_filename(schema_pb.id()));
+        ASSIGN_OR_RETURN(auto wf, fs::new_writable_file(options, schema_file_path));
+        RETURN_IF_ERROR(wf->append(schema_pb.SerializeAsString()));
+        RETURN_IF_ERROR(wf->close());
+
+        // Save the schema into the in-memory cache
+        auto [schema, inserted] = GlobalTabletSchemaMap::Instance()->emplace(schema_pb);
+        if (UNLIKELY(schema == nullptr)) {
+            return Status::InternalError("failed to emplace the schema hash map");
+        }
+        auto cache_value = std::make_unique<CacheValue>(schema);
+        auto cache_size = inserted ? (int)schema->mem_usage() : 0;
+        (void)fill_metacache(cache_key, cache_value.release(), cache_size);
+    }
+    return Status::OK();
+}
+
+StatusOr<TabletSchemaPtr> TabletManager::load_and_parse_schema_file(const std::string& path) {
+    ASSIGN_OR_RETURN(auto rf, fs::new_random_access_file(path));
+    ASSIGN_OR_RETURN(auto file_size, rf->get_size());
+    std::string buffer;
+    raw::stl_string_resize_uninitialized(&buffer, file_size);
+    RETURN_IF_ERROR(rf->read_at_fully(0, buffer.data(), file_size));
+    TabletSchemaPB schema_pb;
+    bool parsed = schema_pb.ParseFromArray(buffer.data(), static_cast<int>(file_size));
+    if (!parsed) {
+        return Status::Corruption(fmt::format("failed to parse schema file {}", rf->filename()));
+    }
+    auto [schema, inserted] = GlobalTabletSchemaMap::Instance()->emplace(schema_pb);
+    if (UNLIKELY(schema == nullptr)) {
+        return Status::InternalError("failed to emplace the schema hash map");
+    }
+    return std::move(schema);
 }
 
 std::set<int64_t> TabletManager::owned_tablets() {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -29,6 +29,7 @@ namespace starrocks {
 class Cache;
 class CacheKey;
 class Segment;
+class TabletSchemaPB;
 class TCreateTabletReq;
 } // namespace starrocks
 
@@ -156,10 +157,13 @@ public:
 private:
     using CacheValue = std::variant<TabletMetadataPtr, TxnLogPtr, TabletSchemaPtr, SegmentPtr, DelVectorPtr>;
 
+    static std::string global_schema_cache_key(int64_t index_id);
     static std::string tablet_schema_cache_key(int64_t tablet_id);
-    static std::string tablet_latest_metadata_key(int64_t tablet_id);
+    static std::string tablet_latest_metadata_cache_key(int64_t tablet_id);
     static void cache_value_deleter(const CacheKey& /*key*/, void* value) { delete static_cast<CacheValue*>(value); }
 
+    Status create_schema_file(int64_t tablet_id, const TabletSchemaPB& schema_pb);
+    StatusOr<TabletSchemaPtr> load_and_parse_schema_file(const std::string& path);
     StatusOr<TabletSchemaPtr> get_tablet_schema(int64_t tablet_id, int64_t* version_hint = nullptr);
 
     StatusOr<TabletMetadataPtr> load_tablet_metadata(const std::string& metadata_location, bool fill_cache);

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -29,6 +29,7 @@
 #include "storage/options.h"
 #include "storage/tablet_schema.h"
 #include "testutil/assert.h"
+#include "testutil/id_generator.h"
 #include "util/filesystem_util.h"
 #include "util/lru_cache.h"
 
@@ -105,9 +106,10 @@ TEST_F(LakeTabletManagerTest, create_and_delete_tablet) {
     req.tablet_id = 65535;
     req.__set_version(1);
     req.__set_version_hash(0);
-    req.tablet_schema.schema_hash = 270068375;
-    req.tablet_schema.short_key_column_count = 2;
-    req.tablet_schema.keys_type = TKeysType::DUP_KEYS;
+    req.tablet_schema.__set_id(next_id());
+    req.tablet_schema.__set_schema_hash(270068375);
+    req.tablet_schema.__set_short_key_column_count(2);
+    req.tablet_schema.__set_keys_type(TKeysType::DUP_KEYS);
     EXPECT_OK(_tablet_manager->create_tablet(req));
     auto res = _tablet_manager->get_tablet(65535);
     EXPECT_TRUE(res.ok());
@@ -130,9 +132,10 @@ TEST_F(LakeTabletManagerTest, create_and_delete_pk_tablet) {
     req.tablet_id = 65535;
     req.__set_version(1);
     req.__set_version_hash(0);
-    req.tablet_schema.schema_hash = 270068375;
-    req.tablet_schema.short_key_column_count = 2;
-    req.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+    req.tablet_schema.__set_id(next_id());
+    req.tablet_schema.__set_schema_hash(270068375);
+    req.tablet_schema.__set_short_key_column_count(2);
+    req.tablet_schema.__set_keys_type(TKeysType::PRIMARY_KEYS);
     EXPECT_OK(_tablet_manager->create_tablet(req));
     auto res = _tablet_manager->get_tablet(65535);
     EXPECT_TRUE(res.ok());
@@ -366,10 +369,10 @@ TEST_F(LakeTabletManagerTest, create_from_base_tablet) {
         TCreateTabletReq req;
         req.tablet_id = 65535;
         req.__set_version(1);
-        req.tablet_schema.__set_id(1);
+        req.tablet_schema.__set_id(next_id());
         req.tablet_schema.__set_schema_hash(0);
         req.tablet_schema.__set_short_key_column_count(1);
-        req.tablet_schema.keys_type = TKeysType::DUP_KEYS;
+        req.tablet_schema.__set_keys_type(TKeysType::DUP_KEYS);
 
         auto& c0 = req.tablet_schema.columns.emplace_back();
         c0.column_name = "c0";
@@ -404,10 +407,10 @@ TEST_F(LakeTabletManagerTest, create_from_base_tablet) {
         req.tablet_id = 65536;
         req.__set_version(1);
         req.__set_base_tablet_id(65535);
-        req.tablet_schema.__set_id(2);
+        req.tablet_schema.__set_id(next_id());
         req.tablet_schema.__set_schema_hash(0);
         req.tablet_schema.__set_short_key_column_count(1);
-        req.tablet_schema.keys_type = TKeysType::DUP_KEYS;
+        req.tablet_schema.__set_keys_type(TKeysType::DUP_KEYS);
 
         auto& c0 = req.tablet_schema.columns.emplace_back();
         c0.column_name = "c0";
@@ -454,10 +457,10 @@ TEST_F(LakeTabletManagerTest, create_from_base_tablet) {
         req.tablet_id = 65537;
         req.__set_version(1);
         req.__set_base_tablet_id(65536);
-        req.tablet_schema.__set_id(3);
+        req.tablet_schema.__set_id(next_id());
         req.tablet_schema.__set_schema_hash(0);
         req.tablet_schema.__set_short_key_column_count(1);
-        req.tablet_schema.keys_type = TKeysType::DUP_KEYS;
+        req.tablet_schema.__set_keys_type(TKeysType::DUP_KEYS);
 
         auto& c0 = req.tablet_schema.columns.emplace_back();
         c0.column_name = "c0";


### PR DESCRIPTION
Create a schema file under the root path of the table. When you need to obtain the schema of a tablet, first get the ID of the materialized index to which the tablet belongs, and then read the schema file according to that ID to avoid the list tablet metadata operation.
