### PR TITLE
[BugFix] Use case-insensitive comparison of storage type when allocating file path

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2020,7 +2020,7 @@ public class Config extends ConfigBase {
     public static int cloud_native_meta_port = 6090;
     // remote storage related configuration
     /**
-     * storage type for cloud native table. Available options: "S3", "HDFS", case-sensitive
+     * storage type for cloud native table. Available options: "S3", "HDFS", "AZBLOB". case-insensitive
      */
     @ConfField
     public static String cloud_native_storage_type = "S3";

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -19,7 +19,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.protobuf.Descriptors.EnumDescriptor;
 import com.staros.client.StarClient;
 import com.staros.client.StarClientException;
 import com.staros.manager.StarManagerServer;
@@ -157,11 +156,24 @@ public class StarOSAgent {
         }
     }
 
+    private FileStoreType getFileStoreType(String storageType) {
+        if (storageType == null) {
+            return null;
+        }
+        for (FileStoreType type : FileStoreType.values()) {
+            if (type.name().equalsIgnoreCase(storageType)) {
+                return type;
+            }
+        }
+        return null;
+    }
+
     public FilePathInfo allocateFilePath(long tableId) throws DdlException {
         try {
-            EnumDescriptor enumDescriptor = FileStoreType.getDescriptor();
-            FileStoreType fsType = FileStoreType.valueOf(
-                    enumDescriptor.findValueByName(Config.cloud_native_storage_type).getNumber());
+            FileStoreType fsType = getFileStoreType(Config.cloud_native_storage_type);
+            if (fsType == null || fsType == FileStoreType.INVALID) {
+                throw new DdlException("Invalid cloud native storage type: " + Config.cloud_native_storage_type);
+            }
             FilePathInfo pathInfo = client.allocateFilePath(serviceId, fsType, Long.toString(tableId));
             LOG.debug("Allocate file path from starmgr: {}", pathInfo);
             return pathInfo;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -35,6 +35,7 @@ import com.staros.proto.StatusCode;
 import com.staros.proto.WorkerGroupDetailInfo;
 import com.staros.proto.WorkerInfo;
 import com.staros.proto.WorkerState;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.UserException;
@@ -71,6 +72,7 @@ public class StarOSAgentTest {
     public void setUp() throws Exception {
         starosAgent = new StarOSAgent();
         starosAgent.init(null);
+        Config.cloud_native_storage_type = "S3";
     }
 
     @Test
@@ -144,16 +146,23 @@ public class StarOSAgentTest {
     }
 
     @Test
-    public void testAllocateFilePath() throws StarClientException, DdlException {
+    public void testAllocateFilePath() throws StarClientException {
+        long tableId = 123;
+
         new Expectations() {
             {
-                FilePathInfo pathInfo = client.allocateFilePath("1", FileStoreType.S3, "123");
-                result = pathInfo;
+                client.allocateFilePath("1", FileStoreType.S3, Long.toString(tableId));
+                result = FilePathInfo.newBuilder().build();
                 minTimes = 0;
             }
         };
 
-        Deencapsulation.setField(starosAgent, "serviceId", "1");
+        Config.cloud_native_storage_type = "s3";
+        ExceptionChecker.expectThrowsNoException(() -> starosAgent.allocateFilePath(tableId));
+
+        Config.cloud_native_storage_type = "ss";
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Invalid cloud native storage type: ss",
+                () -> starosAgent.allocateFilePath(tableId));
     }
 
     @Test
@@ -342,7 +351,6 @@ public class StarOSAgentTest {
         // test delete shard group
         ExceptionChecker.expectThrowsNoException(() -> starosAgent.deleteShardGroup(Lists.newArrayList(1L, 2L)));
     }
-
 
     @Test
     public void testGetBackendByShard() throws StarClientException, UserException {


### PR DESCRIPTION

current implement will throw NPE when creating table if use lower case cloud_native_storage_type config

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
