### PR TITLE
[BugFix] split chunk in SchemaScanChunkSource

### DIFF
--- a/be/src/exec/pipeline/scan/olap_schema_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_schema_chunk_source.h
@@ -20,6 +20,7 @@
 #include "exec/pipeline/scan/olap_schema_scan_context.h"
 #include "exec/pipeline/scan/scan_operator.h"
 #include "runtime/runtime_state.h"
+#include "storage/chunk_helper.h"
 
 namespace starrocks {
 class SchemaScannerParam;
@@ -54,6 +55,8 @@ private:
     // So a mapping relationship between the slot list of schema_scanner and the tuple slot list is needed
     // (it can be understood as the relationship between input slots and output slots of schema_scan)
     std::vector<int> _index_map;
+
+    ChunkAccumulator _accumulator;
 };
 } // namespace pipeline
 } // namespace starrocks


### PR DESCRIPTION
Fixes #issue

`OlapSchemaScanChunkSource` may return a chunk whose size larger than 4096, and breaks constraints of chunk size.

So we apply a `ChunkAccumulator` before returning the chunk, to split large chunks.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
