### PR TITLE
[BugFix][Cherry-Pick][Branch-2.4] The primary key table segment data maybe out of order after finish schema change (#23985)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -21,6 +21,11 @@
 #include "storage/chunk_iterator.h"
 #include "storage/compaction_utils.h"
 #include "storage/del_vector.h"
+<<<<<<< HEAD
+=======
+#include "storage/empty_iterator.h"
+#include "storage/merge_iterator.h"
+>>>>>>> cc29298989 ([BugFix] The primary key table segment data maybe out of order after finish schema change (#23985))
 #include "storage/rowset/default_value_column_iterator.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_meta_manager.h"
@@ -35,6 +40,7 @@
 #include "storage/tablet.h"
 #include "storage/tablet_meta_manager.h"
 #include "storage/types.h"
+#include "storage/union_iterator.h"
 #include "storage/update_compaction_state.h"
 #include "storage/update_manager.h"
 #include "storage/wrapper_field.h"
@@ -2476,7 +2482,7 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
         writer_context.tablet_schema = &_tablet.tablet_schema();
         writer_context.rowset_state = VISIBLE;
         writer_context.version = src_rowset->version();
-        writer_context.segments_overlap = src_rowset->rowset_meta()->segments_overlap();
+        writer_context.segments_overlap = NONOVERLAPPING;
 
         std::unique_ptr<RowsetWriter> rowset_writer;
         status = RowsetFactory::create_rowset_writer(writer_context, &rowset_writer);
@@ -2484,9 +2490,19 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
             LOG(INFO) << "build rowset writer failed";
             return Status::InternalError("build rowset writer failed");
         }
+        ChunkIteratorPtr seg_iterator;
+        if (res.value().empty()) {
+            seg_iterator = new_empty_iterator(base_schema, config::vector_chunk_size);
+        } else {
+            if (src_rowset->rowset_meta()->is_segments_overlapping()) {
+                seg_iterator = new_heap_merge_iterator(res.value());
+            } else {
+                seg_iterator = new_union_iterator(res.value());
+            }
+        }
 
         // notice: rowset's del files not linked, it's not useful
-        status = _convert_from_base_rowset(base_tablet, res.value(), chunk_changer, rowset_writer);
+        status = _convert_from_base_rowset(base_tablet, seg_iterator, chunk_changer, rowset_writer);
         if (!status.ok()) {
             LOG(WARNING) << "failed to convert from base rowset, exit alter process";
             return status;
@@ -2589,8 +2605,7 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
 }
 
 Status TabletUpdates::_convert_from_base_rowset(const std::shared_ptr<Tablet>& base_tablet,
-                                                const std::vector<vectorized::ChunkIteratorPtr>& seg_iterators,
-                                                vectorized::ChunkChanger* chunk_changer,
+                                                const ChunkIteratorPtr& seg_iterator, ChunkChanger* chunk_changer,
                                                 const std::unique_ptr<RowsetWriter>& rowset_writer) {
     vectorized::Schema base_schema = ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema());
     vectorized::ChunkPtr base_chunk = ChunkHelper::new_chunk(base_schema, config::vector_chunk_size);
@@ -2600,10 +2615,7 @@ Status TabletUpdates::_convert_from_base_rowset(const std::shared_ptr<Tablet>& b
 
     std::unique_ptr<MemPool> mem_pool(new MemPool());
 
-    for (auto& seg_iterator : seg_iterators) {
-        if (seg_iterator.get() == nullptr) {
-            continue;
-        }
+    if (seg_iterator.get() != nullptr) {
         while (true) {
             base_chunk->reset();
             new_chunk->reset();

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -21,11 +21,8 @@
 #include "storage/chunk_iterator.h"
 #include "storage/compaction_utils.h"
 #include "storage/del_vector.h"
-<<<<<<< HEAD
-=======
 #include "storage/empty_iterator.h"
 #include "storage/merge_iterator.h"
->>>>>>> cc29298989 ([BugFix] The primary key table segment data maybe out of order after finish schema change (#23985))
 #include "storage/rowset/default_value_column_iterator.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_meta_manager.h"
@@ -2605,7 +2602,8 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
 }
 
 Status TabletUpdates::_convert_from_base_rowset(const std::shared_ptr<Tablet>& base_tablet,
-                                                const ChunkIteratorPtr& seg_iterator, ChunkChanger* chunk_changer,
+                                                const ChunkIteratorPtr& seg_iterator,
+                                                vectorized::ChunkChanger* chunk_changer,
                                                 const std::unique_ptr<RowsetWriter>& rowset_writer) {
     vectorized::Schema base_schema = ChunkHelper::convert_schema_to_format_v2(base_tablet->tablet_schema());
     vectorized::ChunkPtr base_chunk = ChunkHelper::new_chunk(base_schema, config::vector_chunk_size);

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -352,7 +352,8 @@ private:
     void _update_total_stats(const std::vector<uint32_t>& rowsets, size_t* row_count_before, size_t* row_count_after);
 
     Status _convert_from_base_rowset(const std::shared_ptr<Tablet>& base_tablet, const ChunkIteratorPtr& seg_iterator,
-                                     ChunkChanger* chunk_changer, const std::unique_ptr<RowsetWriter>& rowset_writer);
+                                     vectorized::ChunkChanger* chunk_changer,
+                                     const std::unique_ptr<RowsetWriter>& rowset_writer);
 
     void _check_creation_time_increasing();
 

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -351,10 +351,8 @@ private:
 
     void _update_total_stats(const std::vector<uint32_t>& rowsets, size_t* row_count_before, size_t* row_count_after);
 
-    Status _convert_from_base_rowset(const std::shared_ptr<Tablet>& base_tablet,
-                                     const std::vector<vectorized::ChunkIteratorPtr>& seg_iterators,
-                                     vectorized::ChunkChanger* chunk_changer,
-                                     const std::unique_ptr<RowsetWriter>& rowset_writer);
+    Status _convert_from_base_rowset(const std::shared_ptr<Tablet>& base_tablet, const ChunkIteratorPtr& seg_iterator,
+                                     ChunkChanger* chunk_changer, const std::unique_ptr<RowsetWriter>& rowset_writer);
 
     void _check_creation_time_increasing();
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -97,6 +97,63 @@ public:
         return *writer->build();
     }
 
+    RowsetSharedPtr create_rowset_with_mutiple_segments(const TabletSharedPtr& tablet,
+                                                        const vector<vector<int64_t>>& keys_by_segment,
+                                                        Column* one_delete = nullptr, bool empty = false,
+                                                        bool has_merge_condition = false) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = &tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = OVERLAP_UNKNOWN;
+        if (has_merge_condition) {
+            writer_context.merge_condition = "v2";
+        }
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        if (empty) {
+            return *writer->build();
+        }
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        for (int i = 0; i < keys_by_segment.size(); i++) {
+            auto chunk = ChunkHelper::new_chunk(schema, keys_by_segment[i].size());
+            auto& cols = chunk->columns();
+            for (int64_t key : keys_by_segment[i]) {
+                if (schema.num_key_fields() == 1) {
+                    cols[0]->append_datum(Datum(key));
+                } else {
+                    cols[0]->append_datum(Datum(key));
+                    string v = fmt::to_string(key * 234234342345);
+                    cols[1]->append_datum(Datum(Slice(v)));
+                    cols[2]->append_datum(Datum((int32_t)key));
+                }
+                int vcol_start = schema.num_key_fields();
+                cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+                if (cols[vcol_start + 1]->is_binary()) {
+                    string v = fmt::to_string(key % 1000 + 2);
+                    cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+                } else {
+                    cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+                }
+            }
+            if (one_delete == nullptr && !keys_by_segment[i].empty()) {
+                CHECK_OK(writer->flush_chunk(*chunk));
+            } else if (one_delete == nullptr) {
+                CHECK_OK(writer->flush());
+            } else if (one_delete != nullptr) {
+                CHECK_OK(writer->flush_chunk_with_deletes(*chunk, *one_delete));
+            }
+        }
+        return *writer->build();
+    }
+
     RowsetSharedPtr create_partial_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
                                           std::vector<int32_t>& column_indexes,
                                           std::shared_ptr<TabletSchema> partial_schema) {
@@ -409,6 +466,11 @@ public:
     void test_link_from(bool enable_persistent_index);
     void test_convert_from(bool enable_persistent_index);
     void test_convert_from_with_pending(bool enable_persistent_index);
+<<<<<<< HEAD
+=======
+    void test_convert_from_with_mutiple_segment(bool enable_persistent_index);
+    void test_reorder_from(bool enable_persistent_index);
+>>>>>>> cc29298989 ([BugFix] The primary key table segment data maybe out of order after finish schema change (#23985))
     void test_load_snapshot_incremental(bool enable_persistent_index);
     void test_load_snapshot_incremental_ignore_already_committed_version(bool enable_persistent_index);
     void test_load_snapshot_incremental_mismatched_tablet_id(bool enable_persistent_index);
@@ -1425,6 +1487,49 @@ void TabletUpdatesTest::test_convert_from_with_pending(bool enable_persistent_in
     ASSERT_EQ(2 * N, read_tablet_and_compare_schema_changed(tablet_to_schema_change, 4, allkeys));
 }
 
+void TabletUpdatesTest::test_convert_from_with_mutiple_segment(bool enable_persistent_index) {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    _tablet->set_enable_persistent_index(enable_persistent_index);
+    const auto& tablet_to_schema_change = create_tablet_to_schema_change(rand(), rand());
+    std::vector<std::vector<int64_t>> keys_by_segment;
+    keys_by_segment.resize(2);
+    for (int i = 100; i < 200; i++) {
+        keys_by_segment[0].emplace_back(i);
+    }
+    for (int i = 0; i < 100; i++) {
+        keys_by_segment[1].emplace_back(i);
+    }
+    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset_with_mutiple_segments(_tablet, keys_by_segment)).ok());
+
+    tablet_to_schema_change->set_tablet_state(TABLET_NOTREADY);
+    auto chunk_changer = std::make_unique<ChunkChanger>(tablet_to_schema_change->tablet_schema());
+    for (int i = 0; i < tablet_to_schema_change->tablet_schema().num_columns(); ++i) {
+        const auto& new_column = tablet_to_schema_change->tablet_schema().column(i);
+        int32_t column_index = _tablet->field_index(std::string{new_column.name()});
+        auto column_mapping = chunk_changer->get_mutable_column_mapping(i);
+        if (column_index >= 0) {
+            column_mapping->ref_column = column_index;
+        }
+    }
+    std::vector<int64_t> ori_keys;
+    for (int i = 100; i < 200; i++) {
+        ori_keys.emplace_back(i);
+    }
+    for (int i = 0; i < 100; i++) {
+        ori_keys.emplace_back(i);
+    }
+    ASSERT_EQ(200, read_tablet_and_compare(_tablet, 2, ori_keys));
+
+    ASSERT_TRUE(tablet_to_schema_change->updates()->convert_from(_tablet, 2, chunk_changer.get()).ok());
+
+    std::vector<int64_t> keys;
+    for (int i = 0; i < 200; i++) {
+        keys.emplace_back(i);
+    }
+    ASSERT_EQ(200, read_tablet_and_compare_schema_changed(tablet_to_schema_change, 2, keys));
+}
+
 TEST_F(TabletUpdatesTest, convert_from) {
     test_convert_from(false);
 }
@@ -1441,7 +1546,68 @@ TEST_F(TabletUpdatesTest, convert_from_with_pending_and_persistent_index) {
     test_convert_from_with_pending(true);
 }
 
-// NOLINTNEXTLINE
+TEST_F(TabletUpdatesTest, convert_from_with_mutiple_segment) {
+    test_convert_from_with_mutiple_segment(false);
+}
+
+TEST_F(TabletUpdatesTest, convert_from_with_mutiple_segment_with_persistent_index) {
+    test_convert_from_with_mutiple_segment(true);
+}
+
+void TabletUpdatesTest::test_reorder_from(bool enable_persistent_index) {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    _tablet->set_enable_persistent_index(enable_persistent_index);
+    const auto& tablet_with_sort_key1 = create_tablet_with_sort_key(rand(), rand(), {1});
+    std::vector<int64_t> keys;
+    int N = 100;
+    for (int i = 0; i < N; i++) {
+        keys.push_back(i);
+    }
+    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset_schema_change_sort_key(_tablet, keys)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset_schema_change_sort_key(_tablet, keys)).ok());
+    ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset_schema_change_sort_key(_tablet, keys)).ok());
+
+    tablet_with_sort_key1->set_tablet_state(TABLET_NOTREADY);
+    auto chunk_changer = std::make_unique<ChunkChanger>(tablet_with_sort_key1->tablet_schema());
+    for (int i = 0; i < tablet_with_sort_key1->tablet_schema().num_columns(); ++i) {
+        const auto& new_column = tablet_with_sort_key1->tablet_schema().column(i);
+        int32_t column_index = _tablet->field_index(std::string{new_column.name()});
+        auto column_mapping = chunk_changer->get_mutable_column_mapping(i);
+        if (column_index >= 0) {
+            column_mapping->ref_column = column_index;
+            column_mapping->ref_base_reader_column_index = i;
+        }
+    }
+
+    ASSERT_TRUE(tablet_with_sort_key1->updates()->reorder_from(_tablet, 4, chunk_changer.get()).ok());
+
+    ASSERT_EQ(N, read_tablet_and_compare_schema_changed_sort_key1(tablet_with_sort_key1, 4, keys));
+
+    const auto& tablet_with_sort_key2 = create_tablet_with_sort_key(rand(), rand(), {2});
+    tablet_with_sort_key2->set_tablet_state(TABLET_NOTREADY);
+    chunk_changer = std::make_unique<ChunkChanger>(tablet_with_sort_key2->tablet_schema());
+    for (int i = 0; i < tablet_with_sort_key2->tablet_schema().num_columns(); ++i) {
+        const auto& new_column = tablet_with_sort_key2->tablet_schema().column(i);
+        int32_t column_index = _tablet->field_index(std::string{new_column.name()});
+        auto column_mapping = chunk_changer->get_mutable_column_mapping(i);
+        if (column_index >= 0) {
+            column_mapping->ref_column = column_index;
+            column_mapping->ref_base_reader_column_index = i;
+        }
+    }
+    ASSERT_TRUE(tablet_with_sort_key2->updates()->reorder_from(tablet_with_sort_key1, 4, chunk_changer.get()).ok());
+    ASSERT_EQ(N, read_tablet_and_compare_schema_changed_sort_key2(tablet_with_sort_key2, 4, keys));
+}
+
+TEST_F(TabletUpdatesTest, reorder_from) {
+    test_reorder_from(false);
+}
+
+TEST_F(TabletUpdatesTest, reorder_from_with_persistent_index) {
+    test_reorder_from(true);
+}
+
 void TabletUpdatesTest::test_load_snapshot_incremental(bool enable_persistent_index) {
     srand(GetCurrentTimeMicros());
     auto tablet0 = create_tablet(rand(), rand());

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -99,9 +99,8 @@ public:
 
     RowsetSharedPtr create_rowset_with_mutiple_segments(const TabletSharedPtr& tablet,
                                                         const vector<vector<int64_t>>& keys_by_segment,
-                                                        Column* one_delete = nullptr, bool empty = false,
-                                                        bool has_merge_condition = false) {
-        RowsetWriterContext writer_context;
+                                                        vectorized::Column* one_delete = nullptr, bool empty = false) {
+        RowsetWriterContext writer_context(kDataFormatV2, config::storage_format_version);
         RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
         writer_context.rowset_id = rowset_id;
         writer_context.tablet_id = tablet->tablet_id();
@@ -113,34 +112,32 @@ public:
         writer_context.version.first = 0;
         writer_context.version.second = 0;
         writer_context.segments_overlap = OVERLAP_UNKNOWN;
-        if (has_merge_condition) {
-            writer_context.merge_condition = "v2";
-        }
+
         std::unique_ptr<RowsetWriter> writer;
         EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
         if (empty) {
             return *writer->build();
         }
-        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        auto schema = ChunkHelper::convert_schema_to_format_v2(tablet->tablet_schema());
         for (int i = 0; i < keys_by_segment.size(); i++) {
             auto chunk = ChunkHelper::new_chunk(schema, keys_by_segment[i].size());
             auto& cols = chunk->columns();
             for (int64_t key : keys_by_segment[i]) {
                 if (schema.num_key_fields() == 1) {
-                    cols[0]->append_datum(Datum(key));
+                    cols[0]->append_datum(vectorized::Datum(key));
                 } else {
-                    cols[0]->append_datum(Datum(key));
+                    cols[0]->append_datum(vectorized::Datum(key));
                     string v = fmt::to_string(key * 234234342345);
-                    cols[1]->append_datum(Datum(Slice(v)));
-                    cols[2]->append_datum(Datum((int32_t)key));
+                    cols[1]->append_datum(vectorized::Datum(Slice(v)));
+                    cols[2]->append_datum(vectorized::Datum((int32_t)key));
                 }
                 int vcol_start = schema.num_key_fields();
-                cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+                cols[vcol_start]->append_datum(vectorized::Datum((int16_t)(key % 100 + 1)));
                 if (cols[vcol_start + 1]->is_binary()) {
                     string v = fmt::to_string(key % 1000 + 2);
-                    cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+                    cols[vcol_start + 1]->append_datum(vectorized::Datum(Slice(v)));
                 } else {
-                    cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+                    cols[vcol_start + 1]->append_datum(vectorized::Datum((int32_t)(key % 1000 + 2)));
                 }
             }
             if (one_delete == nullptr && !keys_by_segment[i].empty()) {
@@ -466,11 +463,7 @@ public:
     void test_link_from(bool enable_persistent_index);
     void test_convert_from(bool enable_persistent_index);
     void test_convert_from_with_pending(bool enable_persistent_index);
-<<<<<<< HEAD
-=======
     void test_convert_from_with_mutiple_segment(bool enable_persistent_index);
-    void test_reorder_from(bool enable_persistent_index);
->>>>>>> cc29298989 ([BugFix] The primary key table segment data maybe out of order after finish schema change (#23985))
     void test_load_snapshot_incremental(bool enable_persistent_index);
     void test_load_snapshot_incremental_ignore_already_committed_version(bool enable_persistent_index);
     void test_load_snapshot_incremental_mismatched_tablet_id(bool enable_persistent_index);
@@ -1503,7 +1496,7 @@ void TabletUpdatesTest::test_convert_from_with_mutiple_segment(bool enable_persi
     ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset_with_mutiple_segments(_tablet, keys_by_segment)).ok());
 
     tablet_to_schema_change->set_tablet_state(TABLET_NOTREADY);
-    auto chunk_changer = std::make_unique<ChunkChanger>(tablet_to_schema_change->tablet_schema());
+    auto chunk_changer = std::make_unique<vectorized::ChunkChanger>(tablet_to_schema_change->tablet_schema());
     for (int i = 0; i < tablet_to_schema_change->tablet_schema().num_columns(); ++i) {
         const auto& new_column = tablet_to_schema_change->tablet_schema().column(i);
         int32_t column_index = _tablet->field_index(std::string{new_column.name()});
@@ -1552,60 +1545,6 @@ TEST_F(TabletUpdatesTest, convert_from_with_mutiple_segment) {
 
 TEST_F(TabletUpdatesTest, convert_from_with_mutiple_segment_with_persistent_index) {
     test_convert_from_with_mutiple_segment(true);
-}
-
-void TabletUpdatesTest::test_reorder_from(bool enable_persistent_index) {
-    srand(GetCurrentTimeMicros());
-    _tablet = create_tablet(rand(), rand());
-    _tablet->set_enable_persistent_index(enable_persistent_index);
-    const auto& tablet_with_sort_key1 = create_tablet_with_sort_key(rand(), rand(), {1});
-    std::vector<int64_t> keys;
-    int N = 100;
-    for (int i = 0; i < N; i++) {
-        keys.push_back(i);
-    }
-    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset_schema_change_sort_key(_tablet, keys)).ok());
-    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset_schema_change_sort_key(_tablet, keys)).ok());
-    ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset_schema_change_sort_key(_tablet, keys)).ok());
-
-    tablet_with_sort_key1->set_tablet_state(TABLET_NOTREADY);
-    auto chunk_changer = std::make_unique<ChunkChanger>(tablet_with_sort_key1->tablet_schema());
-    for (int i = 0; i < tablet_with_sort_key1->tablet_schema().num_columns(); ++i) {
-        const auto& new_column = tablet_with_sort_key1->tablet_schema().column(i);
-        int32_t column_index = _tablet->field_index(std::string{new_column.name()});
-        auto column_mapping = chunk_changer->get_mutable_column_mapping(i);
-        if (column_index >= 0) {
-            column_mapping->ref_column = column_index;
-            column_mapping->ref_base_reader_column_index = i;
-        }
-    }
-
-    ASSERT_TRUE(tablet_with_sort_key1->updates()->reorder_from(_tablet, 4, chunk_changer.get()).ok());
-
-    ASSERT_EQ(N, read_tablet_and_compare_schema_changed_sort_key1(tablet_with_sort_key1, 4, keys));
-
-    const auto& tablet_with_sort_key2 = create_tablet_with_sort_key(rand(), rand(), {2});
-    tablet_with_sort_key2->set_tablet_state(TABLET_NOTREADY);
-    chunk_changer = std::make_unique<ChunkChanger>(tablet_with_sort_key2->tablet_schema());
-    for (int i = 0; i < tablet_with_sort_key2->tablet_schema().num_columns(); ++i) {
-        const auto& new_column = tablet_with_sort_key2->tablet_schema().column(i);
-        int32_t column_index = _tablet->field_index(std::string{new_column.name()});
-        auto column_mapping = chunk_changer->get_mutable_column_mapping(i);
-        if (column_index >= 0) {
-            column_mapping->ref_column = column_index;
-            column_mapping->ref_base_reader_column_index = i;
-        }
-    }
-    ASSERT_TRUE(tablet_with_sort_key2->updates()->reorder_from(tablet_with_sort_key1, 4, chunk_changer.get()).ok());
-    ASSERT_EQ(N, read_tablet_and_compare_schema_changed_sort_key2(tablet_with_sort_key2, 4, keys));
-}
-
-TEST_F(TabletUpdatesTest, reorder_from) {
-    test_reorder_from(false);
-}
-
-TEST_F(TabletUpdatesTest, reorder_from_with_persistent_index) {
-    test_reorder_from(true);
 }
 
 void TabletUpdatesTest::test_load_snapshot_incremental(bool enable_persistent_index) {


### PR DESCRIPTION
The rowset of the primary key tablet after import may be segmented overlapping until compaction is finished. But if we create an altered job(add an index or change column type) that needs to rewrite the segment data, we ignore the segment overlapping status and splice into a new segment one by one according to the original order of the segments. This may cause the new segment data out of order and the short key index will be incorrect we may get an error query result using a short key index.

