### PR TITLE
[Enhancement] remove the 'replication_num' argument in RESTORE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -432,7 +432,7 @@ public class BackupHandler extends FrontendDaemon implements Writable {
             }
         }
         restoreJob = new RestoreJob(stmt.getLabel(), stmt.getBackupTimestamp(),
-                db.getId(), db.getOriginName(), jobInfo, stmt.allowLoad(), stmt.getReplicationNum(),
+                db.getId(), db.getOriginName(), jobInfo, stmt.allowLoad(),
                 stmt.getTimeoutMs(), globalStateMgr, repository.getId(), backupMeta);
         globalStateMgr.getEditLog().logRestoreJob(restoreJob);
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -82,9 +82,9 @@ public class LakeRestoreJob extends RestoreJob {
     }
 
     public LakeRestoreJob(String label, String backupTs, long dbId, String dbName, BackupJobInfo jobInfo,
-                          boolean allowLoad, int restoreReplicationNum, long timeoutMs,
-                          GlobalStateMgr globalStateMgr, long repoId, BackupMeta backupMeta) {
-        super(label, backupTs, dbId, dbName, jobInfo, allowLoad, restoreReplicationNum, timeoutMs,
+                          boolean allowLoad, long timeoutMs, GlobalStateMgr globalStateMgr,
+                          long repoId, BackupMeta backupMeta) {
+        super(label, backupTs, dbId, dbName, jobInfo, allowLoad, timeoutMs,
                 globalStateMgr, repoId, backupMeta);
         this.type = JobType.LAKE_RESTORE;
     }
@@ -296,7 +296,7 @@ public class LakeRestoreJob extends RestoreJob {
             Range<PartitionKey> remoteRange = remotePartitionInfo.getRange(remotePartId);
             DataProperty remoteDataProperty = remotePartitionInfo.getDataProperty(remotePartId);
             localPartitionInfo.addPartition(restorePart.getId(), false, remoteRange,
-                    remoteDataProperty, (short) restoreReplicationNum,
+                    remoteDataProperty, remoteTbl.getDefaultReplicationNum(),
                     remotePartitionInfo.getIsInMemory(remotePartId),
                     remotePartitionInfo.getStorageCacheInfo(remotePartId));
             localTbl.addPartition(restorePart);
@@ -314,7 +314,7 @@ public class LakeRestoreJob extends RestoreJob {
             LakeTable remoteLakeTbl = (LakeTable) remoteOlapTbl;
             StorageInfo storageInfo = remoteLakeTbl.getTableProperty().getStorageInfo();
             remoteLakeTbl.setStorageInfo(pathInfo, storageInfo.getStorageCacheInfo());
-            remoteLakeTbl.resetIdsForRestore(globalStateMgr, db, restoreReplicationNum);
+            remoteLakeTbl.resetIdsForRestore(globalStateMgr, db, remoteOlapTbl.getDefaultReplicationNum());
         } catch (DdlException e) {
             return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRestoreStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRestoreStmt.java
@@ -26,8 +26,8 @@ import com.starrocks.sql.parser.NodePosition;
 public class ShowRestoreStmt extends ShowStmt {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("JobId").add("Label").add("Timestamp").add("DbName").add("State")
-            .add("AllowLoad").add("ReplicationNum")
-            .add("RestoreObjs").add("CreateTime").add("MetaPreparedTime").add("SnapshotFinishedTime")
+            .add("AllowLoad").add("RestoreObjs")
+            .add("CreateTime").add("MetaPreparedTime").add("SnapshotFinishedTime")
             .add("DownloadFinishedTime").add("FinishedTime").add("UnfinishedTasks").add("Progress")
             .add("TaskErrMsg").add("Status").add("Timeout")
             .build();

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
@@ -263,7 +263,7 @@ public class RestoreJobPrimaryKeyTest {
         tbls.add(expectedRestoreTbl);
         backupMeta = new BackupMeta(tbls);
         job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000,
+                jobInfo, false, 100000,
                 globalStateMgr, repo.getId(), backupMeta);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -264,7 +264,7 @@ public class RestoreJobTest {
         tbls.add(expectedRestoreTbl);
         backupMeta = new BackupMeta(tbls);
         job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000,
+                jobInfo, false, 100000,
                 globalStateMgr, repo.getId(), backupMeta);
     }
 


### PR DESCRIPTION
 Fixes #issue

At present,  we need specify the `replication_num` argument in  `RESTORE`,  that is inconvenient for user. The purpose of  this pr is  to remove the `replication_num` , and then  its  values is adaptive based on the number of replica in the remote table.
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
 - [ ] 3.0
 - [ ] 2.5
 - [ ] 2.4
 - [ ] 2.3
