### PR TITLE
[BugFix] Fix checkpoint failed bug when writing cluster

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/cluster/Cluster.java
+++ b/fe/fe-core/src/main/java/com/starrocks/cluster/Cluster.java
@@ -118,6 +118,7 @@ public class Cluster implements Writable {
         try {
             dbNames.remove(name);
             dbIds.remove(id);
+            dbNameToIDs.remove(name, id);
         } finally {
             unlock();
         }
@@ -182,16 +183,19 @@ public class Cluster implements Writable {
         }
 
         if (dbNames.contains(StarRocksDb.DATABASE_NAME) &&
+                dbNameToIDs.containsKey(StarRocksDb.DATABASE_NAME) &&
                 dbNameToIDs.get(StarRocksDb.DATABASE_NAME).equals(SystemId.STARROCKS_DB_ID)) {
             dbCount--;
         }
 
         out.writeInt(dbCount);
-        // don't persist InfoSchemaDb meta
         for (String name : dbNames) {
+            // don't persist InfoSchemaDb meta
             if (name.equals(InfoSchemaDb.DATABASE_NAME)) {
                 dbIds.remove(dbNameToIDs.get(name));
+            // don't persist StarRocksDb meta
             } else if (name.equals(StarRocksDb.DATABASE_NAME) &&
+                    dbNameToIDs.containsKey(StarRocksDb.DATABASE_NAME) &&
                     dbNameToIDs.get(StarRocksDb.DATABASE_NAME).equals(SystemId.STARROCKS_DB_ID)) {
                 dbIds.remove(dbNameToIDs.get(name));
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4587,7 +4587,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 cluster.addDb(dbName, db.getId());
 
                 if (getFullNameToDb().containsKey(StarRocksDb.DATABASE_NAME)) {
-                    LOG.warn("Since the the database of mysql already exists, " +
+                    LOG.warn("Since the the database of starrocsks already exists, " +
                             "the system will not automatically create the database of starrocks for system.");
                 } else {
                     StarRocksDb starRocksDb = new StarRocksDb();


### PR DESCRIPTION
Fixes #https://starrocks.atlassian.net/browse/SR-18050

If there is a database named `starrocks` in the system, then upgrade to version 3.0, the checkpoint will fail with the following log
```
2023-05-29 15:20:19,471 ERROR (leaderCheckpointer|368) [Checkpoint.replayAndGenerateGlobalStateMgrImage():226] Exception when generate new image file
java.lang.NullPointerException: null
        at com.starrocks.cluster.Cluster.write(Cluster.java:185) ~[starrocks-fe.jar:?]
        at com.starrocks.server.LocalMetastore.saveCluster(LocalMetastore.java:4650) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.saveImage(GlobalStateMgr.java:1702) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.saveImage(GlobalStateMgr.java:1667) ~[starrocks-fe.jar:?]
        at com.starrocks.leader.Checkpoint.replayAndGenerateGlobalStateMgrImage(Checkpoint.java:217) ~[starrocks-fe.jar:?]
        at com.starrocks.leader.Checkpoint.runAfterCatalogReady(Checkpoint.java:106) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.LeaderDaemon.runOneCycle(LeaderDaemon.java:73) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:115) ~[starrocks-fe.jar:?]
```
if the `dbNames` contains `starrocks`, the `dbNameToIDs` will not contain the key of `starrocks` if `starrocks` is loaded from image, because `dbNameToIDs` is not persist to image, so we should check the existence of the key in `dbNameToIDs` before get it.
Since the cluster will be removed from 3.1 and the build-in db `starrocks` is added in 3.0, we only need to fix it on 3.0.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
