### PR TITLE
[Feature] Support showing database and table names for load job

### DIFF
--- a/be/src/exec/schema_scanner/schema_loads_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_loads_scanner.cpp
@@ -105,7 +105,7 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
                 break;
             }
             case 4: {
-                // state
+                // tables
                 Slice tables = Slice(info.tables);
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&tables);
                 break;

--- a/be/src/exec/schema_scanner/schema_loads_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_loads_scanner.cpp
@@ -26,6 +26,7 @@ SchemaScanner::ColumnDesc SchemaLoadsScanner::_s_tbls_columns[] = {
         {"JOB_ID", TYPE_BIGINT, sizeof(int64_t), false},
         {"LABEL", TYPE_VARCHAR, sizeof(StringValue), false},
         {"DATABASE_NAME", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"TABLE_NAMES", TYPE_VARCHAR, sizeof(StringValue), false},
         {"STATE", TYPE_VARCHAR, sizeof(StringValue), false},
         {"PROGRESS", TYPE_VARCHAR, sizeof(StringValue), false},
         {"TYPE", TYPE_VARCHAR, sizeof(StringValue), false},
@@ -81,8 +82,8 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
     for (; _cur_idx < _result.loads.size(); _cur_idx++) {
         auto& info = _result.loads[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
-            if (slot_id < 1 || slot_id > 23) {
-                return Status::InternalError(fmt::format("invalid slot id:$0", slot_id));
+            if (slot_id < 1 || slot_id > 24) {
+                return Status::InternalError(fmt::format("invalid slot id:{}", slot_id));
             }
             ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
             switch (slot_id) {
@@ -105,49 +106,55 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             case 4: {
                 // state
+                Slice tables = Slice(info.tables);
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&tables);
+                break;
+            }
+            case 5: {
+                // state
                 Slice state = Slice(info.state);
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&state);
                 break;
             }
-            case 5: {
+            case 6: {
                 // progress
                 Slice progress = Slice(info.progress);
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&progress);
                 break;
             }
-            case 6: {
+            case 7: {
                 // type
                 Slice type = Slice(info.type);
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&type);
                 break;
             }
-            case 7: {
+            case 8: {
                 // priority
                 Slice priority = Slice(info.priority);
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&priority);
                 break;
             }
-            case 8: {
+            case 9: {
                 // scan_rows
                 fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_scan_rows);
                 break;
             }
-            case 9: {
+            case 10: {
                 // filtered_rows
                 fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_filtered_rows);
                 break;
             }
-            case 10: {
+            case 11: {
                 // unselected_rows
                 fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_unselected_rows);
                 break;
             }
-            case 11: {
+            case 12: {
                 // sink_rows
                 fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.num_sink_rows);
                 break;
             }
-            case 12: {
+            case 13: {
                 // etl_info
                 if (info.__isset.etl_info) {
                     Slice etl_info = Slice(info.etl_info);
@@ -157,13 +164,13 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
                 }
                 break;
             }
-            case 13: {
+            case 14: {
                 // task info
                 Slice task_info = Slice(info.task_info);
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&task_info);
                 break;
             }
-            case 14: {
+            case 15: {
                 // create time
                 DateTimeValue t;
                 if (info.__isset.create_time) {
@@ -175,7 +182,7 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
                 down_cast<NullableColumn*>(column.get())->append_nulls(1);
                 break;
             }
-            case 15: {
+            case 16: {
                 // etl start time
                 DateTimeValue t;
                 if (info.__isset.etl_start_time) {
@@ -187,7 +194,7 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
                 down_cast<NullableColumn*>(column.get())->append_nulls(1);
                 break;
             }
-            case 16: {
+            case 17: {
                 // etl finish time
                 DateTimeValue t;
                 if (info.__isset.etl_finish_time) {
@@ -199,7 +206,7 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
                 down_cast<NullableColumn*>(column.get())->append_nulls(1);
                 break;
             }
-            case 17: {
+            case 18: {
                 // load start time
                 DateTimeValue t;
                 if (info.__isset.load_start_time) {
@@ -211,7 +218,7 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
                 down_cast<NullableColumn*>(column.get())->append_nulls(1);
                 break;
             }
-            case 18: {
+            case 19: {
                 // load finish time
                 DateTimeValue t;
                 if (info.__isset.load_finish_time) {
@@ -223,13 +230,13 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
                 down_cast<NullableColumn*>(column.get())->append_nulls(1);
                 break;
             }
-            case 19: {
+            case 20: {
                 // job details
                 Slice job_details = Slice(info.job_details);
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&job_details);
                 break;
             }
-            case 20: {
+            case 21: {
                 // error_msg
                 if (info.__isset.error_msg) {
                     Slice error_msg = Slice(info.error_msg);
@@ -239,7 +246,7 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
                 }
                 break;
             }
-            case 21: {
+            case 22: {
                 // url
                 if (info.__isset.url) {
                     Slice url = Slice(info.url);
@@ -249,7 +256,7 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
                 }
                 break;
             }
-            case 22: {
+            case 23: {
                 // tracking sql
                 if (info.__isset.tracking_sql) {
                     Slice sql = Slice(info.tracking_sql);
@@ -259,7 +266,7 @@ Status SchemaLoadsScanner::fill_chunk(ChunkPtr* chunk) {
                 }
                 break;
             }
-            case 23: {
+            case 24: {
                 // rejected record path
                 if (info.__isset.rejected_record_path) {
                     Slice path = Slice(info.rejected_record_path);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
@@ -32,6 +32,7 @@ public class LoadsSystemTable {
                         .column("JOB_ID", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("LABEL", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("DATABASE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_NAMES", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("PROGRESS", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LoadProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LoadProcDir.java
@@ -48,7 +48,7 @@ import java.util.List;
 
 public class LoadProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("JobId").add("Label").add("State").add("Progress")
+            .add("JobId").add("Label").add("DatabaseName").add("TableNames").add("State").add("Progress")
             .add("Type").add("Priority").add("ScanRows").add("FilteredRows").add("UnselectedRows")
             .add("SinkRows").add("EtlInfo").add("TaskInfo").add("ErrorMsg").add("CreateTime")
             .add("EtlStartTime").add("EtlFinishTime").add("LoadStartTime").add("LoadFinishTime")

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -719,6 +719,19 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             jobInfo.add(id);
             // label
             jobInfo.add(label);
+            // database_name
+            try {
+                jobInfo.add(getDb().getFullName());
+            } catch (MetaNotFoundException e) {
+                jobInfo.add("");
+            }
+            // table_names
+            Set<String> tableNames = getTableNamesForShow();
+            if (tableNames != null) {
+                jobInfo.add(Joiner.on(',').join(tableNames));
+            } else {
+                jobInfo.add("");
+            }
             // state
             if (state == JobState.COMMITTED) {
                 jobInfo.add("PREPARED");
@@ -806,6 +819,11 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 info.setDb("");
             }
             info.setTxn_id(transactionId);
+
+            Set<String> tableNames = getTableNamesForShow();
+            if (tableNames != null) {
+                info.setTables(Joiner.on(',').join(tableNames));
+            }
 
             if (state == JobState.COMMITTED) {
                 info.setState("PREPARED");

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowLoadStmtTest.java
@@ -60,27 +60,29 @@ public class ShowLoadStmtTest {
         ShowLoadStmt stmt = (ShowLoadStmt) analyzeSuccess("SHOW LOAD FROM test");
         ShowResultSetMetaData metaData = stmt.getMetaData();
         Assert.assertNotNull(metaData);
-        Assert.assertEquals(20, metaData.getColumnCount());
+        Assert.assertEquals(22, metaData.getColumnCount());
         Assert.assertEquals("JobId", metaData.getColumn(0).getName());
         Assert.assertEquals("Label", metaData.getColumn(1).getName());
-        Assert.assertEquals("State", metaData.getColumn(2).getName());
-        Assert.assertEquals("Progress", metaData.getColumn(3).getName());
-        Assert.assertEquals("Type", metaData.getColumn(4).getName());
-        Assert.assertEquals("Priority", metaData.getColumn(5).getName());
-        Assert.assertEquals("ScanRows", metaData.getColumn(6).getName());
-        Assert.assertEquals("FilteredRows", metaData.getColumn(7).getName());
-        Assert.assertEquals("UnselectedRows", metaData.getColumn(8).getName());
-        Assert.assertEquals("SinkRows", metaData.getColumn(9).getName());
-        Assert.assertEquals("EtlInfo", metaData.getColumn(10).getName());
-        Assert.assertEquals("TaskInfo", metaData.getColumn(11).getName());
-        Assert.assertEquals("ErrorMsg", metaData.getColumn(12).getName());
-        Assert.assertEquals("CreateTime", metaData.getColumn(13).getName());
-        Assert.assertEquals("EtlStartTime", metaData.getColumn(14).getName());
-        Assert.assertEquals("EtlFinishTime", metaData.getColumn(15).getName());
-        Assert.assertEquals("LoadStartTime", metaData.getColumn(16).getName());
-        Assert.assertEquals("LoadFinishTime", metaData.getColumn(17).getName());
-        Assert.assertEquals("TrackingSQL", metaData.getColumn(18).getName());
-        Assert.assertEquals("JobDetails", metaData.getColumn(19).getName());
+        Assert.assertEquals("DatabaseName", metaData.getColumn(2).getName());
+        Assert.assertEquals("TableNames", metaData.getColumn(3).getName());
+        Assert.assertEquals("State", metaData.getColumn(4).getName());
+        Assert.assertEquals("Progress", metaData.getColumn(5).getName());
+        Assert.assertEquals("Type", metaData.getColumn(6).getName());
+        Assert.assertEquals("Priority", metaData.getColumn(7).getName());
+        Assert.assertEquals("ScanRows", metaData.getColumn(8).getName());
+        Assert.assertEquals("FilteredRows", metaData.getColumn(9).getName());
+        Assert.assertEquals("UnselectedRows", metaData.getColumn(10).getName());
+        Assert.assertEquals("SinkRows", metaData.getColumn(11).getName());
+        Assert.assertEquals("EtlInfo", metaData.getColumn(12).getName());
+        Assert.assertEquals("TaskInfo", metaData.getColumn(13).getName());
+        Assert.assertEquals("ErrorMsg", metaData.getColumn(14).getName());
+        Assert.assertEquals("CreateTime", metaData.getColumn(15).getName());
+        Assert.assertEquals("EtlStartTime", metaData.getColumn(16).getName());
+        Assert.assertEquals("EtlFinishTime", metaData.getColumn(17).getName());
+        Assert.assertEquals("LoadStartTime", metaData.getColumn(18).getName());
+        Assert.assertEquals("LoadFinishTime", metaData.getColumn(19).getName());
+        Assert.assertEquals("TrackingSQL", metaData.getColumn(20).getName());
+        Assert.assertEquals("JobDetails", metaData.getColumn(21).getName());
     }
 
     @Test

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -459,13 +459,14 @@ struct TLoadInfo {
     15: optional string job_details
     16: optional string error_msg
     17: optional string db
-    18: optional i64 txn_id
-    19: optional string tracking_sql
-    20: optional i64 num_scan_rows
-    21: optional i64 num_filtered_rows
-    22: optional i64 num_unselected_rows
-    23: optional i64 num_sink_rows
-    24: optional string rejected_record_path
+    18: optional string tables
+    19: optional i64 txn_id
+    20: optional string tracking_sql
+    21: optional i64 num_scan_rows
+    22: optional i64 num_filtered_rows
+    23: optional i64 num_unselected_rows
+    24: optional i64 num_sink_rows
+    25: optional string rejected_record_path
 }
 
 // getTableNames returns a list of unqualified table names


### PR DESCRIPTION
As for now, the `show load` result didn't contain database and table names properties. This PR added `DatabaseName` and `TableNames`. Since a broker load job support ingesting to more than one tables, we use commas to separate tables in `TableNames`,  ex. `example_table_1,example_table_2`.

```sql

mysql> show load where label = 'lable_load_test'\G;
*************************** 1. row ***************************
         JobId: 31412
         Label: lable_load_test
  DatabaseName: example_db
    TableNames: example_table_1,example_table_2

    more properties...


mysql> select database_name, table_names from information_schema.loads where label = 'lable_load_test';
+---------------+---------------------------------+
| database_name | table_names                     |
+---------------+---------------------------------+
| example_db    | example_table_1,example_table_2 |
+---------------+---------------------------------+
1 row in set (0.06 sec)
```

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
