### PR TITLE
[Refactor] Add Build category for the PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@ Fixes #issue
 - [ ] UT
 - [ ] Doc
 - [ ] Tool
+- [ ] Build
 
 ## Checklist:
 - [ ] I have added test cases for my bug fix or my new feature

--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,13 +4,13 @@
     "color": "EEEEEE"
   },
   "CHECKS": {
-    "prefixes": ["[BugFix]", "[Enhancement]", "[Feature]", "[Refactor]", "[UT]", "[Doc]", "[Tool]"],
+    "prefixes": ["[BugFix]", "[Enhancement]", "[Feature]", "[Refactor]", "[UT]", "[Doc]", "[Tool]", "[Build]"],
     "regexpFlags": "i",
     "ignoreLabels" : ["ignore-pr-title-check", "pass"]
   },
   "MESSAGES": {
     "success": "All OK",
-    "failure": "Missing type in the title of the pull request. [BugFix], [Enhancement], [Feature], [Refactor], [UT], [Doc], [Tool]. \nExample: [BugFix] Fix some implicit conversion.",
+    "failure": "Missing type in the title of the pull request. [BugFix], [Enhancement], [Feature], [Refactor], [UT], [Doc], [Tool], [Build]. \nExample: [BugFix] Fix some implicit conversion.",
     "notice": ""
   }
 }


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
