### PR TITLE
[BugFix] Fix incorrect error message when create routine load failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -153,6 +153,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     @Override
     public void prepare() throws UserException {
         super.prepare();
+        checkCustomPartition(customKafkaPartitions);
         // should reset converted properties each time the job being prepared.
         // because the file info can be changed anytime.
         convertCustomProperties(true);
@@ -436,7 +437,6 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                 db.getId(), tableId, stmt.getKafkaBrokerList(), stmt.getKafkaTopic());
         kafkaRoutineLoadJob.setOptional(stmt);
         kafkaRoutineLoadJob.checkCustomProperties();
-        kafkaRoutineLoadJob.checkCustomPartition(kafkaRoutineLoadJob.customKafkaPartitions);
 
         return kafkaRoutineLoadJob;
     }


### PR DESCRIPTION
Currently, when a routine load job is created, the FE requests to BE connected to the Kafka broker. However, if the user specified a wrong broker address, BE will wait a very long time to realize the problem (related to librdkafka's implementation), because BE will wait a very long time, FE will call the BE's RPC interface time out, and FE will inform the user that the RPC communication failed, rather than the wrong Kafka broker address. This PR introduces a new policy that stops connecting to the Kafka broker when a routine load job is created, and the behavior of the check partition moves to the time when the task is scheduled. In this way, the PR avoids this issue.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
