### PR TITLE
[Enhancement] support binary predicate on complex type

### DIFF
--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -411,10 +411,8 @@ bool ArrayColumn::equals(size_t left, const Column& rhs, size_t right) const {
     if (lhs_end - lhs_offset != rhs_end - rhs_offset) {
         return false;
     }
-    auto lhs_elements = ColumnHelper::get_data_column(_elements.get());
-    auto rhs_elements = ColumnHelper::get_data_column(rhs_array._elements.get());
     while (lhs_offset < lhs_end) {
-        if (!lhs_elements->equals(lhs_offset, *rhs_elements, rhs_offset)) {
+        if (!_elements->equals(lhs_offset, *(rhs_array._elements.get()), rhs_offset)) {
             return false;
         }
         lhs_offset++;

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -414,17 +414,8 @@ bool ArrayColumn::equals(size_t left, const Column& rhs, size_t right) const {
     auto lhs_elements = ColumnHelper::get_data_column(_elements.get());
     auto rhs_elements = ColumnHelper::get_data_column(rhs_array._elements.get());
     while (lhs_offset < lhs_end) {
-        if (_elements->is_null(lhs_offset)) {
-            if (!rhs_array._elements->is_null(rhs_offset)) {
-                return false;
-            }
-        } else {
-            if (rhs_array._elements->is_null(rhs_offset)) {
-                return false;
-            }
-            if (!lhs_elements->equals(lhs_offset, *rhs_elements, rhs_offset)) {
-                return false;
-            }
+        if (!lhs_elements->equals(lhs_offset, *rhs_elements, rhs_offset)) {
+            return false;
         }
         lhs_offset++;
         rhs_offset++;

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -88,6 +88,11 @@ int ConstColumn::compare_at(size_t left, size_t right, const Column& rhs, int na
     return _data->compare_at(0, 0, *rhs_data, nan_direction_hint);
 }
 
+bool ConstColumn::equals(size_t left, const Column& rhs, size_t right) const {
+    const auto& rhs_data = static_cast<const ConstColumn&>(rhs)._data;
+    return _data->equals(0, *rhs_data, right);
+}
+
 void ConstColumn::check_or_die() const {
     if (_size > 0) {
         CHECK_GE(_data->size(), 1);

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -175,6 +175,8 @@ public:
 
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
 
+    bool equals(size_t left, const Column& rhs, size_t right) const override;
+
     void fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
 
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -442,7 +442,7 @@ void MapColumn::fnv_hash_at(uint32_t* hash, uint32_t idx) const {
         _keys->fnv_hash_at(&pair_hash, ele_offset);
         _values->fnv_hash_at(&pair_hash, ele_offset);
 
-        // for get same hash on un-order map, we need too satisfies the commutative law
+        // for get same hash on un-order map, we need to satisfies the commutative law
         *hash += pair_hash;
     }
 }
@@ -461,7 +461,7 @@ void MapColumn::crc32_hash_at(uint32_t* hash, uint32_t idx) const {
         _keys->crc32_hash_at(&pair_hash, ele_offset);
         _values->crc32_hash_at(&pair_hash, ele_offset);
 
-        // for get same hash on un-order map, we need too satisfies the commutative law
+        // for get same hash on un-order map, we need to satisfies the commutative law
         *hash += pair_hash;
     }
 }

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -406,20 +406,15 @@ bool MapColumn::equals(size_t left, const starrocks::Column& rhs, size_t right) 
         return false;
     }
 
-    auto lhs_keys = ColumnHelper::get_data_column(_keys.get());
-    auto lhs_values = ColumnHelper::get_data_column(_values.get());
-    auto rhs_keys = ColumnHelper::get_data_column(rhs_map._keys.get());
-    auto rhs_values = ColumnHelper::get_data_column(rhs_map._values.get());
-
     for (uint32_t i = lhs_offset; i < lhs_end; ++i) {
         bool found = false;
         for (uint32_t j = rhs_offset; j < rhs_end; ++j) {
-            if (!lhs_keys->equals(i, *rhs_keys, j)) {
+            if (!_keys->equals(i, *(rhs_map._keys.get()), j)) {
                 continue;
             }
 
             // So two keys is the same
-            if (!lhs_values->equals(i, *rhs_values, j)) {
+            if (!_values->equals(i, *(rhs_map._values.get()), j)) {
                 return false;
             }
             found = true;

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -414,30 +414,13 @@ bool MapColumn::equals(size_t left, const starrocks::Column& rhs, size_t right) 
     for (uint32_t i = lhs_offset; i < lhs_end; ++i) {
         bool found = false;
         for (uint32_t j = rhs_offset; j < rhs_end; ++j) {
-            if (_keys->is_null(i)) {
-                if (!rhs_map._keys->is_null(i)) {
-                    continue;
-                }
-            } else {
-                if (rhs_map._keys->is_null(i)) {
-                    continue;
-                }
-                if (!lhs_keys->equals(i, *rhs_keys, j)) {
-                    continue;
-                }
+            if (!lhs_keys->equals(i, *rhs_keys, j)) {
+                continue;
             }
+
             // So two keys is the same
-            if (_values->is_null(i)) {
-                if (!rhs_map._values->is_null(i)) {
-                    return false;
-                }
-            } else {
-                if (rhs_map._values->is_null(i)) {
-                    return false;
-                }
-                if (!lhs_values->equals(i, *rhs_values, j)) {
-                    return false;
-                }
+            if (!lhs_values->equals(i, *rhs_values, j)) {
+                return false;
             }
             found = true;
             break;
@@ -457,10 +440,15 @@ void MapColumn::fnv_hash_at(uint32_t* hash, uint32_t idx) const {
     size_t map_size = _offsets->get_data()[idx + 1] - offset;
 
     *hash = HashUtil::fnv_hash(&map_size, static_cast<uint32_t>(sizeof(map_size)), *hash);
+    uint32_t base_hash = *hash;
     for (size_t i = 0; i < map_size; ++i) {
+        uint32_t pair_hash = base_hash;
         uint32_t ele_offset = offset + static_cast<uint32_t>(i);
-        _keys->fnv_hash_at(hash, ele_offset);
-        _values->fnv_hash_at(hash, ele_offset);
+        _keys->fnv_hash_at(&pair_hash, ele_offset);
+        _values->fnv_hash_at(&pair_hash, ele_offset);
+
+        // for get same hash on un-order map, we need too satisfies the commutative law
+        *hash += pair_hash;
     }
 }
 
@@ -471,10 +459,15 @@ void MapColumn::crc32_hash_at(uint32_t* hash, uint32_t idx) const {
     size_t map_size = _offsets->get_data()[idx + 1] - offset;
 
     *hash = HashUtil::zlib_crc_hash(&map_size, static_cast<uint32_t>(sizeof(map_size)), *hash);
+    uint32_t base_hash = *hash;
     for (size_t i = 0; i < map_size; ++i) {
+        uint32_t pair_hash = base_hash;
         uint32_t ele_offset = offset + i;
-        _keys->crc32_hash_at(hash, ele_offset);
-        _values->crc32_hash_at(hash, ele_offset);
+        _keys->crc32_hash_at(&pair_hash, ele_offset);
+        _values->crc32_hash_at(&pair_hash, ele_offset);
+
+        // for get same hash on un-order map, we need too satisfies the commutative law
+        *hash += pair_hash;
     }
 }
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -251,6 +251,24 @@ int NullableColumn::compare_at(size_t left, size_t right, const Column& rhs, int
     }
 }
 
+bool NullableColumn::equals(size_t left, const Column& rhs, size_t right) const {
+    if (immutable_null_column_data()[left]) {
+        return rhs.is_null(right);
+    }
+
+    // left not null
+    if (rhs.is_nullable()) {
+        const auto& nullable_rhs = down_cast<const NullableColumn&>(rhs);
+        if (nullable_rhs.immutable_null_column_data()[right]) {
+            return false;
+        }
+        const auto& rhs_data = *(nullable_rhs._data_column);
+        return _data_column->equals(left, rhs_data, right);
+    } else {
+        return _data_column->equals(left, rhs, right);
+    }
+}
+
 uint32_t NullableColumn::serialize(size_t idx, uint8_t* pos) {
     // For nullable column don't have null column data and has_null is false.
     if (!_has_null) {

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -206,6 +206,8 @@ public:
 
     int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
 
+    bool equals(size_t left, const Column& rhs, size_t right) const override;
+
     void fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
 
     void crc32_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -300,34 +300,20 @@ bool StructColumn::equals(size_t left, const Column& rhs, size_t right) const {
         return false;
     }
     for (int i = 0; i < _fields.size(); ++i) {
-        if (_fields[i]->is_null(left)) {
-            if (!rhs_struct._fields[i]->is_null(right)) {
-                return false;
-            }
-        } else {
-            if (rhs_struct._fields[i]->is_null(right)) {
-                return false;
-            }
-
-            auto lhs_field = ColumnHelper::get_data_column(_fields[i].get());
-            auto rhs_field = ColumnHelper::get_data_column(rhs_struct._fields[i].get());
-            if (!lhs_field->equals(left, *rhs_field, right)) {
-                return false;
-            }
+        if (!_fields[i]->equals(left, *rhs_struct._fields[i].get(), right)) {
+            return false;
         }
     }
     return true;
 }
 
 void StructColumn::fnv_hash(uint32_t* seed, uint32_t from, uint32_t to) const {
-    // TODO(SmithCruise) Not tested.
     for (const ColumnPtr& column : _fields) {
         column->fnv_hash(seed, from, to);
     }
 }
 
 void StructColumn::crc32_hash(uint32_t* seed, uint32_t from, uint32_t to) const {
-    // TODO(SmithCruise) Not tested.
     for (const ColumnPtr& column : _fields) {
         column->crc32_hash(seed, from, to);
     }
@@ -447,12 +433,13 @@ bool StructColumn::capacity_limit_reached(std::string* msg) const {
 void StructColumn::check_or_die() const {
     // Struct must have at least one field.
     DCHECK(_fields.size() > 0);
-    // DCHECK(_field_names.size() > 0);
+    DCHECK(_field_names.size() > 0);
 
     // fields and field_names must have the same size.
-    // DCHECK(_fields.size() == _field_names.size());
+    DCHECK(_fields.size() == _field_names.size());
 
     for (const auto& column : _fields) {
+        DCHECK(column->is_nullable());
         column->check_or_die();
     }
 }

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -178,6 +178,7 @@ private:
     // A collection that contains each struct subfield name.
     // _fields and _field_names should have the same size (_fields.size() == _field_names.size()).
     // _field_names will not participate in serialization because it is created based on meta information
+    // must be nullable column
     std::vector<std::string> _field_names;
 };
 

--- a/be/src/exprs/binary_predicate.cpp
+++ b/be/src/exprs/binary_predicate.cpp
@@ -196,12 +196,12 @@ DEFINE_UNARY_FN_WITH_IMPL(isNullImpl, v) {
     return v;
 }
 
-class CommonEqualsSafePredicate final : public Predicate {
+class CommonNullSafeEqualsPredicate final : public Predicate {
 public:
-    explicit CommonEqualsSafePredicate(const TExprNode& node) : Predicate(node) {}
-    ~CommonEqualsSafePredicate() override = default;
+    explicit CommonNullSafeEqualsPredicate(const TExprNode& node) : Predicate(node) {}
+    ~CommonNullSafeEqualsPredicate() override = default;
 
-    Expr* clone(ObjectPool* pool) const override { return pool->add(new CommonEqualsSafePredicate(*this)); }
+    Expr* clone(ObjectPool* pool) const override { return pool->add(new CommonNullSafeEqualsPredicate(*this)); }
 
     // if v1 null and v2 null = true
     // if v1 null and v2 not null = false
@@ -338,7 +338,7 @@ Expr* VectorizedBinaryPredicateFactory::from_thrift(const TExprNode& node) {
         if (node.opcode == TExprOpcode::EQ) {
             return new CommonEqualsPredicate(node);
         } else if (node.opcode == TExprOpcode::EQ_FOR_NULL) {
-            return new CommonEqualsSafePredicate(node);
+            return new CommonNullSafeEqualsPredicate(node);
         } else {
             return new ArrayPredicate(node);
         }
@@ -346,7 +346,7 @@ Expr* VectorizedBinaryPredicateFactory::from_thrift(const TExprNode& node) {
         if (node.opcode == TExprOpcode::EQ) {
             return new CommonEqualsPredicate(node);
         } else if (node.opcode == TExprOpcode::EQ_FOR_NULL) {
-            return new CommonEqualsSafePredicate(node);
+            return new CommonNullSafeEqualsPredicate(node);
         } else {
             return nullptr;
         }

--- a/be/src/exprs/binary_predicate.cpp
+++ b/be/src/exprs/binary_predicate.cpp
@@ -215,7 +215,7 @@ public:
             return ColumnHelper::create_const_column<TYPE_BOOLEAN>(true, l->size());
         }
 
-        auto is_null_predicate = [&] (const ColumnPtr& column) {
+        auto is_null_predicate = [&](const ColumnPtr& column) {
             if (!column->is_nullable() || !column->has_null()) {
                 return ColumnHelper::create_const_column<TYPE_BOOLEAN>(false, column->size());
             }

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1446,6 +1446,13 @@ static std::unique_ptr<Expr> create_slot_ref(const TypeDescriptor& type) {
     return std::make_unique<ColumnRef>(ref_node);
 }
 
+
+StatusOr<ColumnPtr> MustNullExpr::evaluate_checked(ExprContext* context, Chunk* ptr) {
+    auto column = ColumnHelper::create_column(_type, true);
+    column->append_nulls(ptr->num_rows());
+    return std::move(column);
+}
+
 Expr* VectorizedCastExprFactory::create_primitive_cast(ObjectPool* pool, const TExprNode& node, LogicalType from_type,
                                                        LogicalType to_type, bool allow_throw_exception) {
     if (to_type == TYPE_CHAR) {
@@ -1633,6 +1640,9 @@ StatusOr<std::unique_ptr<Expr>> VectorizedCastExprFactory::create_cast_expr(Obje
             pool->add(cast_input.release());
         }
         return std::make_unique<CastStructExpr>(node, std::move(field_casts));
+    }
+    if ((from_type.type == TYPE_NULL || from_type.type == TYPE_BOOLEAN) && to_type.is_complex_type()) {
+        return std::make_unique<MustNullExpr>(node);
     }
     auto res = create_primitive_cast(pool, node, from_type.type, to_type.type, allow_throw_exception);
     if (res == nullptr) {

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -64,12 +64,10 @@ struct CastFn {
 };
 
 // All cast implements
-#define SELF_CAST(FROM_TYPE)                                   \
-    template <bool AllowThrowException>                        \
-    struct CastFn<FROM_TYPE, FROM_TYPE, AllowThrowException> { \
-        static ColumnPtr cast_fn(ColumnPtr& column) {          \
-            return column->clone();                            \
-        }                                                      \
+#define SELF_CAST(FROM_TYPE)                                                    \
+    template <bool AllowThrowException>                                         \
+    struct CastFn<FROM_TYPE, FROM_TYPE, AllowThrowException> {                  \
+        static ColumnPtr cast_fn(ColumnPtr& column) { return column->clone(); } \
     };
 
 #define UNARY_FN_CAST(FROM_TYPE, TO_TYPE, UNARY_IMPL)                                                        \
@@ -1062,12 +1060,10 @@ static ColumnPtr cast_from_string_to_time_fn(ColumnPtr& column) {
 }
 CUSTOMIZE_FN_CAST(TYPE_VARCHAR, TYPE_TIME, cast_from_string_to_time_fn);
 
-#define DEFINE_CAST_CONSTRUCT(CLASS)                       \
-    CLASS(const TExprNode& node) : Expr(node) {}           \
-    virtual ~CLASS(){};                                    \
-    virtual Expr* clone(ObjectPool* pool) const override { \
-        return pool->add(new CLASS(*this));                \
-    }
+#define DEFINE_CAST_CONSTRUCT(CLASS)             \
+    CLASS(const TExprNode& node) : Expr(node) {} \
+    virtual ~CLASS(){};                          \
+    virtual Expr* clone(ObjectPool* pool) const override { return pool->add(new CLASS(*this)); }
 
 // vectorized cast expr
 template <LogicalType FromType, LogicalType ToType, bool AllowThrowException>

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -64,10 +64,12 @@ struct CastFn {
 };
 
 // All cast implements
-#define SELF_CAST(FROM_TYPE)                                                    \
-    template <bool AllowThrowException>                                         \
-    struct CastFn<FROM_TYPE, FROM_TYPE, AllowThrowException> {                  \
-        static ColumnPtr cast_fn(ColumnPtr& column) { return column->clone(); } \
+#define SELF_CAST(FROM_TYPE)                                   \
+    template <bool AllowThrowException>                        \
+    struct CastFn<FROM_TYPE, FROM_TYPE, AllowThrowException> { \
+        static ColumnPtr cast_fn(ColumnPtr& column) {          \
+            return column->clone();                            \
+        }                                                      \
     };
 
 #define UNARY_FN_CAST(FROM_TYPE, TO_TYPE, UNARY_IMPL)                                                        \
@@ -1060,10 +1062,12 @@ static ColumnPtr cast_from_string_to_time_fn(ColumnPtr& column) {
 }
 CUSTOMIZE_FN_CAST(TYPE_VARCHAR, TYPE_TIME, cast_from_string_to_time_fn);
 
-#define DEFINE_CAST_CONSTRUCT(CLASS)             \
-    CLASS(const TExprNode& node) : Expr(node) {} \
-    virtual ~CLASS(){};                          \
-    virtual Expr* clone(ObjectPool* pool) const override { return pool->add(new CLASS(*this)); }
+#define DEFINE_CAST_CONSTRUCT(CLASS)                       \
+    CLASS(const TExprNode& node) : Expr(node) {}           \
+    virtual ~CLASS(){};                                    \
+    virtual Expr* clone(ObjectPool* pool) const override { \
+        return pool->add(new CLASS(*this));                \
+    }
 
 // vectorized cast expr
 template <LogicalType FromType, LogicalType ToType, bool AllowThrowException>
@@ -1445,7 +1449,6 @@ static std::unique_ptr<Expr> create_slot_ref(const TypeDescriptor& type) {
     ref_node.slot_ref.tuple_id = 0;
     return std::make_unique<ColumnRef>(ref_node);
 }
-
 
 StatusOr<ColumnPtr> MustNullExpr::evaluate_checked(ExprContext* context, Chunk* ptr) {
     auto column = ColumnHelper::create_column(_type, true);

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -151,6 +151,22 @@ private:
     std::vector<std::unique_ptr<Expr>> _field_casts;
 };
 
+// cast NULL OR Boolean to ComplexType
+// For example.
+//  cast map{1: NULL} to map<int, ARRAY<int>>
+class MustNullExpr final : public Expr {
+public:
+    MustNullExpr(const TExprNode& node): Expr(node) {}
+
+    MustNullExpr(const MustNullExpr& rhs) : Expr(rhs) {}
+
+    ~MustNullExpr() override = default;
+
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
+
+    Expr* clone(ObjectPool* pool) const override { return pool->add(new MustNullExpr(*this)); }
+};
+
 /**
  * Cast other type to string without float, double, string
  */

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -156,7 +156,7 @@ private:
 //  cast map{1: NULL} to map<int, ARRAY<int>>
 class MustNullExpr final : public Expr {
 public:
-    MustNullExpr(const TExprNode& node): Expr(node) {}
+    MustNullExpr(const TExprNode& node) : Expr(node) {}
 
     MustNullExpr(const MustNullExpr& rhs) : Expr(rhs) {}
 

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -1317,4 +1317,90 @@ PARALLEL_TEST(MapColumnTest, test_remove_duplicated_keys) {
     }
 }
 
+// NOLINTNEXTLINE
+TEST(MapColumnTest, test_hash) {
+    ColumnPtr column = nullptr;
+    ColumnPtr column1 = nullptr;
+
+    {
+        auto offsets = UInt32Column::create();
+        auto keys_data = Int32Column::create();
+        auto keys_null = NullColumn::create();
+        auto keys = NullableColumn::create(keys_data, keys_null);
+        auto values_data = Int32Column::create();
+        auto values_null = NullColumn::create();
+        auto values = NullableColumn::create(values_data, values_null);
+
+        offsets->append(0);
+        offsets->append(3);
+
+        keys_null->append(0);
+        keys_null->append(0);
+        keys_null->append(0);
+
+        keys_data->append(1);
+        keys_data->append(2);
+        keys_data->append(3);
+
+        values_null->append(0);
+        values_null->append(0);
+        values_null->append(0);
+
+        values_data->append(11);
+        values_data->append(21);
+        values_data->append(31);
+
+        column = MapColumn::create(keys, values, offsets);
+    }
+
+    {
+        auto offsets = UInt32Column::create();
+        auto keys_data = Int32Column::create();
+        auto keys_null = NullColumn::create();
+        auto keys = NullableColumn::create(keys_data, keys_null);
+        auto values_data = Int32Column::create();
+        auto values_null = NullColumn::create();
+        auto values = NullableColumn::create(values_data, values_null);
+
+        offsets->append(0);
+        offsets->append(3);
+
+        keys_null->append(0);
+        keys_null->append(0);
+        keys_null->append(0);
+
+        keys_data->append(2);
+        keys_data->append(1);
+        keys_data->append(3);
+
+        values_null->append(0);
+        values_null->append(0);
+        values_null->append(0);
+
+        values_data->append(21);
+        values_data->append(11);
+        values_data->append(31);
+
+        column1 = MapColumn::create(keys, values, offsets);
+    }
+
+    ASSERT_EQ("{1:11,2:21,3:31}", column->debug_item(0));
+    ASSERT_EQ("{2:21,1:11,3:31}", column1->debug_item(0));
+
+
+    uint32_t hash = 0;
+    uint32_t hash1 = 0;
+    column->fnv_hash_at(&hash, 0);
+    column1->fnv_hash_at(&hash1, 0);
+
+    ASSERT_EQ(hash, hash1);
+
+    hash = 0;
+    hash1 = 0;
+    column->crc32_hash_at(&hash, 0);
+    column1->crc32_hash_at(&hash1, 0);
+
+    ASSERT_EQ(hash, hash1);
+}
+
 } // namespace starrocks

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -1387,7 +1387,6 @@ TEST(MapColumnTest, test_hash) {
     ASSERT_EQ("{1:11,2:21,3:31}", column->debug_item(0));
     ASSERT_EQ("{2:21,1:11,3:31}", column1->debug_item(0));
 
-
     uint32_t hash = 0;
     uint32_t hash1 = 0;
     column->fnv_hash_at(&hash, 0);

--- a/be/test/exprs/mock_vectorized_expr.h
+++ b/be/test/exprs/mock_vectorized_expr.h
@@ -204,4 +204,19 @@ public:
     ColumnPtr col;
 };
 
+class MockColumnExpr : public MockCostExpr {
+public:
+    MockColumnExpr(const TExprNode& t, ColumnPtr column): MockCostExpr(t), _column(column) {}
+
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
+        start();
+        auto col = _column->clone();
+        stop();
+        return std::move(col);
+    }
+
+private:
+    ColumnPtr _column;
+};
+
 } // namespace starrocks

--- a/be/test/exprs/mock_vectorized_expr.h
+++ b/be/test/exprs/mock_vectorized_expr.h
@@ -206,7 +206,7 @@ public:
 
 class MockColumnExpr : public MockCostExpr {
 public:
-    MockColumnExpr(const TExprNode& t, ColumnPtr column): MockCostExpr(t), _column(column) {}
+    MockColumnExpr(const TExprNode& t, ColumnPtr column) : MockCostExpr(t), _column(column) {}
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
         start();

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -217,7 +217,7 @@ TEST_F(ThreadPoolTest, TestRace) {
         CountDownLatch l(1);
         // CountDownLatch::count_down has multiple overloaded version,
         // so an cast is needed to use std::bind
-        ASSERT_TRUE(_pool->submit_func(std::bind((void(CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
+        ASSERT_TRUE(_pool->submit_func(std::bind((void (CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
         l.wait();
         // Sleeping a different amount in each iteration makes it more likely to hit
         // the bug.

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -217,7 +217,7 @@ TEST_F(ThreadPoolTest, TestRace) {
         CountDownLatch l(1);
         // CountDownLatch::count_down has multiple overloaded version,
         // so an cast is needed to use std::bind
-        ASSERT_TRUE(_pool->submit_func(std::bind((void (CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
+        ASSERT_TRUE(_pool->submit_func(std::bind((void(CountDownLatch::*)())(&CountDownLatch::count_down), &l)).ok());
         l.wait();
         // Sleeping a different amount in each iteration makes it more likely to hit
         // the bug.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -1094,6 +1094,10 @@ public abstract class Type implements Cloneable {
         } else if (from.isJsonType() && to.isArrayScalar()) {
             // now we only support cast json to one dimensional array
             return true;
+        } else if (from.isBoolean() && to.isComplexType()) {
+            // for mock nest type with NULL value, the cast must return NULL
+            // like cast(map{1: NULL} as MAP<int, int>)
+            return true;
         } else {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -605,13 +605,13 @@ public class ExpressionAnalyzer {
 
             Type compatibleType = TypeManager.getCompatibleTypeForBinary(node.getOp(), type1, type2);
             // check child type can be cast
-            final String ERROR_MSG = "Column type %s does not support binary predicate operation";
+            final String ERROR_MSG = "Column type %s does not support binary predicate operation with type %s";
             if (!Type.canCastTo(type1, compatibleType)) {
-                throw new SemanticException(String.format(ERROR_MSG, type1.toSql()), node.getPos());
+                throw new SemanticException(String.format(ERROR_MSG, type1.toSql(), type2.toSql()), node.getPos());
             }
 
             if (!Type.canCastTo(type2, compatibleType)) {
-                throw new SemanticException(String.format(ERROR_MSG, type1.toSql()), node.getPos());
+                throw new SemanticException(String.format(ERROR_MSG, type1.toSql(), type2.toSql()), node.getPos());
             }
 
             node.setType(Type.BOOLEAN);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
@@ -99,7 +99,7 @@ public class PolymorphicFunctionAnalyzer {
 
         int size = Math.max(argsTypes.length, inputArgTypes.length);
         for (int i = 0; i < size; ++i) {
-            Type declType = size >= argsTypes.length ? argsTypes[argsTypes.length - 1] : argsTypes[i];
+            Type declType = i >= argsTypes.length ? argsTypes[argsTypes.length - 1] : argsTypes[i];
             Type inputType = inputArgTypes[i];
 
             // If declaration type is not a pseudo type, use it.
@@ -118,6 +118,8 @@ public class PolymorphicFunctionAnalyzer {
             } else {
                 resolvedTypes[i] = inputType;
             }
+
+            resolvedTypes[i] = AnalyzerUtils.replaceNullType2Boolean(resolvedTypes[i]);
         }
         return resolvedTypes;
     }
@@ -291,7 +293,6 @@ public class PolymorphicFunctionAnalyzer {
         Type[] declTypes = fn.getArgs();
         Function resolvedFunction;
 
-        paramTypes = Arrays.stream(paramTypes).map(AnalyzerUtils::replaceNullType2Boolean).toArray(Type[]::new);
         long numPseudoArgs = Arrays.stream(declTypes).filter(Type::isPseudoType).count();
         // resolve single pseudo type parameter, example: int array_length(ANY_ARRAY)
         if (!retType.isPseudoType() && numPseudoArgs == 1) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -189,7 +189,7 @@ public class TypeManager {
                     (type1.isExactNumericType() && type2.isStringType())) {
                 return Type.STRING;
             } else if (type1.isComplexType() || type2.isComplexType()) {
-                return Type.getCommonType(type1, type2);
+                return TypeManager.getCommonSuperType(type1, type2);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -188,6 +188,8 @@ public class TypeManager {
             if ((type1.isStringType() && type2.isExactNumericType()) ||
                     (type1.isExactNumericType() && type2.isStringType())) {
                 return Type.STRING;
+            } else if (type1.isComplexType() || type2.isComplexType()) {
+                return Type.getCommonType(type1, type2);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -53,6 +53,12 @@ public class TypeManager {
         if (t1.isStructType() && t2.isStructType()) {
             return getCommonStructType((StructType) t1, (StructType) t2);
         }
+        if (t1.isBoolean() && t2.isComplexType()) {
+            return t2;
+        }
+        if (t1.isComplexType() && t2.isBoolean()) {
+            return t1;
+        }
         if (t1.isNull() || t2.isNull()) {
             return t1.isNull() ? t2 : t1;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -22,7 +22,6 @@ import com.starrocks.analysis.ArraySliceExpr;
 import com.starrocks.analysis.ArrowExpr;
 import com.starrocks.analysis.BetweenPredicate;
 import com.starrocks.analysis.BinaryPredicate;
-import com.starrocks.analysis.BinaryType;
 import com.starrocks.analysis.CaseExpr;
 import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.CloneExpr;
@@ -433,38 +432,9 @@ public final class SqlToScalarOperatorTranslator {
 
         @Override
         public ScalarOperator visitBinaryPredicate(BinaryPredicate node, Context context) {
-            switch (node.getOp()) {
-                case EQ:
-                    return new BinaryPredicateOperator(BinaryType.EQ,
-                            visit(node.getChild(0), context.clone(node)),
-                            visit(node.getChild(1), context.clone(node)));
-                case NE:
-                    return new BinaryPredicateOperator(BinaryType.NE,
-                            visit(node.getChild(0), context.clone(node)),
-                            visit(node.getChild(1), context.clone(node)));
-                case GT:
-                    return new BinaryPredicateOperator(BinaryType.GT,
-                            visit(node.getChild(0), context.clone(node)),
-                            visit(node.getChild(1), context.clone(node)));
-                case GE:
-                    return new BinaryPredicateOperator(BinaryType.GE,
-                            visit(node.getChild(0), context.clone(node)),
-                            visit(node.getChild(1), context.clone(node)));
-                case LT:
-                    return new BinaryPredicateOperator(BinaryType.LT,
-                            visit(node.getChild(0), context.clone(node)),
-                            visit(node.getChild(1), context.clone(node)));
-                case LE:
-                    return new BinaryPredicateOperator(BinaryType.LE,
-                            visit(node.getChild(0), context.clone(node)),
-                            visit(node.getChild(1), context.clone(node)));
-                case EQ_FOR_NULL:
-                    return new BinaryPredicateOperator(BinaryType.EQ_FOR_NULL,
-                            visit(node.getChild(0), context.clone(node)),
-                            visit(node.getChild(1), context.clone(node)));
-                default:
-                    throw new UnsupportedOperationException("nonsupport binary predicate type");
-            }
+            return new BinaryPredicateOperator(node.getOp(),
+                    visit(node.getChild(0), context.clone(node)),
+                    visit(node.getChild(1), context.clone(node)));
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
@@ -189,4 +189,13 @@ public class StructTypePlanTest extends PlanTestBase {
         sql = "select map_values(col_map), map_keys(col_map) from (select map_from_arrays([],[]) as col_map)A";
         assertPlanContains(sql, "[], []");
     }
+
+    @Test
+    public void testCast() throws Exception {
+        String sql = "select cast(row(null, null, null) as STRUCT<a int, b MAP<int, int>, c ARRAY<INT>>); ";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "cast(row[(NULL, NULL, NULL); args: BOOLEAN,BOOLEAN,BOOLEAN; " +
+                "result: struct<col1 boolean, col2 boolean, col3 boolean>; args nullable: true; result nullable: true] " +
+                "as struct<a int(11), b map<int(11),int(11)>, c array<int(11)>>)");
+    }
 }

--- a/test/sql/test_semi/R/test_bianry
+++ b/test/sql/test_semi/R/test_bianry
@@ -1,0 +1,263 @@
+-- name: test_binary @system
+CREATE TABLE `sc2` (
+  `v1` bigint(20) NULL COMMENT "",
+  `array1` ARRAY<INT> NULL,
+  `array2` ARRAY<MAP<INT, INT>> NULL,
+  `array3` ARRAY<STRUCT<a INT, b INT>> NULL,
+  `map1` MAP<INT, INT> NULL,
+  `map2` MAP<INT, ARRAY<INT>> NULL,
+  `map3` MAP<INT, STRUCT<c INT, b INT>> NULL,
+  `st1` STRUCT<s1 int, s2 ARRAY<INT>, s3 MAP<INT, INT>, s4 Struct<e INT, f INT>>
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into sc2 values (1, [11,NULL,31,41], [map{11: 110}, map{101: 101}], [row(11, 12), row(12, 13)], map{14: 41, NULL: 11, 12: 31}, map{101: [1, 10, 11, 23]}, map{101: row(NULL, 12)}, row(1, [1, 10, 11], map{101: 111, NULL: NULL}, row(111, 110)));
+-- result:
+-- !result
+insert into sc2 values (2, [12,22,32,42], [map{22: 220}, map{NULL: 201}], [row(21, 22), NULL], NULL, map{202: [2, 20, NULL, 23]}, map{202: row(21, 22)}, row(2, NULL, map{202: NULL}, row(222, 220)));
+-- result:
+-- !result
+insert into sc2 values (3, NULL, [map{33: NULL}, map{303: 301}], [row(31, 32), row(NULL, 33)], map{34: 43, 36: 13, 32: NULL}, map{303: NULL}, map{303: row(31, 32)}, NULL);
+-- result:
+-- !result
+insert into sc2 values (4, [14,24,NULL,44], [map{44: 440}, map{404: 401}], [row(41, 42), row(42, 43)], map{44: 44, 46: 14, 42: 34}, map{NULL: [4, NULL, 41, 23]}, map{404: row(41, 42)}, row(NULL, [4, NULL, 41], map{NULL: 444}, NULL));
+-- result:
+-- !result
+insert into sc2 values (5, [15,25,35,45], [map{NULL: 550}, map{505: 501}], [row(51, 52), row(NULL, 53)], map{54: 45, 56: 15, NULL: NULL}, map{NULL: NULL}, map{505: row(NULL, 52)}, row(5, [5, 50, 51], NULL, row(NULL, 550)));
+-- result:
+-- !result
+select * from sc2 where array1 is null;
+-- result:
+3	None	[{33:null},{303:301}]	[{"a":31,"b":32},{"a":null,"b":33}]	{34:43,36:13,32:null}	{303:null}	{303:{"c":31,"b":32}}	None
+-- !result
+select * from sc2 where array1 = [11,null,31,41];
+-- result:
+1	[11,null,31,41]	[{11:110},{101:101}]	[{"a":11,"b":12},{"a":12,"b":13}]	{14:41,null:11,12:31}	{101:[1,10,11,23]}	{101:{"c":null,"b":12}}	{"s1":1,"s2":[1,10,11],"s3":{101:111,null:null},"s4":{"e":111,"f":110}}
+-- !result
+select * from sc2 where array1 = [15,25,35,45];
+-- result:
+5	[15,25,35,45]	[{null:550},{505:501}]	[{"a":51,"b":52},{"a":null,"b":53}]	{54:45,56:15,null:null}	{null:null}	{505:{"c":null,"b":52}}	{"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}}
+-- !result
+select * from sc2 where array1 = [map{"a":21,"b":22},null];
+-- result:
+E: (1064, 'Getting analyzing error from line 1, column 24 to line 1, column 57. Detail message: Column type array<int(11)> does not support binary predicate operation with type array<map<varchar,tinyint(4)>>.')
+-- !result
+select * from sc2 where array3 = [map{"a":21,"b":22},null];
+-- result:
+E: (1064, 'Getting analyzing error from line 1, column 24 to line 1, column 57. Detail message: Column type array<struct<a int(11), b int(11)>> does not support binary predicate operation with type array<map<varchar,tinyint(4)>>.')
+-- !result
+select * from sc2 where array3 = [named_struct("a",21,"b",22),null];
+-- result:
+2	[12,22,32,42]	[{22:220},{null:201}]	[{"a":21,"b":22},null]	None	{202:[2,20,null,23]}	{202:{"c":21,"b":22}}	{"s1":2,"s2":null,"s3":{202:null},"s4":{"e":222,"f":220}}
+-- !result
+select * from sc2 where array3 = [row(21,22),null];
+-- result:
+2	[12,22,32,42]	[{22:220},{null:201}]	[{"a":21,"b":22},null]	None	{202:[2,20,null,23]}	{202:{"c":21,"b":22}}	{"s1":2,"s2":null,"s3":{202:null},"s4":{"e":222,"f":220}}
+-- !result
+select * from sc2 where array2 = [map{null:550},map{505:501}];
+-- result:
+5	[15,25,35,45]	[{null:550},{505:501}]	[{"a":51,"b":52},{"a":null,"b":53}]	{54:45,56:15,null:null}	{null:null}	{505:{"c":null,"b":52}}	{"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}}
+-- !result
+select * from sc2 where array2 = [map{44:440},map{404:401}];
+-- result:
+4	[14,24,null,44]	[{44:440},{404:401}]	[{"a":41,"b":42},{"a":42,"b":43}]	{44:44,46:14,42:34}	{null:[4,null,41,23]}	{404:{"c":41,"b":42}}	{"s1":null,"s2":[4,null,41],"s3":{null:444},"s4":null}
+-- !result
+select * from sc2 where map1 = null;
+-- result:
+-- !result
+select * from sc2 where map1 = map{14:41,null:11,12:31};
+-- result:
+1	[11,null,31,41]	[{11:110},{101:101}]	[{"a":11,"b":12},{"a":12,"b":13}]	{14:41,null:11,12:31}	{101:[1,10,11,23]}	{101:{"c":null,"b":12}}	{"s1":1,"s2":[1,10,11],"s3":{101:111,null:null},"s4":{"e":111,"f":110}}
+-- !result
+select * from sc2 where map1 = map{44:44,46:14,42:34};
+-- result:
+4	[14,24,null,44]	[{44:440},{404:401}]	[{"a":41,"b":42},{"a":42,"b":43}]	{44:44,46:14,42:34}	{null:[4,null,41,23]}	{404:{"c":41,"b":42}}	{"s1":null,"s2":[4,null,41],"s3":{null:444},"s4":null}
+-- !result
+select * from sc2 where map1 = map{34:43,36:13,32:null};
+-- result:
+3	None	[{33:null},{303:301}]	[{"a":31,"b":32},{"a":null,"b":33}]	{34:43,36:13,32:null}	{303:null}	{303:{"c":31,"b":32}}	None
+-- !result
+select * from sc2 where map2 = map{505:[5,50,51,23]};
+-- result:
+-- !result
+select cast(row(1, null) as struct<a int, b array<int>>);
+-- result:
+{"a":1,"b":null}
+-- !result
+select cast(map{1: null} as map<int, array<int>>);
+-- result:
+{1:null}
+-- !result
+select cast(row(1, TRUE) as struct<a int, b map<int, int>>);
+-- result:
+{"a":1,"b":null}
+-- !result
+select * from sc2 where map2 = map{null:null};
+-- result:
+5	[15,25,35,45]	[{null:550},{505:501}]	[{"a":51,"b":52},{"a":null,"b":53}]	{54:45,56:15,null:null}	{null:null}	{505:{"c":null,"b":52}}	{"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}}
+-- !result
+select * from sc2 where map2 = map{null:[4,null,41,23]};
+-- result:
+4	[14,24,null,44]	[{44:440},{404:401}]	[{"a":41,"b":42},{"a":42,"b":43}]	{44:44,46:14,42:34}	{null:[4,null,41,23]}	{404:{"c":41,"b":42}}	{"s1":null,"s2":[4,null,41],"s3":{null:444},"s4":null}
+-- !result
+select * from sc2 where map2 = map{101:[1,10,11,23]};
+-- result:
+1	[11,null,31,41]	[{11:110},{101:101}]	[{"a":11,"b":12},{"a":12,"b":13}]	{14:41,null:11,12:31}	{101:[1,10,11,23]}	{101:{"c":null,"b":12}}	{"s1":1,"s2":[1,10,11],"s3":{101:111,null:null},"s4":{"e":111,"f":110}}
+-- !result
+select * from sc2 where map1 = map{46:14,42:34,44:44};
+-- result:
+4	[14,24,null,44]	[{44:440},{404:401}]	[{"a":41,"b":42},{"a":42,"b":43}]	{44:44,46:14,42:34}	{null:[4,null,41,23]}	{404:{"c":41,"b":42}}	{"s1":null,"s2":[4,null,41],"s3":{null:444},"s4":null}
+-- !result
+select * from sc2 where map1 = map{54:45,56:15};
+-- result:
+-- !result
+select * from sc2 where map1 = map{null:null, 54:45,56:15};
+-- result:
+5	[15,25,35,45]	[{null:550},{505:501}]	[{"a":51,"b":52},{"a":null,"b":53}]	{54:45,56:15,null:null}	{null:null}	{505:{"c":null,"b":52}}	{"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}}
+-- !result
+select * from sc2 where map3 = map{505:row(null, 52)};
+-- result:
+5	[15,25,35,45]	[{null:550},{505:501}]	[{"a":51,"b":52},{"a":null,"b":53}]	{54:45,56:15,null:null}	{null:null}	{505:{"c":null,"b":52}}	{"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}}
+-- !result
+select * from sc2 where map2 = map{null:[4,null,41,23]};
+-- result:
+4	[14,24,null,44]	[{44:440},{404:401}]	[{"a":41,"b":42},{"a":42,"b":43}]	{44:44,46:14,42:34}	{null:[4,null,41,23]}	{404:{"c":41,"b":42}}	{"s1":null,"s2":[4,null,41],"s3":{null:444},"s4":null}
+-- !result
+select * from sc2 where st1 = row(2,null, map{202:null}, row(222,220));
+-- result:
+2	[12,22,32,42]	[{22:220},{null:201}]	[{"a":21,"b":22},null]	None	{202:[2,20,null,23]}	{202:{"c":21,"b":22}}	{"s1":2,"s2":null,"s3":{202:null},"s4":{"e":222,"f":220}}
+-- !result
+select * from sc2 where st1 = named_struct("s1", 5,"s2",[5,50,51],"s3",null,"s4", row(null,550));
+-- result:
+5	[15,25,35,45]	[{null:550},{505:501}]	[{"a":51,"b":52},{"a":null,"b":53}]	{54:45,56:15,null:null}	{null:null}	{505:{"c":null,"b":52}}	{"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}}
+-- !result
+select * from sc2 where array1 = null;
+-- result:
+-- !result
+select * from sc2 where st1 = null;
+-- result:
+-- !result
+select * from sc2 where array1 is null;
+-- result:
+3	None	[{33:null},{303:301}]	[{"a":31,"b":32},{"a":null,"b":33}]	{34:43,36:13,32:null}	{303:null}	{303:{"c":31,"b":32}}	None
+-- !result
+select * from sc2 where array1 <=> [11,null,31,41];
+-- result:
+1	[11,null,31,41]	[{11:110},{101:101}]	[{"a":11,"b":12},{"a":12,"b":13}]	{14:41,null:11,12:31}	{101:[1,10,11,23]}	{101:{"c":null,"b":12}}	{"s1":1,"s2":[1,10,11],"s3":{101:111,null:null},"s4":{"e":111,"f":110}}
+-- !result
+select * from sc2 where array1 <=> [15,25,35,45];
+-- result:
+5	[15,25,35,45]	[{null:550},{505:501}]	[{"a":51,"b":52},{"a":null,"b":53}]	{54:45,56:15,null:null}	{null:null}	{505:{"c":null,"b":52}}	{"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}}
+-- !result
+select * from sc2 where array1 <=> [map{"a":21,"b":22},null];
+-- result:
+E: (1064, 'Getting analyzing error from line 1, column 24 to line 1, column 59. Detail message: Column type array<int(11)> does not support binary predicate operation with type array<map<varchar,tinyint(4)>>.')
+-- !result
+select * from sc2 where array3 <=> [map{"a":21,"b":22},null];
+-- result:
+E: (1064, 'Getting analyzing error from line 1, column 24 to line 1, column 59. Detail message: Column type array<struct<a int(11), b int(11)>> does not support binary predicate operation with type array<map<varchar,tinyint(4)>>.')
+-- !result
+select * from sc2 where array3 <=> [named_struct("a",21,"b",22),null];
+-- result:
+2	[12,22,32,42]	[{22:220},{null:201}]	[{"a":21,"b":22},null]	None	{202:[2,20,null,23]}	{202:{"c":21,"b":22}}	{"s1":2,"s2":null,"s3":{202:null},"s4":{"e":222,"f":220}}
+-- !result
+select * from sc2 where array3 <=> [row(21,22),null];
+-- result:
+2	[12,22,32,42]	[{22:220},{null:201}]	[{"a":21,"b":22},null]	None	{202:[2,20,null,23]}	{202:{"c":21,"b":22}}	{"s1":2,"s2":null,"s3":{202:null},"s4":{"e":222,"f":220}}
+-- !result
+select * from sc2 where array2 <=> [map{null:550},map{505:501}];
+-- result:
+5	[15,25,35,45]	[{null:550},{505:501}]	[{"a":51,"b":52},{"a":null,"b":53}]	{54:45,56:15,null:null}	{null:null}	{505:{"c":null,"b":52}}	{"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}}
+-- !result
+select * from sc2 where array2 <=> [map{44:440},map{404:401}];
+-- result:
+4	[14,24,null,44]	[{44:440},{404:401}]	[{"a":41,"b":42},{"a":42,"b":43}]	{44:44,46:14,42:34}	{null:[4,null,41,23]}	{404:{"c":41,"b":42}}	{"s1":null,"s2":[4,null,41],"s3":{null:444},"s4":null}
+-- !result
+select * from sc2 where map1 <=> null;
+-- result:
+2	[12,22,32,42]	[{22:220},{null:201}]	[{"a":21,"b":22},null]	None	{202:[2,20,null,23]}	{202:{"c":21,"b":22}}	{"s1":2,"s2":null,"s3":{202:null},"s4":{"e":222,"f":220}}
+-- !result
+select * from sc2 where map1 <=> map{14:41,null:11,12:31};
+-- result:
+1	[11,null,31,41]	[{11:110},{101:101}]	[{"a":11,"b":12},{"a":12,"b":13}]	{14:41,null:11,12:31}	{101:[1,10,11,23]}	{101:{"c":null,"b":12}}	{"s1":1,"s2":[1,10,11],"s3":{101:111,null:null},"s4":{"e":111,"f":110}}
+-- !result
+select * from sc2 where map1 <=> map{44:44,46:14,42:34};
+-- result:
+4	[14,24,null,44]	[{44:440},{404:401}]	[{"a":41,"b":42},{"a":42,"b":43}]	{44:44,46:14,42:34}	{null:[4,null,41,23]}	{404:{"c":41,"b":42}}	{"s1":null,"s2":[4,null,41],"s3":{null:444},"s4":null}
+-- !result
+select * from sc2 where map1 <=> map{34:43,36:13,32:null};
+-- result:
+3	None	[{33:null},{303:301}]	[{"a":31,"b":32},{"a":null,"b":33}]	{34:43,36:13,32:null}	{303:null}	{303:{"c":31,"b":32}}	None
+-- !result
+select * from sc2 where map2 <=> map{505:[5,50,51,23]};
+-- result:
+-- !result
+select cast(row(1, null) as struct<a int, b array<int>>);
+-- result:
+{"a":1,"b":null}
+-- !result
+select cast(map{1: null} as map<int, array<int>>);
+-- result:
+{1:null}
+-- !result
+select cast(row(1, TRUE) as struct<a int, b map<int, int>>);
+-- result:
+{"a":1,"b":null}
+-- !result
+select * from sc2 where map2 <=> map{null:null};
+-- result:
+5	[15,25,35,45]	[{null:550},{505:501}]	[{"a":51,"b":52},{"a":null,"b":53}]	{54:45,56:15,null:null}	{null:null}	{505:{"c":null,"b":52}}	{"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}}
+-- !result
+select * from sc2 where map2 <=> map{null:[4,null,41,23]};
+-- result:
+4	[14,24,null,44]	[{44:440},{404:401}]	[{"a":41,"b":42},{"a":42,"b":43}]	{44:44,46:14,42:34}	{null:[4,null,41,23]}	{404:{"c":41,"b":42}}	{"s1":null,"s2":[4,null,41],"s3":{null:444},"s4":null}
+-- !result
+select * from sc2 where map2 <=> map{101:[1,10,11,23]};
+-- result:
+1	[11,null,31,41]	[{11:110},{101:101}]	[{"a":11,"b":12},{"a":12,"b":13}]	{14:41,null:11,12:31}	{101:[1,10,11,23]}	{101:{"c":null,"b":12}}	{"s1":1,"s2":[1,10,11],"s3":{101:111,null:null},"s4":{"e":111,"f":110}}
+-- !result
+select * from sc2 where map1 <=> map{46:14,42:34,44:44};
+-- result:
+4	[14,24,null,44]	[{44:440},{404:401}]	[{"a":41,"b":42},{"a":42,"b":43}]	{44:44,46:14,42:34}	{null:[4,null,41,23]}	{404:{"c":41,"b":42}}	{"s1":null,"s2":[4,null,41],"s3":{null:444},"s4":null}
+-- !result
+select * from sc2 where map1 <=> map{54:45,56:15};
+-- result:
+-- !result
+select * from sc2 where map1 <=> map{null:null, 54:45,56:15};
+-- result:
+5	[15,25,35,45]	[{null:550},{505:501}]	[{"a":51,"b":52},{"a":null,"b":53}]	{54:45,56:15,null:null}	{null:null}	{505:{"c":null,"b":52}}	{"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}}
+-- !result
+select * from sc2 where map3 <=> map{505:row(null, 52)};
+-- result:
+5	[15,25,35,45]	[{null:550},{505:501}]	[{"a":51,"b":52},{"a":null,"b":53}]	{54:45,56:15,null:null}	{null:null}	{505:{"c":null,"b":52}}	{"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}}
+-- !result
+select * from sc2 where map2 <=> map{null:[4,null,41,23]};
+-- result:
+4	[14,24,null,44]	[{44:440},{404:401}]	[{"a":41,"b":42},{"a":42,"b":43}]	{44:44,46:14,42:34}	{null:[4,null,41,23]}	{404:{"c":41,"b":42}}	{"s1":null,"s2":[4,null,41],"s3":{null:444},"s4":null}
+-- !result
+select * from sc2 where st1 <=> row(2,null, map{202:null}, row(222,220));
+-- result:
+2	[12,22,32,42]	[{22:220},{null:201}]	[{"a":21,"b":22},null]	None	{202:[2,20,null,23]}	{202:{"c":21,"b":22}}	{"s1":2,"s2":null,"s3":{202:null},"s4":{"e":222,"f":220}}
+-- !result
+select * from sc2 where st1 <=> named_struct("s1", 5,"s2",[5,50,51],"s3",null,"s4", row(null,550));
+-- result:
+5	[15,25,35,45]	[{null:550},{505:501}]	[{"a":51,"b":52},{"a":null,"b":53}]	{54:45,56:15,null:null}	{null:null}	{505:{"c":null,"b":52}}	{"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}}
+-- !result
+select * from sc2 where array1 <=> null;
+-- result:
+3	None	[{33:null},{303:301}]	[{"a":31,"b":32},{"a":null,"b":33}]	{34:43,36:13,32:null}	{303:null}	{303:{"c":31,"b":32}}	None
+-- !result
+select * from sc2 where st1 <=> null;
+-- result:
+3	None	[{33:null},{303:301}]	[{"a":31,"b":32},{"a":null,"b":33}]	{34:43,36:13,32:null}	{303:null}	{303:{"c":31,"b":32}}	None
+-- !result

--- a/test/sql/test_semi/T/test_bianry
+++ b/test/sql/test_semi/T/test_bianry
@@ -1,0 +1,90 @@
+-- name: test_binary @system
+CREATE TABLE `sc2` (
+  `v1` bigint(20) NULL COMMENT "",
+  `array1` ARRAY<INT> NULL,
+  `array2` ARRAY<MAP<INT, INT>> NULL,
+  `array3` ARRAY<STRUCT<a INT, b INT>> NULL,
+  `map1` MAP<INT, INT> NULL,
+  `map2` MAP<INT, ARRAY<INT>> NULL,
+  `map3` MAP<INT, STRUCT<c INT, b INT>> NULL,
+  `st1` STRUCT<s1 int, s2 ARRAY<INT>, s3 MAP<INT, INT>, s4 Struct<e INT, f INT>>
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+
+insert into sc2 values (1, [11,NULL,31,41], [map{11: 110}, map{101: 101}], [row(11, 12), row(12, 13)], map{14: 41, NULL: 11, 12: 31}, map{101: [1, 10, 11, 23]}, map{101: row(NULL, 12)}, row(1, [1, 10, 11], map{101: 111, NULL: NULL}, row(111, 110)));
+insert into sc2 values (2, [12,22,32,42], [map{22: 220}, map{NULL: 201}], [row(21, 22), NULL], NULL, map{202: [2, 20, NULL, 23]}, map{202: row(21, 22)}, row(2, NULL, map{202: NULL}, row(222, 220)));
+insert into sc2 values (3, NULL, [map{33: NULL}, map{303: 301}], [row(31, 32), row(NULL, 33)], map{34: 43, 36: 13, 32: NULL}, map{303: NULL}, map{303: row(31, 32)}, NULL);
+insert into sc2 values (4, [14,24,NULL,44], [map{44: 440}, map{404: 401}], [row(41, 42), row(42, 43)], map{44: 44, 46: 14, 42: 34}, map{NULL: [4, NULL, 41, 23]}, map{404: row(41, 42)}, row(NULL, [4, NULL, 41], map{NULL: 444}, NULL));
+insert into sc2 values (5, [15,25,35,45], [map{NULL: 550}, map{505: 501}], [row(51, 52), row(NULL, 53)], map{54: 45, 56: 15, NULL: NULL}, map{NULL: NULL}, map{505: row(NULL, 52)}, row(5, [5, 50, 51], NULL, row(NULL, 550)));
+
+
+select * from sc2 where array1 is null;
+select * from sc2 where array1 = [11,null,31,41];
+select * from sc2 where array1 = [15,25,35,45];
+select * from sc2 where array1 = [map{"a":21,"b":22},null];
+select * from sc2 where array3 = [map{"a":21,"b":22},null];
+select * from sc2 where array3 = [named_struct("a",21,"b",22),null];
+select * from sc2 where array3 = [row(21,22),null];
+select * from sc2 where array2 = [map{null:550},map{505:501}];
+select * from sc2 where array2 = [map{44:440},map{404:401}];
+select * from sc2 where map1 = null;
+select * from sc2 where map1 = map{14:41,null:11,12:31};
+select * from sc2 where map1 = map{44:44,46:14,42:34};
+select * from sc2 where map1 = map{34:43,36:13,32:null};
+select * from sc2 where map2 = map{505:[5,50,51,23]};
+select cast(row(1, null) as struct<a int, b array<int>>);
+select cast(map{1: null} as map<int, array<int>>);
+select cast(row(1, TRUE) as struct<a int, b map<int, int>>);
+select * from sc2 where map2 = map{null:null};
+select * from sc2 where map2 = map{null:[4,null,41,23]};
+select * from sc2 where map2 = map{101:[1,10,11,23]};
+select * from sc2 where map1 = map{46:14,42:34,44:44};
+select * from sc2 where map1 = map{54:45,56:15};
+select * from sc2 where map1 = map{null:null, 54:45,56:15};
+select * from sc2 where map3 = map{505:row(null, 52)};
+select * from sc2 where map2 = map{null:[4,null,41,23]};
+select * from sc2 where st1 = row(2,null, map{202:null}, row(222,220));
+select * from sc2 where st1 = named_struct("s1", 5,"s2",[5,50,51],"s3",null,"s4", row(null,550));
+select * from sc2 where array1 = null;
+select * from sc2 where st1 = null;
+
+
+select * from sc2 where array1 is null;
+select * from sc2 where array1 <=> [11,null,31,41];
+select * from sc2 where array1 <=> [15,25,35,45];
+select * from sc2 where array1 <=> [map{"a":21,"b":22},null];
+select * from sc2 where array3 <=> [map{"a":21,"b":22},null];
+select * from sc2 where array3 <=> [named_struct("a",21,"b",22),null];
+select * from sc2 where array3 <=> [row(21,22),null];
+select * from sc2 where array2 <=> [map{null:550},map{505:501}];
+select * from sc2 where array2 <=> [map{44:440},map{404:401}];
+select * from sc2 where map1 <=> null;
+select * from sc2 where map1 <=> map{14:41,null:11,12:31};
+select * from sc2 where map1 <=> map{44:44,46:14,42:34};
+select * from sc2 where map1 <=> map{34:43,36:13,32:null};
+select * from sc2 where map2 <=> map{505:[5,50,51,23]};
+select cast(row(1, null) as struct<a int, b array<int>>);
+select cast(map{1: null} as map<int, array<int>>);
+select cast(row(1, TRUE) as struct<a int, b map<int, int>>);
+select * from sc2 where map2 <=> map{null:null};
+select * from sc2 where map2 <=> map{null:[4,null,41,23]};
+select * from sc2 where map2 <=> map{101:[1,10,11,23]};
+select * from sc2 where map1 <=> map{46:14,42:34,44:44};
+select * from sc2 where map1 <=> map{54:45,56:15};
+select * from sc2 where map1 <=> map{null:null, 54:45,56:15};
+select * from sc2 where map3 <=> map{505:row(null, 52)};
+select * from sc2 where map2 <=> map{null:[4,null,41,23]};
+select * from sc2 where st1 <=> row(2,null, map{202:null}, row(222,220));
+select * from sc2 where st1 <=> named_struct("s1", 5,"s2",[5,50,51],"s3",null,"s4", row(null,550));
+select * from sc2 where array1 <=> null;
+select * from sc2 where st1 <=> null;


### PR DESCRIPTION
Fixes #issue

* support hash/equals on complex type column
* support binary predicate on complex type

* resolve cast(map{null: null} as map<INT, ARRAY<INT>>)

I add a MustNullExpr to handle this case, FE will resolve NULL_TYPE to BOOLEAN_TYPE, so BE only check from type is boolean and to type is complex type

example:
```
MySQL test> select * from sc2 where st1 = named_struct("s1", 5,"s2",[5,50,51],"s3",null,"s4", row(null,550))
+----+---------------+------------------------+-------------------------------------+-------------------------+-------------+-------------------------+-----------------------------------------------------------+
| v1 | array1        | array2                 | array3                              | map1                    | map2        | map3                    | st1                                                       |
+----+---------------+------------------------+-------------------------------------+-------------------------+-------------+-------------------------+-----------------------------------------------------------+
| 5  | [15,25,35,45] | [{null:550},{505:501}] | [{"a":51,"b":52},{"a":null,"b":53}] | {54:45,56:15,null:null} | {null:null} | {505:{"c":null,"b":52}} | {"s1":5,"s2":[5,50,51],"s3":null,"s4":{"e":null,"f":550}} |
+----+---------------+------------------------+-------------------------------------+-------------------------+-------------+-------------------------+-----------------------------------------------------------+

MySQL test> select * from sc2 where  map1 = map{46:14,42:34,44:44}
+----+-----------------+----------------------+-----------------------------------+---------------------+-----------------------+-----------------------+--------------------------------------------------------+
| v1 | array1          | array2               | array3                            | map1                | map2                  | map3                  | st1                                                    |
+----+-----------------+----------------------+-----------------------------------+---------------------+-----------------------+-----------------------+--------------------------------------------------------+
| 4  | [14,24,null,44] | [{44:440},{404:401}] | [{"a":41,"b":42},{"a":42,"b":43}] | {44:44,46:14,42:34} | {null:[4,null,41,23]} | {404:{"c":41,"b":42}} | {"s1":null,"s2":[4,null,41],"s3":{null:444},"s4":null} |
+----+-----------------+----------------------+-----------------------------------+---------------------+-----------------------+-----------------------+--------------------------------------------------------+
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
