### PR TITLE
[Feature] support allocate session function

### DIFF
--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -205,6 +205,11 @@ public:
     }
 
     template <LogicalType LT>
+    static AggregateFunctionPtr MakeAllocateSessionWindowFunction() {
+        return std::make_shared<AllocateSessionWindowFunction<LT>>();
+    }
+
+    template <LogicalType LT>
     static AggregateFunctionPtr MakeHistogramAggregationFunction() {
         return std::make_shared<HistogramAggregationFunction<LT>>();
     }

--- a/be/src/exprs/agg/factory/aggregate_resolver_window.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_window.cpp
@@ -63,6 +63,11 @@ void AggregateFuncResolver::register_window() {
     add_aggregate_mapping_notnull<TYPE_BIGINT, TYPE_BIGINT>("row_number", true,
                                                             AggregateFactory::MakeRowNumberWindowFunction());
     add_aggregate_mapping_notnull<TYPE_BIGINT, TYPE_BIGINT>("ntile", true, AggregateFactory::MakeNtileWindowFunction());
+
+    add_aggregate_mapping_notnull<TYPE_BIGINT, TYPE_BIGINT>(
+            "allocate_session", true, AggregateFactory::MakeAllocateSessionWindowFunction<TYPE_BIGINT>());
+    add_aggregate_mapping_notnull<TYPE_INT, TYPE_BIGINT>(
+            "allocate_session", true, AggregateFactory::MakeAllocateSessionWindowFunction<TYPE_INT>());
 }
 
 } // namespace starrocks

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -14,6 +14,8 @@
 
 #pragma once
 #include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
 #include "exprs/agg/aggregate.h"
 #include "exprs/agg/aggregate_traits.h"
 
@@ -580,6 +582,87 @@ class LeadLagWindowFunction final : public ValueWindowFunction<LT, LeadLagState<
     }
 
     std::string get_name() const override { return "lead-lag"; }
+};
+
+// result value
+template <LogicalType LT>
+struct AllocateSessionState {
+    using T = AggDataValueType<LT>;
+    int64_t session_id{};
+    T last_not_null_value{};
+    bool is_null{};
+    bool has_value{};
+    int32_t delta{};
+};
+
+template <LogicalType LT, typename T = RunTimeCppType<LT>>
+class AllocateSessionWindowFunction final : public WindowFunction<AllocateSessionState<LT>> {
+public:
+    using InputColumnType = RunTimeColumnType<LT>;
+
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
+        this->data(state).session_id = 1;
+        this->data(state).last_not_null_value = {};
+        this->data(state).is_null = false;
+        this->data(state).has_value = false;
+
+        const Column* delta_column = args[1].get();
+        DCHECK(delta_column->is_constant());
+        DCHECK(!delta_column->only_null());
+        if (!delta_column->only_null() && !delta_column->empty()) {
+            this->data(state).delta = ColumnHelper::get_const_value<LogicalType::TYPE_INT>(args[1]);
+        }
+    }
+
+    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
+                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
+                                              int64_t frame_end) const override {
+        const Column* data_column = ColumnHelper::get_data_column(columns[0]);
+        const InputColumnType* column = down_cast<const InputColumnType*>(data_column);
+
+        DCHECK(frame_start < frame_end);
+        if (frame_start > frame_end) {
+            return;
+        }
+
+        auto delta = this->data(state).delta;
+        size_t current_row = frame_end - 1;
+        if (columns[0]->is_null(current_row)) {
+            this->data(state).is_null = true;
+        } else {
+            auto current_value = AggDataTypeTraits<LT>::get_row_ref(*column, current_row);
+            if (this->data(state).has_value && current_value - this->data(state).last_not_null_value > delta) {
+                this->data(state).session_id++;
+            }
+            this->data(state).is_null = false;
+            this->data(state).last_not_null_value = AggDataTypeTraits<LT>::get_row_ref(*column, frame_start);
+        }
+        this->data(state).has_value = true;
+    }
+
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
+        auto& s = this->data(state);
+        if (dst->is_nullable()) {
+            auto* nullable_dst = down_cast<NullableColumn*>(dst);
+            auto* data_column = down_cast<Int64Column*>(nullable_dst->data_column().get());
+            for (size_t i = start; i < end; ++i) {
+                data_column->get_data()[i] = s.session_id;
+            }
+            if (s.is_null) {
+                for (size_t i = start; i < end; ++i) {
+                    nullable_dst->set_null(i);
+                }
+            }
+        } else {
+            auto* data_column = down_cast<Int64Column*>(dst);
+            for (size_t i = start; i < end; ++i) {
+                data_column->get_data()[i] = s.session_id;
+            }
+        }
+    }
+
+    std::string get_name() const override { return "allocate_session"; }
 };
 
 } // namespace starrocks

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -608,7 +608,6 @@ public:
 
         const Column* delta_column = args[1].get();
         DCHECK(delta_column->is_constant());
