### PR TITLE
[BugFix] Fix retry operation when kafka rpc timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -216,8 +216,11 @@ public class KafkaUtil {
                         result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
                     } catch (Exception e) {
                         LOG.warn("failed to send proxy request to " + address + " err " + e.getMessage());
-                        if (e instanceof TimeoutException) {
-                            // When getting kafka info timed out, we tried again three times.
+                        // Jprotobuf-rpc-socket throws an ExecutionException when an exception occurs，please reference:
+                        // https://github.com/baidu/Jprotobuf-rpc-socket/blob/66038807a6bd6475efeb7ec72e3e2dbea4f59d5d/jprotobuf-rpc-core/src/main/java/com/baidu/jprotobuf/pbrpc/client/ProtobufRpcProxy.java#LL573C25-L573C25
+                        // We use the error message to identify the type of exception.
+                        if (e.getMessage().contains("Ocurrs time out")) {
+                             // When getting kafka info timed out, we tried again three times.
                             if (++retryTimes > 3 || (retryTimes + 1) * Config.routine_load_kafka_timeout_second >
                                                                             Config.routine_load_task_timeout_second) {
                                 throw e;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -219,7 +219,7 @@ public class KafkaUtil {
                         // Jprotobuf-rpc-socket throws an ExecutionException when an exception occurs.
                         // We use the error message to identify the type of exception.
                         if (e.getMessage().contains("Ocurrs time out")) {
-                             // When getting kafka info timed out, we tried again three times.
+                            // When getting kafka info timed out, we tried again three times.
                             if (++retryTimes > 3 || (retryTimes + 1) * Config.routine_load_kafka_timeout_second >
                                                                             Config.routine_load_task_timeout_second) {
                                 throw e;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -216,8 +216,7 @@ public class KafkaUtil {
                         result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
                     } catch (Exception e) {
                         LOG.warn("failed to send proxy request to " + address + " err " + e.getMessage());
-                        // Jprotobuf-rpc-socket throws an ExecutionException when an exception occurs，please reference:
-                        // https://github.com/baidu/Jprotobuf-rpc-socket/blob/66038807a6bd6475efeb7ec72e3e2dbea4f59d5d/jprotobuf-rpc-core/src/main/java/com/baidu/jprotobuf/pbrpc/client/ProtobufRpcProxy.java#LL573C25-L573C25
+                        // Jprotobuf-rpc-socket throws an ExecutionException when an exception occurs.
                         // We use the error message to identify the type of exception.
                         if (e.getMessage().contains("Ocurrs time out")) {
                              // When getting kafka info timed out, we tried again three times.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -64,7 +64,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class KafkaUtil {
     private static final Logger LOG = LogManager.getLogger(KafkaUtil.class);


### PR DESCRIPTION
Jprotobuf-rpc-socket throws an ExecutionException when an exception occurs，please reference:
https://github.com/baidu/Jprotobuf-rpc-socket/blob/66038807a6bd6475efeb7ec72e3e2dbea4f59d5d/jprotobuf-rpc-core/src/main/java/com/baidu/jprotobuf/pbrpc/client/ProtobufRpcProxy.java#LL573C25-L573C25
The previous approach failed to trigger a retry, and this PR triggers a retry based on an error message.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
