### PR TITLE
[Enhancement] change map type constructor to aovid conflicting with json or struct

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -758,14 +758,14 @@ public class AstToStringBuilder {
 
         public String visitMapExpr(MapExpr node, Void context) {
             StringBuilder sb = new StringBuilder();
-            sb.append('{');
+            sb.append("map{");
             for (int i = 0; i < node.getChildren().size(); i = i + 2) {
                 if (i > 0) {
                     sb.append(',');
                 }
                 sb.append(visit(node.getChild(i)) + ":" + visit(node.getChild(i + 1)));
             }
-            sb.append('}');
+            sb.append("}");
             return sb.toString();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MapExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MapExpr.java
@@ -80,14 +80,14 @@ public class MapExpr extends Expr {
     @Override
     protected String toSqlImpl() {
         StringBuilder sb = new StringBuilder();
-        sb.append('{');
+        sb.append("map{");
         for (int i = 0; i < children.size(); i += 2) {
             if (i > 0) {
                 sb.append(",");
             }
             sb.append(children.get(i).toSql() + ":" + children.get(i + 1).toSql());
         }
-        sb.append('}');
+        sb.append("}");
         return sb.toString();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -2033,7 +2033,8 @@ primaryExpression
     | CASE caseExpr=expression whenClause+ (ELSE elseExpression=expression)? END          #simpleCase
     | CASE whenClause+ (ELSE elseExpression=expression)? END                              #searchedCase
     | arrayType? '[' (expressionList)? ']'                                                #arrayConstructor
-    | mapType? '{' (mapExpressionList)? '}'                                               #mapConstructor
+    | mapType '{' (mapExpressionList)? '}'                                                #mapConstructor
+    | MAP '{' (mapExpressionList)? '}'                                                    #mapConstructor
     | value=primaryExpression '[' index=valueExpression ']'                               #collectionSubscript
     | primaryExpression '[' start=INTEGER_VALUE? ':' end=INTEGER_VALUE? ']'               #arraySlice
     | primaryExpression ARROW string                                                      #arrowExpression

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -299,21 +299,21 @@ public class AnalyzeExprTest {
         analyzeSuccess("select map()");
         analyzeSuccess("select map(NULL,NULL)");
         analyzeSuccess("select map(1,NULL)");
-        analyzeSuccess("select {}");
-        analyzeSuccess("select {NULL:NULL}");
-        analyzeSuccess("select map<int,map<varchar,int>>{2:{3:3}}");
-        analyzeSuccess("select map<int,map<int,int>>{2:{'3':3}}");
-        analyzeSuccess("select map<int,map<int,int>>{{3:3}:2}"); // runtime error will report when cast
-        analyzeSuccess("select map<int,map<int,int>>{'2s':{3:3}}");
+        analyzeSuccess("select map{}");
+        analyzeSuccess("select map{NULL:NULL}");
+        analyzeSuccess("select map<int,map<varchar,int>>{2:map{3:3}}");
+        analyzeSuccess("select map<int,map<int,int>>{2:map{'3':3}}");
+        analyzeSuccess("select map<int,map<int,int>>{map{3:3}:2}"); // runtime error will report when cast
+        analyzeSuccess("select map<int,map<int,int>>{'2s':map{3:3}}");
 
         analyzeFail("select map(null)");
         analyzeFail("select map(1:4)");
         analyzeFail("select map(1,3,4)");
         analyzeFail("select {)");
-        analyzeFail("select {NULL}");
-        analyzeFail("select {1,3}");
-        analyzeFail("select {1:3:3}");
-        analyzeFail("select {1:3,}");
+        analyzeFail("select map{NULL}");
+        analyzeFail("select map{1,3}");
+        analyzeFail("select map{1:3:3}");
+        analyzeFail("select map{1:3,}");
         analyzeFail("select map<hll,int>{1:3}");
         analyzeFail("select map<map<int,int>,int>{{1:3}:11}");
     }
@@ -321,19 +321,19 @@ public class AnalyzeExprTest {
 
     @Test
     public void testAnalyzeMapFunc() {
-        analyzeSuccess("select cardinality({1:3,3:5,2:45})");
-        analyzeSuccess("select cardinality({})");
-        analyzeSuccess("select element_at({1:2,3:3,4:3},3)");
-        analyzeSuccess("select element_at({1:2,3:3,4:3},312)");
-        analyzeSuccess("select element_at({1:2,3:3,4:3},null)");
+        analyzeSuccess("select cardinality(map{1:3,3:5,2:45})");
+        analyzeSuccess("select cardinality(map{})");
+        analyzeSuccess("select element_at(map{1:2,3:3,4:3},3)");
+        analyzeSuccess("select element_at(map{1:2,3:3,4:3},312)");
+        analyzeSuccess("select element_at(map{1:2,3:3,4:3},null)");
         analyzeSuccess("select map_concat(NULL)");
         analyzeSuccess("select map_concat(NULL,NULL)");
-        analyzeSuccess("select map_concat(NULL,{})");
+        analyzeSuccess("select map_concat(NULL,map{})");
 
         analyzeFail("select cardinality();");
-        analyzeFail("select cardinality({},{})");
+        analyzeFail("select cardinality(map{},map{})");
         analyzeFail("select cardinality(1)");
-        analyzeFail("select element_at({1:2,3:3,4:3})");
+        analyzeFail("select element_at(map{1:2,3:3,4:3})");
         analyzeFail("select map_concat()");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1473,7 +1473,7 @@ public class ExpressionTest extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         assertCContains(plan, "struct<col1 varchar, col2 tinyint(4), col3 tinyint(4), col4 smallint(6)>");
 
-        sql = "select row('a', 1, 2, 10000, [1, 2, 3], NULL, {'a': 1, 'b': 2})";
+        sql = "select row('a', 1, 2, 10000, [1, 2, 3], NULL, map{'a': 1, 'b': 2})";
         plan = getVerboseExplain(sql);
         assertCContains(plan, "struct<col1 varchar, col2 tinyint(4), col3 tinyint(4), col4 smallint(6), " +
                 "col5 array<tinyint(4)>, col6 boolean, col7 map<varchar,tinyint(4)>>");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -759,13 +759,13 @@ public class InsertPlanTest extends PlanTestBase {
         explainString = getInsertExecPlan("insert into tmap values (2,2,map(2,2))");
         Assert.assertTrue(explainString.contains("2 | 2 | {2:'2'}")); // implicit cast
 
-        explainString = getInsertExecPlan("insert into tmap values (2,2,{})");
+        explainString = getInsertExecPlan("insert into tmap values (2,2,map{})");
         Assert.assertTrue(explainString.contains("2 | 2 | {}"));
 
-        explainString = getInsertExecPlan("insert into tmap values (2,2,{2:3, 2:4})");
+        explainString = getInsertExecPlan("insert into tmap values (2,2,map{2:3, 2:4})");
         Assert.assertTrue(explainString.contains("2 | 2 | {2:'3',2:'4'}")); // will distinct in BE
 
-        explainString = getInsertExecPlan("insert into tmap values (2,2,{2:2})");
+        explainString = getInsertExecPlan("insert into tmap values (2,2,map{2:2})");
         Assert.assertTrue(explainString.contains("2 | 2 | {2:'2'}")); // implicit cast
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -751,22 +751,22 @@ public class InsertPlanTest extends PlanTestBase {
     @Test
     public void testInsertMapColumn() throws Exception {
         String explainString = getInsertExecPlan("insert into tmap values (2,2,map())");
-        Assert.assertTrue(explainString.contains("2 | 2 | {}"));
+        Assert.assertTrue(explainString.contains("2 | 2 | map{}"));
 
         explainString = getInsertExecPlan("insert into tmap values (2,2,null)");
         Assert.assertTrue(explainString.contains("2 | 2 | NULL"));
 
         explainString = getInsertExecPlan("insert into tmap values (2,2,map(2,2))");
-        Assert.assertTrue(explainString.contains("2 | 2 | {2:'2'}")); // implicit cast
+        Assert.assertTrue(explainString.contains("2 | 2 | map{2:'2'}")); // implicit cast
 
         explainString = getInsertExecPlan("insert into tmap values (2,2,map{})");
-        Assert.assertTrue(explainString.contains("2 | 2 | {}"));
+        Assert.assertTrue(explainString.contains("2 | 2 | map{}"));
 
         explainString = getInsertExecPlan("insert into tmap values (2,2,map{2:3, 2:4})");
-        Assert.assertTrue(explainString.contains("2 | 2 | {2:'3',2:'4'}")); // will distinct in BE
+        Assert.assertTrue(explainString.contains("2 | 2 | map{2:'3',2:'4'}")); // will distinct in BE
 
         explainString = getInsertExecPlan("insert into tmap values (2,2,map{2:2})");
-        Assert.assertTrue(explainString.contains("2 | 2 | {2:'2'}")); // implicit cast
+        Assert.assertTrue(explainString.contains("2 | 2 | map{2:'2'}")); // implicit cast
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MapTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MapTypeTest.java
@@ -35,7 +35,7 @@ public class MapTypeTest extends PlanTestBase {
 
     @Test
     public void testMapFunc() throws Exception { // get super common return type
-        String sql = "select map_concat({16865432442:3},{3.323777777:'3'})";
+        String sql = "select map_concat(map{16865432442:3},map{3.323777777:'3'})";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "MAP<DECIMAL128(28,9),VARCHAR>");
     }

--- a/test/sql/test_function/R/test_conditional_fn
+++ b/test/sql/test_function/R/test_conditional_fn
@@ -5,13 +5,13 @@ CREATE TABLE `tc` (   `i` int(11) NULL COMMENT "",   `ai` array<int(11)> NULL CO
 insert into tc values (4, null,null, null,null);
 -- result:
 -- !result
-insert into tc values (3, null,['a','b'], null,{1:null,null:null});
+insert into tc values (3, null,['a','b'], null,map{1:null,null:null});
 -- result:
 -- !result
-insert into tc values (1, [1,2],null, {1:1,null:2},null);
+insert into tc values (1, [1,2],null, map{1:1,null:2},null);
 -- result:
 -- !result
-insert into tc values (2, [1,2],['a','b'], {1:1,null:2},{1:'b',null:null});
+insert into tc values (2, [1,2],['a','b'], map{1:1,null:2},map{1:'b',null:null});
 -- result:
 -- !result
 select case i when 1 then ai when 3 then ass else ai end from tc order by i;

--- a/test/sql/test_function/T/test_conditional_fn
+++ b/test/sql/test_function/T/test_conditional_fn
@@ -3,9 +3,9 @@
 CREATE TABLE `tc` (   `i` int(11) NULL COMMENT "",   `ai` array<int(11)> NULL COMMENT "",   `ass` array<varchar(100)> NULL COMMENT "",   `mi` map<int(11),int> NULL COMMENT "",   `ms` map<int(11),varchar(100)> NULL COMMENT "" ) ENGINE=OLAP DUPLICATE KEY(`i`) COMMENT "OLAP" DISTRIBUTED BY HASH(`i`) BUCKETS 2 PROPERTIES ( "replication_num" = "1" );
 
 insert into tc values (4, null,null, null,null);
-insert into tc values (3, null,['a','b'], null,{1:null,null:null});
-insert into tc values (1, [1,2],null, {1:1,null:2},null);
-insert into tc values (2, [1,2],['a','b'], {1:1,null:2},{1:'b',null:null});
+insert into tc values (3, null,['a','b'], null,map{1:null,null:null});
+insert into tc values (1, [1,2],null, map{1:1,null:2},null);
+insert into tc values (2, [1,2],['a','b'], map{1:1,null:2},map{1:'b',null:null});
 
 
 select case i when 1 then ai when 3 then ass else ai end from tc order by i;

--- a/test/sql/test_semi/R/test_struct
+++ b/test/sql/test_semi/R/test_struct
@@ -49,28 +49,28 @@ insert into t1 values (4, 4, 4);
 insert into t1 values (5, 5, 5);
 -- result:
 -- !result
-insert into sc2 values (1, {1: {10:{100: 101}}}, row(1, {10: 101}, {10: {100: 101}}), row(1, [1,10,101], row(1, row(10, 11))));
+insert into sc2 values (1, map{1: map{10:map{100: 101}}}, row(1, map{10: 101}, map{10: map{100: 101}}), row(1, [1,10,101], row(1, row(10, 11))));
 -- result:
 -- !result
-insert into sc2 values (2, {2: {20:{200: 202}}}, row(2, {20: 202}, {20: {200: 202}}), row(2, [2,20,202], row(2, row(20, 22))));
+insert into sc2 values (2, map{2: map{20:map{200: 202}}}, row(2, map{20: 202}, map{20: map{200: 202}}), row(2, [2,20,202], row(2, row(20, 22))));
 -- result:
 -- !result
-insert into sc2 values (3, {3: {30:{300: 303}}}, row(3, {30: 303}, {30: {300: 303}}), row(3, [3,30,303], row(3, row(30, 33))));
+insert into sc2 values (3, map{3: map{30:map{300: 303}}}, row(3, map{30: 303}, map{30: map{300: 303}}), row(3, [3,30,303], row(3, row(30, 33))));
 -- result:
 -- !result
-insert into sc2 values (4, {4: {40:{400: 404}}}, row(4, {40: 404}, {40: {400: 404}}), row(4, [4,40,404], row(4, row(40, 44))));
+insert into sc2 values (4, map{4: map{40:map{400: 404}}}, row(4, map{40: 404}, map{40: map{400: 404}}), row(4, [4,40,404], row(4, row(40, 44))));
 -- result:
 -- !result
-insert into sc2 values (5, {5: {50:{500: 505}}}, row(5, {50: 505}, {50: {500: 505}}), row(5, [5,50,505], row(5, row(50, 55))));
+insert into sc2 values (5, map{5: map{50:map{500: 505}}}, row(5, map{50: 505}, map{50: map{500: 505}}), row(5, [5,50,505], row(5, row(50, 55))));
 -- result:
 -- !result
-insert into sc2 values (5, {5: {50:{500: 506}}}, row(5, {50: 506}, {50: {500: 506}}), row(5, [5,50,506], row(5, row(50, 56))));
+insert into sc2 values (5, map{5: map{50:map{500: 506}}}, row(5, map{50: 506}, map{50: map{500: 506}}), row(5, [5,50,506], row(5, row(50, 56))));
 -- result:
 -- !result
-insert into sc2 values (5, {5: {50:{500: 507}}}, row(5, {50: 507}, {50: {500: 507}}), row(5, [5,50,507], row(5, row(50, 57))));
+insert into sc2 values (5, map{5: map{50:map{500: 507}}}, row(5, map{50: 507}, map{50: map{500: 507}}), row(5, [5,50,507], row(5, row(50, 57))));
 -- result:
 -- !result
-insert into sc2 values (5, {5: {50:{500: 508}}}, row(5, {50: 508}, {50: {500: 508}}), row(5, [5,50,508], row(5, row(50, 58))));
+insert into sc2 values (5, map{5: map{50:map{500: 508}}}, row(5, map{50: 508}, map{50: map{500: 508}}), row(5, [5,50,508], row(5, row(50, 58))));
 -- result:
 -- !result
 select st1.s1, st2.sa2 from sc2;

--- a/test/sql/test_semi/T/test_struct
+++ b/test/sql/test_semi/T/test_struct
@@ -40,14 +40,14 @@ insert into t1 values (3, 3, 3);
 insert into t1 values (4, 4, 4);
 insert into t1 values (5, 5, 5);
 
-insert into sc2 values (1, {1: {10:{100: 101}}}, row(1, {10: 101}, {10: {100: 101}}), row(1, [1,10,101], row(1, row(10, 11))));
-insert into sc2 values (2, {2: {20:{200: 202}}}, row(2, {20: 202}, {20: {200: 202}}), row(2, [2,20,202], row(2, row(20, 22))));
-insert into sc2 values (3, {3: {30:{300: 303}}}, row(3, {30: 303}, {30: {300: 303}}), row(3, [3,30,303], row(3, row(30, 33))));
-insert into sc2 values (4, {4: {40:{400: 404}}}, row(4, {40: 404}, {40: {400: 404}}), row(4, [4,40,404], row(4, row(40, 44))));
-insert into sc2 values (5, {5: {50:{500: 505}}}, row(5, {50: 505}, {50: {500: 505}}), row(5, [5,50,505], row(5, row(50, 55))));
-insert into sc2 values (5, {5: {50:{500: 506}}}, row(5, {50: 506}, {50: {500: 506}}), row(5, [5,50,506], row(5, row(50, 56))));
-insert into sc2 values (5, {5: {50:{500: 507}}}, row(5, {50: 507}, {50: {500: 507}}), row(5, [5,50,507], row(5, row(50, 57))));
-insert into sc2 values (5, {5: {50:{500: 508}}}, row(5, {50: 508}, {50: {500: 508}}), row(5, [5,50,508], row(5, row(50, 58))));
+insert into sc2 values (1, map{1: map{10:map{100: 101}}}, row(1, map{10: 101}, map{10: map{100: 101}}), row(1, [1,10,101], row(1, row(10, 11))));
+insert into sc2 values (2, map{2: map{20:map{200: 202}}}, row(2, map{20: 202}, map{20: map{200: 202}}), row(2, [2,20,202], row(2, row(20, 22))));
+insert into sc2 values (3, map{3: map{30:map{300: 303}}}, row(3, map{30: 303}, map{30: map{300: 303}}), row(3, [3,30,303], row(3, row(30, 33))));
+insert into sc2 values (4, map{4: map{40:map{400: 404}}}, row(4, map{40: 404}, map{40: map{400: 404}}), row(4, [4,40,404], row(4, row(40, 44))));
+insert into sc2 values (5, map{5: map{50:map{500: 505}}}, row(5, map{50: 505}, map{50: map{500: 505}}), row(5, [5,50,505], row(5, row(50, 55))));
+insert into sc2 values (5, map{5: map{50:map{500: 506}}}, row(5, map{50: 506}, map{50: map{500: 506}}), row(5, [5,50,506], row(5, row(50, 56))));
+insert into sc2 values (5, map{5: map{50:map{500: 507}}}, row(5, map{50: 507}, map{50: map{500: 507}}), row(5, [5,50,507], row(5, row(50, 57))));
+insert into sc2 values (5, map{5: map{50:map{500: 508}}}, row(5, map{50: 508}, map{50: map{500: 508}}), row(5, [5,50,508], row(5, row(50, 58))));
 
 
 select st1.s1, st2.sa2 from sc2;


### PR DESCRIPTION
Fixes #issue
change may type's constructor to aovid conflicting with json or struct
```
select map{1:1, 2:2, 3:3} as numbers;
select map(1,1,2,2,3,3) as numbers; -- The result is {1:1,2:2,3:3}

select map{true:map{3.13:"abc"}, false:map{}} as nest;
select map(true, map(3.13, "abc"), false, map{}) as nest; -- The result is {1:{3.13:"abc"},0:{}}
```
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
