### PR TITLE
[Doc] fix dead link of create table page

### DIFF
--- a/docs/introduction/StarRocks_intro.md
+++ b/docs/introduction/StarRocks_intro.md
@@ -22,7 +22,7 @@ Join our [Slack channel](https://join.slack.com/t/starrocks/shared_invite/zt-z5z
 <NavBoxPartItem>
 
 - [Deploy with Docker](../quick_start/deploy_with_docker.md)
-- [Create a table](../quick_start/create_table.md)
+- [Create a table](../quick_start/Create_table.md)
 - [Ingest and query data](../quick_start/Import_and_query.md)
 
 </NavBoxPartItem>


### PR DESCRIPTION
Fixes #issue

The create table leads me to 404 in the [introduction page](https://docs.starrocks.io/en-us/latest/introduction/StarRocks_intro).

![dead link](https://github.com/StarRocks/starrocks/assets/9587680/b0ba6dce-d7ad-4811-bdf9-24b43f1f194e)

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
