### PR TITLE
[BugFix] Fix HDFS stat information lost in profile and avoid BE crashed when get HDFS stat

### DIFF
--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -196,7 +196,8 @@ uint64_t HdfsScanner::exit_pending_queue() {
 
 Status HdfsScanner::open_random_access_file() {
     CHECK(_file == nullptr) << "File has already been opened";
-    ASSIGN_OR_RETURN(std::unique_ptr<RandomAccessFile> raw_file, _scanner_params.fs->new_random_access_file(_scanner_params.path))
+    ASSIGN_OR_RETURN(std::unique_ptr<RandomAccessFile> raw_file,
+                     _scanner_params.fs->new_random_access_file(_scanner_params.path))
     const int64_t file_size = _scanner_params.file_size;
     raw_file->set_size(file_size);
     const std::string& filename = raw_file->filename();

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -315,7 +315,6 @@ protected:
     RuntimeState* _runtime_state = nullptr;
     HdfsScanStats _stats;
     HdfsScanStats _fs_stats;
-    std::unique_ptr<RandomAccessFile> _raw_file;
     std::unique_ptr<RandomAccessFile> _file;
     // by default it's no compression.
     CompressionTypePB _compression_type = CompressionTypePB::NO_COMPRESSION;

--- a/be/src/fs/fs_util.h
+++ b/be/src/fs/fs_util.h
@@ -167,6 +167,10 @@ inline bool is_jfs_uri(std::string_view uri) {
     return starts_with(uri, "jfs://");
 }
 
+inline bool is_hdfs_uri(std::string_view uri) {
+    return starts_with(uri, "hdfs://");
+}
+
 inline bool is_posix_uri(std::string_view uri) {
     return (memchr(uri.data(), ':', uri.size()) == nullptr) || starts_with(uri, "posix://");
 }

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -110,8 +110,8 @@ void HdfsInputStream::set_size(int64_t value) {
 }
 
 StatusOr<std::unique_ptr<io::NumericStatistics>> HdfsInputStream::get_numeric_statistics() {
-    // `GetReadStatistics` is not supported in Juicefs & Azure hadoop sdk & GCS sdk, and will cause Be crashed
-    if (fs::is_jfs_uri(_file_name) || fs::is_azure_uri(_file_name) || fs::is_gcs_uri(_file_name)) {
+    // `GetReadStatistics` is only supported in HDFS input stream
+    if (!fs::is_hdfs_uri(_file_name)) {
         return nullptr;
     }
 

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -20,7 +20,7 @@ namespace starrocks::io {
 
 SharedBufferedInputStream::SharedBufferedInputStream(std::shared_ptr<SeekableInputStream> stream,
                                                      const std::string& filename, size_t file_size)
-        : _stream(stream), _filename(filename), _file_size(file_size) {}
+        : _stream(std::move(stream)), _filename(std::move(filename)), _file_size(file_size) {}
 
 void SharedBufferedInputStream::SharedBuffer::align(int64_t align_size, int64_t file_size) {
     if (align_size != 0) {

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -20,7 +20,7 @@ namespace starrocks::io {
 
 SharedBufferedInputStream::SharedBufferedInputStream(std::shared_ptr<SeekableInputStream> stream,
                                                      const std::string& filename, size_t file_size)
-        : _stream(std::move(stream)), _filename(std::move(filename)), _file_size(file_size) {}
+        : _stream(std::move(stream)), _filename(filename), _file_size(file_size) {}
 
 void SharedBufferedInputStream::SharedBuffer::align(int64_t align_size, int64_t file_size) {
     if (align_size != 0) {

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -90,9 +90,8 @@ private:
     void _update_estimated_mem_usage();
     Status _get_bytes(const uint8_t** buffer, size_t offset, size_t nbytes);
     StatusOr<SharedBuffer*> _find_shared_buffer(size_t offset, size_t count);
-    Status _read_stream_buffer(SharedBuffer& sb, size_t offset, size_t count);
-    std::shared_ptr<SeekableInputStream> _stream;
-    std::string _filename;
+    const std::shared_ptr<SeekableInputStream> _stream;
+    const std::string _filename;
     std::map<int64_t, SharedBuffer> _map;
     CoalesceOptions _options;
     int64_t _offset = 0;

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -53,6 +53,10 @@ public:
         return _stream->skip(count);
     }
 
+    StatusOr<std::unique_ptr<NumericStatistics>> get_numeric_statistics() override {
+        return _stream->get_numeric_statistics();
+    }
+
     Status set_io_ranges(const std::vector<IORange>& ranges);
     void release_to_offset(int64_t offset);
     void release();


### PR DESCRIPTION
Fix HDFS stat information lost in the profile and avoid BE crashing when get HDFS stat.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
