### PR TITLE
[Refactor] Use CpuInfo::num_cores() instead of gutil::NumCPUs()

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -245,7 +245,7 @@ void AgentServer::Impl::init_or_die() {
 #define CREATE_AND_START_POOL(pool_name, CLASS_NAME, worker_num)
 #endif // BE_TEST
 
-        CREATE_AND_START_POOL(_publish_version_workers, PublishVersionTaskWorkerPool, base::NumCPUs())
+        CREATE_AND_START_POOL(_publish_version_workers, PublishVersionTaskWorkerPool, CpuInfo::num_cores())
         // Both PUSH and REALTIME_PUSH type use _push_workers
         CREATE_AND_START_POOL(_push_workers, PushTaskWorkerPool,
                               config::push_worker_count_high_priority + config::push_worker_count_normal_priority)

--- a/be/src/gutil/sysinfo.cc
+++ b/be/src/gutil/sysinfo.cc
@@ -447,14 +447,4 @@ double CyclesPerSecond() {
     return cpuinfo_cycles_per_second;
 }
 
-int NumCPUs() {
-    InitializeSystemInfo();
-    return cpuinfo_num_cpus;
-}
-
-int MaxCPUIndex() {
-    InitializeSystemInfo();
-    return cpuinfo_max_cpu_index;
-}
-
 } // namespace base

--- a/be/src/gutil/sysinfo.h
+++ b/be/src/gutil/sysinfo.h
@@ -33,19 +33,6 @@
 #include <cstdint>
 
 namespace base {
-
-// Return the number of online CPUs. This is computed and cached the first time this or
-// NumCPUs() is called, so does not reflect any CPUs enabled or disabled at a later
-// point in time.
-//
-// Note that, if not all CPUs are online, this may return a value lower than the maximum
-// value of sched_getcpu().
-extern int NumCPUs();
-
-// Return the maximum CPU index that may be returned by sched_getcpu(). For example, on
-// an 8-core machine, this will return '7' even if some of the CPUs have been disabled.
-extern int MaxCPUIndex();
-
 void SleepForNanoseconds(int64_t nanoseconds);
 void SleepForMilliseconds(int64_t milliseconds);
 

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -42,6 +42,7 @@
 #include "gutil/map_util.h"
 #include "gutil/strings/substitute.h"
 #include "gutil/sysinfo.h"
+#include "util/cpu_info.h"
 #include "util/scoped_cleanup.h"
 #include "util/thread.h"
 
@@ -63,7 +64,7 @@ private:
 ThreadPoolBuilder::ThreadPoolBuilder(string name)
         : _name(std::move(name)),
           _min_threads(0),
-          _max_threads(base::NumCPUs()),
+          _max_threads(CpuInfo::num_cores()),
           _max_queue_size(std::numeric_limits<int>::max()),
           _idle_timeout(MonoDelta::FromMilliseconds(500)) {}
 

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -165,7 +165,7 @@ TEST_F(ThreadPoolTest, TestThreadPoolWithNoMaxThreads) {
     // By default a threadpool's max_threads is set to the number of CPUs, so
     // this test submits more tasks than that to ensure that the number of CPUs
     // isn't some kind of upper bound.
-    const int kNumCPUs = base::NumCPUs();
+    const int kNumCPUs = CpuInfo::num_cores();
 
     // Build a threadpool with no limit on the maximum number of threads.
     ASSERT_TRUE(rebuild_pool_with_builder(


### PR DESCRIPTION
Use CpuInfo::num_cores() instead of gutil::NumCPUs() 