### PR TITLE
[BugFix] Fix export job persist bug where the queryId is null and the startTime/finishTime is Inaccuracy

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -695,7 +695,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
                 break;
         }
         if (!isReplay) {
-            GlobalStateMgr.getCurrentState().getEditLog().logExportUpdateState(id, newState,
+            GlobalStateMgr.getCurrentState().getEditLog().logExportUpdateState(id, newState, stateChangeTime,
                     snapshotPaths, exportTempPath, exportedFiles, failMsg);
         }
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -140,6 +140,8 @@ public class ExportJob implements Writable, GsonPostProcessable {
     @SerializedName("id")
     private long id;
     private UUID queryId;
+    @SerializedName("qd")
+    private String queryIdString;
     @SerializedName("dd")
     private long dbId;
     @SerializedName("td")
@@ -208,6 +210,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
         this();
         this.id = jobId;
         this.queryId = queryId;
+        this.queryIdString = queryId.toString();
     }
 
     public void setJob(ExportStmt stmt) throws UserException {
@@ -665,10 +668,10 @@ public class ExportJob implements Writable, GsonPostProcessable {
     }
 
     public synchronized boolean updateState(JobState newState) {
-        return this.updateState(newState, false);
+        return this.updateState(newState, false, System.currentTimeMillis());
     }
 
-    public synchronized boolean updateState(JobState newState, boolean isReplay) {
+    public synchronized boolean updateState(JobState newState, boolean isReplay, long stateChangeTime) {
         if (isExportDone()) {
             LOG.warn("export job state is finished or cancelled");
             return false;
@@ -680,11 +683,11 @@ public class ExportJob implements Writable, GsonPostProcessable {
                 progress = 0;
                 break;
             case EXPORTING:
-                startTimeMs = System.currentTimeMillis();
+                startTimeMs = stateChangeTime;
                 break;
             case FINISHED:
             case CANCELLED:
-                finishTimeMs = System.currentTimeMillis();
+                finishTimeMs = stateChangeTime;
                 progress = 100;
                 break;
             default:
@@ -1019,6 +1022,9 @@ public class ExportJob implements Writable, GsonPostProcessable {
 
     @Override
     public void gsonPostProcess() throws IOException {
+        if (!Strings.isNullOrEmpty(queryIdString)) {
+            queryId = UUID.fromString(queryIdString);
+        }
         isReplayed = true;
         GlobalStateMgr stateMgr = GlobalStateMgr.getCurrentState();
         Database db = null;
@@ -1070,6 +1076,8 @@ public class ExportJob implements Writable, GsonPostProcessable {
         long jobId;
         @SerializedName("state")
         JobState state;
+        @SerializedName("stateChangeTime")
+        long stateChangeTime;
         @SerializedName("snapshotPaths")
         List<Pair<NetworkAddress, String>> snapshotPaths;
         @SerializedName("exportTempPath")
@@ -1088,10 +1096,12 @@ public class ExportJob implements Writable, GsonPostProcessable {
             this.failMsg = new ExportFailMsg();
         }
 
-        public ExportUpdateInfo(long jobId, JobState state, List<Pair<TNetworkAddress, String>> snapshotPaths,
-                String exportTempPath, Set<String> exportedFiles, ExportFailMsg failMsg) {
+        public ExportUpdateInfo(long jobId, JobState state, long stateChangeTime,
+                                List<Pair<TNetworkAddress, String>> snapshotPaths,
+                                String exportTempPath, Set<String> exportedFiles, ExportFailMsg failMsg) {
             this.jobId = jobId;
             this.state = state;
+            this.stateChangeTime = stateChangeTime;
             this.snapshotPaths = serialize(snapshotPaths);
             this.exportTempPath = exportTempPath;
             this.exportedFiles = exportedFiles;

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -341,11 +341,12 @@ public class ExportMgr {
         }
     }
 
+    @Deprecated
     public void replayUpdateJobState(long jobId, ExportJob.JobState newState) {
         writeLock();
         try {
             ExportJob job = idToJob.get(jobId);
-            job.updateState(newState, true);
+            job.updateState(newState, true, System.currentTimeMillis());
             if (isJobExpired(job, System.currentTimeMillis())) {
                 LOG.info("remove expired job: {}", job);
                 idToJob.remove(jobId);
@@ -359,7 +360,7 @@ public class ExportMgr {
         writeLock();
         try {
             ExportJob job = idToJob.get(info.jobId);
-            job.updateState(info.state, true);
+            job.updateState(info.state, true, info.stateChangeTime);
             if (isJobExpired(job, System.currentTimeMillis())) {
                 LOG.info("remove expired job: {}", job);
                 idToJob.remove(info.jobId);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -1394,15 +1394,15 @@ public class EditLog {
         }
     }
 
-    public void logExportUpdateState(long jobId, ExportJob.JobState newState,
+    public void logExportUpdateState(long jobId, ExportJob.JobState newState, long stateChangeTime,
                                      List<Pair<TNetworkAddress, String>> snapshotPaths, String exportTempPath,
                                      Set<String> exportedFiles, ExportFailMsg failMsg) {
         if (FeConstants.STARROCKS_META_VERSION >= StarRocksFEMetaVersion.VERSION_4) {
-            ExportJob.ExportUpdateInfo updateInfo = new ExportJob.ExportUpdateInfo(jobId, newState,
+            ExportJob.ExportUpdateInfo updateInfo = new ExportJob.ExportUpdateInfo(jobId, newState, stateChangeTime,
                     snapshotPaths, exportTempPath, exportedFiles, failMsg);
             logJsonObject(OperationType.OP_EXPORT_UPDATE_INFO_V2, updateInfo);
         } else {
-            ExportJob.ExportUpdateInfo updateInfo = new ExportJob.ExportUpdateInfo(jobId, newState,
+            ExportJob.ExportUpdateInfo updateInfo = new ExportJob.ExportUpdateInfo(jobId, newState, stateChangeTime,
                     snapshotPaths, exportTempPath, exportedFiles, failMsg);
             logEdit(OperationType.OP_EXPORT_UPDATE_INFO, updateInfo);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -95,6 +95,7 @@ public class OperationType {
     // 30~39 130~139 230~239 ...
     // load job for only hadoop load
     public static final short OP_EXPORT_CREATE = 36;
+    @Deprecated
     public static final short OP_EXPORT_UPDATE_STATE = 37;
     public static final short OP_EXPORT_UPDATE_INFO = 38;
 


### PR DESCRIPTION
1. Persist the queryId using String.
2. Store the stateChangeTime to bdb log, instead of using currentTime.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
