### PR TITLE
[Feature] Support comment and builtin property for role in RBAC

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeBuiltinConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeBuiltinConstants.java
@@ -41,6 +41,9 @@ public class  PrivilegeBuiltinConstants {
     public static final Set<Long> IMMUTABLE_BUILT_IN_ROLE_IDS = new HashSet<>(Arrays.asList(
             ROOT_ROLE_ID, DB_ADMIN_ROLE_ID, CLUSTER_ADMIN_ROLE_ID, USER_ADMIN_ROLE_ID));
 
+    public static final Set<String> IMMUTABLE_BUILT_IN_ROLE_NAMES = new HashSet<>(Arrays.asList(
+            ROOT_ROLE_NAME, DB_ADMIN_ROLE_NAME, CLUSTER_ADMIN_ROLE_NAME, USER_ADMIN_ROLE_NAME, PUBLIC_ROLE_NAME));
+
     public static final long ALL_CATALOGS_ID = -1; // -1 represent all catalogs
 
     public static final String ALL_DATABASES_UUID = "ALL_DATABASES_UUID"; // represent all databases

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/RolePrivilegeCollection.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/RolePrivilegeCollection.java
@@ -32,6 +32,8 @@ public class RolePrivilegeCollection extends PrivilegeCollection {
     private Set<Long> parentRoleIds;
     @SerializedName(value = "s")
     private Set<Long> subRoleIds;
+    @SerializedName(value = "c")
+    private String comment;
 
     public enum RoleFlags {
         MUTABLE(1),
@@ -50,15 +52,21 @@ public class RolePrivilegeCollection extends PrivilegeCollection {
         this.mask = 0;
         this.parentRoleIds = new HashSet<>();
         this.subRoleIds = new HashSet<>();
+        this.comment = "";
     }
 
     public RolePrivilegeCollection(String name, RoleFlags... flags) {
+        this(name, null, flags);
+    }
+
+    public RolePrivilegeCollection(String name, String comment, RoleFlags... flags) {
         this.name = name;
         for (RoleFlags flag : flags) {
             this.mask |= flag.mask;
         }
         this.parentRoleIds = new HashSet<>();
         this.subRoleIds = new HashSet<>();
+        this.comment = comment;
     }
 
     private void assertMutable() throws PrivilegeException {
@@ -75,8 +83,20 @@ public class RolePrivilegeCollection extends PrivilegeCollection {
         return checkFlag(RoleFlags.REMOVABLE);
     }
 
+    public boolean isMutable() {
+        return checkFlag(RoleFlags.MUTABLE);
+    }
+
     public String getName() {
         return name;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
     }
 
     private boolean checkFlag(RoleFlags flag) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -40,6 +40,7 @@ import com.starrocks.sql.ast.AlterLoadStmt;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterResourceGroupStmt;
 import com.starrocks.sql.ast.AlterResourceStmt;
+import com.starrocks.sql.ast.AlterRoleStmt;
 import com.starrocks.sql.ast.AlterRoutineLoadStmt;
 import com.starrocks.sql.ast.AlterStorageVolumeStmt;
 import com.starrocks.sql.ast.AlterSystemStmt;
@@ -476,6 +477,14 @@ public class DDLStmtExecutor {
         public ShowResultSet visitCreateRoleStatement(CreateRoleStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
                 context.getGlobalStateMgr().getAuthorizationMgr().createRole(stmt);
+            });
+            return null;
+        }
+
+        @Override
+        public ShowResultSet visitAlterRoleStatement(AlterRoleStmt stmt, ConnectContext context) {
+            ErrorReport.wrapWithRuntimeException(() -> {
+                context.getGlobalStateMgr().getAuthorizationMgr().alterRole(stmt);
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -2136,11 +2136,12 @@ public class ShowExecutor {
     private void handleShowRoles() {
         ShowRolesStmt showStmt = (ShowRolesStmt) stmt;
 
-
         List<List<String>> infos = new ArrayList<>();
         AuthorizationMgr authorizationManager = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
         List<String> roles = authorizationManager.getAllRoles();
-        roles.forEach(e -> infos.add(Lists.newArrayList(e)));
+        roles.forEach(e -> infos.add(Lists.newArrayList(e,
+                authorizationManager.isBuiltinRole(e) ? "true" : "false",
+                authorizationManager.getRoleComment(e))));
 
         resultSet = new ShowResultSet(showStmt.getMetaData(), infos);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeChecker.java
@@ -60,6 +60,7 @@ import com.starrocks.sql.ast.AlterLoadStmt;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterResourceGroupStmt;
 import com.starrocks.sql.ast.AlterResourceStmt;
+import com.starrocks.sql.ast.AlterRoleStmt;
 import com.starrocks.sql.ast.AlterRoutineLoadStmt;
 import com.starrocks.sql.ast.AlterSystemStmt;
 import com.starrocks.sql.ast.AlterTableStmt;
@@ -1030,6 +1031,14 @@ public class PrivilegeChecker {
 
         @Override
         public Void visitCreateRoleStatement(CreateRoleStmt statement, ConnectContext context) {
+            if (!PrivilegeActions.checkSystemAction(context, PrivilegeType.GRANT)) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitAlterRoleStatement(AlterRoleStmt statement, ConnectContext context) {
             if (!PrivilegeActions.checkSystemAction(context, PrivilegeType.GRANT)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "GRANT");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzer.java
@@ -263,7 +263,7 @@ public class PrivilegeStmtAnalyzer {
             }
 
             PrivilegeType privilegeType = PrivilegeType.valueOf(p);
-            if (!authorizationManager.isAvailablePirvType(objectType, privilegeType)) {
+            if (!authorizationManager.isAvailablePrivType(objectType, privilegeType)) {
                 throw new SemanticException("Cannot grant or revoke " + privTypeString + " on '"
                         + objectType + "' type object");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterRoleStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterRoleStmt.java
@@ -19,19 +19,19 @@ import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
 
-public class CreateRoleStmt extends DdlStmt {
+public class AlterRoleStmt extends DdlStmt {
     private final List<String> roles;
-    private final boolean ifNotExists;
+    private final boolean ifExists;
     private final String comment;
 
-    public CreateRoleStmt(List<String> roles, boolean ifNotExists, String comment) {
-        this(roles, ifNotExists, comment, NodePosition.ZERO);
+    public AlterRoleStmt(List<String> roles, boolean ifExists, String comment) {
+        this(roles, ifExists, comment, NodePosition.ZERO);
     }
 
-    public CreateRoleStmt(List<String> roles, boolean ifNotExists, String comment, NodePosition pos) {
+    public AlterRoleStmt(List<String> roles, boolean ifExists, String comment, NodePosition pos) {
         super(pos);
         this.roles = roles;
-        this.ifNotExists = ifNotExists;
+        this.ifExists = ifExists;
         this.comment = comment;
     }
 
@@ -39,8 +39,8 @@ public class CreateRoleStmt extends DdlStmt {
         return roles;
     }
 
-    public boolean isIfNotExists() {
-        return ifNotExists;
+    public boolean isIfExists() {
+        return ifExists;
     }
 
     public String getComment() {
@@ -49,6 +49,6 @@ public class CreateRoleStmt extends DdlStmt {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitCreateRoleStatement(this, context);
+        return visitor.visitAlterRoleStatement(this, context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -601,6 +601,10 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(statement, context);
     }
 
+    public R visitAlterRoleStatement(AlterRoleStmt statement, C context) {
+        return visitStatement(statement, context);
+    }
+
     public R visitDropRoleStatement(DropRoleStmt statement, C context) {
         return visitStatement(statement, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRolesStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRolesStmt.java
@@ -27,6 +27,8 @@ public class ShowRolesStmt extends ShowStmt {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
 
         builder.addColumn(new Column("Name", ScalarType.createVarchar(100)));
+        builder.addColumn(new Column("Builtin", ScalarType.createVarchar(30)));
+        builder.addColumn(new Column("Comment", ScalarType.createVarchar(300)));
 
         META_DATA = builder.build();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -122,6 +122,7 @@ import com.starrocks.sql.ast.AlterLoadStmt;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterResourceGroupStmt;
 import com.starrocks.sql.ast.AlterResourceStmt;
+import com.starrocks.sql.ast.AlterRoleStmt;
 import com.starrocks.sql.ast.AlterRoutineLoadStmt;
 import com.starrocks.sql.ast.AlterStorageVolumeClause;
 import com.starrocks.sql.ast.AlterStorageVolumeCommentClause;
@@ -4593,10 +4594,20 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitCreateRoleStatement(StarRocksParser.CreateRoleStatementContext context) {
-        List<String> roles = new ArrayList<>();
-        roles.addAll(context.roleList().identifierOrString().stream().map(this::visit).map(
-                s -> ((Identifier) s).getValue()).collect(toList()));
-        return new CreateRoleStmt(roles, context.NOT() != null, createPos(context));
+        List<String> roles = context.roleList().identifierOrString().stream().map(this::visit).map(
+                s -> ((Identifier) s).getValue()).collect(Collectors.toList());
+        String comment = context.comment() == null ? "" : ((StringLiteral) visit(context.comment())).getStringValue();
+        return new CreateRoleStmt(roles, context.NOT() != null, comment, createPos(context));
+    }
+
+    @Override
+    public ParseNode visitAlterRoleStatement(StarRocksParser.AlterRoleStatementContext context) {
+        List<String> roles = context.roleList().identifierOrString().stream().map(this::visit).map(
+                s -> ((Identifier) s).getValue()).collect(Collectors.toList());
+
+        StringLiteral stringLiteral = (StringLiteral) visit(context.string());
+        String comment = stringLiteral.getStringValue();
+        return new AlterRoleStmt(roles, context.IF() != null, comment);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -208,6 +208,7 @@ statement
     | showAuthenticationStatement
     | executeAsStatement
     | createRoleStatement
+    | alterRoleStatement
     | dropRoleStatement
     | showRolesStatement
     | grantRoleStatement
@@ -1358,7 +1359,11 @@ executeAsStatement
     ;
 
 createRoleStatement
-    : CREATE ROLE (IF NOT EXISTS)? roleList
+    : CREATE ROLE (IF NOT EXISTS)? roleList comment?
+    ;
+
+alterRoleStatement
+    : ALTER ROLE (IF EXISTS)? roleList SET COMMENT '=' string
     ;
 
 dropRoleStatement

--- a/fe/fe-core/src/test/java/com/starrocks/privilege/AuthorizationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/privilege/AuthorizationMgrTest.java
@@ -53,7 +53,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class AuthorizationManagerTest {
+public class AuthorizationMgrTest {
     private ConnectContext ctx;
     private static final String DB_NAME = "db";
     private static final String TABLE_NAME_0 = "tbl0";
@@ -342,6 +342,30 @@ public class AuthorizationManagerTest {
 
         // not check drop twice
         DDLStmtExecutor.execute(stmt, ctx);
+
+        // test create role with comment
+        sql = "create role test_role2 comment \"yi shan yi shan, liang jing jing\"";
+        stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        DDLStmtExecutor.execute(stmt, ctx);
+        System.out.println(manager.getRoleComment("test_role2"));
+        Assert.assertTrue(manager.getRoleComment("test_role2").contains("yi shan yi shan, liang jing jing"));
+
+        // test alter role comment
+        sql = "alter role test_role2 set comment=\"man tian dou shi xiao xing xing\"";
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, ctx), ctx);
+        Assert.assertTrue(manager.getRoleComment("test_role2").contains("man tian dou shi xiao xing xing"));
+
+        // test alter immutable role comment, then throw exception
+        sql = "alter role root set comment=\"gua zai tian shang fang guang ming\"";
+        try {
+            DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, ctx), ctx);
+            Assert.fail();
+        } catch (DdlException e) {
+            Assert.assertTrue(e.getMessage().contains("root is immutable"));
+        }
+
+        // clean
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser("drop role test_role2", ctx), ctx);
     }
 
     // used in testPersistRole

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RBACExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RBACExecutorTest.java
@@ -126,12 +126,25 @@ public class RBACExecutorTest {
 
     @Test
     public void testShowRoles() throws Exception {
+        String sql = "create role test_role comment \"yi shan yi shan, liang jing jing\"";
+        StatementBase createRoleStmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        DDLStmtExecutor.execute(createRoleStmt, ctx);
+
         ShowRolesStmt stmt = new ShowRolesStmt();
         ctx.setCurrentUserIdentity(UserIdentity.ROOT);
         ShowExecutor executor = new ShowExecutor(ctx, stmt);
         ShowResultSet resultSet = executor.execute();
-        Assert.assertEquals("[[root], [db_admin], [cluster_admin], [user_admin], [public], " +
-                "[r0], [r1], [r2], [r3], [r4]]", resultSet.getResultRows().toString());
+        String resultString = resultSet.getResultRows().toString();
+        // sampling test a some of the result rows
+        Assert.assertTrue(
+                resultString.contains("[root, true, built-in root role which has all privileges on all objects]"));
+        Assert.assertTrue(
+                resultString.contains("[db_admin, true, built-in database administration role]"));
+        Assert.assertTrue(
+                resultString.contains("[test_role, false, yi shan yi shan, liang jing jing]"));
+
+        // clean
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser("drop role test_role", ctx), ctx);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -81,7 +81,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
-public class PrivilegeCheckerV2Test {
+public class PrivilegeCheckerTest {
     private static StarRocksAssert starRocksAssert;
     private static UserIdentity testUser;
 
@@ -1255,6 +1255,9 @@ public class PrivilegeCheckerV2Test {
         verifyGrantRevoke(sql, grantSql, revokeSql, err);
 
         sql = "create role testrole2";
+        verifyGrantRevoke(sql, grantSql, revokeSql, err);
+
+        sql = "alter role testrole2 set comment=\"yi shan yi shan, liang jing jing\"";
         verifyGrantRevoke(sql, grantSql, revokeSql, err);
 
         sql = "drop role test_role";


### PR DESCRIPTION
Fixes SR-17552
Add a new comment property on role in RBAC and support
to set comment when creating role and alter role comment.
`show roles` will show the role comment and also show whether
this role is a builtin role or not.

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
