### PR TITLE
[Refactor][cherry-pick][branch-3.0] Adjust the auto tablet distribution for exist table (#24543)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -21,6 +21,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.MultiItemListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
@@ -307,6 +308,46 @@ public class CatalogUtils {
             bucketNum = Math.min(backendNum, 48);
         }
         return bucketNum;
-
     }
+
+    public static int calAvgBucketNumOfRecentPartitions(OlapTable olapTable, int recentPartitionNum,
+                                                        boolean enableAutoTabletDistribution) {
+        // 1. If the partition is less than recentPartitionNum, use backendNum to speculate the bucketNum
+        //    Or the Config.enable_auto_tablet_distribution is disabled
+        int bucketNum = 0;
+        if (olapTable.getPartitions().size() < recentPartitionNum || !enableAutoTabletDistribution) {
+            bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
+            return bucketNum;
+        }
+
+        // 2. If the partition is not imported anydata, use backendNum to speculate the bucketNum
+        List<Partition> partitions = (List<Partition>) olapTable.getRecentPartitions(recentPartitionNum);
+        boolean dataImported = true;
+        for (Partition partition : partitions) {
+            if (partition.getVisibleVersion() == 1) {
+                dataImported = false;
+                break;
+            }
+        }
+
+        bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
+        if (!dataImported) {
+            return bucketNum;
+        }
+
+        // 3. Use the totalSize of recentPartitions to speculate the bucketNum
+        long maxDataSize = 0;
+        for (Partition partition : partitions) {
+            maxDataSize = Math.max(maxDataSize, partition.getDataSize());
+        }
+        // A tablet will be regarded using the 1GB size
+        // And also the number will not be larger than the calBucketNumAccordingToBackends()
+        long speculateTabletNum = (maxDataSize + FeConstants.AUTO_DISTRIBUTION_UNIT - 1) / FeConstants.AUTO_DISTRIBUTION_UNIT;
+        bucketNum = (int) Math.min(bucketNum, speculateTabletNum);
+        if (bucketNum == 0) {
+            bucketNum = 1;
+        }
+        return bucketNum;
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DistributionInfo.java
@@ -88,6 +88,10 @@ public abstract class DistributionInfo implements Writable {
         throw new NotImplementedException();
     }
 
+    public DistributionInfo copy() {
+        throw new NotImplementedException();
+    }
+
     @Override
     public void write(DataOutput out) throws IOException {
         Text.writeString(out, type.name());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HashDistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HashDistributionInfo.java
@@ -159,6 +159,11 @@ public class HashDistributionInfo extends DistributionInfo {
     }
 
     @Override
+    public HashDistributionInfo copy() {
+        return new HashDistributionInfo(bucketNum, distributionColumns);
+    }
+
+    @Override
     public String toSql() {
         StringBuilder builder = new StringBuilder();
         builder.append("DISTRIBUTED BY HASH(");
@@ -169,8 +174,10 @@ public class HashDistributionInfo extends DistributionInfo {
         }
         String colList = Joiner.on(", ").join(colNames);
         builder.append(colList);
-
-        builder.append(") BUCKETS ").append(bucketNum).append(" ");
+        builder.append(")");
+        if (bucketNum > 0) {
+            builder.append(" BUCKETS ").append(bucketNum).append(" ");
+        }
         return builder.toString();
     }
 
@@ -185,7 +192,9 @@ public class HashDistributionInfo extends DistributionInfo {
         }
         builder.append("]; ");
 
-        builder.append("bucket num: ").append(bucketNum).append("; ");
+        if (bucketNum > 0) {
+            builder.append("bucket num: ").append(bucketNum).append("; ");
+        }
 
         return builder.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RandomDistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RandomDistributionInfo.java
@@ -77,9 +77,17 @@ public class RandomDistributionInfo extends DistributionInfo {
     }
 
     @Override
+    public RandomDistributionInfo copy() {
+        return new RandomDistributionInfo(bucketNum);
+    }
+
+    @Override
     public String toSql() {
         StringBuilder builder = new StringBuilder();
-        builder.append("DISTRIBUTED BY RANDOM BUCKETS ").append(bucketNum);
+        builder.append("DISTRIBUTED BY RANDOM");
+        if (bucketNum > 0) {
+            builder.append(" BUCKETS ").append(bucketNum);
+        }
         return builder.toString();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -982,44 +982,6 @@ public class LocalMetastore implements ConnectorMetadata {
         }
     }
 
-    private int calAvgBucketNumOfRecentPartitions(OlapTable olapTable, int recentPartitionNum) {
-        // 1. If the partition is less than recentPartitionNum, use backendNum to speculate the bucketNum
-        int bucketNum = 0;
-        if (olapTable.getPartitions().size() < recentPartitionNum) {
-            bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
-            return bucketNum;
-        }
-
-        // 2. If the partition is not imported anydata, use backendNum to speculate the bucketNum
-        List<Partition> partitions = (List<Partition>) olapTable.getRecentPartitions(recentPartitionNum);
-        boolean dataImported = true;
-        for (Partition partition : partitions) {
-            if (partition.getVisibleVersion() == 1) {
-                dataImported = false;
-                break;
-            }
-        }
-
-        bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
-        if (!dataImported) {
-            return bucketNum;
-        }
-
-        // 3. Use the totalSize of recentPartitions to speculate the bucketNum
-        long maxDataSize = 0;
-        for (Partition partition : partitions) {
-            maxDataSize = Math.max(maxDataSize, partition.getDataSize());
-        }
-        // A tablet will be regarded using the 1GB size
-        // And also the number will not be larger than the calBucketNumAccordingToBackends()
-        long speculateTabletNum = (maxDataSize + FeConstants.AUTO_DISTRIBUTION_UNIT - 1) / FeConstants.AUTO_DISTRIBUTION_UNIT;
-        bucketNum = (int) Math.min(bucketNum, speculateTabletNum);
-        if (bucketNum == 0) {
-            bucketNum = 1;
-        }
-        return bucketNum;
-    }
-
     private DistributionInfo getDistributionInfo(OlapTable olapTable, AddPartitionClause addPartitionClause)
             throws DdlException {
         DistributionInfo distributionInfo;
@@ -1048,17 +1010,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 }
             }
         } else {
-            if (defaultDistributionInfo.getType() == DistributionInfo.DistributionInfoType.HASH
-                    && Config.enable_auto_tablet_distribution
-                    && !colocateTableIndex.isColocateTable(olapTable.getId())) {
-                // 1. If enable_auto_tablet_distribution = true, AUTO Tablet Distibution
-                //    also take effect on exist table when adding new partitions
-                // 2. ColocateTable should comply the original tablet num when creating table.
-                HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) defaultDistributionInfo;
-                distributionInfo = new HashDistributionInfo(0, hashDistributionInfo.getDistributionColumns());
-            } else {
-                distributionInfo = defaultDistributionInfo;
-            }
+            distributionInfo = defaultDistributionInfo;
         }
         return distributionInfo;
     }
