### PR TITLE
[BugFix] Fix could not choose mv plan when mv has statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1575,7 +1575,13 @@ public class GlobalStateMgr {
 
     public void updateBaseTableRelatedMv(Long dbId, MaterializedView mv, List<BaseTableInfo> baseTableInfos) {
         for (BaseTableInfo baseTableInfo : baseTableInfos) {
-            Table table = baseTableInfo.getTable();
+            Table table;
+            try {
+                table = baseTableInfo.getTable();
+            } catch (Exception e) {
+                LOG.warn("there is an exception during get table from mv base table. exception:", e);
+                continue;
+            }
             if (table == null) {
                 LOG.warn("Setting the materialized view {}({}) to invalid because " +
                         "the table {} was not exist.", mv.getName(), mv.getId(), baseTableInfo.getTableName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
@@ -135,6 +135,14 @@ public class ExpressionContext {
         return statisticsForMv != null ? statisticsForMv : statistics;
     }
 
+    public Statistics getGroupStatistics() {
+        return isGroupExprContext() ? statistics : null;
+    }
+
+    public GroupExpression getGroupExpression() {
+        return groupExpression;
+    }
+
     public void setStatistics(Statistics statistics) {
         this.statistics = statistics;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.optimizer.base.LogicalProperty;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -241,6 +242,10 @@ public class Group {
             return lowestCostExpressions.get(physicalPropertySet).second;
         }
         return null;
+    }
+
+    public Collection<Pair<Double, GroupExpression>> getAllBestExpressionWithCost() {
+        return lowestCostExpressions.values();
     }
 
     public boolean hasBestExpression(PhysicalPropertySet physicalPropertySet) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -16,6 +16,8 @@ package com.starrocks.sql.optimizer.cost;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
@@ -57,6 +59,7 @@ import com.starrocks.statistic.StatisticUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -140,6 +143,30 @@ public class CostModel {
                     // or the cost of mv may be larger than origal query,
                     // which will lead to mismatch of mv
                     usedColumns.except(projection.getColumnRefMap().keySet());
+                }
+
+                Statistics groupStatistics = context.getGroupStatistics();
+                Statistics mvStatistics = context.getStatistics();
+                // only adjust cost for mv scan operator when group statistics is unknown and mv group expression
+                // statistics is not unknown
+                if (groupStatistics != null && groupStatistics.getColumnStatistics().values().stream().
+                        anyMatch(ColumnStatistic::isUnknown) && mvStatistics.getColumnStatistics().values().stream().
+                        noneMatch(ColumnStatistic::isUnknown)) {
+                    Group group = context.getGroupExpression().getGroup();
+                    List<Double> costs = Lists.newArrayList();
+                    // get the costs of all expression in this group
+                    for (Pair<Double, GroupExpression> pair : group.getAllBestExpressionWithCost()) {
+                        if (!(pair.second.getOp() instanceof PhysicalOlapScanOperator)) {
+                            costs.add(pair.first);
+                        }
+                    }
+                    double groupMinCost = Double.MAX_VALUE;
+                    if (costs.size() > 0) {
+                        groupMinCost = Collections.min(costs);
+                    }
+                    // use row count as the adjust cost
+                    double adjustCost = mvStatistics.getOutputRowCount();
+                    return CostEstimate.of(Math.min(Math.max(groupMinCost - 1, 0), adjustCost), 0, 0);
                 }
                 return CostEstimate.of(statistics.getOutputSize(usedColumns), 0, 0);
             }


### PR DESCRIPTION
Fixes #issue
when we create a materialized view for hive table, if mv plan has multi join, it need to compare cost between mv plan and origin plan,  if mv collect statistics but there is no column statisrics for hive table, it would not choose mv plan because it's cost are heigher.
In order to fix this problem, we adjusted the cost of mv when there are  no exact statistis in the origin plan  