### PR TITLE
[BugFix] fix crash issue when hash join  spilled partition split multi times

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -297,20 +297,20 @@ void SpillableHashJoinProbeOperator::_check_partitions() {
     if (_is_finishing) {
 #ifndef NDEBUG
         auto partitioned_writer = down_cast<spill::PartitionedSpillerWriter*>(_probe_spiller->writer().get());
+        size_t build_rows = 0;
         for (const auto& [level, partitions] : partitioned_writer->level_to_partitions()) {
             auto writer = down_cast<spill::PartitionedSpillerWriter*>(_join_builder->spiller()->writer().get());
             auto& build_partitions = writer->level_to_partitions().find(level)->second;
             DCHECK_EQ(build_partitions.size(), partitions.size());
-            size_t build_rows = 0;
             for (size_t i = 0; i < partitions.size(); ++i) {
                 build_rows += build_partitions[i]->num_rows;
             }
-            DCHECK_EQ(build_rows, _join_builder->spiller()->spilled_append_rows());
             // CHECK if left table is the same as right table
             // for (size_t i = 0; i < partitions.size(); ++i) {
             //     DCHECK_EQ(partitions[i]->num_rows, build_partitions[i]->num_rows);
             // }
         }
+        DCHECK_EQ(build_rows, _join_builder->spiller()->spilled_append_rows());
 #endif
     }
 }

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -235,7 +235,9 @@ void PartitionedSpillerWriter::_remove_partition(const SpilledPartition* partiti
                                   [partition](auto& val) { return val->partition_id == partition->partition_id; }));
     if (partitions.empty()) {
         _level_to_partitions.erase(level);
-        _min_level = level + 1;
+        if (_min_level == level) {
+            _min_level = level + 1;
+        }
     }
 }
 
@@ -260,6 +262,10 @@ void PartitionedSpillerWriter::shuffle(std::vector<uint32_t>& dst, const SpillHa
         int32_t current_level = _min_level;
         // if has multi level, may be have performance issue
         while (current_level <= _max_level) {
+            if (_level_to_partitions.find(current_level) == _level_to_partitions.end()) {
+                current_level++;
+                continue;
+            }
             auto& partitions = _level_to_partitions[current_level];
             uint32_t hash_mask = partitions.front()->mask();
             for (size_t i = 0; i < hashs.size(); ++i) {


### PR DESCRIPTION
Fixes #24085

The root cause is that there is a problem with the  maintenance of min_level. When a partition is continuously split, the middle level may be empty, but the upper and lower levels have partitions, here is an example:

1. at first, all partitions in level 2
level 2: [4,5,6,7]
2. then partition  4 split to 8 and 12
level 2: [5,6,7]
level 3: [8,12]
3. then partition 8 split to 16 and 24, partition 12 split to 20 and 28
level 2: [5, 6, 7]
level 3: []
level 4: [16, 20, 24, 28]

so we can only move forward min_level when there is no partition in this level


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool
-
## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
-
## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch 
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
