### PR TITLE
[BugFix] fix incorrect LocalExchangePeakMemoryUsage in profile

### DIFF
--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.cpp
@@ -25,7 +25,8 @@ Status LocalExchangeSinkOperator::prepare(RuntimeState* state) {
     _exchanger->incr_sinker();
     _unique_metrics->add_info_string("ShuffleNum", std::to_string(_exchanger->source_dop()));
     _peak_memory_usage_counter = _unique_metrics->AddHighWaterMarkCounter(
-            "LocalExchangePeakMemoryUsage", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TUnit::BYTES));
+            "LocalExchangePeakMemoryUsage", TUnit::BYTES,
+            RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_FIRST_MERGE));
     return Status::OK();
 }
 


### PR DESCRIPTION
exchanger is shared among all local exchange operators in a same fragment instance, we shouldn't accumulate the result inside fragment instance, so change the merge type to SKIP_FIRST_MERGE

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
