### PR TITLE
[Enhancement] Make l0 snapshot size configurable (#24748)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -823,6 +823,8 @@ CONF_Int64(max_length_for_bitmap_function, "1000000");
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
+// if l0_mem_size exceeds this value, l0 need snapshot
+CONF_mInt64(l0_snapshot_size, "16777216"); // 16MB
 
 // Used to limit buffer size of tablet send channel.
 CONF_mInt64(send_channel_buffer_limit, "67108864");

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -37,12 +37,6 @@ constexpr uint64_t kPageMax = 1ULL << 32;
 constexpr size_t kPackSize = 16;
 constexpr size_t kPagePackLimit = (kPageSize - kPageHeaderSize) / kPackSize;
 constexpr size_t kBucketSizeMax = 256;
-// if l0_mem_size exceeds this value, l0 need snapshot
-#if BE_TEST
-constexpr size_t kL0SnapshotSizeMax = 1 * 1024 * 1024;
-#else
-constexpr size_t kL0SnapshotSizeMax = 16 * 1024 * 1024;
-#endif
 constexpr size_t kLongKeySize = 64;
 
 const char* const kIndexFileMagic = "IDX1";
@@ -2677,7 +2671,7 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta) {
             RETURN_IF_ERROR(_merge_compaction());
         }
         // if l1 is empty, and l0 memory usage is large enough
-    } else if (l0_mem_size > kL0SnapshotSizeMax) {
+    } else if (l0_mem_size > config::l0_snapshot_size) {
         // do flush l0
         _flushed = true;
         RETURN_IF_ERROR(_flush_l0());
@@ -2861,7 +2855,7 @@ size_t PersistentIndex::_dump_bound() {
 // TODO: maybe build snapshot is better than append wals when almost
 // operations are upsert or erase
 bool PersistentIndex::_can_dump_directly() {
-    return _dump_bound() <= kL0SnapshotSizeMax;
+    return _dump_bound() <= config::l0_snapshot_size;
 }
 
 Status PersistentIndex::_delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version) {

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -37,6 +37,7 @@ int main(int argc, char** argv) {
     butil::FilePath storage_root;
     CHECK(butil::CreateNewTempDirectory("tmp_ut_", &storage_root));
     starrocks::config::storage_root_path = storage_root.value();
+    starrocks::config::l0_snapshot_size = 1048576;
 
     starrocks::init_glog("be_test", true);
     starrocks::CpuInfo::init();


### PR DESCRIPTION
Make l0 snapshot size configurable.

In a scenario with a large number of tablets, such as a scenario where there are many wide tables and many tablets, one tablet is relatively large, but the PrimaryIndex is around 10M, which cannot trigger the flush l1 condition, resulting in large memory usage.