-        DCHECK(!delta_column->only_null());
         if (!delta_column->only_null() && !delta_column->empty()) {
             this->data(state).delta = ColumnHelper::get_const_value<LogicalType::TYPE_INT>(args[1]);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/AnalyticExpr.java
@@ -103,6 +103,7 @@ public class AnalyticExpr extends Expr {
     public static String MAX = "MAX";
     public static String SUM = "SUM";
     public static String COUNT = "COUNT";
+    public static String ALLOCATE_SESSION = "ALLOCATE_SESSION";
 
     // The function of HLL_UNION_AGG can't be used with a window by now.
     public static String HLL_UNION_AGG = "HLL_UNION_AGG";

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -399,6 +399,7 @@ public class FunctionSet {
     public static final String CUME_DIST = "cume_dist";
     public static final String NTILE = "ntile";
     public static final String ROW_NUMBER = "row_number";
+    public static final String ALLOCATE_SESSION = "allocate_session";
 
     // Other functions:
     public static final String HLL_HASH = "hll_hash";
@@ -544,6 +545,7 @@ public class FunctionSet {
             .add(FunctionSet.FIRST_VALUE)
             .add(FunctionSet.LAST_VALUE)
             .add(FunctionSet.FIRST_VALUE_REWRITE)
+            .add(FunctionSet.ALLOCATE_SESSION)
             .build();
 
     public static final Set<String> VARIANCE_FUNCTIONS = ImmutableSet.<String>builder()
@@ -954,6 +956,11 @@ public class FunctionSet {
         // Ntile
         addBuiltin(AggregateFunction.createAnalyticBuiltin(NTILE,
                 Lists.newArrayList(Type.BIGINT), Type.BIGINT, Type.BIGINT));
+        // Allocate session
+        addBuiltin(AggregateFunction.createAnalyticBuiltin(ALLOCATE_SESSION,
+                Lists.newArrayList(Type.BIGINT, Type.INT), Type.BIGINT, Type.BIGINT));
+        addBuiltin(AggregateFunction.createAnalyticBuiltin(ALLOCATE_SESSION,
+                Lists.newArrayList(Type.INT, Type.INT), Type.BIGINT, Type.BIGINT));
 
         addBuiltin(AggregateFunction.createBuiltin(DICT_MERGE, Lists.newArrayList(Type.VARCHAR),
                 Type.VARCHAR, Type.VARCHAR, true, false, false));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -165,6 +165,14 @@ public class FunctionAnalyzer {
             }
         }
 
+        if (fnName.getFunction().equals(FunctionSet.ALLOCATE_SESSION)) {
+            if (!functionCallExpr.getChild(1).isConstant()) {
+                throw new SemanticException(
+                        "The delta parameter (parameter 2) of ALLOCATE_SESSION must be a constant: "
+                                + functionCallExpr.toSql(), functionCallExpr.getChild(1).getPos());
+            }
+        }
+
         if (FunctionSet.onlyAnalyticUsedFunctions.contains(fnName.getFunction())) {
             if (!functionCallExpr.isAnalyticFnCall()) {
                 throw new SemanticException(fnName.getFunction() + " only used in analytic function", functionCallExpr.getPos());

--- a/test/sql/test_window_function/R/test_allocate_session_window_function
+++ b/test/sql/test_window_function/R/test_allocate_session_window_function
@@ -1,0 +1,115 @@
+-- name: test_allocate_session_window_function
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1, 4096, 3));
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1, 4096, 2));
+-- result:
+-- !result
+select c0, c1, allocate_session(c0, 4) over (partition by c1 order by c0) from t0 order by c1 limit 10;
+-- result:
+4096	0	1
+1	1	1
+3	3	1
+4093	3	2
+5	5	1
+4090	6	1
+7	7	1
+9	9	1
+4087	9	2
+11	11	1
+-- !result
+select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) from t0 order by c1 limit 10;
+-- result:
+4096	0	1
+1	1	1
+3	3	1
+4093	3	2
+5	5	1
+4090	6	1
+7	7	1
+9	9	1
+4087	9	2
+11	11	1
+-- !result
+select c0, c1, allocate_session(c0, 1) over (partition by c1 order by c0) from t0 order by c1 limit 10;
+-- result:
+4096	0	1
+1	1	1
+3	3	1
+4093	3	2
+5	5	1
+4090	6	1
+7	7	1
+9	9	1
+4087	9	2
+11	11	1
+-- !result
+select c0, c1, allocate_session(null, null) over (partition by c1 order by c0) from t0 order by c1 limit 10;
+-- result:
+4096	0	None
+1	1	None
+3	3	None
+4093	3	None
+5	5	None
+4090	6	None
+7	7	None
+9	9	None
+4087	9	None
+11	11	None
+-- !result
+select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) from t0 order by c1 limit 10;
+-- result:
+4096	0	1
+1	1	1
+3	3	1
+4093	3	2
+5	5	1
+4090	6	1
+7	7	1
+9	9	1
+4087	9	2
+11	11	1
+-- !result
+select c0, c1, allocate_session(c0, c1) over (partition by c1 order by c0) from t0 order by c1 limit 10;
+-- result:
+E: (1064, 'Getting analyzing error at line 1, column 36. Detail message: The delta parameter (parameter 2) of ALLOCATE_SESSION must be a constant: allocate_session(`test_db_dd39d8d3ac9347d3a7a7965373e30039`.`t0`.`c0`, `test_db_dd39d8d3ac9347d3a7a7965373e30039`.`t0`.`c1`).')
+-- !result
+select sum(session), count(session) from (select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) as session from t0) tb;
+-- result:
+4096	3414
+-- !result
+create table empty_tbl like t0;
+-- result:
+-- !result
+select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) from empty_tbl;
+-- result:
+-- !result
+select c0, c1, allocate_session(c0, null) over (partition by c1 order by c0) from empty_tbl;
+-- result:
+-- !result
+insert into t0 SELECT generate_series, null FROM TABLE(generate_series(1, 4096, 2));
+-- result:
+-- !result
+select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) as session from t0 order by c1 limit 10;
+-- result:
+7	None	1
+3	None	1
+9	None	1
+15	None	1
+11	None	1
+17	None	1
+19	None	1
+13	None	1
+5	None	1
+1	None	1
+-- !result
+select sum(session), count(session) from (select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) as session from t0) tb;
+-- result:
+6144	5462
+-- !result

