### PR TITLE
[Enhancement] Support expression evaluation in RollupJobV2 for schema change

### DIFF
--- a/be/src/storage/column_mapping.h
+++ b/be/src/storage/column_mapping.h
@@ -37,6 +37,8 @@
 #include <memory>
 
 #include "column/datum.h"
+#include "exprs/expr_context.h"
+#include "gen_cpp/Exprs_types.h"
 #include "types/bitmap_value.h"
 #include "types/hll.h"
 #include "util/json.h"
@@ -49,11 +51,8 @@ struct ColumnMapping {
     // >=0: use origin column
     int32_t ref_column{-1};
 
-    // The base reader selects part of the column
-    // so it's different to ref_column
-    int32_t ref_base_reader_column_index = -1;
-    // materialize view transform function used in schema change
-    std::string materialized_function;
+    // materialized view function.
+    ExprContext* mv_expr_ctx;
 
     // the following data is used by default_value_datum, because default_value_datum only
     // have the reference. We need to keep the content has the same life cycle as the

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -548,7 +548,12 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
     sc_params.base_tablet = base_tablet;
     sc_params.new_tablet = new_tablet;
     sc_params.chunk_changer = std::make_unique<ChunkChanger>(sc_params.new_tablet->tablet_schema());
-    if (request.__isset.query_options && request.__isset.query_options) {
+
+    if (request.__isset.materialized_view_params && request.materialized_view_params.size() > 0) {
+        if (!request.__isset.query_options || !request.__isset.query_globals) {
+            return Status::InternalError(_alter_msg_header +
+                                         "change materialized view but query_options/query_globals is not set");
+        }
         sc_params.chunk_changer->init_runtime_state(request.query_options, request.query_globals);
     }
 

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -212,13 +212,13 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const
                      << ", mapping_schema_size=" << _schema_mapping.size();
         return false;
     }
-    if (base_chunk->num_columns() != _slot_id_to_index_map.size()) {
-        LOG(WARNING) << "base chunk does not match with _slot_id_to_index_map mapping rules. "
-                     << "base_chunk_size=" << base_chunk->num_columns()
-                     << ", slot_id_to_index_map's size=" << _slot_id_to_index_map.size();
-        return false;
-    }
     if (_has_mv_expr_context) {
+        if (base_chunk->num_columns() != _slot_id_to_index_map.size()) {
+            LOG(WARNING) << "base chunk does not match with _slot_id_to_index_map mapping rules. "
+                         << "base_chunk_size=" << base_chunk->num_columns()
+                         << ", slot_id_to_index_map's size=" << _slot_id_to_index_map.size();
+            return false;
+        }
         // init for expression evaluation only
         for (auto& iter : _slot_id_to_index_map) {
             base_chunk->set_slot_id_to_index(iter.first, iter.second);
@@ -349,13 +349,13 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
                      << ", mapping_schema_size=" << _schema_mapping.size();
         return false;
     }
-    if (base_chunk->num_columns() != _slot_id_to_index_map.size()) {
-        LOG(WARNING) << "base chunk does not match with _slot_id_to_index_map mapping rules. "
-                     << "base_chunk_size=" << base_chunk->num_columns()
-                     << ", slot_id_to_index_map's size=" << _slot_id_to_index_map.size();
-        return false;
-    }
     if (_has_mv_expr_context) {
+        if (base_chunk->num_columns() != _slot_id_to_index_map.size()) {
+            LOG(WARNING) << "base chunk does not match with _slot_id_to_index_map mapping rules. "
+                         << "base_chunk_size=" << base_chunk->num_columns()
+                         << ", slot_id_to_index_map's size=" << _slot_id_to_index_map.size();
+            return false;
+        }
         // init for expression evaluation only
         for (auto& iter : _slot_id_to_index_map) {
             base_chunk->set_slot_id_to_index(iter.first, iter.second);
@@ -374,6 +374,7 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
                 new_col = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
                 new_chunk->update_column_by_index(new_col, i);
             } else {
+                DCHECK(_slot_id_to_index_map.find(ref_column) != _slot_id_to_index_map.end());
                 int base_index = _slot_id_to_index_map[ref_column];
                 const TypeInfoPtr& ref_type_info = base_schema.field(base_index)->type();
                 const TypeInfoPtr& new_type_info = new_schema.field(i)->type();

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -212,7 +212,7 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const
                      << ", mapping_schema_size=" << _schema_mapping.size();
         return false;
     }
-    if (_has_mv_expr_context && base_chunk->num_columns() != _slot_id_to_index_map.size()) {
+    if (base_chunk->num_columns() != _slot_id_to_index_map.size()) {
         LOG(WARNING) << "base chunk does not match with _slot_id_to_index_map mapping rules. "
                      << "base_chunk_size=" << base_chunk->num_columns()
                      << ", slot_id_to_index_map's size=" << _slot_id_to_index_map.size();

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -336,8 +336,7 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const
             }
         }
     }
-}
-return true;
+    return true;
 }
 
 bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const Schema& base_schema,
