### PR TITLE
[BugFix] fix the problem that auto spilling trigger timing is wrong

### DIFF
--- a/be/src/exec/spill/query_spill_manager.h
+++ b/be/src/exec/spill/query_spill_manager.h
@@ -35,7 +35,7 @@ public:
 
 private:
     TUniqueId _uid;
-    std::atomic_size_t _spilled_bytes;
+    std::atomic_size_t _spilled_bytes = 0;
     std::unique_ptr<BlockManager> _block_manager;
 };
 } // namespace starrocks::spill


### PR DESCRIPTION
_spilled_bytes is not initialized correctly, so fix it.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