@@ -1342,10 +1294,10 @@ public class LocalMetastore implements ConnectorMetadata {
             analyzeAddPartition(olapTable, partitionDescs, addPartitionClause, partitionInfo);
 
             // get distributionInfo
-            distributionInfo = getDistributionInfo(olapTable, addPartitionClause);
-
+            distributionInfo = getDistributionInfo(olapTable, addPartitionClause).copy();
             if (distributionInfo.getBucketNum() == 0) {
-                int numBucket = calAvgBucketNumOfRecentPartitions(olapTable, 5);
+                int numBucket = CatalogUtils.calAvgBucketNumOfRecentPartitions(olapTable, 5,
+                                    Config.enable_auto_tablet_distribution);
                 distributionInfo.setBucketNum(numBucket);
             }
 
@@ -1640,7 +1592,11 @@ public class LocalMetastore implements ConnectorMetadata {
             MaterializedIndex rollup = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
             indexMap.put(indexId, rollup);
         }
-        DistributionInfo distributionInfo = table.getDefaultDistributionInfo();
+        DistributionInfo distributionInfo = table.getDefaultDistributionInfo().copy();
+        if (distributionInfo.getBucketNum() == 0) {
+            int numBucket = CatalogUtils.calAvgBucketNumOfRecentPartitions(table, 5, Config.enable_auto_tablet_distribution);
+            distributionInfo.setBucketNum(numBucket);
+        }
 
         // create shard group
         long shardGroupId = 0;
@@ -1980,14 +1936,14 @@ public class LocalMetastore implements ConnectorMetadata {
         return colocateTableIndex;
     }
 
-    private void processColocationProperties(String colocateGroup, Database db, OlapTable olapTable, boolean expectLakeTable)
+    private boolean processColocationProperties(String colocateGroup, Database db, OlapTable olapTable, boolean expectLakeTable)
             throws DdlException {
         if (Strings.isNullOrEmpty(colocateGroup)) {
-            return;
+            return false;
         }
 
         if (olapTable.isCloudNativeTable() != expectLakeTable) {
-            return;
+            return false;
         }
 
         String fullGroupName = db.getId() + "_" + colocateGroup;
@@ -2011,6 +1967,7 @@ public class LocalMetastore implements ConnectorMetadata {
                         new ColocateTableIndex.GroupId(db.getId(), colocateGrpIdInOtherDb.grpId),
                 false /* isReplay */);
         olapTable.setColocateGroup(colocateGroup);
+        return true;
     }
 
     private void setLakeStorageInfo(OlapTable table, Map<String, String> properties) throws DdlException {
@@ -2326,7 +2283,16 @@ public class LocalMetastore implements ConnectorMetadata {
         String colocateGroup = null;
         try {
             colocateGroup = PropertyAnalyzer.analyzeColocate(properties);
-            processColocationProperties(colocateGroup, db, table, false /* expectLakeTable */);
+            boolean addedToColocateGroup = processColocationProperties(colocateGroup, db,
+                                                table, false /* expectLakeTable */);
+            if (table instanceof ExternalOlapTable == false && addedToColocateGroup) {
+                // Colocate table should keep the same bucket number accross the partitions
+                DistributionInfo defaultDistributionInfo = table.getDefaultDistributionInfo();
+                if (defaultDistributionInfo.getBucketNum() == 0) {
+                    int bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
+                    defaultDistributionInfo.setBucketNum(bucketNum);
+                }
+            }
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
         }
@@ -3402,10 +3368,6 @@ public class LocalMetastore implements ConnectorMetadata {
         DistributionDesc distributionDesc = stmt.getDistributionDesc();
         Preconditions.checkNotNull(distributionDesc);
         DistributionInfo distributionInfo = distributionDesc.toDistributionInfo(baseSchema);
-        if (distributionInfo.getBucketNum() == 0) {
-            int numBucket = CatalogUtils.calBucketNumAccordingToBackends();
-            distributionInfo.setBucketNum(numBucket);
-        }
         // create refresh scheme
         MaterializedView.MvRefreshScheme mvRefreshScheme;
         RefreshSchemeDesc refreshSchemeDesc = stmt.getRefreshSchemeDesc();

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
@@ -162,7 +162,7 @@ public class CreateTableAutoTabletTest {
         } finally {
             db.readUnlock();
         }
-        Assert.assertEquals(bucketNum, 20);
+        Assert.assertEquals(bucketNum, 10);
     }
 
     @Test
@@ -212,7 +212,7 @@ public class CreateTableAutoTabletTest {
         } finally {
             db.readUnlock();
         }
-        Assert.assertEquals(bucketNum, 20);
+        Assert.assertEquals(bucketNum, 10);
     }
 
     @Test


### PR DESCRIPTION
1. If the user specifies the bucket number when creating a table, the bucket number will be used for the table creation and the following partitions.

2. If the user doesn't specify the bucket number when creating a table, the bucker number is calculated by the following rules when creating a table.
  ```
  if (backendNum <= 12) {
    bucketNum = 2 * backendNum;
  } else if (backendNum <= 24) {
    bucketNum = (int) (1.5 * backendNum);
  } else if (backendNum <= 36) {
    bucketNum = 36;
  } else {
    bucketNum = Math.min(backendNum, 48);
  }
```

3. If the user doesn't specify the bucket number, the number is speculated when adding partitions.
    ``` bucket_number = max(data size of last five partitions) / 3GB ```

4. If the speculation is not correct, you can disable it by setting
   ```enable_auto_tablet_distribution``` in the fe.conf.
   After that, the bucket number is determined as step 2 when adding partitions.

5. Of course, you can specify the bucket as the last resort when adding partitions.
    ```
    ALTER TABLE site_access ADD PARTITION p4
    VALUES LESS THAN ("2020-04-30") DISTRIBUTED BY HASH(site_id)
    BUCKETS 20;
    ```