### PR TITLE
[BugFix] avoid link useless delta column files

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -315,7 +315,7 @@ Status Rowset::_remove_delta_column_group_files(std::shared_ptr<FileSystem> fs) 
     return Status::OK();
 }
 
-Status Rowset::link_files_to(const std::string& dir, RowsetId new_rowset_id) {
+Status Rowset::link_files_to(const std::string& dir, RowsetId new_rowset_id, int64_t version) {
     for (int i = 0; i < num_segments(); ++i) {
         std::string dst_link_path = segment_file_path(dir, new_rowset_id, i);
         std::string src_file_path = segment_file_path(_rowset_path, rowset_id(), i);
@@ -343,11 +343,11 @@ Status Rowset::link_files_to(const std::string& dir, RowsetId new_rowset_id) {
             VLOG(1) << "success to link " << src_file_path << " to " << dst_link_path;
         }
     }
-    RETURN_IF_ERROR(_link_delta_column_group_files(dir));
+    RETURN_IF_ERROR(_link_delta_column_group_files(dir, version));
     return Status::OK();
 }
 
-Status Rowset::_link_delta_column_group_files(const std::string& dir) {
+Status Rowset::_link_delta_column_group_files(const std::string& dir, int64_t version) {
     if (num_segments() > 0) {
         std::filesystem::path schema_hash_path(_rowset_path);
         std::filesystem::path data_dir_path = schema_hash_path.parent_path().parent_path().parent_path().parent_path();
@@ -362,7 +362,7 @@ Status Rowset::_link_delta_column_group_files(const std::string& dir) {
             DeltaColumnGroupList list;
             RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(data_dir->get_meta(), _rowset_meta->tablet_id(),
                                                                        _rowset_meta->get_rowset_seg_id() + i, 0,
-                                                                       INT64_MAX, &list));
+                                                                       version, &list));
             for (const auto& dcg : list) {
                 std::string src_file_path = dcg->column_file(_rowset_path);
                 std::string dst_link_path = dcg->column_file(dir);

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -257,7 +257,8 @@ public:
     }
 
     // hard link all files in this rowset to `dir` to form a new rowset with id `new_rowset_id`.
-    Status link_files_to(const std::string& dir, RowsetId new_rowset_id);
+    // `version` is used for link col files, default using INT64_MAX means link all col files
+    Status link_files_to(const std::string& dir, RowsetId new_rowset_id, int64_t version = INT64_MAX);
 
     // copy all files to `dir`
     Status copy_files_to(const std::string& dir);
@@ -368,7 +369,7 @@ private:
 
     Status _remove_delta_column_group_files(std::shared_ptr<FileSystem> fs);
 
-    Status _link_delta_column_group_files(const std::string& dir);
+    Status _link_delta_column_group_files(const std::string& dir, int64_t version);
 
     std::vector<SegmentSharedPtr> _segments;
 };

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -379,7 +379,7 @@ StatusOr<std::string> SnapshotManager::snapshot_incremental(const TabletSharedPt
 
     // 4. Link files to snapshot directory.
     for (const auto& rowset : snapshot_rowsets) {
-        auto st = rowset->link_files_to(snapshot_dir, rowset->rowset_id());
+        auto st = rowset->link_files_to(snapshot_dir, rowset->rowset_id(), 0 /*snapshot_version*/);
         if (!st.ok()) {
             LOG(WARNING) << "Fail to link rowset file:" << st;
             (void)fs::remove_all(snapshot_id_path);
@@ -443,7 +443,7 @@ StatusOr<std::string> SnapshotManager::snapshot_full(const TabletSharedPtr& tabl
     }
 
     for (const auto& snapshot_rowset : snapshot_rowsets) {
-        auto st = snapshot_rowset->link_files_to(snapshot_dir, snapshot_rowset->rowset_id());
+        auto st = snapshot_rowset->link_files_to(snapshot_dir, snapshot_rowset->rowset_id(), snapshot_version);
         if (!st.ok()) {
             LOG(WARNING) << "Fail to link rowset file:" << st;
             (void)fs::remove_all(snapshot_id_path);
@@ -536,7 +536,7 @@ StatusOr<std::string> SnapshotManager::snapshot_primary(const TabletSharedPtr& t
 
     // 4. Link files to snapshot directory.
     for (const auto& rowset : snapshot_rowsets) {
-        auto st = rowset->link_files_to(snapshot_dir, rowset->rowset_id());
+        auto st = rowset->link_files_to(snapshot_dir, rowset->rowset_id(), full_snapshot_version);
         if (!st.ok()) {
             LOG(WARNING) << "Fail to link rowset file:" << st;
             (void)fs::remove_all(snapshot_id_path);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2804,7 +2804,7 @@ Status TabletUpdates::link_from(Tablet* base_tablet, int64_t request_version, st
     for (int i = 0; i < rowsets.size(); i++) {
         auto& src_rowset = *rowsets[i];
         RowsetId rid = StorageEngine::instance()->next_rowset_id();
-        auto st = src_rowset.link_files_to(_tablet.schema_hash_path(), rid);
+        auto st = src_rowset.link_files_to(_tablet.schema_hash_path(), rid, version.major());
         if (!st.ok()) {
             return st;
         }


### PR DESCRIPTION
Fixes #20436

Using specific snapshot version when linking rowset, so that we can avoid link useless delta column files which are belong to higher version delta column group.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
