### PR TITLE
[Enhancement] Make repair for bad tablet start ASAP

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -248,7 +248,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
             relocateAndBalancePerGroup();
             relocateAndBalanceAllGroups();
         }
-        matchGroup();
+        matchGroups();
     }
 
     /*
@@ -683,162 +683,210 @@ public class ColocateTableBalancer extends FrontendDaemon {
         return hasBad && st == TabletStatus.COLOCATE_REDUNDANT;
     }
 
+    private long doMatchOneGroup(GroupId groupId,
+                                 boolean isUrgent,
+                                 GlobalStateMgr globalStateMgr,
+                                 ColocateTableIndex colocateIndex,
+                                 TabletScheduler tabletScheduler) {
+        long checkStartTime = System.currentTimeMillis();
+        long lockTotalTime = 0;
+        List<Long> tableIds = colocateIndex.getAllTableIds(groupId);
+        Database db = globalStateMgr.getDbIncludeRecycleBin(groupId.dbId);
+        if (db == null) {
+            return lockTotalTime;
+        }
+
+        List<Set<Long>> backendBucketsSeq = colocateIndex.getBackendsPerBucketSeqSet(groupId);
+        if (backendBucketsSeq.isEmpty()) {
+            return lockTotalTime;
+        }
+
+        boolean isGroupStable = true;
+        // set the config to a local variable to avoid config params changed.
+        int partitionBatchNum = Config.tablet_checker_partition_batch_num;
+        int partitionChecked = 0;
+        db.readLock();
+        long lockStart = System.nanoTime();
+        try {
+            TABLE:
+            for (Long tableId : tableIds) {
+                OlapTable olapTable = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(db, tableId);
+                if (olapTable == null || !colocateIndex.isColocateTable(olapTable.getId())) {
+                    continue;
+                }
+
+                if ((isUrgent && !globalStateMgr.getTabletChecker().isUrgentTable(db.getId(), tableId)) ||
+                        (!isUrgent && globalStateMgr.getTabletChecker().isUrgentTable(db.getId(), tableId))) {
+                    continue;
+                }
+
+                for (Partition partition : globalStateMgr.getPartitionsIncludeRecycleBin(olapTable)) {
+                    partitionChecked++;
+                    if (partitionChecked % partitionBatchNum == 0) {
+                        lockTotalTime += System.nanoTime() - lockStart;
+                        // release lock, so that lock can be acquired by other threads.
+                        db.readUnlock();
+                        db.readLock();
+                        lockStart = System.nanoTime();
+                        if (globalStateMgr.getDbIncludeRecycleBin(groupId.dbId) == null) {
+                            return lockTotalTime;
+                        }
+                        if (globalStateMgr.getTableIncludeRecycleBin(db, olapTable.getId()) == null) {
+                            continue TABLE;
+                        }
+                        if (globalStateMgr.getPartitionIncludeRecycleBin(olapTable, partition.getId()) == null) {
+                            continue;
+                        }
+                    }
+                    short replicationNum =
+                            globalStateMgr.getReplicationNumIncludeRecycleBin(olapTable.getPartitionInfo(),
+                                    partition.getId());
+                    if (replicationNum == (short) -1) {
+                        continue;
+                    }
+
+                    boolean isPartitionUrgent =
+                            globalStateMgr.getTabletChecker().isPartitionUrgent(db.getId(), tableId, partition.getId());
+                    boolean isUrgentPartitionHealthy = true;
+                    if ((isUrgent && !isPartitionUrgent) || (!isUrgent && isPartitionUrgent)) {
+                        continue;
+                    }
+
+                    long visibleVersion = partition.getVisibleVersion();
+                    // Here we only get VISIBLE indexes. All other indexes are not queryable.
+                    // So it does not matter if tablets of other indexes are not matched.
+                    for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                        Preconditions.checkState(backendBucketsSeq.size() == index.getTablets().size(),
+                                backendBucketsSeq.size() + " v.s. " + index.getTablets().size());
+                        int idx = 0;
+                        for (Long tabletId : index.getTabletIdsInOrder()) {
+                            LocalTablet tablet = (LocalTablet) index.getTablet(tabletId);
+                            Set<Long> bucketsSeq = backendBucketsSeq.get(idx);
+                            // Tablet has already been scheduled, no need to schedule again
+                            if (!tabletScheduler.containsTablet(tablet.getId())) {
+                                Preconditions.checkState(bucketsSeq.size() == replicationNum,
+                                        bucketsSeq.size() + " vs. " + replicationNum);
+                                TabletStatus st = tablet.getColocateHealthStatus(visibleVersion,
+                                        replicationNum, bucketsSeq);
+                                if (st != TabletStatus.HEALTHY) {
+                                    isGroupStable = false;
+                                    Priority colocateUnhealthyPrio = Priority.HIGH;
+                                    if (isPartitionUrgent) {
+                                        colocateUnhealthyPrio = Priority.VERY_HIGH;
+                                        isUrgentPartitionHealthy = false;
+                                    }
+
+                                    // We should also check if the tablet is ready to be repaired like
+                                    // `TabletChecker` did. Slightly delay the repair action can avoid unnecessary
+                                    // clone in situation like temporarily restart BE Nodes.
+                                    if (tablet.readyToBeRepaired(st, colocateUnhealthyPrio)) {
+                                        LOG.debug("get unhealthy tablet {} in colocate table. status: {}",
+                                                tablet.getId(), st);
+                                        TabletSchedCtx tabletCtx = new TabletSchedCtx(
+                                                TabletSchedCtx.Type.REPAIR,
+                                                db.getId(), tableId, partition.getId(), index.getId(),
+                                                tablet.getId(),
+                                                System.currentTimeMillis());
+                                        // the tablet status will be checked and set again when being scheduled
+                                        tabletCtx.setTabletStatus(st);
+                                        // using HIGH priority, because we want to stabilize the colocate group
+                                        // as soon as possible
+                                        tabletCtx.setOrigPriority(colocateUnhealthyPrio);
+                                        tabletCtx.setTabletOrderIdx(idx);
+                                        tabletCtx.setColocateGroupId(groupId);
+                                        tabletCtx.setTablet(tablet);
+                                        ColocateRelocationInfo info = group2ColocateRelocationInfo.get(groupId);
+                                        tabletCtx.setRelocationForRepair(info != null
+                                                && info.getRelocationForRepair()
+                                                && st == TabletStatus.COLOCATE_MISMATCH);
+
+                                        // For bad replica, we ignore the size limit of scheduler queue
+                                        AddResult res = tabletScheduler.addTablet(tabletCtx,
+                                                needToForceRepair(st, tablet,
+                                                        bucketsSeq) || isPartitionUrgent /* forcefully add or not */);
+                                        if (res == AddResult.LIMIT_EXCEED) {
+                                            // tablet in scheduler exceed limit, skip this group and check next one.
+                                            LOG.info("number of scheduling tablets in tablet scheduler"
+                                                    + " exceed to limit. stop colocate table check");
+                                            break TABLE;
+                                        }
+                                        if (res == AddResult.ADDED && tabletCtx.getRelocationForRepair()) {
+                                            LOG.info("add tablet relocation task to scheduler, tablet id: {}, " +
+                                                            "bucket sequence before: {}, bucket sequence now: {}",
+                                                    tableId,
+                                                    info != null ? info.getLastBackendsPerBucketSeq().get(idx) :
+                                                            Lists.newArrayList(),
+                                                    bucketsSeq);
+                                        }
+                                    }
+                                } else {
+                                    tablet.setLastStatusCheckTime(checkStartTime);
+                                }
+                            } else {
+                                // tablet maybe added to scheduler because of balance between local disks,
+                                // in this case we shouldn't mark the group unstable
+                                if (tablet.getColocateHealthStatus(visibleVersion, replicationNum, bucketsSeq)
+                                        != TabletStatus.HEALTHY) {
+                                    isGroupStable = false;
+                                }
+                            }
+                            idx++;
+                        } // end for tablets
+                    } // end for materialize indexes
+
+                    if (isUrgentPartitionHealthy && isPartitionUrgent) {
+                        globalStateMgr.getTabletChecker().removeFromUrgentTable(
+                                new TabletChecker.RepairTabletInfo(db.getId(), tableId,
+                                        Lists.newArrayList(partition.getId())));
+                    }
+                } // end for partitions
+            } // end for tables
+
+            // mark group as stable or unstable
+            if (isGroupStable) {
+                colocateIndex.markGroupStable(groupId, true);
+            } else {
+                colocateIndex.markGroupUnstable(groupId, true);
+            }
+        } finally {
+            lockTotalTime += System.nanoTime() - lockStart;
+            db.readUnlock();
+        }
+
+        return lockTotalTime;
+    }
+
+    private long matchOneGroupUrgent(GroupId groupId,
+                                     GlobalStateMgr globalStateMgr,
+                                     ColocateTableIndex colocateIndex,
+                                     TabletScheduler tabletScheduler) {
+        return doMatchOneGroup(groupId, true, globalStateMgr, colocateIndex, tabletScheduler);
+    }
+
+    private long matchOneGroupNonUrgent(GroupId groupId,
+                                        GlobalStateMgr globalStateMgr,
+                                        ColocateTableIndex colocateIndex,
+                                        TabletScheduler tabletScheduler) {
+        return doMatchOneGroup(groupId, false, globalStateMgr, colocateIndex, tabletScheduler);
+    }
+
     /*
      * Check every tablet of a group, if replica's location does not match backends in group, relocating those
      * replicas, and mark that group as unstable.
      * If every replicas match the backends in group, mark that group as stable.
      */
