### PR TITLE
[Enhancement] for big gap we involve efficiency to avoid too much useless data

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -753,6 +753,7 @@ CONF_Bool(parquet_late_materialization_enable, "true");
 
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
+CONF_Int32(io_coalesce_read_efficiency, "1");
 CONF_Int32(io_tasks_per_scan_operator, "4");
 CONF_Int32(connector_io_tasks_per_scan_operator, "16");
 CONF_Int32(connector_io_tasks_min_size, "2");

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -224,7 +224,8 @@ Status HdfsScanner::open_random_access_file() {
                 std::make_shared<io::SharedBufferedInputStream>(input_stream, filename, file_size);
         io::SharedBufferedInputStream::CoalesceOptions options = {
                 .max_dist_size = config::io_coalesce_read_max_distance_size,
-                .max_buffer_size = config::io_coalesce_read_max_buffer_size};
+                .max_buffer_size = config::io_coalesce_read_max_buffer_size,
+                .efficiency = config::io_coalesce_read_efficiency};
         _shared_buffered_input_stream->set_coalesce_options(options);
         input_stream = _shared_buffered_input_stream;
 

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -84,8 +84,10 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
             const auto& now = small_ranges[i];
             size_t now_end = now.offset + now.size;
             size_t prev_end = prev.offset + prev.size;
+            size_t gap = now.offset - prev_end;
             if (((now_end - small_ranges[unmerge].offset) <= _options.max_buffer_size) &&
-                (now.offset - prev_end) <= _options.max_dist_size) {
+                (gap <= _options.max_dist_size) &&
+                ((gap <= _options.max_dist_size * 0.3) || (gap * _options.efficiency <= now.size))) {
                 continue;
             } else {
                 update_map(unmerge, i - 1);

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -34,6 +34,7 @@ public:
         static constexpr int64_t MB = 1024 * 1024;
         int64_t max_dist_size = 1 * MB;
         int64_t max_buffer_size = 8 * MB;
+        int64_t efficiency = 1;
     };
 
     SharedBufferedInputStream(std::shared_ptr<SeekableInputStream> stream, const std::string& filename,


### PR DESCRIPTION


Fixes #issue
when gap between io ranges is big but still smaller then threshold, we estimate efficiency.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
