### PR TITLE
[Refactor] Rename getVisibleIndexIdToMeta to getVisibleIndexMetas

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -51,7 +51,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.ForeignKeyConstraint;
 import com.starrocks.catalog.KeysType;
-import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
@@ -226,10 +226,10 @@ public class AlterJobMgr {
             for (Table t : db.getTables()) {
                 if (t instanceof OlapTable) {
                     OlapTable olapTable = (OlapTable) t;
-                    for (MaterializedIndex mvIdx : olapTable.getVisibleIndex()) {
-                        String indexName = olapTable.getIndexNameById(mvIdx.getId());
+                    for (MaterializedIndexMeta mvMeta : olapTable.getVisibleIndexMetas()) {
+                        String indexName = olapTable.getIndexNameById(mvMeta.getIndexId());
                         if (indexName == null) {
-                            LOG.warn("OlapTable {} miss index {}", olapTable.getName(), mvIdx.getId());
+                            LOG.warn("OlapTable {} miss index {}", olapTable.getName(), mvMeta.getIndexId());
                             continue;
                         }
                         if (indexName.equals(stmt.getMvName())) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -45,6 +45,7 @@ import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
@@ -438,9 +439,9 @@ public class MaterializedViewHandler extends AlterHandler {
                     throw new DdlException("Table [" + addMVClause.getMVName() + "] already exists, ");
                 }
 
-                List<MaterializedIndex> visibleMaterializedViews = ((OlapTable) tbl).getVisibleIndex();
-                for (MaterializedIndex mvIdx : visibleMaterializedViews) {
-                    if (((OlapTable) tbl).getIndexNameById(mvIdx.getId()).equals(addMVClause.getMVName())) {
+                List<MaterializedIndexMeta> visibleMaterializedViews = ((OlapTable) tbl).getVisibleIndexMetas();
+                for (MaterializedIndexMeta mvMeta : visibleMaterializedViews) {
+                    if (((OlapTable) tbl).getIndexNameById(mvMeta.getIndexId()).equals(addMVClause.getMVName())) {
                         throw new DdlException("Materialized view[" + addMVClause.getMVName() + "] already exists");
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -643,18 +643,18 @@ public class Database extends MetaObject implements Writable {
         return null;
     }
 
-    public Pair<Table, MaterializedIndex> getMaterializedViewIndex(String mvName) {
+    public Pair<Table, MaterializedIndexMeta> getMaterializedViewIndex(String mvName) {
         // TODO: add an index to speed it up.
         for (Table table : idToTable.values()) {
             if (table instanceof OlapTable) {
                 OlapTable olapTable = (OlapTable) table;
-                for (MaterializedIndex mvIndex : olapTable.getVisibleIndex()) {
-                    String indexName = olapTable.getIndexNameById(mvIndex.getId());
+                for (MaterializedIndexMeta mvMeta : olapTable.getVisibleIndexMetas()) {
+                    String indexName = olapTable.getIndexNameById(mvMeta.getIndexId());
                     if (indexName == null) {
                         continue;
                     }
                     if (indexName.equals(mvName)) {
-                        return Pair.create(table, mvIndex);
+                        return Pair.create(table, mvMeta);
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -548,33 +548,26 @@ public class OlapTable extends Table {
         return null;
     }
 
-    public Map<Long, MaterializedIndexMeta> getVisibleIndexIdToMeta() {
-        Map<Long, MaterializedIndexMeta> visibleMVs = Maps.newHashMap();
+    public List<MaterializedIndexMeta> getVisibleIndexMetas() {
+        List<MaterializedIndexMeta> visibleMVs = Lists.newArrayList();
         List<MaterializedIndex> mvs = getVisibleIndex();
         for (MaterializedIndex mv : mvs) {
-            visibleMVs.put(mv.getId(), indexIdToMeta.get(mv.getId()));
+            if (!indexIdToMeta.containsKey(mv.getId())) {
+                continue;
+            }
+            visibleMVs.add(indexIdToMeta.get(mv.getId()));
         }
         return visibleMVs;
     }
 
-    public List<MaterializedIndex> getVisibleIndex() {
+    // Fetch the 1th partition's MaterializedViewIndex which should be not used directly.
+    private List<MaterializedIndex> getVisibleIndex() {
         Optional<Partition> firstPartition = idToPartition.values().stream().findFirst();
         if (firstPartition.isPresent()) {
             Partition partition = firstPartition.get();
             return partition.getMaterializedIndices(IndexExtState.VISIBLE);
         }
         return Lists.newArrayList();
-    }
-
-    public Column getVisibleColumn(String columnName) {
-        for (MaterializedIndexMeta meta : getVisibleIndexIdToMeta().values()) {
-            for (Column column : meta.getSchema()) {
-                if (column.getName().equalsIgnoreCase(columnName)) {
-                    return column;
-                }
-            }
-        }
-        return null;
     }
 
     // this is only for schema change.
@@ -1542,7 +1535,6 @@ public class OlapTable extends Table {
         }
 
         baseIndexId = in.readLong();
-
 
         // read indexes
         if (in.readBoolean()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -18,7 +18,7 @@ package com.starrocks.connector;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
@@ -104,7 +104,7 @@ public interface ConnectorMetadata {
      * @param tblName - the string represents the table name
      * @return a Table instance
      */
-    default Pair<Table, MaterializedIndex> getMaterializedViewIndex(String dbName, String tblName) {
+    default Pair<Table, MaterializedIndexMeta> getMaterializedViewIndex(String dbName, String tblName) {
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -69,6 +69,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MetadataViewer;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
@@ -424,7 +425,7 @@ public class ShowExecutor {
         MetaUtils.checkDbNullAndReport(db, dbName);
 
         List<MaterializedView> materializedViews = Lists.newArrayList();
-        List<Pair<OlapTable, MaterializedIndex>> singleTableMVs = Lists.newArrayList();
+        List<Pair<OlapTable, MaterializedIndexMeta>> singleTableMVs = Lists.newArrayList();
         db.readLock();
         try {
             PatternMatcher matcher = null;
@@ -463,16 +464,16 @@ public class ShowExecutor {
                     materializedViews.add(mvTable);
                 } else if (Table.TableType.OLAP == table.getType()) {
                     OlapTable olapTable = (OlapTable) table;
-                    List<MaterializedIndex> visibleMaterializedViews = olapTable.getVisibleIndex();
+                    List<MaterializedIndexMeta> visibleMaterializedViews = olapTable.getVisibleIndexMetas();
                     long baseIdx = olapTable.getBaseIndexId();
-                    for (MaterializedIndex mvIdx : visibleMaterializedViews) {
-                        if (baseIdx == mvIdx.getId()) {
+                    for (MaterializedIndexMeta mvMeta : visibleMaterializedViews) {
+                        if (baseIdx == mvMeta.getIndexId()) {
                             continue;
                         }
-                        if (matcher != null && !matcher.match(olapTable.getIndexNameById(mvIdx.getId()))) {
+                        if (matcher != null && !matcher.match(olapTable.getIndexNameById(mvMeta.getIndexId()))) {
                             continue;
                         }
-                        singleTableMVs.add(Pair.create(olapTable, mvIdx));
+                        singleTableMVs.add(Pair.create(olapTable, mvMeta));
                     }
                 }
             }
@@ -514,7 +515,7 @@ public class ShowExecutor {
     public static List<List<String>> listMaterializedViewStatus(
             String dbName,
             List<MaterializedView> materializedViews,
-            List<Pair<OlapTable, MaterializedIndex>> singleTableMVs) {
+            List<Pair<OlapTable, MaterializedIndexMeta>> singleTableMVs) {
         List<List<String>> rowSets = Lists.newArrayList();
 
         // Now there are two MV cases:
@@ -559,15 +560,15 @@ public class ShowExecutor {
             rowSets.add(resultRow);
         }
 
-        for (Pair<OlapTable, MaterializedIndex> singleTableMV : singleTableMVs) {
+        for (Pair<OlapTable, MaterializedIndexMeta> singleTableMV : singleTableMVs) {
             OlapTable olapTable = singleTableMV.first;
-            MaterializedIndex mvIdx = singleTableMV.second;
+            MaterializedIndexMeta mvMeta = singleTableMV.second;
 
+            long mvId = mvMeta.getIndexId();
             ArrayList<String> resultRow = new ArrayList<>();
-            MaterializedIndexMeta mvMeta = olapTable.getVisibleIndexIdToMeta().get(mvIdx.getId());
-            resultRow.add(String.valueOf(mvIdx.getId()));
+            resultRow.add(String.valueOf(mvId));
             resultRow.add(dbName);
-            resultRow.add(olapTable.getIndexNameById(mvIdx.getId()));
+            resultRow.add(olapTable.getIndexNameById(mvId));
             // refresh_type
             resultRow.add("ROLLUP");
             // is_active
@@ -583,9 +584,15 @@ public class ShowExecutor {
             // task run status
             setTaskRunStatus(resultRow, null);
             // rows
-            resultRow.add(String.valueOf(mvIdx.getRowCount()));
+            if (olapTable.getPartitionInfo().getType() == PartitionType.UNPARTITIONED) {
+                Partition partition = olapTable.getPartitions().iterator().next();
+                MaterializedIndex index = partition.getIndex(mvId);
+                resultRow.add(String.valueOf(index.getRowCount()));
+            } else {
+                resultRow.add(String.valueOf(0L));
+            }
             if (mvMeta.getOriginStmt() == null) {
-                String mvName = olapTable.getIndexNameById(mvIdx.getId());
+                String mvName = olapTable.getIndexNameById(mvId);
                 resultRow.add(buildCreateMVSql(olapTable, mvName, mvMeta));
             } else {
                 resultRow.add(mvMeta.getOriginStmt().replace("\n", "").replace("\t", "")
@@ -1088,12 +1095,12 @@ public class ShowExecutor {
                     for (Table tbl : db.getTables()) {
                         if (tbl.getType() == Table.TableType.OLAP) {
                             OlapTable olapTable = (OlapTable) tbl;
-                            List<MaterializedIndex> visibleMaterializedViews = olapTable.getVisibleIndex();
-                            for (MaterializedIndex mvIdx : visibleMaterializedViews) {
-                                if (olapTable.getIndexNameById(mvIdx.getId()).equals(showStmt.getTable())) {
-                                    MaterializedIndexMeta mvMeta = olapTable.getVisibleIndexIdToMeta().get(mvIdx.getId());
+                            List<MaterializedIndexMeta> visibleMaterializedViews =
+                                    olapTable.getVisibleIndexMetas();
+                            for (MaterializedIndexMeta mvMeta : visibleMaterializedViews) {
+                                if (olapTable.getIndexNameById(mvMeta.getIndexId()).equals(showStmt.getTable())) {
                                     if (mvMeta.getOriginStmt() == null) {
-                                        String mvName = olapTable.getIndexNameById(mvIdx.getId());
+                                        String mvName = olapTable.getIndexNameById(mvMeta.getIndexId());
                                         rows.add(Lists.newArrayList(showStmt.getTable(), buildCreateMVSql(olapTable,
                                                 mvName, mvMeta), "utf8", "utf8_general_ci"));
                                     } else {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2372,7 +2372,7 @@ public class LocalMetastore implements ConnectorMetadata {
     }
 
     @Override
-    public Pair<Table, MaterializedIndex> getMaterializedViewIndex(String dbName, String indexName) {
+    public Pair<Table, MaterializedIndexMeta> getMaterializedViewIndex(String dbName, String indexName) {
         Database database = getDb(dbName);
         if (database == null) {
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
@@ -217,11 +217,9 @@ public class MetadataMgr {
         return connectorTable;
     }
 
-    public Pair<Table, MaterializedIndex> getMaterializedViewIndex(String catalogName, String dbName, String tblName) {
+    public Pair<Table, MaterializedIndexMeta> getMaterializedViewIndex(String catalogName, String dbName, String tblName) {
         Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
-        Pair<Table, MaterializedIndex> materializedIndex =
-                connectorMetadata.map(metadata -> metadata.getMaterializedViewIndex(dbName, tblName)).orElse(null);
-        return materializedIndex;
+        return connectorMetadata.map(metadata -> metadata.getMaterializedViewIndex(dbName, tblName)).orElse(null);
     }
 
     public List<String> listPartitionNames(String catalogName, String dbName, String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -51,6 +51,7 @@ import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -504,7 +505,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                                                      UserIdentity currentUser, String dbName) {
         Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
         List<MaterializedView> materializedViews = Lists.newArrayList();
-        List<Pair<OlapTable, MaterializedIndex>> singleTableMVs = Lists.newArrayList();
+        List<Pair<OlapTable, MaterializedIndexMeta>> singleTableMVs = Lists.newArrayList();
         db.readLock();
         try {
             for (Table table : db.getTables()) {
@@ -520,16 +521,16 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     materializedViews.add(mvTable);
                 } else if (table.getType() == Table.TableType.OLAP) {
                     OlapTable olapTable = (OlapTable) table;
-                    List<MaterializedIndex> visibleMaterializedViews = olapTable.getVisibleIndex();
+                    List<MaterializedIndexMeta> visibleMaterializedViews = olapTable.getVisibleIndexMetas();
                     long baseIdx = olapTable.getBaseIndexId();
-                    for (MaterializedIndex mvIdx : visibleMaterializedViews) {
-                        if (baseIdx == mvIdx.getId()) {
+                    for (MaterializedIndexMeta mvMeta : visibleMaterializedViews) {
+                        if (baseIdx == mvMeta.getIndexId()) {
                             continue;
                         }
-                        if (matcher != null && !matcher.match(olapTable.getIndexNameById(mvIdx.getId()))) {
+                        if (matcher != null && !matcher.match(olapTable.getIndexNameById(mvMeta.getIndexId()))) {
                             continue;
                         }
-                        singleTableMVs.add(Pair.create(olapTable, mvIdx));
+                        singleTableMVs.add(Pair.create(olapTable, mvMeta));
                     }
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -33,7 +33,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.HiveTable;
-import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Resource;
 import com.starrocks.catalog.Table;
@@ -892,7 +892,7 @@ public class QueryAnalyzer {
 
             Table table = null;
             if (tableRelation.isSyncMVQuery()) {
-                Pair<Table, MaterializedIndex> materializedIndex =
+                Pair<Table, MaterializedIndexMeta> materializedIndex =
                         metadataMgr.getMaterializedViewIndex(catalogName, dbName, tbName);
                 if (materializedIndex != null) {
                     Table mvTable = materializedIndex.first;
@@ -903,7 +903,7 @@ public class QueryAnalyzer {
                         database.readLock();
                         OlapTable mvOlapTable = ((OlapTable) mvTable).copyOnlyForQuery();
                         // Copy the necessary olap table meta to avoid changing original meta;
-                        mvOlapTable.setBaseIndexId(materializedIndex.second.getId());
+                        mvOlapTable.setBaseIndexId(materializedIndex.second.getIndexId());
                         table = mvOlapTable;
                     } finally {
                         database.readUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ShowStmtAnalyzer.java
@@ -30,7 +30,6 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.KeysType;
-import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.OlapTable;
@@ -347,9 +346,9 @@ public class ShowStmtAnalyzer {
                     for (Table tb : db.getTables()) {
                         if (tb.getType() == Table.TableType.OLAP) {
                             OlapTable olapTable = (OlapTable) tb;
-                            for (MaterializedIndex mvIdx : olapTable.getVisibleIndex()) {
-                                if (olapTable.getIndexNameById(mvIdx.getId()).equalsIgnoreCase(node.getTableName())) {
-                                    List<Column> columns = olapTable.getIndexIdToSchema().get(mvIdx.getId());
+                            for (MaterializedIndexMeta mvMeta : olapTable.getVisibleIndexMetas()) {
+                                if (olapTable.getIndexNameById(mvMeta.getIndexId()).equalsIgnoreCase(node.getTableName())) {
+                                    List<Column> columns = olapTable.getIndexIdToSchema().get(mvMeta.getIndexId());
                                     for (Column column : columns) {
                                         // Extra string (aggregation and bloom filter)
                                         List<String> extras = Lists.newArrayList();


### PR DESCRIPTION
Fixes #22401 


1. Make getVisibleIndex from `public` to `private` because this method is only return 1th partition's MaterializedIndex instead of IndexMeta. use `getVisibleIndexIdToMeta ` is better.
```
private List<MaterializedIndex> getVisibleIndex() 
```
2. getVisibleIndexIdToMeta return `List` instead of `Map` because `MaterializedIndexMeta ` contains mv index id itself, and rename it to `getVisibleIndexMetas`;

Further:
- we can  support associate index meta in `getVisibleIndexMetas`.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
