### PR TITLE
[BugFix] Use case-insensitive comparison of storage type when allocating file path (#24424)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1986,7 +1986,7 @@ public class Config extends ConfigBase {
     public static int cloud_native_meta_port = 6090;
     // remote storage related configuration
     /**
-     * storage type for cloud native table. Available options: "S3", "HDFS", case-sensitive
+     * storage type for cloud native table. Available options: "S3", "HDFS", "AZBLOB". case-insensitive
      */
     @ConfField
     public static String cloud_native_storage_type = "S3";


### PR DESCRIPTION
current implement will throw NPE when creating cloud native table if use lower case cloud_native_storage_type config

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
