### PR TITLE
[Enhancement] Stop compaction tasks for other tablets if one task fails within a transaction

### DIFF
--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -201,7 +201,8 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
     } else {
         auto task_or = _tablet_mgr->compact(tablet_id, version, txn_id);
         if (task_or.ok()) {
-            status.update(task_or.value()->execute(&context->progress));
+            auto should_cancel = [&]() { return context->callback->has_error(); };
+            status.update(task_or.value()->execute(&context->progress, std::move(should_cancel)));
         } else {
             status.update(task_or.status());
         }

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -57,6 +57,11 @@ public:
 
     void finish_task(std::unique_ptr<CompactionTaskContext>&& context);
 
+    bool has_error() const {
+        std::lock_guard l(_mtx);
+        return !_status.ok();
+    }
+
 private:
     CompactionScheduler* _scheduler;
     mutable bthread::Mutex _mtx;

--- a/be/src/storage/lake/compaction_task.h
+++ b/be/src/storage/lake/compaction_task.h
@@ -42,8 +42,8 @@ public:
 
     virtual Status execute(Progress* stats, CancelFunc cancel_func) = 0;
 
-    inline static const CancelFunc kNoCancel = []() { return false; };
-    inline static const CancelFunc kCancelled = []() { return true; };
+    inline static const CancelFunc kNoCancelFn = []() { return false; };
+    inline static const CancelFunc kCancelledFn = []() { return true; };
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_task.h
+++ b/be/src/storage/lake/compaction_task.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <ostream>
 
 #include "common/status.h"
@@ -33,9 +34,16 @@ public:
         std::atomic<int> _value{0};
     };
 
+    // CancelFunc is a function that used to tell the compaction task whether the task
+    // should be cancelled.
+    using CancelFunc = std::function<bool()>;
+
     virtual ~CompactionTask() = default;
 
-    virtual Status execute(Progress* stats) = 0;
+    virtual Status execute(Progress* stats, CancelFunc cancel_func) = 0;
+
+    inline static const CancelFunc kNoCancel = []() { return false; };
+    inline static const CancelFunc kCancelled = []() { return true; };
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/horizontal_compaction_task.h
+++ b/be/src/storage/lake/horizontal_compaction_task.h
@@ -41,7 +41,7 @@ public:
 
     ~HorizontalCompactionTask() override = default;
 
-    Status execute(Progress* progress) override;
+    Status execute(Progress* progress, CancelFunc cancel_func) override;
 
 private:
     StatusOr<int32_t> calculate_chunk_size();

--- a/be/src/storage/lake/vertical_compaction_task.h
+++ b/be/src/storage/lake/vertical_compaction_task.h
@@ -44,7 +44,7 @@ public:
 
     ~VerticalCompactionTask() override = default;
 
-    Status execute(Progress* progress) override;
+    Status execute(Progress* progress, CancelFunc cancel_func) override;
 
 private:
     StatusOr<int32_t> calculate_chunk_size_for_column_group(const std::vector<uint32_t>& column_group);
@@ -52,7 +52,7 @@ private:
     Status compact_column_group(bool is_key, int column_group_index, size_t num_column_groups,
                                 const std::vector<uint32_t>& column_group, std::unique_ptr<TabletWriter>& writer,
                                 RowSourceMaskBuffer* mask_buffer, std::vector<RowSourceMask>* source_masks,
-                                Progress* progress);
+                                Progress* progress, const CancelFunc& cancel_func);
 
     int64_t _txn_id;
     int64_t _version;

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -206,7 +206,7 @@ TEST_P(DuplicateKeyCompactionTest, test1) {
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, txn_id));
     check_task(task);
     CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
     version++;
@@ -232,7 +232,7 @@ TEST_F(DuplicateKeyCompactionTest, test_empty_tablet) {
     auto txn_id = next_id();
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, txn_id));
     CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
     version++;
@@ -369,7 +369,7 @@ TEST_P(DuplicateKeyOverlapSegmentsCompactionTest, test) {
         ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, txn_id));
         check_task(task);
         CompactionTask::Progress progress;
-        auto st = task->execute(&progress, CompactionTask::kCancelled);
+        auto st = task->execute(&progress, CompactionTask::kCancelledFn);
         EXPECT_EQ(0, progress.value());
         EXPECT_TRUE(st.is_cancelled()) << st;
     }
@@ -379,7 +379,7 @@ TEST_P(DuplicateKeyOverlapSegmentsCompactionTest, test) {
         ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, txn_id));
         check_task(task);
         CompactionTask::Progress progress;
-        ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+        ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
         EXPECT_EQ(100, progress.value());
         ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
         version++;
@@ -545,7 +545,7 @@ TEST_P(UniqueKeyCompactionTest, test1) {
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, txn_id));
     check_task(task);
     CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
     version++;
