### PR TITLE
[BugFix] Fix incorrect error message when create routine load failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -435,22 +435,8 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                 db.getId(), tableId, stmt.getKafkaBrokerList(), stmt.getKafkaTopic());
         kafkaRoutineLoadJob.setOptional(stmt);
         kafkaRoutineLoadJob.checkCustomProperties();
-        kafkaRoutineLoadJob.checkCustomPartition(kafkaRoutineLoadJob.customKafkaPartitions);
 
         return kafkaRoutineLoadJob;
-    }
-
-    private void checkCustomPartition(List<Integer> customKafkaPartitions) throws UserException {
-        if (customKafkaPartitions.isEmpty()) {
-            return;
-        }
-        List<Integer> allKafkaPartitions = getAllKafkaPartitions();
-        for (Integer customPartition : customKafkaPartitions) {
-            if (!allKafkaPartitions.contains(customPartition)) {
-                throw new LoadException("there is a custom kafka partition " + customPartition
-                        + " which is invalid for topic " + topic);
-            }
-        }
     }
 
     private void checkCustomProperties() throws DdlException {
@@ -627,13 +613,6 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                     if (! customKafkaPartitions.contains(pair.first)) {
                         throw new DdlException("The specified partition " + pair.first + " is not in the custom partitions");
                     }
-                }
-            } else {
-                // check if partition is validate
-                try {
-                    checkCustomPartition(kafkaPartitionOffsets.stream().map(k -> k.first).collect(Collectors.toList()));
-                } catch (UserException e) {
-                    throw new DdlException("The specified partition is not in the consumed partitions ", e);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -86,7 +86,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * KafkaRoutineLoadJob is a kind of RoutineLoadJob which fetch data from kafka.


### PR DESCRIPTION
Currently, when a routine load job is created, the FE requests to BE connected to the Kafka broker. However, if the user specified a wrong broker address, BE will wait a very long time to realize the problem (related to librdkafka's implementation), because BE will wait a very long time, FE will call the BE's RPC interface time out, and FE will inform the user that the RPC communication failed, rather than the wrong Kafka broker address. This PR avoids this issue by deleting the logic of connecting the Kafa broker when a routine load task is created. If the Kafka broker address is incorrect, the user can run the show routine load command to obtain the information.
 
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
