### PR TITLE
[Enhancement] check dict bound with SIMD

### DIFF
--- a/be/src/formats/parquet/encoding.h
+++ b/be/src/formats/parquet/encoding.h
@@ -80,14 +80,6 @@ public:
     virtual Status next_batch(size_t count, uint8_t* dst) {
         return Status::NotSupported("next_batch is not supported");
     }
-
-protected:
-    inline Status check_dict_index_in_bounds(size_t index, size_t dict_size) {
-        if (LIKELY(0 <= index && index < dict_size)) {
-            return Status::OK();
-        }
-        return Status::InternalError("Index not in dictionary bounds");
-    }
 };
 
 class EncodingInfo {


### PR DESCRIPTION
Fixes #issue

The Original Code cost too much on Status ctor and dtor, 17% + 14% of next_batch
<img width="1043" alt="截屏2023-05-28 12 42 51" src="https://github.com/StarRocks/starrocks/assets/28446271/f92fa6f9-ce49-408e-91b7-600da6312e6b">

another code:
`       auto flag = 0;
        auto size = _dict.size();
        for (int i = 0; i < count; i++) {
            flag |= _indexes[i] >= size;
            auto index = _indexes[i] >= size ? 0 : _indexes[i];
            data[i] = _dict[index];
        }
        return flag ? Status::InternalError("Error Dict, Index not in dictionary bounds") : Status::OK();`
can not vectorized on check index,  still too much cost.
<img width="558" alt="截屏2023-05-28 12 57 07" src="https://github.com/StarRocks/starrocks/assets/28446271/9382ca67-6730-436b-bf1a-9523063ca841">

final code:
`auto flag = 0;
        size_t size = _dict.size();
        for (int i = 0; i < count; i++) {
            flag |= _indexes[i] >= size;
        }
        if (flag) {
            return Status::InternalError("Index not in dictionary bounds");
        }

        for (int i = 0; i < count; i++) {
            data[i] = _dict[_indexes[i]];
        }
        return Status::OK();`
works good, check bound only cost no more than 1/10 of decode.
Decode:
<img width="550" alt="截屏2023-05-28 13 27 51" src="https://github.com/StarRocks/starrocks/assets/28446271/bf8d5767-2cef-4099-8df6-24cffc2283c7">
check:
<img width="516" alt="截屏2023-05-28 13 29 26" src="https://github.com/StarRocks/starrocks/assets/28446271/ae608c36-ac04-4dde-9783-f4962e550130">


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
