### PR TITLE
[Enhancement]Handle expr with null when to thrift

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.TreeNode;
@@ -770,6 +771,12 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
 
     // Append a flattened version of this expr, including all children, to 'container'.
     final void treeToThriftHelper(TExpr container, ExprVisitor visitor) {
+        if (type.isNull()) {
+            Preconditions.checkState(this instanceof NullLiteral || this instanceof SlotRef);
+            NullLiteral.create(ScalarType.BOOLEAN).treeToThriftHelper(container, visitor);
+            return;
+        }
+
         TExprNode msg = new TExprNode();
 
         Preconditions.checkState(!type.isNull(), "NULL_TYPE is illegal in thrift stage");


### PR DESCRIPTION
After https://github.com/StarRocks/starrocks/pull/24444, Sync Mvterialized views can support complex expressions.

When create materialized view, it need refresh historical data.  Then if we have expression like
```sql
case when a > 0 then a else NULL
```   
 We have `NULL` in the expression, so when convert to Thrift by `treeToThriftHelper`, we need handle the `NULL` type, otherwise, exception will happened.