### PR TITLE
[Enhancement] Add ls_tablet_dir to script engine

### DIFF
--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -16,6 +16,8 @@
 
 #include <google/protobuf/util/json_util.h>
 
+#include <regex>
+
 #include "common/greplog.h"
 #include "common/logging.h"
 #include "exec/schema_scanner/schema_be_tablets_scanner.h"
@@ -119,6 +121,41 @@ static int64_t unix_seconds() {
     return UnixSeconds();
 }
 
+static std::string exec(const std::string& cmd) {
+    std::string ret;
+
+    FILE* fp = popen(cmd.c_str(), "r");
+    if (fp == NULL) {
+        ret = strings::Substitute("popen failed: $0 cmd: $1", strerror(errno), cmd);
+        return ret;
+    }
+
+    char buff[4096];
+    while (true) {
+        size_t r = fread(buff, 1, 4096, fp);
+        if (r == 0) {
+            break;
+        }
+        ret.append(buff, r);
+    }
+    int status = pclose(fp);
+    if (status == -1) {
+        ret.append(strings::Substitute("pclose failed: $0", strerror(errno)));
+    } else if (status != 0) {
+        ret.append(strings::Substitute("exit: $0", status));
+    }
+    return ret;
+}
+
+static std::string exec_whitelist(const std::string& cmd) {
+    static std::regex legal_cmd("(ls|cat|head|tail|grep|free|echo)[^<>\\|;`\\\\]*");
+    std::cmatch m;
+    if (!std::regex_match(cmd.c_str(), m, legal_cmd)) {
+        return "illegal cmd";
+    }
+    return exec(cmd);
+}
+
 void bind_exec_env(ForeignModule& m) {
     {
         auto& cls = m.klass<MemTracker>("MemTracker");
@@ -147,6 +184,8 @@ void bind_exec_env(ForeignModule& m) {
         cls.funcStaticExt<&grep_log_as_string>("grep_log_as_string");
         cls.funcStaticExt<&get_file_write_history>("get_file_write_history");
         cls.funcStaticExt<&unix_seconds>("unix_seconds");
+        // uncomment this to enable executing shell commands
+        // cls.funcStaticExt<&exec_whitelist>("exec");
         REG_METHOD(ExecEnv, process_mem_tracker);
         REG_METHOD(ExecEnv, query_pool_mem_tracker);
         REG_METHOD(ExecEnv, load_mem_tracker);
@@ -250,6 +289,14 @@ public:
         return StorageEngine::instance()->get_manual_compaction_status();
     }
 
+    static std::string ls_tablet_dir(int64_t tablet_id) {
+        auto tablet = get_tablet(tablet_id);
+        if (!tablet) {
+            return "tablet not found";
+        }
+        return exec_whitelist(strings::Substitute("ls -al $0", tablet->schema_hash_path()));
+    }
+
     static void bind(ForeignModule& m) {
         {
             auto& cls = m.klass<TabletBasicInfo>("TabletBasicInfo");
@@ -266,6 +313,9 @@ public:
             REG_VAR(TabletBasicInfo, create_time);
             REG_VAR(TabletBasicInfo, state);
             REG_VAR(TabletBasicInfo, type);
+            REG_VAR(TabletBasicInfo, data_dir);
+            REG_VAR(TabletBasicInfo, shard_id);
+            REG_VAR(TabletBasicInfo, schema_hash);
         }
         {
             auto& cls = m.klass<TabletSchema>("TabletSchema");
@@ -399,6 +449,7 @@ public:
             REG_STATIC_METHOD(StorageEngineRef, submit_manual_compaction_task_for_partition);
             REG_STATIC_METHOD(StorageEngineRef, submit_manual_compaction_task_for_tablet);
             REG_STATIC_METHOD(StorageEngineRef, get_manual_compaction_status);
+            REG_STATIC_METHOD(StorageEngineRef, ls_tablet_dir);
         }
     }
 };


### PR DESCRIPTION
Adds ls_tablet_dir to BE script engine. 

This PR also adds the ability to invoke some shell commands(actually ls_tablet_dir uses this function), for easy debugging, cause it's dangerous to expose service env, so it's disabled, dev can uncomment binding code to enable this.

```
mysql> admin execute on 10006 'System.print(StorageEngine.ls_tablet_dir(23007))';
+---------------------------------------------------------------------------------------------------------+
| result                                                                                                  |
+---------------------------------------------------------------------------------------------------------+
| total 12                                                                                                |
| drwxrwxr-x 2 decster decster 4096  6月  6 16:40 .                                                       |
| drwxrwxr-x 3 decster decster 4096  6月  6 16:40 ..                                                      |
| -rw-rw-r-- 1 decster decster  419  6月  6 16:40 020000000000001fc5474b383bd1ba6371672d1de58c74a0_0.dat  |
+---------------------------------------------------------------------------------------------------------+
4 rows in set (0.01 sec)

```
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
