### PR TITLE
[BugFix][Cherry-pick][Branch-2.5] Fix memory illegal modification (#24680)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -935,4 +935,6 @@ CONF_mInt64(load_tablet_timeout_seconds, "30");
 
 CONF_mBool(enable_pk_value_column_zonemap, "true");
 
+// Max size of key columns size of primary key table, default value is 128 bytes
+CONF_mInt32(primary_key_limit_size, "128");
 } // namespace starrocks::config

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -20,7 +20,6 @@ namespace starrocks::vectorized {
 
 // TODO(cbl): move to common space latter
 static const string LOAD_OP_COLUMN = "__op";
-static const size_t kPrimaryKeyLimitSize = 128;
 
 Schema MemTable::convert_schema(const TabletSchema* tablet_schema, const std::vector<SlotDescriptor*>* slot_descs) {
     Schema schema = ChunkHelper::convert_schema_to_format_v2(*tablet_schema);
@@ -213,7 +212,7 @@ Status MemTable::finalize() {
             _result_chunk = _aggregator->aggregate_result();
             if (_keys_type == PRIMARY_KEYS &&
                 PrimaryKeyEncoder::encode_exceed_limit(*_vectorized_schema, *_result_chunk.get(), 0,
-                                                       _result_chunk->num_rows(), kPrimaryKeyLimitSize)) {
+                                                       _result_chunk->num_rows(), config::primary_key_limit_size)) {
                 _aggregator.reset();
                 _aggregator_memory_usage = 0;
                 _aggregator_bytes_usage = 0;

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -47,7 +47,7 @@ constexpr size_t kL0SnapshotSizeMax = 1 * 1024 * 1024;
 constexpr size_t kL0SnapshotSizeMax = 16 * 1024 * 1024;
 #endif
 constexpr size_t kLongKeySize = 64;
-constexpr size_t kMaxKeyLength = 128; // we only support key length is less than or equal to 128 bytes for now
+constexpr size_t kFixedMaxKeySize = 128;
 
 const char* const kIndexFileMagic = "IDX1";
 
@@ -3053,7 +3053,7 @@ Status PersistentIndex::_update_usage_and_size_by_key_length(
 
         int64_t slice_usage = 0;
         int64_t slice_size = 0;
-        for (int key_size = kSliceMaxFixLength + 1; key_size <= kMaxKeyLength; key_size++) {
+        for (int key_size = kSliceMaxFixLength + 1; key_size <= kFixedMaxKeySize; key_size++) {
             slice_usage += add_usage_and_size[key_size].first;
             slice_size += add_usage_and_size[key_size].second;
         }
@@ -3079,13 +3079,15 @@ Status PersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue* va
     } else {
         RETURN_IF_ERROR(_get_from_immutable_index(n, keys, old_values, not_founds_by_key_size));
     }
-    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
+    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kFixedMaxKeySize + 1,
+                                                                std::pair<int64_t, int64_t>(0, 0));
     for (size_t i = 0; i < n; i++) {
         if (old_values[i].get_value() == NullIndexValue) {
             _size++;
             _usage += keys[i].size + kIndexValueSize;
-            add_usage_and_size[keys[i].size].first += keys[i].size + kIndexValueSize;
-            add_usage_and_size[keys[i].size].second++;
+            int64_t len = keys[i].size > kFixedMaxKeySize ? 0 : keys[i].size;
+            add_usage_and_size[len].first += keys[i].size + kIndexValueSize;
+            add_usage_and_size[len].second++;
         }
     }
 
@@ -3109,12 +3111,14 @@ Status PersistentIndex::insert(size_t n, const Slice* keys, const IndexValue* va
             RETURN_IF_ERROR(_l1_vec[0]->check_not_exist(n, keys, check_l1_key_size));
         }
     }
-    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
+    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kFixedMaxKeySize + 1,
+                                                                std::pair<int64_t, int64_t>(0, 0));
     _size += n;
     for (size_t i = 0; i < n; i++) {
         _usage += keys[i].size + kIndexValueSize;
-        add_usage_and_size[keys[i].size].first += keys[i].size + kIndexValueSize;
-        add_usage_and_size[keys[i].size].second++;
+        int64_t len = keys[i].size > kFixedMaxKeySize ? 0 : keys[i].size;
+        add_usage_and_size[len].first += keys[i].size + kIndexValueSize;
+        add_usage_and_size[len].second++;
     }
     RETURN_IF_ERROR(_update_usage_and_size_by_key_length(add_usage_and_size));
 
@@ -3131,13 +3135,15 @@ Status PersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_value
     } else {
         RETURN_IF_ERROR(_get_from_immutable_index(n, keys, old_values, not_founds_by_key_size));
     }
-    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
+    std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kFixedMaxKeySize + 1,
+                                                                std::pair<int64_t, int64_t>(0, 0));
     for (size_t i = 0; i < n; i++) {
         if (old_values[i].get_value() != NullIndexValue) {
             _size--;
             _usage -= keys[i].size + kIndexValueSize;
-            add_usage_and_size[keys[i].size].first -= keys[i].size + kIndexValueSize;
-            add_usage_and_size[keys[i].size].second--;
+            int64_t len = keys[i].size > kFixedMaxKeySize ? 0 : keys[i].size;
+            add_usage_and_size[len].first -= keys[i].size + kIndexValueSize;
+            add_usage_and_size[len].second--;
         }
     }
     RETURN_IF_ERROR(_update_usage_and_size_by_key_length(add_usage_and_size));

