### PR TITLE
[Enhancement] update compaction stragety about partial update by column

### DIFF
--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -50,7 +50,6 @@ Status RowsetColumnUpdateState::load(Tablet* tablet, Rowset* rowset, MemTracker*
     }
     std::call_once(_load_once_flag, [&] {
         _tablet_id = tablet->tablet_id();
-        _check_if_preload_column_mode_update_data(rowset, update_mem_tracker);
         _status = _do_load(tablet, rowset);
         if (!_status.ok()) {
             LOG(WARNING) << "load RowsetColumnUpdateState error: " << _status << " tablet:" << _tablet_id << " stack:\n"

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -312,6 +312,7 @@ private:
         size_t num_dels = 0;
         size_t byte_size = 0;
         int64_t compaction_score = 0;
+        bool partial_update_by_column = false;
         std::string to_string() const;
     };
 


### PR DESCRIPTION
Fixes #20436
This pr contains two parts:
1. During the continuous execution of partial updates by column, a large number of empty rowsets are generated, which will lead to frequent merging of data between empty rowsets and rowsets been updated, causing a waste of IO resources. After this optimization, only empty rowsets will be merged first.
2. Close the preload strategy.
