### PR TITLE
[Enhancement] support dynamice config apply thread count

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -112,6 +112,10 @@ CONF_Int32(push_worker_count_high_priority, "3");
 // The count of thread to publish version per transaction
 CONF_mInt32(transaction_publish_version_worker_count, "0");
 
+// The count of thread to apply rowset in primary key table
+// 0 means apply worker count is equal to cpu core count
+CONF_mInt32(transaction_apply_worker_count, "0");
+
 // The count of thread to clear transaction task.
 CONF_Int32(clear_transaction_task_worker_count, "1");
 // The count of thread to delete.

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -124,6 +124,13 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             auto tablet_mgr = _exec_env->lake_tablet_manager();
             if (tablet_mgr != nullptr) tablet_mgr->update_metacache_limit(config::lake_metadata_cache_limit);
         });
+        _config_callback.emplace("transaction_apply_worker_count", [&]() {
+            int max_thread_cnt = CpuInfo::num_cores();
+            if (config::transaction_apply_worker_count > 0) {
+                max_thread_cnt = config::transaction_apply_worker_count;
+            }
+            StorageEngine::instance()->update_manager()->apply_thread_pool()->update_max_threads(max_thread_cnt);
+        });
     });
 
     Status s = config::set_config(name, value);

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -86,7 +86,11 @@ UpdateManager::~UpdateManager() {
 }
 
 Status UpdateManager::init() {
-    auto st = ThreadPoolBuilder("update_apply").build(&_apply_thread_pool);
+    int max_thread_cnt = CpuInfo::num_cores();
+    if (config::transaction_apply_worker_count > 0) {
+        max_thread_cnt = config::transaction_apply_worker_count;
+    }
+    auto st = ThreadPoolBuilder("update_apply").set_max_threads(max_thread_cnt).build(&_apply_thread_pool);
     return st;
 }
 


### PR DESCRIPTION
Add config item `transaction_apply_worker_count` and make apply thread count configable. When `transaction_apply_worker_count` = 0, using cpu number as worker count.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
