### PR TITLE
[Enhancement] Support struct cast function

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1621,6 +1621,9 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
         if (from_type.children.size() != to_type.children.size()) {
             return Status::NotSupported("vectorized engine not support cast struct with different number of children.");
         }
+        if (to_type.field_names.empty() || from_type.field_names.size() != to_type.field_names.size()) {
+            return Status::NotSupported("vectorized engine not support cast struct with different field of children.");
+        }
         std::vector<std::unique_ptr<Expr>> field_casts{from_type.children.size()};
         for (int i = 0; i < from_type.children.size(); ++i) {
             ASSIGN_OR_RETURN(field_casts[i],

--- a/be/src/exprs/cast_nested.cpp
+++ b/be/src/exprs/cast_nested.cpp
@@ -82,7 +82,8 @@ StatusOr<ColumnPtr> CastStructExpr::evaluate_checked(ExprContext* context, Chunk
             casted_fields.emplace_back(struct_column->fields()[i]->clone_shared());
         }
     }
-    auto casted_struct = StructColumn::create(std::move(casted_fields));
+    
+    auto casted_struct = StructColumn::create(std::move(casted_fields), _type.field_names);
     RETURN_IF_ERROR(casted_struct->unfold_const_children(_type));
     if (!orig_column->is_nullable()) {
         return std::move(casted_struct);

--- a/be/src/exprs/cast_nested.cpp
+++ b/be/src/exprs/cast_nested.cpp
@@ -82,7 +82,7 @@ StatusOr<ColumnPtr> CastStructExpr::evaluate_checked(ExprContext* context, Chunk
             casted_fields.emplace_back(struct_column->fields()[i]->clone_shared());
         }
     }
-    
+ 
     auto casted_struct = StructColumn::create(std::move(casted_fields), _type.field_names);
     RETURN_IF_ERROR(casted_struct->unfold_const_children(_type));
     if (!orig_column->is_nullable()) {

--- a/be/src/exprs/cast_nested.cpp
+++ b/be/src/exprs/cast_nested.cpp
@@ -82,7 +82,7 @@ StatusOr<ColumnPtr> CastStructExpr::evaluate_checked(ExprContext* context, Chunk
             casted_fields.emplace_back(struct_column->fields()[i]->clone_shared());
         }
     }
- 
+
     auto casted_struct = StructColumn::create(std::move(casted_fields), _type.field_names);
     RETURN_IF_ERROR(casted_struct->unfold_const_children(_type));
     if (!orig_column->is_nullable()) {

--- a/docs/sql-reference/sql-statements/data-types/STRUCT.md
+++ b/docs/sql-reference/sql-statements/data-types/STRUCT.md
@@ -67,7 +67,7 @@ There are two ways to write struct values to StarRocks. Insert into is suitable 
 * **INSERT INTO**
 
   ~~~SQL
-  create table t0(c0 INT, c1 `STRUCT<a INT, b INT>`)duplicate key(c0);
+  create table t0(c0 INT, c1 STRUCT<a INT, b INT>)duplicate key(c0);
   INSERT INTO t0 VALUES(1, row(1, 1));
   ~~~
 

--- a/docs/sql-reference/sql-statements/data-types/STRUCT.md
+++ b/docs/sql-reference/sql-statements/data-types/STRUCT.md
@@ -47,16 +47,16 @@ The struct type has the following restrictions:
 
 ### Construct structs in SQL
 
-Struct can be constructed in SQL using function `row`, `name_struct`, `struct` 
+Struct can be constructed in SQL using function `row`, `named_struct`, `struct` 
 
 ~~~SQL
 select row(1, 2, 3, 4) as numbers; -- The result is {'col1': 1, 'col2': 2, 'col3': 3, 'col4': 4}
 select struct(1, 2, 3, 4) as numbers; -- The result is {'col1': 1, 'col2': 2, 'col3': 3, 'col4': 4}
-select name_struct('a', 1, 'b', 2, 'c', 3, 'd', 4) as numbers; -- The result is {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+select named_struct('a', 1, 'b', 2, 'c', 3, 'd', 4) as numbers; -- The result is {'a': 1, 'b': 2, 'c': 3, 'd': 4}
 ~~~
 
 `row`, `struct` support un-named struct, StarRocks will automatically generate column names, like `col1`, `col2`...
-`name_struct` support a named struct, the parameters must be a Name/Value pairs, and the number of parameters must be even.
+`named_struct` support a named struct, the parameters must be a Name/Value pairs, and the number of parameters must be even.
 
 StarRocks will automatically determine the type of the struct.
 
@@ -78,21 +78,28 @@ There are two ways to write struct values to StarRocks. Insert into is suitable 
 
 ### Struct element access
 
-Access a subfield of a struct using `.`
+Access a subfield of a struct using `.`, or using `[subfield-index]`
 
 ~~~Plain Text
-mysql> select name_struct('a', 1, 'b', 2, 'c', 3, 'd', 4).a;
+mysql> select named_struct('a', 1, 'b', 2, 'c', 3, 'd', 4).a;
 
-+-----------------------------------------------+
-| name_struct('a', 1, 'b', 2, 'c', 3, 'd', 4).a |
-+-----------------------------------------------+
-| 1                                             |
-+-----------------------------------------------+
++------------------------------------------------+
+| named_struct('a', 1, 'b', 2, 'c', 3, 'd', 4).a |
++------------------------------------------------+
+| 1                                              |
++------------------------------------------------+
 
 mysql> select row(1, 2, 3, 4).col1;
-+------------------+
-| row(1, 2, 3, 4)  |
-+------------------+
-| 1                |
-+------------------+
++-----------------------+
+| row(1, 2, 3, 4).col1  |
++-----------------------+
+| 1                     |
++-----------------------+
+
+mysql> select row(1, 2, 3, 4)[2];
++---------------------+
+| row(1, 2, 3, 4)[2]  |
++---------------------+
+| 2                   |
++---------------------+
 ~~~

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SubfieldExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SubfieldExpr.java
@@ -25,28 +25,30 @@ import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
 
+import java.util.List;
+
 public class SubfieldExpr extends Expr {
 
     // We use fieldNames to extract subfield column from children[0],
     // children[0] must be an StructType.
-    private final ImmutableList<String> fieldNames;
+    private final List<String> fieldNames;
 
     // Only used in parser, in parser, we can't determine column's type
-    public SubfieldExpr(Expr child, ImmutableList<String> fieldNames) {
+    public SubfieldExpr(Expr child, List<String> fieldNames) {
         this(child, null, fieldNames);
     }
 
-    public SubfieldExpr(Expr child, ImmutableList<String> fieldNames, NodePosition pos) {
+    public SubfieldExpr(Expr child, List<String> fieldNames, NodePosition pos) {
         this(child, null, fieldNames, pos);
     }
 
     // In this constructor, we can determine column's type
     // child must be an StructType
-    public SubfieldExpr(Expr child, Type type, ImmutableList<String> fieldNames) {
+    public SubfieldExpr(Expr child, Type type, List<String> fieldNames) {
         this(child, type, fieldNames, NodePosition.ZERO);
     }
 
-    public SubfieldExpr(Expr child, Type type, ImmutableList<String> fieldNames, NodePosition pos) {
+    public SubfieldExpr(Expr child, Type type, List<String> fieldNames, NodePosition pos) {
         super(pos);
         if (type != null) {
             Preconditions.checkArgument(child.getType().isStructType());
@@ -61,7 +63,7 @@ public class SubfieldExpr extends Expr {
         fieldNames = other.fieldNames;
     }
 
-    public ImmutableList<String> getFieldNames() {
+    public List<String> getFieldNames() {
         return fieldNames;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.thrift.TTypeDesc;
 import com.starrocks.thrift.TTypeNode;
 import com.starrocks.thrift.TTypeNodeType;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -125,6 +126,9 @@ public class StructType extends Type {
         }
         for (int i = 0; i < fields.size(); ++i) {
             if (!fields.get(i).getType().matchesType(rhsType.fields.get(i).getType())) {
+                return false;
+            }
+            if (!StringUtils.equals(fields.get(i).getName(), rhsType.fields.get(i).getName())) {
                 return false;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -1051,20 +1051,6 @@ public abstract class Type implements Cloneable {
         }
     }
 
-    public static boolean canCastToAsFunctionParameter(Type from, Type to) {
-        if (from.isNull()) {
-            return true;
-        } else if (from.isScalarType() && to.isScalarType()) {
-            return ScalarType.canCastTo((ScalarType) from, (ScalarType) to);
-        } else if (from.isArrayType() && to.isArrayType()) {
-            return canCastTo(((ArrayType) from).getItemType(), ((ArrayType) to).getItemType());
-        } else if (from.isMapType() && to.isMapType()) {
-            return canCastTo(from, to);
-        } else {
-            return false;
-        }
-    }
-
     public static boolean canCastTo(Type from, Type to) {
         if (from.isNull()) {
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -438,10 +438,6 @@ public class ExpressionAnalyzer {
         public Void visitCollectionElementExpr(CollectionElementExpr node, Scope scope) {
             Expr expr = node.getChild(0);
             Expr subscript = node.getChild(1);
-            if (!expr.getType().isArrayType() && !expr.getType().isMapType()) {
-                throw new SemanticException("cannot subscript type " + expr.getType()
-                        + " because it is not an array or a map", expr.getPos());
-            }
             if (expr.getType().isArrayType()) {
                 if (!subscript.getType().isNumericType()) {
                     throw new SemanticException("array subscript must have type integer", subscript.getPos());
@@ -454,7 +450,7 @@ public class ExpressionAnalyzer {
                 } catch (AnalysisException e) {
                     throw new SemanticException(e.getMessage());
                 }
-            } else {
+            } else if (expr.getType().isMapType()) {
                 try {
                     if (subscript.getType().getPrimitiveType() !=
                             ((MapType) expr.getType()).getKeyType().getPrimitiveType()) {
@@ -464,6 +460,24 @@ public class ExpressionAnalyzer {
                 } catch (AnalysisException e) {
                     throw new SemanticException(e.getMessage());
                 }
+            } else if (expr.getType().isStructType()) {
+                if (!(subscript instanceof IntLiteral)) {
+                    throw new SemanticException("struct subscript must have integer pos", subscript.getPos());
+                }
+                long index = ((IntLiteral) subscript).getValue();
+                long fieldSize = ((StructType) expr.getType()).getFields().size();
+                if (fieldSize < Math.abs(index)) {
+                    throw new SemanticException("the pos is out of struct subfields", subscript.getPos());
+                } else if (index == 0) {
+                    throw new SemanticException("the pos can't set to zero", subscript.getPos());
+                }
+
+                index = index > 0 ? index - 1 : fieldSize + index;
+                StructField structField = ((StructType) expr.getType()).getFields().get((int) index);
+                node.setType(structField.getType());
+            } else {
+                throw new SemanticException("cannot subscript type " + expr.getType()
+                        + " because it is not an array or a map or a struct", expr.getPos());
             }
 
             return null;
@@ -1044,7 +1058,7 @@ public class ExpressionAnalyzer {
 
             for (int i = 0; i < fn.getNumArgs(); i++) {
                 if (!argumentTypes[i].matchesType(fn.getArgs()[i]) &&
-                        !Type.canCastToAsFunctionParameter(argumentTypes[i], fn.getArgs()[i])) {
+                        !Type.canCastTo(argumentTypes[i], fn.getArgs()[i])) {
                     String msg = String.format("No matching function with signature: %s(%s)", fnName,
                             node.getParams().isStar() ? "*" :
                                     Arrays.stream(argumentTypes).map(Type::toSql).collect(Collectors.joining(", ")));
@@ -1056,7 +1070,7 @@ public class ExpressionAnalyzer {
                 Type varType = fn.getArgs()[fn.getNumArgs() - 1];
                 for (int i = fn.getNumArgs(); i < argumentTypes.length; i++) {
                     if (!argumentTypes[i].matchesType(varType) &&
-                            !Type.canCastToAsFunctionParameter(argumentTypes[i], varType)) {
+                            !Type.canCastTo(argumentTypes[i], varType)) {
                         String msg = String.format("Variadic function %s(%s) can't support type: %s", fnName,
                                 Arrays.stream(fn.getArgs()).map(Type::toSql).collect(Collectors.joining(", ")),
                                 argumentTypes[i]);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -21,11 +21,13 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.MapType;
 import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.StructField;
 import com.starrocks.catalog.StructType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.analyzer.SemanticException;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -96,16 +98,17 @@ public class TypeManager {
         if (t1.getFields().size() != t1.getFields().size()) {
             return Type.INVALID;
         }
-        List<Type> fieldTypes = Lists.newArrayList();
+        ArrayList<StructField> fields = Lists.newArrayList();
         for (int i = 0; i < t1.getFields().size(); ++i) {
             Type fieldCommon = getCommonSuperType(t1.getField(i).getType(), t2.getField(i).getType());
             if (!fieldCommon.isValid()) {
                 return Type.INVALID;
             }
-            fieldTypes.add(fieldCommon);
+
+            // default t1's field name
+            fields.add(new StructField(t1.getField(i).getName(), fieldCommon));
         }
-        // TODO(alvin): needed to assign field names for this struct type
-        return new StructType(fieldTypes);
+        return new StructType(fields);
     }
 
     public static Expr addCastExpr(Expr expr, Type targetType) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/SubfieldOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/SubfieldOperator.java
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.operator.scalar;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.starrocks.analysis.SubfieldExpr;
 import com.starrocks.catalog.StructField;
 import com.starrocks.catalog.StructType;
@@ -32,7 +32,7 @@ import java.util.Objects;
 public class SubfieldOperator extends ScalarOperator {
 
     // Only one child
-    private final List<ScalarOperator> children = new ArrayList<>();
+    private List<ScalarOperator> children = new ArrayList<>();
     private final ImmutableList<String> fieldNames;
 
     // Build based on SubfieldExpr
@@ -55,13 +55,13 @@ public class SubfieldOperator extends ScalarOperator {
         return new SubfieldOperator(child, tmpType, ImmutableList.copyOf(usedSubfieldNames));
     }
 
-    private SubfieldOperator(ScalarOperator child, Type type, ImmutableList<String> fieldNames) {
+    private SubfieldOperator(ScalarOperator child, Type type, List<String> fieldNames) {
         super(OperatorType.SUBFIELD, type);
         this.children.add(child);
         this.fieldNames = fieldNames.stream().map(String::toLowerCase).collect(ImmutableList.toImmutableList());
     }
 
-    public ImmutableList<String> getFieldNames() {
+    public List<String> getFieldNames() {
         return fieldNames;
     }
 
@@ -85,6 +85,16 @@ public class SubfieldOperator extends ScalarOperator {
     public void setChild(int index, ScalarOperator child) {
         Preconditions.checkArgument(index == 0);
         children.set(0, child);
+    }
+
+    @Override
+    public ScalarOperator clone() {
+        SubfieldOperator subfieldOperator = (SubfieldOperator) super.clone();
+        // Deep copy here
+        List<ScalarOperator> newChildren = Lists.newArrayList();
+        this.children.forEach(p -> newChildren.add(p.clone()));
+        subfieldOperator.children = newChildren;
+        return subfieldOperator;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StructTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StructTypeTest.java
@@ -99,7 +99,7 @@ public class StructTypeTest {
                 new StructField("st", ScalarType.createType(PrimitiveType.INT)),
                 new StructField("cc", c1)
         ));
-        Assert.assertTrue(root.matchesType(diffName));
+        Assert.assertFalse(root.matchesType(diffName));
 
         // Different field type
         StructType diffType = new StructType(Lists.newArrayList(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -337,4 +337,12 @@ public class AnalyzeExprTest {
         analyzeFail("select map_concat()");
     }
 
+    @Test
+    public void testAnalyzeStructFunc() {
+        analyzeFail("select row('a', 1, 'b', 2)[0]");
+        analyzeFail("select row('a', 1, 'b', 2)[5]");
+        analyzeFail("select row('a', 1, 'b', 2)[-5]");
+        analyzeSuccess("select row('a', 1, 'b', 2)[1]");
+        analyzeSuccess("select row('a', 1, 'b', 2)[-1]");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1510,4 +1510,28 @@ public class ExpressionTest extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         assertCContains(plan, "row('a', 1, 'a', 2).col1");
     }
+
+    @Test
+    public void testStructCollection() throws Exception {
+        String sql = "select row('a', 1, 'a', 2)[1]";
+        String plan = getVerboseExplain(sql);
+        assertCContains(plan, "row('a', 1, 'a', 2).col1");
+
+        sql = "select row('a', 1, 'a', 2)[4]";
+        plan = getVerboseExplain(sql);
+        assertCContains(plan, "row('a', 1, 'a', 2).col4");
+
+        sql = "select row('a', 1, 'a', 2)[4]";
+        plan = getVerboseExplain(sql);
+        assertCContains(plan, "row('a', 1, 'a', 2).col4");
+
+        sql = "select row('a', 1, 'a', 2)[-1]";
+        plan = getVerboseExplain(sql);
+        assertCContains(plan, "row('a', 1, 'a', 2).col4");
+
+        sql = "select row('a', 1, 'a', 2)[-4]";
+        plan = getVerboseExplain(sql);
+        assertCContains(plan, "row('a', 1, 'a', 2).col1");
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -100,24 +100,22 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "ColumnAccessPath: [/st1/s2, /st1/s1]");
     }
 
-    // @todo: Fix UNION Struct type deriver
-    // @Test
-    // public void testUnionAllPruneColumn() throws Exception {
-    //     String sql = "select st1.s1 from (" +
-    //             " select v1, st1, st2, st3 from sc0 x1 " +
-    //             " union all " +
-    //             " select v1, st1, st2, st3 from sc0 x2) x3";
-    //     System.out.println(sql);
-    //     String plan = getVerboseExplain(sql);
-    //     System.out.println(plan);
-    // }
+    @Test
+    public void testUnionAllPruneColumn() throws Exception {
+        String sql = "select st1.s1 from (" +
+                " select v1, st1, st2, st3 from sc0 x1 " +
+                " union all " +
+                " select v1, st1, st2, st3 from sc0 x2) x3";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "[/st1/s1]");
+    }
 
     @Test
     public void testCTEPruneColumn() throws Exception {
         String sql =
                 "with t1 as (select * from sc0) select x1.st1.s1, x2.st2.s2 from t1 x1 join t1 x2 on x1.v1 = x2.v1";
         String plan = getVerboseExplain(sql);
-        assertContains("ColumnAccessPath: [/st1/s1, /st2/s2]");
+        assertContains(plan, "ColumnAccessPath: [/st1/s1, /st2/s2]");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
@@ -50,25 +50,18 @@ public class StructTypePlanTest extends PlanTestBase {
         connectContext.getSessionVariable().setCboPruneSubfield(true);
     }
 
-    // @Test
+    @Test
     public void testStruct() throws Exception {
         String sql = "select * from test1 union all select * from test1";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "0:UNION\n" +
                 "  |  \n" +
-                "  |----6:EXCHANGE\n" +
+                "  |----4:EXCHANGE\n" +
                 "  |    \n" +
-                "  3:EXCHANGE");
+                "  2:EXCHANGE");
         sql = "select c2 from test1 union all select c2_0 from test1";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "2:Project\n" +
-                "  |  <slot 6> : CAST(3: c2 AS struct<col1 int(11), col2 varchar(10)>)\n" +
-                "  |  \n" +
-                "  1:OlapScanNode", "0:UNION\n" +
-                "  |  \n" +
-                "  |----6:EXCHANGE\n" +
-                "  |    \n" +
-                "  3:EXCHANGE");
+        assertContains(plan, "CAST(3: c2 AS struct<a int(11), b varchar(10)>)");
     }
 
     @Test

--- a/test/sql/test_semi/R/test_struct
+++ b/test/sql/test_semi/R/test_struct
@@ -216,7 +216,7 @@ select row(1,v1,'a') from t1;
 {"col1":1,"col2":4,"col3":"a"}
 {"col1":1,"col2":5,"col3":"a"}
 -- !result
-select name_struct('a',v1,'b', v2) from t1;
+select named_struct('a',v1,'b', v2) from t1;
 -- result:
 {"a":2,"b":2}
 {"a":3,"b":3}
@@ -254,7 +254,7 @@ select row(map1), row(map1).col1 from sc2;
 {"col1":{5:{50:{500:507}}}}	{5:{50:{500:507}}}
 {"col1":{5:{50:{500:508}}}}	{5:{50:{500:508}}}
 -- !result
-select name_struct('a', st1, 'b', st2) from sc2;
+select named_struct('a', st1, 'b', st2) from sc2;
 -- result:
 {"a":{"s1":2,"sm2":{20:202},"sm3":{20:{200:202}}},"b":{"s1":2,"sa2":[2,20,202],"ss3":{"sss1":2,"sss2":{"ssss1":20,"ssss2":22}}}}
 {"a":{"s1":1,"sm2":{10:101},"sm3":{10:{100:101}}},"b":{"s1":1,"sa2":[1,10,101],"ss3":{"sss1":1,"sss2":{"ssss1":10,"ssss2":11}}}}
@@ -265,7 +265,7 @@ select name_struct('a', st1, 'b', st2) from sc2;
 {"a":{"s1":5,"sm2":{50:507},"sm3":{50:{500:507}}},"b":{"s1":5,"sa2":[5,50,507],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":57}}}}
 {"a":{"s1":5,"sm2":{50:508},"sm3":{50:{500:508}}},"b":{"s1":5,"sa2":[5,50,508],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":58}}}}
 -- !result
-select name_struct('a', st1, 'b', st2)[1] from sc2;
+select named_struct('a', st1, 'b', st2)[1] from sc2;
 -- result:
 {"s1":2,"sm2":{20:202},"sm3":{20:{200:202}}}
 {"s1":1,"sm2":{10:101},"sm3":{10:{100:101}}}
@@ -276,7 +276,7 @@ select name_struct('a', st1, 'b', st2)[1] from sc2;
 {"s1":5,"sm2":{50:507},"sm3":{50:{500:507}}}
 {"s1":5,"sm2":{50:508},"sm3":{50:{500:508}}}
 -- !result
-select name_struct('a', st1, 'b', st2)[1].sm2 from sc2;
+select named_struct('a', st1, 'b', st2)[1].sm2 from sc2;
 -- result:
 {20:202}
 {30:303}
@@ -291,7 +291,7 @@ select cast(row(1,2,3) as STRUCT<a double, b string, c BIGINT>);
 -- result:
 {"a":1,"b":"2","c":3}
 -- !result
-select cast(name_struct('1', 1, '2', 2, '3', 3) as STRUCT<a double, b string, c BIGINT>);
+select cast(named_struct('1', 1, '2', 2, '3', 3) as STRUCT<a double, b string, c BIGINT>);
 -- result:
 {"a":1,"b":"2","c":3}
 -- !result

--- a/test/sql/test_semi/R/test_struct
+++ b/test/sql/test_semi/R/test_struct
@@ -1,0 +1,297 @@
+-- name: test_prune_column @system
+CREATE TABLE `sc2` (
+  `v1` bigint(20) NULL COMMENT "",
+  `map1` MAP<int(11),MAP<int(11),MAP<int(11),int(11)>>> NULL COMMENT "",
+  `st1` STRUCT<s1 int(11), sm2 MAP<int(11),int(11)>, sm3 MAP<int(11),MAP<int(11),int(11)>>> NULL COMMENT "",
+  `st2` STRUCT<s1 int(11), sa2 ARRAY<int(11)>, ss3 STRUCT<sss1 int(11), sss2 STRUCT<ssss1 int(11), ssss2 int(11)>>> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t1 values (1, 2, 3);
+-- result:
+-- !result
+insert into t1 values (2, 2, 2);
+-- result:
+-- !result
+insert into t1 values (3, 3, 3);
+-- result:
+-- !result
+insert into t1 values (4, 4, 4);
+-- result:
+-- !result
+insert into t1 values (5, 5, 5);
+-- result:
+-- !result
+insert into sc2 values (1, {1: {10:{100: 101}}}, row(1, {10: 101}, {10: {100: 101}}), row(1, [1,10,101], row(1, row(10, 11))));
+-- result:
+-- !result
+insert into sc2 values (2, {2: {20:{200: 202}}}, row(2, {20: 202}, {20: {200: 202}}), row(2, [2,20,202], row(2, row(20, 22))));
+-- result:
+-- !result
+insert into sc2 values (3, {3: {30:{300: 303}}}, row(3, {30: 303}, {30: {300: 303}}), row(3, [3,30,303], row(3, row(30, 33))));
+-- result:
+-- !result
+insert into sc2 values (4, {4: {40:{400: 404}}}, row(4, {40: 404}, {40: {400: 404}}), row(4, [4,40,404], row(4, row(40, 44))));
+-- result:
+-- !result
+insert into sc2 values (5, {5: {50:{500: 505}}}, row(5, {50: 505}, {50: {500: 505}}), row(5, [5,50,505], row(5, row(50, 55))));
+-- result:
+-- !result
+insert into sc2 values (5, {5: {50:{500: 506}}}, row(5, {50: 506}, {50: {500: 506}}), row(5, [5,50,506], row(5, row(50, 56))));
+-- result:
+-- !result
+insert into sc2 values (5, {5: {50:{500: 507}}}, row(5, {50: 507}, {50: {500: 507}}), row(5, [5,50,507], row(5, row(50, 57))));
+-- result:
+-- !result
+insert into sc2 values (5, {5: {50:{500: 508}}}, row(5, {50: 508}, {50: {500: 508}}), row(5, [5,50,508], row(5, row(50, 58))));
+-- result:
+-- !result
+select st1.s1, st2.sa2 from sc2;
+-- result:
+2	[2,20,202]
+1	[1,10,101]
+5	[5,50,505]
+4	[4,40,404]
+3	[3,30,303]
+5	[5,50,506]
+5	[5,50,507]
+5	[5,50,508]
+-- !result
+select st1.sm2[10], map_size(map1[3][30]), st2.sa2[1]  from sc2;
+-- result:
+None	None	2
+101	None	1
+None	None	5
+None	1	3
+None	None	4
+None	None	5
+None	None	5
+None	None	5
+-- !result
+select st2.ss3.sss1, st2.ss3.sss2.ssss2, st2.ss3 from sc2;
+-- result:
+2	22	{"sss1":2,"sss2":{"ssss1":20,"ssss2":22}}
+1	11	{"sss1":1,"sss2":{"ssss1":10,"ssss2":11}}
+3	33	{"sss1":3,"sss2":{"ssss1":30,"ssss2":33}}
+5	55	{"sss1":5,"sss2":{"ssss1":50,"ssss2":55}}
+4	44	{"sss1":4,"sss2":{"ssss1":40,"ssss2":44}}
+5	56	{"sss1":5,"sss2":{"ssss1":50,"ssss2":56}}
+5	57	{"sss1":5,"sss2":{"ssss1":50,"ssss2":57}}
+5	58	{"sss1":5,"sss2":{"ssss1":50,"ssss2":58}}
+-- !result
+select * from t1 join sc2 on t1.v2 = sc2.v1;
+-- result:
+1	2	3	2	{2:{20:{200:202}}}	{"s1":2,"sm2":{20:202},"sm3":{20:{200:202}}}	{"s1":2,"sa2":[2,20,202],"ss3":{"sss1":2,"sss2":{"ssss1":20,"ssss2":22}}}
+2	2	2	2	{2:{20:{200:202}}}	{"s1":2,"sm2":{20:202},"sm3":{20:{200:202}}}	{"s1":2,"sa2":[2,20,202],"ss3":{"sss1":2,"sss2":{"ssss1":20,"ssss2":22}}}
+4	4	4	4	{4:{40:{400:404}}}	{"s1":4,"sm2":{40:404},"sm3":{40:{400:404}}}	{"s1":4,"sa2":[4,40,404],"ss3":{"sss1":4,"sss2":{"ssss1":40,"ssss2":44}}}
+5	5	5	5	{5:{50:{500:505}}}	{"s1":5,"sm2":{50:505},"sm3":{50:{500:505}}}	{"s1":5,"sa2":[5,50,505],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":55}}}
+3	3	3	3	{3:{30:{300:303}}}	{"s1":3,"sm2":{30:303},"sm3":{30:{300:303}}}	{"s1":3,"sa2":[3,30,303],"ss3":{"sss1":3,"sss2":{"ssss1":30,"ssss2":33}}}
+5	5	5	5	{5:{50:{500:506}}}	{"s1":5,"sm2":{50:506},"sm3":{50:{500:506}}}	{"s1":5,"sa2":[5,50,506],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":56}}}
+5	5	5	5	{5:{50:{500:507}}}	{"s1":5,"sm2":{50:507},"sm3":{50:{500:507}}}	{"s1":5,"sa2":[5,50,507],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":57}}}
+5	5	5	5	{5:{50:{500:508}}}	{"s1":5,"sm2":{50:508},"sm3":{50:{500:508}}}	{"s1":5,"sa2":[5,50,508],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":58}}}
+-- !result
+select st1.sm2, map_keys(map1) from t1 join[broadcast] sc2 on t1.v2 = sc2.v1;
+-- result:
+{20:202}	[2]
+{30:303}	[3]
+{20:202}	[2]
+{40:404}	[4]
+{50:508}	[5]
+{50:507}	[5]
+{50:506}	[5]
+{50:505}	[5]
+-- !result
+select st1.sm2, map_keys(map1) from t1 join[shuffle] sc2 on t1.v2 = sc2.v1;
+-- result:
+{20:202}	[2]
+{30:303}	[3]
+{20:202}	[2]
+{40:404}	[4]
+{50:508}	[5]
+{50:507}	[5]
+{50:506}	[5]
+{50:505}	[5]
+-- !result
+select * from sc2 union all select * from sc2;
+-- result:
+2	{2:{20:{200:202}}}	{"s1":2,"sm2":{20:202},"sm3":{20:{200:202}}}	{"s1":2,"sa2":[2,20,202],"ss3":{"sss1":2,"sss2":{"ssss1":20,"ssss2":22}}}
+1	{1:{10:{100:101}}}	{"s1":1,"sm2":{10:101},"sm3":{10:{100:101}}}	{"s1":1,"sa2":[1,10,101],"ss3":{"sss1":1,"sss2":{"ssss1":10,"ssss2":11}}}
+5	{5:{50:{500:505}}}	{"s1":5,"sm2":{50:505},"sm3":{50:{500:505}}}	{"s1":5,"sa2":[5,50,505],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":55}}}
+3	{3:{30:{300:303}}}	{"s1":3,"sm2":{30:303},"sm3":{30:{300:303}}}	{"s1":3,"sa2":[3,30,303],"ss3":{"sss1":3,"sss2":{"ssss1":30,"ssss2":33}}}
+4	{4:{40:{400:404}}}	{"s1":4,"sm2":{40:404},"sm3":{40:{400:404}}}	{"s1":4,"sa2":[4,40,404],"ss3":{"sss1":4,"sss2":{"ssss1":40,"ssss2":44}}}
+2	{2:{20:{200:202}}}	{"s1":2,"sm2":{20:202},"sm3":{20:{200:202}}}	{"s1":2,"sa2":[2,20,202],"ss3":{"sss1":2,"sss2":{"ssss1":20,"ssss2":22}}}
+5	{5:{50:{500:506}}}	{"s1":5,"sm2":{50:506},"sm3":{50:{500:506}}}	{"s1":5,"sa2":[5,50,506],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":56}}}
+1	{1:{10:{100:101}}}	{"s1":1,"sm2":{10:101},"sm3":{10:{100:101}}}	{"s1":1,"sa2":[1,10,101],"ss3":{"sss1":1,"sss2":{"ssss1":10,"ssss2":11}}}
+5	{5:{50:{500:507}}}	{"s1":5,"sm2":{50:507},"sm3":{50:{500:507}}}	{"s1":5,"sa2":[5,50,507],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":57}}}
+5	{5:{50:{500:505}}}	{"s1":5,"sm2":{50:505},"sm3":{50:{500:505}}}	{"s1":5,"sa2":[5,50,505],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":55}}}
+4	{4:{40:{400:404}}}	{"s1":4,"sm2":{40:404},"sm3":{40:{400:404}}}	{"s1":4,"sa2":[4,40,404],"ss3":{"sss1":4,"sss2":{"ssss1":40,"ssss2":44}}}
+5	{5:{50:{500:508}}}	{"s1":5,"sm2":{50:508},"sm3":{50:{500:508}}}	{"s1":5,"sa2":[5,50,508],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":58}}}
+3	{3:{30:{300:303}}}	{"s1":3,"sm2":{30:303},"sm3":{30:{300:303}}}	{"s1":3,"sa2":[3,30,303],"ss3":{"sss1":3,"sss2":{"ssss1":30,"ssss2":33}}}
+5	{5:{50:{500:506}}}	{"s1":5,"sm2":{50:506},"sm3":{50:{500:506}}}	{"s1":5,"sa2":[5,50,506],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":56}}}
+5	{5:{50:{500:507}}}	{"s1":5,"sm2":{50:507},"sm3":{50:{500:507}}}	{"s1":5,"sa2":[5,50,507],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":57}}}
+5	{5:{50:{500:508}}}	{"s1":5,"sm2":{50:508},"sm3":{50:{500:508}}}	{"s1":5,"sa2":[5,50,508],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":58}}}
+-- !result
+select x1.st1.sm2, x1.st2.ss3 from sc2 x1 union all select x2.st1.sm3[10], x2.st2.ss3 from sc2 x2;
+-- result:
+{20:202}	{"sss1":2,"sss2":{"ssss1":20,"ssss2":22}}
+{10:101}	{"sss1":1,"sss2":{"ssss1":10,"ssss2":11}}
+{50:505}	{"sss1":5,"sss2":{"ssss1":50,"ssss2":55}}
+{30:303}	{"sss1":3,"sss2":{"ssss1":30,"ssss2":33}}
+{40:404}	{"sss1":4,"sss2":{"ssss1":40,"ssss2":44}}
+{50:506}	{"sss1":5,"sss2":{"ssss1":50,"ssss2":56}}
+{50:507}	{"sss1":5,"sss2":{"ssss1":50,"ssss2":57}}
+{50:508}	{"sss1":5,"sss2":{"ssss1":50,"ssss2":58}}
+None	{"sss1":2,"sss2":{"ssss1":20,"ssss2":22}}
+{100:101}	{"sss1":1,"sss2":{"ssss1":10,"ssss2":11}}
+None	{"sss1":3,"sss2":{"ssss1":30,"ssss2":33}}
+None	{"sss1":4,"sss2":{"ssss1":40,"ssss2":44}}
+None	{"sss1":5,"sss2":{"ssss1":50,"ssss2":55}}
+None	{"sss1":5,"sss2":{"ssss1":50,"ssss2":56}}
+None	{"sss1":5,"sss2":{"ssss1":50,"ssss2":57}}
+None	{"sss1":5,"sss2":{"ssss1":50,"ssss2":58}}
+-- !result
+select x.st2.ss3 from (select * from sc2 union all select * from sc2) x;
+-- result:
+{"sss1":2,"sss2":{"ssss1":20,"ssss2":22}}
+{"sss1":1,"sss2":{"ssss1":10,"ssss2":11}}
+{"sss1":3,"sss2":{"ssss1":30,"ssss2":33}}
+{"sss1":5,"sss2":{"ssss1":50,"ssss2":55}}
+{"sss1":4,"sss2":{"ssss1":40,"ssss2":44}}
+{"sss1":5,"sss2":{"ssss1":50,"ssss2":56}}
+{"sss1":5,"sss2":{"ssss1":50,"ssss2":57}}
+{"sss1":5,"sss2":{"ssss1":50,"ssss2":58}}
+{"sss1":2,"sss2":{"ssss1":20,"ssss2":22}}
+{"sss1":1,"sss2":{"ssss1":10,"ssss2":11}}
+{"sss1":3,"sss2":{"ssss1":30,"ssss2":33}}
+{"sss1":4,"sss2":{"ssss1":40,"ssss2":44}}
+{"sss1":5,"sss2":{"ssss1":50,"ssss2":55}}
+{"sss1":5,"sss2":{"ssss1":50,"ssss2":56}}
+{"sss1":5,"sss2":{"ssss1":50,"ssss2":57}}
+{"sss1":5,"sss2":{"ssss1":50,"ssss2":58}}
+-- !result
+select row(1,2,3);
+-- result:
+{"col1":1,"col2":2,"col3":3}
+-- !result
+select * from t1;
+-- result:
+2	2	2
+3	3	3
+1	2	3
+4	4	4
+5	5	5
+-- !result
+select row(1,v1,'a') from t1;
+-- result:
+{"col1":1,"col2":2,"col3":"a"}
+{"col1":1,"col2":3,"col3":"a"}
+{"col1":1,"col2":1,"col3":"a"}
+{"col1":1,"col2":4,"col3":"a"}
+{"col1":1,"col2":5,"col3":"a"}
+-- !result
+select name_struct('a',v1,'b', v2) from t1;
+-- result:
+{"a":2,"b":2}
+{"a":3,"b":3}
+{"a":1,"b":2}
+{"a":4,"b":4}
+{"a":5,"b":5}
+-- !result
+select struct(v1,v2,v3) from t1;
+-- result:
+{"col1":2,"col2":2,"col3":2}
+{"col1":3,"col2":3,"col3":3}
+{"col1":1,"col2":2,"col3":3}
+{"col1":4,"col2":4,"col3":4}
+{"col1":5,"col2":5,"col3":5}
+-- !result
+select row(map1) from sc2;
+-- result:
+{"col1":{2:{20:{200:202}}}}
+{"col1":{1:{10:{100:101}}}}
+{"col1":{3:{30:{300:303}}}}
+{"col1":{4:{40:{400:404}}}}
+{"col1":{5:{50:{500:505}}}}
+{"col1":{5:{50:{500:506}}}}
+{"col1":{5:{50:{500:507}}}}
+{"col1":{5:{50:{500:508}}}}
+-- !result
+select row(map1), row(map1).col1 from sc2;
+-- result:
+{"col1":{2:{20:{200:202}}}}	{2:{20:{200:202}}}
+{"col1":{1:{10:{100:101}}}}	{1:{10:{100:101}}}
+{"col1":{3:{30:{300:303}}}}	{3:{30:{300:303}}}
+{"col1":{4:{40:{400:404}}}}	{4:{40:{400:404}}}
+{"col1":{5:{50:{500:505}}}}	{5:{50:{500:505}}}
+{"col1":{5:{50:{500:506}}}}	{5:{50:{500:506}}}
+{"col1":{5:{50:{500:507}}}}	{5:{50:{500:507}}}
+{"col1":{5:{50:{500:508}}}}	{5:{50:{500:508}}}
+-- !result
+select name_struct('a', st1, 'b', st2) from sc2;
+-- result:
+{"a":{"s1":2,"sm2":{20:202},"sm3":{20:{200:202}}},"b":{"s1":2,"sa2":[2,20,202],"ss3":{"sss1":2,"sss2":{"ssss1":20,"ssss2":22}}}}
+{"a":{"s1":1,"sm2":{10:101},"sm3":{10:{100:101}}},"b":{"s1":1,"sa2":[1,10,101],"ss3":{"sss1":1,"sss2":{"ssss1":10,"ssss2":11}}}}
+{"a":{"s1":5,"sm2":{50:505},"sm3":{50:{500:505}}},"b":{"s1":5,"sa2":[5,50,505],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":55}}}}
+{"a":{"s1":3,"sm2":{30:303},"sm3":{30:{300:303}}},"b":{"s1":3,"sa2":[3,30,303],"ss3":{"sss1":3,"sss2":{"ssss1":30,"ssss2":33}}}}
+{"a":{"s1":4,"sm2":{40:404},"sm3":{40:{400:404}}},"b":{"s1":4,"sa2":[4,40,404],"ss3":{"sss1":4,"sss2":{"ssss1":40,"ssss2":44}}}}
+{"a":{"s1":5,"sm2":{50:506},"sm3":{50:{500:506}}},"b":{"s1":5,"sa2":[5,50,506],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":56}}}}
+{"a":{"s1":5,"sm2":{50:507},"sm3":{50:{500:507}}},"b":{"s1":5,"sa2":[5,50,507],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":57}}}}
+{"a":{"s1":5,"sm2":{50:508},"sm3":{50:{500:508}}},"b":{"s1":5,"sa2":[5,50,508],"ss3":{"sss1":5,"sss2":{"ssss1":50,"ssss2":58}}}}
+-- !result
+select name_struct('a', st1, 'b', st2)[1] from sc2;
+-- result:
+{"s1":2,"sm2":{20:202},"sm3":{20:{200:202}}}
+{"s1":1,"sm2":{10:101},"sm3":{10:{100:101}}}
+{"s1":3,"sm2":{30:303},"sm3":{30:{300:303}}}
+{"s1":5,"sm2":{50:505},"sm3":{50:{500:505}}}
+{"s1":4,"sm2":{40:404},"sm3":{40:{400:404}}}
+{"s1":5,"sm2":{50:506},"sm3":{50:{500:506}}}
+{"s1":5,"sm2":{50:507},"sm3":{50:{500:507}}}
+{"s1":5,"sm2":{50:508},"sm3":{50:{500:508}}}
+-- !result
+select name_struct('a', st1, 'b', st2)[1].sm2 from sc2;
+-- result:
+{20:202}
+{30:303}
+{10:101}
+{50:505}
+{50:506}
+{40:404}
+{50:507}
+{50:508}
+-- !result
+select cast(row(1,2,3) as STRUCT<a double, b string, c BIGINT>);
+-- result:
+{"a":1,"b":"2","c":3}
+-- !result
+select cast(name_struct('1', 1, '2', 2, '3', 3) as STRUCT<a double, b string, c BIGINT>);
+-- result:
+{"a":1,"b":"2","c":3}
+-- !result

--- a/test/sql/test_semi/T/test_struct
+++ b/test/sql/test_semi/T/test_struct
@@ -64,13 +64,13 @@ select x.st2.ss3 from (select * from sc2 union all select * from sc2) x;
 select row(1,2,3);
 select * from t1;
 select row(1,v1,'a') from t1;
-select name_struct('a',v1,'b', v2) from t1;
+select named_struct('a',v1,'b', v2) from t1;
 select struct(v1,v2,v3) from t1;
 select row(map1) from sc2;
 select row(map1), row(map1).col1 from sc2;
-select name_struct('a', st1, 'b', st2) from sc2;
-select name_struct('a', st1, 'b', st2)[1] from sc2;
-select name_struct('a', st1, 'b', st2)[1].sm2 from sc2;
+select named_struct('a', st1, 'b', st2) from sc2;
+select named_struct('a', st1, 'b', st2)[1] from sc2;
+select named_struct('a', st1, 'b', st2)[1].sm2 from sc2;
 
 select cast(row(1,2,3) as STRUCT<a double, b string, c BIGINT>);
-select cast(name_struct('1', 1, '2', 2, '3', 3) as STRUCT<a double, b string, c BIGINT>);
+select cast(named_struct('1', 1, '2', 2, '3', 3) as STRUCT<a double, b string, c BIGINT>);

--- a/test/sql/test_semi/T/test_struct
+++ b/test/sql/test_semi/T/test_struct
@@ -1,0 +1,76 @@
+-- name: test_prune_column @system
+
+CREATE TABLE `sc2` (
+  `v1` bigint(20) NULL COMMENT "",
+  `map1` MAP<int(11),MAP<int(11),MAP<int(11),int(11)>>> NULL COMMENT "",
+  `st1` STRUCT<s1 int(11), sm2 MAP<int(11),int(11)>, sm3 MAP<int(11),MAP<int(11),int(11)>>> NULL COMMENT "",
+  `st2` STRUCT<s1 int(11), sa2 ARRAY<int(11)>, ss3 STRUCT<sss1 int(11), sss2 STRUCT<ssss1 int(11), ssss2 int(11)>>> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `t1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+
+insert into t1 values (1, 2, 3);
+insert into t1 values (2, 2, 2);
+insert into t1 values (3, 3, 3);
+insert into t1 values (4, 4, 4);
+insert into t1 values (5, 5, 5);
+
+insert into sc2 values (1, {1: {10:{100: 101}}}, row(1, {10: 101}, {10: {100: 101}}), row(1, [1,10,101], row(1, row(10, 11))));
+insert into sc2 values (2, {2: {20:{200: 202}}}, row(2, {20: 202}, {20: {200: 202}}), row(2, [2,20,202], row(2, row(20, 22))));
+insert into sc2 values (3, {3: {30:{300: 303}}}, row(3, {30: 303}, {30: {300: 303}}), row(3, [3,30,303], row(3, row(30, 33))));
+insert into sc2 values (4, {4: {40:{400: 404}}}, row(4, {40: 404}, {40: {400: 404}}), row(4, [4,40,404], row(4, row(40, 44))));
+insert into sc2 values (5, {5: {50:{500: 505}}}, row(5, {50: 505}, {50: {500: 505}}), row(5, [5,50,505], row(5, row(50, 55))));
+insert into sc2 values (5, {5: {50:{500: 506}}}, row(5, {50: 506}, {50: {500: 506}}), row(5, [5,50,506], row(5, row(50, 56))));
+insert into sc2 values (5, {5: {50:{500: 507}}}, row(5, {50: 507}, {50: {500: 507}}), row(5, [5,50,507], row(5, row(50, 57))));
+insert into sc2 values (5, {5: {50:{500: 508}}}, row(5, {50: 508}, {50: {500: 508}}), row(5, [5,50,508], row(5, row(50, 58))));
+
+
+select st1.s1, st2.sa2 from sc2;
+select st1.sm2[10], map_size(map1[3][30]), st2.sa2[1]  from sc2;
+select st2.ss3.sss1, st2.ss3.sss2.ssss2, st2.ss3 from sc2;
+
+select * from t1 join sc2 on t1.v2 = sc2.v1;
+select st1.sm2, map_keys(map1) from t1 join[broadcast] sc2 on t1.v2 = sc2.v1;
+select st1.sm2, map_keys(map1) from t1 join[shuffle] sc2 on t1.v2 = sc2.v1;
+select * from sc2 union all select * from sc2;
+select x1.st1.sm2, x1.st2.ss3 from sc2 x1 union all select x2.st1.sm3[10], x2.st2.ss3 from sc2 x2;
+select x.st2.ss3 from (select * from sc2 union all select * from sc2) x;
+
+select row(1,2,3);
+select * from t1;
+select row(1,v1,'a') from t1;
+select name_struct('a',v1,'b', v2) from t1;
+select struct(v1,v2,v3) from t1;
+select row(map1) from sc2;
+select row(map1), row(map1).col1 from sc2;
+select name_struct('a', st1, 'b', st2) from sc2;
+select name_struct('a', st1, 'b', st2)[1] from sc2;
+select name_struct('a', st1, 'b', st2)[1].sm2 from sc2;
+
+select cast(row(1,2,3) as STRUCT<a double, b string, c BIGINT>);
+select cast(name_struct('1', 1, '2', 2, '3', 3) as STRUCT<a double, b string, c BIGINT>);


### PR DESCRIPTION
Fixes #issue

* check and update struct cast function
* support index expression for struct
* add struct test

```

MySQL tpcds_1g> select row(1, 2, 3, 4)[1]
+--------------------+
| row(1, 2, 3, 4)[1] |
+--------------------+
|         1          |
+--------------------+

MySQL tpcds_1g> select cast(row(1, 2) as STRUCT<a string, b string>);
+-----------------------------------------------------------------+
| CAST((row(1, 2)) AS struct<a varchar(65533), b varchar(65533)>) |
+-----------------------------------------------------------------+
| {"a":"1","b":"2"}                                               |
+-----------------------------------------------------------------+
1 row in set
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
