### PR TITLE
[BugFix][Branch-3.0] Support Iceberg rest catalog in tabular

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -27,12 +27,15 @@ import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.util.ThreadPools;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
 import java.util.Properties;
+
+import static org.apache.iceberg.CatalogProperties.FILE_IO_IMPL;
 
 public class IcebergConnector implements Connector {
     private static final Logger LOG = LogManager.getLogger(IcebergConnector.class);
@@ -77,6 +80,7 @@ public class IcebergConnector implements Connector {
                 catalogLoader = CatalogLoader.glue(icebergNativeCatalogName, conf, properties);
                 break;
             case REST_CATALOG:
+                properties.put(FILE_IO_IMPL, HadoopFileIO.class.getName());
                 catalogLoader = CatalogLoader.rest(icebergNativeCatalogName, conf, properties);
                 break;
             case CUSTOM_CATALOG:


### PR DESCRIPTION
Fix: #23432
cp from https://github.com/StarRocks/starrocks/pull/24634
Always using HadoopFileIO in iceberg rest catalog.

```sql
create external catalog tabular properties (
	"type"="iceberg",
	"iceberg.catalog.type"="rest",
	"uri"="https://api.tabular.io/ws",
	"credential"="t-5Ii8e32E-D5tT9m0",
	"warehouse"="chenao",
	"aws.s3.region"="us-west-2",
	"aws.s3.access_key"="AKIST",
	"aws.s3.secret_key"="LJUcvytmacTuf+"
);
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
