### PR TITLE
[BugFix] fix comment lost escape character

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Catalog.java
@@ -68,6 +68,10 @@ public class Catalog implements Writable {
         return comment;
     }
 
+    public String getDisplayComment() {
+        return CatalogUtils.addEscapeCharacter(comment);
+    }
+
     public void getProcNodeData(BaseProcResult result) {
         result.addRow(Lists.newArrayList(this.getName(), StringUtils.capitalize(config.get(CATALOG_TYPE)), this.getComment()));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -26,6 +26,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.MultiItemListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.SingleItemListPartitionDesc;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -350,6 +351,24 @@ public class CatalogUtils {
             bucketNum = 1;
         }
         return bucketNum;
+    }
+
+    public static String addEscapeCharacter(String comment) {
+        if (StringUtils.isEmpty(comment)) {
+            return comment;
+        }
+        StringBuilder output = new StringBuilder();
+        for (int i = 0; i < comment.length(); i++) {
+            char c = comment.charAt(i);
+
+            if (c == '\\' || c == '"') {
+                output.append('\\');
+                output.append(c);
+            } else {
+                output.append(c);
+            }
+        }
+        return output.toString();
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -318,6 +318,12 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return comment;
     }
 
+    // Attention: cause the remove escape character in parser phase, when you want to print the
+    // comment, you need add the escape character back
+    public String getDisplayComment() {
+        return CatalogUtils.addEscapeCharacter(comment);
+    }
+
     public boolean isMaterializedColumn() {
         return materializedColumnExpr != null;
     }
@@ -510,7 +516,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         } else if (isMaterializedColumn()) {
             sb.append("AS " + materializedColumnExpr.toSql() + " ");
         }
-        sb.append("COMMENT \"").append(comment).append("\"");
+        sb.append("COMMENT \"").append(getDisplayComment()).append("\"");
 
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -836,14 +836,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             StringBuilder colSb = new StringBuilder();
             colSb.append(column.getName());
             if (!Strings.isNullOrEmpty(column.getComment())) {
-                colSb.append(" COMMENT ").append("\"").append(column.getComment()).append("\"");
+                colSb.append(" COMMENT ").append("\"").append(column.getDisplayComment()).append("\"");
             }
             colDef.add(colSb.toString());
         }
         sb.append(Joiner.on(", ").join(colDef));
         sb.append(")");
         if (!Strings.isNullOrEmpty(this.getComment())) {
-            sb.append("\nCOMMENT \"").append(this.getComment()).append("\"");
+            sb.append("\nCOMMENT \"").append(this.getDisplayComment()).append("\"");
         }
 
         // partition

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -561,6 +561,15 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
         return "";
     }
 
