### PR TITLE
[BugFix] fix schema change hang when data loading concurrent with schema change (backport #23456)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -155,6 +155,9 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
      *      There are new load jobs after alter task, and at least one of them is succeed on this replica.
      *      So the replica's version should be larger than X. So we don't need to modify the replica version
      *      because its already looks like normal.
+     * Case 3:
+     *      There are new load jobs after alter task, and their version and LFV is smaller or equal to X. 
+     *      And because alter request report success, it means that we can increase replica's version to X.
      */
     public void handleFinishAlterTask() throws MetaNotFoundException {
         Database db = GlobalStateMgr.getCurrentState().getDb(getDbId());
@@ -189,18 +192,9 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
             if (replica.getVersion() > getVersion()) {
                 // Case 2.2, do nothing
             } else {
-                if (replica.getLastFailedVersion() > getVersion()) {
-                    // Case 2.1
-                    replica.updateRowCount(getVersion(), replica.getDataSize(),
-                            replica.getRowCount());
-                    versionChanged = true;
-                } else {
-                    // Case 1
-                    Preconditions.checkState(replica.getLastFailedVersion() == -1, replica.getLastFailedVersion());
-                    replica.updateRowCount(getVersion(), replica.getDataSize(),
-                            replica.getRowCount());
-                    versionChanged = true;
-                }
+                // Case 1, Case 2.1 or Case 3
+                replica.updateRowCount(getVersion(), replica.getDataSize(), replica.getRowCount());
+                versionChanged = true;
             }
 
             if (versionChanged) {


### PR DESCRIPTION


Fixes #23452
1. Assume there is a partition, current visible version is 13378, and all loading task is finished.
2. Trigger schema change, it will create new replica, and at the same time, one loading task is trigger and finished, and it's version is 13379.
3. Before send alter replica request, FE check that all loading task is finished, but loading task on new create replica haven't finish yet and V=1, LFV=13379.
4. Alter replica finish on BE, and BE send finish alter replica request back to FE. When call `handleFinishAlterTask`, `checkState` fail because LFV != -1.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
  - [ ] 2.3
