### PR TITLE
[Enhancement] [Refactor] Introduce PENDING_CANCELLED

### DIFF
--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -139,10 +139,6 @@ public:
     void set_is_stream_test(bool is_stream_test) { _is_stream_test = is_stream_test; }
     bool is_stream_test() const { return _is_stream_test; }
 
-    size_t expired_log_count() { return _expired_log_count; }
-
-    void set_expired_log_count(size_t val) { _expired_log_count = val; }
-
 private:
     // Id of this query
     TUniqueId _query_id;
@@ -188,8 +184,6 @@ private:
 
     bool _enable_adaptive_dop = false;
     AdaptiveDopParam _adaptive_dop_param;
-
-    size_t _expired_log_count = 0;
 };
 
 class FragmentContextManager {

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -215,7 +215,7 @@ bool PipelineDriver::is_expirable() const {
 bool PipelineDriver::is_cancelable() const {
     // Return false,
     // - when the driver is at finished state,
-    // - or has already been cancelled and at pending state.
+    // - or has already been cancelled and still at pending state.
     return !is_finished() && _state != DriverState::PENDING_CANCELLED && _state != DriverState::EPOCH_PENDING_CANCELLED;
 };
 

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -407,7 +407,7 @@ public:
     /// Handle the event where the fragment instance is cancelled.
     /// Transition to CANCELLED or PENDING_CANCELLED.
     DriverState on_cancelling(DriverState final_state = DriverState::CANCELED);
-    /// Handle the event where the sink operator.
+    /// Handle the event where the sink operator is finished.
     /// Transition to FINISH or PENDING_FINISH.
     DriverState on_finishing();
     /// Handle the event where the pending state is finished.

--- a/be/src/exec/pipeline/pipeline_driver_poller.h
+++ b/be/src/exec/pipeline/pipeline_driver_poller.h
@@ -65,6 +65,8 @@ public:
 
 private:
     void run_internal();
+    void maybe_change_driver_state(DriverRawPtr driver);
+
     PipelineDriverPoller(const PipelineDriverPoller&) = delete;
     PipelineDriverPoller& operator=(const PipelineDriverPoller&) = delete;
 

--- a/be/src/exec/pipeline/stream_pipeline_driver.cpp
+++ b/be/src/exec/pipeline/stream_pipeline_driver.cpp
@@ -276,9 +276,7 @@ StatusOr<DriverState> StreamPipelineDriver::_handle_finish_operators(RuntimeStat
     }
     _first_unfinished = new_first_unfinished;
     if (sink_operator()->is_finished()) {
-        finish_operators(runtime_state);
-        set_driver_state(is_still_pending_finish() ? DriverState::PENDING_FINISH : DriverState::FINISH);
-        return _state;
+        return on_finishing();
     }
     return _state;
 }

--- a/be/src/exec/pipeline/stream_pipeline_driver.h
+++ b/be/src/exec/pipeline/stream_pipeline_driver.h
@@ -36,7 +36,7 @@ public:
 
     StatusOr<DriverState> process(RuntimeState* runtime_state, int worker_id) override;
 
-    bool is_query_never_expired() override { return true; }
+    bool is_query_never_expired() const override { return true; }
 
     void epoch_finalize(RuntimeState* runtime_state, DriverState state);
     Status reset_epoch(RuntimeState* state);


### PR DESCRIPTION
When a pipeline driver has already been cancelled but still at `PENDING_FINISH` state, it will be cancelled again and again in the poller util not `PENDING_FINISH` anymore, which will output lots of WARNING log `[Driver] Timeout, query_id=xxxx`.
```C++
if (driver->fragment_ctx()->is_canceled()) {
     // cancel this driver.
}
```

However, each `Driver::set_cancelled` is guaranteed that invoked once, so cancelled many times is meaningless.

Therefore, introduce `PENDING_CANCELLED` state to indicate that the driver is at `PENDING` state and has already been cancelled.

BTW, refactor to make driver handle some common events and simplify the logic of poller.
```
/// A pipeline driver switch states according to the following graph:
/// NOT_READY
///   │
///   │
///   ▼
/// READY ────────────► RUNNING ───────────────────────────────────┬──────────────────────────────────┐
///   ▲                   │                                        │                                  │
///   │                   │                                        ▼                                  │
///   │                   │            ┌───────────────────────────────────────────────────────┐      │
///   └── on_ready ───────┼────────────┤PRECONDITION_BLOCK      INPUT_EMPTY        OUTPUT_FULL │      │
///                       │            └───────────────────────────┬───────────────────────────┘      ▼
///                       ▼                                        │                                  │
///                       │                                        │                                  │
///                       ├────────────────────◄───────────────────┴───────────►──────────────────────┤
///                       │                                    ┌──────────►───────────────────────────│
///                 on_finishing[is_still_pending_finish]      │    on_cancelling[is_still_pending_finish]
///                       │                                    │                                      │
///                       ├───────────────────► PENDING_FINISH ┘     PENDING_CANCELLED ◄──────────────┤
///                       │                          │                       │                        │
///                 on_finishing                     │  on_pending_finished  │                 on_cancelling
///                       │                          ▼                       ▼                        │
///                       └───────────────────────►FINISH                CANCELLED ◄──────────────────┘
```




## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
