### PR TITLE
[Enhancement] mv rewrite support time_slice

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -184,7 +184,8 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 "time_slice(`dt`, INTERVAL 5 minute) AS `ts`\n" +
                 "FROM `test_partition_expr_tbl1`\n" +
                 "WHERE `dt` >= '2023-04-10 17:00:00' and `dt` < '2023-04-10 18:00:00'\n" +
-                "group by ts").nonMatch("test_partition_expr_mv1");
+                "group by ts")
+                .match("test_partition_expr_mv1");
         starRocksAssert.dropMaterializedView("test_partition_expr_mv1");
     }
 


### PR DESCRIPTION
mv:    SELECT time_slice(dt, INTERVAL 5 MINUTE) as t FROM table
query: SELECT time_slice(dt, INTERVAL 5 MINUTE) FROM table WHERE dt > '2023-06-01'

default can replace time_slice(dt, INTERVAL 5 MINUTE)  => t
if '2023-06-01'=time_slice('2023-06-01', INTERVAL 5 MINUTE), can replace predicate dt => t

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
