### PR TITLE
[Enhancement] Import the starcachelib to block cache by staros to replace starcache submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "be/src/thirdparty/starcache"]
-	path = be/src/thirdparty/starcache
-	url = https://github.com/StarRocks/starcache.git

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -75,6 +75,8 @@ option(WITH_COMPRESS "Build binary with compresss debug section" ON)
 
 option(WITH_CACHELIB "Build binary with cachelib library" OFF)
 
+option(WITH_STARCACHE "Build binary with starcache library" OFF)
+
 option(WITH_BENCH "Build binary with bench" OFF)
 
 option(USE_STAROS "Use StarOS to manager tablet info" OFF)
@@ -490,6 +492,9 @@ endif()
 if (${WITH_CACHELIB} STREQUAL "ON")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DWITH_CACHELIB")
 endif()
+if (${WITH_STARCACHE} STREQUAL "ON")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DWITH_STARCACHE")
+endif()
 
 # When LLVM is used, should give GCC_HOME to get c++11 header to use new string and list
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -648,7 +653,6 @@ set(STARROCKS_LINK_LIBS
     Tools
     Geo
     BlockCache
-    starcache
     ${WL_END_GROUP}
 )
 
@@ -885,7 +889,6 @@ add_subdirectory(${SRC_DIR}/testutil)
 add_subdirectory(${SRC_DIR}/types)
 add_subdirectory(${SRC_DIR}/udf)
 add_subdirectory(${SRC_DIR}/block_cache)
-add_subdirectory(${SRC_DIR}/thirdparty/starcache)
 
 add_subdirectory(${SRC_DIR}/tools)
 add_subdirectory(${SRC_DIR}/util)

--- a/be/src/bench/block_cache_bench.cpp
+++ b/be/src/bench/block_cache_bench.cpp
@@ -28,7 +28,7 @@
 #include "block_cache/starcache_wrapper.h"
 #include "common/config.h"
 #include "common/statusor.h"
-#include "thirdparty/starcache/src/common/config.h"
+#include "starcache/common/types.h"
 #include "util/logging.h"
 #include "util/random.h"
 #include "util/time.h"
