### PR TITLE
[BugFix] Morsel::set_rowsets references local variables

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -83,7 +83,14 @@ public:
     int64_t from_version() { return _from_version; }
 
     void set_rowsets(const std::vector<RowsetSharedPtr>& rowsets) { _rowsets = &rowsets; }
-    const std::vector<RowsetSharedPtr>& rowsets() const { return *_rowsets; }
+    void set_delta_rowsets(std::vector<RowsetSharedPtr>&& delta_rowsets) { _delta_rowsets = std::move(delta_rowsets); }
+    const std::vector<RowsetSharedPtr>& rowsets() const {
+        if (_delta_rowsets.has_value()) {
+            return _delta_rowsets.value();
+        } else {
+            return *_rowsets;
+        }
+    }
 
 private:
     int32_t _plan_node_id;
@@ -92,6 +99,7 @@ private:
     static const std::vector<RowsetSharedPtr> kEmptyRowsets;
     // _rowsets is owned by MorselQueue, whose lifecycle is longer than that of Morsel.
     const std::vector<RowsetSharedPtr>* _rowsets = &kEmptyRowsets;
+    std::optional<std::vector<RowsetSharedPtr>> _delta_rowsets;
 };
 
 class ScanMorsel : public Morsel {

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -458,7 +458,7 @@ Status ScanOperator::_pickup_morsel(RuntimeState* state, int chunk_source_index)
                     // We must reset rowsets of Morsel to captured delta rowsets, because TabletReader now
                     // created from rowsets passed in to itself instead of capturing it from TabletManager again.
                     morsel->set_from_version(delta_version);
-                    morsel->set_rowsets(delta_rowsets);
+                    morsel->set_delta_rowsets(std::move(delta_rowsets));
                     break;
                 } else {
                     ASSIGN_OR_RETURN(morsel, _morsel_queue->try_get());
@@ -472,7 +472,7 @@ Status ScanOperator::_pickup_morsel(RuntimeState* state, int chunk_source_index)
                 auto [delta_verrsion, delta_rowsets] = _cache_operator->delta_version_and_rowsets(lane_owner);
                 if (!delta_rowsets.empty()) {
                     morsel->set_from_version(delta_verrsion);
-                    morsel->set_rowsets(delta_rowsets);
+                    morsel->set_delta_rowsets(std::move(delta_rowsets));
                 }
                 break;
             }


