### PR TITLE
[Enhancement] Support get partition nams from hms/glue using partition filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -55,6 +55,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 public interface ConnectorMetadata {
     /**
@@ -83,6 +84,18 @@ public interface ConnectorMetadata {
      * @return a list of partition names
      */
     default List<String> listPartitionNames(String databaseName, String tableName) {
+        return Lists.newArrayList();
+    }
+
+    /**
+     * Return partial partition names of the table using partitionValues to filter.
+     * @param databaseName the name of the database
+     * @param tableName the name of the table
+     * @param partitionValues the partition value to filter
+     * @return a list of partition names
+     */
+    default List<String> listPartitionNamesByValue(String databaseName, String tableName,
+                                                   List<Optional<String>> partitionValues) {
         return Lists.newArrayList();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -59,6 +59,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
@@ -209,6 +210,29 @@ public class PartitionUtil {
                     "table type %s", table.getType());
         }
         return partitionNames;
+    }
+
+    // use partitionValues to filter partitionNames
+    // eg. partitionNames: [p1=1/p2=2, p1=1/p2=3, p1=2/p2=2, p1=2/p2=3]
+    //     partitionValues: [empty, 2]
+    // return [p1=1/p2=2, p1=2/p2=2]
+    public static List<String> getFilteredPartitionKeys(List<String> partitionNames, List<Optional<String>> partitionValues) {
+        List<String> filteredPartitionName = Lists.newArrayList();
+        for (String partitionName : partitionNames) {
+            List<String> values = toPartitionValues(partitionName);
+            int index = 0;
+            for (; index < values.size(); ++index) {
+                if (partitionValues.get(index).isPresent()) {
+                    if (!values.get(index).equals(partitionValues.get(index).get())) {
+                        break;
+                    }
+                }
+            }
+            if (index == values.size()) {
+                filteredPartitionName.add(partitionName);
+            }
+        }
+        return filteredPartitionName;
     }
 
     public static List<Column> getPartitionColumns(Table table) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CacheUpdateProcessor.java
