### PR TITLE
[Enhancement] Add table_id to information_schema.tables_config

### DIFF
--- a/be/src/exec/schema_scanner/schema_tables_config_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tables_config_scanner.cpp
@@ -34,6 +34,7 @@ SchemaScanner::ColumnDesc SchemaTablesConfigScanner::_s_table_tables_config_colu
         {"DISTRIBUTE_BUCKET", TYPE_INT, sizeof(int32_t), false},
         {"SORT_KEY", TYPE_VARCHAR, sizeof(StringValue), false},
         {"PROPERTIES", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"TABLE_ID", TYPE_BIGINT, sizeof(int64_t), false},
 };
 
 SchemaTablesConfigScanner::SchemaTablesConfigScanner()
@@ -197,6 +198,14 @@ Status SchemaTablesConfigScanner::fill_chunk(ChunkPtr* chunk) {
                 const std::string* str = &info.properties;
                 Slice value(str->c_str(), str->length());
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+            break;
+        }
+        case 12: {
+            // table id
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(12);
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.table_id);
             }
             break;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesConfigSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesConfigSystemTable.java
@@ -15,6 +15,7 @@ package com.starrocks.catalog.system.information;
 
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
@@ -40,6 +41,7 @@ public class TablesConfigSystemTable {
                         .column("DISTRIBUTE_BUCKET", ScalarType.INT)
                         .column("SORT_KEY", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("PROPERTIES", ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("TABLE_ID", Type.BIGINT)
                         .build(), TSchemaTableType.SCH_TABLES_CONFIG);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.service;
 
 import com.google.common.base.Joiner;
@@ -58,7 +57,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-
 public class InformationSchemaDataSource {
 
     private static final Logger LOG = LogManager.getLogger(InformationSchemaDataSource.class);
@@ -70,7 +68,6 @@ public class InformationSchemaDataSource {
 
     @NotNull
     private static AuthDbRequestResult getAuthDbRequestResult(TAuthInfo authInfo) throws TException {
-
 
         List<String> authorizedDbs = Lists.newArrayList();
         PatternMatcher matcher = null;
@@ -117,7 +114,6 @@ public class InformationSchemaDataSource {
         }
     }
 
-
     // tables_config
     public static TGetTablesConfigResponse generateTablesConfigResponse(TGetTablesConfigRequest request)
             throws TException {
@@ -163,7 +159,6 @@ public class InformationSchemaDataSource {
         resp.tables_config_infos = tList;
         return resp;
     }
-
 
     private static Map<String, String> genProps(Table table) {
         if (table.isMaterializedView()) {
@@ -285,6 +280,7 @@ public class InformationSchemaDataSource {
             tableConfigInfo.setSort_key(Joiner.on(", ").join(sortKeysColumnNames));
         }
         tableConfigInfo.setProperties(new Gson().toJson(genProps(table)));
+        tableConfigInfo.setTable_id(table.getId());
         return tableConfigInfo;
     }
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1151,6 +1151,7 @@ struct TTableConfigInfo {
     9: optional i32 distribute_bucket
     10: optional string sort_key
     11: optional string properties
+    12: optional i64 table_id
 }
 
 struct TGetTablesInfoRequest {


### PR DESCRIPTION
Add table_id to information_schema.tables_config, so user can join be_tablets and tables_config to get db and table name of the tablet.

Fixes #24014
