### PR TITLE
[BugFix] Fix invalid available_chunk_source_count make broker load hang

### DIFF
--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -39,7 +39,7 @@ struct ConnectorScanOperatorIOTasksMemLimiter {
         std::shared_lock<std::shared_mutex> L(lock);
 
         int64_t max_count = mem_limit / estimated_mem_usage_per_chunk_source;
-        int64_t avail_count = (max_count - running_chunk_source_count) / dop;
+        int64_t avail_count = (max_count - running_chunk_source_count) / static_cast<int64_t>(dop);
         avail_count = std::max<int64_t>(avail_count, 0);
         if (avail_count == 0 && running_chunk_source_count == 0) {
             avail_count = 1;


### PR DESCRIPTION
int64_t divided by size_t (uint64_t) will be converted to uint64_t, when int64_t is less than 0, this value will be very large

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
