### PR TITLE
[BugFix][CherryPick] fix mv on union bug for 3.0 (#24465)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -22,7 +22,6 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.scheduler.persist.TaskSchedule;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
@@ -88,7 +87,6 @@ public class TaskBuilder {
         Map<String, String> taskProperties = Maps.newHashMap();
         taskProperties.put(PartitionBasedMaterializedViewRefreshProcessor.MV_ID,
                 String.valueOf(materializedView.getId()));
-        taskProperties.put(SessionVariable.ENABLE_INSERT_STRICT, "false");
         taskProperties.putAll(materializedView.getProperties());
 
         task.setProperties(taskProperties);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -358,11 +358,12 @@ public class MaterializedViewAnalyzer {
         private void genColumnAndSetIntoStmt(CreateMaterializedViewStatement statement, QueryRelation queryRelation,
                                              List<String> columnNames, Map<Column, Expr> columnExprMap) {
             List<Column> mvColumns = Lists.newArrayList();
+            Scope queryScope = statement.getQueryStatement().getQueryRelation().getScope();
+            List<Field> relationFields = queryScope.getRelationFields().getAllFields();
             List<Expr> outputExpression = queryRelation.getOutputExpression();
-            for (int i = 0; i < outputExpression.size(); ++i) {
-                Type type = AnalyzerUtils.transformTypeForMv(outputExpression.get(i).getType());
-                Column column = new Column(columnNames.get(i), type,
-                        outputExpression.get(i).isNullable());
+            for (int i = 0; i < relationFields.size(); ++i) {
+                Type type = AnalyzerUtils.transformTypeForMv(relationFields.get(i).getType());
+                Column column = new Column(columnNames.get(i), type, relationFields.get(i).isNullable());
                 // set default aggregate type, look comments in class Column
                 column.setAggregationType(AggregateType.NONE, false);
                 mvColumns.add(column);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -2702,5 +2702,100 @@ public class CreateMaterializedViewTest {
         starRocksAssert.dropTable("emps");
         starRocksAssert.dropTable("depts");
     }
+
+    @Test
+    public void testMvOnUnion() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `customer_nullable_1` (\n" +
+                "  `c_custkey` int(11) NULL COMMENT \"\",\n" +
+                "  `c_name` varchar(26) NULL COMMENT \"\",\n" +
+                "  `c_address` varchar(41) NULL COMMENT \"\",\n" +
+                "  `c_city` varchar(11) NULL COMMENT \"\",\n" +
+                "  `c_nation` varchar(16) NULL COMMENT \"\",\n" +
+                "  `c_region` varchar(13) NULL COMMENT \"\",\n" +
+                "  `c_phone` varchar(16) NOT NULL COMMENT \"\",\n" +
+                "  `c_mktsegment` varchar(11) NOT NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`c_custkey`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 12\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+
+        starRocksAssert.withTable("CREATE TABLE `customer_nullable_2` (\n" +
+                "  `c_custkey` int(11) NULL COMMENT \"\",\n" +
+                "  `c_name` varchar(26) NULL COMMENT \"\",\n" +
+                "  `c_address` varchar(41) NULL COMMENT \"\",\n" +
+                "  `c_city` varchar(11) NULL COMMENT \"\",\n" +
+                "  `c_nation` varchar(16) NULL COMMENT \"\",\n" +
+                "  `c_region` varchar(13) NULL COMMENT \"\",\n" +
+                "  `c_phone` varchar(16) NOT NULL COMMENT \"\",\n" +
+                "  `c_mktsegment` varchar(11) NOT NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`c_custkey`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 12\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+
+        starRocksAssert.withTable("\n" +
+                "CREATE TABLE `customer_nullable_3` (\n" +
+                "  `c_custkey` int(11)  NULL COMMENT \"\",\n" +
+                "  `c_name` varchar(26)  NULL COMMENT \"\",\n" +
+                "  `c_address` varchar(41)  NULL COMMENT \"\",\n" +
+                "  `c_city` varchar(11)  NULL COMMENT \"\",\n" +
+                "  `c_nation` varchar(16)  NULL COMMENT \"\",\n" +
+                "  `c_region` varchar(13)  NULL COMMENT \"\",\n" +
+                "  `c_phone` varchar(16) NOT NULL COMMENT \"\",\n" +
+                "  `c_mktsegment` varchar(11) NOT NULL COMMENT \"\",\n" +
+                "  `c_total` decimal(19,6) null default \"0.0\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`c_custkey`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 12\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+
+        starRocksAssert.withMaterializedView("\n" +
+                "create materialized view customer_mv\n" +
+                "distributed by hash(`custkey`)\n" +
+                "as\n" +
+                "\n" +
+                "select\n" +
+                "\tc_custkey custkey,\n" +
+                "\tc_name name,\n" +
+                "\tc_phone phone,\n" +
+                "\t0 total,\n" +
+                "\t c_mktsegment segment\n" +
+                "from customer_nullable_1\n" +
+                "\n" +
+                "union all\n" +
+                "\n" +
+                "select\n" +
+                "\tc_custkey custkey,\n" +
+                "\tnull name,\n" +
+                "\tnull phone,\n" +
+                "\t0 total,\n" +
+                "\t c_mktsegment segment\n" +
+                "from customer_nullable_2\n" +
+                "\n" +
+                "union all\n" +
+                "\n" +
+                "select\n" +
+                "\tc_custkey custkey,\n" +
+                "\tnull name,\n" +
+                "\tnull phone,\n" +
+                "\tc_total total,\n" +
+                "\t c_mktsegment segment\n" +
+                "from customer_nullable_3;");
+
+        Database db = starRocksAssert.getCtx().getGlobalStateMgr().getDb("test");
+
+        MaterializedView mv = (MaterializedView) db.getTable("customer_mv");
+        Assert.assertTrue(mv.getColumn("total").getType().isDecimalOfAnyVersion());
+        Assert.assertFalse(mv.getColumn("segment").isAllowNull());
+    }
 }
 

--- a/test/sql/test_materialized_view/R/test_materialized_view_union
+++ b/test/sql/test_materialized_view/R/test_materialized_view_union
@@ -112,7 +112,7 @@ union
 select k1, v1, v2 from t2;
 -- result:
 -- !result
-insert into t2 values (202301,1,1),(202305,1,2);
+insert into t1 values (202301,1,1),(202305,1,2);
 -- result:
 -- !result
 select sleep(2);


### PR DESCRIPTION
Fixes #24460
the bugs' reason are:
1. the mv's column type and nullable are invalid
2. the refresh process does not fail when there are filtered rows.

Fix it by deriving the correct nullable property and column type for mv and enable insert strict mode for mv refresh.

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
