### PR TITLE
[Enhancement] Decorrelate the NetworkTime calculation from the system clocks

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -209,11 +209,11 @@ void SinkBuffer::cancel_one_sinker(RuntimeState* const state) {
 }
 
 void SinkBuffer::_update_network_time(const TUniqueId& instance_id, const int64_t send_timestamp,
-                                      const int64_t receive_process_time) {
+                                      const int64_t receiver_post_process_time) {
     const int64_t get_response_timestamp = MonotonicNanos();
     _last_receive_time = get_response_timestamp;
     int32_t concurrency = _num_in_flight_rpcs[instance_id.lo];
-    int64_t time_usage = get_response_timestamp - send_timestamp - receive_process_time;
+    int64_t time_usage = get_response_timestamp - send_timestamp - receiver_post_process_time;
     _network_times[instance_id.lo].update(time_usage, concurrency);
     _rpc_cumulative_time += time_usage;
     _rpc_count++;
@@ -355,7 +355,7 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
                                             status.message());
             } else {
                 _try_to_send_rpc(ctx.instance_id, [&]() {
-                    _update_network_time(ctx.instance_id, ctx.send_timestamp, result.receive_process_time());
+                    _update_network_time(ctx.instance_id, ctx.send_timestamp, result.receiver_post_process_time());
                     _process_send_window(ctx.instance_id, ctx.sequence);
                 });
             }

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -210,10 +210,10 @@ void SinkBuffer::cancel_one_sinker(RuntimeState* const state) {
 
 void SinkBuffer::_update_network_time(const TUniqueId& instance_id, const int64_t send_timestamp,
                                       const int64_t receive_process_time) {
-    const int64_t receive_response_time = MonotonicNanos();
-    _last_receive_time = receive_response_time;
+    const int64_t get_response_timestamp = MonotonicNanos();
+    _last_receive_time = get_response_timestamp;
     int32_t concurrency = _num_in_flight_rpcs[instance_id.lo];
-    int64_t time_usage = receive_response_time - send_timestamp - receive_process_time;
+    int64_t time_usage = get_response_timestamp - send_timestamp - receive_process_time;
     _network_times[instance_id.lo].update(time_usage, concurrency);
     _rpc_cumulative_time += time_usage;
     _rpc_count++;
@@ -355,8 +355,8 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
                                             status.message());
             } else {
                 _try_to_send_rpc(ctx.instance_id, [&]() {
-                    _process_send_window(ctx.instance_id, ctx.sequence);
                     _update_network_time(ctx.instance_id, ctx.send_timestamp, result.receive_process_time());
+                    _process_send_window(ctx.instance_id, ctx.sequence);
                 });
             }
             --_total_in_flight_rpc;

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -101,7 +101,7 @@ private:
     using Mutex = bthread::Mutex;
 
     void _update_network_time(const TUniqueId& instance_id, const int64_t send_timestamp,
-                              const int64_t receive_process_time);
+                              const int64_t receiver_post_process_time);
     // Update the discontinuous acked window, here are the invariants:
     // all acks received with sequence from [0, _max_continuous_acked_seqs[x]]
     // not all the acks received with sequence from [_max_continuous_acked_seqs[x]+1, _request_seqs[x]]

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -101,7 +101,7 @@ private:
     using Mutex = bthread::Mutex;
 
     void _update_network_time(const TUniqueId& instance_id, const int64_t send_timestamp,
-                              const int64_t receive_timestamp);
+                              const int64_t receive_process_time);
     // Update the discontinuous acked window, here are the invariants:
     // all acks received with sequence from [0, _max_continuous_acked_seqs[x]]
     // not all the acks received with sequence from [_max_continuous_acked_seqs[x]+1, _request_seqs[x]]

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -40,6 +40,7 @@
 #include <memory>
 #include <shared_mutex>
 #include <sstream>
+#include <utility>
 
 #include "agent/agent_server.h"
 #include "agent/publish_version.h"
@@ -77,6 +78,7 @@
 #include "storage/txn_manager.h"
 #include "util/stopwatch.hpp"
 #include "util/thrift_util.h"
+#include "util/time.h"
 #include "util/uid_util.h"
 
 namespace starrocks {
@@ -141,6 +143,27 @@ template <typename T>
 void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcController* cntl_base,
                                                   const PTransmitChunkParams* request, PTransmitChunkResult* response,
                                                   google::protobuf::Closure* done) {
+    class WrapClosure : public google::protobuf::Closure {
+    public:
+        WrapClosure(google::protobuf::Closure* done, PTransmitChunkResult* response)
+                : _done(done), _response(response) {}
+        ~WrapClosure() override = default;
+        void Run() override {
+            std::unique_ptr<WrapClosure> self_guard(this);
+            const auto response_timestamp = MonotonicNanos();
+            _response->set_receive_process_time(response_timestamp - _receive_timestamp);
+            if (_done != nullptr) {
+                _done->Run();
+            }
+        }
+
+    private:
+        google::protobuf::Closure* _done;
+        PTransmitChunkResult* _response;
+        const int64_t _receive_timestamp = MonotonicNanos();
+    };
+    google::protobuf::Closure* wrapped_done = new WrapClosure(done, response);
+
     auto begin_ts = MonotonicNanos();
     std::string transmit_info = "";
     auto gen_transmit_info = [&transmit_info, &request]() {
@@ -157,8 +180,6 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
     // transmit_data(), which will cause a dirty memory access.
     auto* cntl = static_cast<brpc::Controller*>(cntl_base);
     auto* req = const_cast<PTransmitChunkParams*>(request);
-    const auto receive_timestamp = GetCurrentTimeNanos();
-    response->set_receive_timestamp(receive_timestamp);
     Status st;
     st.to_protobuf(response->mutable_status());
     DeferOp defer([&]() {
@@ -166,10 +187,10 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
             gen_transmit_info();
             LOG(WARNING) << "failed to " << transmit_info;
         }
-        if (done != nullptr) {
+        if (wrapped_done != nullptr) {
             // NOTE: only when done is not null, we can set response status
             st.to_protobuf(response->mutable_status());
-            done->Run();
+            wrapped_done->Run();
         }
         VLOG_ROW << transmit_info << " cost time = " << MonotonicNanos() - begin_ts;
     });
@@ -194,7 +215,7 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
         }
     }
 
