### PR TITLE
[BugFix] Fix memory illegal modification

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -969,4 +969,7 @@ CONF_mBool(enable_pk_value_column_zonemap, "true");
 // Used by default mv resource group
 CONF_Double(default_mv_resource_group_memory_limit, "0.8");
 CONF_Int32(default_mv_resource_group_cpu_limit, "1");
+
+// Max size of key columns size of primary key table, default value is 128 bytes
+CONF_mInt32(primary_key_limit_size, "128");
 } // namespace starrocks::config

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -34,7 +34,6 @@ namespace starrocks {
 
 // TODO(cbl): move to common space latter
 static const string LOAD_OP_COLUMN = "__op";
-static const size_t kPrimaryKeyLimitSize = 128;
 
 Schema MemTable::convert_schema(const TabletSchema* tablet_schema, const std::vector<SlotDescriptor*>* slot_descs) {
     Schema schema = ChunkHelper::convert_schema(*tablet_schema);
@@ -228,7 +227,7 @@ Status MemTable::finalize() {
             _result_chunk = _aggregator->aggregate_result();
             if (_keys_type == PRIMARY_KEYS &&
                 PrimaryKeyEncoder::encode_exceed_limit(*_vectorized_schema, *_result_chunk.get(), 0,
-                                                       _result_chunk->num_rows(), kPrimaryKeyLimitSize)) {
+                                                       _result_chunk->num_rows(), config::primary_key_limit_size)) {
                 _aggregator.reset();
                 _aggregator_memory_usage = 0;
                 _aggregator_bytes_usage = 0;

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -58,7 +58,6 @@ constexpr size_t kL0SnapshotSizeMax = 1 * 1024 * 1024;
 constexpr size_t kL0SnapshotSizeMax = 16 * 1024 * 1024;
 #endif
 constexpr size_t kLongKeySize = 64;
-constexpr size_t kMaxKeyLength = 128; // we only support key length is less than or equal to 128 bytes for now
 
 const char* const kIndexFileMagic = "IDX1";
 
@@ -3062,13 +3061,11 @@ Status PersistentIndex::_update_usage_and_size_by_key_length(
             }
         }
 
+        DCHECK(_key_size == 0);
         int64_t slice_usage = 0;
         int64_t slice_size = 0;
-        for (int key_size = kSliceMaxFixLength + 1; key_size <= kMaxKeyLength; key_size++) {
-            slice_usage += add_usage_and_size[key_size].first;
-            slice_size += add_usage_and_size[key_size].second;
-        }
-        DCHECK(_key_size == 0);
+        slice_usage += add_usage_and_size[0].first;
+        slice_size += add_usage_and_size[0].second;
         auto iter = _usage_and_size_by_key_length.find(_key_size);
         if (iter == _usage_and_size_by_key_length.end()) {
             std::string msg = strings::Substitute("no key_size: $0 in usage info", _key_size);
@@ -3090,13 +3087,15 @@ Status PersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue* va
     } else {
         RETURN_IF_ERROR(_get_from_immutable_index(n, keys, old_values, not_founds_by_key_size));
     }
-    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
+    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kSliceMaxFixLength + 1,
+                                                                std::pair<int64_t, int64_t>(0, 0));
     for (size_t i = 0; i < n; i++) {
         if (old_values[i].get_value() == NullIndexValue) {
             _size++;
             _usage += keys[i].size + kIndexValueSize;
-            add_usage_and_size[keys[i].size].first += keys[i].size + kIndexValueSize;
-            add_usage_and_size[keys[i].size].second++;
+            int64_t len = keys[i].size >= kSliceMaxFixLength ? 0 : keys[i].size;
+            add_usage_and_size[len].first += keys[i].size + kIndexValueSize;
+            add_usage_and_size[len].second++;
         }
     }
 
@@ -3120,12 +3119,14 @@ Status PersistentIndex::insert(size_t n, const Slice* keys, const IndexValue* va
             RETURN_IF_ERROR(_l1_vec[0]->check_not_exist(n, keys, check_l1_key_size));
         }
     }
-    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
+    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kSliceMaxFixLength + 1,
+                                                                std::pair<int64_t, int64_t>(0, 0));
     _size += n;
     for (size_t i = 0; i < n; i++) {
         _usage += keys[i].size + kIndexValueSize;
-        add_usage_and_size[keys[i].size].first += keys[i].size + kIndexValueSize;
-        add_usage_and_size[keys[i].size].second++;
+        int64_t len = keys[i].size >= kSliceMaxFixLength ? 0 : keys[i].size;
+        add_usage_and_size[len].first += keys[i].size + kIndexValueSize;
+        add_usage_and_size[len].second++;
     }
     RETURN_IF_ERROR(_update_usage_and_size_by_key_length(add_usage_and_size));
 
@@ -3142,13 +3143,15 @@ Status PersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_value
     } else {
         RETURN_IF_ERROR(_get_from_immutable_index(n, keys, old_values, not_founds_by_key_size));
     }
-    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
+    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kSliceMaxFixLength + 1,
+                                                                std::pair<int64_t, int64_t>(0, 0));
     for (size_t i = 0; i < n; i++) {
         if (old_values[i].get_value() != NullIndexValue) {
             _size--;
             _usage -= keys[i].size + kIndexValueSize;
-            add_usage_and_size[keys[i].size].first -= keys[i].size + kIndexValueSize;
-            add_usage_and_size[keys[i].size].second--;
+            int64_t len = keys[i].size >= kSliceMaxFixLength ? 0 : keys[i].size;
+            add_usage_and_size[len].first -= keys[i].size + kIndexValueSize;
+            add_usage_and_size[len].second--;
         }
     }
     RETURN_IF_ERROR(_update_usage_and_size_by_key_length(add_usage_and_size));

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -170,4 +170,32 @@ TEST(PrimaryKeyEncoderTest, testEncodeCompositeLimit) {
     }
 }
 
+TEST(PrimaryKeyEncoderTest, testEncodeVarcharLimit) {
+    auto sc = create_key_schema({TYPE_VARCHAR});
+    const int n = 2;
+    {
+        auto pchunk = ChunkHelper::new_chunk(*sc, n);
+        Datum tmp;
+        string tmpstr("slice00000");
+        tmp.set_slice(tmpstr);
+        pchunk->columns()[0]->append_datum(tmp);
+        tmpstr = "slice0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                 "00000000000000000000000000000000000";
+        tmp.set_slice(tmpstr);
+        pchunk->columns()[0]->append_datum(tmp);
+        EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128));
+    }
+    {
+        auto pchunk = ChunkHelper::new_chunk(*sc, n);
+        Datum tmp;
+        string tmpstr("slice00000");
+        tmp.set_slice(tmpstr);
+        pchunk->columns()[0]->append_datum(tmp);
+        tmpstr = "slice00000000000000000000000000000000000";
+        tmp.set_slice(tmpstr);
+        pchunk->columns()[0]->append_datum(tmp);
+        EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128));
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
When we create a primary key table, we will check the total length of the key columns and we don't support the length of the key column greater than 128 bytes. However, when the primary key table only has one key column and the column type is varchar, we may write some data whose key column length is larger than 128 bytes. So in some code of persistent index, we may create a vector that contains at most 129 elements and modify the vector by key column sizes

```
e.g.

// kMaxKeyLength is defined as 128
std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
....
add_usage_and_size[keys[i].size].first -= keys[i].size + kIndexValueSize;
add_usage_and_size[keys[i].size].second--;
```

So if we can not guarantee the size of the key column is not larger than 128 bytes, the above code is illegal memory modification which may cause unexpected errors.


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