--- a/be/src/storage/primary_key_encoder.cpp
+++ b/be/src/storage/primary_key_encoder.cpp
@@ -487,9 +487,12 @@ bool PrimaryKeyEncoder::encode_exceed_limit(const vectorized::Schema& schema, co
     vector<const void*> datas(ncol, nullptr);
     if (ncol == 1) {
         if (schema.field(0)->type()->type() == OLAP_FIELD_TYPE_VARCHAR) {
-            if (static_cast<const Slice*>(static_cast<const void*>(chunk.get_column_by_index(0)->raw_data()))
-                        ->get_size() > limit_size) {
-                return true;
+            const Slice* keys =
+                    static_cast<const Slice*>(static_cast<const void*>(chunk.get_column_by_index(0)->raw_data()));
+            for (size_t i = 0; i < len; i++) {
+                if (keys[offset + i].size > limit_size) {
+                    return true;
+                }
             }
         }
     } else {
@@ -515,9 +518,9 @@ bool PrimaryKeyEncoder::encode_exceed_limit(const vectorized::Schema& schema, co
             size = accumulated_fixed_size;
             for (const auto varchar_index : varchar_indexes) {
                 if (varchar_index + 1 == ncol) {
-                    size += static_cast<const Slice*>(datas[varchar_index])[i].get_size();
+                    size += static_cast<const Slice*>(datas[varchar_index])[offset + i].get_size();
                 } else {
-                    auto s = static_cast<const Slice*>(datas[varchar_index])[i];
+                    auto s = static_cast<const Slice*>(datas[varchar_index])[offset + i];
                     std::string_view sv(s.get_data(), s.get_size());
                     size += s.get_size() + std::count(sv.begin(), sv.end(), 0) + 2;
                 }

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -159,4 +159,32 @@ TEST(PrimaryKeyEncoderTest, testEncodeCompositeLimit) {
     }
 }
 
+TEST(PrimaryKeyEncoderTest, testEncodeVarcharLimit) {
+    auto sc = create_key_schema({TYPE_VARCHAR});
+    const int n = 2;
+    {
+        auto pchunk = ChunkHelper::new_chunk(*sc, n);
+        Datum tmp;
+        string tmpstr("slice00000");
+        tmp.set_slice(tmpstr);
+        pchunk->columns()[0]->append_datum(tmp);
+        tmpstr = "slice0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                 "00000000000000000000000000000000000";
+        tmp.set_slice(tmpstr);
+        pchunk->columns()[0]->append_datum(tmp);
+        EXPECT_TRUE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128));
+    }
+    {
+        auto pchunk = ChunkHelper::new_chunk(*sc, n);
+        Datum tmp;
+        string tmpstr("slice00000");
+        tmp.set_slice(tmpstr);
+        pchunk->columns()[0]->append_datum(tmp);
+        tmpstr = "slice00000000000000000000000000000000000";
+        tmp.set_slice(tmpstr);
+        pchunk->columns()[0]->append_datum(tmp);
+        EXPECT_FALSE(PrimaryKeyEncoder::encode_exceed_limit(*sc, *pchunk, 0, n, 128));
+    }
+}
+
 } // namespace starrocks

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -164,7 +164,7 @@ TEST(PrimaryKeyEncoderTest, testEncodeVarcharLimit) {
     const int n = 2;
     {
         auto pchunk = ChunkHelper::new_chunk(*sc, n);
-        Datum tmp;
+        vectorized::Datum tmp;
         string tmpstr("slice00000");
         tmp.set_slice(tmpstr);
         pchunk->columns()[0]->append_datum(tmp);
@@ -176,7 +176,7 @@ TEST(PrimaryKeyEncoderTest, testEncodeVarcharLimit) {
     }
     {
         auto pchunk = ChunkHelper::new_chunk(*sc, n);
-        Datum tmp;
+        vectorized::Datum tmp;
         string tmpstr("slice00000");
         tmp.set_slice(tmpstr);
         pchunk->columns()[0]->append_datum(tmp);

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -160,7 +160,7 @@ TEST(PrimaryKeyEncoderTest, testEncodeCompositeLimit) {
 }
 
 TEST(PrimaryKeyEncoderTest, testEncodeVarcharLimit) {
-    auto sc = create_key_schema({TYPE_VARCHAR});
+    auto sc = create_key_schema({OLAP_FIELD_TYPE_VARCHAR});
     const int n = 2;
     {
         auto pchunk = ChunkHelper::new_chunk(*sc, n);


### PR DESCRIPTION
When we create a primary key table, we will check the total length of the key columns and we don't support the length of the key column greater than 128 bytes. However, when the primary key table only has one key column and the column type is varchar, we may write some data whose key column length is larger than 128 bytes. So in some code of persistent index, we may create a vector that contains at most 129 elements and modify the vector by key column sizes

```
e.g.

// kMaxKeyLength is defined as 128
std::vector<std::pair<int64_t, int64_t>> add_usage_and_size(kMaxKeyLength + 1, std::pair<int64_t, int64_t>(0, 0));
....
add_usage_and_size[keys[i].size].first -= keys[i].size + kIndexValueSize;
add_usage_and_size[keys[i].size].second--;
```

So if we can not guarantee the size of the key column is not larger than 128 bytes, the above code is illegal memory modification which may cause unexpected errors.
