### PR TITLE
[Cherry-pick][Branch-2.5][BugFix] Fix could not choose mv plan when mv has statistics (#24080)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1378,7 +1378,13 @@ public class GlobalStateMgr {
 
     public void updateBaseTableRelatedMv(Long dbId, MaterializedView mv, List<BaseTableInfo> baseTableInfos) {
         for (BaseTableInfo baseTableInfo : baseTableInfos) {
-            Table table = baseTableInfo.getTable();
+            Table table;
+            try {
+                table = baseTableInfo.getTable();
+            } catch (Exception e) {
+                LOG.warn("there is an exception during get table from mv base table. exception:", e);
+                continue;
+            }
             if (table == null) {
                 LOG.warn("Setting the materialized view {}({}) to invalid because " +
                         "the table {} was not exist.", mv.getName(), mv.getId(), baseTableInfo.getTableName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ExpressionContext.java
@@ -128,6 +128,14 @@ public class ExpressionContext {
         return statisticsForMv != null ? statisticsForMv : statistics;
     }
 
+    public Statistics getGroupStatistics() {
+        return isGroupExprContext() ? statistics : null;
+    }
+
+    public GroupExpression getGroupExpression() {
+        return groupExpression;
+    }
+
     public void setStatistics(Statistics statistics) {
         this.statistics = statistics;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Group.java
@@ -11,6 +11,7 @@ import com.starrocks.sql.optimizer.base.LogicalProperty;
 import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -244,6 +245,10 @@ public class Group {
             return lowestCostExpressions.get(physicalPropertySet).second;
         }
         return null;
+    }
+
+    public Collection<Pair<Double, GroupExpression>> getAllBestExpressionWithCost() {
+        return lowestCostExpressions.values();
     }
 
     public boolean hasBestExpression(PhysicalPropertySet physicalPropertySet) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -4,6 +4,8 @@ package com.starrocks.sql.optimizer.cost;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
@@ -21,6 +23,7 @@ import com.starrocks.sql.optimizer.operator.DataSkewInfo;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
+import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalAssertOneRowOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEAnchorOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalCTEConsumeOperator;
@@ -44,6 +47,7 @@ import com.starrocks.statistic.StatisticUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -113,10 +117,53 @@ public class CostModel {
             return CostEstimate.zero();
         }
 
+        private CostEstimate adjustCostForMV(ExpressionContext context) {
+            Statistics mvStatistics = context.getStatistics();
+            Group group = context.getGroupExpression().getGroup();
+            List<Double> costs = Lists.newArrayList();
+            // get the costs of all expression in this group
+            for (Pair<Double, GroupExpression> pair : group.getAllBestExpressionWithCost()) {
+                if (!(pair.second.getOp() instanceof PhysicalOlapScanOperator)) {
+                    costs.add(pair.first);
+                }
+            }
+            double groupMinCost = Double.MAX_VALUE;
+            if (costs.size() > 0) {
+                groupMinCost = Collections.min(costs);
+            }
+            // use row count as the adjust cost
+            double adjustCost = mvStatistics.getOutputRowCount();
+            return CostEstimate.of(Math.min(Math.max(groupMinCost - 1, 0), adjustCost), 0, 0);
+        }
+
         @Override
         public CostEstimate visitPhysicalOlapScan(PhysicalOlapScanOperator node, ExpressionContext context) {
             Statistics statistics = context.getStatistics();
             Preconditions.checkNotNull(statistics);
+            if (node.getTable().isMaterializedView()) {
+                Statistics groupStatistics = context.getGroupStatistics();
+                Statistics mvStatistics = context.getStatistics();
+                // only adjust cost for mv scan operator when group statistics is unknown and mv group expression
+                // statistics is not unknown
+                if (groupStatistics != null && groupStatistics.getColumnStatistics().values().stream().
+                        anyMatch(ColumnStatistic::isUnknown) && mvStatistics.getColumnStatistics().values().stream().
+                        noneMatch(ColumnStatistic::isUnknown)) {
+                    return adjustCostForMV(context);
+                } else {
+                    ColumnRefSet usedColumns = statistics.getUsedColumns();
+                    Projection projection = node.getProjection();
+                    if (projection != null) {
+                        // we will add a projection on top of rewritten mv plan to keep the output columns the same as
+                        // original query.
+                        // excludes this projection keys when costing mv,
+                        // or the cost of mv may be larger than origal query,
+                        // which will lead to mismatch of mv
+                        usedColumns.except(projection.getColumnRefMap().keySet());
+                    }
+                    // use the used columns to calculate the cost of mv
+                    return CostEstimate.of(statistics.getOutputSize(usedColumns), 0, 0);
+                }
+            }
             return CostEstimate.of(statistics.getComputeSize(), 0, 0);
         }
 


### PR DESCRIPTION
Fixes #issue
when we create a materialized view for hive table, if mv plan has multi join, it need to compare cost between mv plan and origin plan, if mv collect statistics but there is no column statisrics for hive table, it would not choose mv plan because it's cost are heigher. In order to fix this problem, we adjusted the cost of mv when there are no exact statistis in the origin plan

---------

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