+    // Attention: cause the remove escape character in parser phase, when you want to print the
+    // comment, you need add the escape character back
+    public String getDisplayComment() {
+        if (!Strings.isNullOrEmpty(comment)) {
+            return CatalogUtils.addEscapeCharacter(comment);
+        }
+        return "";
+    }
+
     public void setComment(String comment) {
         this.comment = Strings.nullToEmpty(comment);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.staros.proto.FileCacheInfo;
 import com.staros.proto.FilePathInfo;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.KeysType;
@@ -169,6 +170,14 @@ public class LakeMaterializedView extends MaterializedView {
     public String getComment() {
         if (!Strings.isNullOrEmpty(comment)) {
             return comment;
+        }
+        return TableType.MATERIALIZED_VIEW.name();
+    }
+
+    @Override
+    public String getDisplayComment() {
+        if (!Strings.isNullOrEmpty(comment)) {
+            return CatalogUtils.addEscapeCharacter(comment);
         }
         return TableType.MATERIALIZED_VIEW.name();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -21,6 +21,7 @@ import com.staros.proto.FilePathInfo;
 import com.starrocks.alter.AlterJobV2Builder;
 import com.starrocks.alter.LakeTableAlterJobV2Builder;
 import com.starrocks.backup.Status;
+import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.KeysType;
@@ -200,6 +201,14 @@ public class LakeTable extends OlapTable {
     public String getComment() {
         if (!Strings.isNullOrEmpty(comment)) {
             return comment;
+        }
+        return TableType.OLAP.name();
+    }
+
+    @Override
+    public String getDisplayComment() {
+        if (!Strings.isNullOrEmpty(comment)) {
+            return CatalogUtils.addEscapeCharacter(comment);
         }
         return TableType.OLAP.name();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -946,7 +946,7 @@ public class ShowExecutor {
                     // Create_options
                     row.add("");
                     // Comment
-                    row.add(table.getComment());
+                    row.add(table.getDisplayComment());
 
                     rows.add(row);
                 }
@@ -1066,7 +1066,7 @@ public class ShowExecutor {
         sb.append(" DEFAULT NULL");
 
         if (!Strings.isNullOrEmpty(column.getComment())) {
-            sb.append(" COMMENT \"").append(column.getComment()).append("\"");
+            sb.append(" COMMENT \"").append(column.getDisplayComment()).append("\"");
         }
 
         return sb.toString();
@@ -1201,7 +1201,7 @@ public class ShowExecutor {
                             defaultValue,
                             aggType,
                             "",
-                            col.getComment()));
+                            col.getDisplayComment()));
                 } else {
                     // Field Type Null Key Default Extra
                     rows.add(Lists.newArrayList(columnName,
@@ -2528,7 +2528,7 @@ public class ShowExecutor {
         // Comment
         String comment = catalog.getComment();
         if (comment != null) {
-            createCatalogSql.append("comment \"").append(catalog.getComment()).append("\"\n");
+            createCatalogSql.append("comment \"").append(catalog.getDisplayComment()).append("\"\n");
         }
         Map<String, String> clonedConfig = new HashMap<>(catalog.getConfig());
         CloudCredentialUtil.maskCloudCredential(clonedConfig);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2424,15 +2424,14 @@ public class GlobalStateMgr {
                 StringBuilder colSb = new StringBuilder();
                 colSb.append(column.getName());
                 if (!Strings.isNullOrEmpty(column.getComment())) {
-                    colSb.append(" COMMENT ").append("\"").append(column.getComment()).append("\"");
+                    colSb.append(" COMMENT ").append("\"").append(column.getDisplayComment()).append("\"");
                 }
                 colDef.add(colSb.toString());
             }
             sb.append(Joiner.on(", ").join(colDef));
             sb.append(")");
-            if (!Strings.isNullOrEmpty(view.getComment())) {
-                sb.append(" COMMENT \"").append(view.getComment()).append("\"");
-            }
+            addTableComment(sb, view);
+
             sb.append(" AS ").append(view.getInlineViewDef()).append(";");
             createTableStmt.add(sb.toString());
             return;
@@ -2495,9 +2494,7 @@ public class GlobalStateMgr {
                 }
             }
             sb.append(Joiner.on(", ").join(keysColumnNames)).append(")");
-            if (!Strings.isNullOrEmpty(table.getComment())) {
-                sb.append("\nCOMMENT \"").append(table.getComment()).append("\"");
-            }
+            addTableComment(sb, table);
 
             // partition
             PartitionInfo partitionInfo = olapTable.getPartitionInfo();
@@ -2699,9 +2696,8 @@ public class GlobalStateMgr {
             sb.append("\n)");
         } else if (table.getType() == TableType.MYSQL) {
             MysqlTable mysqlTable = (MysqlTable) table;
-            if (!Strings.isNullOrEmpty(table.getComment())) {
-                sb.append("\nCOMMENT \"").append(table.getComment()).append("\"");
-            }
+            addTableComment(sb, table);
+
             // properties
             sb.append("\nPROPERTIES (\n");
             sb.append("\"host\" = \"").append(mysqlTable.getHost()).append("\",\n");
@@ -2713,9 +2709,8 @@ public class GlobalStateMgr {
             sb.append(")");
         } else if (table.getType() == TableType.BROKER) {
             BrokerTable brokerTable = (BrokerTable) table;
-            if (!Strings.isNullOrEmpty(table.getComment())) {
-                sb.append("\nCOMMENT \"").append(table.getComment()).append("\"");
-            }
+            addTableComment(sb, table);
+
             // properties
             sb.append("\nPROPERTIES (\n");
             sb.append("\"broker_name\" = \"").append(brokerTable.getBrokerName()).append("\",\n");
@@ -2731,9 +2726,7 @@ public class GlobalStateMgr {
             }
         } else if (table.getType() == TableType.ELASTICSEARCH) {
             EsTable esTable = (EsTable) table;
-            if (!Strings.isNullOrEmpty(table.getComment())) {
-                sb.append("\nCOMMENT \"").append(table.getComment()).append("\"");
-            }
+            addTableComment(sb, table);
 
             // partition
             PartitionInfo partitionInfo = esTable.getPartitionInfo();
@@ -2768,9 +2761,7 @@ public class GlobalStateMgr {
             sb.append(")");
         } else if (table.getType() == TableType.HIVE) {
             HiveTable hiveTable = (HiveTable) table;
-            if (!Strings.isNullOrEmpty(table.getComment())) {
-                sb.append("\nCOMMENT \"").append(table.getComment()).append("\"");
-            }
+            addTableComment(sb, table);
 
             // properties
             sb.append("\nPROPERTIES (\n");
@@ -2786,17 +2777,14 @@ public class GlobalStateMgr {
             FileTable fileTable = (FileTable) table;
             Map<String, String> clonedFileProperties = new HashMap<>(fileTable.getFileProperties());
             CloudCredentialUtil.maskCloudCredential(clonedFileProperties);
-            if (!Strings.isNullOrEmpty(table.getComment())) {
-                sb.append("\nCOMMENT \"").append(table.getComment()).append("\"");
-            }
+            addTableComment(sb, table);
+
             sb.append("\nPROPERTIES (\n");
             sb.append(new PrintableMap<>(clonedFileProperties, " = ", true, true, false).toString());
             sb.append("\n)");
         } else if (table.getType() == TableType.HUDI) {
             HudiTable hudiTable = (HudiTable) table;
-            if (!Strings.isNullOrEmpty(table.getComment())) {
-                sb.append("\nCOMMENT \"").append(table.getComment()).append("\"");
-            }
+            addTableComment(sb, table);
 
             // properties
             sb.append("\nPROPERTIES (\n");
@@ -2806,9 +2794,7 @@ public class GlobalStateMgr {
             sb.append("\n)");
         } else if (table.getType() == TableType.ICEBERG) {
             IcebergTable icebergTable = (IcebergTable) table;
-            if (!Strings.isNullOrEmpty(table.getComment())) {
-                sb.append("\nCOMMENT \"").append(table.getComment()).append("\"");
-            }
+            addTableComment(sb, table);
 
             // properties
             sb.append("\nPROPERTIES (\n");
@@ -2818,9 +2804,7 @@ public class GlobalStateMgr {
             sb.append("\n)");
         } else if (table.getType() == TableType.JDBC) {
             JDBCTable jdbcTable = (JDBCTable) table;
-            if (!Strings.isNullOrEmpty(table.getComment())) {
-                sb.append("\nCOMMENT \"").append(table.getComment()).append("\"");
-            }
+            addTableComment(sb, table);
 
             // properties
             sb.append("\nPROPERTIES (\n");
@@ -2881,6 +2865,12 @@ public class GlobalStateMgr {
                 sb.append(");");
                 createRollupStmt.add(sb.toString());
             }
+        }
+    }
+
+    private static void addTableComment(StringBuilder sb, Table table) {
+        if (!Strings.isNullOrEmpty(table.getComment())) {
+            sb.append("\nCOMMENT \"").append(table.getDisplayComment()).append("\"");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocksLex.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocksLex.g4
@@ -500,10 +500,6 @@ DIGIT_IDENTIFIER
     : DIGIT (LETTER | DIGIT | '_')+
     ;
 
-QUOTED_IDENTIFIER
-    : '"' ( ~'"' | '""' )* '"'
-    ;
-
 BACKQUOTED_IDENTIFIER
     : '`' ( ~'`' | '``' )* '`'
     ;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateViewStmtTest.java
@@ -23,10 +23,12 @@ import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.ast.DescribeStmt;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -89,6 +91,23 @@ public class ShowCreateViewStmtTest {
                         "PROPERTIES(\n" +
                         "\"replication_num\" = \"1\",\n" +
                         "\"in_memory\" = \"false\"\n" +
+                        ");")
+                .withTable("CREATE TABLE `comment_test` (\n" +
+                        "  `a` varchar(125) NULL COMMENT \"\\\\'abc'\",\n" +
+                        "  `b` varchar(125) NULL COMMENT 'abc \"ef\" abc',\n" +
+                        "  `c` varchar(123) NULL COMMENT \"abc \\\"ef\\\" abc\",\n" +
+                        "  `d` varchar(123) NULL COMMENT \"\\\\abc\",\n" +
+                        "  `e` varchar(123) NULL COMMENT '\\\\\\\\\"'\n" +
+                        ") ENGINE=OLAP\n" +
+                        "DUPLICATE KEY(`a`)\n" +
+                        "COMMENT \"abc \\\"ef\\\" 'abc' \\\\abc\"\n" +
+                        "DISTRIBUTED BY HASH(`a`) BUCKETS 3\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"in_memory\" = \"false\",\n" +
+                        "\"enable_persistent_index\" = \"false\",\n" +
+                        "\"replicated_storage\" = \"true\",\n" +
+                        "\"compression\" = \"LZ4\"\n" +
                         ");");
     }
 
@@ -116,8 +135,8 @@ public class ShowCreateViewStmtTest {
         List<String> res = Lists.newArrayList();
         GlobalStateMgr.getDdlStmt(createViewStmt.getDbName(), views.get(0), res,
                 null, null, false, false);
-        Assert.assertEquals("CREATE VIEW `test_view` (k1 COMMENT \"dt\", k2, v1) COMMENT \"view comment\" " +
-                "AS SELECT `test`.`tbl1`.`k1`, `test`.`tbl1`.`k2`, `test`.`tbl1`.`v1`\n" +
+        Assert.assertEquals("CREATE VIEW `test_view` (k1 COMMENT \"dt\", k2, v1)\n" +
+                "COMMENT \"view comment\" AS SELECT `test`.`tbl1`.`k1`, `test`.`tbl1`.`k2`, `test`.`tbl1`.`v1`\n" +
                 "FROM `test`.`tbl1`;", res.get(0));
     }
 
@@ -174,5 +193,16 @@ public class ShowCreateViewStmtTest {
         String dropViewSql = "drop view if exists v2";
         DropTableStmt dropViewStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropViewSql, ctx);
         GlobalStateMgr.getCurrentState().dropTable(dropViewStmt);
+    }
+
+    @Test
+    public void testDdlComment() {
+        List<Table> tables = GlobalStateMgr.getCurrentState().getDb("test").getTables();
+        Table commentTest = tables.stream().filter(table -> table.getName().equals("comment_test")).findFirst().get();
+        List<String> res = Lists.newArrayList();
+        GlobalStateMgr.getDdlStmt("test", commentTest, res,
+                null, null, false, false);
+        StatementBase stmt = SqlParser.parse(res.get(0), connectContext.getSessionVariable()).get(0);
+        Assert.assertTrue(stmt instanceof CreateTableStmt);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -250,6 +250,10 @@ public class ShowExecutorTest {
                 minTimes = 0;
                 result = "TEST MATERIALIZED VIEW";
 
+                mv.getDisplayComment();
+                minTimes = 0;
+                result = "TEST MATERIALIZED VIEW";
+
                 mv.getPartitionInfo();
                 minTimes = 0;
                 result = new ExpressionRangePartitionInfo(


### PR DESCRIPTION
Fixes #24908

When parse a string, we need obtain the real meaning of a character followed by a escape character (like insert string values). The `escapeBackSlash()` method do this job. 
```
@Override
    public ParseNode visitString(StarRocksParser.StringContext context) {
        String quotedString;
        NodePosition pos = createPos(context);
        if (context.SINGLE_QUOTED_TEXT() != null) {
             ....
        } else {
            .....
        }
        return new StringLiteral(escapeBackSlash(quotedString), pos);
    }
```
But when parse comment string value, we need remain these escape character or the show result is not a legal string. Like comment `"\"abc\""`, it becomes `""abc""` if we remove the escape character.

I don't want to change the exist comment object too much, so I just add the escape character back when print the comment string.

Reason for removing `QUOTED_IDENTIFIER` in `StarRocksLex.g4`:
Some tokens have been regard as `QUOTED_IDENTIFIER` affectting the extract string process. Actually, ee haven't referenced this lex def in `StarRocks.g4`, so delete it.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [ ] 2.3
