### PR TITLE
[Enhancement] improve parquet reader performance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "be/src/thirdparty/libdeflate"]
+	path = be/src/thirdparty/libdeflate
+	url = https://github.com/ebiggers/libdeflate.git

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -166,6 +166,14 @@ endif()
 include_directories(${Boost_INCLUDE_DIRS})
 message(STATUS ${Boost_LIBRARIES})
 
+add_subdirectory(${SRC_DIR}/thirdparty/libdeflate)
+include_directories(libdeflate)
+set(libdeflate_DIR ${BUILD_DIR}/src/thirdparty/libdeflate)
+message(STATUS "Using libdeflate Dir: ${libdeflate_DIR}")
+if(NOT TARGET libdeflate::libdeflate_static)
+    find_package(libdeflate CONFIG REQUIRED)
+endif()
+
 set(GPERFTOOLS_HOME "${THIRDPARTY_DIR}/gperftools")
 
 # Set all libraries
@@ -790,6 +798,7 @@ set(STARROCKS_DEPENDENCIES
     avro
     serdes
     fiu
+    libdeflate::libdeflate_static
     ${WL_END_GROUP}
 )
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -136,7 +136,7 @@ bool NullableColumn::append_nulls(size_t count) {
     if (count == 0) {
         return true;
     }
-    _data_column->append_default(count);
+    _data_column->resize_uninitialized(_data_column->size() + count);
     null_column_data().insert(null_column_data().end(), count, 1);
     DCHECK_EQ(_null_column->size(), _data_column->size());
     _has_null = true;

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -306,7 +306,7 @@ public:
         case VALUE: {
             raw::stl_vector_resize_uninitialized(&_slices, count);
             auto ret = _rle_batch_reader.GetBatchWithDict(_dict.data(), _dict.size(), _slices.data(), count);
-            if (UNLIKELY(!ret)) {
+            if (UNLIKELY(ret == -1)) {
                 return Status::InternalError("DictDecoder append strings to column failed");
             }
             ret = dst->append_strings_overflow(_slices, _max_value_length);

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -102,8 +102,8 @@ public:
     Status set_data(const Slice& data) override {
         if (data.size > 0) {
             uint8_t bit_width = *data.data;
-            _rle_batch_reader = RleDecoder<uint32_t>(reinterpret_cast<uint8_t*>(data.data) + 1,
-                                                     static_cast<int>(data.size) - 1, bit_width);
+            _rle_batch_reader = RleBatchDecoder<uint32_t>(reinterpret_cast<uint8_t*>(data.data) + 1,
+                                                          static_cast<int>(data.size) - 1, bit_width);
         } else {
             return Status::Corruption("input encoded data size is 0");
         }
@@ -271,8 +271,8 @@ public:
     Status set_data(const Slice& data) override {
         if (data.size > 0) {
             uint8_t bit_width = *data.data;
-            _rle_batch_reader = RleDecoder<uint32_t>(reinterpret_cast<uint8_t*>(data.data) + 1,
-                                                     static_cast<int>(data.size) - 1, bit_width);
+            _rle_batch_reader = RleBatchDecoder<uint32_t>(reinterpret_cast<uint8_t*>(data.data) + 1,
+                                                          static_cast<int>(data.size) - 1, bit_width);
         } else {
             return Status::Corruption("input encoded data size is 0");
         }

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -301,12 +301,6 @@ public:
             data_column->resize_uninitialized(cur_size + count);
             int32_t* __restrict__ data = data_column->get_data().data() + cur_size;
             _index_batch_decoder.GetBatch(reinterpret_cast<uint32_t*>(data), count);
-
-            auto ret = dst->append_numbers(&_indexes[0], count * SIZE_OF_DICT_CODE_TYPE);
-            if (UNLIKELY(!ret)) {
-                return Status::InternalError("DictDecoder append numbers to column failed");
-            }
-            DCHECK(ret) << "append_numbers failed";
             break;
         }
         case VALUE: {

--- a/be/src/util/compression/block_compression.cpp
+++ b/be/src/util/compression/block_compression.cpp
@@ -979,6 +979,11 @@ public:
     ~GzipBlockCompressionV2() override = default;
 
     Status decompress(const Slice& input, Slice* output) const override {
+        if (input.empty()) {
+            output->size = 0;
+            return Status::OK();
+        }
+
         thread_local libdeflate_decompressor* decompressor = libdeflate_alloc_decompressor();
         if (!decompressor) {
             return Status::InternalError("libdeflate_alloc_decompressor failed");

--- a/be/src/util/compression/block_compression.cpp
+++ b/be/src/util/compression/block_compression.cpp
@@ -981,7 +981,6 @@ public:
     Status decompress(const Slice& input, Slice* output) const override {
         thread_local libdeflate_decompressor* decompressor = libdeflate_alloc_decompressor();
         if (!decompressor) {
-            std::cout<< "libdeflate_alloc_decompressor failed"<<std::endl;
             return Status::InternalError("libdeflate_alloc_decompressor failed");
         }
 
@@ -989,7 +988,6 @@ public:
         auto result =
                 libdeflate_gzip_decompress(decompressor, input.data, input.size, output->data, output->size, &out_len);
         if (result != LIBDEFLATE_SUCCESS) {
-            std::cout<< result <<std::endl;
             return Status::InvalidArgument("libdeflate_gzip_decompress failed");
         }
 

--- a/be/src/util/compression/block_compression.cpp
+++ b/be/src/util/compression/block_compression.cpp
@@ -44,6 +44,7 @@
 
 #include "gutil/endian.h"
 #include "gutil/strings/substitute.h"
+#include "thirdparty/libdeflate/libdeflate.h"
 #include "util/compression/compression_context_pool_singletons.h"
 #include "util/faststring.h"
 
@@ -966,6 +967,62 @@ private:
     const static int MEM_LEVEL = 8;
 };
 
+class GzipBlockCompressionV2 final : public BlockCompressionCodec {
+public:
+    GzipBlockCompressionV2() : BlockCompressionCodec(CompressionTypePB::GZIP) {
+    }
+
+    GzipBlockCompressionV2(CompressionTypePB type) : BlockCompressionCodec(type) {}
+
+    static const GzipBlockCompressionV2* instance() {
+        static GzipBlockCompressionV2 s_instance;
+        return &s_instance;
+    }
+
+    ~GzipBlockCompressionV2() override = default;
+
+    virtual Status init_compress_stream(z_stream& zstrm) const {
+        return Status::NotSupported("");
+    }
+
+    Status compress(const Slice& input, Slice* output, bool use_compression_buffer, size_t uncompressed_size,
+                    faststring* compressed_body1, raw::RawString* compressed_body2) const override {
+        return Status::NotSupported("");
+    }
+
+    Status compress(const std::vector<Slice>& inputs, Slice* output, bool use_compression_buffer,
+                    size_t uncompressed_size, faststring* compressed_body1,
+                    raw::RawString* compressed_body2) const override {
+        return Status::NotSupported("");
+    }
+
+    Status decompress(const Slice& input, Slice* output) const override {
+        // 初始化libdeflate解压缩器
+        struct libdeflate_decompressor* decompressor = libdeflate_alloc_decompressor();
+        if (!decompressor) {
+            return Status::InternalError("libdeflate_alloc_decompressor failed");
+        }
+
+        // 解压缩数据
+        std::size_t out_len;
+        auto result = libdeflate_gzip_decompress(decompressor, input.data, input.size, output->data, output->size, &out_len);
+        if (result != LIBDEFLATE_SUCCESS) {
+            libdeflate_free_decompressor(decompressor);
+            return Status::InvalidArgument("libdeflate_gzip_decompress failed");
+        }
+
+        libdeflate_free_decompressor(decompressor);
+
+        return Status::OK();
+    }
+
+    size_t max_compressed_len(size_t len) const override {
+        // one-time overhead of six bytes for the entire stream plus five bytes
+        // per 16 KB block
+        return len + 6 + 5 * ((len >> 14) + 1);
+    }
+};
+
 Status get_block_compression_codec(CompressionTypePB type, const BlockCompressionCodec** codec) {
     switch (type) {
     case CompressionTypePB::NO_COMPRESSION:
@@ -987,7 +1044,7 @@ Status get_block_compression_codec(CompressionTypePB type, const BlockCompressio
         *codec = ZstdBlockCompression::instance();
         break;
     case CompressionTypePB::GZIP:
-        *codec = GzipBlockCompression::instance();
+        *codec = GzipBlockCompressionV2::instance();
         break;
     case CompressionTypePB::LZ4_HADOOP:
         *codec = Lz4HadoopBlockCompression::instance();

--- a/be/src/util/rle_encoding.h
+++ b/be/src/util/rle_encoding.h
@@ -190,7 +190,7 @@ public:
 
     // Reserve 'num_bytes' bytes for a plain encoded header, set each
     // byte with 'val': this is used for the RLE-encoded data blocks in
-    // order to be able to able to store the initial ordinal position
+    // order to be able to store the initial ordinal position
     // and number of elements. This is a part of RleEncoder in order to
     // maintain the correct offset in 'buffer'.
     void Reserve(int num_bytes, uint8_t val);
@@ -406,7 +406,7 @@ inline size_t RleDecoder<T>::Skip(size_t to_skip) {
             to_skip -= nskip;
             for (; nskip > 0; nskip--) {
                 T value = 0;
-                bool result = bit_reader_.GetValue(bit_width_, &value);
+                result = bit_reader_.GetValue(bit_width_, &value);
                 DCHECK(result);
                 if (value != 0) {
                     set_count++;
@@ -708,7 +708,7 @@ public:
     int32_t GetBatch(T* values, int32_t batch_num);
 
     // Like GetBatch but the values are then decoded using the provided dictionary
-    template<typename TV>
+    template <typename TV>
     int GetBatchWithDict(const TV* dictionary, int32_t dictionary_length, TV* values, int32_t batch_num);
 
 private:
@@ -898,6 +898,24 @@ inline int32_t RleBatchDecoder<T>::GetBatch(T* values, int32_t batch_num) {
 }
 
 template <typename T>
+static inline bool IndexInRange(T idx, int32_t dictionary_length) {
+    return idx >= 0 && idx < dictionary_length;
+}
+
+template <typename T>
+static inline bool IndicesInRange(const T* values, int32_t length, int32_t dictionary_length) {
+    using IndexType = int32_t;
+    IndexType min_index = std::numeric_limits<IndexType>::max();
+    IndexType max_index = std::numeric_limits<IndexType>::min();
+    for (int x = 0; x < length; x++) {
+        min_index = std::min(values[x], min_index);
+        max_index = std::max(values[x], max_index);
+    }
+
+    return IndexInRange(min_index, dictionary_length) && IndexInRange(max_index, dictionary_length);
+}
+
+template <typename T>
 template <typename TV>
 inline int RleBatchDecoder<T>::GetBatchWithDict(const TV* dictionary, int32_t dictionary_length, TV* values,
                                                 int32_t batch_num) {
@@ -909,8 +927,10 @@ inline int RleBatchDecoder<T>::GetBatchWithDict(const TV* dictionary, int32_t di
         if (num_repeats > 0) {
             int32_t num_repeats_to_set = std::min(num_repeats, batch_num - num_consumed);
             T repeated_value = GetRepeatedValue(num_repeats_to_set);
+            if (UNLIKELY(!IndexInRange(repeated_value, dictionary_length))) {
+                return -1;
+            }
             TV value = dictionary[repeated_value];
-            // TODO(@DorianZheng) Check if index out of dictionary bound here
             for (int i = 0; i < num_repeats_to_set; ++i) {
                 values[num_consumed + i] = value;
             }
@@ -931,7 +951,9 @@ inline int RleBatchDecoder<T>::GetBatchWithDict(const TV* dictionary, int32_t di
         if (!GetLiteralValues(num_literals_to_set, indices)) {
             return 0;
         }
-        // TODO(@DorianZheng) Check if index out of dictionary bound here
+        if (UNLIKELY(!IndicesInRange(indices, num_literals_to_set, dictionary_length))) {
+            return -1;
+        }
         for (int i = 0; i < num_literals_to_set; ++i) {
             values[num_consumed + i] = dictionary[indices[i]];
         }

--- a/be/src/util/rle_encoding.h
+++ b/be/src/util/rle_encoding.h
@@ -904,9 +904,8 @@ static inline bool IndexInRange(T idx, int32_t dictionary_length) {
 
 template <typename T>
 static inline bool IndicesInRange(const T* values, int32_t length, int32_t dictionary_length) {
-    using IndexType = int32_t;
-    IndexType min_index = std::numeric_limits<IndexType>::max();
-    IndexType max_index = std::numeric_limits<IndexType>::min();
+    T min_index = std::numeric_limits<T>::max();
+    T max_index = std::numeric_limits<T>::min();
     for (int x = 0; x < length; x++) {
         min_index = std::min(values[x], min_index);
         max_index = std::max(values[x], max_index);

--- a/be/test/column/fixed_length_column_test.cpp
+++ b/be/test/column/fixed_length_column_test.cpp
@@ -118,7 +118,6 @@ TEST(FixedLengthColumnTest, test_nullable) {
     for (int i = 0; i < 100; i++) {
         if (i % 3) {
             ASSERT_EQ(true, column->is_null(i));
-            ASSERT_EQ(0, data[i]);
         } else {
             ASSERT_EQ(false, column->is_null(i));
             ASSERT_EQ(i, data[i]);

--- a/be/test/exprs/subfield_expr_test.cpp
+++ b/be/test/exprs/subfield_expr_test.cpp
@@ -133,7 +133,7 @@ TEST_F(SubfieldExprTest, subfield_null_test) {
         EXPECT_TRUE(subfield_column->is_numeric());
         EXPECT_EQ(3, subfield_column->size());
         EXPECT_EQ("1", subfield_column->debug_item(0));
-        EXPECT_EQ("0", subfield_column->debug_item(1));
+        EXPECT_TRUE(result->is_null(1));
         EXPECT_EQ("3", subfield_column->debug_item(2));
     }
 
@@ -194,7 +194,7 @@ TEST_F(SubfieldExprTest, subfield_clone_test) {
     EXPECT_TRUE(subfield_column->is_numeric());
     EXPECT_EQ(3, subfield_column->size());
     EXPECT_EQ("1", subfield_column->debug_item(0));
-    EXPECT_EQ("0", subfield_column->debug_item(1));
+    EXPECT_TRUE(result->is_null(1));
     EXPECT_EQ("3", subfield_column->debug_item(2));
 
     // Column must be cloned

--- a/be/test/storage/column_aggregator_test.cpp
+++ b/be/test/storage/column_aggregator_test.cpp
@@ -157,7 +157,6 @@ TEST(ColumnAggregator, testNullIntSum) {
     ASSERT_EQ(1022, dst->get_data()[1]);
     ASSERT_EQ(0, ndst->get_data()[1]);
 
-    ASSERT_EQ(0, dst->get_data()[2]);
     ASSERT_EQ(1, ndst->get_data()[2]);
 
     aggregator->update_source(nsrc3);
@@ -178,13 +177,10 @@ TEST(ColumnAggregator, testNullIntSum) {
     ASSERT_EQ(1022, dst->get_data()[1]);
     ASSERT_EQ(0, ndst->get_data()[1]);
 
-    ASSERT_EQ(0, dst->get_data()[2]);
     ASSERT_EQ(1, ndst->get_data()[2]);
 
-    ASSERT_EQ(0, dst->get_data()[3]);
     ASSERT_EQ(1, ndst->get_data()[3]);
 
-    ASSERT_EQ(0, dst->get_data()[4]);
     ASSERT_EQ(1, ndst->get_data()[4]);
 
     ASSERT_EQ(512, dst->get_data()[5]);
@@ -456,7 +452,6 @@ TEST(ColumnAggregator, testNullIntReplaceIfNotNull) {
     EXPECT_EQ(1023, dst->get_data()[1]);
     EXPECT_EQ(0, ndst->get_data()[1]);
 
-    EXPECT_EQ(0, dst->get_data()[2]);
     EXPECT_EQ(1, ndst->get_data()[2]);
 
     aggregator->update_source(nsrc3);
@@ -477,10 +472,8 @@ TEST(ColumnAggregator, testNullIntReplaceIfNotNull) {
     EXPECT_EQ(1023, dst->get_data()[1]);
     EXPECT_EQ(0, ndst->get_data()[1]);
 
-    EXPECT_EQ(0, dst->get_data()[2]);
     EXPECT_EQ(1, ndst->get_data()[2]);
 
-    EXPECT_EQ(0, dst->get_data()[3]);
     EXPECT_EQ(1, ndst->get_data()[3]);
 
     EXPECT_EQ(0, dst->get_data()[4]);

--- a/be/test/util/rle_encoding_test.cpp
+++ b/be/test/util/rle_encoding_test.cpp
@@ -499,4 +499,26 @@ TEST_F(TestRle, TestGetBatchWithDict) {
     ASSERT_EQ(1024, n);
 }
 
+TEST_F(TestRle, TestGetBatchWithDictOutOfRange) {
+    faststring buffer;
+    RleEncoder<int> encoder(&buffer, 16);
+    std::vector<int> values;
+    std::vector<int> dict;
+    for (int i = 0; i < 1023; i++) {
+        dict.push_back(i % 5);
+    }
+    for (int i = 0; i < 1023; ++i) {
+        values.push_back(dict[i]);
+        encoder.Put(i);
+    }
+    values.push_back(dict[0]);
+    encoder.Put(1024);
+    encoder.Flush();
+
+    RleBatchDecoder<int> decoder(buffer.data(), buffer.size(), 16);
+    std::vector<int> to_check(2048);
+    auto n = decoder.GetBatchWithDict(dict.data(), dict.size(), &to_check[0], 2048);
+    ASSERT_EQ(-1, n);
+}
+
 } // namespace starrocks

--- a/be/test/util/rle_encoding_test.cpp
+++ b/be/test/util/rle_encoding_test.cpp
@@ -484,7 +484,7 @@ TEST_F(TestRle, TestGetBatchWithDict) {
     std::vector<int> values;
     std::vector<int> dict;
     for (int i = 0; i < 1024; ++i) {
-        dict[i] = i % 5;
+        dict.push_back(i % 5);
         values.push_back(dict[i]);
         encoder.Put(i);
     }

--- a/be/test/util/rle_encoding_test.cpp
+++ b/be/test/util/rle_encoding_test.cpp
@@ -478,4 +478,25 @@ TEST_F(TestRle, TestBatch) {
     ASSERT_EQ(1024, n);
 }
 
+TEST_F(TestRle, TestGetBatchWithDict) {
+    faststring buffer;
+    RleEncoder<int> encoder(&buffer, 16);
+    std::vector<int> values;
+    std::vector<int> dict;
+    for (int i = 0; i < 1024; ++i) {
+        dict[i] = i % 5;
+        values.push_back(dict[i]);
+        encoder.Put(i);
+    }
+    encoder.Flush();
+
+    RleBatchDecoder<int> decoder(buffer.data(), buffer.size(), 16);
+    std::vector<int> to_check(2048);
+    auto n = decoder.GetBatchWithDict(dict.data(), dict.size(), &to_check[0], 2048);
+    for (int i = 0; i < values.size(); i++) {
+        ASSERT_EQ(to_check[i], values[i]);
+    }
+    ASSERT_EQ(1024, n);
+}
+
 } // namespace starrocks

--- a/build.sh
+++ b/build.sh
@@ -314,6 +314,8 @@ if [ ${BUILD_BE} -eq 1 ] ; then
 
     source ${STARROCKS_HOME}/bin/common.sh
 
+    update_submodules
+
     cd ${CMAKE_BUILD_DIR}
     if [ "${USE_STAROS}" == "ON"  ]; then
       if [ -z "$STARLET_INSTALL_DIR" ] ; then

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -142,6 +142,8 @@ fi
 
 source ${STARROCKS_HOME}/bin/common.sh
 
+update_submodules
+
 cd ${CMAKE_BUILD_DIR}
 if [ "${USE_STAROS}" == "ON"  ]; then
   if [ -z "$STARLET_INSTALL_DIR" ] ; then


### PR DESCRIPTION
- `resize_uninitialized` instead of `append_default` which saves cpu for generate default value and emplace one by one
- `GetBatchWithDict` which leverages repeated value for set value by batch and saves cpu
- use libdeflate to decompress gzip for better performance 

## total latency
### before:
![image](https://github.com/StarRocks/starrocks/assets/8065637/17edd312-2bb8-4851-a56c-975ca7f5a305)

### after:
![image](https://github.com/StarRocks/starrocks/assets/8065637/9d4ac76d-b023-4c15-9cc9-260574ae0c86)




## parquet reader cpu cost
### before:
![image](https://github.com/StarRocks/starrocks/assets/8065637/da5edb7a-8fa0-4747-9c35-051522c1a958)

### after:
![image](https://github.com/StarRocks/starrocks/assets/8065637/79d1f62e-cc77-40ba-91db-35c04c274e05)




## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
