### PR TITLE
[BugFix] dont update `bytes_read` when peek fails

### DIFF
--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -47,7 +47,6 @@ public:
     }
 
     StatusOr<std::string_view> peek(int64_t count) override {
-        SCOPED_RAW_TIMER(&_stats->io_ns);
         auto st = _stream->peek(count);
         if (st.ok()) {
             _stats->io_count += 1;

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -48,9 +48,12 @@ public:
 
     StatusOr<std::string_view> peek(int64_t count) override {
         SCOPED_RAW_TIMER(&_stats->io_ns);
-        _stats->io_count += 1;
-        _stats->bytes_read += count;
-        return _stream->peek(count);
+        auto st = _stream->peek(count);
+        if (st.ok()) {
+            _stats->io_count += 1;
+            _stats->bytes_read += count;
+        }
+        return st;
     }
 
 private:


### PR DESCRIPTION
Fixes #issue

Since we have zero-copy feature, we use `peek` to check if we can do zero-copy.

If `peek` does not  return OK, it means we can not use zero-copy. And in this case
- we don't need to update `bytes_read`(and `io_count`)
- and since `peek` is very fast, we don't need to time it


-----

we use `select * from nation` as test case

before PR, you can see `ApppIOBytesRead(11.2KB) > BlockCacheReadBytes(9.33KB)`, which is not normal when all data is from cache.

<img width="493" alt="BlockCache" src="https://github.com/StarRocks/starrocks/assets/1081215/0f9a6ddf-033e-4c77-8142-cd0b37cca583">

and after PR, you can see two values are equal

<img width="668" alt="BlockCache" src="https://github.com/StarRocks/starrocks/assets/1081215/4f122c88-2d35-4757-ad18-c059bbf91360">



## What type of PR is this:
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
