### PR TITLE
[Enhancement] Add property prefix in Iceberg rest catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -43,7 +43,7 @@ public class IcebergConnector implements Connector {
     @Deprecated
     public static final String ICEBERG_METASTORE_URIS = "iceberg.catalog.hive.metastore.uris";
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
-
+    public static final String ICEBERG_REST_CATALOG_PREFIX = "iceberg.rest-catalog.";
     private final Map<String, String> properties;
     private final CloudConfiguration cloudConfiguration;
     private final HdfsEnvironment hdfsEnvironment;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
+import static com.starrocks.connector.iceberg.IcebergConnector.ICEBERG_REST_CATALOG_PREFIX;
 
 public class IcebergRESTCatalog implements IcebergCatalog {
 
@@ -59,6 +60,15 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     public IcebergRESTCatalog(String name, Configuration conf, Map<String, String> properties) {
         this.conf = conf;
         Map<String, String> copiedProperties = Maps.newHashMap(properties);
+
+        properties.forEach((key, value) -> {
+            String newKey = key.toLowerCase();
+            String newValue = value.toLowerCase();
+            if (newKey.startsWith(ICEBERG_REST_CATALOG_PREFIX)) {
+                newKey = newKey.substring(ICEBERG_REST_CATALOG_PREFIX.length());
+                copiedProperties.put(newKey, newValue);
+            }
+        });
 
         copiedProperties.put(CatalogProperties.FILE_IO_IMPL, IcebergCachingFileIO.class.getName());
         copiedProperties.put(CatalogProperties.METRICS_REPORTER_IMPL, IcebergMetricsReporter.class.getName());


### PR DESCRIPTION
We add some properties' prefix `iceberg.rest-catalog.` for iceberg rest catalog.

Now we can create tabular in below way:
```sql
create external catalog tabular properties (
	"type"="iceberg",
	"iceberg.catalog.type"="rest",
	"iceberg.rest-catalog.uri"="https://api.tabular.io/ws",
	"iceberg.rest-catalog.credential"="t-5Ii8e32E-D5tT9m0",
	"iceberg.rest-catalog.warehouse"="chenao",
	"aws.s3.region"="us-west-2",
	"aws.s3.access_key"="AKIST",
	"aws.s3.secret_key"="LJUcvytmacTuf+"
);
```

Of course we will compatible with original way:
```sql
create external catalog tabular properties (
	"type"="iceberg",
	"iceberg.catalog.type"="rest",
	"uri"="https://api.tabular.io/ws",
	"credential"="t-5Ii8e32E-D5tT9m0",
	"warehouse"="chenao",
	"aws.s3.region"="us-west-2",
	"aws.s3.access_key"="AKIST",
	"aws.s3.secret_key"="LJUcvytmacTuf+"
);
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
