### PR TITLE
[Feature] Format the output of show proc as stardard JSON

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowProcAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ShowProcAction.java
@@ -35,8 +35,10 @@
 package com.starrocks.http.rest;
 
 import com.google.common.base.Strings;
-import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import com.starrocks.analysis.RedirectStatus;
+import com.starrocks.catalog.Column;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.proc.ProcNodeInterface;
@@ -57,6 +59,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 // Format:
 //   http://username:password@192.168.1.1:8030/api/show_proc?path=/
@@ -109,9 +112,12 @@ public class ShowProcAction extends RestBaseAction {
                 return;
             }
 
-            Gson gson = new Gson();
+            List<String> columnNames = resultSet.getMetaData().getColumns()
+                    .stream().map(Column::getName).collect(Collectors.toList());
+            List<List<String>> rows = resultSet.getResultRows();
+
             response.setContentType("application/json");
-            response.getContent().append(gson.toJson(resultSet.getResultRows()));
+            response.getContent().append(formatResultToJson(columnNames, rows));
 
         } else {
             ProcNodeInterface procNode = null;
@@ -131,11 +137,11 @@ public class ShowProcAction extends RestBaseAction {
                 ProcResult result;
                 try {
                     result = procNode.fetchResult();
+                    List<String> columnNames = result.getColumnNames();
                     List<List<String>> rows = result.getRows();
 
-                    Gson gson = new Gson();
                     response.setContentType("application/json");
-                    response.getContent().append(gson.toJson(rows));
+                    response.getContent().append(formatResultToJson(columnNames, rows));
                 } catch (AnalysisException e) {
                     LOG.warn(e.getMessage());
                     response.getContent().append("[]");
@@ -144,5 +150,17 @@ public class ShowProcAction extends RestBaseAction {
         }
 
         sendResult(request, response);
+    }
+
+    public String formatResultToJson(List<String> columnNames, List<List<String>> rows) {
+        JsonArray jarray = new JsonArray();
+        for (List<String> row : rows) {
+            JsonObject jobject = new JsonObject();
+            for (int i = 0; i < columnNames.size(); i++) {
+                jobject.addProperty(columnNames.get(i), row.get(i));
+            }
+            jarray.add(jobject);
+        }
+        return jarray.toString();
     }
 }


### PR DESCRIPTION
 Format the output of show proc as stardard JSON

before:
```
curl -u root:qwer1234 http://127.0.0.1:8038/api/show_proc?path=/backends
[["10003","192.168.7.221","9050","9060","8048","8060","2023-05-27 13:02:41","2023-05-27 18:19:30","true","false","false","42","13.255 KB","157.025 GB","195.861 GB","19.83 %","19.83 %","","DEV-MAIN-f2dc764","{\"lastSuccessReportTabletsTime\":\"2023-05-27 18:18:42\"}","157.025 GB","0.00 %","16","0","0.10 %","0.0 %"]]
```
after:
```
curl -u root:qwer1234 http://127.0.0.1:8038/api/show_proc?path=/backends
[{"BackendId":"10003","IP":"192.168.7.221","HeartbeatPort":"9050","BePort":"9060","HttpPort":"8048","BrpcPort":"8060","LastStartTime":"2023-05-27 18:37:17","LastHeartbeat":"2023-05-27 18:37:37","Alive":"true","SystemDecommissioned":"false","ClusterDecommissioned":"false","TabletNum":"42","DataUsedCapacity":"13.255 KB","AvailCapacity":"157.024 GB","TotalCapacity":"195.861 GB","UsedPct":"19.83 %","MaxDiskUsedPct":"19.83 %","ErrMsg":"","Version":"JSON-410e4c8","Status":"{\"lastSuccessReportTabletsTime\":\"2023-05-27 18:37:17\"}","DataTotalCapacity":"157.024 GB","DataUsedPct":"0.00 %","CpuCores":"16","NumRunningQueries":"0","MemUsedPct":"0.10 %","CpuUsedPct":"0.0 %"}]
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