### PR DESCRIPTION
Fixes bug introduced by #22892, Morsel's internal rowsets references to local variables in pick_morsels. In ASAN mode, tests on multiversion query cache  would crash(https://github.com/StarRocks/StarRocksTest/issues/2627).
```
==13613==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7f92031bca78 at pc 0x00000a06a8cd bp 0x7f92031bb830 sp 0x7f92031bb828
READ of size 8 at 0x7f92031bca78 thread T211 (pip_wg_executor)
    #0 0xa06a8cc in std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > >::size() const /opt/gcc/usr/include/c++/10.3.0/bits/stl_vector.h:919
    #1 0xa0672e9 in std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > >::vector(std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&) /opt/gcc/usr/include/c++/10.3.0/bits/stl_vector.h:555
    #2 0xfc210d5 in starrocks::TabletReader::TabletReader(std::shared_ptr<starrocks::Tablet>, starrocks::Version const&, starrocks::Schema, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&) /root/starrocks/be/src/storage/tablet_reader.cpp:53
    #3 0xbbb63e4 in void __gnu_cxx::new_allocator<starrocks::TabletReader>::construct<starrocks::TabletReader, std::shared_ptr<starrocks::Tablet>&, starrocks::Version, starrocks::Schema, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&>(starrocks::TabletReader*, std::shared_ptr<starrocks::Tablet>&, starrocks::Version&&, starrocks::Schema&&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&) /opt/gcc/usr/include/c++/10.3.0/ext/new_allocator.h:150
    #4 0xbbb6134 in void std::allocator_traits<std::allocator<starrocks::TabletReader> >::construct<starrocks::TabletReader, std::shared_ptr<starrocks::Tablet>&, starrocks::Version, starrocks::Schema, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&>(std::allocator<starrocks::TabletReader>&, starrocks::TabletReader*, std::shared_ptr<starrocks::Tablet>&, starrocks::Version&&, starrocks::Schema&&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&) /opt/gcc/usr/include/c++/10.3.0/bits/alloc_traits.h:512
    #5 0xbbb5d43 in std::_Sp_counted_ptr_inplace<starrocks::TabletReader, std::allocator<starrocks::TabletReader>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::shared_ptr<starrocks::Tablet>&, starrocks::Version, starrocks::Schema, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&>(std::allocator<starrocks::TabletReader>, std::shared_ptr<starrocks::Tablet>&, starrocks::Version&&, starrocks::Schema&&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&) /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr_base.h:551
    #6 0xbbb5564 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<starrocks::TabletReader, std::allocator<starrocks::TabletReader>, std::shared_ptr<starrocks::Tablet>&, starrocks::Version, starrocks::Schema, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&>(starrocks::TabletReader*&, std::_Sp_alloc_shared_tag<std::allocator<starrocks::TabletReader> >, std::shared_ptr<starrocks::Tablet>&, starrocks::Version&&, starrocks::Schema&&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&) /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr_base.h:682
    #7 0xbbb4bff in std::__shared_ptr<starrocks::TabletReader, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<starrocks::TabletReader>, std::shared_ptr<starrocks::Tablet>&, starrocks::Version, starrocks::Schema, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&>(std::_Sp_alloc_shared_tag<std::allocator<starrocks::TabletReader> >, std::shared_ptr<starrocks::Tablet>&, starrocks::Version&&, starrocks::Schema&&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&) /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr_base.h:1371
    #8 0xbbb3ee0 in std::shared_ptr<starrocks::TabletReader>::shared_ptr<std::allocator<starrocks::TabletReader>, std::shared_ptr<starrocks::Tablet>&, starrocks::Version, starrocks::Schema, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&>(std::_Sp_alloc_shared_tag<std::allocator<starrocks::TabletReader> >, std::shared_ptr<starrocks::Tablet>&, starrocks::Version&&, starrocks::Schema&&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&) /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr.h:408
    #9 0xbbb2fd3 in std::shared_ptr<starrocks::TabletReader> std::allocate_shared<starrocks::TabletReader, std::allocator<starrocks::TabletReader>, std::shared_ptr<starrocks::Tablet>&, starrocks::Version, starrocks::Schema, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&>(std::allocator<starrocks::TabletReader> const&, std::shared_ptr<starrocks::Tablet>&, starrocks::Version&&, starrocks::Schema&&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&) /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr.h:860
    #10 0xbbb1d80 in std::shared_ptr<starrocks::TabletReader> std::make_shared<starrocks::TabletReader, std::shared_ptr<starrocks::Tablet>&, starrocks::Version, starrocks::Schema, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&>(std::shared_ptr<starrocks::Tablet>&, starrocks::Version&&, starrocks::Schema&&, std::vector<std::shared_ptr<starrocks::Rowset>, std::allocator<std::shared_ptr<starrocks::Rowset> > > const&) /opt/gcc/usr/include/c++/10.3.0/bits/shared_ptr.h:876
    #11 0xbba8ac7 in starrocks::pipeline::OlapChunkSource::_init_olap_reader(starrocks::RuntimeState*) /root/starrocks/be/src/exec/pipeline/scan/olap_chunk_source.cpp:298
    #12 0xbb9d97e in starrocks::pipeline::OlapChunkSource::prepare(starrocks::RuntimeState*) /root/starrocks/be/src/exec/pipeline/scan/olap_chunk_source.cpp:79
    #13 0xa0b95d0 in starrocks::pipeline::ScanOperator::_pickup_morsel(starrocks::RuntimeState*, int) /root/starrocks/be/src/exec/pipeline/scan/scan_operator.cpp:485
    #14 0xa0b5088 in starrocks::pipeline::ScanOperator::_try_to_trigger_next_scan(starrocks::RuntimeState*) /root/starrocks/be/src/exec/pipeline/scan/scan_operator.cpp:297
    #15 0xa0b3eec in starrocks::pipeline::ScanOperator::pull_chunk(starrocks::RuntimeState*) /root/starrocks/be/src/exec/pipeline/scan/scan_operator.cpp:229
    #16 0x9f8ccfa in starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int) /root/starrocks/be/src/exec/pipeline/pipeline_driver.cpp:297
    #17 0x12de6363 in starrocks::pipeline::GlobalDriverExecutor::_worker_thread() /root/starrocks/be/src/exec/pipeline/pipeline_driver_executor.cpp:154
    #18 0x12de4aa3 in operator() /root/starrocks/be/src/exec/pipeline/pipeline_driver_executor.cpp:69
    #19 0x12dee787 in __invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:60
    #20 0x12dedc8c in __invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::<lambda()>&> /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:110
    #21 0x12decf96 in _M_invoke /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:291
    #22 0x9bd122f in std::function<void ()>::operator()() const /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
    #23 0x11a92f75 in starrocks::FunctionRunnable::run() /root/starrocks/be/src/util/threadpool.cpp:58
    #24 0x11a8fd2a in starrocks::ThreadPool::dispatch_thread() /root/starrocks/be/src/util/threadpool.cpp:553
    #25 0x11aab983 in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:73
    #26 0x11aab2dc in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:95
    #27 0x11aaa6d3 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /opt/gcc/usr/include/c++/10.3.0/functional:416
    #28 0x11aa9035 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /opt/gcc/usr/include/c++/10.3.0/functional:499
    #29 0x11aa6099 in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:60
    #30 0x11aa39fd in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:110
    #31 0x11a9fa66 in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:291
    #32 0x9bd122f in std::function<void ()>::operator()() const /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
    #33 0x11a77ae6 in starrocks::Thread::supervise_thread(void*) /root/starrocks/be/src/util/thread.cpp:364
    #34 0x7f926a69cea4 in start_thread (/lib64/libpthread.so.0+0x7ea4)
    #35 0x7f9269cb7b0c in clone (/lib64/libc.so.6+0xfeb0c)
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