--- a/test/sql/test_window_function/R/test_allocate_session_window_function
+++ b/test/sql/test_window_function/R/test_allocate_session_window_function
@@ -78,7 +78,7 @@ select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) from t
 -- !result
 select c0, c1, allocate_session(c0, c1) over (partition by c1 order by c0) from t0 order by c1 limit 10;
 -- result:
-E: (1064, 'Getting analyzing error at line 1, column 36. Detail message: The delta parameter (parameter 2) of ALLOCATE_SESSION must be a constant: allocate_session(`test_db_dd39d8d3ac9347d3a7a7965373e30039`.`t0`.`c0`, `test_db_dd39d8d3ac9347d3a7a7965373e30039`.`t0`.`c1`).')
+[REGEX] *analyzing error*
 -- !result
 select sum(session), count(session) from (select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) as session from t0) tb;
 -- result:

--- a/test/sql/test_window_function/T/test_allocate_session_window_function
+++ b/test/sql/test_window_function/T/test_allocate_session_window_function
@@ -1,0 +1,26 @@
+-- name: test_allocate_session_window_function
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1, 4096, 3));
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1, 4096, 2));
+
+-- basic test
+select c0, c1, allocate_session(c0, 4) over (partition by c1 order by c0) from t0 order by c1 limit 10;
+select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) from t0 order by c1 limit 10;
+select c0, c1, allocate_session(c0, 1) over (partition by c1 order by c0) from t0 order by c1 limit 10;
+select c0, c1, allocate_session(null, null) over (partition by c1 order by c0) from t0 order by c1 limit 10;
+select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) from t0 order by c1 limit 10;
+select c0, c1, allocate_session(c0, c1) over (partition by c1 order by c0) from t0 order by c1 limit 10;
+select sum(session), count(session) from (select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) as session from t0) tb;
+
+-- test from empty table
+create table empty_tbl like t0;
+select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) from empty_tbl;
+select c0, c1, allocate_session(c0, null) over (partition by c1 order by c0) from empty_tbl;
+
+-- test null input
+insert into t0 SELECT generate_series, null FROM TABLE(generate_series(1, 4096, 2));
+select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) as session from t0 order by c1 limit 10;
+select sum(session), count(session) from (select c0, c1, allocate_session(c0, 2) over (partition by c1 order by c0) as session from t0) tb;


