### PR TITLE
[BugFix] fix the incorrent page count hint in PersistentIndex when create shard

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -646,6 +646,7 @@ public:
             const auto value = values[idx];
             uint64_t hash = FixedKeyHash<KeySize>()(key);
             if (auto [it, inserted] = _map.emplace_with_hash(hash, key, value); inserted) {
+                old_values[idx] = NullIndexValue;
                 not_found->key_infos.emplace_back((uint32_t)idx, hash);
             } else {
                 auto old_value = it->second;
@@ -933,6 +934,7 @@ public:
             put_fixed64_le(&composite_key, value.get_value());
             uint64_t hash = StringHasher2()(composite_key);
             if (auto [it, inserted] = _set.emplace_with_hash(hash, composite_key); inserted) {
+                old_values[idx] = NullIndexValue;
                 not_found->key_infos.emplace_back((uint32_t)idx, hash);
                 _total_kv_pairs_usage += composite_key.size();
             } else {


### PR DESCRIPTION
We use `_usage_and_size_by_key_length` to record the size and kv cnt in l0, so we can decide how many pages need to create in one shard by `estimate_nshard_and_npage`. But if we upsert kvs in l0 and l1 not exists, then `_usage_and_size_by_key_length` will not change even if these kvs are not in l0, because `old_value` return by `_l0->upsert` isn't `NullIndexValue` but 0.
```
        if (old_values[i].get_value() == NullIndexValue) {
            _size++;
            _usage += keys[i].size + kIndexValueSize;
            add_usage_and_size[keys[i].size].first += keys[i].size + kIndexValueSize;
            add_usage_and_size[keys[i].size].second++;
        }
```
And we only increase `add_usage_and_size` when `old_values` is `NullIndexValue`.

This error log will be shown:
```
E0603 23:01:27.256518 116668 persistent_index.cpp:354] find an empty shard with kvs, key size: 8, kv_num: 100000
```
And it will be slow when creating a shard because it has to try so many times to increase `npage` from 0.
```
StatusOr<std::unique_ptr<ImmutableIndexShard>> ImmutableIndexShard::create(size_t key_size, size_t npage_hint,
                                                                           size_t nbucket,
                                                                           const std::vector<KVRef>& kv_refs) {
    if (kv_refs.size() == 0) {
        return std::make_unique<ImmutableIndexShard>(0);
    }
    for (size_t npage = npage_hint; npage < kPageMax; npage++) {
        auto rs_create = ImmutableIndexShard::try_create(key_size, npage, nbucket, kv_refs);
        // increase npage and retry
        if (!rs_create.ok()) {
            continue;
        }
        return std::move(rs_create.value());
    }
...
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