-    st = _exec_env->stream_mgr()->transmit_chunk(*request, &done);
+    st = _exec_env->stream_mgr()->transmit_chunk(*request, &wrapped_done);
 }
 
 template <typename T>

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -151,7 +151,7 @@ void PInternalServiceImplBase<T>::_transmit_chunk(google::protobuf::RpcControlle
         void Run() override {
             std::unique_ptr<WrapClosure> self_guard(this);
             const auto response_timestamp = MonotonicNanos();
-            _response->set_receive_process_time(response_timestamp - _receive_timestamp);
+            _response->set_receiver_post_process_time(response_timestamp - _receive_timestamp);
             if (_done != nullptr) {
                 _done->Run();
             }

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -103,7 +103,7 @@ message PTransmitDataResult {
 message PTransmitChunkResult {
     optional StatusPB status = 1;
     optional int64 receive_timestamp = 2; // Deprecated
-    optional int64 receive_process_time = 3;
+    optional int64 receiver_post_process_time = 3;
 };
 
 message PTransmitRuntimeFilterForwardTarget {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -102,7 +102,8 @@ message PTransmitDataResult {
 
 message PTransmitChunkResult {
     optional StatusPB status = 1;
-    optional int64 receive_timestamp = 2;
+    optional int64 receive_timestamp = 2; // Deprecated
+    optional int64 receive_process_time = 3;
 };
 
 message PTransmitRuntimeFilterForwardTarget {


### PR DESCRIPTION
## Enhancement

Before this pr, here is how we calculate the NetworkTime
* Sender side record a `send_timestamp` right before sending the packet.
* Receiver side record a `receive_timestamp` right after receiveing the packet(excluding the post-receiveing processing time usage), and send back this time to sender.
* Sender side receive the response containing the `receive_timestamp` and use `receive_timestamp - send_timestamp` to get the final NetworkTime

But here's problem, if the system clocks across the machine are inconsistent, then the time computation hits an exception.

After this pr, the NetworkTime calculation changes to 
* Sender side record a `send_timestamp` right before sending the packet.
* Receiver side record a `receive_timestamp` right after receiveing the packet, and record another `response_timestamp` right before sending the response, and get the `receive_process_time` with `response_timestamp - receive_timestamp`, and send this time to sender.
* Sender side record a `receive_response_time` right after receving the response and use `receive_response_time - send_timestamp - receive_process_time` to get the final NetworkTime.

This approach works fine even the system clock are inconsistent.

## Experiment

1fe/3be with machine specification 16c/64g

Pick up one machine to execute the following shell script to introduce time difference

```sh
#!/bin/bash

# Define the maximum drift in seconds
max_drift=60

while true; do
  # Get the current system time in seconds since the Unix epoch
  current_time=$(date +%s)

  # Generate a random drift value within the specified range
  drift=$(( (RANDOM % (2 * max_drift + 1)) - max_drift ))

  # Calculate the modified time by adding the drift
  modified_time=$(( current_time + drift ))

  # Set the system time to the modified time
  # Note: Changing the system time requires administrative privileges
  # and can have broader implications on the machine's functionality.
  # Exercise caution when modifying the system clock.
  # This code assumes a Unix-like environment.
  if [[ $EUID -eq 0 ]]; then
    date -s "@$modified_time" > /dev/null 2>&1
    if [ $? -eq 0 ]; then
      echo "System time changed to $(date)"
    else
      echo "Error: Failed to set the system time."
    fi
  else
    echo "Error: Insufficient privileges to modify the system time."
  fi

  # Wait for a random interval before introducing the next drift
  wait_time=$(shuf -i 1-10 -n 1)
  sleep $wait_time
done
```

Before this pr, the profile like blow, the quer(tpch-q9) execution time is 2s, but the execution time in profile shows 12min:

![image](https://github.com/StarRocks/starrocks/assets/18071213/3f91dd9a-9d2d-4fd3-bc31-083ddcd29cb7)

After this pr, the networkTime return back to normal

![image](https://github.com/StarRocks/starrocks/assets/18071213/20e47daa-08d2-492f-a59b-41a89202e334)

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
