### PR TITLE
[Refactor] Adjust the auto tablet distribution for exist table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -179,15 +179,15 @@ public class ColocateTableIndex implements Writable {
         this.lock.writeLock().unlock();
     }
 
-    public void addTableToGroup(Database db,
+    public boolean addTableToGroup(Database db,
                                 OlapTable olapTable, String colocateGroup, boolean expectLakeTable)
             throws DdlException {
         if (Strings.isNullOrEmpty(colocateGroup)) {
-            return;
+            return false;
         }
 
         if (olapTable.isCloudNativeTableOrMaterializedView() != expectLakeTable) {
-            return;
+            return false;
         }
 
         String fullGroupName = db.getId() + "_" + colocateGroup;
@@ -211,6 +211,7 @@ public class ColocateTableIndex implements Writable {
                         new ColocateTableIndex.GroupId(db.getId(), colocateGrpIdInOtherDb.grpId),
                 false /* isReplay */);
         olapTable.setColocateGroup(colocateGroup);
+        return true;
     }
 
     // NOTICE: call 'addTableToGroup()' will not modify 'group2BackendsPerBucketSeq'

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DistributionInfo.java
@@ -87,6 +87,10 @@ public abstract class DistributionInfo implements Writable {
         throw new NotImplementedException();
     }
 
+    public DistributionInfo copy() {
+        throw new NotImplementedException();
+    }
+
     @Override
     public void write(DataOutput out) throws IOException {
         Text.writeString(out, type.name());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HashDistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HashDistributionInfo.java
@@ -159,6 +159,11 @@ public class HashDistributionInfo extends DistributionInfo {
     }
 
     @Override
+    public HashDistributionInfo copy() {
+        return new HashDistributionInfo(bucketNum, distributionColumns);
+    }
+
+    @Override
     public String toSql() {
         StringBuilder builder = new StringBuilder();
         builder.append("DISTRIBUTED BY HASH(");
@@ -169,8 +174,10 @@ public class HashDistributionInfo extends DistributionInfo {
         }
         String colList = Joiner.on(", ").join(colNames);
         builder.append(colList);
-
-        builder.append(") BUCKETS ").append(bucketNum).append(" ");
+        builder.append(")");
+        if (bucketNum > 0) {
+            builder.append(" BUCKETS ").append(bucketNum).append(" ");
+        }
         return builder.toString();
     }
 
@@ -185,7 +192,9 @@ public class HashDistributionInfo extends DistributionInfo {
         }
         builder.append("]; ");
 
-        builder.append("bucket num: ").append(bucketNum).append("; ");
+        if (bucketNum > 0) {
+            builder.append("bucket num: ").append(bucketNum).append("; ");
+        }
 
         return builder.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RandomDistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RandomDistributionInfo.java
@@ -77,9 +77,17 @@ public class RandomDistributionInfo extends DistributionInfo {
     }
 
     @Override
+    public RandomDistributionInfo copy() {
+        return new RandomDistributionInfo(bucketNum);
+    }
+
+    @Override
     public String toSql() {
         StringBuilder builder = new StringBuilder();
-        builder.append("DISTRIBUTED BY RANDOM BUCKETS ").append(bucketNum);
+        builder.append("DISTRIBUTED BY RANDOM");
+        if (bucketNum > 0) {
+            builder.append(" BUCKETS ").append(bucketNum);
+        }
         return builder.toString();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -249,18 +249,21 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
                             dynamicPartitionProperty.getTimeUnit());
             SingleRangePartitionDesc rangePartitionDesc =
                     new SingleRangePartitionDesc(false, partitionName, partitionKeyDesc, partitionProperties);
+            if (dynamicPartitionProperty.getBuckets() == 0) {
+                addPartitionClauses.add(new AddPartitionClause(rangePartitionDesc, null, null, false));
+            } else {
+                // construct distribution desc
+                HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) olapTable.getDefaultDistributionInfo();
+                List<String> distColumnNames = new ArrayList<>();
+                for (Column distributionColumn : hashDistributionInfo.getDistributionColumns()) {
+                    distColumnNames.add(distributionColumn.getName());
+                }
+                DistributionDesc distributionDesc = new HashDistributionDesc(dynamicPartitionProperty.getBuckets(),
+                                                                             distColumnNames);
 
-            // construct distribution desc
-            HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) olapTable.getDefaultDistributionInfo();
-            List<String> distColumnNames = new ArrayList<>();
-            for (Column distributionColumn : hashDistributionInfo.getDistributionColumns()) {
-                distColumnNames.add(distributionColumn.getName());
+                // add partition according to partition desc and distribution desc
+                addPartitionClauses.add(new AddPartitionClause(rangePartitionDesc, distributionDesc, null, false));
             }
-            DistributionDesc distributionDesc =
-                    new HashDistributionDesc(dynamicPartitionProperty.getBuckets(), distColumnNames);
-
-            // add partition according to partition desc and distribution desc
-            addPartitionClauses.add(new AddPartitionClause(rangePartitionDesc, distributionDesc, null, false));
         }
         return addPartitionClauses;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -194,11 +194,6 @@ public class OlapTableFactory implements AbstractTableFactory {
             table = new ExternalOlapTable(db.getId(), tableId, tableName, baseSchema, keysType, partitionInfo,
                     distributionInfo, indexes, properties);
         } else if (stmt.isOlapEngine()) {
-            if (distributionInfo.getBucketNum() == 0) {
-                int bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
-                distributionInfo.setBucketNum(bucketNum);
-            }
-
             RunMode runMode = RunMode.getCurrentRunMode();
             String volume = (properties != null) ? properties.remove(PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME) : null;
 
@@ -359,7 +354,16 @@ public class OlapTableFactory implements AbstractTableFactory {
         String colocateGroup = null;
         try {
             colocateGroup = PropertyAnalyzer.analyzeColocate(properties);
-            colocateTableIndex.addTableToGroup(db, table, colocateGroup, false /* expectLakeTable */);
+            boolean addedToColocateGroup = colocateTableIndex.addTableToGroup(db, table,
+                                                colocateGroup, false /* expectLakeTable */);
+            if (table instanceof ExternalOlapTable == false && addedToColocateGroup) {
+                // Colocate table should keep the same bucket number accross the partitions
+                DistributionInfo defaultDistributionInfo = table.getDefaultDistributionInfo();
+                if (defaultDistributionInfo.getBucketNum() == 0) {
+                    int bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
+                    defaultDistributionInfo.setBucketNum(bucketNum);
+                }
+            }
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
@@ -159,7 +159,7 @@ public class CreateTableAutoTabletTest {
         } finally {
             db.readUnlock();
         }
-        Assert.assertEquals(bucketNum, 20);
+        Assert.assertEquals(bucketNum, 10);
     }
 
     @Test
@@ -209,7 +209,7 @@ public class CreateTableAutoTabletTest {
         } finally {
             db.readUnlock();
         }
-        Assert.assertEquals(bucketNum, 20);
+        Assert.assertEquals(bucketNum, 10);
     }
 
     @Test

--- a/test/sql/test_random_distribution/R/test_random_distribution
+++ b/test/sql/test_random_distribution/R/test_random_distribution
@@ -58,7 +58,7 @@ t	CREATE TABLE `t` (
 DUPLICATE KEY(`k`, `v`)
 COMMENT "OLAP"
 PARTITION BY date_trunc('day', k)
-DISTRIBUTED BY RANDOM BUCKETS 6
+DISTRIBUTED BY RANDOM
 PROPERTIES (
 "replication_num" = "3",
 "in_memory" = "false",


### PR DESCRIPTION
1. If the user specifies the bucket number when creating a table, the bucket number will be used for the table creation and the following partitions.

2. If the user doesn't specify the bucket number when creating a table, the bucker number is calculated by the following rules when creating a table. 
  ```
  if (backendNum <= 12) {
    bucketNum = 2 * backendNum;
  } else if (backendNum <= 24) {
    bucketNum = (int) (1.5 * backendNum);
  } else if (backendNum <= 36) {
    bucketNum = 36; 
  } else {
    bucketNum = Math.min(backendNum, 48); 
  }
```

3. If the user doesn't specify the bucket number, the number is speculated when adding partitions. 
    ``` bucket_number = max(data size of last five partitions) / 3GB ```

4. If the speculation is not correct, you can disable it by setting
   ```enable_auto_tablet_distribution``` in the fe.conf.
   After that, the bucket number is determined as step 2 when adding partitions.

5. Of course, you can specify the bucket as the last resort when adding partitions.
    ```
    ALTER TABLE site_access ADD PARTITION p4
    VALUES LESS THAN ("2020-04-30") DISTRIBUTED BY HASH(site_id)
    BUCKETS 20;
    ```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
