### PR TITLE
[Enhancement] Add zone map for sort key column

### DIFF
--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -153,7 +153,7 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
                                         is_zone_map_key_type(column.type());
         const bool enable_dup_zone_map =
                 _tablet_schema->keys_type() == KeysType::DUP_KEYS && is_zone_map_key_type(column.type());
-        opts.need_zone_map = column.is_key() || enable_pk_zone_map || enable_dup_zone_map;
+        opts.need_zone_map = column.is_key() || enable_pk_zone_map || enable_dup_zone_map || column.is_sort_key();
         if (column.type() == LogicalType::TYPE_ARRAY) {
             opts.need_zone_map = false;
         }

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -365,6 +365,9 @@ void TabletSchema::_init_from_pb(const TabletSchemaPB& schema) {
             _sort_key_idxes.push_back(schema.sort_key_idxes(i));
         }
     }
+    for (auto cid : _sort_key_idxes) {
+        _cols[cid].set_is_sort_key(true);
+    }
     _num_short_key_columns = schema.num_short_key_columns();
     _num_rows_per_row_block = schema.num_rows_per_row_block();
     _next_column_unique_id = schema.next_column_unique_id();

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -112,6 +112,9 @@ public:
     bool has_bitmap_index() const { return _check_flag(kHasBitmapIndexShift); }
     void set_has_bitmap_index(bool value) { _set_flag(kHasBitmapIndexShift, value); }
 
+    bool is_sort_key() const { return _check_flag(kIsSortKey); }
+    void set_is_sort_key(bool value) { _set_flag(kIsSortKey, value); }
+
     ColumnLength length() const { return _length; }
     void set_length(ColumnLength length) { _length = length; }
 
@@ -172,6 +175,7 @@ private:
     constexpr static uint8_t kHasPrecisionShift = 4;
     constexpr static uint8_t kHasScaleShift = 5;
     constexpr static uint8_t kHasAutoIncrementShift = 6;
+    constexpr static uint8_t kIsSortKey = 7;
 
     ExtraFields* _get_or_alloc_extra_fields() {
         if (_extra_fields == nullptr) {


### PR DESCRIPTION
We support separate primary key and sort key for the PrimaryKey table so far, but we don't create a ZoneMap index for the sort key column if the sort key column is not the key column. So the query may need to read more data and use predicates to filter rows. We should create a ZoneMap index for sorting key columns too.