### PR TITLE
[Feature] support sync refresh mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -41,7 +41,6 @@ import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.DropPartitionClause;
 import com.starrocks.sql.ast.DropTableStmt;
-import com.starrocks.sql.ast.PartitionRangeDesc;
 import com.starrocks.sql.ast.PartitionRenameClause;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.sql.ast.TableRenameClause;
@@ -236,14 +235,7 @@ public interface ConnectorMetadata {
             throws DdlException, MetaNotFoundException, AnalysisException {
     }
 
-    default String refreshMaterializedView(String dbName, String mvName, boolean force, PartitionRangeDesc range,
-                                           int priority, boolean mergeRedundant, boolean isManual)
-            throws DdlException, MetaNotFoundException {
-        return null;
-    }
-
-    default String refreshMaterializedView(RefreshMaterializedViewStatement refreshMaterializedViewStatement,
-                                           int priority)
+    default String refreshMaterializedView(RefreshMaterializedViewStatement refreshMaterializedViewStatement)
             throws DdlException, MetaNotFoundException {
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -601,6 +601,10 @@ public class ConnectContext {
         this.parent = parent;
     }
 
+    public ConnectContext getParent() {
+        return parent;
+    }
+
     // kill operation with no protect.
     public void kill(boolean killConnection) {
         LOG.warn("kill query, {}, kill connection: {}",

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -195,6 +195,8 @@ public class ConnectContext {
 
     protected SSLContext sslContext;
 
+    private ConnectContext parent;
+
     public StmtExecutor getExecutor() {
         return executor;
     }
@@ -492,7 +494,7 @@ public class ConnectContext {
     }
 
     public boolean isKilled() {
-        return isKilled;
+        return (parent != null && parent.isKilled()) || isKilled;
     }
 
     // Set kill flag to true;
@@ -593,6 +595,10 @@ public class ConnectContext {
 
     public void setCurrentWarehouse(String currentWarehouse) {
         this.currentWarehouse = currentWarehouse;
+    }
+
+    public void setParentConnectContext(ConnectContext parent) {
+        this.parent = parent;
     }
 
     // kill operation with no protect.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -303,9 +303,8 @@ public class DDLStmtExecutor {
             List<String> info = Lists.newArrayList();
             ErrorReport.wrapWithRuntimeException(() -> {
                 // The priority of manual refresh is higher than that of general refresh
-                String taskId = context.getGlobalStateMgr().getLocalMetastore()
-                        .refreshMaterializedView(stmt, Constants.TaskRunPriority.HIGH.value());
-                info.add(taskId);
+                String taskRunId = context.getGlobalStateMgr().getLocalMetastore().refreshMaterializedView(stmt);
+                info.add(taskRunId);
             });
 
             return new ShowResultSet(RefreshMaterializedViewStatement.META_DATA, Arrays.asList(info));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1544,6 +1544,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return transactionVisibleWaitTimeout;
     }
 
+    public void setTransactionVisibleWaitTimeout(long transactionVisibleWaitTimeout) {
+        this.transactionVisibleWaitTimeout = transactionVisibleWaitTimeout;
+    }
+
     public boolean getForceScheduleLocal() {
         return forceScheduleLocal;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
@@ -24,6 +24,7 @@ public class ExecuteOption {
     private Map<String, String> taskRunProperties;
     // indicates whether the current execution is manual
     private boolean isManual = false;
+    private boolean isSync = false;
 
     public ExecuteOption() {
     }
@@ -64,5 +65,13 @@ public class ExecuteOption {
 
     public void setManual() {
         this.isManual = true;
+    }
+
+    public boolean getIsSync() {
+        return isSync;
+    }
+
+    public void setSync(boolean isSync) {
+        this.isSync = isSync;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -968,6 +968,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         ConnectContext ctx = mvContext.getCtx();
         StmtExecutor executor = new StmtExecutor(ctx, insertStmt);
         ctx.setExecutor(executor);
+        if (ctx.getParent() != null && ctx.getParent().getExecutor() != null) {
+            StmtExecutor parentStmtExecutor = ctx.getParent().getExecutor();
+            parentStmtExecutor.registerSubStmtExecutor(executor);
+        }
         ctx.setStmtId(new AtomicInteger().incrementAndGet());
         ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -108,11 +108,11 @@ import java.util.stream.Collectors;
 
 /**
  * Core logic of materialized view refresh task run
- * PartitionBasedMaterializedViewRefreshProcessor is not thread safe for concurrent runs of the same materialized view
+ * PartitionBasedMvRefreshProcessor is not thread safe for concurrent runs of the same materialized view
  */
-public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunProcessor {
+public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
-    private static final Logger LOG = LogManager.getLogger(PartitionBasedMaterializedViewRefreshProcessor.class);
+    private static final Logger LOG = LogManager.getLogger(PartitionBasedMvRefreshProcessor.class);
 
     public static final String MV_ID = "mvId";
 
@@ -123,6 +123,8 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
     private MvTaskRunContext mvContext;
     // table id -> <base table info, snapshot table>
     private Map<Long, Pair<BaseTableInfo, Table>> snapshotBaseTables;
+
+    private long oldTransactionVisibleWaitTimeout;
 
     @VisibleForTesting
     public MvTaskRunContext getMvContext() {
@@ -142,7 +144,14 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
     @Override
     public void processTaskRun(TaskRunContext context) throws Exception {
         prepare(context);
+        try {
+            doMvRefresh(context);
+        } finally {
+            postProcess();
+        }
+    }
 
+    private void doMvRefresh(TaskRunContext context) throws Exception {
         InsertStmt insertStmt = null;
         ExecPlan execPlan = null;
         int retryNum = 0;
@@ -228,6 +237,10 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         if (mvContext.hasNextBatchPartition()) {
             generateNextTaskRun();
         }
+    }
+
+    private void postProcess() {
+        mvContext.ctx.getSessionVariable().setTransactionVisibleWaitTimeout(oldTransactionVisibleWaitTimeout);
     }
 
     public MVTaskRunExtraMessage getMVTaskRunExtraMessage() {
@@ -452,6 +465,11 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
             LOG.warn(errorMsg);
             throw new DmlException(errorMsg);
         }
+        // wait util transaction is visible for mv refresh task
+        // because mv will update base tables' visible version after insert, the mv's visible version
+        // should keep up with the base tables, or it will return outdated result.
+        oldTransactionVisibleWaitTimeout = context.ctx.getSessionVariable().getTransactionVisibleWaitTimeout();
+        context.ctx.getSessionVariable().setTransactionVisibleWaitTimeout(Long.MAX_VALUE / 1000);
         mvContext = new MvTaskRunContext(context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -86,7 +86,7 @@ public class TaskBuilder {
         task.setSource(Constants.TaskSource.MV);
         task.setDbName(dbName);
         Map<String, String> taskProperties = Maps.newHashMap();
-        taskProperties.put(PartitionBasedMaterializedViewRefreshProcessor.MV_ID,
+        taskProperties.put(PartitionBasedMvRefreshProcessor.MV_ID,
                 String.valueOf(materializedView.getId()));
         taskProperties.put(SessionVariable.ENABLE_INSERT_STRICT, "false");
         taskProperties.putAll(materializedView.getProperties());
@@ -104,7 +104,7 @@ public class TaskBuilder {
         Task task = new Task(getMvTaskName(materializedView.getId()));
         task.setSource(Constants.TaskSource.MV);
         task.setDbName(dbName);
-        previousTaskProperties.put(PartitionBasedMaterializedViewRefreshProcessor.MV_ID,
+        previousTaskProperties.put(PartitionBasedMvRefreshProcessor.MV_ID,
                 String.valueOf(materializedView.getId()));
         task.setProperties(previousTaskProperties);
         task.setDefinition(

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -96,6 +96,10 @@ public class TaskRun implements Comparable<TaskRun> {
         this.task = task;
     }
 
+    public void setConnectContext(ConnectContext context) {
+        this.runCtx = context;
+    }
+
     public TaskRunProcessor getProcessor() {
         return processor;
     }
@@ -119,7 +123,7 @@ public class TaskRun implements Comparable<TaskRun> {
 
         try {
             // NOTE: mvId is set in Task's properties when creating
-            long mvId = Long.parseLong(properties.get(PartitionBasedMaterializedViewRefreshProcessor.MV_ID));
+            long mvId = Long.parseLong(properties.get(PartitionBasedMvRefreshProcessor.MV_ID));
             Database database = GlobalStateMgr.getCurrentState().getDb(ctx.getDatabase());
             if (database == null) {
                 LOG.warn("database {} do not exist when refreshing materialized view:{}", ctx.getDatabase(), mvId);
@@ -146,7 +150,9 @@ public class TaskRun implements Comparable<TaskRun> {
         Preconditions.checkNotNull(status.getDefinition(), "The definition of task run should not null");
         taskRunContext.setDefinition(status.getDefinition());
         taskRunContext.setPostRun(status.getPostRun());
-        runCtx = new ConnectContext(null);
+        if (runCtx == null) {
+            runCtx = new ConnectContext(null);
+        }
         runCtx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
         runCtx.setDatabase(task.getDbName());
         runCtx.setQualifiedUser(status.getUser());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -58,6 +58,8 @@ public class TaskRun implements Comparable<TaskRun> {
 
     private ConnectContext runCtx;
 
+    private ConnectContext parentRunCtx;
+
     private TaskRunProcessor processor;
 
     private TaskRunStatus status;
@@ -97,7 +99,7 @@ public class TaskRun implements Comparable<TaskRun> {
     }
 
     public void setConnectContext(ConnectContext context) {
-        this.runCtx = context;
+        this.parentRunCtx = context;
     }
 
     public TaskRunProcessor getProcessor() {
@@ -150,8 +152,9 @@ public class TaskRun implements Comparable<TaskRun> {
         Preconditions.checkNotNull(status.getDefinition(), "The definition of task run should not null");
         taskRunContext.setDefinition(status.getDefinition());
         taskRunContext.setPostRun(status.getPostRun());
-        if (runCtx == null) {
-            runCtx = new ConnectContext(null);
+        runCtx = new ConnectContext(null);
+        if (parentRunCtx != null) {
+            runCtx.setParentConnectContext(parentRunCtx);
         }
         runCtx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
         runCtx.setDatabase(task.getDbName());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunBuilder.java
@@ -15,6 +15,8 @@
 
 package com.starrocks.scheduler;
 
+import com.starrocks.qe.ConnectContext;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,6 +24,7 @@ public class TaskRunBuilder {
     private final Task task;
     private Map<String, String> properties;
     private Constants.TaskType type;
+    private ConnectContext connectContext;
 
     public static TaskRunBuilder newBuilder(Task task) {
         return new TaskRunBuilder(task);
@@ -31,15 +34,21 @@ public class TaskRunBuilder {
         this.task = task;
     }
 
+    public TaskRunBuilder setConnectContext(ConnectContext connectContext) {
+        this.connectContext = connectContext;
+        return this;
+    }
+
     // TaskRun is the smallest unit of execution.
     public TaskRun build() {
         TaskRun taskRun = new TaskRun();
+        taskRun.setConnectContext(connectContext);
         taskRun.setTaskId(task.getId());
         taskRun.setProperties(mergeProperties());
         taskRun.setTask(task);
         taskRun.setType(getTaskType());
         if (task.getSource().equals(Constants.TaskSource.MV)) {
-            taskRun.setProcessor(new PartitionBasedMaterializedViewRefreshProcessor());
+            taskRun.setProcessor(new PartitionBasedMvRefreshProcessor());
         } else {
             taskRun.setProcessor(new SqlTaskRunProcessor());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshMaterializedViewStatement.java
@@ -21,9 +21,11 @@ import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.parser.NodePosition;
 
 public class RefreshMaterializedViewStatement extends DdlStmt {
+
     private final TableName mvName;
     private final PartitionRangeDesc partitionRangeDesc;
     private final boolean forceRefresh;
+    private final boolean isSync;
 
     public static final ShowResultSetMetaData META_DATA =
             ShowResultSetMetaData.builder()
@@ -32,17 +34,18 @@ public class RefreshMaterializedViewStatement extends DdlStmt {
 
     public RefreshMaterializedViewStatement(TableName mvName,
                                             PartitionRangeDesc partitionRangeDesc,
-                                            boolean forceRefresh) {
-        this(mvName, partitionRangeDesc, forceRefresh, NodePosition.ZERO);
+                                            boolean forceRefresh, boolean isSync) {
+        this(mvName, partitionRangeDesc, forceRefresh, isSync, NodePosition.ZERO);
     }
 
     public RefreshMaterializedViewStatement(TableName mvName,
                                             PartitionRangeDesc partitionRangeDesc,
-                                            boolean forceRefresh, NodePosition pos) {
+                                            boolean forceRefresh, boolean isSync, NodePosition pos) {
         super(pos);
         this.mvName = mvName;
         this.partitionRangeDesc = partitionRangeDesc;
         this.forceRefresh = forceRefresh;
+        this.isSync = isSync;
     }
 
     public TableName getMvName() {
@@ -60,5 +63,9 @@ public class RefreshMaterializedViewStatement extends DdlStmt {
 
     public boolean isForceRefresh() {
         return forceRefresh;
+    }
+
+    public boolean isSync() {
+        return isSync;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1657,6 +1657,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                     (PartitionRangeDesc) visit(context.partitionRangeDesc());
         }
         return new RefreshMaterializedViewStatement(mvName, partitionRangeDesc, context.FORCE() != null,
+                context.SYNC() != null,
                 createPos(context));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -593,7 +593,7 @@ alterMaterializedViewStatement
     ;
 
 refreshMaterializedViewStatement
-    : REFRESH MATERIALIZED VIEW mvName=qualifiedName (PARTITION partitionRangeDesc)? FORCE?
+    : REFRESH MATERIALIZED VIEW mvName=qualifiedName (PARTITION partitionRangeDesc)? FORCE? (WITH (SYNC | ASYNC) MODE)?
     ;
 
 cancelRefreshMaterializedViewStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewStatementTest.java
@@ -22,9 +22,6 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.scheduler.Task;
-import com.starrocks.scheduler.TaskBuilder;
-import com.starrocks.scheduler.TaskManager;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -97,15 +94,8 @@ public class RefreshMaterializedViewStatementTest {
         Table t2 = db.getTable("mv1");
         Assert.assertNotNull(t2);
         MaterializedView mv1 = (MaterializedView) t2;
+        cluster.runSql("test", "refresh materialized view mv1 with sync mode");
 
-        TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
-        final String mvTaskName = TaskBuilder.getMvTaskName(mv1.getId());
-        if (!taskManager.containTask(mvTaskName)) {
-            Task task = TaskBuilder.buildMvTask(mv1, "test");
-            TaskBuilder.updateTaskInfo(task, mv1);
-            taskManager.createTask(task, false);
-        }
-        taskManager.executeTaskSync(mvTaskName);
         MaterializedView.MvRefreshScheme refreshScheme = mv1.getRefreshScheme();
         Assert.assertNotNull(refreshScheme);
         System.out.println("visibleVersionMap:" + refreshScheme.getAsyncRefreshContext().getBaseTableVisibleVersionMap());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -28,9 +28,6 @@ import com.starrocks.common.Config;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
-import com.starrocks.scheduler.Task;
-import com.starrocks.scheduler.TaskBuilder;
-import com.starrocks.scheduler.TaskManager;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.DmlStmt;
@@ -169,15 +166,7 @@ public class RefreshMaterializedViewTest {
     }
 
     private void refreshMaterializedView(String dbName, String mvName) throws Exception {
-        MaterializedView mv = getMv(dbName, mvName);
-        TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
-        final String mvTaskName = TaskBuilder.getMvTaskName(mv.getId());
-        if (!taskManager.containTask(mvTaskName)) {
-            Task task = TaskBuilder.buildMvTask(mv, "test");
-            TaskBuilder.updateTaskInfo(task, mv);
-            taskManager.createTask(task, false);
-        }
-        taskManager.executeTaskSync(mvTaskName);
+        cluster.runSql(dbName, String.format("refresh materialized view %s with sync mode", mvName));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -359,12 +359,13 @@ public class MaterializedViewTestBase extends PlanTestBase {
         MaterializedView mv = getMv(dbName, mvName);
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         final String mvTaskName = TaskBuilder.getMvTaskName(mv.getId());
-        if (!taskManager.containTask(mvTaskName)) {
-            Task task = TaskBuilder.buildMvTask(mv, dbName);
+        Task task = taskManager.getTask(mvTaskName);
+        if (task == null) {
+            task = TaskBuilder.buildMvTask(mv, dbName);
             TaskBuilder.updateTaskInfo(task, mv);
             taskManager.createTask(task, false);
         }
-        taskManager.executeTaskSync(mvTaskName);
+        taskManager.executeTaskSync(task);
     }
 
     protected static void createAndRefreshMV(String db, String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -68,7 +68,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.starrocks.scheduler.TaskRun.PARTITION_END;
 import static com.starrocks.scheduler.TaskRun.PARTITION_START;
 
-public class PartitionBasedMaterializedViewRefreshProcessorTest {
+public class PartitionBasedMvRefreshProcessorTest {
 
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
@@ -287,7 +287,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
             new StmtExecutor(connectContext, insertSql).execute();
 
             taskRun.executeTaskRun();
-            PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
             MvTaskRunContext mvContext = processor.getMvContext();
@@ -608,7 +608,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -684,7 +684,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -696,7 +696,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         mockedHiveMetadata.addPartition("partitioned_db", "lineitem_par", "l_shipdate=1998-01-06");
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
 
@@ -728,7 +728,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -741,7 +741,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("par_col=0/par_date=2020-01-03"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "par_date >= '2020-01-03', 9: par_date < '2020-01-04'", "partitions=2/6");
@@ -750,7 +750,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("par_col=0"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "partitions=6/6", "partitions=3/3");
@@ -776,7 +776,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -789,7 +789,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("l_shipdate=1998-01-04"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
 
@@ -799,7 +799,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         mockedHiveMetadata.updateTable("tpch", "orders");
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "partitions=6/6", "partitions=1/1");
@@ -823,7 +823,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -835,7 +835,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         mockedHiveMetadata.updateTable("tpch", "nation");
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "partitions=1/1");
@@ -866,7 +866,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -881,7 +881,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "PARTITION PREDICATES: 16: l_shipdate >= '1998-01-02', 16: l_shipdate < '1998-01-04'",
@@ -915,7 +915,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -928,7 +928,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "partitions=6/6");
@@ -960,7 +960,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -973,7 +973,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "partitions=6/6");
@@ -1004,7 +1004,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -1017,7 +1017,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "PARTITION PREDICATES: 16: l_shipdate >= '1998-01-02', 16: l_shipdate < '1998-01-04'",
@@ -1053,7 +1053,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -1066,7 +1066,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "PARTITION PREDICATES: 16: l_shipdate >= '1998-01-02', 16: l_shipdate < '1998-01-04'",
@@ -1102,7 +1102,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -1115,7 +1115,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("par_col=0"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "par_col >= 0, 4: par_col < 1", "partitions=1/3");
@@ -1166,7 +1166,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         Assert.assertEquals(1, materializedView.getPartition("p19980104").getVisibleVersion());
         Assert.assertEquals(1, materializedView.getPartition("p19980105").getVisibleVersion());
 
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -1205,7 +1205,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(mvProperties).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -1244,7 +1244,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(mvProperties).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -1347,7 +1347,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         String insertSql = "insert into tbl1 partition(p0) values('2021-12-01', 2, 10);";
         new StmtExecutor(connectContext, insertSql).execute();
 
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public void processTaskRun(TaskRunContext context) throws Exception {
                 throw new RuntimeException("new exception");
@@ -1367,7 +1367,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
     public void testBaseTablePartitionRename(TaskRun taskRun)
             throws Exception {
         // mv need refresh with base table partition p1, p1 renamed with p10 after collect and before insert overwrite
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             private Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
                 Map<Long, Pair<BaseTableInfo, Table>> olapTables = Maps.newHashMap();
@@ -1419,7 +1419,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
             throws Exception {
         // mv need refresh with base table partition p2, p2 replace with tp2 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
                 Map<Long, Pair<BaseTableInfo, Table>> olapTables = Maps.newHashMap();
@@ -1478,7 +1478,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
             throws Exception {
         // mv need refresh with base table partition p3, add partition p99 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
                 Map<Long, Pair<BaseTableInfo, Table>> olapTables = Maps.newHashMap();
@@ -1531,7 +1531,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
             throws Exception {
         // mv need refresh with base table partition p3, add partition p99 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public void refreshMaterializedView(MvTaskRunContext mvContext, ExecPlan execPlan,
                                                 InsertStmt insertStmt) throws Exception {
@@ -1569,7 +1569,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
             throws Exception {
         // mv need refresh with base table partition p4, drop partition p4 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             private Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
                 Map<Long, Pair<BaseTableInfo, Table>> olapTables = Maps.newHashMap();
@@ -1618,7 +1618,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
             throws Exception {
         // drop partition p4 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public void refreshMaterializedView(MvTaskRunContext mvContext, ExecPlan execPlan,
                                                 InsertStmt insertStmt) throws Exception {
@@ -1670,7 +1670,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
         materializedView.getTableProperty().setPartitionRefreshNumber(3);
-        PartitionBasedMaterializedViewRefreshProcessor processor = new PartitionBasedMaterializedViewRefreshProcessor();
+        PartitionBasedMvRefreshProcessor processor = new PartitionBasedMvRefreshProcessor();
 
         MvTaskRunContext mvContext = new MvTaskRunContext(new TaskRunContext());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTest.java
@@ -185,12 +185,13 @@ public class OptimizerTest {
         MaterializedView mv = getMv(dbName, mvName);
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         final String mvTaskName = TaskBuilder.getMvTaskName(mv.getId());
+        Task task = taskManager.getTask(mvTaskName);
         if (!taskManager.containTask(mvTaskName)) {
-            Task task = TaskBuilder.buildMvTask(mv, "test");
+            task = TaskBuilder.buildMvTask(mv, dbName);
             TaskBuilder.updateTaskInfo(task, mv);
             taskManager.createTask(task, false);
         }
-        taskManager.executeTaskSync(mvTaskName);
+        taskManager.executeTaskSync(task);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -60,7 +60,7 @@ import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.MvTaskRunContext;
-import com.starrocks.scheduler.PartitionBasedMaterializedViewRefreshProcessor;
+import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskRun;
@@ -337,7 +337,7 @@ public class StarRocksAssert {
     }
 
     private void waitingTaskFinish(TaskRun taskRun) {
-        MvTaskRunContext mvContext = ((PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor()).getMvContext();
+        MvTaskRunContext mvContext = ((PartitionBasedMvRefreshProcessor) taskRun.getProcessor()).getMvContext();
         int retryCount = 0;
         int maxRetry = 5;
         while (retryCount < maxRetry) {

--- a/test/sql/test_materialized_view/R/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_rewrite
@@ -26,9 +26,31 @@ insert into user_tags values('2023-04-13', 3, 'e', 6);
 create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
 -- result:
 -- !result
-select sleep(2);
+refresh materialized view user_tags_mv1 with sync mode;
+-- result:
+-- !result
+select count(*) from user_tags_mv1;
+-- result:
+3
+-- !result
+select user_id from user_tags_mv1 order by user_id;
 -- result:
 1
+2
+3
+-- !result
+refresh materialized view user_tags_mv1 force with sync mode;
+-- result:
+-- !result
+select count(*) from user_tags_mv1;
+-- result:
+3
+-- !result
+select user_id from user_tags_mv1 order by user_id;
+-- result:
+1
+2
+3
 -- !result
 set enable_materialized_view_rewrite = off;
 -- result:

--- a/test/sql/test_materialized_view/T/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_rewrite
@@ -10,7 +10,7 @@ insert into user_tags values('2023-04-13', 3, 'e', 6);
 
 -- TEST BITMAP: NO ROLLUP
 create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;
-select sleep(2);
+refresh materialized view user_tags_mv1 with sync mode;
 set enable_materialized_view_rewrite = off;
 select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
 select user_id, bitmap_union_count(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
@@ -24,7 +24,7 @@ drop materialized view user_tags_mv1;
 
 -- TEST BITMAP: ROLLUP
 create materialized view user_tags_mv2  distributed by hash(user_id) as select user_id, time, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id, time;
-select sleep(2);
+refresh materialized view user_tags_mv2 with sync mode;
 set enable_materialized_view_rewrite = on;
 explain logical select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
 select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
@@ -34,7 +34,7 @@ drop materialized view user_tags_mv2;
 
 -- TEST HLL: NO ROLLUP
 create materialized view user_tags_hll_mv1  distributed by hash(user_id) as select user_id, time, hll_union(hll_hash(tag_id)) a  from user_tags group by user_id;
-select sleep(2);
+refresh materialized view user_tags_hll_mv1 with sync mode;
 set enable_materialized_view_rewrite = off;
 select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
 select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
@@ -49,7 +49,7 @@ drop materialized view user_tags_hll_mv1;
 
 -- TEST HLL: ROLLUP
 create materialized view user_tags_hll_mv2  distributed by hash(user_id) as select user_id, time, hll_union(hll_hash(tag_id)) from user_tags group by user_id, time;
-select sleep(2);
+refresh materialized view user_tags_hll_mv2 with sync mode;
 set enable_materialized_view_rewrite = on;
 select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
 select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
@@ -59,7 +59,7 @@ drop materialized view user_tags_hll_mv2;
 
 -- TEST PERCENTILE: NO ROLLUP
 create materialized view user_tags_percential_mv1 distributed by hash(user_id) as select user_id, percentile_union(percentile_hash(tag_id)) from user_tags group by user_id order by user_id;
-select sleep(2);
+refresh materialized view user_tags_percential_mv1 with sync mode;
 set enable_materialized_view_rewrite = off;
 select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
 select user_id, percentile_approx(tag_id, 0) x from user_tags group by user_id order by user_id;
@@ -73,6 +73,7 @@ drop materialized view user_tags_percential_mv1;
 
 -- TEST PERCENTILE: ROLLUP
 create materialized view user_tags_percential_mv2 distributed by hash(user_id) as select user_id, time, percentile_union(percentile_hash(tag_id)) from user_tags group by user_id, time;
+refresh materialized view user_tags_percential_mv2 with sync mode;
 set enable_materialized_view_rewrite = on;
 select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
 select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
@@ -82,7 +83,7 @@ drop materialized view user_tags_percential_mv2;
 
 -- TEST BITMAP : UNOION
 create materialized view user_tags_mv3  distributed by hash(user_id) as select user_id, tag_id from user_tags where user_id > 2;
-select sleep(2);
+refresh materialized view user_tags_mv3 with sync mode;
 set enable_materialized_view_rewrite = off;
 select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
 select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;


### PR DESCRIPTION
Fixes #24045

Support refresh materialized view synchronously, add the following sql:
```sql
REFRESH MATERIALIZED VIEW mvName=qualifiedName (PARTITION partitionRangeDesc)? FORCE? (WITH (SYNC | ASYNC) MODE)?.
```

- In SYNC mode, refresh statement will submit a new refresh task and wait the task util finish.
- In ASYNC mode, refresh statement will submit a new refresh task and return immediately. The refresh task will run in background. The ASYNC mode is the default mode