@@ -304,7 +304,6 @@ static void BM_bench_starcache(benchmark::State& state, Args&&... args) {
     options.disk_spaces.push_back({.path = DISK_CACHE_PATH, .size = 1 * GB});
     options.block_size = 4 * MB;
     options.checksum = false;
-    starcache::config::FLAGS_enable_disk_checksum = false;
 
     BlockCacheBenchSuite::BenchParams params;
     params.obj_count = 1000;
@@ -324,7 +323,6 @@ static void BM_bench_starcache(benchmark::State& state, Args&&... args) {
     options.disk_spaces.push_back({.path = DISK_CACHE_PATH, .size = 10 * GB});
     options.block_size = 4 * MB;
     options.checksum = true;
-    starcache::config::FLAGS_enable_disk_checksum = true;
 
     BlockCacheBenchSuite::BenchParams params;
     params.obj_count = 1000;
@@ -344,7 +342,6 @@ static void BM_bench_starcache(benchmark::State& state, Args&&... args) {
     options.disk_spaces.push_back({.path = DISK_CACHE_PATH, .size = 10 * GB});
     options.block_size = 4 * MB;
     options.checksum = true;
-    starcache::config::FLAGS_enable_disk_checksum = true;
 
     BlockCacheBenchSuite::BenchParams params;
     params.obj_count = 1000;
@@ -367,7 +364,6 @@ static void BM_bench_starcache(benchmark::State& state, Args&&... args) {
     options.disk_spaces.push_back({.path = DISK_CACHE_PATH, .size = 10 * GB});
     options.block_size = 1 * MB;
     options.checksum = true;
-    starcache::config::FLAGS_enable_disk_checksum = true;
 
     BlockCacheBenchSuite::BenchParams params;
     params.obj_count = 1000;

--- a/be/src/block_cache/CMakeLists.txt
+++ b/be/src/block_cache/CMakeLists.txt
@@ -20,11 +20,14 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/block_cache")
 
 set(CACHE_FILES
   block_cache.cpp
-  starcache_wrapper.cpp
 )
 
 if (${WITH_CACHELIB} STREQUAL "ON")
     list(APPEND CACHE_FILES cachelib_wrapper.cpp)
+endif()
+
+if (${WITH_STARCACHE} STREQUAL "ON")
+    list(APPEND CACHE_FILES starcache_wrapper.cpp)
 endif()
 
 add_library(BlockCache STATIC

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -42,10 +42,9 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
     for (auto& dir : options.disk_spaces) {
         opt.disk_dir_spaces.push_back({.path = dir.path, .quota_bytes = dir.size});
     }
-    _load_starcache_conf();
-    starcache::config::FLAGS_block_size = options.block_size;
-    starcache::config::FLAGS_enable_disk_checksum = options.checksum;
-    starcache::config::FLAGS_max_concurrent_writes = options.max_concurrent_inserts;
+    opt.block_size = options.block_size;
+    opt.enable_disk_checksum = options.checksum;
+    opt.max_concurrent_writes = options.max_concurrent_inserts;
 
     _cache = std::make_unique<starcache::StarCache>();
     return to_status(_cache->init(opt));
@@ -87,22 +86,6 @@ std::unordered_map<std::string, double> StarCacheWrapper::cache_stats() {
 
 Status StarCacheWrapper::shutdown() {
     return Status::OK();
-}
-
-void StarCacheWrapper::_load_starcache_conf() {
-    const char* starrocks_home = getenv("STARROCKS_HOME");
-    const std::string starcache_conf = "conf/starcache.conf";
-    std::string conf_file;
-    if (starrocks_home) {
-        conf_file = std::string(starrocks_home) + "/" + starcache_conf;
-    } else {
-        conf_file = starcache_conf;
-    }
-    std::filesystem::path conf_path(conf_file);
-    if (std::filesystem::exists(conf_path)) {
-        gflags::ReadFromFlagsFile(conf_path.string(), "starcache", true);
-        LOG(INFO) << "load gflag configuration file from " << conf_path.string();
-    }
 }
 
 } // namespace starrocks

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -16,7 +16,7 @@
 
 #include "block_cache/kv_cache.h"
 #include "common/status.h"
-#include "thirdparty/starcache/src/star_cache.h"
+#include "starcache/star_cache.h"
 
 namespace starrocks {
 
@@ -39,8 +39,6 @@ public:
     Status shutdown() override;
 
 private:
-    void _load_starcache_conf();
-
     std::unique_ptr<starcache::StarCache> _cache;
 };
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -916,8 +916,10 @@ CONF_Bool(block_cache_report_stats, "false");
 // will be inserted 1/2 from the end of the LRU, 2 means 1/4 from the end of the LRU, and so on.
 // It is only useful for the cachelib engine currently.
 CONF_Int64(block_cache_lru_insertion_point, "1");
-// cachelib, starcache
-CONF_String(block_cache_engine, "starcache");
+// Block cache engines, alternatives: cachelib, starcache.
+// Set the default value empty to indicate whether it is manully configured by users.
+// If not, we need to adjust the default engine based on build switches like "WITH_CACHELIB" and "WITH_STARCACHE".
+CONF_String(block_cache_engine, "");
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -206,32 +206,6 @@ int main(int argc, char** argv) {
     }
 #endif
 
-    if (starrocks::config::block_cache_enable) {
-        starrocks::BlockCache* cache = starrocks::BlockCache::instance();
-        starrocks::CacheOptions cache_options;
-        cache_options.mem_space_size = starrocks::config::block_cache_mem_size;
-
-        std::vector<std::string> paths;
-        auto parse_res = starrocks::parse_conf_block_cache_paths(starrocks::config::block_cache_disk_path, &paths);
-        if (!parse_res.ok()) {
-            LOG(FATAL) << "parse config block cache disk path failed, path="
-                       << starrocks::config::block_cache_disk_path;
-            exit(-1);
-        }
-        for (auto& p : paths) {
-            cache_options.disk_spaces.push_back(
-                    {.path = p, .size = static_cast<size_t>(starrocks::config::block_cache_disk_size)});
-        }
-        cache_options.meta_path = starrocks::config::block_cache_meta_path;
-        cache_options.block_size = starrocks::config::block_cache_block_size;
-        cache_options.checksum = starrocks::config::block_cache_checksum_enable;
-        cache_options.max_parcel_memory_mb = starrocks::config::block_cache_max_parcel_memory_mb;
-        cache_options.max_concurrent_inserts = starrocks::config::block_cache_max_concurrent_inserts;
-        cache_options.lru_insertion_point = starrocks::config::block_cache_lru_insertion_point;
-        cache_options.engine = starrocks::config::block_cache_engine;
-        EXIT_IF_ERROR(cache->init(cache_options));
-    }
-
     Aws::SDKOptions aws_sdk_options;
     if (starrocks::config::aws_sdk_logging_trace_enabled) {
         auto level = parse_aws_sdk_log_level(starrocks::config::aws_sdk_logging_trace_level);
@@ -341,12 +315,49 @@ int main(int argc, char** argv) {
     starrocks::init_staros_worker();
 #endif
 
-    // cn need to support all ops for cloudnative table, so just start_be
-    start_be();
+#if !defined(WITH_CACHELIB) && !defined(WITH_STARCACHE)
+    if (starrocks::config::block_cache_enable) {
+        starrocks::config::block_cache_enable = false;
+    }
+#endif
 
     if (starrocks::config::block_cache_enable) {
-        starrocks::BlockCache::instance()->shutdown();
+        starrocks::BlockCache* cache = starrocks::BlockCache::instance();
+        starrocks::CacheOptions cache_options;
+        cache_options.mem_space_size = starrocks::config::block_cache_mem_size;
+
+        std::vector<std::string> paths;
+        auto parse_res = starrocks::parse_conf_block_cache_paths(starrocks::config::block_cache_disk_path, &paths);
+        if (!parse_res.ok()) {
+            LOG(FATAL) << "parse config block cache disk path failed, path="
+                       << starrocks::config::block_cache_disk_path;
+            exit(-1);
+        }
+        for (auto& p : paths) {
+            cache_options.disk_spaces.push_back(
+                    {.path = p, .size = static_cast<size_t>(starrocks::config::block_cache_disk_size)});
+        }
+
+        // Adjust the default engine based on build switches.
+        if (starrocks::config::block_cache_engine == "") {
+#if defined(WITH_STARCACHE)
+            starrocks::config::block_cache_engine = "starcache";
+#else
+            starrocks::config::block_cache_engine = "cachelib";
+#endif
+        }
+        cache_options.meta_path = starrocks::config::block_cache_meta_path;
+        cache_options.block_size = starrocks::config::block_cache_block_size;
+        cache_options.checksum = starrocks::config::block_cache_checksum_enable;
+        cache_options.max_parcel_memory_mb = starrocks::config::block_cache_max_parcel_memory_mb;
+        cache_options.max_concurrent_inserts = starrocks::config::block_cache_max_concurrent_inserts;
+        cache_options.lru_insertion_point = starrocks::config::block_cache_lru_insertion_point;
+        cache_options.engine = starrocks::config::block_cache_engine;
+        EXIT_IF_ERROR(cache->init(cache_options));
     }
+
+    // cn need to support all ops for cloudnative table, so just start_be
+    start_be();
 
     if (starrocks::k_starrocks_exit_quick.load()) {
         LOG(INFO) << "BE is shutting down，will exit quickly";
@@ -358,6 +369,12 @@ int main(int argc, char** argv) {
 
 #ifdef USE_STAROS
     starrocks::shutdown_staros_worker();
+#endif
+
+#if defined(WITH_CACHELIB) || defined(WITH_STARCACHE)
+    if (starrocks::config::block_cache_enable) {
+        starrocks::BlockCache::instance()->shutdown();
+    }
 #endif
 
     Aws::ShutdownAPI(aws_sdk_options);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -365,9 +365,12 @@ set(EXEC_FILES
         ./gutil/cpu_test.cc
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp
-        ./block_cache/block_cache_test.cpp
-        ./io/cache_input_stream_test.cpp
         )
+
+if ("${WITH_STARCACHE}" STREQUAL "ON" OR "${WITH_CACHELIB}" STREQUAL "ON")
+    list(APPEND EXEC_FILES ./block_cache/block_cache_test.cpp)
+    list(APPEND EXEC_FILES ./io/cache_input_stream_test.cpp)
+endif ()
 
 if ("${USE_STAROS}" STREQUAL "ON")
     list(APPEND EXEC_FILES ./fs/fs_starlet_test.cpp)

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -49,7 +49,7 @@ public:
 protected:
     void _create_runtime_state(const std::string& timezone);
     void _create_runtime_profile();
-    Status _init_block_cache(size_t mem_size);
+    Status _init_block_cache(size_t mem_size, const std::string& engine);
     HdfsScannerParams* _create_param(const std::string& file, THdfsScanRange* range, const TupleDescriptor* tuple_desc);
     void build_hive_column_names(HdfsScannerParams* params, const TupleDescriptor* tuple_desc,
                                  bool diff_case_sensitive = false);
@@ -80,13 +80,13 @@ void HdfsScannerTest::_create_runtime_state(const std::string& timezone) {
     _runtime_state->init_instance_mem_tracker();
 }
 
-Status HdfsScannerTest::_init_block_cache(size_t mem_size) {
+Status HdfsScannerTest::_init_block_cache(size_t mem_size, const std::string& engine) {
     BlockCache* cache = BlockCache::instance();
     CacheOptions cache_options;
     cache_options.mem_space_size = mem_size;
     cache_options.block_size = starrocks::config::block_cache_block_size;
     cache_options.checksum = starrocks::config::block_cache_checksum_enable;
-    cache_options.engine = starrocks::config::block_cache_engine;
+    cache_options.engine = engine;
     return cache->init(cache_options);
 }
 
@@ -1547,13 +1547,18 @@ TEST_F(HdfsScannerTest, TestCSVWithoutEndDelemeter) {
     Status status;
 
     {
-        status = _init_block_cache(50 * 1024 * 1024); // 50MB
-        ASSERT_TRUE(status.ok()) << status.get_error_msg();
-
         auto* range = _create_scan_range(small_file, 0, 0);
         auto* tuple_desc = _create_tuple_desc(csv_descs);
         auto* param = _create_param(small_file, range, tuple_desc);
+#if defined(WITH_STARCACHE)
+        status = _init_block_cache(50 * 1024 * 1024, "starcache"); // 50MB
+        ASSERT_TRUE(status.ok()) << status.get_error_msg();
         param->use_block_cache = true;
+#elif defined(WITH_CACHELIB)
+        status = _init_block_cache(50 * 1024 * 1024, "cachelib"); // 50MB
+        ASSERT_TRUE(status.ok()) << status.get_error_msg();
+        param->use_block_cache = true;
+#endif
         build_hive_column_names(param, tuple_desc, true);
         auto scanner = std::make_shared<HdfsTextScanner>();
 

--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -54,7 +54,11 @@ public:
         auto cache = BlockCache::instance();
         CacheOptions options;
         options.mem_space_size = 100 * 1024 * 1024;
+#ifdef WITH_STARCACHE
         options.engine = "starcache";
+#else
+        options.engine = "cachelib";
+#endif
         options.block_size = block_size;
         ASSERT_OK(cache->init(options));
     }

--- a/build.sh
+++ b/build.sh
@@ -157,7 +157,7 @@ if [ -e /proc/cpuinfo ] ; then
     fi
 fi
 
-# The `WITH_CACHELIB` just controls whether cachelib is compiled in, while starcache is now always compiled in.
+# The `WITH_CACHELIB` just controls whether cachelib is compiled in, while starcache is controlled by "USE_STAROS".
 # This option will soon be deprecated.
 if [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
     # force turn off cachelib on arm platform
@@ -308,7 +308,6 @@ if [ ${BUILD_BE} -eq 1 ] ; then
     mkdir -p ${CMAKE_BUILD_DIR}
 
     source ${STARROCKS_HOME}/bin/common.sh
-    update_submodules
 
     cd ${CMAKE_BUILD_DIR}
     if [ "${USE_STAROS}" == "ON"  ]; then
@@ -329,8 +328,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                     -DUSE_STAROS=${USE_STAROS} \
                     -DWITH_BENCH=${WITH_BENCH} \
                     -DWITH_CACHELIB=${WITH_CACHELIB} \
-                    -DSTARCACHE_THIRDPARTY_DIR=${STARROCKS_THIRDPARTY}/installed \
-                    -DSTARCACHE_SKIP_INSTALL=ON \
+                    -DWITH_STARCACHE=${USE_STAROS} \
                     -Dabsl_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/absl \
                     -DgRPC_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/grpc \
                     -Dprometheus-cpp_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/prometheus-cpp \
@@ -356,8 +354,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                     -DWITH_BENCH=${WITH_BENCH} \
                     -DWITH_COMPRESS=${WITH_COMPRESS} \
                     -DWITH_CACHELIB=${WITH_CACHELIB} \
-                    -DSTARCACHE_THIRDPARTY_DIR=${STARROCKS_THIRDPARTY}/installed \
-                    -DSTARCACHE_SKIP_INSTALL=ON \
+                    -DWITH_STARCACHE=${USE_STAROS} \
                     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  ..
     fi
     time ${BUILD_SYSTEM} -j${PARALLEL}

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -83,7 +83,6 @@ TEST_MODULE=".*"
 HELP=0
 WITH_AWS=OFF
 USE_STAROS=OFF
-WITH_CACHELIB=OFF
 WITH_GCOV=OFF
 while true; do
     case "$1" in
@@ -132,8 +131,16 @@ if [ ! -d ${CMAKE_BUILD_DIR} ]; then
     mkdir -p ${CMAKE_BUILD_DIR}
 fi
 
+# The `WITH_CACHELIB` just controls whether cachelib is compiled in, while starcache is controlled by "USE_STAROS".
+# This option will soon be deprecated.
+if [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
+    # force turn off cachelib on arm platform
+    WITH_CACHELIB=OFF
+elif [[ -z ${WITH_CACHELIB} ]]; then
+    WITH_CACHELIB=OFF
+fi
+
 source ${STARROCKS_HOME}/bin/common.sh
-update_submodules
 
 cd ${CMAKE_BUILD_DIR}
 if [ "${USE_STAROS}" == "ON"  ]; then
@@ -150,6 +157,7 @@ if [ "${USE_STAROS}" == "ON"  ]; then
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
               -DUSE_STAROS=${USE_STAROS} -DWITH_GCOV=${WITH_GCOV} \
               -DWITH_CACHELIB=${WITH_CACHELIB} \
+              -DWITH_STARCACHE=${USE_STAROS} \
               -DSTARCACHE_THIRDPARTY_DIR=${STARROCKS_THIRDPARTY}/installed \
               -DSTARCACHE_SKIP_INSTALL=ON \
               -Dabsl_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/absl \
@@ -173,6 +181,7 @@ else
               -DUSE_AVX2=$USE_AVX2 -DUSE_AVX512=$USE_AVX512 -DUSE_SSE4_2=$USE_SSE4_2 \
               -DWITH_GCOV=${WITH_GCOV} \
               -DWITH_CACHELIB=${WITH_CACHELIB} \
+              -DWITH_STARCACHE=${USE_STAROS} \
               -DSTARCACHE_THIRDPARTY_DIR=${STARROCKS_THIRDPARTY}/installed \
               -DSTARCACHE_SKIP_INSTALL=ON \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../


### PR DESCRIPTION
Fixes #issue

As the starcache library has been installed into staros output and imported into starrocks. So we remove the original starcache sumodule and depend on the starcache library directly.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
