### PR TITLE
[Refactor] Move the STARROCKS_VERSION and STARROCKS_COMMIT_HASH to the build.sh

### DIFF
--- a/build-support/gen_build_version.py
+++ b/build-support/gen_build_version.py
@@ -21,21 +21,15 @@ import subprocess
 from datetime import datetime
 
 def get_version():
-    git_res = subprocess.Popen(["git", "rev-parse", "--abbrev-ref", "HEAD"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = git_res.communicate()
-
-    version = u''
-    if git_res.returncode == 0:
-        version = out.decode('utf-8').strip()
+    version = os.getenv("STARROCKS_VERSION")
+    if not version:
+        version = "UNKNOWN"
     return version
 
 def get_commit_hash():
-    git_res = subprocess.Popen(["git", "rev-parse", "--short", "HEAD"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = git_res.communicate()
-
-    commit_hash = u''
-    if git_res.returncode == 0:
-        commit_hash = out.decode('utf-8').strip()
+    commit_hash = os.getenv("STARROCKS_COMMIT_HASH")
+    if not commit_hash:
+        commit_hash = "UNKNOWN"
     return commit_hash
 
 def get_build_type():

--- a/build.sh
+++ b/build.sh
@@ -32,8 +32,6 @@
 # compiled and installed correctly.
 ##############################################################
 
-set -eo pipefail
-
 ROOT=`dirname "$0"`
 ROOT=`cd "$ROOT"; pwd`
 MACHINE_TYPE=$(uname -m)
@@ -44,6 +42,23 @@ if [ -z $BUILD_TYPE ]; then
     export BUILD_TYPE=Release
 fi
 
+if [ -z $STARROCKS_VERSION ]; then
+    tag_name=$(git describe --tags --exact-match 2>/dev/null)
+    branch_name=$(git symbolic-ref -q --short HEAD)
+    if [ ! -z $tag_name ]; then
+        export STARROCKS_VERSION=$tag_name
+    elif [ ! -z $branch_name ]; then
+        export STARROCKS_VERSION=$branch_name
+    else
+        export STARROCKS_VERSION=$(git rev-parse --short HEAD)
+    fi
+fi
+
+if [ -z $STARROCKS_COMMIT_HASH]; then
+    export STARROCKS_COMMIT_HASH=$(git rev-parse --short HEAD)
+fi
+
+set -eo pipefail
 . ${STARROCKS_HOME}/env.sh
 
 if [[ $OSTYPE == darwin* ]] ; then


### PR DESCRIPTION
Currently, the two variables are defined in the `build-support/gen_build_version.py`. It's hard to debug and search. The pull request move the logic to the build.sh. The definition logic of STARROCKS_VERSION is as the following.
1. If the user set the STARROCKS_VERSION, use the user's definition.
2. If the current commit is a tag, use the tag name.
3. If no tag is available, use the branch name
4. If not a branch, use the commit-hash

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