@@ -167,7 +167,8 @@ public class CacheUpdateProcessor {
             String path = metastore.getPartition(dbName, tblName, Lists.newArrayList()).getFullPath();
             existPaths = Lists.newArrayList(path.endsWith("/") ? path : path + "/");
         } else {
-            List<String> partitionNames = metastore.getPartitionKeys(dbName, tblName);
+            List<String> partitionNames = metastore.getPartitionKeysByValue(dbName, tblName,
+                    HivePartitionValue.ALL_PARTITION_VALUES);
             existPaths = metastore.getPartitionsByNames(dbName, tblName, partitionNames)
                     .values().stream()
                     .map(Partition::getFullPath)

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -56,7 +56,6 @@ import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.cache.CacheLoader.asyncReloading;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
-import static com.starrocks.connector.PartitionUtil.toPartitionValues;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class CachingHiveMetastore implements IHiveMetastore {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -191,6 +191,13 @@ public class HiveMetaClient {
         }
     }
 
+    public List<String> getPartitionKeysByValue(String dbName, String tableName, List<String> partitionValues) {
+        try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.listPartitionNamesByValue")) {
+            return callRPC("listPartitionNames", String.format("Failed to get partitionKeys on [%s.%s]", dbName, tableName),
+                    dbName, tableName, partitionValues, (short) -1);
+        }
+    }
+
     public Database getDb(String dbName) {
         try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.getDatabase")) {
             return callRPC("getDatabase", String.format("Failed to get database %s", dbName), dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -84,6 +84,12 @@ public class HiveMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public List<String> listPartitionNamesByValue(String dbName, String tblName,
+                                                  List<Optional<String>> partitionValues) {
+        return hmsOps.getPartitionKeysByValue(dbName, tblName, partitionValues);
+    }
+
+    @Override
     public Database getDb(String dbName) {
         Database database;
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -86,8 +87,15 @@ public class HiveMetastore implements IHiveMetastore {
         }
     }
 
-    public List<String> getPartitionKeys(String dbName, String tableName) {
-        return client.getPartitionKeys(dbName, tableName);
+    @Override
+    public List<String> getPartitionKeysByValue(String dbName, String tableName, List<Optional<String>> partitionValues) {
+        if (partitionValues.isEmpty()) {
+            return client.getPartitionKeys(dbName, tableName);
+        } else {
+            List<String> partitionValuesStr = partitionValues.stream()
+                    .map(v -> v.orElse("")).collect(Collectors.toList());
+            return client.getPartitionKeysByValue(dbName, tableName, partitionValuesStr);
+        }
     }
 
     public Partition getPartition(String dbName, String tblName, List<String> partitionValues) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
@@ -23,6 +23,7 @@ import com.starrocks.connector.PartitionUtil;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -47,7 +48,11 @@ public class HiveMetastoreOperations {
     }
 
     public List<String> getPartitionKeys(String dbName, String tableName) {
-        return metastore.getPartitionKeys(dbName, tableName);
+        return metastore.getPartitionKeysByValue(dbName, tableName, HivePartitionValue.ALL_PARTITION_VALUES);
+    }
+
+    public List<String> getPartitionKeysByValue(String dbName, String tableName, List<Optional<String>> partitionValues) {
+        return metastore.getPartitionKeysByValue(dbName, tableName, partitionValues);
     }
 
     public Database getDb(String dbName) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HivePartitionValue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HivePartitionValue.java
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+public class HivePartitionValue {
+    // use empty list to represent all partition values when get partition names from partitionKeysCache
+    public static final List<Optional<String>> ALL_PARTITION_VALUES = ImmutableList.of();
+
+    private final HiveTableName tableName;
+
+    private final List<Optional<String>> partitionValues;
+
+    public HivePartitionValue(HiveTableName tableName, List<Optional<String>> partitionValues) {
+        this.tableName = tableName;
+        this.partitionValues = partitionValues;
+    }
+
+    public static HivePartitionValue of(HiveTableName tableName, List<Optional<String>> partitionValues) {
+        return new HivePartitionValue(tableName, partitionValues);
+    }
+
+    public HiveTableName getHiveTableName() {
+        return tableName;
+    }
+
+    public List<Optional<String>> getPartitionValues() {
+        return partitionValues;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HivePartitionValue)) {
+            return false;
+        }
+        HivePartitionValue that = (HivePartitionValue) o;
+        return Objects.equal(tableName, that.tableName) &&
+                Objects.equal(partitionValues, that.partitionValues);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(tableName, partitionValues);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Table;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface IHiveMetastore {
 
@@ -33,7 +34,7 @@ public interface IHiveMetastore {
 
     Table getTable(String dbName, String tableName);
 
-    List<String> getPartitionKeys(String dbName, String tableName);
+    List<String> getPartitionKeysByValue(String dbName, String tableName, List<Optional<String>> partitionValues);
 
     default Map<HivePartitionName, Partition> getCachedPartitions(List<HivePartitionName> hivePartitionNames) {
         return Maps.newHashMap();
@@ -72,7 +73,7 @@ public interface IHiveMetastore {
     default void invalidatePartition(HivePartitionName partitionName) {
     }
 
-    default void invalidatePartitionKeys(HiveTableName tableName) {
+    default void invalidatePartitionKeys(HivePartitionValue partitionValue) {
     }
 
     default long getCurrentEventId() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -86,6 +86,12 @@ public class HudiMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public List<String> listPartitionNamesByValue(String databaseName, String tableName,
+                                                  List<Optional<String>> partitionValues) {
+        return hmsOps.getPartitionKeysByValue(databaseName, tableName, partitionValues);
+    }
+
+    @Override
     public Database getDb(String dbName) {
         Database database;
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -238,6 +238,32 @@ public class MetadataMgr {
         return ImmutableList.copyOf(partitionNames.build());
     }
 
+    /**
+     * List partition names by partition values, The partition values are in the same order as the partition columns,
+     * it used for get partial partition names from hms/glue
+     * <p>
+     * For example:
+     * SQL ： select dt,hh,mm from tbl where hh = '12' and mm = '30';
+     * the partition columns are [dt,hh,mm]
+     * the partition values should be [empty,'12','30']
+     *
+     */
+    public List<String> listPartitionNamesByValue(String catalogName, String dbName, String tableName,
+                                                  List<Optional<String>> partitionValues) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+        ImmutableSet.Builder<String> partitionNames = ImmutableSet.builder();
+        if (connectorMetadata.isPresent()) {
+            try {
+                connectorMetadata.get().listPartitionNamesByValue(dbName, tableName, partitionValues).
+                        forEach(partitionNames::add);
+            } catch (Exception e) {
+                LOG.error("Failed to listPartitionNamesByValue on [{}.{}]", catalogName, dbName, e);
+                throw e;
+            }
+        }
+        return ImmutableList.copyOf(partitionNames.build());
+    }
+
     public Statistics getTableStatistics(OptimizerContext session,
                                          String catalogName,
                                          Table table,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -48,6 +48,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.transformation.ListPartitionPruner;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -55,8 +56,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import static com.starrocks.connector.PartitionUtil.createPartitionKey;
 import static com.starrocks.connector.PartitionUtil.toPartitionValues;
@@ -122,6 +125,49 @@ public class OptExternalPartitionPruner {
         return logicalScanOperator;
     }
 
+    // get equivalence predicate which column ref is partition column
+    private static List<Optional<ScalarOperator>> getEffectivePartitionPredicate(LogicalScanOperator operator,
+                                                                                 List<Column> partitionColumns,
+                                                                                 ScalarOperator predicate) {
+        if (partitionColumns.isEmpty()) {
+            return Lists.newArrayList();
+        }
+        PredicateSplit predicateSplit = PredicateSplit.splitPredicate(predicate);
+        List<ScalarOperator> equalPredicates = Utils.extractConjuncts(predicateSplit.getRangePredicates()).
+                stream().filter(rangePredicate -> ((BinaryPredicateOperator) rangePredicate).getBinaryType().isEqual()).
+                collect(Collectors.toList());
+        Map<ColumnRefOperator, ScalarOperator> equalPredicateMap = equalPredicates.stream().
+                collect(Collectors.toMap(rangePredicate -> rangePredicate.getChild(0).cast(),
+                        rangePredicate -> rangePredicate));
+
+        List<Optional<ScalarOperator>> effectivePartitionPredicate = Lists.newArrayList();
+        for (Column partitionColumn : partitionColumns) {
+            ColumnRefOperator partitionColumnRefOperator = operator.getColumnReference(partitionColumn);
+            // only support string type partition column
+            if (partitionColumn.getType().isStringType() && equalPredicateMap.containsKey(partitionColumnRefOperator)) {
+                effectivePartitionPredicate.add(Optional.of(equalPredicateMap.get(partitionColumnRefOperator)));
+            } else {
+                effectivePartitionPredicate.add(Optional.empty());
+            }
+        }
+        return effectivePartitionPredicate;
+    }
+
+    private static List<Optional<String>> getPartitionValue(List<Optional<ScalarOperator>> predicates) {
+        List<Optional<String>> partitionValues = Lists.newArrayList();
+        for (Optional<ScalarOperator> predicate : predicates) {
+            if (predicate.isPresent()) {
+                Preconditions.checkState(predicate.get() instanceof BinaryPredicateOperator);
+                ConstantOperator constantOperator = predicate.get().getChild(1).cast();
+                partitionValues.add(Optional.of(constantOperator.getVarchar()));
+            } else {
+                partitionValues.add(Optional.empty());
+            }
+        }
+        return partitionValues;
+    }
+
+
     private static void initPartitionInfo(LogicalScanOperator operator, OptimizerContext context,
                                           Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap,
                                           Map<ColumnRefOperator, Set<Long>> columnToNullPartitions)
@@ -141,13 +187,26 @@ public class OptExternalPartitionPruner {
                 partitionColumnRefOperators.add(partitionColumnRefOperator);
             }
 
-            List<String> partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
-                    hmsTable.getCatalogName(), hmsTable.getDbName(), hmsTable.getTableName());
+
             context.getDumpInfo().getHMSTable(hmsTable.getResourceName(), hmsTable.getDbName(),
                     hmsTable.getTableName()).setPartitionNames(new ArrayList<>());
 
             Map<PartitionKey, Long> partitionKeys = Maps.newHashMap();
             if (!hmsTable.isUnPartitioned()) {
+                // get partition names
+                List<String> partitionNames;
+                // check if the partition predicate could be used for filter partition names
+                List<Optional<ScalarOperator>> effectivePartitionPredicate =
+                        getEffectivePartitionPredicate(operator, partitionColumns, operator.getPredicate());
+                if (effectivePartitionPredicate.stream().anyMatch(Optional::isPresent)) {
+                    List<Optional<String>> partitionValues = getPartitionValue(effectivePartitionPredicate);
+                    partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNamesByValue(
+                            hmsTable.getCatalogName(), hmsTable.getDbName(), hmsTable.getTableName(), partitionValues);
+                } else {
+                    partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
+                            hmsTable.getCatalogName(), hmsTable.getDbName(), hmsTable.getTableName());
+                }
+
                 long partitionId = 0;
                 for (String partName : partitionNames) {
                     List<String> values = toPartitionValues(partName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -187,7 +187,6 @@ public class OptExternalPartitionPruner {
                 partitionColumnRefOperators.add(partitionColumnRefOperator);
             }
 
-
             context.getDumpInfo().getHMSTable(hmsTable.getResourceName(), hmsTable.getDbName(),
                     hmsTable.getTableName()).setPartitionNames(new ArrayList<>());
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -109,7 +109,8 @@ public class CachingHiveMetastoreTest {
     public void testGetPartitionKeys() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
                 metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
-        Assert.assertEquals(Lists.newArrayList("col1"), cachingHiveMetastore.getPartitionKeys("db1", "tbl1"));
+        Assert.assertEquals(Lists.newArrayList("col1"), cachingHiveMetastore.getPartitionKeysByValue("db1", "tbl1",
+                HivePartitionValue.ALL_PARTITION_VALUES));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -23,12 +23,6 @@ import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
-import com.starrocks.connector.hive.HiveColumnStats;
-import com.starrocks.connector.hive.HiveCommonStats;
-import com.starrocks.connector.hive.HiveMetaClient;
-import com.starrocks.connector.hive.HiveMetastore;
-import com.starrocks.connector.hive.HivePartitionStats;
-import com.starrocks.connector.hive.HiveTableName;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
@@ -101,7 +95,8 @@ public class HiveMetastoreTest {
     public void testGetPartitionKeys() {
         HiveMetaClient client = new MockedHiveMetaClient();
         HiveMetastore metastore = new HiveMetastore(client, "hive_catalog");
-        Assert.assertEquals(Lists.newArrayList("col1"), metastore.getPartitionKeys("db1", "tbl1"));
+        Assert.assertEquals(Lists.newArrayList("col1"), metastore.getPartitionKeysByValue("db1", "tbl1",
+                HivePartitionValue.ALL_PARTITION_VALUES));
     }
 
     @Test


### PR DESCRIPTION
Fixes #issue
When read hive table, SR need to list all partition names which may get many useless partitition names.
Actually, we could use equals predicate on partition columns to list partition names by partition values.
For example :
 SQL ： 
`select dt,hh,mm from tbl where hh = '12' and mm = '30'; `
 the partition columns are [dt,hh,mm], we could use partition values ["","12","30"]  to get partition names from hms/glue,
 it will return the matched partition names


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
