### PR TITLE
[BugFix] Fix parse "not in one value" delete predicate failed bug

### DIFF
--- a/be/src/storage/predicate_parser.cpp
+++ b/be/src/storage/predicate_parser.cpp
@@ -53,7 +53,8 @@ ColumnPredicate* PredicateParser::parse_thrift_cond(const TCondition& condition)
     ColumnPredicate* pred = nullptr;
     if ((condition.condition_op == "*=" || condition.condition_op == "=") && condition.condition_values.size() == 1) {
         pred = new_column_eq_predicate(type_info, index, condition.condition_values[0]);
-    } else if (condition.condition_op == "!=" && condition.condition_values.size() == 1) {
+    } else if ((condition.condition_op == "!*=" || condition.condition_op == "!=") &&
+               condition.condition_values.size() == 1) {
         pred = new_column_ne_predicate(type_info, index, condition.condition_values[0]);
     } else if (condition.condition_op == "<<") {
         pred = new_column_lt_predicate(type_info, index, condition.condition_values[0]);

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -534,4 +534,140 @@ TEST_F(DuplicateTabletReaderWithDeleteTest, test_read_success) {
     reader->close();
 }
 
+class DuplicateTabletReaderWithDeleteNotInOneValueTest : public testing::Test {
+public:
+    DuplicateTabletReaderWithDeleteNotInOneValueTest() {
+        _location_provider = std::make_unique<FixedLocationProvider>(kTestGroupPath);
+        _update_manager = std::make_unique<UpdateManager>(_location_provider.get());
+        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), _update_manager.get(), 0);
+        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+        }
+
+        _tablet_schema = TabletSchema::create(*schema);
+        _schema = std::make_shared<VSchema>(ChunkHelper::convert_schema(*_tablet_schema));
+    }
+
+    void SetUp() override {
+        (void)fs::remove_all(kTestGroupPath);
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kTxnLogDirectoryName)));
+        CHECK_OK(_tablet_manager->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { (void)fs::remove_all(kTestGroupPath); }
+
+protected:
+    constexpr static const char* const kTestGroupPath = "test_duplicate_lake_tablet_reader_with_delete_not_in_one";
+
+    std::unique_ptr<FixedLocationProvider> _location_provider;
+    std::unique_ptr<TabletManager> _tablet_manager;
+    std::unique_ptr<UpdateManager> _update_manager;
+    std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<VSchema> _schema;
+};
+
+TEST_F(DuplicateTabletReaderWithDeleteNotInOneValueTest, test_read_success) {
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+
+    VChunk chunk0({c0, c1}, _schema);
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(_tablet_metadata->id()));
+
+    {
+        // write rowset 1 with 1 segments
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+
+        // write rowset data
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->finish());
+
+        auto files = writer->files();
+        ASSERT_EQ(1, files.size());
+
+        // add rowset metadata
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(true);
+        rowset->set_id(1);
+        auto* segs = rowset->mutable_segments();
+        for (auto& file : writer->files()) {
+            segs->Add(std::move(file));
+        }
+
+        writer->close();
+    }
+
+    {
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(false);
+        rowset->set_num_rows(0);
+        rowset->set_data_size(0);
+
+        auto* delete_predicate = rowset->mutable_delete_predicate();
+        delete_predicate->set_version(-1);
+        // delete c0 not in (10)
+        auto* in_predicate = delete_predicate->add_in_predicates();
+        in_predicate->set_column_name("c0");
+        in_predicate->set_is_not_in(true);
+        in_predicate->add_values("10");
+    }
+
+    // write tablet metadata
+    _tablet_metadata->set_version(3);
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*_tablet_metadata));
+
+    // test reader
+    ASSIGN_OR_ABORT(auto reader, tablet.new_reader(3, *_schema));
+    ASSERT_OK(reader->prepare());
+    TabletReaderParams params;
+    ASSERT_OK(reader->open(params));
+
+    auto read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);
+    ASSERT_OK(reader->get_next(read_chunk_ptr.get()));
+    ASSERT_EQ(1, read_chunk_ptr->num_rows());
+    EXPECT_EQ(10, read_chunk_ptr->get(0)[0].get_int32());
+    EXPECT_EQ(20, read_chunk_ptr->get(0)[1].get_int32());
+
+    read_chunk_ptr->reset();
+    ASSERT_TRUE(reader->get_next(read_chunk_ptr.get()).is_end_of_file());
+
+    reader->close();
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
For cloud native tablet, not in one value predicate was not converted to not equal when deleting, so add this convertion in predicate parse when reading.

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
