### PR TITLE
[Enhancement] Fix the crash of destruct FlushMemTableThreadPool

### DIFF
--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -111,6 +111,7 @@ public:
     // Initial exec environment. must call this to init all
     static Status init(ExecEnv* env, const std::vector<StorePath>& store_paths);
     static bool is_init();
+    static void stop(ExecEnv* exec_env);
     static void destroy(ExecEnv* exec_env);
 
     /// Returns the first created exec env instance. In a normal starrocks, this is
@@ -241,6 +242,7 @@ public:
 
 private:
     Status _init(const std::vector<StorePath>& store_paths);
+    void _stop();
     void _destroy();
     void _reset_tracker();
     template <class... Args>

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -80,6 +80,15 @@ LoadChannelMgr::~LoadChannelMgr() {
     }
 }
 
+void LoadChannelMgr::clear() {
+    std::lock_guard l(_lock);
+    for (auto iter = _load_channels.begin(); iter != _load_channels.end();) {
+        iter->second->cancel();
+        iter->second->abort();
+        iter = _load_channels.erase(iter);
+    }
+}
+
 Status LoadChannelMgr::init(MemTracker* mem_tracker) {
     _mem_tracker = mem_tracker;
     RETURN_IF_ERROR(_start_bg_worker());

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -86,6 +86,8 @@ public:
 
     std::shared_ptr<LoadChannel> remove_load_channel(const UniqueId& load_id);
 
+    void clear();
+
 private:
     static void* load_channel_clean_bg_worker(void* arg);
 

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -59,6 +59,7 @@
 #include "runtime/exec_env.h"
 #include "runtime/heartbeat_flags.h"
 #include "runtime/jdbc_driver_manager.h"
+#include "runtime/load_channel_mgr.h"
 #include "service/backend_options.h"
 #include "service/service.h"
 #include "service/staros_worker.h"
@@ -366,6 +367,8 @@ int main(int argc, char** argv) {
     heartbeat_thrift_server->join();
 
     exec_env->agent_server()->stop();
+
+    starrocks::ExecEnv::stop(exec_env);
     engine->stop();
     delete engine;
     starrocks::ExecEnv::destroy(exec_env);


### PR DESCRIPTION
Fixes #issue

```
F0531 14:23:27.710640 129140 threadpool.cpp:256] Check failed: 1 == _tokens.size() (1 vs. 5) Threadpool memtable_flush destroyed with 5 allocated tokens
```

```
*** Aborted at 1685514207 (unix time) try "date -d @1685514207" if you are using GNU date ***
PC: @     0x7f6fa031e387 __GI_raise
*** SIGABRT (@0x3f00001f874) received by PID 129140 (TID 0x7f6fa21c9480) from PID 129140; stack trace: ***
    @         0x13c6cdd2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f6fa06c5630 (unknown)
    @     0x7f6fa031e387 __GI_raise
    @     0x7f6fa031fa78 __GI_abort
    @          0x99da211 starrocks::failure_function()
    @         0x13c607ad google::LogMessage::Fail()
    @         0x13c62c1f google::LogMessage::SendToLog()
    @         0x13c602fe google::LogMessage::Flush()
    @         0x13c63229 google::LogMessageFatal::~LogMessageFatal()
    @         0x11723acc starrocks::ThreadPool::~ThreadPool()
    @          0x979aa52 std::default_delete<>::operator()()
    @          0x9797ffb std::unique_ptr<>::~unique_ptr()
    @          0xf2fc550 starrocks::MemTableFlushExecutor::~MemTableFlushExecutor()
    @          0xf2fc576 std::default_delete<>::operator()()
    @          0xf2f64fd std::unique_ptr<>::~unique_ptr()
    @          0xf2c7ee8 starrocks::StorageEngine::~StorageEngine()
    @          0xf2c80f8 starrocks::StorageEngine::~StorageEngine()
    @          0x978f736 main
    @     0x7f6fa030a555 __libc_start_main
    @          0x96c627f (unknown)
    @                0x0 (unknown)
```

Clear load channel should be executed before stopping the storage engine, otherwise some writing tasks will still be in the MemTableFlushThreadPool of the storage engine, so when the ThreadPool is destroyed, it will crash.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
