### PR TITLE
[BugFix] set jobStatus to RUNNING for PREPARED transaction in LabelAlreadyUsedException

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/LabelAlreadyUsedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/LabelAlreadyUsedException.java
@@ -37,6 +37,7 @@ public class LabelAlreadyUsedException extends DdlException {
         switch (txnStatus) {
             case UNKNOWN:
             case PREPARE:
+            case PREPARED:
                 jobStatus = "RUNNING";
                 break;
             case COMMITTED:


### PR DESCRIPTION

Fixes #issue
