### PR TITLE
[BugFix] runtimefilter evaluate_min_max should based on the original selection

### DIFF
--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -694,10 +694,8 @@ private:
     void _evaluate_min_max(const CppType* values, uint8_t* selection, size_t size) const {
         if constexpr (!IsSlice<CppType>) {
             for (size_t i = 0; i < size; i++) {
-                selection[i] = (values[i] >= _min && values[i] <= _max);
+                selection[i] = (selection[i] && values[i] >= _min && values[i] <= _max);
             }
-        } else {
-            memset(selection, 0x1, size);
         }
     }
 


### PR DESCRIPTION
Fixes #issue
runtimefilter evaluate_min_max filter should based on the original selection, otherwise we'll lose the original selection information.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
