### PR TITLE
[Enhancement]Support  last offset of kafka partition in routine load task

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -309,7 +309,8 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         KafkaTaskInfo oldKafkaTaskInfo = (KafkaTaskInfo) routineLoadTaskInfo;
         // add new task
         KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(timeToExecuteMs, oldKafkaTaskInfo,
-                ((KafkaProgress) progress).getPartitionIdToOffset(oldKafkaTaskInfo.getPartitions()));
+                ((KafkaProgress) progress).getPartitionIdToOffset(oldKafkaTaskInfo.getPartitions()),
+                ((KafkaTaskInfo) routineLoadTaskInfo).getLatestOffset());
         // remove old task
         routineLoadTaskInfoList.remove(routineLoadTaskInfo);
         // add new task

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -196,7 +196,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
 
         Gson gson = new Gson();
         result.append("Progress:").append(gson.toJson(partitionIdToOffset));
-        result.append(" ");
+        result.append(",");
         result.append("LatestOffset:").append(gson.toJson(latestPartOffset));
         return result.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -77,6 +77,11 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         this.partitionIdToOffset = partitionIdToOffset;
     }
 
+    public KafkaTaskInfo(long timeToExecuteMs, KafkaTaskInfo kafkaTaskInfo, Map<Integer, Long> partitionIdToOffset,
+                         Map<Integer, Long> latestPartOffset) {
+        this(timeToExecuteMs, kafkaTaskInfo, partitionIdToOffset);
+    }
+
     public KafkaTaskInfo(long timeToExecuteMs, KafkaTaskInfo kafkaTaskInfo, Map<Integer, Long> partitionIdToOffset) {
         super(UUID.randomUUID(), kafkaTaskInfo.getJobId(),
                 kafkaTaskInfo.getTaskScheduleIntervalMs(), timeToExecuteMs, kafkaTaskInfo.getBeId());
@@ -187,8 +192,17 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
 
     @Override
     protected String getTaskDataSourceProperties() {
+        StringBuilder result = new StringBuilder();
+
         Gson gson = new Gson();
-        return gson.toJson(partitionIdToOffset);
+        result.append("Progress:").append(gson.toJson(partitionIdToOffset));
+        result.append(" ");
+        result.append("LatestOffset:").append(gson.toJson(latestPartOffset));
+        return result.toString();
+    }
+
+    public Map<Integer, Long> getLatestOffset() {
+        return latestPartOffset;
     }
 
     private TExecPlanFragmentParams plan(RoutineLoadJob routineLoadJob) throws UserException {


### PR DESCRIPTION
Add the latest offset of the Kafka partition in the routine load task to observe the lag between Kafka and starrocks

![image](https://github.com/StarRocks/starrocks/assets/13373748/55058787-f3db-48f7-971c-b14eff2b22ab)

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
