### PR TITLE
[Enhancement] merge small chunks when split partition in spillable hash join

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -29,6 +29,7 @@ bool SpillableAggregateDistinctBlockingSinkOperator::is_finished() const {
 }
 
 Status SpillableAggregateDistinctBlockingSinkOperator::set_finishing(RuntimeState* state) {
+    auto defer_set_finishing = DeferOp([this]() { _aggregator->spill_channel()->set_finishing(); });
     _is_finished = true;
     if (state->is_cancelled()) {
         _aggregator->spiller()->cancel();
@@ -37,18 +38,13 @@ Status SpillableAggregateDistinctBlockingSinkOperator::set_finishing(RuntimeStat
     // TODO: FIXME after refactor cancel
     auto io_executor = _aggregator->spill_channel()->io_executor();
     auto set_call_back_function = [this](RuntimeState* state, auto io_executor) {
-        _aggregator->spill_channel()->set_finishing();
         RETURN_IF_ERROR(AggregateDistinctBlockingSinkOperator::set_finishing(state));
-        RETURN_IF_ERROR(_aggregator->spiller()->flush(
-                state, *io_executor,
-                spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this())));
-        return _aggregator->spiller()->set_flush_all_call_back(
-                []() { return Status::OK(); }, state, *io_executor,
-                spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this()));
+        RETURN_IF_ERROR(_aggregator->spiller()->flush(state, *io_executor, RESOURCE_TLS_MEMTRACER_GUARD(state)));
+        return _aggregator->spiller()->set_flush_all_call_back([]() { return Status::OK(); }, state, *io_executor,
+                                                               RESOURCE_TLS_MEMTRACER_GUARD(state));
     };
 
     if (_aggregator->spill_channel()->is_working()) {
-        DCHECK(_spill_strategy == spill::SpillStrategy::SPILL_ALL);
         std::function<StatusOr<ChunkPtr>()> task = [state, io_executor,
                                                     set_call_back_function]() -> StatusOr<ChunkPtr> {
             RETURN_IF_ERROR(set_call_back_function(state, io_executor));
@@ -214,10 +210,8 @@ StatusOr<ChunkPtr> SpillableAggregateDistinctBlockingSourceOperator::_pull_spill
 
     if (!_aggregator->is_spilled_eos()) {
         auto executor = _aggregator->spill_channel()->io_executor();
-        ASSIGN_OR_RETURN(auto chunk, _aggregator->spiller()->restore(
-                                             state, *executor,
-                                             spill::ResourceMemTrackerGuard(tls_mem_tracker,
-                                                                            state->query_ctx()->weak_from_this())));
+        ASSIGN_OR_RETURN(auto chunk,
+                         _aggregator->spiller()->restore(state, *executor, RESOURCE_TLS_MEMTRACER_GUARD(state)));
 
         if (chunk->is_empty()) {
             return chunk;

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -225,9 +225,8 @@ Status SpillableHashJoinProbeOperator::_push_probe_chunk(RuntimeState* state, co
         }
         probe_partition->num_rows += size;
     };
-    RETURN_IF_ERROR(_probe_spiller->partitioned_spill(
-            state, chunk, hash_column.get(), partition_processer, executor,
-            spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this())));
+    RETURN_IF_ERROR(_probe_spiller->partitioned_spill(state, chunk, hash_column.get(), partition_processer, executor,
+                                                      RESOURCE_TLS_MEMTRACER_GUARD(state)));
 
     return Status::OK();
 }
@@ -321,14 +320,10 @@ Status SpillableHashJoinProbeOperator::_restore_probe_partition(RuntimeState* st
         // probe partition has been processed
         if (_probe_read_eofs[i]) continue;
         RETURN_IF_ERROR(_current_reader[i]->trigger_restore(
-                state, *_executor,
-                spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this(),
-                                               std::weak_ptr(_current_reader[i]))));
+                state, *_executor, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_current_reader[i]))));
         if (_current_reader[i]->has_output_data()) {
             auto chunk_st = _current_reader[i]->restore(
-                    state, *_executor,
-                    spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this(),
-                                                   std::weak_ptr(_current_reader[i])));
+                    state, *_executor, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_current_reader[i])));
             if (chunk_st.ok() && chunk_st.value() && !chunk_st.value()->is_empty()) {
                 _probers[i]->push_probe_chunk(state, std::move(chunk_st.value()));
             } else if (chunk_st.status().is_end_of_file()) {

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -55,10 +55,10 @@ Status SpillablePartitionSortSinkOperator::push_chunk(RuntimeState* state, const
 }
 
 Status SpillablePartitionSortSinkOperator::set_finishing(RuntimeState* state) {
+    auto defer_set_finishing = DeferOp([this]() { _chunks_sorter->spill_channel()->set_finishing(); });
     if (state->is_cancelled()) {
         _is_finished = true;
         _chunks_sorter->cancel();
-        _chunks_sorter->spill_channel()->set_finishing();
         return Status::Cancelled("runtime state is cancelled");
     }
 
@@ -68,7 +68,6 @@ Status SpillablePartitionSortSinkOperator::set_finishing(RuntimeState* state) {
     // TODO: test cancel case
     auto io_executor = _chunks_sorter->spill_channel()->io_executor();
     auto set_call_back_function = [this](RuntimeState* state, auto io_executor) {
-        _chunks_sorter->spill_channel()->set_finishing();
         return _chunks_sorter->spiller()->set_flush_all_call_back(
                 [this]() {
                     // Current partition sort is ended, and
@@ -78,8 +77,7 @@ Status SpillablePartitionSortSinkOperator::set_finishing(RuntimeState* state) {
                     _is_finished = true;
                     return Status::OK();
                 },
-                state, *io_executor,
-                spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this()));
+                state, *io_executor, RESOURCE_TLS_MEMTRACER_GUARD(state));
     };
 
     Status ret_status;

--- a/be/src/exec/pipeline/spill_process_channel.h
+++ b/be/src/exec/pipeline/spill_process_channel.h
@@ -109,7 +109,6 @@ private:
     UnboundedBlockingQueue<SpillProcessTask> _spill_tasks;
     SpillProcessTask _current_task;
     SpillProcessChannelFactory* _parent;
-    std::mutex _mutex;
 };
 
 } // namespace starrocks

