### PR TITLE
[BugFix] Fix driver pending due to unclosed sink buffer

### DIFF
--- a/be/src/exec/pipeline/sink/file_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/file_sink_operator.cpp
@@ -134,6 +134,7 @@ void FileSinkIOBuffer::_process_chunk(bthread::TaskIterator<ChunkPtr>& iter) {
             status = status.clone_and_prepend("open file writer failed, error");
             LOG(WARNING) << status;
             _fragment_ctx->cancel(status);
+            close(_state);
             return;
         }
         _is_writer_opened = true;


### PR DESCRIPTION
In cases where creating a hdfs writer fails, we should close the sink buffer to avoid drivers forever pending.