### PR TITLE
[BugFix] array_length() crash when input const columns

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -29,7 +29,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_length([[maybe_unused]] FunctionContex
     DCHECK_EQ(1, columns.size());
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
-    Column* arg0 = columns[0].get();
+    Column* arg0 = ColumnHelper::unpack_and_duplicate_const_column(columns[0]->size(), columns[0]).get();
     const size_t num_rows = arg0->size();
 
     auto* col_array = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(arg0));

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -244,11 +244,22 @@ TEST_F(ArrayFunctionsTest, array_length) {
 
     // [] only null
     {
-        auto c = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, true, true, 1);
+        auto c = ColumnHelper::create_column(TYPE_ARRAY_ARRAY_INT, true, true, 10);
 
         auto result = ArrayFunctions::array_length(nullptr, {c}).value();
-        EXPECT_EQ(1, result->size());
+        EXPECT_EQ(10, result->size());
         EXPECT_TRUE(result->is_null(0));
+    }
+
+    // [] only const
+    {
+        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_VARCHAR, true);
+        src_column->append_datum(DatumArray{"5", "5", "33", "666"});
+        src_column = std::make_shared<ConstColumn>(src_column, 3);
+
+        auto result = ArrayFunctions::array_length(nullptr, {src_column}).value();
+        EXPECT_EQ(3, result->size());
+        EXPECT_EQ(4, result->get(1).get_int32());
     }
 }
 


### PR DESCRIPTION
Fixes #issue
follow #24586 to fix bugs when array functions has const inputs.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check: (already cp with #24586)
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
