### PR TITLE
[Enhancement] Make l0 snapshot size configurable (#24748)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -801,6 +801,9 @@ CONF_Int64(max_length_for_to_base64, "200000");
 // Used by bitmap functions
 CONF_Int64(max_length_for_bitmap_function, "1000000");
 
+// if l0_mem_size exceeds this value, l0 need snapshot
+CONF_mInt64(l0_snapshot_size, "16777216"); // 16MB
+
 // Used to limit buffer size of tablet send channel.
 CONF_mInt64(send_channel_buffer_limit, "67108864");
 


### PR DESCRIPTION
Fixes #issue

Make l0 snapshot size configurable.

In a scenario with a large number of tablets, such as a scenario where there are many wide tables and many tablets, one tablet is relatively large, but the PrimaryIndex is around 10M, which cannot trigger the flush l1 condition, resulting in a large memory usage.
