### PR TITLE
[BugFix] condition update maybe save duplicate recode if  primary key table using persistent index

### DIFF
--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1161,7 +1161,8 @@ Status PrimaryIndex::_build_persistent_values(uint32_t rssid, const vector<uint3
 const Slice* PrimaryIndex::_build_persistent_keys(const Column& pks, uint32_t idx_begin, uint32_t idx_end,
                                                   std::vector<Slice>* key_slices) const {
     if (pks.is_binary()) {
-        return reinterpret_cast<const Slice*>(pks.raw_data());
+        const Slice* vkeys = reinterpret_cast<const Slice*>(pks.raw_data());
+        return vkeys + idx_begin;
     } else {
         const uint8_t* keys = pks.raw_data();
         for (size_t i = idx_begin; i < idx_end; i++) {


### PR DESCRIPTION
If we create a table using persistent index and the encoded primary key column is binary column,  we will create an encoded primary key column for each segment and we will upsert the encoded primary key column once a time. But when we use condition update, we may need to upsert several times for an encoded primary key column and we only upsert a part of data into the index once a time. So for each upsert, we need to get the specified data of the column using `idx_begin` and `idx_end`, just as shown in the following code.
```
const Slice* PrimaryIndex::_build_persistent_keys(const Column& pks, uint32_t idx_begin, uint32_t idx_end,
                                                  std::vector<Slice>* key_slices) const {
    if (pks.is_binary()) {
        return reinterpret_cast<const Slice*>(pks.raw_data());
    } else {
        const uint8_t* keys = pks.raw_data();
        for (size_t i = idx_begin; i < idx_end; i++) {
            key_slices->emplace_back(keys, _key_size);
            keys += _key_size;
        }
        return reinterpret_cast<const Slice*>(key_slices->data());
    }
}
```
However, when the encoded primary key column is binary column, we ignore the `idx_begin` and always return the data from beginning, so we will upsert duplicate recode and delete the data that should not be deleted.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
