### PR TITLE
[BugFix] Make pipeline_driver's total_timer exclude the prepare time

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -181,12 +181,6 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     _input_empty_timer_sw = runtime_state->obj_pool()->add(new MonotonicStopWatch());
     _output_full_timer_sw = runtime_state->obj_pool()->add(new MonotonicStopWatch());
     _pending_finish_timer_sw = runtime_state->obj_pool()->add(new MonotonicStopWatch());
-    _total_timer_sw->start();
-    _pending_timer_sw->start();
-    _precondition_block_timer_sw->start();
-    _input_empty_timer_sw->start();
-    _output_full_timer_sw->start();
-    _pending_finish_timer_sw->start();
 
     return Status::OK();
 }
@@ -433,6 +427,15 @@ void PipelineDriver::mark_precondition_ready(RuntimeState* runtime_state) {
         op->set_precondition_ready(runtime_state);
         submit_operators();
     }
+}
+
+void PipelineDriver::start_timers() {
+    _total_timer_sw->start();
+    _pending_timer_sw->start();
+    _precondition_block_timer_sw->start();
+    _input_empty_timer_sw->start();
+    _output_full_timer_sw->start();
+    _pending_finish_timer_sw->start();
 }
 
 void PipelineDriver::submit_operators() {

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -298,6 +298,7 @@ public:
     // drivers in PRECONDITION_BLOCK state must be marked READY after its dependent runtime-filters or hash tables
     // are finished.
     void mark_precondition_ready(RuntimeState* runtime_state);
+    void start_timers();
     void submit_operators();
     // Notify all the unfinished operators to be finished.
     // It is usually used when the sink operator is finished, or the fragment is cancelled or expired.

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -246,6 +246,8 @@ StatusOr<DriverRawPtr> GlobalDriverExecutor::_get_next_driver(std::queue<DriverR
 }
 
 void GlobalDriverExecutor::submit(DriverRawPtr driver) {
+    driver->start_timers();
+
     if (driver->is_precondition_block()) {
         driver->set_driver_state(DriverState::PRECONDITION_BLOCK);
         driver->mark_precondition_not_ready();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1684,6 +1684,8 @@ public class Coordinator {
                 instanceProfile.removeInfoString("Address");
             });
             fragmentProfile.addInfoString("BackendAddresses", String.join(",", backendAddresses));
+            Counter backendNum = fragmentProfile.addCounter("BackendNum", TUnit.UNIT, null);
+            backendNum.setValue(backendAddresses.size());
 
             // Setup number of instance
             Counter counter = fragmentProfile.addCounter("InstanceNum", TUnit.UNIT, null);
@@ -1708,21 +1710,6 @@ public class Coordinator {
         // Remove redundant MIN/MAX metrics if MIN and MAX are identical
         for (RuntimeProfile fragmentProfile : fragmentProfiles) {
             RuntimeProfile.removeRedundantMinMaxMetrics(fragmentProfile);
-        }
-
-        // Set backend number
-        for (int i = 0; i < fragments.size(); i++) {
-            PlanFragment fragment = fragments.get(i);
-            RuntimeProfile profile = fragmentProfiles.get(i);
-
-            Set<TNetworkAddress> networkAddresses =
-                    coordinatorPreprocessor.getFragmentExecParamsMap()
-                            .get(fragment.getFragmentId()).instanceExecParams.stream()
-                            .map(param -> param.host)
-                            .collect(Collectors.toSet());
-
-            Counter backendNum = profile.addCounter("BackendNum", TUnit.UNIT, null);
-            backendNum.setValue(networkAddresses.size());
         }
 
         long queryAllocatedMemoryUsage = 0;


### PR DESCRIPTION
Fixes #24534

`PipelineDriver::prepre` is executed in a serial way. And some of the timers are triggered at prepare stage. And the total time may include other driver's prepare time usage, which further results in an abnomal ScheduleTime in profile if other dirver's prepare stage persists for a long while.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
