### PR TITLE
[Feature] support struct constructor

### DIFF
--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -345,25 +345,14 @@ int64_t StructColumn::xor_checksum(uint32_t from, uint32_t to) const {
 void StructColumn::put_mysql_row_buffer(MysqlRowBuffer* buf, size_t idx) const {
     DCHECK_LT(idx, size());
     buf->begin_push_bracket();
-    if (is_unnamed_struct()) {
-        for (size_t i = 0; i < _fields.size(); ++i) {
-            const auto& field = _fields[i];
-            field->put_mysql_row_buffer(buf, idx);
-            if (i < _fields.size() - 1) {
-                // Add struct field separator, last field don't need ','.
-                buf->separator(',');
-            }
-        }
-    } else {
-        for (size_t i = 0; i < _fields.size(); ++i) {
-            const auto& field = _fields[i];
-            buf->push_string(_field_names[i]);
-            buf->separator(':');
-            field->put_mysql_row_buffer(buf, idx);
-            if (i < _fields.size() - 1) {
-                // Add struct field separator, last field don't need ','.
-                buf->separator(',');
-            }
+    for (size_t i = 0; i < _fields.size(); ++i) {
+        const auto& field = _fields[i];
+        buf->push_string(_field_names[i]);
+        buf->separator(':');
+        field->put_mysql_row_buffer(buf, idx);
+        if (i < _fields.size() - 1) {
+            // Add struct field separator, last field don't need ','.
+            buf->separator(',');
         }
     }
     buf->finish_push_bracket();
@@ -373,25 +362,14 @@ std::string StructColumn::debug_item(size_t idx) const {
     DCHECK_LT(idx, size());
     std::stringstream ss;
     ss << '{';
-    if (is_unnamed_struct()) {
-        for (size_t i = 0; i < _fields.size(); i++) {
-            const auto& field = _fields[i];
-            ss << field->debug_item(idx);
-            if (i < _fields.size() - 1) {
-                // Add struct field separator, last field don't need ','.
-                ss << ",";
-            }
-        }
-    } else {
-        for (size_t i = 0; i < _fields.size(); i++) {
-            const auto& field = _fields[i];
-            ss << _field_names[i];
-            ss << ":";
-            ss << field->debug_item(idx);
-            if (i < _fields.size() - 1) {
-                // Add struct field separator, last field don't need ','.
-                ss << ",";
-            }
+    for (size_t i = 0; i < _fields.size(); i++) {
+        const auto& field = _fields[i];
+        ss << _field_names[i];
+        ss << ":";
+        ss << field->debug_item(idx);
+        if (i < _fields.size() - 1) {
+            // Add struct field separator, last field don't need ','.
+            ss << ",";
         }
     }
     ss << '}';

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -163,8 +163,6 @@ public:
     // Struct Column own functions
     const Columns& fields() const;
 
-    bool is_unnamed_struct() const { return _field_names.empty(); }
-
     Columns& fields_column();
 
     ColumnPtr field_column(const std::string& field_name);

--- a/be/src/exprs/struct_functions.cpp
+++ b/be/src/exprs/struct_functions.cpp
@@ -14,16 +14,40 @@
 
 #include "exprs/struct_functions.h"
 
+#include "column/column_helper.h"
 #include "column/struct_column.h"
 
 namespace starrocks {
 
-StatusOr<ColumnPtr> StructFunctions::row(FunctionContext* context, const Columns& columns) {
-    Columns field_columns;
-    for (auto& column : columns) {
-        field_columns.emplace_back(column->clone());
+StatusOr<ColumnPtr> StructFunctions::new_struct(FunctionContext* context, const Columns& columns) {
+    ColumnPtr res = context->create_column(context->get_return_type(), false);
+
+    StructColumn* st = down_cast<StructColumn*>(res.get());
+    auto fields = st->fields_column();
+
+    DCHECK_EQ(fields.size(), columns.size());
+
+    for (int i = 0; i < columns.size(); i++) {
+        auto column = columns[i];
+        if (column->only_null()) {
+            fields[i]->append_nulls(column->size());
+        } else if (column->is_constant()) {
+            auto* cc = ColumnHelper::get_data_column(column.get());
+            fields[i]->append_value_multiple_times(*cc, 0, column->size(), true);
+        } else {
+            fields[i]->append(*column, 0, column->size());
+        }
     }
-    return StructColumn::create(std::move(field_columns));
+
+    return res;
 }
 
+StatusOr<ColumnPtr> StructFunctions::name_struct(FunctionContext* context, const Columns& columns) {
+    Columns cols;
+    for (int i = 1; i < columns.size(); i = i + 2) {
+        cols.emplace_back(columns[i]);
+    }
+
+    return new_struct(context, cols);
+}
 } // namespace starrocks

--- a/be/src/exprs/struct_functions.cpp
+++ b/be/src/exprs/struct_functions.cpp
@@ -42,7 +42,7 @@ StatusOr<ColumnPtr> StructFunctions::new_struct(FunctionContext* context, const 
     return res;
 }
 
-StatusOr<ColumnPtr> StructFunctions::name_struct(FunctionContext* context, const Columns& columns) {
+StatusOr<ColumnPtr> StructFunctions::named_struct(FunctionContext* context, const Columns& columns) {
     Columns cols;
     for (int i = 1; i < columns.size(); i = i + 2) {
         cols.emplace_back(columns[i]);

--- a/be/src/exprs/struct_functions.h
+++ b/be/src/exprs/struct_functions.h
@@ -22,7 +22,7 @@ class StructFunctions {
 public:
     DEFINE_VECTORIZED_FN(new_struct);
 
-    DEFINE_VECTORIZED_FN(name_struct);
+    DEFINE_VECTORIZED_FN(named_struct);
 };
 
 } // namespace starrocks

--- a/be/src/exprs/struct_functions.h
+++ b/be/src/exprs/struct_functions.h
@@ -20,7 +20,9 @@ namespace starrocks {
 
 class StructFunctions {
 public:
-    DEFINE_VECTORIZED_FN(row);
+    DEFINE_VECTORIZED_FN(new_struct);
+
+    DEFINE_VECTORIZED_FN(name_struct);
 };
 
 } // namespace starrocks

--- a/be/test/column/struct_column_test.cpp
+++ b/be/test/column/struct_column_test.cpp
@@ -528,28 +528,6 @@ TEST(StructColumnTest, test_assign) {
     ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(1));
 }
 
-TEST(StructColumnTest, test_unnamed) {
-    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    Columns fields{id, name};
-    auto column = StructColumn::create(fields);
-
-    ASSERT_TRUE(column->is_struct());
-    ASSERT_FALSE(column->is_nullable());
-    ASSERT_EQ(0, column->size());
-
-    DatumStruct struct1{uint64_t(1), Slice("smith")};
-    DatumStruct struct2{uint64_t(2), Slice("cruise")};
-    column->append_datum(struct1);
-    column->append_datum(struct2);
-
-    ASSERT_EQ(column->size(), 2);
-    ASSERT_EQ("{1,'smith'}", column->debug_item(0));
-    ASSERT_EQ("{2,'cruise'}", column->debug_item(1));
-
-    ASSERT_EQ("{1,'smith'}, {2,'cruise'}", column->debug_string());
-}
-
 TEST(StructColumnTest, test_reference_memory_usage) {
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());

--- a/be/test/exprs/struct_functions_test.cpp
+++ b/be/test/exprs/struct_functions_test.cpp
@@ -47,21 +47,21 @@ PARALLEL_TEST(StructFunctionsTest, test_new_struct) {
         input_columns[i]->append_datum({5 - i});
     }
 
-    MemPool pool;
-    FunctionContext::TypeDesc ret;
+    FunctionContext::TypeDesc ret_type;
     FunctionContext::TypeDesc cint;
     std::vector<FunctionContext::TypeDesc> arg_types;
     cint.type = starrocks::TYPE_INT;
-    ret.type = starrocks::TYPE_STRUCT;
+    ret_type.type = starrocks::TYPE_STRUCT;
     for (int i = 0; i < 5; ++i) {
-        ret.field_names.emplace_back(fmt::format("col%d", (i + 1)));
-        ret.children.emplace_back(cint);
+        ret_type.field_names.emplace_back(fmt::format("col%d", (i + 1)));
+        ret_type.children.emplace_back(cint);
         arg_types.emplace_back(cint);
     }
 
-    FunctionContext* context = FunctionContext::create_context(nullptr, &pool, ret, arg_types);
+    FunctionContext* context = FunctionContext::create_context(nullptr, nullptr, ret_type, arg_types);
 
-    auto ret = StructFunctions::new_struct(&context, input_columns);
+    auto ret = StructFunctions::new_struct(context, input_columns);
+    delete context;
     ASSERT_TRUE(ret.ok());
     auto struct_col = std::move(ret).value();
     ASSERT_EQ(3, struct_col->size());
@@ -93,23 +93,23 @@ PARALLEL_TEST(StructFunctionsTest, test_name_struct) {
         input_columns[i]->append_nulls(1);
     }
 
-    MemPool pool;
-    FunctionContext::TypeDesc ret;
+    FunctionContext::TypeDesc ret_type;
     FunctionContext::TypeDesc cint;
     std::vector<FunctionContext::TypeDesc> arg_types;
     cint.type = starrocks::TYPE_INT;
-    ret.type = starrocks::TYPE_STRUCT;
+    ret_type.type = starrocks::TYPE_STRUCT;
     for (int i = 0; i < 3; ++i) {
-        ret.field_names.emplace_back(fmt::format("col%d", (i + 1)));
-        ret.children.emplace_back(cint);
+        ret_type.field_names.emplace_back(fmt::format("col%d", (i + 1)));
+        ret_type.children.emplace_back(cint);
     }
     for (int i = 0; i < 6; ++i) {
         arg_types.emplace_back(cint);
     }
 
-    FunctionContext* context = FunctionContext::create_context(nullptr, &pool, ret, arg_types);
+    FunctionContext* context = FunctionContext::create_context(nullptr, nullptr, ret_type, arg_types);
 
-    auto ret = StructFunctions::name_struct(nullptr, input_columns);
+    auto ret = StructFunctions::name_struct(context, input_columns);
+    delete context;
     ASSERT_TRUE(ret.ok());
     auto struct_col = std::move(ret).value();
     ASSERT_EQ(3, struct_col->size());

--- a/be/test/exprs/struct_functions_test.cpp
+++ b/be/test/exprs/struct_functions_test.cpp
@@ -22,7 +22,7 @@
 
 namespace starrocks {
 
-PARALLEL_TEST(StructFunctionsTest, test_row) {
+PARALLEL_TEST(StructFunctionsTest, test_new_struct) {
     Columns input_columns;
     for (int i = 0; i < 5; ++i) {
         TypeDescriptor type;
@@ -47,14 +47,76 @@ PARALLEL_TEST(StructFunctionsTest, test_row) {
         input_columns[i]->append_datum({5 - i});
     }
 
-    auto ret = StructFunctions::row(nullptr, input_columns);
+    MemPool pool;
+    FunctionContext::TypeDesc ret;
+    FunctionContext::TypeDesc cint;
+    std::vector<FunctionContext::TypeDesc> arg_types;
+    cint.type = starrocks::TYPE_INT;
+    ret.type = starrocks::TYPE_STRUCT;
+    for (int i = 0; i < 5; ++i) {
+        ret.field_names.emplace_back(fmt::format("col%d", (i + 1)));
+        ret.children.emplace_back(cint);
+        arg_types.emplace_back(cint);
+    }
+
+    FunctionContext* context = FunctionContext::create_context(nullptr, &pool, ret, arg_types);
+
+    auto ret = StructFunctions::new_struct(&context, input_columns);
     ASSERT_TRUE(ret.ok());
     auto struct_col = std::move(ret).value();
     ASSERT_EQ(3, struct_col->size());
 
-    ASSERT_STREQ("{0,1,2,3,4}", struct_col->debug_item(0).c_str());
-    ASSERT_STREQ("{NULL,1,NULL,3,NULL}", struct_col->debug_item(1).c_str());
-    ASSERT_STREQ("{5,4,3,2,1}", struct_col->debug_item(2).c_str());
+    ASSERT_STREQ("{col1:0,col2:1,col3:2,col4:3,col5:4}", struct_col->debug_item(0).c_str());
+    ASSERT_STREQ("{col1:NULL,col2:1,col3:NULL,col4:3,col5:NULL}", struct_col->debug_item(1).c_str());
+    ASSERT_STREQ("{col1:5,col2:4,col3:3,col4:2,col5:1}", struct_col->debug_item(2).c_str());
+}
+
+PARALLEL_TEST(StructFunctionsTest, test_name_struct) {
+    Columns input_columns;
+    for (int i = 0; i < 6; ++i) {
+        TypeDescriptor type;
+        type.type = LogicalType::TYPE_INT;
+        input_columns.emplace_back(ColumnHelper::create_column(type, true));
+    }
+
+    for (int i = 0; i < 6; ++i) {
+        input_columns[i]->append_datum({i});
+    }
+    for (int i = 0; i < 6; ++i) {
+        if ((i % 2) == 0) {
+            input_columns[i]->append_nulls(1);
+        } else {
+            input_columns[i]->append_datum({1});
+        }
+    }
+    for (int i = 0; i < 6; ++i) {
+        input_columns[i]->append_nulls(1);
+    }
+
+    MemPool pool;
+    FunctionContext::TypeDesc ret;
+    FunctionContext::TypeDesc cint;
+    std::vector<FunctionContext::TypeDesc> arg_types;
+    cint.type = starrocks::TYPE_INT;
+    ret.type = starrocks::TYPE_STRUCT;
+    for (int i = 0; i < 3; ++i) {
+        ret.field_names.emplace_back(fmt::format("col%d", (i + 1)));
+        ret.children.emplace_back(cint);
+    }
+    for (int i = 0; i < 6; ++i) {
+        arg_types.emplace_back(cint);
+    }
+
+    FunctionContext* context = FunctionContext::create_context(nullptr, &pool, ret, arg_types);
+
+    auto ret = StructFunctions::name_struct(nullptr, input_columns);
+    ASSERT_TRUE(ret.ok());
+    auto struct_col = std::move(ret).value();
+    ASSERT_EQ(3, struct_col->size());
+
+    ASSERT_STREQ("{col1:1,col2:3,col3:5}", struct_col->debug_item(0).c_str());
+    ASSERT_STREQ("{col1:1,col2:1,col3:1}", struct_col->debug_item(1).c_str());
+    ASSERT_STREQ("{col1:NULL,col2:NULL,col3:NULL}", struct_col->debug_item(2).c_str());
 }
 
 } // namespace starrocks

--- a/be/test/exprs/struct_functions_test.cpp
+++ b/be/test/exprs/struct_functions_test.cpp
@@ -53,7 +53,7 @@ PARALLEL_TEST(StructFunctionsTest, test_new_struct) {
     cint.type = starrocks::TYPE_INT;
     ret_type.type = starrocks::TYPE_STRUCT;
     for (int i = 0; i < 5; ++i) {
-        ret_type.field_names.emplace_back(fmt::format("col%d", (i + 1)));
+        ret_type.field_names.emplace_back(fmt::format("col{}", (i + 1)));
         ret_type.children.emplace_back(cint);
         arg_types.emplace_back(cint);
     }
@@ -99,7 +99,7 @@ PARALLEL_TEST(StructFunctionsTest, test_name_struct) {
     cint.type = starrocks::TYPE_INT;
     ret_type.type = starrocks::TYPE_STRUCT;
     for (int i = 0; i < 3; ++i) {
-        ret_type.field_names.emplace_back(fmt::format("col%d", (i + 1)));
+        ret_type.field_names.emplace_back(fmt::format("col{}", (i + 1)));
         ret_type.children.emplace_back(cint);
     }
     for (int i = 0; i < 6; ++i) {

--- a/be/test/exprs/struct_functions_test.cpp
+++ b/be/test/exprs/struct_functions_test.cpp
@@ -71,7 +71,7 @@ PARALLEL_TEST(StructFunctionsTest, test_new_struct) {
     ASSERT_STREQ("{col1:5,col2:4,col3:3,col4:2,col5:1}", struct_col->debug_item(2).c_str());
 }
 
-PARALLEL_TEST(StructFunctionsTest, test_name_struct) {
+PARALLEL_TEST(StructFunctionsTest, test_named_struct) {
     Columns input_columns;
     for (int i = 0; i < 6; ++i) {
         TypeDescriptor type;
@@ -108,7 +108,7 @@ PARALLEL_TEST(StructFunctionsTest, test_name_struct) {
 
     FunctionContext* context = FunctionContext::create_context(nullptr, nullptr, ret_type, arg_types);
 
-    auto ret = StructFunctions::name_struct(context, input_columns);
+    auto ret = StructFunctions::named_struct(context, input_columns);
     delete context;
     ASSERT_TRUE(ret.ok());
     auto struct_col = std::move(ret).value();

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -309,6 +309,7 @@
         + [HLL](./sql-reference/sql-statements/data-types/HLL.md)
         + [JSON](./sql-reference/sql-statements/data-types/JSON.md)
         + [MAP](./sql-reference/sql-statements/data-types/Map.md)
+        + [STRUCT](./sql-reference/sql-statements/data-types/STRUCT.md)
 
     + [Keywords](./sql-reference/sql-statements/keywords.md)
     + [AUTO_INCREMENT](./sql-reference/sql-statements/auto_increment.md)

--- a/docs/sql-reference/sql-statements/data-types/STRUCT.md
+++ b/docs/sql-reference/sql-statements/data-types/STRUCT.md
@@ -1,0 +1,98 @@
+# Struct
+
+## Background
+
+Struct, as an extended type of database, are supported in Trino, ClickHouse and other systems. They are contains a set of named fields, each field has a type and a name. Structs are widely used to express complex data types. Note there are no duplicate field names in a struct.
+
+## Struct usage
+
+### Struct definition
+
+`Struct<NAME, TYPE>`
+
+`NAME` column name, it's same as the column name in the `CREATE TABLE` statement.
+`TYPE` can be any supported types, and it's natively nullable.
+
+The following is an example of defining a struct column in StarRocks:
+
+~~~SQL
+-- One-dimensional struct
+create table t0(
+  c0 INT,
+  c1 STRUCT<a INT, b INT>
+)
+duplicate key(c0);
+
+-- Define complex structs
+create table t1(
+  c0 INT,
+  c1 STRUCT<a INT, b STRUCT<c INT, d INT>, c MAP<INT, INT>, d ARRAY<INT>>
+)
+duplicate key(c0);
+
+-- Define not-null nullable structs
+create table t2(
+  c0 INT,
+  c1 STRUCT<a INT, b INT> NOT NULL
+)
+duplicate key(c0)
+~~~
+
+The struct type has the following restrictions:
+
+* Struct columns cannot be used as key columns (maybe supported later)
+* Struct columns cannot be used as distribution columns
+* Struct columns cannot be used as partition columns
+* Struct columns only support REPLACE in Aggregate Table Model
+
+### Construct structs in SQL
+
+Struct can be constructed in SQL using function `row`, `name_struct`, `struct` 
+
+~~~SQL
+select row(1, 2, 3, 4) as numbers; -- The result is {'col1': 1, 'col2': 2, 'col3': 3, 'col4': 4}
+select struct(1, 2, 3, 4) as numbers; -- The result is {'col1': 1, 'col2': 2, 'col3': 3, 'col4': 4}
+select name_struct('a', 1, 'b', 2, 'c', 3, 'd', 4) as numbers; -- The result is {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+~~~
+
+`row`, `struct` support un-named struct, StarRocks will automatically generate column names, like `col1`, `col2`...
+`name_struct` support a named struct, the parameters must be a Name/Value pairs, and the number of parameters must be even.
+
+StarRocks will automatically determine the type of the struct.
+
+### Struct import
+
+There are two ways to write struct values to StarRocks. Insert into is suitable for small-scale data testing. ORC or Parquet import is suitable for large-scale data import. NOTE StarRocks will automatically cast the data type to the corresponding struct type.
+
+* **INSERT INTO**
+
+  ~~~SQL
+  create table t0(c0 INT, c1 `STRUCT<a INT, b INT>`)duplicate key(c0);
+  INSERT INTO t0 VALUES(1, row(1, 1));
+  ~~~
+
+* **Import from ORC Parquet file**
+
+  The struct type in StarRocks corresponds to the list structure in ORC/Parquet format; no additional specification is needed. 
+
+
+### Struct element access
+
+Access a subfield of a struct using `.`
+
+~~~Plain Text
+mysql> select name_struct('a', 1, 'b', 2, 'c', 3, 'd', 4).a;
+
++-----------------------------------------------+
+| name_struct('a', 1, 'b', 2, 'c', 3, 'd', 4).a |
++-----------------------------------------------+
+| 1                                             |
++-----------------------------------------------+
+
+mysql> select row(1, 2, 3, 4).col1;
++------------------+
+| row(1, 2, 3, 4)  |
++------------------+
+| 1                |
++------------------+
+~~~

--- a/docs/sql-reference/sql-statements/data-types/STRUCT.md
+++ b/docs/sql-reference/sql-statements/data-types/STRUCT.md
@@ -35,7 +35,7 @@ create table t2(
   c0 INT,
   c1 STRUCT<a INT, b INT> NOT NULL
 )
-duplicate key(c0)
+duplicate key(c0);
 ~~~
 
 The struct type has the following restrictions:
@@ -73,7 +73,7 @@ There are two ways to write struct values to StarRocks. Insert into is suitable 
 
 * **Import from ORC Parquet file**
 
-  The struct type in StarRocks corresponds to the list structure in ORC/Parquet format; no additional specification is needed. 
+  The struct type in StarRocks corresponds to the nest columns structure in ORC/Parquet format; no additional specification is needed. 
 
 
 ### Struct element access

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -422,6 +422,8 @@ public class FunctionSet {
     public static final String CARDINALITY = "cardinality";
     // Struct functions:
     public static final String ROW = "row";
+    public static final String STRUCT = "struct";
+    public static final String NAME_STRUCT = "name_struct";
 
     // JSON functions
     public static final Function JSON_QUERY_FUNC = new Function(

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -423,7 +423,7 @@ public class FunctionSet {
     // Struct functions:
     public static final String ROW = "row";
     public static final String STRUCT = "struct";
-    public static final String NAME_STRUCT = "name_struct";
+    public static final String NAMED_STRUCT = "named_struct";
 
     // JSON functions
     public static final Function JSON_QUERY_FUNC = new Function(

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
@@ -17,7 +17,13 @@ package com.starrocks.catalog;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.thrift.TTypeDesc;
 import com.starrocks.thrift.TTypeNode;
 import com.starrocks.thrift.TTypeNodeType;
@@ -186,6 +192,21 @@ public class MapType extends Type {
             clone.selectedFields = this.selectedFields.clone();
         }
         return clone;
+    }
+
+    // Todo: remove it after remove selectedFields
+    public static class MapTypeDeserializer implements JsonDeserializer<MapType> {
+        @Override
+        public MapType deserialize(JsonElement jsonElement, java.lang.reflect.Type type,
+                                   JsonDeserializationContext jsonDeserializationContext)
+                throws JsonParseException {
+            JsonObject dumpJsonObject = jsonElement.getAsJsonObject();
+            JsonObject key = dumpJsonObject.getAsJsonObject("keyType");
+            Type keyType = GsonUtils.GSON.fromJson(key, Type.class);
+            JsonObject value = dumpJsonObject.getAsJsonObject("valueType");
+            Type valueType = GsonUtils.GSON.fromJson(value, Type.class);
+            return new MapType(keyType, valueType);
+        }
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
@@ -17,13 +17,7 @@ package com.starrocks.catalog;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.thrift.TTypeDesc;
 import com.starrocks.thrift.TTypeNode;
 import com.starrocks.thrift.TTypeNodeType;
@@ -42,7 +36,7 @@ public class MapType extends Type {
     public MapType(Type keyType, Type valueType) {
         Preconditions.checkNotNull(keyType);
         Preconditions.checkNotNull(valueType);
-        selectedFields = new Boolean[] { false, false };
+        selectedFields = new Boolean[] {false, false};
         this.keyType = keyType;
         this.valueType = valueType;
     }
@@ -188,22 +182,10 @@ public class MapType extends Type {
         MapType clone = (MapType) super.clone();
         clone.keyType = this.keyType.clone();
         clone.valueType = this.valueType.clone();
-        clone.selectedFields = this.selectedFields.clone();
-        return clone;
-    }
-
-    public static class MapTypeDeserializer implements JsonDeserializer<MapType> {
-        @Override
-        public MapType deserialize(JsonElement jsonElement, java.lang.reflect.Type type,
-                                   JsonDeserializationContext jsonDeserializationContext)
-                throws JsonParseException {
-            JsonObject dumpJsonObject = jsonElement.getAsJsonObject();
-            JsonObject key = dumpJsonObject.getAsJsonObject("keyType");
-            Type keyType = GsonUtils.GSON.fromJson(key, Type.class);
-            JsonObject value = dumpJsonObject.getAsJsonObject("valueType");
-            Type valueType = GsonUtils.GSON.fromJson(value, Type.class);
-            return new MapType(keyType, valueType);
+        if (this.selectedFields != null) {
+            clone.selectedFields = this.selectedFields.clone();
         }
+        return clone;
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
@@ -78,8 +78,8 @@ public class StructType extends Type {
         ArrayList<StructField> newFields = new ArrayList<>();
         for (int i = 0; i < fieldTypes.size(); i++) {
             Type fieldType = fieldTypes.get(i);
-            // unnamed struct, default column name is col0, col1, ...
-            newFields.add(new StructField("col" + i, fieldType));
+            // unnamed struct, default column name is col1, ...
+            newFields.add(new StructField("col" + (i + 1), fieldType));
         }
         this.fields = newFields;
         selectedFields = new Boolean[fields.size()];

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
@@ -82,13 +82,15 @@ public class StructType extends Type {
     // row(1, 'b') to create an unnamed struct type struct<int, string>
     public StructType(List<Type> fieldTypes) {
         isNamed = false;
-        ArrayList<StructField> newFields = new ArrayList<>();
+        this.fields = new ArrayList<>();
         for (int i = 0; i < fieldTypes.size(); i++) {
             Type fieldType = fieldTypes.get(i);
             // unnamed struct, default column name is col1, ...
-            newFields.add(new StructField("col" + (i + 1), fieldType));
+            StructField field = new StructField("col" + (i + 1), fieldType);
+            this.fields.add(field);
+            field.setPosition(i);
+            fieldMap.put(field.getName(), field);
         }
-        this.fields = newFields;
         selectedFields = new Boolean[fields.size()];
         Arrays.fill(selectedFields, false);
     }
@@ -136,7 +138,7 @@ public class StructType extends Type {
         }
         ArrayList<String> fieldsSql = Lists.newArrayList();
         for (StructField f : fields) {
-            fieldsSql.add(f.toSql(depth + 1, isNamed));
+            fieldsSql.add(f.toSql(depth + 1, true));
         }
         return String.format("struct<%s>", Joiner.on(", ").join(fieldsSql));
     }
@@ -146,7 +148,7 @@ public class StructType extends Type {
         String leftPadding = Strings.repeat(" ", lpad);
         ArrayList<String> fieldsSql = Lists.newArrayList();
         for (StructField f : fields) {
-            fieldsSql.add(f.prettyPrint(lpad + 2, isNamed));
+            fieldsSql.add(f.prettyPrint(lpad + 2, true));
         }
         return String.format("%sSTRUCT<\n%s\n%s>",
                 leftPadding, Joiner.on(",\n").join(fieldsSql), leftPadding);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -359,11 +359,6 @@ public class GsonUtils {
 
     private static final JsonDeserializer<PrimitiveType> PRIMITIVE_TYPE_DESERIALIZER = new PrimitiveTypeDeserializer();
 
-    private static final JsonDeserializer<MapType> MAP_TYPE_JSON_DESERIALIZER = new MapType.MapTypeDeserializer();
-
-    private static final JsonDeserializer<StructType> STRUCT_TYPE_JSON_DESERIALIZER =
-            new StructType.StructTypeDeserializer();
-
     // the builder of GSON instance.
     // Add any other adapters if necessary.
     private static final GsonBuilder GSON_BUILDER = new GsonBuilder()
@@ -373,11 +368,6 @@ public class GsonUtils {
             .registerTypeHierarchyAdapter(Table.class, new GuavaTableAdapter())
             .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
             .registerTypeAdapterFactory(new ProcessHookTypeAdapterFactory())
-            // specified subclass deserializer must be ahead of superclass,
-            // because when doing GsonBuilder::create(), the order will be reversed,
-            // and gson::getDelegateAdapter will skip the factory ahead of super TypeAdapterFactory factory.
-            .registerTypeAdapter(MapType.class, MAP_TYPE_JSON_DESERIALIZER)
-            .registerTypeAdapter(StructType.class, STRUCT_TYPE_JSON_DESERIALIZER)
             .registerTypeAdapterFactory(COLUMN_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapterFactory(DISTRIBUTION_INFO_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapterFactory(RESOURCE_TYPE_ADAPTER_FACTORY)

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -368,6 +368,9 @@ public class GsonUtils {
             .registerTypeHierarchyAdapter(Table.class, new GuavaTableAdapter())
             .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
             .registerTypeAdapterFactory(new ProcessHookTypeAdapterFactory())
+            // For call constructor with selectedFields
+            .registerTypeAdapter(MapType.class, new MapType.MapTypeDeserializer())
+            .registerTypeAdapter(StructType.class, new StructType.StructTypeDeserializer())
             .registerTypeAdapterFactory(COLUMN_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapterFactory(DISTRIBUTION_INFO_TYPE_ADAPTER_FACTORY)
             .registerTypeAdapterFactory(RESOURCE_TYPE_ADAPTER_FACTORY)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -992,9 +992,9 @@ public class ExpressionAnalyzer {
                     fn = Expr.getBuiltinFunction(FunctionSet.ARRAY_CONCAT, argumentTypes,
                             Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
                 }
-            } else if (FunctionSet.NAME_STRUCT.equals(fnName)) {
+            } else if (FunctionSet.NAMED_STRUCT.equals(fnName)) {
                 // deriver struct type
-                fn = Expr.getBuiltinFunction(FunctionSet.NAME_STRUCT, argumentTypes,
+                fn = Expr.getBuiltinFunction(FunctionSet.NAMED_STRUCT, argumentTypes,
                         Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
                 fn = fn.copy();
                 ArrayList<StructField> sf = Lists.newArrayList();
@@ -1159,7 +1159,7 @@ public class ExpressionAnalyzer {
                     }
                     break;
                 }
-                case FunctionSet.NAME_STRUCT: {
+                case FunctionSet.NAMED_STRUCT: {
                     if (node.getChildren().size() < 2) {
                         throw new SemanticException(fnName + " should have at least two inputs", node.getPos());
                     }
@@ -1171,13 +1171,13 @@ public class ExpressionAnalyzer {
                     for (int i = 0; i < node.getChildren().size(); i = i + 2) {
                         if (!(node.getChild(i) instanceof StringLiteral)) {
                             throw new SemanticException(
-                                    "The " + (i + 1) + "-th input of name_struct must be string literal",
+                                    "The " + (i + 1) + "-th input of named_struct must be string literal",
                                     node.getPos());
                         }
 
                         String name = ((StringLiteral) node.getChild(i)).getValue();
                         if (check.contains(name)) {
-                            throw new SemanticException("name_struct contains duplicate subfield name: " +
+                            throw new SemanticException("named_struct contains duplicate subfield name: " +
                                     name + " at " + (i + 1) + "-th input", node.getPos());
                         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -18,6 +18,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.re2j.Pattern;
 import com.starrocks.analysis.AnalyticExpr;
 import com.starrocks.analysis.ArithmeticExpr;
@@ -536,7 +537,8 @@ public class ExpressionAnalyzer {
                 Expr child = node.getChild(i);
                 if (child.getType().isBoolean() || child.getType().isNull()) {
                     // do nothing
-                } else if (!session.getSessionVariable().isEnableStrictType() && Type.canCastTo(child.getType(), Type.BOOLEAN)) {
+                } else if (!session.getSessionVariable().isEnableStrictType() &&
+                        Type.canCastTo(child.getType(), Type.BOOLEAN)) {
                     node.getChildren().set(i, new CastExpr(Type.BOOLEAN, child));
                 } else {
                     throw new SemanticException(child.toSql() + " can not be converted to boolean type.");
@@ -990,6 +992,17 @@ public class ExpressionAnalyzer {
                     fn = Expr.getBuiltinFunction(FunctionSet.ARRAY_CONCAT, argumentTypes,
                             Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
                 }
+            } else if (FunctionSet.NAME_STRUCT.equals(fnName)) {
+                // deriver struct type
+                fn = Expr.getBuiltinFunction(FunctionSet.NAME_STRUCT, argumentTypes,
+                        Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                fn = fn.copy();
+                ArrayList<StructField> sf = Lists.newArrayList();
+                for (int i = 0; i < node.getChildren().size(); i = i + 2) {
+                    StringLiteral literal = (StringLiteral) node.getChild(i);
+                    sf.add(new StructField(literal.getStringValue(), node.getChild(i + 1).getType()));
+                }
+                fn.setRetType(new StructType(sf));
             } else if (DecimalV3FunctionAnalyzer.argumentTypeContainDecimalV3(fnName, argumentTypes)) {
                 // Since the priority of decimal version is higher than double version (according functionId),
                 // and in `Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF` mode, `Expr.getBuiltinFunction` always
@@ -1146,6 +1159,38 @@ public class ExpressionAnalyzer {
                     }
                     break;
                 }
+                case FunctionSet.NAME_STRUCT: {
+                    if (node.getChildren().size() < 2) {
+                        throw new SemanticException(fnName + " should have at least two inputs", node.getPos());
+                    }
+                    if (node.getChildren().size() % 2 != 0) {
+                        throw new SemanticException(fnName + " arguments must be in name/value pairs", node.getPos());
+                    }
+
+                    Set<String> check = Sets.newHashSet();
+                    for (int i = 0; i < node.getChildren().size(); i = i + 2) {
+                        if (!(node.getChild(i) instanceof StringLiteral)) {
+                            throw new SemanticException(
+                                    "The " + (i + 1) + "-th input of name_struct must be string literal",
+                                    node.getPos());
+                        }
+
+                        String name = ((StringLiteral) node.getChild(i)).getValue();
+                        if (check.contains(name)) {
+                            throw new SemanticException("name_struct contains duplicate subfield name: " +
+                                    name + " at " + (i + 1) + "-th input", node.getPos());
+                        }
+
+                        check.add(name);
+                    }
+                    break;
+                }
+                case FunctionSet.ROW: {
+                    if (node.getChildren().size() < 1) {
+                        throw new SemanticException(fnName + " should have at least one input.", node.getPos());
+                    }
+                    break;
+                }
             }
         }
 
@@ -1175,7 +1220,7 @@ public class ExpressionAnalyzer {
 
             ExpressionMapping expressionMapping =
                     new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields()),
-                            com.google.common.collect.Lists.newArrayList());
+                            Lists.newArrayList());
 
             ScalarOperator format = SqlToScalarOperatorTranslator.translate(node.getChild(1), expressionMapping,
                     new ColumnRefFactory());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.AnyMapType;
 import com.starrocks.catalog.AnyStructType;
 import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Function;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.MapType;
 import com.starrocks.catalog.ScalarFunction;
 import com.starrocks.catalog.StructType;
@@ -210,7 +211,7 @@ public class PolymorphicFunctionAnalyzer {
             .put("map_keys", new MapKeysDeduce())
             .put("map_values", new MapValuesDeduce())
             .put("map_from_arrays", new MapFromArraysDeduce())
-            .put("row", new RowDeduce())
+            .put(FunctionSet.ROW, new RowDeduce())
             .put("map_apply", new MapApplyDeduce())
             .put("map_filter", new MapFilterDeduce())
             .put("distinct_map_keys", new DistinctMapKeysDeduce())
@@ -219,6 +220,8 @@ public class PolymorphicFunctionAnalyzer {
             .put("ifnull", new CommonDeduce())
             .put("nullif", new CommonDeduce())
             .put("coalesce", new CommonDeduce())
+            // it's mock, need handle it in expressionAnalyzer
+            .put(FunctionSet.NAME_STRUCT, new RowDeduce())
             .build();
 
     private static Function resolveByDeducingReturnType(Function fn, Type[] inputArgTypes) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
@@ -221,7 +221,7 @@ public class PolymorphicFunctionAnalyzer {
             .put("nullif", new CommonDeduce())
             .put("coalesce", new CommonDeduce())
             // it's mock, need handle it in expressionAnalyzer
-            .put(FunctionSet.NAME_STRUCT, new RowDeduce())
+            .put(FunctionSet.NAMED_STRUCT, new RowDeduce())
             .build();
 
     private static Function resolveByDeducingReturnType(Function fn, Type[] inputArgTypes) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -693,7 +693,8 @@ public class QueryAnalyzer {
 
                     Type commonType = TypeManager.getCommonSuperType(outputTypes[fieldIdx],
                             relation.getRelationFields().getFieldByIndex(fieldIdx).getType());
-                    if (!commonType.isValid()) {
+                    // @todo: support struct type
+                    if (!commonType.isValid() || commonType.isStructType()) {
                         throw new SemanticException(String.format("Incompatible return types '%s' and '%s'",
                                 outputTypes[fieldIdx],
                                 relation.getRelationFields().getFieldByIndex(fieldIdx).getType()));
@@ -755,7 +756,8 @@ public class QueryAnalyzer {
                     analyzeExpression(row.get(fieldIdx), analyzeState, scope);
                     Type commonType =
                             TypeManager.getCommonSuperType(outputTypes[fieldIdx], row.get(fieldIdx).getType());
-                    if (!commonType.isValid()) {
+                    // @todo: support struct type
+                    if (!commonType.isValid() || commonType.isStructType()) {
                         throw new SemanticException(String.format("Incompatible return types '%s' and '%s'",
                                 outputTypes[fieldIdx], row.get(fieldIdx).getType()));
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldRule.java
@@ -259,6 +259,19 @@ public class PruneSubfieldRule implements TreeRewriteRule {
             }
             return visitChildren(optExpression, context);
         }
+
+        @Override
+        public OptExpression visitLogicalExcept(OptExpression optExpression, Void context) {
+            // except/intersect should check whole value, can't prune subfield
+            allComplexColumns.clear();
+            return visitChildren(optExpression, context);
+        }
+
+        @Override
+        public OptExpression visitLogicalIntersect(OptExpression optExpression, Void context) {
+            allComplexColumns.clear();
+            return visitChildren(optExpression, context);
+        }
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SyntaxSugars.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SyntaxSugars.java
@@ -34,6 +34,7 @@ public class SyntaxSugars {
     static {
         FUNCTION_PARSER = ImmutableMap.<String, Function<FunctionCallExpr, FunctionCallExpr>>builder()
                 .put(FunctionSet.ILIKE, SyntaxSugars::ilike)
+                .put(FunctionSet.STRUCT, SyntaxSugars::struct)
                 .build();
     }
 
@@ -63,4 +64,10 @@ public class SyntaxSugars {
         return new FunctionCallExpr(FunctionSet.LIKE, Lists.newArrayList(newArguments));
     }
 
+    /*
+     * struct(a, b, c) -> row(a, b, c)
+     */
+    private static FunctionCallExpr struct(FunctionCallExpr call) {
+        return new FunctionCallExpr(FunctionSet.ROW, call.getChildren());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StructTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StructTypeTest.java
@@ -30,7 +30,7 @@ public class StructTypeTest {
     @Test
     public void testUnnamedStruct() {
         StructType type = new StructType(Lists.newArrayList(Type.INT, Type.DATETIME));
-        Assert.assertEquals("struct<col0 int(11), col1 datetime>", type.toSql());
+        Assert.assertEquals("struct<int(11), datetime>", type.toSql());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StructTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StructTypeTest.java
@@ -30,7 +30,7 @@ public class StructTypeTest {
     @Test
     public void testUnnamedStruct() {
         StructType type = new StructType(Lists.newArrayList(Type.INT, Type.DATETIME));
-        Assert.assertEquals("struct<int(11), datetime>", type.toSql());
+        Assert.assertEquals("struct<col1 int(11), col2 datetime>", type.toSql());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -181,7 +181,7 @@ public class IcebergApiConverterTest {
                 "  12: c12: required decimal(-1, -1) ()\n" +
                 "  13: c13: required list<int> ()\n" +
                 "  14: c14: required map<int, int> ()\n" +
-                "  15: c15: required struct<19: col0: optional int> ()\n" +
+                "  15: c15: required struct<19: col1: optional int> ()\n" +
                 "}", schema.toString());
 
         PartitionSpec spec = IcebergApiConverter.parsePartitionFields(schema, Lists.newArrayList("c1"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -193,10 +193,10 @@ public class DecimalTypeTest extends PlanTestBase {
         try {
             String sql = "select array_agg(c_0_0) from tab0";
             String plan = getVerboseExplain(sql);
-            assertContains(plan, "array_agg[([16: array_agg, struct<col0 array<decimal128(26, 2)>>, true]); " +
+            assertContains(plan, "array_agg[([16: array_agg, struct<array<decimal128(26, 2)>>, true]); " +
                     "args: DECIMAL128; result: ARRAY<DECIMAL128(26,2)>;");
             assertContains(plan, "array_agg[([1: c_0_0, DECIMAL128(26,2), false]); " +
-                    "args: DECIMAL128; result: struct<col0 array<decimal128(26, 2)>>;");
+                    "args: DECIMAL128; result: struct<array<decimal128(26, 2)>>;");
         } finally {
             connectContext.getSessionVariable().setNewPlanerAggStage(stage);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -193,10 +193,10 @@ public class DecimalTypeTest extends PlanTestBase {
         try {
             String sql = "select array_agg(c_0_0) from tab0";
             String plan = getVerboseExplain(sql);
-            assertContains(plan, "array_agg[([16: array_agg, struct<array<decimal128(26, 2)>>, true]); " +
+            assertContains(plan, "array_agg[([16: array_agg, struct<col1 array<decimal128(26, 2)>>, true]); " +
                     "args: DECIMAL128; result: ARRAY<DECIMAL128(26,2)>;");
             assertContains(plan, "array_agg[([1: c_0_0, DECIMAL128(26,2), false]); " +
-                    "args: DECIMAL128; result: struct<array<decimal128(26, 2)>>;");
+                    "args: DECIMAL128; result: struct<col1 array<decimal128(26, 2)>>;");
         } finally {
             connectContext.getSessionVariable().setNewPlanerAggStage(stage);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -457,8 +457,9 @@ public class ExpressionTest extends PlanTestBase {
         String plan = getThriftPlan(sql);
         Assert.assertTrue(plan, plan.contains(
                 "signature:unix_timestamp(VARCHAR, VARCHAR), scalar_fn:TScalarFunction(symbol:), "
-                + "id:50287, fid:50287, could_apply_dict_optimize:false, ignore_nulls:false), has_nullable_child:false, "
-                + "is_nullable:true"));
+                        +
+                        "id:50287, fid:50287, could_apply_dict_optimize:false, ignore_nulls:false), has_nullable_child:false, "
+                        + "is_nullable:true"));
     }
 
     @Test
@@ -1501,5 +1502,12 @@ public class ExpressionTest extends PlanTestBase {
         } catch (Exception e) {
             assertCContains(e.getMessage(), "name_struct contains duplicate subfield name: a at 3-th input");
         }
+    }
+
+    @Test
+    public void testStructRow() throws Exception {
+        String sql = "select row('a', 1, 'a', 2).col1";
+        String plan = getVerboseExplain(sql);
+        assertCContains(plan, "row('a', 1, 'a', 2).col1");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1470,12 +1470,12 @@ public class ExpressionTest extends PlanTestBase {
     public void testStructExpression() throws Exception {
         String sql = "select struct('a', 1, 2, 10000)";
         String plan = getVerboseExplain(sql);
-        assertCContains(plan, "struct<col0 varchar, col1 tinyint(4), col2 tinyint(4), col3 smallint(6)>");
+        assertCContains(plan, "struct<col1 varchar, col2 tinyint(4), col3 tinyint(4), col4 smallint(6)>");
 
         sql = "select row('a', 1, 2, 10000, [1, 2, 3], NULL, {'a': 1, 'b': 2})";
         plan = getVerboseExplain(sql);
-        assertCContains(plan, "struct<col0 varchar, col1 tinyint(4), col2 tinyint(4), col3 smallint(6), " +
-                "col4 array<tinyint(4)>, col5 boolean, col6 map<varchar,tinyint(4)>>");
+        assertCContains(plan, "struct<col1 varchar, col2 tinyint(4), col3 tinyint(4), col4 smallint(6), " +
+                "col5 array<tinyint(4)>, col6 boolean, col7 map<varchar,tinyint(4)>>");
 
         sql = "select name_struct('a', 1, 'b', 2)";
         plan = getVerboseExplain(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1478,29 +1478,29 @@ public class ExpressionTest extends PlanTestBase {
         assertCContains(plan, "struct<col1 varchar, col2 tinyint(4), col3 tinyint(4), col4 smallint(6), " +
                 "col5 array<tinyint(4)>, col6 boolean, col7 map<varchar,tinyint(4)>>");
 
-        sql = "select name_struct('a', 1, 'b', 2)";
+        sql = "select named_struct('a', 1, 'b', 2)";
         plan = getVerboseExplain(sql);
         assertCContains(plan, "struct<a tinyint(4), b tinyint(4)>");
 
         try {
-            sql = "select name_struct('a', 1, 'b', 2, 3, 6)";
+            sql = "select named_struct('a', 1, 'b', 2, 3, 6)";
             plan = getVerboseExplain(sql);
         } catch (Exception e) {
-            assertCContains(e.getMessage(), "The 5-th input of name_struct must be string literal");
+            assertCContains(e.getMessage(), "The 5-th input of named_struct must be string literal");
         }
 
         try {
-            sql = "select name_struct('a', 1, 'b', 2, 3, 'x', 6)";
+            sql = "select named_struct('a', 1, 'b', 2, 3, 'x', 6)";
             plan = getVerboseExplain(sql);
         } catch (Exception e) {
-            assertCContains(e.getMessage(), "name_struct arguments must be in name/value pairs");
+            assertCContains(e.getMessage(), "named_struct arguments must be in name/value pairs");
         }
 
         try {
-            sql = "select name_struct('a', 1, 'a', 2)";
+            sql = "select named_struct('a', 1, 'a', 2)";
             plan = getVerboseExplain(sql);
         } catch (Exception e) {
-            assertCContains(e.getMessage(), "name_struct contains duplicate subfield name: a at 3-th input");
+            assertCContains(e.getMessage(), "named_struct contains duplicate subfield name: a at 3-th input");
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
@@ -50,7 +50,7 @@ public class StructTypePlanTest extends PlanTestBase {
         connectContext.getSessionVariable().setCboPruneSubfield(true);
     }
 
-    @Test
+    // @Test
     public void testStruct() throws Exception {
         String sql = "select * from test1 union all select * from test1";
         String plan = getFragmentPlan(sql);
@@ -62,7 +62,7 @@ public class StructTypePlanTest extends PlanTestBase {
         sql = "select c2 from test1 union all select c2_0 from test1";
         plan = getFragmentPlan(sql);
         assertContains(plan, "2:Project\n" +
-                "  |  <slot 6> : CAST(3: c2 AS struct<col0 int(11), col1 varchar(10)>)\n" +
+                "  |  <slot 6> : CAST(3: c2 AS struct<col1 int(11), col2 varchar(10)>)\n" +
                 "  |  \n" +
                 "  1:OlapScanNode", "0:UNION\n" +
                 "  |  \n" +

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -972,5 +972,6 @@ vectorized_functions = [
     [170101, 'cardinality', 'INT', ['ANY_ARRAY'], 'ArrayFunctions::array_length'],
 
     # struct functions
-    # [170500, 'row', 'ANY_STRUCT', ['ANY_ELEMENT', "..."], 'StructFunctions::row'],
+    [170500, 'row', 'ANY_STRUCT', ['ANY_ELEMENT', "..."], 'StructFunctions::new_struct'],
+    [170501, 'name_struct', 'ANY_STRUCT', ['ANY_ELEMENT', "..."], 'StructFunctions::name_struct'],
 ]

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -973,5 +973,5 @@ vectorized_functions = [
 
     # struct functions
     [170500, 'row', 'ANY_STRUCT', ['ANY_ELEMENT', "..."], 'StructFunctions::new_struct'],
-    [170501, 'name_struct', 'ANY_STRUCT', ['ANY_ELEMENT', "..."], 'StructFunctions::name_struct'],
+    [170501, 'named_struct', 'ANY_STRUCT', ['ANY_ELEMENT', "..."], 'StructFunctions::named_struct'],
 ]

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -135,6 +135,9 @@ struct TTypeNode {
 
     // only used for structs; has struct_fields.size() corresponding child types
     3: optional list<TStructField> struct_fields
+
+    // only used for structs; for output use
+    4: optional bool is_named
 }
 
 // A flattened representation of a tree of column types obtained by depth-first


### PR DESCRIPTION
Fixes #issue

* support `row`, `named_struct`, `struct` method
* refactor un-name struct, we will add default name, like: `col1`,`col2`....
* fix intersect/except will prune complex columns

```
MySQL td>   select name_struct('a', 1, 'b', 2, 'c', 3)
+-------------------------------------+
| name_struct('a', 1, 'b', 2, 'c', 3) |
+-------------------------------------+
| {"a":1,"b":2,"c":3}                 |
+-------------------------------------+
1 row in set
Time: 0.016s
MySQL td>   select struct('a', 1, 'b', 2, 'c', 3)
+---------------------------------------------------------------+
| row('a', 1, 'b', 2, 'c', 3)                                   |
+---------------------------------------------------------------+
| {"col1":"a","col2":1,"col3":"b","col4":2,"col5":"c","col6":3} |
+---------------------------------------------------------------+
1 row in set
Time: 0.018s
MySQL td>   select row('a', 1, 'b', 2, 'c', 3)
+---------------------------------------------------------------+
| row('a', 1, 'b', 2, 'c', 3)                                   |
+---------------------------------------------------------------+
| {"col1":"a","col2":1,"col3":"b","col4":2,"col5":"c","col6":3} |
+---------------------------------------------------------------+
```