### PR DESCRIPTION
support allocate_session function

allocate_sessoin(sequence, delta).
delta must be const literal

Assign session_id to the input window sequence. if the difference between the two sequences is <delta, then we consider the two sequences to be the same session. otherwise we consider them to be different sessions. if the input is null, then return null

Suppose we have the following table
```
CREATE TABLE `user_event_time` (
  `user_id` int(11) NOT NULL COMMENT "",
  `event` string NOT NULL COMMENT "",
  `timestamp` int(6) NOT NULL COMMENT ""
) ENGINE=OLAP 
DUPLICATE KEY(`user_id`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`user_id`) BUCKETS 1 PROPERTIES ("replication_num" = "1");

insert into user_event_time values
(1, 'prepare', 1),
(1, 'open', 2),
(1, 'get_next', 3),
(1, 'get_next', 4),
(1, 'close', 5),
(1, 'prepare', 15),
(1, 'open', 16),
(1, 'close', 16),
(2, 'prepare', 6),
(2, 'close', 7);
```

```
select user_id, event, timestamp from user_event_time order by user_id, timestamp, event;
+---------+----------+-----------+
| user_id | event    | timestamp |
+---------+----------+-----------+
|       1 | prepare  |         1 |
|       1 | open     |         2 |
|       1 | get_next |         3 |
|       1 | get_next |         4 |
|       1 | close    |         5 |
|       1 | prepare  |        15 |
|       1 | close    |        16 |
|       1 | open     |        16 |
|       2 | prepare  |         6 |
|       2 | close    |         7 |
+---------+----------+-----------+
```

If the difference between consecutive sequences is greater than 5, we will assign a new session id
```
mysql> select user_id, event, timestamp, allocate_session(timestamp, 5) over (partition by user_id order by timestamp) as session from user_event_time order by user_id, timestamp, event;
+---------+----------+-----------+---------+
| user_id | event    | timestamp | session |
+---------+----------+-----------+---------+
|       1 | prepare  |         1 |       1 |
|       1 | open     |         2 |       1 |
|       1 | get_next |         3 |       1 |
|       1 | get_next |         4 |       1 |
|       1 | close    |         5 |       1 |
|       1 | prepare  |        15 |       2 |
|       1 | close    |        16 |       2 |
|       1 | open     |        16 |       2 |
|       2 | prepare  |         6 |       1 |
|       2 | close    |         7 |       1 |
+---------+----------+-----------+---------+
10 rows in set (0.04 sec)
```


## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
