### PR TITLE
[BugFix] Fix the crash of get_compaction_status

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2394,7 +2394,7 @@ void TabletUpdates::get_compaction_status(std::string* json_result) {
     root.AddMember("rowsets_count", rowsets_count, root.GetAllocator());
 
     rapidjson::Value last_version_value;
-    std::string last_version_str = strings::Substitute("$1_$2", last_version.major(), last_version.minor());
+    std::string last_version_str = strings::Substitute("$0_$1", last_version.major(), last_version.minor());
     rowsets_count.SetString(last_version_str.c_str(), last_version_str.size(), root.GetAllocator());
     root.AddMember("last_version", last_version_value, root.GetAllocator());
 


### PR DESCRIPTION
Fixes #issue

```
F0601 17:33:04.157392 46114 substitute.cc:39] strings::Substitute format string invalid: asked for "$2", but only 2 args were given.  Full format string was: "$1_$2".
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
