### PR TITLE
[Enhancement] clear unsupported keys from array nested types (backport #24811)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -657,30 +657,42 @@ public abstract class Type implements Cloneable {
 
     public boolean canApplyToNumeric() {
         // TODO(mofei) support sum, avg for JSON
-        return !isOnlyMetricType() && !isJsonType();
+        return !isOnlyMetricType() && !isJsonType() && !isArrayType();
     }
 
     public boolean canJoinOn() {
-        return !isOnlyMetricType() && !isJsonType();
+        return !isOnlyMetricType() && !isJsonType() && !isArrayType();
     }
 
     public boolean canGroupBy() {
+        if (isArrayType()) {
+            return ((ArrayType) this).getItemType().canGroupBy();
+        }
         // TODO(mofei) support group by for JSON
         return !isOnlyMetricType() && !isJsonType();
     }
 
     public boolean canOrderBy() {
         // TODO(mofei) support order by for JSON
+        if (isArrayType()) {
+            return ((ArrayType) this).getItemType().canOrderBy();
+        }
         return !isOnlyMetricType() && !isJsonType();
     }
 
     public boolean canPartitionBy() {
         // TODO(mofei) support partition by for JSON
+        if (isArrayType()) {
+            return ((ArrayType) this).getItemType().canPartitionBy();
+        }
         return !isOnlyMetricType() && !isJsonType();
     }
 
     public boolean canDistinct() {
         // TODO(mofei) support distinct by for JSON
+        if (isArrayType()) {
+            return ((ArrayType) this).getItemType().canDistinct();
+        }
         return !isOnlyMetricType() && !isJsonType();
     }
 
@@ -707,7 +719,7 @@ public abstract class Type implements Cloneable {
     }
 
     public static final String OnlyMetricTypeErrorMsg =
-            "Type percentile/hll/bitmap/json not support aggregation/group-by/order-by/union/join";
+            "Type (nested) percentile/hll/bitmap/json not support aggregation/group-by/order-by/union/join";
 
     public boolean isHllType() {
         return isScalarType(PrimitiveType.HLL);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
@@ -25,7 +25,7 @@ public class AnalyticAnalyzer {
                         + e.toSql() + " (in " + analyticExpr.toSql() + ")");
             }
             if (!e.getType().canPartitionBy()) {
-                throw new SemanticException("HLL, BITMAP and PERCENTILE type can't as partition by column");
+                throw new SemanticException(e.getType().toSql() + " type can't as partition by column");
             }
         }
 
@@ -35,7 +35,7 @@ public class AnalyticAnalyzer {
                         + e.getExpr().toSql() + " (in " + analyticExpr.toSql() + ")");
             }
             if (!e.getExpr().getType().canOrderBy()) {
-                throw new SemanticException("HLL, BITMAP and PERCENTILE type can't as order by column");
+                throw new SemanticException(e.getExpr().getType().toString() + " type can't as order by column");
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -327,4 +327,19 @@ public class AnalyzeStmtTest {
         Assert.assertEquals("select.insert",
                 ((SelectRelation) stmt.getQueryRelation()).getRelation().getResolveTableName().toString());
     }
+
+    @Test
+    public void testTypeKeys() throws Exception {
+        analyzeSuccess("select count(*) from tarray group by v4");
+        analyzeSuccess("select distinct v4 from tarray");
+        analyzeSuccess("select * from tarray order by v4");
+        analyzeSuccess("select DENSE_RANK() OVER(partition by v3 order by v4) from tarray");
+        analyzeFail("select avg(v4) from tarray");
+        analyzeFail("select count(*) from tarray group by v5");
+        analyzeFail("select distinct v5 from tarray");
+        analyzeFail("select * from tarray join tarray y using(v4)");
+        analyzeFail("select * from tarray join tarray y using(v5)");
+        analyzeFail("select * from tarray order by v5");
+        analyzeFail("select DENSE_RANK() OVER(partition by v5 order by v4) from tarray");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTestUtil.java
@@ -107,7 +107,8 @@ public class AnalyzeTestUtil {
                 "  `v1` bigint NULL COMMENT \"\",\n" +
                 "  `v2` bigint NULL COMMENT \"\",\n" +
                 "  `v3` ARRAY<bigint(20)>  NULL,\n" +
-                "  `v4` ARRAY<largeint>  NULL\n" +
+                "  `v4` ARRAY<largeint>  NULL,\n" +
+                "  `v5` ARRAY<json>  NULL\n" +
                 ") ENGINE=OLAP\n" +
                 "DUPLICATE KEY(`v1`, `v2`)\n" +
                 "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
@@ -40,14 +40,14 @@ public class JsonTypeTest extends PlanTestBase {
     @Test
     public void testJoin() {
         ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
-                "Type percentile/hll/bitmap/json not support aggregation/group-by/order-by/union/join",
+                "Type (nested) percentile/hll/bitmap/json not support aggregation/group-by/order-by/union/join",
                 () -> getFragmentPlan("select * from tjson_test t1 join tjson_test t2 using(v_json)"));
 
         ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
-                "Type percentile/hll/bitmap/json not support aggregation/group-by/order-by/union/join",
+                "Type (nested) percentile/hll/bitmap/json not support aggregation/group-by/order-by/union/join",
                 () -> getFragmentPlan("select * from tjson_test t1 join tjson_test t2 on t1.v_json = t2.v_json"));
         ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
-                "Type percentile/hll/bitmap/json not support aggregation/group-by/order-by/union/join",
+                "Type (nested) percentile/hll/bitmap/json not support aggregation/group-by/order-by/union/join",
                 () -> getFragmentPlan("select * from tjson_test t1 join tjson_test t2 on t1.v_json > t2.v_json"));
 
         ExceptionChecker.expectThrowsNoException(
@@ -62,7 +62,7 @@ public class JsonTypeTest extends PlanTestBase {
                         " cast(t1.v_json->'a' as int) = cast(t2.v_json->'a' as int) and t1.v_id = t2.v_id"));
 
         ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
-                "Type percentile/hll/bitmap/json not support aggregation/group-by/order-by/union/join",
+                "Type (nested) percentile/hll/bitmap/json not support aggregation/group-by/order-by/union/join",
                 () -> getFragmentPlan("select * from tjson_test t1 join tjson_test t2 on" +
                         " t1.v_id = t2.v_id and t1.v_json = t2.v_json"));
     }


### PR DESCRIPTION
Fixes #issue

group by array<json> crash, because the nested type json is not supported to do grouping by.

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
