### PR TITLE
[Enhancement] Move `load_profile_collect_second` to BE to reduce overhead of profile report

### DIFF
--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -90,6 +90,9 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request) {
     if (request.query_options.__isset.enable_profile) {
         enable_profile = request.query_options.enable_profile;
     }
+    if (request.query_options.__isset.load_profile_collect_second) {
+        load_profile_collect_second = request.query_options.load_profile_collect_second;
+    }
 
     // set up desc tbl
     DescriptorTbl* desc_tbl = nullptr;
@@ -305,6 +308,12 @@ void PlanFragmentExecutor::send_report(bool done) {
     // This may happen when the query limit reached and
     // a internal cancellation being processed
     if (!enable_profile && !_is_report_on_cancel) {
+        return;
+    }
+
+    auto start_timestamp = _runtime_state->timestamp_ms() / 1000;
+    auto now = std::time(nullptr);
+    if (load_profile_collect_second != -1 && now - start_timestamp < load_profile_collect_second) {
         return;
     }
 

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -168,6 +168,10 @@ private:
 
     bool enable_profile;
 
+    // If load_profile_collect_second is set and time cost of load is less than the value,
+    // then profile will not be reported to FE even though enable_profile=true
+    int64_t load_profile_collect_second = -1;
+
     // If this is set to false, and 'enable_profile' is false as well,
     // This executor will not report status to FE on being cancelled.
     bool _is_report_on_cancel;

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -170,7 +170,7 @@ private:
 
     // If load_profile_collect_second is set and time cost of load is less than the value,
     // then profile will not be reported to FE even though enable_profile=true
-    int64_t load_profile_collect_second = -1;
+    int32_t load_profile_collect_second = -1;
 
     // If this is set to false, and 'enable_profile' is false as well,
     // This executor will not report status to FE on being cancelled.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -261,6 +261,21 @@ public class Config extends ConfigBase {
     public static int label_keep_max_num = 1000;
 
     /**
+     * StreamLoadTasks hold by StreamLoadMgr will be cleaned
+     */
+    @ConfField(mutable = true)
+    public static int stream_load_task_keep_max_num = 1000;
+
+    /**
+     * StreamLoadTasks of finished or cancelled can be removed
+     * 1. after *stream_load_task_keep_max_second*
+     * or
+     * 2. tasks total num > *stream_load_task_keep_max_num*
+     */
+    @ConfField(mutable = true)
+    public static int stream_load_task_keep_max_second = 3 * 24 * 3600; // 3 days
+
+    /**
      * Load label cleaner will run every *label_clean_interval_second* to clean the outdated jobs.
      */
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -813,7 +813,6 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             TExecPlanFragmentParams planParams = planner.plan(loadId);
             planParams.query_options.setLoad_job_type(TLoadJobType.ROUTINE_LOAD);
             if (planParams.query_options.enable_profile) {
-                planParams.query_options.setEnable_profile(true);
                 StreamLoadMgr streamLoadManager = GlobalStateMgr.getCurrentState().getStreamLoadMgr();
 
                 StreamLoadTask streamLoadTask = streamLoadManager.createLoadTask(db, table.getName(), label,

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -236,15 +236,15 @@ public class StreamLoadMgr {
         }
 
         // Clear the stream load tasks manually
-        if (idToStreamLoadTask.size() > Config.label_keep_max_num) {
+        if (idToStreamLoadTask.size() > Config.stream_load_task_keep_max_num) {
             // If enable_load_profile = true,
             // most stream load tasks are generated through flink-cdc and routine load generally,
             // so clearing the syncStreamLoadTask is preferred.
             LOG.info("trigger cleanSyncStreamLoadTasks when add load task label:{}", task.getLabel());
             cleanSyncStreamLoadTasks();
             // The size of idToStreamLoadTask is still huge, indicates that the type of most tasks is PARALLEL,
-            // so clean all the streamLoadTasks manaully not waitting for Config.label_keep_max_second.
-            if (idToStreamLoadTask.size() > Config.label_keep_max_num / 2) {
+            // so clean all the streamLoadTasks manaully not waitting for Config.stream_load_task_keep_max_second.
+            if (idToStreamLoadTask.size() > Config.stream_load_task_keep_max_num / 2) {
                 LOG.info("trigger cleanOldStreamLoadTasks when add load task label{}", task.getLabel());
                 cleanOldStreamLoadTasks(true);
             }
@@ -383,7 +383,7 @@ public class StreamLoadMgr {
 
     // Remove old stream load tasks from idToStreamLoadTask and dbToLabelToStreamLoadTask
     // This function is called periodically.
-    // Cancelled and Committed task will be removed after Configure.label_keep_max_second seconds
+    // Cancelled and Committed task will be removed after Config.stream_load_task_keep_max_second seconds
     public void cleanOldStreamLoadTasks(boolean isForce) {
         LOG.debug("begin to clean old stream load tasks");
         writeLock();

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -888,7 +888,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback implements Wr
                 txnId, commitInfos, failInfos, txnCommitAttachment);
     }
 
-    public boolean checkNeedRemove(long currentMs) {
+    public boolean checkNeedRemove(long currentMs, boolean isForce) {
         readLock();
         try {
             if (!isFinalState()) {
@@ -898,7 +898,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback implements Wr
             readUnlock();
         }
         Preconditions.checkState(endTimeMs != -1, endTimeMs);
-        if ((currentMs - endTimeMs) > Config.label_keep_max_second * 1000) {
+        if (isForce || ((currentMs - endTimeMs) > Config.label_keep_max_second * 1000)) {
             return true;
         }
         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -984,7 +984,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback implements Wr
         }
 
         // sync stream load collect profile
-        if (isSyncStreamLoad() && coord.isEnableLoadProfile()) {
+        if (isSyncStreamLoad() && coord.isProfileAlreadyReported()) {
             collectProfile();
             QeProcessorImpl.INSTANCE.unregisterQuery(loadId);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -898,7 +898,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback implements Wr
             readUnlock();
         }
         Preconditions.checkState(endTimeMs != -1, endTimeMs);
-        if (isForce || ((currentMs - endTimeMs) > Config.label_keep_max_second * 1000)) {
+        if (isForce || ((currentMs - endTimeMs) > Config.stream_load_task_keep_max_second * 1000L)) {
             return true;
         }
         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -264,6 +264,7 @@ public class StreamLoadPlanner {
 
         if (connectContext.getSessionVariable().isEnableLoadProfile()) {
             queryOptions.setEnable_profile(true);
+            queryOptions.setLoad_profile_collect_second(Config.stream_load_profile_collect_second);
         }
 
         params.setQuery_options(queryOptions);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -184,6 +184,12 @@ public class Coordinator {
     private final ConnectContext connectContext;
     private final boolean needReport;
 
+    // True indicates that the profile has been reported
+    // When `enable_load_profile` is enabled,
+    // if the time costs of stream load is less than `stream_load_profile_collect_second`,
+    // the profile will not be reported to FE to reduce the overhead of profile under high-frequency import
+    private boolean profileAlreadyReported = false;
+
     private final CoordinatorPreprocessor coordinatorPreprocessor;
 
     private boolean thriftServerHighLoad;
@@ -1482,6 +1488,11 @@ public class Coordinator {
                     backendExecStates.keySet());
             return;
         }
+
+        if (params.isSetProfile()) {
+            profileAlreadyReported = true;
+        }
+
         lock();
         try {
             if (!execState.updateProfile(params)) {
@@ -1878,6 +1889,10 @@ public class Coordinator {
 
     public boolean isThriftServerHighLoad() {
         return this.thriftServerHighLoad;
+    }
+
+    public boolean isProfileAlreadyReported() {
+        return this.profileAlreadyReported;
     }
 
     // record backend execute state

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -3948,7 +3948,7 @@ public class GlobalStateMgr {
             LOG.warn("backup handler clean old jobs failed", t);
         }
         try {
-            streamLoadMgr.cleanOldStreamLoadTasks();
+            streamLoadMgr.cleanOldStreamLoadTasks(false);
         } catch (Throwable t) {
             LOG.warn("delete handler remove old delete info failed", t);
         }

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -209,6 +209,8 @@ struct TQueryOptions {
   95: optional double connector_scan_use_query_mem_ratio = 0.3;
   // used to identify which operators allow spill, only meaningful when enable_spill=true
   96: optional i64 spillable_operator_mask;
+  // used to judge whether the profile need to report to FE, only meaningful when enable_profile=true
+  97: optional i64 load_profile_collect_second;
 }
 
 


### PR DESCRIPTION
1. In pr #21441, when `enable_load_profile`  = true,  if the cost time of load is less than `load_profile_collect_second`, the profile will be discarded in FE, therefore, there is no need to report the profile in this case. This pr optimizes the logic of the profile report, if the time cost of the load is less than `load_profile_collect_second` , then the profile won't be reported to FE to reduce the overhead of the profile.
2.  Add Independent configuration to clean StreamLoadTask，when streamloadtasks exceed the limit of `Config.stream_load_task_keep_max_num`, Committed and Cancelled tasks will be cleaned instead of waiting for the time of `Config.stream_load_task_keep_max_second`

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
