### PR TITLE
[Feature] support function get_query_profile

### DIFF
--- a/be/src/exprs/utility_functions.h
+++ b/be/src/exprs/utility_functions.h
@@ -59,6 +59,8 @@ public:
      * return the host name
      */
     DEFINE_VECTORIZED_FN(host_name);
+
+    DEFINE_VECTORIZED_FN(get_query_profile);
 };
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -83,6 +83,7 @@ import com.starrocks.common.ThriftServerContext;
 import com.starrocks.common.ThriftServerEventProcessor;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.ProfileManager;
 import com.starrocks.http.BaseAction;
 import com.starrocks.http.UnauthorizedException;
 import com.starrocks.http.rest.TransactionResult;
@@ -164,6 +165,8 @@ import com.starrocks.thrift.TGetGrantsToRolesOrUserRequest;
 import com.starrocks.thrift.TGetGrantsToRolesOrUserResponse;
 import com.starrocks.thrift.TGetLoadsParams;
 import com.starrocks.thrift.TGetLoadsResult;
+import com.starrocks.thrift.TGetProfileRequest;
+import com.starrocks.thrift.TGetProfileResponse;
 import com.starrocks.thrift.TGetRoleEdgesRequest;
 import com.starrocks.thrift.TGetRoleEdgesResponse;
 import com.starrocks.thrift.TGetTableMetaRequest;
@@ -723,6 +726,24 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 }).collect(Collectors.toList()));
             }
             tTablePrivs.addAll(tPrivs);
+        }
+        return result;
+    }
+
+    @Override
+    public TGetProfileResponse getQueryProfile(TGetProfileRequest params) throws TException {
+        LOG.debug("get query profile request: {}", params);
+        List<String> queryIds = params.query_id;
+        TGetProfileResponse result = new TGetProfileResponse();
+        if (queryIds != null) {
+            for (String queryId : queryIds) {
+                String profile = ProfileManager.getInstance().getProfile(queryId);
+                if (profile != null && !profile.isEmpty()) {
+                    result.addToQuery_result(profile);
+                } else {
+                    result.addToQuery_result("");
+                }
+            }
         }
         return result;
     }

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -606,6 +606,7 @@ vectorized_functions = [
     [100017, 'assert_true', 'BOOLEAN', ['BOOLEAN'], 'UtilityFunctions::assert_true'],
     [100019, 'assert_true', 'BOOLEAN', ['BOOLEAN', "VARCHAR"], 'UtilityFunctions::assert_true'],
     [100018, 'host_name', 'VARCHAR', [], "UtilityFunctions::host_name"],
+    [100020, 'get_query_profile', 'VARCHAR', ['VARCHAR'], "UtilityFunctions::get_query_profile"],
 
     # json string function
     [110000, "get_json_int", "INT", ["VARCHAR", "VARCHAR"], "JsonFunctions::get_json_int",

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1274,6 +1274,15 @@ struct TGetGrantsToRolesOrUserResponse {
     1: optional list<TGetGrantsToRolesOrUserItem> grants_to
 }
 
+struct TGetProfileRequest {
+    1: optional list<string> query_id
+}
+
+struct TGetProfileResponse {
+    1: optional Status.TStatus status
+    2: optional list<string> query_result
+}
+
 service FrontendService {
     TGetDbsResult getDbNames(1:TGetDbsParams params)
     TGetTablesResult getTableNames(1:TGetTablesParams params)
@@ -1287,6 +1296,7 @@ service FrontendService {
     TGetTablePrivsResult getTablePrivs(1:TGetTablePrivsParams params)
 
     TGetLoadsResult getLoads(1:TGetLoadsParams params)
+    TGetProfileResponse getQueryProfile(1:TGetProfileRequest request)
 
     TDescribeTableResult describeTable(1:TDescribeTableParams params)
     TShowVariableResult showVariables(1:TShowVariableRequest params)


### PR DESCRIPTION
support function get_query_profile

eg:
```
admin set frontend config ("profile_info_format" = "json");
set enable_profile=true;
select 1;
set @last_id = last_query_id();
select get_query_profile(@last_id);
select get_json_string(get_query_profile(@last_id), '$.Query.Execution Profile 388868f9-fedb-11ed-be1d-162d24e49988.Fragment 0.Pipeline (id=0)');
```

case2:
```
insert into profiles select get_query_profile(last_query_id());
```

case3:
```
select 1;
select last_query_id();
```
```
echo "select get_query_profile()"| mysql -hXXX -PXXX > profile.txt
```


## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