@@ -357,7 +356,6 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
 
     for (size_t i = 0; i < new_chunk->num_columns(); ++i) {
         int ref_column = _schema_mapping[i].ref_column;
-        DCHECK_NE(ref_column, -1);
         if (ref_column >= 0) {
             if (_schema_mapping[i].mv_expr_ctx != nullptr) {
                 // init for expression evaluation only
@@ -370,7 +368,6 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
                     return false;
                 }
                 auto new_col = new_col_status.value();
-                // TODO: no need to unpack const column later.
                 new_col = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
                 new_chunk->update_column_by_index(new_col, i);
             } else {

--- a/be/src/storage/schema_change_utils.h
+++ b/be/src/storage/schema_change_utils.h
@@ -39,9 +39,6 @@ public:
 
     const SchemaMapping& get_schema_mapping() const { return _schema_mapping; }
 
-    const std::vector<ColumnId>& get_selected_column_indexes() const { return _selected_column_indexes; }
-    std::vector<ColumnId>* get_mutable_selected_column_indexes() { return &_selected_column_indexes; }
-
     const std::unordered_map<int32_t, int32_t>& get_slot_id_to_index_map() const { return _slot_id_to_index_map; }
     std::unordered_map<int32_t, int32_t>* get_mutable_slot_id_to_index_map() { return &_slot_id_to_index_map; }
 
@@ -61,7 +58,12 @@ public:
 
     void init_runtime_state(TQueryOptions query_options, TQueryGlobals query_globals);
 
+    const std::vector<ColumnId>& get_selected_column_indexes() const { return _selected_column_indexes; }
+    std::vector<ColumnId>* get_mutable_selected_column_indexes() { return &_selected_column_indexes; }
+
     void set_has_mv_expr_context(bool has_mv_expr_context) { this->_has_mv_expr_context = has_mv_expr_context; }
+
+    Status prepare();
 
 private:
     // @brief column-mapping specification of new schema

--- a/be/src/storage/schema_change_utils.h
+++ b/be/src/storage/schema_change_utils.h
@@ -61,6 +61,8 @@ public:
 
     void init_runtime_state(TQueryOptions query_options, TQueryGlobals query_globals);
 
+    void set_has_mv_expr_context(bool has_mv_expr_context) { this->_has_mv_expr_context = has_mv_expr_context; }
+
 private:
     // @brief column-mapping specification of new schema
     SchemaMapping _schema_mapping;
@@ -70,6 +72,8 @@ private:
     ObjectPool _obj_pool;
     RuntimeState* _state = nullptr;
     std::unordered_map<int, ExprContext*> _mc_exprs;
+
+    bool _has_mv_expr_context{false};
     // base table's slot_id to index mapping
     std::unordered_map<int32_t, int32_t> _slot_id_to_index_map;
 

--- a/be/src/storage/schema_change_utils.h
+++ b/be/src/storage/schema_change_utils.h
@@ -26,7 +26,7 @@ namespace starrocks {
 struct AlterMaterializedViewParam {
     std::string column_name;
     std::string origin_column_name;
-    std::string mv_expr;
+    std::unique_ptr<TExpr> mv_expr;
 };
 using MaterializedViewParamMap = std::unordered_map<std::string, AlterMaterializedViewParam>;
 
@@ -39,9 +39,11 @@ public:
 
     const SchemaMapping& get_schema_mapping() const { return _schema_mapping; }
 
+    const std::vector<ColumnId>& get_selected_column_indexes() const { return _selected_column_indexes; }
     std::vector<ColumnId>* get_mutable_selected_column_indexes() { return &_selected_column_indexes; }
 
-    const std::vector<ColumnId>& get_selected_column_indexes() const { return _selected_column_indexes; }
+    const std::unordered_map<int32_t, int32_t>& get_slot_id_to_index_map() const { return _slot_id_to_index_map; }
+    std::unordered_map<int32_t, int32_t>* get_mutable_slot_id_to_index_map() { return &_slot_id_to_index_map; }
 
     ObjectPool* get_object_pool() { return &_obj_pool; }
 
@@ -60,9 +62,6 @@ public:
     void init_runtime_state(TQueryOptions query_options, TQueryGlobals query_globals);
 
 private:
-    const MaterializeTypeConverter* get_materialize_type_converter(const std::string& materialized_function,
-                                                                   LogicalType type);
-
     // @brief column-mapping specification of new schema
     SchemaMapping _schema_mapping;
 
@@ -71,6 +70,8 @@ private:
     ObjectPool _obj_pool;
     RuntimeState* _state = nullptr;
     std::unordered_map<int, ExprContext*> _mc_exprs;
+    // base table's slot_id to index mapping
+    std::unordered_map<int32_t, int32_t> _slot_id_to_index_map;
 
     DISALLOW_COPY(ChunkChanger);
 };

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3117,8 +3117,7 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
 Status TabletUpdates::_convert_from_base_rowset(const std::shared_ptr<Tablet>& base_tablet,
                                                 const ChunkIteratorPtr& seg_iterator, ChunkChanger* chunk_changer,
                                                 const std::unique_ptr<RowsetWriter>& rowset_writer) {
-    Schema base_schema =
-            ChunkHelper::convert_schema(base_tablet->tablet_schema(), chunk_changer->get_selected_column_indexes());
+    Schema base_schema = ChunkHelper::convert_schema(base_tablet->tablet_schema());
     ChunkPtr base_chunk = ChunkHelper::new_chunk(base_schema, config::vector_chunk_size);
 
     Schema new_schema = ChunkHelper::convert_schema(_tablet.tablet_schema());

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -3117,7 +3117,8 @@ Status TabletUpdates::convert_from(const std::shared_ptr<Tablet>& base_tablet, i
 Status TabletUpdates::_convert_from_base_rowset(const std::shared_ptr<Tablet>& base_tablet,
                                                 const ChunkIteratorPtr& seg_iterator, ChunkChanger* chunk_changer,
                                                 const std::unique_ptr<RowsetWriter>& rowset_writer) {
-    Schema base_schema = ChunkHelper::convert_schema(base_tablet->tablet_schema());
+    Schema base_schema =
+            ChunkHelper::convert_schema(base_tablet->tablet_schema(), chunk_changer->get_selected_column_indexes());
     ChunkPtr base_chunk = ChunkHelper::new_chunk(base_schema, config::vector_chunk_size);
 
     Schema new_schema = ChunkHelper::convert_schema(_tablet.tablet_schema());

--- a/be/test/storage/schema_change_test.cpp
+++ b/be/test/storage/schema_change_test.cpp
@@ -437,7 +437,8 @@ TEST_F(SchemaChangeTest, schema_change_with_directing_v2) {
     read_params.reader_type = ReaderType::READER_ALTER_TABLE;
     read_params.skip_aggregation = false;
     read_params.chunk_size = config::vector_chunk_size;
-    Schema base_schema = ChunkHelper::convert_schema(base_tablet->tablet_schema());
+    Schema base_schema =
+            ChunkHelper::convert_schema(base_tablet->tablet_schema(), chunk_changer.get_selected_column_indexes());
     auto* tablet_rowset_reader = new TabletReader(base_tablet, rowset->version(), base_schema);
     ASSERT_TRUE(tablet_rowset_reader != nullptr);
     ASSERT_TRUE(tablet_rowset_reader->prepare().ok());
@@ -498,7 +499,8 @@ TEST_F(SchemaChangeTest, schema_change_with_sorting_v2) {
     read_params.reader_type = ReaderType::READER_ALTER_TABLE;
     read_params.skip_aggregation = false;
     read_params.chunk_size = config::vector_chunk_size;
-    Schema base_schema = ChunkHelper::convert_schema(base_tablet->tablet_schema());
+    Schema base_schema =
+            ChunkHelper::convert_schema(base_tablet->tablet_schema(), chunk_changer.get_selected_column_indexes());
     auto* tablet_rowset_reader = new TabletReader(base_tablet, rowset->version(), base_schema);
     ASSERT_TRUE(tablet_rowset_reader != nullptr);
     ASSERT_TRUE(tablet_rowset_reader->prepare().ok());
@@ -556,7 +558,8 @@ TEST_F(SchemaChangeTest, schema_change_with_agg_key_reorder) {
     read_params.reader_type = ReaderType::READER_ALTER_TABLE;
     read_params.skip_aggregation = false;
     read_params.chunk_size = config::vector_chunk_size;
-    Schema base_schema = ChunkHelper::convert_schema(base_tablet->tablet_schema());
+    Schema base_schema =
+            ChunkHelper::convert_schema(base_tablet->tablet_schema(), chunk_changer.get_selected_column_indexes());
     auto* tablet_rowset_reader = new TabletReader(base_tablet, rowset->version(), base_schema);
     ASSERT_TRUE(tablet_rowset_reader != nullptr);
     ASSERT_TRUE(tablet_rowset_reader->prepare().ok());
@@ -678,7 +681,8 @@ TEST_F(SchemaChangeTest, schema_change_with_materialized_column) {
     read_params.reader_type = ReaderType::READER_ALTER_TABLE;
     read_params.skip_aggregation = false;
     read_params.chunk_size = config::vector_chunk_size;
-    Schema base_schema = ChunkHelper::convert_schema(base_tablet->tablet_schema());
+    Schema base_schema =
+            ChunkHelper::convert_schema(base_tablet->tablet_schema(), chunk_changer.get_selected_column_indexes());
     auto* tablet_rowset_reader = new TabletReader(base_tablet, rowset->version(), base_schema);
     ASSERT_TRUE(tablet_rowset_reader != nullptr);
     ASSERT_TRUE(tablet_rowset_reader->prepare().ok());

--- a/be/test/storage/schema_change_test.cpp
+++ b/be/test/storage/schema_change_test.cpp
@@ -423,12 +423,11 @@ TEST_F(SchemaChangeTest, schema_change_with_directing_v2) {
     TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1101);
 
     ChunkChanger chunk_changer(new_tablet->tablet_schema());
-    auto indexs = chunk_changer.get_mutable_selected_column_indexes();
     for (size_t i = 0; i < 4; ++i) {
         ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(i);
         column_mapping->ref_column = i;
-        indexs->emplace_back(i);
     }
+    ASSERT_TRUE(chunk_changer.prepare().ok());
     _sc_procedure = new (std::nothrow) SchemaChangeDirectly(&chunk_changer);
     Version version(3, 3);
     RowsetSharedPtr rowset = base_tablet->get_rowset_by_version(version);
@@ -479,19 +478,15 @@ TEST_F(SchemaChangeTest, schema_change_with_sorting_v2) {
     TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1103);
 
     ChunkChanger chunk_changer(new_tablet->tablet_schema());
-    auto indexs = chunk_changer.get_mutable_selected_column_indexes();
     ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(0);
     column_mapping->ref_column = 1;
-    indexs->emplace_back(0);
     column_mapping = chunk_changer.get_mutable_column_mapping(1);
     column_mapping->ref_column = 0;
-    indexs->emplace_back(1);
     column_mapping = chunk_changer.get_mutable_column_mapping(2);
     column_mapping->ref_column = 2;
-    indexs->emplace_back(2);
     column_mapping = chunk_changer.get_mutable_column_mapping(3);
     column_mapping->ref_column = 3;
-    indexs->emplace_back(3);
+    ASSERT_TRUE(chunk_changer.prepare().ok());
 
     _sc_procedure = new (std::nothrow) SchemaChangeWithSorting(
             &chunk_changer, config::memory_limitation_per_thread_for_schema_change * 1024 * 1024 * 1024);
@@ -543,16 +538,13 @@ TEST_F(SchemaChangeTest, schema_change_with_agg_key_reorder) {
     TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1203);
 
     ChunkChanger chunk_changer(new_tablet->tablet_schema());
-    auto indexs = chunk_changer.get_mutable_selected_column_indexes();
     ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(0);
     column_mapping->ref_column = 1;
-    indexs->emplace_back(0);
     column_mapping = chunk_changer.get_mutable_column_mapping(1);
     column_mapping->ref_column = 0;
-    indexs->emplace_back(1);
     column_mapping = chunk_changer.get_mutable_column_mapping(2);
     column_mapping->ref_column = 2;
-    indexs->emplace_back(2);
+    ASSERT_TRUE(chunk_changer.prepare().ok());
 
     _sc_procedure = new (std::nothrow) SchemaChangeWithSorting(
             &chunk_changer, config::memory_limitation_per_thread_for_schema_change * 1024 * 1024 * 1024);
@@ -641,12 +633,11 @@ TEST_F(SchemaChangeTest, schema_change_with_materialized_column) {
     TabletSharedPtr base_tablet = engine->tablet_manager()->get_tablet(1301);
 
     ChunkChanger chunk_changer(new_tablet->tablet_schema());
-    auto indexs = chunk_changer.get_mutable_selected_column_indexes();
     for (size_t i = 0; i < 4; ++i) {
         ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(i);
         column_mapping->ref_column = i;
-        indexs->emplace_back(i);
     }
+    ASSERT_TRUE(chunk_changer.prepare().ok());
 
     std::vector<TExprNode> nodes;
 

--- a/be/test/storage/schema_change_test.cpp
+++ b/be/test/storage/schema_change_test.cpp
@@ -427,7 +427,6 @@ TEST_F(SchemaChangeTest, schema_change_with_directing_v2) {
     for (size_t i = 0; i < 4; ++i) {
         ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(i);
         column_mapping->ref_column = i;
-        column_mapping->ref_base_reader_column_index = i;
         indexs->emplace_back(i);
     }
     _sc_procedure = new (std::nothrow) SchemaChangeDirectly(&chunk_changer);
@@ -483,19 +482,15 @@ TEST_F(SchemaChangeTest, schema_change_with_sorting_v2) {
     auto indexs = chunk_changer.get_mutable_selected_column_indexes();
     ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(0);
     column_mapping->ref_column = 1;
-    column_mapping->ref_base_reader_column_index = 0;
     indexs->emplace_back(0);
     column_mapping = chunk_changer.get_mutable_column_mapping(1);
     column_mapping->ref_column = 0;
-    column_mapping->ref_base_reader_column_index = 1;
     indexs->emplace_back(1);
     column_mapping = chunk_changer.get_mutable_column_mapping(2);
     column_mapping->ref_column = 2;
-    column_mapping->ref_base_reader_column_index = 2;
     indexs->emplace_back(2);
     column_mapping = chunk_changer.get_mutable_column_mapping(3);
     column_mapping->ref_column = 3;
-    column_mapping->ref_base_reader_column_index = 3;
     indexs->emplace_back(3);
 
     _sc_procedure = new (std::nothrow) SchemaChangeWithSorting(
@@ -551,15 +546,12 @@ TEST_F(SchemaChangeTest, schema_change_with_agg_key_reorder) {
     auto indexs = chunk_changer.get_mutable_selected_column_indexes();
     ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(0);
     column_mapping->ref_column = 1;
-    column_mapping->ref_base_reader_column_index = 0;
     indexs->emplace_back(0);
     column_mapping = chunk_changer.get_mutable_column_mapping(1);
     column_mapping->ref_column = 0;
-    column_mapping->ref_base_reader_column_index = 1;
     indexs->emplace_back(1);
     column_mapping = chunk_changer.get_mutable_column_mapping(2);
     column_mapping->ref_column = 2;
-    column_mapping->ref_base_reader_column_index = 2;
     indexs->emplace_back(2);
 
     _sc_procedure = new (std::nothrow) SchemaChangeWithSorting(
@@ -653,7 +645,6 @@ TEST_F(SchemaChangeTest, schema_change_with_materialized_column) {
     for (size_t i = 0; i < 4; ++i) {
         ColumnMapping* column_mapping = chunk_changer.get_mutable_column_mapping(i);
         column_mapping->ref_column = i;
-        column_mapping->ref_base_reader_column_index = i;
         indexs->emplace_back(i);
     }
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -2137,7 +2137,6 @@ void TabletUpdatesTest::test_reorder_from(bool enable_persistent_index) {
         auto column_mapping = chunk_changer->get_mutable_column_mapping(i);
         if (column_index >= 0) {
             column_mapping->ref_column = column_index;
-            column_mapping->ref_base_reader_column_index = i;
         }
     }
 
@@ -2154,7 +2153,6 @@ void TabletUpdatesTest::test_reorder_from(bool enable_persistent_index) {
         auto column_mapping = chunk_changer->get_mutable_column_mapping(i);
         if (column_index >= 0) {
             column_mapping->ref_column = column_index;
-            column_mapping->ref_base_reader_column_index = i;
         }
     }
     ASSERT_TRUE(tablet_with_sort_key2->updates()->reorder_from(tablet_with_sort_key1, 4, chunk_changer.get()).ok());

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -2003,6 +2003,7 @@ void TabletUpdatesTest::test_convert_from(bool enable_persistent_index) {
             column_mapping->ref_column = column_index;
         }
     }
+    ASSERT_TRUE(chunk_changer->prepare().ok());
     ASSERT_TRUE(tablet_to_schema_change->updates()->convert_from(_tablet, 4, chunk_changer.get()).ok());
 
     ASSERT_EQ(N, read_tablet_and_compare_schema_changed(tablet_to_schema_change, 4, keys));
@@ -2037,6 +2038,7 @@ void TabletUpdatesTest::test_convert_from_with_pending(bool enable_persistent_in
             column_mapping->ref_column = column_index;
         }
     }
+    ASSERT_TRUE(chunk_changer->prepare().ok());
     ASSERT_TRUE(tablet_to_schema_change->rowset_commit(3, create_rowset(tablet_to_schema_change, keys3)).ok());
     ASSERT_TRUE(tablet_to_schema_change->rowset_commit(4, create_rowset(tablet_to_schema_change, keys4)).ok());
 
@@ -2073,6 +2075,7 @@ void TabletUpdatesTest::test_convert_from_with_mutiple_segment(bool enable_persi
             column_mapping->ref_column = column_index;
         }
     }
+    ASSERT_TRUE(chunk_changer->prepare().ok());
     std::vector<int64_t> ori_keys;
     for (int i = 100; i < 200; i++) {
         ori_keys.emplace_back(i);
@@ -2139,6 +2142,7 @@ void TabletUpdatesTest::test_reorder_from(bool enable_persistent_index) {
             column_mapping->ref_column = column_index;
         }
     }
+    ASSERT_TRUE(chunk_changer->prepare().ok());
 
     ASSERT_TRUE(tablet_with_sort_key1->updates()->reorder_from(_tablet, 4, chunk_changer.get()).ok());
 
@@ -2155,6 +2159,7 @@ void TabletUpdatesTest::test_reorder_from(bool enable_persistent_index) {
             column_mapping->ref_column = column_index;
         }
     }
+    ASSERT_TRUE(chunk_changer->prepare().ok());
     ASSERT_TRUE(tablet_with_sort_key2->updates()->reorder_from(tablet_with_sort_key1, 4, chunk_changer.get()).ok());
     ASSERT_EQ(N, read_tablet_and_compare_schema_changed_sort_key2(tablet_with_sort_key2, 4, keys));
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -39,7 +39,12 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.SlotDescriptor;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.TableName;
+import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.KeysType;
@@ -63,8 +68,14 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Field;
+import com.starrocks.sql.analyzer.RelationFields;
+import com.starrocks.sql.analyzer.RelationId;
+import com.starrocks.sql.analyzer.Scope;
+import com.starrocks.sql.analyzer.SelectAnalyzer;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
@@ -83,11 +94,16 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Version 2 of RollupJob.
@@ -367,11 +383,88 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                     long rollupTabletId = rollupTablet.getId();
                     long baseTabletId = tabletIdMap.get(rollupTabletId);
 
-                    Map<String, Expr> defineExprs = Maps.newHashMap();
+                    DescriptorTable descTable = new DescriptorTable();
+                    TupleDescriptor tupleDesc = descTable.createTupleDescriptor();
+                    Map<String, SlotDescriptor> slotDescByName = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+                    List<Column> rollupColumns = new ArrayList<Column>();
+                    Set<String> columnNames = new HashSet<String>();
+                    for (Column column : tbl.getBaseSchema()) {
+                        rollupColumns.add(column);
+                        columnNames.add(column.getName());
+                    }
                     for (Column column : rollupSchema) {
-                        if (column.getDefineExpr() != null) {
-                            defineExprs.put(column.getName(), column.getDefineExpr());
+                        if (columnNames.contains(column.getName())) {
+                            continue;
                         }
+                        rollupColumns.add(column);
+                    }
+
+                    /*
+                     * The expression substitution is needed here, because all slotRefs in
+                     * definedExpr are still is unAnalyzed. slotRefs get isAnalyzed == true
+                     * if it is init by SlotDescriptor. The slot information will be used by be to identify
+                     * the column location in a chunk.
+                     */
+                    for (Column column : rollupColumns) {
+                        SlotDescriptor destSlotDesc = descTable.addSlotDescriptor(tupleDesc);
+                        destSlotDesc.setIsMaterialized(true);
+                        destSlotDesc.setColumn(column);
+                        destSlotDesc.setIsNullable(column.isAllowNull());
+
+                        slotDescByName.put(column.getName(), destSlotDesc);
+                    }
+
+                    List<Expr> outputExprs = Lists.newArrayList();
+                    for (Column col : tbl.getBaseSchema()) {
+                        SlotDescriptor slotDesc = slotDescByName.get(col.getName());
+                        if (slotDesc == null) {
+                            throw new AlterCancelException("Expression for materialized view column can not find " +
+                                    "the ref column");
+                        }
+                        SlotRef slotRef = new SlotRef(slotDesc);
+                        slotRef.setColumnName(col.getName());
+                        outputExprs.add(slotRef);
+                    }
+
+                    TableName tableName = new TableName(db.getFullName(), tbl.getName());
+                    Map<String, Expr> defineExprs = Maps.newHashMap();
+                    for (Column column : rollupColumns) {
+                        if (column.getDefineExpr() == null) {
+                            continue;
+                        }
+
+                        List<SlotRef> slots = new ArrayList<>();
+                        column.getDefineExpr().collect(SlotRef.class, slots);
+                        for (SlotRef slot : slots) {
+                            SlotDescriptor slotDesc = slotDescByName.get(slot.getColumnName());
+                            if (slotDesc == null) {
+                                slotDesc = slotDescByName.get(column.getName());
+                            }
+                            if (slotDesc == null) {
+                                throw new AlterCancelException("slotDesc is null, slot=" + slot.getColumnName()
+                                        + ", column=" + column.getName());
+                            }
+                            slot.setDesc(slotDesc);
+                        }
+
+                        // sourceScope must be set null tableName for its Field in RelationFields
+                        // because we hope slotRef can not be resolved in sourceScope but can be
+                        // resolved in outputScope to force to replace the node using outputExprs.
+                        Scope sourceScope = new Scope(RelationId.anonymous(),
+                                new RelationFields(tbl.getBaseSchema().stream().map(col ->
+                                                new Field(col.getName(), col.getType(), null, null))
+                                        .collect(Collectors.toList())));
+                        Scope outputScope = new Scope(RelationId.anonymous(),
+                                new RelationFields(tbl.getBaseSchema().stream().map(col ->
+                                                new Field(col.getName(), col.getType(), tableName, null))
+                                        .collect(Collectors.toList())));
+                        SelectAnalyzer.RewriteAliasVisitor visitor =
+                                new SelectAnalyzer.RewriteAliasVisitor(sourceScope, outputScope,
+                                        outputExprs, new ConnectContext());
+                        Expr definedExpr = column.getDefineExpr().clone();
+                        definedExpr = definedExpr.accept(visitor, null);
+                        definedExpr = Expr.analyzeAndCastFold(definedExpr);
+                        defineExprs.put(column.getName(), definedExpr);
                     }
 
                     List<Replica> rollupReplicas = ((LocalTablet) rollupTablet).getImmutableReplicas();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Field.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/Field.java
@@ -210,7 +210,8 @@ public class Field {
     }
 
     public boolean matchesPrefix(TableName tableName) {
-        if (tableName.getCatalog() != null && !tableName.getCatalog().equals(relationAlias.getCatalog())) {
+        if (tableName.getCatalog() != null && relationAlias.getCatalog() != null &&
+                !tableName.getCatalog().equals(relationAlias.getCatalog())) {
             return false;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -47,16 +47,21 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.persist.ReplicaPersistInfo;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TAlterMaterializedViewParam;
 import com.starrocks.thrift.TAlterTabletMaterializedColumnReq;
 import com.starrocks.thrift.TAlterTabletReqV2;
+import com.starrocks.thrift.TQueryGlobals;
+import com.starrocks.thrift.TQueryOptions;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TTaskType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -172,6 +177,19 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
             }
         }
         req.setMaterialized_column_req(materializedColumnReq);
+
+        if (defineExprs != null || materializedColumnReq != null) {
+            // we need this thing, otherwise some expr evalution will fail in BE
+            TQueryGlobals queryGlobals = new TQueryGlobals();
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+            queryGlobals.setNow_string(dateFormat.format(new Date()));
+            queryGlobals.setTimestamp_ms(new Date().getTime());
+            queryGlobals.setTime_zone(TimeUtils.DEFAULT_TIME_ZONE);
+            TQueryOptions queryOptions = new TQueryOptions();
+            req.setQuery_globals(queryGlobals);
+            req.setQuery_options(queryOptions);
+        }
+
         req.setTablet_type(tabletType);
         req.setTxn_id(txnId);
         req.setJob_id(jobId);

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -178,7 +178,8 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
         }
         req.setMaterialized_column_req(materializedColumnReq);
 
-        if (defineExprs != null || materializedColumnReq != null) {
+        // TODO: merge `materializedColumnReq`'s query options into this later.
+        if (defineExprs != null && defineExprs.size() > 0) {
             // we need this thing, otherwise some expr evalution will fail in BE
             TQueryGlobals queryGlobals = new TQueryGlobals();
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -136,6 +136,8 @@ struct TAlterTabletReqV2 {
     9: optional i64 txn_id
     10: optional TAlterTabletMaterializedColumnReq materialized_column_req
     11: optional i64 job_id
+    12: optional InternalService.TQueryGlobals query_globals
+    13: optional InternalService.TQueryOptions query_options
 }
 
 struct TAlterMaterializedViewParam {


### PR DESCRIPTION
Fixes #22401 

### Before
Sync MV uses schema change to support the refresh of historic data. However, the old code only supports converters such as to_bitmap/hll_hash/count_field/percentile_hash, and does not utilize the query's expressions.

This limitation makes it difficult to extend and negatively impacts performance.
```
 /*
        * TODO(lhy)
        * Building the materialized view function for schema_change here based on defineExpr.
        * This is a trick because the current storage layer does not support expression evaluation.
        * We can refactor this part of the code until the uniform expression evaluates the logic.
        * count distinct materialized view will set mv_expr with to_bitmap or hll_hash.
        * count materialized view will set mv_expr with count.
        */
        if (item.__isset.mv_expr) {
            if (item.mv_expr.nodes[0].node_type == TExprNodeType::FUNCTION_CALL) {
                mv_param.mv_expr = item.mv_expr.nodes[0].fn.name.function_name;
            } else if (item.mv_expr.nodes[0].node_type == TExprNodeType::CASE_EXPR) {
                mv_param.mv_expr = "count_field";
            }
        }


const MaterializeTypeConverter* ChunkChanger::get_materialize_type_converter(const std::string& materialized_function,
                                                                             LogicalType type) {
    if (materialized_function == "to_bitmap") {
        return get_materialized_converter(type, OLAP_MATERIALIZE_TYPE_BITMAP);
    } else if (materialized_function == "hll_hash") {
        return get_materialized_converter(type, OLAP_MATERIALIZE_TYPE_HLL);
    } else if (materialized_function == "count_field") {
        return get_materialized_converter(type, OLAP_MATERIALIZE_TYPE_COUNT);
    } else if (materialized_function == "percentile_hash") {
        return get_materialized_converter(type, OLAP_MATERIALIZE_TYPE_PERCENTILE);
    } else {
        return nullptr;
    }
}
```

### Patched
To address this issue, we propose introducing support for common expression evaluation in order to refresh the historic data, similar to generated columns.

This pull request (PR) consists of two parts:

The front-end (FE) component normalizes the expressions.
The back-end (BE) component utilizes expression evaluation to refresh the historic data.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
