### PR TITLE
[BugFix] Fix unnessary ref change since abort is under lock

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -251,14 +251,13 @@ void LoadChannel::abort() {
 }
 
 void LoadChannel::abort(int64_t index_id, const std::vector<int64_t>& tablet_ids) {
-    auto channel = get_tablets_channel(index_id);
-    if (channel != nullptr) {
-        auto local_tablets_channel = dynamic_cast<LocalTabletsChannel*>(channel.get());
+    std::lock_guard l(_lock);
+    auto it = _tablets_channels.find(index_id);
+    if (it != _tablets_channels.end()) {
+        auto local_tablets_channel = dynamic_cast<LocalTabletsChannel*>(it->second.get());
+        // only use for replicated storage
         if (local_tablets_channel != nullptr) {
-            local_tablets_channel->incr_num_ref_senders();
             local_tablets_channel->abort(tablet_ids);
-        } else {
-            channel->abort();
         }
     }
 }

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -573,7 +573,6 @@ void LocalTabletsChannel::abort() {
     LOG(INFO) << "cancel LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << _key.id
               << " index_id: " << _key.index_id << " #tablet:" << _delta_writers.size()
               << " tablet_ids:" << tablet_id_list_str;
-    _num_ref_senders.fetch_sub(1);
 }
 
 void LocalTabletsChannel::abort(const std::vector<int64_t>& tablet_ids) {


### PR DESCRIPTION
Fixes #issue
abort operation can under lock, no need to change reference of TabletsChannel.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
