### PR TITLE
[Enhancement] Make the output of bin/show_be_version.sh more clear

### DIFF
--- a/be/src/exprs/utility_functions.cpp
+++ b/be/src/exprs/utility_functions.cpp
@@ -52,7 +52,7 @@ StatusOr<ColumnPtr> UtilityFunctions::version(FunctionContext* context, const Co
 }
 
 StatusOr<ColumnPtr> UtilityFunctions::current_version(FunctionContext* context, const Columns& columns) {
-    static std::string version = std::string(STARROCKS_VERSION) + " " + STARROCKS_COMMIT_HASH;
+    static std::string version = std::string(STARROCKS_VERSION) + "-" + STARROCKS_COMMIT_HASH;
     return ColumnHelper::create_const_column<TYPE_VARCHAR>(version, 1);
 }
 

--- a/be/src/util/debug_util.cpp
+++ b/be/src/util/debug_util.cpp
@@ -62,7 +62,7 @@ std::string print_plan_node_type(const TPlanNodeType::type& type) {
 
 std::string get_build_version(bool compact) {
     std::stringstream ss;
-    ss << STARROCKS_VERSION << " " << STARROCKS_BUILD_TYPE << " (build " << STARROCKS_COMMIT_HASH << ")";
+    ss << STARROCKS_VERSION << "-" << STARROCKS_COMMIT_HASH << std::endl << "BuildType: " << STARROCKS_BUILD_TYPE;
     if (!compact) {
         ss << std::endl
            << "Built on " << STARROCKS_BUILD_TIME << " by " << STARROCKS_BUILD_USER << "@" << STARROCKS_BUILD_HOST;

--- a/build-support/gen_build_version.py
+++ b/build-support/gen_build_version.py
@@ -21,10 +21,13 @@ import subprocess
 from datetime import datetime
 
 def get_version():
-    version = os.getenv("STARROCKS_VERSION")
-    if not version:
-        version = "UNKNOWN"
-    return version.upper()
+    git_res = subprocess.Popen(["git", "rev-parse", "--abbrev-ref", "HEAD"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = git_res.communicate()
+
+    version = u''
+    if git_res.returncode == 0:
+        version = out.decode('utf-8').strip()
+    return version
 
 def get_commit_hash():
     git_res = subprocess.Popen(["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/build.sh
+++ b/build.sh
@@ -40,6 +40,10 @@ MACHINE_TYPE=$(uname -m)
 
 export STARROCKS_HOME=${ROOT}
 
+if [ -z $BUILD_TYPE ]; then
+    export BUILD_TYPE=Release
+fi
+
 . ${STARROCKS_HOME}/env.sh
 
 if [[ $OSTYPE == darwin* ]] ; then
@@ -274,7 +278,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
         exit 1
     fi
 
-    CMAKE_BUILD_TYPE=${BUILD_TYPE:-Release}
+    CMAKE_BUILD_TYPE=$BUILD_TYPE
     echo "Build Backend: ${CMAKE_BUILD_TYPE}"
     CMAKE_BUILD_DIR=${STARROCKS_HOME}/be/build_${CMAKE_BUILD_TYPE}
     if [ "${WITH_GCOV}" = "ON" ]; then

--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -73,7 +73,7 @@ public final class GlobalVariable {
     public static final String ACTIVATE_ALL_ROLES_ON_LOGIN_V2 = "activate_all_roles_on_login_v2";
 
     @VariableMgr.VarAttr(name = VERSION_COMMENT, flag = VariableMgr.READ_ONLY)
-    public static String versionComment = "StarRocks version " + Version.STARROCKS_VERSION;
+    public static String versionComment = Version.STARROCKS_VERSION + "-" + Version.STARROCKS_COMMIT_HASH;
 
     @VariableMgr.VarAttr(name = VERSION, flag = VariableMgr.READ_ONLY)
     public static String version = Config.mysql_server_version;


### PR DESCRIPTION
Currently, the output will be UNKNOWN. It's not friendly.
In the pull request, I change it to `branchName-commitHash`, for example `main-e318ec5`.
