### PR TITLE
[Feature] Completely resolving the issue of query failures in Hive external tables due to inconsistent metadata caching

### DIFF
--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -215,6 +215,8 @@ std::string Status::code_as_string() const {
         return "Resource busy";
     case TStatusCode::SR_EAGAIN:
         return "Resource temporarily unavailable";
+    case TStatusCode::REMOTE_FILE_NOT_FOUND:
+        return "Remote file not found";
     default: {
         char tmp[30];
         snprintf(tmp, sizeof(tmp), "Unknown code(%d): ", static_cast<int>(code()));

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -149,6 +149,8 @@ public:
 
     static Status EAgain(const Slice& msg) { return Status(TStatusCode::SR_EAGAIN, msg); }
 
+    static Status RemoteFileNotFound(const Slice& msg) { return Status(TStatusCode::REMOTE_FILE_NOT_FOUND, msg); }
+
     bool ok() const { return _state == nullptr; }
 
     bool is_cancelled() const { return code() == TStatusCode::CANCELLED; }

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -461,7 +461,11 @@ StatusOr<std::unique_ptr<WritableFile>> HdfsFileSystem::new_writable_file(const 
 
     hdfsFile file = hdfsOpenFile(hdfs_client->hdfs_fs, path.c_str(), flags, hdfs_write_buffer_size, 0, 0);
     if (file == nullptr) {
-        return Status::InternalError(fmt::format("hdfsOpenFile failed, file={}", path));
+        if (errno == ENOENT) {
+            return Status::RemoteFileNotFound(fmt::format("hdfsOpenFile failed, file={}", path));
+        } else {
+            return Status::InternalError(fmt::format("hdfsOpenFile failed, file={}", path));
+        }
     }
     return std::make_unique<HDFSWritableFile>(hdfs_client->hdfs_fs, file, path, 0);
 }
@@ -483,7 +487,11 @@ StatusOr<std::unique_ptr<SequentialFile>> HdfsFileSystem::new_sequential_file(co
     }
     hdfsFile file = hdfsOpenFile(hdfs_client->hdfs_fs, path.c_str(), O_RDONLY, hdfs_read_buffer_size, 0, 0);
     if (file == nullptr) {
-        return Status::InternalError("hdfsOpenFile failed, path={}"_format(path));
+        if (errno == ENOENT) {
+            return Status::RemoteFileNotFound(fmt::format("hdfsOpenFile failed, file={}", path));
+        } else {
+            return Status::InternalError(fmt::format("hdfsOpenFile failed, file={}", path));
+        }
     }
     auto stream = std::make_shared<HdfsInputStream>(hdfs_client->hdfs_fs, file, path);
     return std::make_unique<SequentialFile>(std::move(stream), path);
@@ -505,7 +513,11 @@ StatusOr<std::unique_ptr<RandomAccessFile>> HdfsFileSystem::new_random_access_fi
     }
     hdfsFile file = hdfsOpenFile(hdfs_client->hdfs_fs, path.c_str(), O_RDONLY, hdfs_read_buffer_size, 0, 0);
     if (file == nullptr) {
-        return Status::InternalError("hdfsOpenFile failed, path={}"_format(path));
+        if (errno == ENOENT) {
+            return Status::RemoteFileNotFound(fmt::format("hdfsOpenFile failed, file={}", path));
+        } else {
+            return Status::InternalError(fmt::format("hdfsOpenFile failed, file={}", path));
+        }
     }
     auto stream = std::make_shared<HdfsInputStream>(hdfs_client->hdfs_fs, file, path);
     return std::make_unique<RandomAccessFile>(std::move(stream), path);

--- a/fe/fe-core/src/main/java/com/starrocks/common/Status.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Status.java
@@ -88,6 +88,10 @@ public class Status {
         return this.errorCode == TStatusCode.THRIFT_RPC_ERROR;
     }
 
+    public boolean isRemoteFileNotFound() {
+        return this.errorCode == TStatusCode.REMOTE_FILE_NOT_FOUND;
+    }
+
     public boolean isGlobalDictError() {
         return this.errorCode == TStatusCode.GLOBAL_DICT_ERROR;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.connector;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.catalog.HiveMetaStoreTable;
@@ -46,6 +45,22 @@ public class RemoteScanRangeLocations {
     private static final Logger LOG = LogManager.getLogger(RemoteScanRangeLocations.class);
 
     private final List<TScanRangeLocations> result = new ArrayList<>();
+    private final List<DescriptorTable.ReferencedPartitionInfo> partitionInfos = new ArrayList<>();
+
+    public void setup(DescriptorTable descTbl, Table table, HDFSScanNodePredicates scanNodePredicates) {
+        Collection<Long> selectedPartitionIds = scanNodePredicates.getSelectedPartitionIds();
+        if (selectedPartitionIds.isEmpty()) {
+            return;
+        }
+
+        for (long partitionId : selectedPartitionIds) {
+            PartitionKey partitionKey = scanNodePredicates.getIdToPartitionKey().get(partitionId);
+            DescriptorTable.ReferencedPartitionInfo partitionInfo =
+                    new DescriptorTable.ReferencedPartitionInfo(partitionId, partitionKey);
+            partitionInfos.add(partitionInfo);
+            descTbl.addReferencedPartitions(table, partitionInfo);
+        }
+    }
 
     private void addScanRangeLocations(long partitionId, RemoteFileInfo partition, RemoteFileDesc fileDesc,
                                        RemoteFileBlockDesc blockDesc) {
@@ -162,21 +177,16 @@ public class RemoteScanRangeLocations {
         result.add(scanRangeLocations);
     }
 
-    public void setupScanRangeLocations(DescriptorTable descTbl, Table table,
-                                        HDFSScanNodePredicates scanNodePredicates) {
+    public List<TScanRangeLocations> getScanRangeLocations(DescriptorTable descTbl, Table table,
+                                           HDFSScanNodePredicates scanNodePredicates) {
+        result.clear();
         HiveMetaStoreTable hiveMetaStoreTable = (HiveMetaStoreTable) table;
-        Collection<Long> selectedPartitionIds = scanNodePredicates.getSelectedPartitionIds();
-        if (selectedPartitionIds.isEmpty()) {
-            return;
-        }
 
         long start = System.currentTimeMillis();
         List<PartitionKey> partitionKeys = Lists.newArrayList();
-        List<DescriptorTable.ReferencedPartitionInfo> partitionInfos = Lists.newArrayList();
-        for (long partitionId : selectedPartitionIds) {
+        for (long partitionId : scanNodePredicates.getSelectedPartitionIds()) {
             PartitionKey partitionKey = scanNodePredicates.getIdToPartitionKey().get(partitionId);
             partitionKeys.add(partitionKey);
-            partitionInfos.add(new DescriptorTable.ReferencedPartitionInfo(partitionId, partitionKey));
         }
         String catalogName = hiveMetaStoreTable.getCatalogName();
         List<RemoteFileInfo> partitions;
@@ -189,9 +199,7 @@ public class RemoteScanRangeLocations {
         }
 
         if (table instanceof HiveTable) {
-            Preconditions.checkState(partitions.size() == partitionKeys.size());
             for (int i = 0; i < partitions.size(); i++) {
-                descTbl.addReferencedPartitions(table, partitionInfos.get(i));
                 for (RemoteFileDesc fileDesc : partitions.get(i).getFiles()) {
                     if (fileDesc.getLength() == 0) {
                         continue;
@@ -237,9 +245,6 @@ public class RemoteScanRangeLocations {
 
         LOG.debug("Get {} scan range locations cost: {} ms",
                 getScanRangeLocationsSize(), (System.currentTimeMillis() - start));
-    }
-
-    public List<TScanRangeLocations> getScanRangeLocations(long maxScanRangeLength) {
         return result;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/exception/RemoteFileNotFoundException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/exception/RemoteFileNotFoundException.java
@@ -16,16 +16,16 @@ package com.starrocks.connector.exception;
 
 import static java.lang.String.format;
 
-public class StarRocksConnectorException extends RuntimeException {
-    public StarRocksConnectorException(String message) {
+public class RemoteFileNotFoundException extends RuntimeException {
+    public RemoteFileNotFoundException(String message) {
         super(message);
     }
 
-    public StarRocksConnectorException(String formatString, Object... args) {
+    public RemoteFileNotFoundException(String formatString, Object... args) {
         super(format(formatString, args));
     }
 
-    public StarRocksConnectorException(String message, Throwable cause) {
+    public RemoteFileNotFoundException(String message, Throwable cause) {
         super(message, cause);
     }
 
@@ -37,11 +37,4 @@ public class StarRocksConnectorException extends RuntimeException {
     public String getMessage() {
         return getErrorMessage();
     }
-
-    public static void check(boolean test, String message, Object... args) {
-        if (!test) {
-            throw new StarRocksConnectorException(message, args);
-        }
-    }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -60,6 +60,8 @@ public class HdfsScanNode extends ScanNode {
     private CloudConfiguration cloudConfiguration = null;
     private final HDFSScanNodePredicates scanNodePredicates = new HDFSScanNodePredicates();
 
+    private DescriptorTable descTbl;
+
     public HdfsScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
         super(id, desc, planNodeName);
         hiveTable = (HiveTable) desc.getTable();
@@ -82,8 +84,9 @@ public class HdfsScanNode extends ScanNode {
         return helper.toString();
     }
 
-    public void setupScanRangeLocations(DescriptorTable descTbl) throws UserException {
-        scanRangeLocations.setupScanRangeLocations(descTbl, hiveTable, scanNodePredicates);
+    public void setupScanRangeLocations(DescriptorTable descTbl) {
+        this.descTbl = descTbl;
+        scanRangeLocations.setup(descTbl, hiveTable, scanNodePredicates);
     }
 
     private void setupCloudCredential() {
@@ -99,7 +102,7 @@ public class HdfsScanNode extends ScanNode {
 
     @Override
     public List<TScanRangeLocations> getScanRangeLocations(long maxScanRangeLength) {
-        return scanRangeLocations.getScanRangeLocations(maxScanRangeLength);
+        return scanRangeLocations.getScanRangeLocations(descTbl, hiveTable, scanNodePredicates);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -53,7 +53,7 @@ import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.Counter;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.RuntimeProfile;
-import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.exception.RemoteFileNotFoundException;
 import com.starrocks.load.loadv2.BulkLoadJob;
 import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.planner.PlanFragment;
@@ -1391,7 +1391,7 @@ public class Coordinator {
             }
 
             if (copyStatus.isRemoteFileNotFound()) {
-                throw new StarRocksConnectorException(copyStatus.getErrorMsg());
+                throw new RemoteFileNotFoundException(copyStatus.getErrorMsg());
             }
 
             if (copyStatus.isRpcError()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -53,6 +53,7 @@ import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.Counter;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.RuntimeProfile;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.load.loadv2.BulkLoadJob;
 import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.planner.PlanFragment;
@@ -1388,6 +1389,11 @@ public class Coordinator {
             if (Strings.isNullOrEmpty(copyStatus.getErrorMsg())) {
                 copyStatus.rewriteErrorMsg();
             }
+
+            if (copyStatus.isRemoteFileNotFound()) {
+                throw new StarRocksConnectorException(copyStatus.getErrorMsg());
+            }
+
             if (copyStatus.isRpcError()) {
                 throw new RpcException("unknown", copyStatus.getErrorMsg());
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -72,7 +72,7 @@ import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.ConnectorMetadata;
-import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.exception.RemoteFileNotFoundException;
 import com.starrocks.load.EtlJobType;
 import com.starrocks.load.InsertOverwriteJob;
 import com.starrocks.load.InsertOverwriteJobMgr;
@@ -469,7 +469,7 @@ public class StmtExecutor {
 
                         handleQueryStmt(execPlan);
                         break;
-                    } catch (StarRocksConnectorException e) {
+                    } catch (RemoteFileNotFoundException e) {
                         // If modifications are made to the partition files of a Hive table by user,
                         // such as through "insert overwrite partition", the Frontend couldn't be aware of these changes.
                         // As a result, queries may use the file information cached in the FE for execution.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -46,6 +46,7 @@ import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExternalOlapTable;
+import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.ResourceGroup;
@@ -70,6 +71,8 @@ import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.load.EtlJobType;
 import com.starrocks.load.InsertOverwriteJob;
 import com.starrocks.load.InsertOverwriteJobMgr;
@@ -83,6 +86,7 @@ import com.starrocks.mysql.MysqlEofPacket;
 import com.starrocks.mysql.MysqlSerializer;
 import com.starrocks.persist.CreateInsertOverwriteJobLog;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.planner.HdfsScanNode;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
@@ -94,6 +98,7 @@ import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.proto.QueryStatisticsItemPB;
 import com.starrocks.qe.QueryState.MysqlStateType;
 import com.starrocks.rpc.RpcException;
+import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.PlannerProfile;
@@ -464,6 +469,52 @@ public class StmtExecutor {
 
                         handleQueryStmt(execPlan);
                         break;
+                    } catch (StarRocksConnectorException e) {
+                        // If modifications are made to the partition files of a Hive table by user,
+                        // such as through "insert overwrite partition", the Frontend couldn't be aware of these changes.
+                        // As a result, queries may use the file information cached in the FE for execution.
+                        // When the Backend cannot find the corresponding files, it returns a "Status::ACCESS_REMOTE_FILE_ERROR."
+                        // To handle this exception, we perform a retry. Before initiating the retry, we need to
+                        // refresh the metadata cache for the table and clear the query-level metadata cache.
+                        if (i == retryTime - 1) {
+                            throw e;
+                        }
+
+                        List<ScanNode> scanNodes = execPlan.getScanNodes();
+                        boolean existExternalCatalog = false;
+                        for (ScanNode scanNode : scanNodes) {
+                            if (scanNode instanceof HdfsScanNode) {
+                                HiveTable hiveTable = ((HdfsScanNode) scanNode).getHiveTable();
+                                String catalogName = hiveTable.getCatalogName();
+                                if (CatalogMgr.isExternalCatalog(catalogName)) {
+                                    existExternalCatalog = true;
+                                    ConnectorMetadata metadata = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                                            .getOptionalMetadata(hiveTable.getCatalogName()).get();
+                                    // refresh catalog level metadata cache
+                                    metadata.refreshTable(hiveTable.getDbName(), hiveTable, new ArrayList<>(), true);
+                                    // clear query level metadata cache
+                                    metadata.clear();
+                                }
+                            }
+                        }
+
+                        if (!existExternalCatalog) {
+                            throw e;
+                        }
+
+                        if (!context.getMysqlChannel().isSend()) {
+                            String originStmt;
+                            if (parsedStmt.getOrigStmt() != null) {
+                                originStmt = parsedStmt.getOrigStmt().originStmt;
+                            } else {
+                                originStmt = this.originStmt.originStmt;
+                            }
+                            needRetry = true;
+                            LOG.warn("retry {} times. stmt: {}", (i + 1), originStmt);
+                        } else {
+                            throw e;
+                        }
+                        PlannerProfile.addCustomProperties("HMS.RETRY", String.valueOf(i + 1));
                     } catch (RpcException e) {
                         // When enable_collect_query_detail_info is set to true, the plan will be recorded in the query detail,
                         // and hence there is no need to log it here.

--- a/gensrc/thrift/StatusCode.thrift
+++ b/gensrc/thrift/StatusCode.thrift
@@ -102,6 +102,8 @@ enum TStatusCode {
 
     RESOURCE_BUSY = 53,
 
-    SR_EAGAIN = 54
+    SR_EAGAIN = 54,
+
+    REMOTE_FILE_NOT_FOUND = 55 // for hive external table
 }
 


### PR DESCRIPTION
Fixes #issue
If modifications are made to the partition files of a Hive table by user, such as through "insert overwrite partition", the Frontend couldn't be aware of these changes. As a result, queries may use the old file information cached in the FE for execution. Be will throw exception when accessing a non-exist remote files. So we need to resolve this issue.
There are some alternative solutions:
- aws sqs/sns  // Cannot be aware of a complete transaction.
- glue notification // it can't work when user use hive metastore.
- hive metastore listener // user need to enable metastore events in the hive metastore config and restart it. most of user can't do this operation.
- Background Periodic Refresh  // The refresh interval is long, and users still have a high probability of encoutering query errors. The refresh interval is short, background tasks put a lot of pressure on hive metastore and namenode.

I think the most out-of-the-box solution is to retry the query. When the file can't be found, refresh the metadata cache and regenerate the scan range.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