--- a/be/src/exec/pipeline/spill_process_operator.cpp
+++ b/be/src/exec/pipeline/spill_process_operator.cpp
@@ -30,6 +30,10 @@ bool SpillProcessOperator::is_finished() const {
     return _channel->is_finished();
 }
 
+void SpillProcessOperator::close(RuntimeState* state) {
+    SourceOperator::close(state);
+}
+
 StatusOr<ChunkPtr> SpillProcessOperator::pull_chunk(RuntimeState* state) {
     if (!_channel->current_task()) {
         bool res = _channel->acquire_spill_task();

--- a/be/src/exec/pipeline/spill_process_operator.h
+++ b/be/src/exec/pipeline/spill_process_operator.h
@@ -37,7 +37,7 @@ public:
 
     Status prepare(RuntimeState* state) override { return SourceOperator::prepare(state); }
 
-    void close(RuntimeState* state) override { SourceOperator::close(state); }
+    void close(RuntimeState* state) override;
 
     bool has_output() const override;
 

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -272,11 +272,11 @@ public:
 
     const auto& level_to_partitions() { return _level_to_partitions; }
 
+    template <class ChunkProvider>
+    Status spill_partition(SerdeContext& context, SpilledPartition* partition, ChunkProvider&& provider);
+
 private:
     Status _init_with_partition_nums(RuntimeState* state, int num_partitions);
-
-    template <class ChunkProvider>
-    Status _spill_partition(SerdeContext& context, SpilledPartition* partition, ChunkProvider&& provider);
 
     // split partition by hash
     // hash-based partitioning can have significant degradation in the case of heavily skewed data.


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

case:
```
set pipeline_dop=1;
select count(r.lo_shipmode) from lineorder l join [colocate] lineorder r on l.lo_orderkey=r.lo_orderkey and l.lo_linenumber=r.lo_linenumber;
```

with variables:
```
mysql> show variables like '%spill%';
+---------------------------+-----------+
| Variable_name             | Value     |
+---------------------------+-----------+
| enable_spill              | true      |
| spill_encode_level        | 7         |
| spill_mem_limit_threshold | 0.5       |
| spill_mem_table_num       | 2         |
| spill_mem_table_size      | 104857600 |
| spill_mode                | force     |
| spill_operator_max_bytes  | 204857600 |
| spill_operator_min_bytes  | 10485760  |
| spillable_operator_mask   | -1        |
+---------------------------+-----------+
9 rows in set (0.00 sec)
```

baseline:
```
          UniqueMetrics:
             - JoinPredicates: 1: lo_orderkey = 18: lo_orderkey, 2: lo_linenumber = 19: lo_linenumber
             - DistributionMode: COLOCATE
             - JoinType: INNER_JOIN
             - BuildBuckets: 0
             - BuildConjunctEvaluateTime: 164.443ms
             - BuildHashTableTime: 15s712ms
             - CopyRightTableChunkTime: 9s262ms
             - RuntimeFilterBuildTime: 0ns
             - RuntimeFilterNum: 0
             - SpillDeserializeTimer: 875.191ms
             - SpillFlushBytes: 16.08 GB
             - SpillFlushTimer: 7s295ms
             - SpillRestoreBytes: 16.08 GB
             - SpillRestoreRows: 0
             - SpillRestoreTimer: 6s184ms
             - SpillSerializeTimer: 1s386ms
             - SpillShuffleTimer: 12s128ms
             - SpillTime: 12s525ms
             - SpillWriteIOTimer: 0ns
             - SpilledRows: 600.037902M (600037902)
             - SplitPartitionTimer: 27s318ms
```

patched:
```
          UniqueMetrics:
             - JoinPredicates: 1: lo_orderkey = 18: lo_orderkey, 2: lo_linenumber = 19: lo_linenumber
             - DistributionMode: COLOCATE
             - JoinType: INNER_JOIN
             - BuildBuckets: 0
             - BuildConjunctEvaluateTime: 78.691ms
             - BuildHashTableTime: 15s116ms
             - CopyRightTableChunkTime: 8s465ms
             - RuntimeFilterBuildTime: 0ns
             - RuntimeFilterNum: 0
             - SpillDeserializeTimer: 962.490ms
             - SpillFlushBytes: 18.95 GB
             - SpillFlushTimer: 6s970ms
             - SpillRestoreBytes: 18.95 GB
             - SpillRestoreRows: 0
             - SpillRestoreTimer: 6s80ms
             - SpillSerializeTimer: 1s515ms
             - SpillShuffleTimer: 12s342ms
             - SpillTime: 12s680ms
             - SpillWriteIOTimer: 0ns
             - SpilledRows: 600.037902M (600037902)
             - SplitPartitionTimer: 20s950ms
```


## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