@@ -714,7 +714,7 @@ TEST_P(UniqueKeyCompactionWithDeleteTest, test_base_compaction_with_delete) {
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, txn_id));
     check_task(task);
     CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
     version++;

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -270,7 +270,7 @@ TEST_P(PrimaryKeyCompactionTest, test1) {
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
     check_task(task);
     CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1).status());
     version++;
@@ -331,7 +331,7 @@ TEST_P(PrimaryKeyCompactionTest, test2) {
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
     check_task(task);
     CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1).status());
     version++;
@@ -384,7 +384,7 @@ TEST_P(PrimaryKeyCompactionTest, test3) {
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
     check_task(task);
     CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1).status());
     version++;
@@ -528,7 +528,7 @@ TEST_P(PrimaryKeyCompactionTest, test_compaction_sorted) {
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
     check_task(task);
     CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1).status());
     version++;

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -44,9 +44,6 @@
 
 namespace starrocks::lake {
 
-using VSchema = starrocks::Schema;
-using VChunk = starrocks::Chunk;
-
 class TestLocationProvider : public LocationProvider {
 public:
     explicit TestLocationProvider(std::string dir) : _dir(std::move(dir)) {}
@@ -108,7 +105,7 @@ public:
         }
 
         _tablet_schema = TabletSchema::create(*schema);
-        _schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(*_tablet_schema));
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(*_tablet_schema));
     }
 
 protected:
@@ -133,7 +130,7 @@ protected:
         (void)fs::remove_all(kTestGroupPath);
     }
 
-    VChunk generate_data(int64_t chunk_size, int shift) {
+    Chunk generate_data(int64_t chunk_size, int shift) {
         std::vector<int> v0(chunk_size);
         std::vector<int> v1(chunk_size);
         for (int i = 0; i < chunk_size; i++) {
@@ -149,10 +146,10 @@ protected:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        return VChunk({c0, c1}, _schema);
+        return Chunk({c0, c1}, _schema);
     }
 
-    VChunk generate_data2(int64_t chunk_size, int interval, int shift) {
+    Chunk generate_data2(int64_t chunk_size, int interval, int shift) {
         std::vector<int> v0(chunk_size);
         std::vector<int> v1(chunk_size);
         for (int i = 0; i < chunk_size; i++) {
@@ -168,7 +165,7 @@ protected:
         auto c1 = Int32Column::create();
         c0->append_numbers(v0.data(), v0.size() * sizeof(int));
         c1->append_numbers(v1.data(), v1.size() * sizeof(int));
-        return VChunk({c0, c1}, _schema);
+        return Chunk({c0, c1}, _schema);
     }
 
     int64_t read(int64_t version) {
@@ -227,7 +224,7 @@ protected:
 
     std::shared_ptr<TabletMetadata> _tablet_metadata;
     std::shared_ptr<TabletSchema> _tablet_schema;
-    std::shared_ptr<VSchema> _schema;
+    std::shared_ptr<Schema> _schema;
     int64_t _partition_id = 4561;
     int64_t _txn_id = 1231;
 };
@@ -272,7 +269,9 @@ TEST_P(PrimaryKeyCompactionTest, test1) {
 
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
     check_task(task);
-    ASSERT_OK(task->execute(nullptr));
+    CompactionTask::Progress progress;
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+    EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1).status());
     version++;
     ASSERT_EQ(kChunkSize, read(version));
@@ -331,7 +330,9 @@ TEST_P(PrimaryKeyCompactionTest, test2) {
 
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
     check_task(task);
-    ASSERT_OK(task->execute(nullptr));
+    CompactionTask::Progress progress;
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+    EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1).status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -382,7 +383,9 @@ TEST_P(PrimaryKeyCompactionTest, test3) {
 
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
     check_task(task);
-    ASSERT_OK(task->execute(nullptr));
+    CompactionTask::Progress progress;
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+    EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1).status());
     version++;
     ASSERT_EQ(kChunkSize * 2, read(version));
@@ -524,7 +527,9 @@ TEST_P(PrimaryKeyCompactionTest, test_compaction_sorted) {
 
     ASSIGN_OR_ABORT(auto task, _tablet_manager->compact(_tablet_metadata->id(), version, _txn_id));
     check_task(task);
-    ASSERT_OK(task->execute(nullptr));
+    CompactionTask::Progress progress;
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancel));
+    EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_manager->publish_version(_tablet_metadata->id(), version, version + 1, &_txn_id, 1).status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));


### PR DESCRIPTION
If one tablet's compaction task fails within a transaction, the
whole transaction fails. Therefore, no need to continue executing
other tablet's compaction tasks to avoid wasting resources.