### PR TITLE
[BugFix] Abnormally exit in JAVA UDF call_function_in_pthread shows all-zeros of query_id and fragment_instance_id

### DIFF
--- a/be/src/udf/java/utils.cpp
+++ b/be/src/udf/java/utils.cpp
@@ -32,6 +32,7 @@ PromiseStatusPtr call_function_in_pthread(RuntimeState* state, const std::functi
     if (bthread_self()) {
         state->exec_env()->udf_call_pool()->offer([promise = ms.get(), state, func]() {
             MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(state->instance_mem_tracker());
+            SCOPED_SET_TRACE_INFO({}, state->query_id(), state->fragment_instance_id());
             DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
             promise->set_value(func());
         });


### PR DESCRIPTION
Some methods' invocations of Java UADF  is off-loaded to other pthreads from bthread, in these off-load threads, query_id and fragment_instance_id is missed to set for the thread_local tls_thread_status, so when crashes happen in these off-load threads,  Abnormally exit print all-zeros query_id and fragment_instance_id, for an example:
```
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
```
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
