### PR TITLE
[BugFix] Make decimal-typed ArithmeticExpr analyzing idempotent

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
@@ -322,17 +322,9 @@ public class ArithmeticExpr extends Expr {
         return result;
     }
 
-    private void rewriteDecimalDecimalOperation() throws AnalysisException {
+    private TypeTriple rewriteDecimalDecimalOperation() throws AnalysisException {
         final Type lhsOriginType = getChild(0).type;
         final Type rhsOriginType = getChild(1).type;
-
-        // if both of left child and right child are implict cast.
-        // It means ArithmeticExpr has been applied rewriteDecimalDecimalOperation.
-        // so we don't have to rewrite again.
-        // TODO:
-        if (getChild(0).isImplicitCast() && getChild(1).isImplicitCast()) {
-            return;
-        }
 
         Type lhsTargetType = lhsOriginType;
         Type rhsTargetType = rhsOriginType;
@@ -343,29 +335,15 @@ public class ArithmeticExpr extends Expr {
         if (!rhsTargetType.isDecimalV3()) {
             rhsTargetType = nonDecimalToDecimal(rhsTargetType);
         }
-        TypeTriple triple = getReturnTypeOfDecimal(op, (ScalarType) lhsTargetType, (ScalarType) rhsTargetType);
-        if (!triple.lhsTargetType.equals(lhsOriginType)) {
-            Preconditions.checkState(triple.lhsTargetType.isValid());
-            castChild(triple.lhsTargetType, 0);
-        }
-        if (!triple.rhsTargetType.equals(rhsOriginType)) {
-            Preconditions.checkState(triple.rhsTargetType.isValid());
-            castChild(triple.rhsTargetType, 1);
-        }
-        type = triple.returnType;
+        return getReturnTypeOfDecimal(op, (ScalarType) lhsTargetType, (ScalarType) rhsTargetType);
     }
 
-    private void rewriteDecimalFloatingPointOperation() throws AnalysisException {
-        Type lhsType = getChild(0).type;
-        Type rhsType = getChild(1).type;
-        Type resultType = Type.DOUBLE;
-        if (!resultType.equals(lhsType)) {
-            castChild(resultType, 0);
-        }
-        if (!resultType.equals(rhsType)) {
-            castChild(resultType, 1);
-        }
-        this.type = resultType;
+    private TypeTriple rewriteDecimalFloatingPointOperation() throws AnalysisException {
+        TypeTriple typeTriple = new TypeTriple();
+        typeTriple.lhsTargetType = Type.DOUBLE;
+        typeTriple.rhsTargetType = Type.DOUBLE;
+        typeTriple.returnType = Type.DOUBLE;
+        return typeTriple;
     }
 
     private boolean hasFloatingPointOrStringType() {
@@ -391,11 +369,11 @@ public class ArithmeticExpr extends Expr {
         }
     }
 
-    public void rewriteDecimalOperation() throws AnalysisException {
+    public TypeTriple rewriteDecimalOperation() throws AnalysisException {
         if (hasFloatingPointOrStringType() && !resultTypeIsBigInt()) {
-            rewriteDecimalFloatingPointOperation();
+            return rewriteDecimalFloatingPointOperation();
         } else {
-            rewriteDecimalDecimalOperation();
+            return rewriteDecimalDecimalOperation();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/ArithmeticExpr.java
@@ -36,6 +36,7 @@ package com.starrocks.analysis;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.PrimitiveType;
@@ -53,6 +54,7 @@ import com.starrocks.thrift.TExprOpcode;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 public class ArithmeticExpr extends Expr {
     private static final Map<String, Operator> SUPPORT_FUNCTIONS = ImmutableMap.<String, Operator>builder()
@@ -70,6 +72,14 @@ public class ArithmeticExpr extends Expr {
             .put(Operator.BIT_SHIFT_RIGHT_LOGICAL.getName(), Operator.BIT_SHIFT_RIGHT_LOGICAL)
             .build();
 
+    public static Set<String> DECIMAL_SCALE_ADJUST_OPERATOR_SET = ImmutableSet.<String>builder()
+            .add(Operator.ADD.name)
+            .add(Operator.SUBTRACT.name)
+            .add(Operator.MULTIPLY.name)
+            .add(Operator.DIVIDE.name)
+            .add(Operator.MOD.name)
+            .add(Operator.INT_DIVIDE.name)
+            .build();
     private final Operator op;
 
     public enum OperatorPosition {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -591,22 +591,21 @@ public class ExpressionAnalyzer {
                 Type t1 = node.getChild(0).getType().getNumResultType();
                 Type t2 = node.getChild(1).getType().getNumResultType();
                 if (t1.isDecimalV3() || t2.isDecimalV3()) {
+                    ArithmeticExpr.TypeTriple typeTriple = null;
                     try {
-                        node.rewriteDecimalOperation();
+                        typeTriple = node.rewriteDecimalOperation();
                     } catch (AnalysisException ex) {
                         throw new SemanticException(ex.getMessage());
                     }
-                    Type lhsType = node.getChild(0).getType();
-                    Type rhsType = node.getChild(1).getType();
-                    Type resultType = node.getType();
-                    Type[] args = {lhsType, rhsType};
+                    Preconditions.checkArgument(typeTriple != null);
+                    Type[] args = {typeTriple.lhsTargetType, typeTriple.rhsTargetType};
                     Function fn = Expr.getBuiltinFunction(op.getName(), args, Function.CompareMode.IS_IDENTICAL);
                     // In resolved function instance, it's argTypes and resultType are wildcard decimal type
                     // (both precision and and scale are -1, only used in function instance resolution), it's
                     // illegal for a function and expression to has a wildcard decimal type as its type in BE,
                     // so here substitute wildcard decimal types with real decimal types.
-                    Function newFn = new ScalarFunction(fn.getFunctionName(), args, resultType, fn.hasVarArgs());
-                    node.setType(resultType);
+                    Function newFn = new ScalarFunction(fn.getFunctionName(), args, typeTriple.returnType, fn.hasVarArgs());
+                    node.setType(typeTriple.returnType);
                     node.setFn(newFn);
                     return null;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rewrite.scalar;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.ArithmeticExpr;
 import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
@@ -83,6 +84,8 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
                         String.format("Resolved function %s has wildcard decimal as argument type", fn.functionName()));
             }
 
+            boolean needAdjustScale = ArithmeticExpr.DECIMAL_SCALE_ADJUST_OPERATOR_SET
+                    .contains(fn.getFunctionName().getFunction());
             for (int i = 0; i < fn.getNumArgs(); i++) {
                 Type type = fn.getArgs()[i];
                 ScalarOperator child = call.getChild(i);
@@ -94,7 +97,10 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
                     continue;
                 }
 
-                if (!type.matchesType(child.getType())) {
+                // for compatibility, decimal ArithmeticExpr(+-*/%) use Type::equals instead of Type::matchesType to
+                // determine whether to cast child of the ArithmeticExpr
+                if ((needAdjustScale && type.isDecimalOfAnyVersion() && !type.equals(child.getType())) ||
+                        !type.matchesType(child.getType())) {
                     addCastChild(type, call, i);
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ArithmeticExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ArithmeticExprTest.java
@@ -26,11 +26,9 @@ public class ArithmeticExprTest {
         ScalarType decimal64p10s2 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2);
         ExpressionAnalyzer.analyzeExpressionIgnoreSlot(addExpr, ConnectContext.get());
         Assert.assertEquals(addExpr.type, decimal64p10s2);
-        Assert.assertTrue(addExpr.getChild(0) instanceof CastExpr);
-        Assert.assertTrue(addExpr.getChild(1) instanceof CastExpr);
-        Assert.assertEquals(addExpr.getChild(0).type, decimal64p10s2);
-        Assert.assertEquals(addExpr.getChild(1).type, decimal64p10s2);
-
+        Assert.assertNotNull(addExpr.getFn());
+        Assert.assertEquals(addExpr.getFn().getArgs()[0], decimal64p10s2);
+        Assert.assertEquals(addExpr.getFn().getArgs()[1], decimal64p10s2);
     }
 
     private ScalarType dec(int bits, int precision, int scale) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -83,12 +83,29 @@ public class SelectStmtTest {
                 "\"replication_num\" = \"1\"\n" +
                 ");";
 
+        String createTable1 = "CREATE TABLE `t0` (\n" +
+                "  `c0` varchar(24) NOT NULL COMMENT \"\",\n" +
+                "  `c1` decimal128(24, 5) NOT NULL COMMENT \"\",\n" +
+                "  `c2` decimal128(24, 2) NOT NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`c0`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`c0`) BUCKETS 1 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\",\n" +
+                "\"enable_persistent_index\" = \"false\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"compression\" = \"LZ4\"\n" +
+                "); ";
         starRocksAssert = new StarRocksAssert();
         starRocksAssert.withDatabase("db1").useDatabase("db1");
         starRocksAssert.withTable(createTblStmtStr)
                 .withTable(createBaseAllStmtStr)
                 .withTable(createDateTblStmtStr)
-                .withTable(createPratitionTableStr);
+                .withTable(createPratitionTableStr)
+                .withTable(createTable1);
     }
 
     @Test
@@ -419,6 +436,72 @@ public class SelectStmtTest {
             Assert.assertTrue(plan, plan.contains("dt IN ('2022-01-02', '2022-01-03')"));
         } catch (Exception e) {
             Assert.fail("Should not throw an exception");
+        }
+    }
+
+    public void testAnalyzeDecimalArithmeticExprIdempotently()
+            throws Exception {
+        {
+            String sql = "select c0, sum(c2/(1+c1)) as a, sum(c2/(1+c1)) as b from t0 group by c0;";
+            String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+            Assert.assertTrue(plan, plan.contains("PLAN FRAGMENT 0(F00)\n" +
+                    "  Output Exprs:1: c0 | 5: sum | 5: sum\n" +
+                    "  Input Partition: RANDOM\n" +
+                    "  RESULT SINK\n" +
+                    "\n" +
+                    "  2:AGGREGATE (update finalize)\n" +
+                    "  |  aggregate: sum[([4: expr, DECIMAL128(38,8), true]); " +
+                    "args: DECIMAL128; result: DECIMAL128(38,8); args nullable: true; " +
+                    "result nullable: true]\n" +
+                    "  |  group by: [1: c0, VARCHAR, false]\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  1:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  1 <-> [1: c0, VARCHAR, false]\n" +
+                    "  |  4 <-> [3: c2, DECIMAL128(24,2), false] / 1 + [2: c1, DECIMAL128(24,5), false]\n" +
+                    "  |  cardinality: 1"));
+        }
+
+        {
+            String sql = " select c0, sum(1/(1+cast(substr('1.12',1,4) as decimal(24,4)))) as a, " +
+                    "sum(1/(1+cast(substr('1.12',1,4) as decimal(24,4)))) as b from t0 group by c0;";
+            String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+            Assert.assertTrue(plan, plan.contains("PLAN FRAGMENT 0(F00)\n" +
+                    "  Output Exprs:1: c0 | 4: sum | 4: sum\n" +
+                    "  Input Partition: RANDOM\n" +
+                    "  RESULT SINK\n" +
+                    "\n" +
+                    "  1:AGGREGATE (update finalize)\n" +
+                    "  |  aggregate: sum[(1 / 1 + cast(substr[('1.12', 1, 4); " +
+                    "args: VARCHAR,INT,INT; result: VARCHAR; args nullable: false; " +
+                    "result nullable: true] as DECIMAL128(24,4))); args: DECIMAL128; " +
+                    "result: DECIMAL128(38,6); args nullable: true; result nullable: true]\n" +
+                    "  |  group by: [1: c0, VARCHAR, false]\n" +
+                    "  |  cardinality: 1"));
+        }
+
+        {
+            String sql = "select c0, sum(cast(c2 as decimal(38,19))/(1+c1)) as a, " +
+                    "sum(cast(c2 as decimal(38,19))/(1+c1)) as b from t0 group by c0;";
+            String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+            Assert.assertTrue(plan, plan.contains("PLAN FRAGMENT 0(F00)\n" +
+                    "  Output Exprs:1: c0 | 5: sum | 5: sum\n" +
+                    "  Input Partition: RANDOM\n" +
+                    "  RESULT SINK\n" +
+                    "\n" +
+                    "  2:AGGREGATE (update finalize)\n" +
+                    "  |  aggregate: sum[(cast([4: expr, DECIMAL128(38,19), true] as DECIMAL128(38,18))); " +
+                    "args: DECIMAL128; result: DECIMAL128(38,18); args nullable: true; result nullable: true]\n" +
+                    "  |  group by: [1: c0, VARCHAR, false]\n" +
+                    "  |  cardinality: 1\n" +
+                    "  |  \n" +
+                    "  1:Project\n" +
+                    "  |  output columns:\n" +
+                    "  |  1 <-> [1: c0, VARCHAR, false]\n" +
+                    "  |  4 <-> cast([3: c2, DECIMAL128(24,2), false] as DECIMAL128(38,19)) / 1 + " +
+                    "[2: c1, DECIMAL128(24,5), false]\n" +
+                    "  |  cardinality: 1"));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1944,15 +1944,14 @@ public class AggregateTest extends PlanTestBase {
         sql = "select sum(id_decimal + 1 + 2) from test_all_type";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  3:Project\n" +
-                "  |  <slot 12> : 14: sum + CAST(15: count AS DECIMAL128(18,0)) * 2\n" +
+                "  |  <slot 12> : 16: sum + CAST(17: count AS DECIMAL128(18,0)) * 1 + CAST(15: count AS DECIMAL128(18,0)) * 2\n" +
                 "  |  \n" +
                 "  2:AGGREGATE (update finalize)\n" +
-                "  |  output: sum(13: cast), count(13: cast)\n" +
+                "  |  output: count(10: id_decimal), count(CAST(10: id_decimal AS DECIMAL64(12,2)) + 1), sum(10: id_decimal)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
                 "  1:Project\n" +
-                "  |  <slot 13> : " +
-                "CAST(CAST(CAST(10: id_decimal AS DECIMAL64(12,2)) AS DECIMAL64(15,2)) + 1 AS DECIMAL64(13,2))\n" +
+                "  |  <slot 10> : 10: id_decimal\n" +
                 "  |  \n" +
                 "  0:OlapScanNode");
         // 1.2 not null

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q1.sql
@@ -115,7 +115,7 @@ OutPut Exchange Id: 03
 |  9 <-> [9: l_returnflag, VARCHAR, true]
 |  10 <-> [10: l_linestatus, VARCHAR, true]
 |  17 <-> [32: multiply, DECIMAL128(33,4), true]
-|  18 <-> [32: multiply, DECIMAL128(33,4), true] * 1 + cast([8: l_tax, DECIMAL64(15,2), true] as DECIMAL128(19,2))
+|  18 <-> [32: multiply, DECIMAL128(33,4), true] * cast(1 + [8: l_tax, DECIMAL64(15,2), true] as DECIMAL128(16,2))
 |  common expressions:
 |  32 <-> [28: cast, DECIMAL128(15,2), true] * [31: cast, DECIMAL128(18,2), true]
 |  28 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
@@ -151,3 +151,4 @@ column statistics:
 * expr-->[810.9, 104949.5, 0.0, 16.0, 3736520.0] ESTIMATE
 * expr-->[810.9, 113345.46, 0.0, 16.0, 3736520.0] ESTIMATE
 [end]
+


### PR DESCRIPTION
When analyzing a decimal ArithmeticExpr, CastExpr is interpolated, so analyzing a decimal ArithmeticExpr multiple times give different result, which can cause  that the query contains duplicate aggregation function applying to decimal ArithmeticExpr fails to parse. the query looks like the one as follows:
```
-- c0: decimal(24, 2);
-- c1: decimal(25 ,5);
select c0, sum(c1/(1+c2)), sum(c1/(1+c2)) from t0 group by c0;
```
First analyzing is that SelectAnalyzer.analyze invoke SelectAnalyzer.analyzeSelect to get output exprs, then collect aggregations from output exprs, only one aggregation is collected since the two are duplicate.
Second analyzing  that SelectAnalyzer.analyzeAggregations analyze collected aggregation again, then try to substitute this aggregation with ColumnRefOperator in output exprs(QueryTransform.plan invokes project() after invoking aggregate()), but because the collected aggregation is analyzed twice, it is different from another aggregation in output exprs.

We should make decimal ArithmeticExpr analyzing idempotent,  so CastExpr intepolation is moved to ImplicitCastRule.


## What type of PR is this
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
