### PR TITLE
[BugFix] fixed_hash_map'find() return opposite result

### DIFF
--- a/be/src/util/fixed_hash_map.h
+++ b/be/src/util/fixed_hash_map.h
@@ -96,7 +96,7 @@ public:
 
     iterator find(KeyType key) {
         auto search_key = static_cast<search_key_type>(key);
-        if (_hash_table[search_key] != nullptr) {
+        if (_hash_table[search_key] == nullptr) {
             return end();
         }
         return iterator(_hash_table, search_key);


### PR DESCRIPTION
Fixes #issue
SmallFixedSizeHashMap' find() return opposite result.
I encounter this bug when select count(*) from xx group by month(date time) limit 0,1;
when the first chunk is all the same month, the aggregator will generate a map that 
contains the month->aggData. when the second chunk comes, the map.size() > limit, 
so there is no need generator new month->aggData, but they will get wrong _streaming_selection, 
and wrong aggData(nullptr) and that raise be crash.