### PR TITLE
[Refactor] Use CpuInfo::num_cores() instead of hardware_concurrency()

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -241,8 +241,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
             new pipeline::GlobalDriverExecutor("wg_pip_exe", std::move(wg_driver_executor_thread_pool), true);
     _wg_driver_executor->initialize(_max_executor_threads);
 
-    int connector_num_io_threads =
-            config::pipeline_connector_scan_thread_num_per_cpu * std::thread::hardware_concurrency();
+    int connector_num_io_threads = config::pipeline_connector_scan_thread_num_per_cpu * CpuInfo::num_cores();
     CHECK_GT(connector_num_io_threads, 0) << "pipeline_connector_scan_thread_num_per_cpu should greater than 0";
 
     std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_without_workgroup;


### PR DESCRIPTION
Fixes #issue

Use config::num_cores uniformly to calculate the number of threads. It is convenient to do some tests.

