### PR TITLE
[Enhancement] Make l0 snapshot size configurable

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -922,6 +922,8 @@ CONF_String(block_cache_engine, "starcache");
 CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
 CONF_mInt64(l0_max_mem_usage, "67108864");  // 64MB
+// if l0_mem_size exceeds this value, l0 need snapshot
+CONF_mInt64(l0_snapshot_size, "16777216");  // 16MB
 CONF_mInt64(max_tmp_l1_num, "10");
 CONF_mBool(enable_parallel_get_and_bf, "true");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -923,7 +923,7 @@ CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
 CONF_mInt64(l0_max_mem_usage, "67108864");  // 64MB
 // if l0_mem_size exceeds this value, l0 need snapshot
-CONF_mInt64(l0_snapshot_size, "16777216");  // 16MB
+CONF_mInt64(l0_snapshot_size, "16777216"); // 16MB
 CONF_mInt64(max_tmp_l1_num, "10");
 CONF_mBool(enable_parallel_get_and_bf, "true");
 

--- a/be/test/exec/sorting_test.cpp
+++ b/be/test/exec/sorting_test.cpp
@@ -392,10 +392,6 @@ TEST(SortingTest, merge_sorted_stream) {
 static void test_merge_path(const size_t num_cols, const size_t left_start, const size_t left_num_rows,
                             const size_t right_start, const size_t right_num_rows, const size_t dest_num_rows,
                             const size_t processor_num, bool& success) {
-    fmt::print(
-            "test_merge_path: num_cols={}, left_start={}, left_num_rows={}, right_start={}, right_num_rows={}, "
-            "dest_num_rows={}, processor_num={}\n",
-            num_cols, left_start, left_num_rows, right_start, right_num_rows, dest_num_rows, processor_num);
     ASSERT_LE(dest_num_rows, (left_num_rows - left_start) + (right_num_rows - right_start));
     auto runtime_state = create_runtime_state();
     TypeDescriptor type_desc = TypeDescriptor(TYPE_INT);

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -50,6 +50,7 @@ int main(int argc, char** argv) {
     CHECK(butil::CreateNewTempDirectory("tmp_ut_", &storage_root));
     starrocks::config::storage_root_path = storage_root.value();
     starrocks::config::enable_event_based_compaction_framework = false;
+    starrocks::config::l0_snapshot_size = 1048576;
 
     starrocks::init_glog("be_test", true);
     starrocks::CpuInfo::init();


### PR DESCRIPTION
Fixes #issue

Make l0 snapshot size configurable.

In a scenario with a large number of tablets, such as a scenario where there are many wide tables and many tablets, one tablet is relatively large, but the PrimaryIndex is around 10M, which cannot trigger the flush l1 condition, resulting in a large memory usage.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
