### PR TITLE
[BugFix] Fix GSON Util concurrent bug 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -593,6 +593,9 @@ public class GsonUtils {
 
             return new TypeAdapter<T>() {
                 public void write(JsonWriter out, T obj) throws IOException {
+                    // Use Object lock to protect its properties from changed by other serialize thread.
+                    // But this will only take effect when all threads uses GSONUtils to serialize object,
+                    // because other methods of changing properties do not necessarily require the acquisition of the object lock
                     if (obj instanceof GsonPreProcessable) {
                         synchronized (obj) {
                             ((GsonPreProcessable) obj).gsonPreProcess();

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -594,9 +594,13 @@ public class GsonUtils {
             return new TypeAdapter<T>() {
                 public void write(JsonWriter out, T obj) throws IOException {
                     if (obj instanceof GsonPreProcessable) {
-                        ((GsonPreProcessable) obj).gsonPreProcess();
+                        synchronized (obj) {
+                            ((GsonPreProcessable) obj).gsonPreProcess();
+                            delegate.write(out, obj);
+                        }
+                    } else {
+                        delegate.write(out, obj);
                     }
-                    delegate.write(out, obj);
                 }
 
                 public T read(JsonReader reader) throws IOException {


### PR DESCRIPTION
Fixes SR-17990

Use Object lock to protect its properties from changed by other serialize thread. But this will only take effect when all threads uses GSONUtils to serialize object, because other methods of changing properties do not necessarily require the acquisition of the object lock.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