-    private void matchGroup() {
+    private void matchGroups() {
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         ColocateTableIndex colocateIndex = globalStateMgr.getColocateTableIndex();
         TabletScheduler tabletScheduler = globalStateMgr.getTabletScheduler();
-        long checkStartTime = System.currentTimeMillis();
 
         long start = System.nanoTime();
         long lockTotalTime = 0;
-        long lockStart;
         // check each group
         Set<GroupId> groupIds = colocateIndex.getAllGroupIds();
-        GROUP:
         for (GroupId groupId : groupIds) {
-            List<Long> tableIds = colocateIndex.getAllTableIds(groupId);
-            Database db = globalStateMgr.getDbIncludeRecycleBin(groupId.dbId);
-            if (db == null) {
-                continue;
-            }
-
-            List<Set<Long>> backendBucketsSeq = colocateIndex.getBackendsPerBucketSeqSet(groupId);
-            if (backendBucketsSeq.isEmpty()) {
-                continue;
-            }
-
-            boolean isGroupStable = true;
-            // set the config to a local variable to avoid config params changed.
-            int partitionBatchNum = Config.tablet_checker_partition_batch_num;
-            int partitionChecked = 0;
-            db.readLock();
-            lockStart = System.nanoTime();
-            try {
-                TABLE:
-                for (Long tableId : tableIds) {
-                    OlapTable olapTable = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(db, tableId);
-                    if (olapTable == null || !colocateIndex.isColocateTable(olapTable.getId())) {
-                        continue;
-                    }
-
-                    for (Partition partition : globalStateMgr.getPartitionsIncludeRecycleBin(olapTable)) {
-                        partitionChecked++;
-                        if (partitionChecked % partitionBatchNum == 0) {
-                            lockTotalTime += System.nanoTime() - lockStart;
-                            // release lock, so that lock can be acquired by other threads.
-                            db.readUnlock();
-                            db.readLock();
-                            lockStart = System.nanoTime();
-                            if (globalStateMgr.getDbIncludeRecycleBin(groupId.dbId) == null) {
-                                continue GROUP;
-                            }
-                            if (globalStateMgr.getTableIncludeRecycleBin(db, olapTable.getId()) == null) {
-                                continue TABLE;
-                            }
-                            if (globalStateMgr.getPartitionIncludeRecycleBin(olapTable, partition.getId()) == null) {
-                                continue;
-                            }
-                        }
-                        short replicationNum =
-                                globalStateMgr.getReplicationNumIncludeRecycleBin(olapTable.getPartitionInfo(),
-                                        partition.getId());
-                        if (replicationNum == (short) -1) {
-                            continue;
-                        }
-                        long visibleVersion = partition.getVisibleVersion();
-                        // Here we only get VISIBLE indexes. All other indexes are not queryable.
-                        // So it does not matter if tablets of other indexes are not matched.
-                        for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
-                            Preconditions.checkState(backendBucketsSeq.size() == index.getTablets().size(),
-                                    backendBucketsSeq.size() + " v.s. " + index.getTablets().size());
-                            int idx = 0;
-                            for (Long tabletId : index.getTabletIdsInOrder()) {
-                                LocalTablet tablet = (LocalTablet) index.getTablet(tabletId);
-                                Set<Long> bucketsSeq = backendBucketsSeq.get(idx);
-                                // Tablet has already been scheduled, no need to schedule again
-                                if (!tabletScheduler.containsTablet(tablet.getId())) {
-                                    Preconditions.checkState(bucketsSeq.size() == replicationNum,
-                                            bucketsSeq.size() + " vs. " + replicationNum);
-                                    TabletStatus st = tablet.getColocateHealthStatus(visibleVersion,
-                                            replicationNum, bucketsSeq);
-                                    if (st != TabletStatus.HEALTHY) {
-                                        isGroupStable = false;
-                                        Priority colocateUnhealthyPrio = Priority.HIGH;
-                                        // We should also check if the tablet is ready to be repaired like
-                                        // `TabletChecker` did. Slightly delay the repair action can avoid unnecessary
-                                        // clone in situation like temporarily restart BE Nodes.
-                                        if (tablet.readyToBeRepaired(st, colocateUnhealthyPrio)) {
-                                            LOG.debug("get unhealthy tablet {} in colocate table. status: {}",
-                                                    tablet.getId(), st);
-                                            TabletSchedCtx tabletCtx = new TabletSchedCtx(
-                                                    TabletSchedCtx.Type.REPAIR,
-                                                    db.getId(), tableId, partition.getId(), index.getId(),
-                                                    tablet.getId(),
-                                                    System.currentTimeMillis());
-                                            // the tablet status will be checked and set again when being scheduled
-                                            tabletCtx.setTabletStatus(st);
-                                            // using HIGH priority, because we want to stabilize the colocate group
-                                            // as soon as possible
-                                            tabletCtx.setOrigPriority(colocateUnhealthyPrio);
-                                            tabletCtx.setTabletOrderIdx(idx);
-                                            tabletCtx.setColocateGroupId(groupId);
-                                            tabletCtx.setTablet(tablet);
-                                            ColocateRelocationInfo info = group2ColocateRelocationInfo.get(groupId);
-                                            tabletCtx.setRelocationForRepair(info != null
-                                                    && info.getRelocationForRepair()
-                                                    && st == TabletStatus.COLOCATE_MISMATCH);
-
-                                            // For bad replica, we ignore the size limit of scheduler queue
-                                            AddResult res = tabletScheduler.addTablet(tabletCtx,
-                                                    needToForceRepair(st, tablet,
-                                                            bucketsSeq) /* forcefully add or not */);
-                                            if (res == AddResult.LIMIT_EXCEED) {
-                                                // tablet in scheduler exceed limit, skip this group and check next one.
-                                                LOG.info("number of scheduling tablets in tablet scheduler"
-                                                        + " exceed to limit. stop colocate table check");
-                                                break TABLE;
-                                            }
-                                            if (res == AddResult.ADDED && tabletCtx.getRelocationForRepair()) {
-                                                LOG.info("add tablet relocation task to scheduler, tablet id: {}, " +
-                                                                "bucket sequence before: {}, bucket sequence now: {}",
-                                                        tableId,
-                                                        info != null ? info.getLastBackendsPerBucketSeq().get(idx) :
-                                                                Lists.newArrayList(),
-                                                        bucketsSeq);
-                                            }
-                                        }
-                                    } else {
-                                        tablet.setLastStatusCheckTime(checkStartTime);
-                                    }
-                                } else {
-                                    // tablet maybe added to scheduler because of balance between local disks,
-                                    // in this case we shouldn't mark the group unstable
-                                    if (tablet.getColocateHealthStatus(visibleVersion, replicationNum, bucketsSeq)
-                                            != TabletStatus.HEALTHY) {
-                                        isGroupStable = false;
-                                    }
-                                }
-                                idx++;
-                            }
-                        }
-                    }
-                } // end for tables
-
-                // mark group as stable or unstable
-                if (isGroupStable) {
-                    colocateIndex.markGroupStable(groupId, true);
-                } else {
-                    colocateIndex.markGroupUnstable(groupId, true);
-                }
-            } finally {
-                lockTotalTime += System.nanoTime() - lockStart;
-                db.readUnlock();
-            }
+            lockTotalTime += matchOneGroupUrgent(groupId, globalStateMgr, colocateIndex, tabletScheduler);
+            lockTotalTime += matchOneGroupNonUrgent(groupId, globalStateMgr, colocateIndex, tabletScheduler);
         } // end for groups
 
         long cost = (System.nanoTime() - start) / 1000000;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -56,15 +56,18 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AdminStmtAnalyzer;
 import com.starrocks.sql.ast.AdminCancelRepairTableStmt;
 import com.starrocks.sql.ast.AdminRepairTableStmt;
 import com.starrocks.system.SystemInfoService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -75,14 +78,14 @@ import java.util.stream.Collectors;
 public class TabletChecker extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(TabletChecker.class);
 
-    private GlobalStateMgr globalStateMgr;
-    private SystemInfoService infoService;
-    private TabletScheduler tabletScheduler;
-    private TabletSchedulerStat stat;
+    private final GlobalStateMgr globalStateMgr;
+    private final SystemInfoService infoService;
+    private final TabletScheduler tabletScheduler;
+    private final TabletSchedulerStat stat;
 
     // db id -> (tbl id -> PrioPart)
-    // priority of replicas of partitions in this table will be set to VERY_HIGH if not healthy
-    private com.google.common.collect.Table<Long, Long, Set<PrioPart>> prios = HashBasedTable.create();
+    // priority of replicas of partitions in this table will be set to VERY_HIGH if unhealthy
+    private com.google.common.collect.Table<Long, Long, Set<PrioPart>> urgentTable = HashBasedTable.create();
 
     // represent a partition which need to be repaired preferentially
     public static class PrioPart {
@@ -135,14 +138,14 @@ public class TabletChecker extends FrontendDaemon {
         this.stat = stat;
     }
 
-    private void addPrios(RepairTabletInfo repairTabletInfo, long timeoutMs) {
+    private void addToUrgentTable(RepairTabletInfo repairTabletInfo, long timeoutMs) {
         Preconditions.checkArgument(!repairTabletInfo.partIds.isEmpty());
         long currentTime = System.currentTimeMillis();
-        synchronized (prios) {
-            Set<PrioPart> parts = prios.get(repairTabletInfo.dbId, repairTabletInfo.tblId);
+        synchronized (urgentTable) {
+            Set<PrioPart> parts = urgentTable.get(repairTabletInfo.dbId, repairTabletInfo.tblId);
             if (parts == null) {
                 parts = Sets.newHashSet();
-                prios.put(repairTabletInfo.dbId, repairTabletInfo.tblId, parts);
+                urgentTable.put(repairTabletInfo.dbId, repairTabletInfo.tblId, parts);
             }
 
             for (long partId : repairTabletInfo.partIds) {
@@ -156,10 +159,23 @@ public class TabletChecker extends FrontendDaemon {
                 repairTabletInfo.partIds);
     }
 
-    private void removePrios(RepairTabletInfo repairTabletInfo) {
+    /**
+     * When setting a tablet to `bad` status manually, call this method to put the corresponding partition into
+     * the `urgentTable` so that the bad tablet can be repaired ASAP.
+     *
+     * @param dbId database id
+     * @param tableId table id
+     * @param partitionId partition to which the tablet belongs
+     */
+    public void setTabletForUrgentRepair(long dbId, long tableId, long partitionId) {
+        RepairTabletInfo repairTabletInfo = new RepairTabletInfo(dbId, tableId, Collections.singletonList(partitionId));
+        addToUrgentTable(repairTabletInfo, AdminStmtAnalyzer.DEFAULT_PRIORITY_REPAIR_TIMEOUT_SEC);
+    }
+
+    public void removeFromUrgentTable(RepairTabletInfo repairTabletInfo) {
         Preconditions.checkArgument(!repairTabletInfo.partIds.isEmpty());
-        synchronized (prios) {
-            Map<Long, Set<PrioPart>> tblMap = prios.row(repairTabletInfo.dbId);
+        synchronized (urgentTable) {
+            Map<Long, Set<PrioPart>> tblMap = urgentTable.row(repairTabletInfo.dbId);
             if (tblMap == null) {
                 return;
             }
@@ -194,7 +210,7 @@ public class TabletChecker extends FrontendDaemon {
 
         checkAllTablets();
 
-        removePriosIfNecessary();
+        cleanInvalidUrgentTable();
 
         stat.counterTabletCheckRound.incrementAndGet();
         LOG.info(stat.incrementalBrief());
@@ -205,15 +221,15 @@ public class TabletChecker extends FrontendDaemon {
      * so that they can be scheduled for repair at first place.
      */
     private void checkAllTablets() {
-        checkTabletsOnlyInPrios();
-        checkTabletsNotInPrios();
+        checkUrgentTablets();
+        checkNonUrgentTablets();
     }
 
-    private void checkTabletsOnlyInPrios() {
+    private void checkUrgentTablets() {
         doCheck(true);
     }
 
-    private void checkTabletsNotInPrios() {
+    private void checkNonUrgentTablets() {
         doCheck(false);
     }
 
@@ -239,7 +255,7 @@ public class TabletChecker extends FrontendDaemon {
         }
     }
 
-    private void doCheck(boolean checkInPrios) {
+    private void doCheck(boolean isUrgent) {
         long start = System.nanoTime();
         long totalTabletNum = 0;
         long unhealthyTabletNum = 0;
@@ -278,8 +294,8 @@ public class TabletChecker extends FrontendDaemon {
                         continue;
                     }
 
-                    if ((checkInPrios && !isTableInPrios(dbId, table.getId())) ||
-                            (!checkInPrios && isTableInPrios(dbId, table.getId()))) {
+                    if ((isUrgent && !isUrgentTable(dbId, table.getId())) ||
+                            (!isUrgent && isUrgentTable(dbId, table.getId()))) {
                         continue;
                     }
 
@@ -316,9 +332,9 @@ public class TabletChecker extends FrontendDaemon {
                             continue;
                         }
 
-                        boolean isPartitionInPrios = isPartitionInPrios(dbId, table.getId(), partition.getId());
-                        boolean prioPartIsHealthy = true;
-                        if ((checkInPrios && !isPartitionInPrios) || (!checkInPrios && isPartitionInPrios)) {
+                        boolean isPartitionUrgent = isPartitionUrgent(dbId, table.getId(), partition.getId());
+                        boolean isUrgentPartitionHealthy = true;
+                        if ((isUrgent && !isPartitionUrgent) || (!isUrgent && isPartitionUrgent)) {
                             continue;
                         }
 
@@ -346,9 +362,9 @@ public class TabletChecker extends FrontendDaemon {
                                     // Only set last status check time when status is healthy.
                                     localTablet.setLastStatusCheckTime(System.currentTimeMillis());
                                     continue;
-                                } else if (isPartitionInPrios) {
+                                } else if (isPartitionUrgent) {
                                     statusWithPrio.second = TabletSchedCtx.Priority.VERY_HIGH;
-                                    prioPartIsHealthy = false;
+                                    isUrgentPartitionHealthy = false;
                                 }
 
                                 unhealthyTabletNum++;
@@ -371,7 +387,9 @@ public class TabletChecker extends FrontendDaemon {
                                     continue;
                                 }
 
-                                AddResult res = tabletScheduler.addTablet(tabletCtx, false /* not force */);
+                                // ignore the scheduler queue length limitation if it's an urgent repair
+                                AddResult res = tabletScheduler.addTablet(tabletCtx,
+                                        isPartitionUrgent /* force or not */);
                                 if (res == AddResult.LIMIT_EXCEED) {
                                     LOG.info("number of scheduling tablets in tablet scheduler"
                                             + " exceed to limit. stop tablet checker");
@@ -382,12 +400,12 @@ public class TabletChecker extends FrontendDaemon {
                             }
                         } // indices
 
-                        if (prioPartIsHealthy && isPartitionInPrios) {
+                        if (isUrgentPartitionHealthy && isPartitionUrgent) {
                             // if all replicas in this partition are healthy, remove this partition from
                             // priorities.
-                            LOG.debug("partition is healthy, remove from prios: {}-{}-{}",
+                            LOG.debug("partition is healthy, remove from urgent table: {}-{}-{}",
                                     db.getId(), olapTbl.getId(), partition.getId());
-                            removePrios(new RepairTabletInfo(db.getId(),
+                            removeFromUrgentTable(new RepairTabletInfo(db.getId(),
                                     olapTbl.getId(), Lists.newArrayList(partition.getId())));
                         }
                     } // partitions
@@ -406,38 +424,38 @@ public class TabletChecker extends FrontendDaemon {
         stat.counterUnhealthyTabletNum.addAndGet(unhealthyTabletNum);
         stat.counterTabletAddToBeScheduled.addAndGet(addToSchedulerTabletNum);
 
-        LOG.info("finished to check tablets. checkInPrios: {}, " +
+        LOG.info("finished to check tablets. isUrgent: {}, " +
                         "unhealthy/total/added/in_sched/not_ready: {}/{}/{}/{}/{}, " +
                         "cost: {} ms, in lock time: {} ms",
-                checkInPrios, unhealthyTabletNum, totalTabletNum, addToSchedulerTabletNum,
+                isUrgent, unhealthyTabletNum, totalTabletNum, addToSchedulerTabletNum,
                 tabletInScheduler, tabletNotReady, cost, lockTotalTime);
     }
 
-    private boolean isTableInPrios(long dbId, long tblId) {
-        synchronized (prios) {
-            return prios.contains(dbId, tblId);
+    public boolean isUrgentTable(long dbId, long tblId) {
+        synchronized (urgentTable) {
+            return urgentTable.contains(dbId, tblId);
         }
     }
 
-    private boolean isPartitionInPrios(long dbId, long tblId, long partId) {
-        synchronized (prios) {
-            if (isTableInPrios(dbId, tblId)) {
-                return prios.get(dbId, tblId).contains(new PrioPart(partId, -1, -1));
+    public boolean isPartitionUrgent(long dbId, long tblId, long partId) {
+        synchronized (urgentTable) {
+            if (isUrgentTable(dbId, tblId)) {
+                return Objects.requireNonNull(urgentTable.get(dbId, tblId)).contains(new PrioPart(partId, -1, -1));
             }
             return false;
         }
     }
 
-    // remove partition from prios if:
+    // remove partition from urgent table if:
     // 1. timeout
     // 2. meta not found
-    private void removePriosIfNecessary() {
-        com.google.common.collect.Table<Long, Long, Set<PrioPart>> copiedPrios = null;
-        synchronized (prios) {
-            copiedPrios = HashBasedTable.create(prios);
+    private void cleanInvalidUrgentTable() {
+        com.google.common.collect.Table<Long, Long, Set<PrioPart>> copiedUrgentTable;
+        synchronized (urgentTable) {
+            copiedUrgentTable = HashBasedTable.create(urgentTable);
         }
-        List<Pair<Long, Long>> deletedPrios = Lists.newArrayList();
-        Iterator<Map.Entry<Long, Map<Long, Set<PrioPart>>>> iter = copiedPrios.rowMap().entrySet().iterator();
+        List<Pair<Long, Long>> deletedUrgentTable = Lists.newArrayList();
+        Iterator<Map.Entry<Long, Map<Long, Set<PrioPart>>>> iter = copiedUrgentTable.rowMap().entrySet().iterator();
         while (iter.hasNext()) {
             Map.Entry<Long, Map<Long, Set<PrioPart>>> dbEntry = iter.next();
             long dbId = dbEntry.getKey();
@@ -449,13 +467,11 @@ public class TabletChecker extends FrontendDaemon {
 
             db.readLock();
             try {
-                Iterator<Map.Entry<Long, Set<PrioPart>>> jter = dbEntry.getValue().entrySet().iterator();
-                while (jter.hasNext()) {
-                    Map.Entry<Long, Set<PrioPart>> tblEntry = jter.next();
+                for (Map.Entry<Long, Set<PrioPart>> tblEntry : dbEntry.getValue().entrySet()) {
                     long tblId = tblEntry.getKey();
                     OlapTable tbl = (OlapTable) db.getTable(tblId);
                     if (tbl == null) {
-                        deletedPrios.add(Pair.create(dbId, tblId));
+                        deletedUrgentTable.add(Pair.create(dbId, tblId));
                         continue;
                     }
 
@@ -463,7 +479,7 @@ public class TabletChecker extends FrontendDaemon {
                     parts = parts.stream().filter(p -> (tbl.getPartition(p.partId) != null && !p.isTimeout())).collect(
                             Collectors.toSet());
                     if (parts.isEmpty()) {
-                        deletedPrios.add(Pair.create(dbId, tblId));
+                        deletedUrgentTable.add(Pair.create(dbId, tblId));
                     }
                 }
 
@@ -474,55 +490,55 @@ public class TabletChecker extends FrontendDaemon {
                 db.readUnlock();
             }
         }
-        for (Pair<Long, Long> prio : deletedPrios) {
-            copiedPrios.remove(prio.first, prio.second);
+        for (Pair<Long, Long> prio : deletedUrgentTable) {
+            copiedUrgentTable.remove(prio.first, prio.second);
         }
-        prios = copiedPrios;
+        urgentTable = copiedUrgentTable;
     }
 
     /*
      * handle ADMIN REPAIR TABLE stmt send by user.
-     * This operation will add specified tables into 'prios', and tablets of this table will be set VERY_HIGH
+     * This operation will add specified tables into 'urgentTable', and tablets of this table will be set VERY_HIGH
      * when being scheduled.
      */
     public void repairTable(AdminRepairTableStmt stmt) throws DdlException {
         RepairTabletInfo repairTabletInfo =
                 getRepairTabletInfo(stmt.getDbName(), stmt.getTblName(), stmt.getPartitions());
-        addPrios(repairTabletInfo, stmt.getTimeoutS());
+        addToUrgentTable(repairTabletInfo, stmt.getTimeoutS());
         LOG.info("repair database: {}, table: {}, partition: {}", repairTabletInfo.dbId, repairTabletInfo.tblId,
                 repairTabletInfo.partIds);
     }
 
     /*
      * handle ADMIN CANCEL REPAIR TABLE stmt send by user.
-     * This operation will remove the specified partitions from 'prios'
+     * This operation will remove the specified partitions from 'urgentTable'
      */
     public void cancelRepairTable(AdminCancelRepairTableStmt stmt) throws DdlException {
         RepairTabletInfo repairTabletInfo =
                 getRepairTabletInfo(stmt.getDbName(), stmt.getTblName(), stmt.getPartitions());
-        removePrios(repairTabletInfo);
+        removeFromUrgentTable(repairTabletInfo);
         LOG.info("cancel repair database: {}, table: {}, partition: {}", repairTabletInfo.dbId, repairTabletInfo.tblId,
                 repairTabletInfo.partIds);
     }
 
     public int getPrioPartitionNum() {
         int count = 0;
-        synchronized (prios) {
-            for (Set<PrioPart> set : prios.values()) {
+        synchronized (urgentTable) {
+            for (Set<PrioPart> set : urgentTable.values()) {
                 count += set.size();
             }
         }
         return count;
     }
 
-    public List<List<String>> getPriosInfo() {
+    public List<List<String>> getUrgentTableInfo() {
         List<List<String>> infos = Lists.newArrayList();
-        synchronized (prios) {
-            for (Cell<Long, Long, Set<PrioPart>> cell : prios.cellSet()) {
-                for (PrioPart part : cell.getValue()) {
+        synchronized (urgentTable) {
+            for (Cell<Long, Long, Set<PrioPart>> cell : urgentTable.cellSet()) {
+                for (PrioPart part : Objects.requireNonNull(cell.getValue())) {
                     List<String> row = Lists.newArrayList();
-                    row.add(cell.getRowKey().toString());
-                    row.add(cell.getColumnKey().toString());
+                    row.add(Objects.requireNonNull(cell.getRowKey()).toString());
+                    row.add(Objects.requireNonNull(cell.getColumnKey()).toString());
                     row.add(String.valueOf(part.partId));
                     row.add(String.valueOf(part.timeoutMs - (System.currentTimeMillis() - part.addTime)));
                     infos.add(row);
@@ -541,7 +557,7 @@ public class TabletChecker extends FrontendDaemon {
         }
 
         long dbId = db.getId();
-        long tblId = -1;
+        long tblId;
         List<Long> partIds = Lists.newArrayList();
         db.readLock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -111,9 +111,6 @@ import java.util.stream.Stream;
 public class TabletScheduler extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(TabletScheduler.class);
 
-    // handle at most BATCH_NUM tablets in one loop
-    private static final int MIN_BATCH_NUM = 50;
-
     // the minimum interval of updating cluster statistics and priority of tablet info
     private static final long STAT_UPDATE_INTERVAL_MS = 20L * 1000L; // 20s
 
@@ -294,6 +291,10 @@ public class TabletScheduler extends FrontendDaemon {
                 && (pendingTablets.size() > Config.tablet_sched_max_scheduling_tablets
                 || runningTablets.size() > Config.tablet_sched_max_scheduling_tablets)) {
             return AddResult.LIMIT_EXCEED;
+        }
+
+        if (force) {
+            LOG.debug("forcefully add tablet {} to table scheduler pending queue", tablet.getTabletId());
         }
 
         allTabletIds.add(tablet.getTabletId());

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PriorityRepairProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PriorityRepairProcNode.java
@@ -54,7 +54,7 @@ public class PriorityRepairProcNode implements ProcNodeInterface {
         result.setNames(TITLE_NAMES);
 
         TabletChecker tabletChecker = GlobalStateMgr.getCurrentState().getTabletChecker();
-        result.setRows(tabletChecker.getPriosInfo());
+        result.setRows(tabletChecker.getUrgentTableInfo());
 
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4436,6 +4436,9 @@ public class LocalMetastore implements ConnectorMetadata {
             if (status == Replica.ReplicaStatus.BAD || status == Replica.ReplicaStatus.OK) {
                 if (replica.setBadForce(status == Replica.ReplicaStatus.BAD)) {
                     if (!isReplay) {
+                        // Put this tablet into urgent table so that it can be repaired ASAP.
+                        stateMgr.getTabletChecker().setTabletForUrgentRepair(dbId, meta.getTableId(),
+                                meta.getPartitionId());
                         SetReplicaStatusOperationLog log =
                                 new SetReplicaStatusOperationLog(backendId, tabletId, status);
                         GlobalStateMgr.getCurrentState().getEditLog().logSetReplicaStatus(log);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AdminStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AdminStmtAnalyzer.java
@@ -45,6 +45,8 @@ import java.util.List;
 import static com.starrocks.sql.common.ErrorMsgProxy.PARSER_ERROR_MSG;
 
 public class AdminStmtAnalyzer {
+    public static final long DEFAULT_PRIORITY_REPAIR_TIMEOUT_SEC = 4 * 3600L;
+
     public static void analyze(StatementBase statementBase, ConnectContext session) {
         new AdminStmtAnalyzerVisitor().analyze(statementBase, session);
     }
@@ -181,7 +183,7 @@ public class AdminStmtAnalyzer {
                 }
                 adminRepairTableStmt.setPartitions(partitionNames);
             }
-            adminRepairTableStmt.setTimeoutSec(4 * 3600L); // default 4 hours
+            adminRepairTableStmt.setTimeoutSec(DEFAULT_PRIORITY_REPAIR_TIMEOUT_SEC); // default 4 hours
             return null;
         }
 


### PR DESCRIPTION
Fixes SR-16234

For manually set bad tablet or manually repaired partition/table,
we should ignore the queue limitation of tablet scheduler and
put them into scheduler queue with top priority.
Also refactored the original "prios" concept with `urgentTable`.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
