### PR TITLE
[BugFix] Set _get_pindex_thread_pool as a global thread pool

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -115,6 +115,7 @@ CONF_mInt32(transaction_publish_version_worker_count, "0");
 // The count of thread to apply rowset in primary key table
 // 0 means apply worker count is equal to cpu core count
 CONF_mInt32(transaction_apply_worker_count, "0");
+CONF_mInt32(get_pindex_worker_count, "0");
 
 // The count of thread to clear transaction task.
 CONF_Int32(clear_transaction_task_worker_count, "1");

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -131,6 +131,13 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             }
             StorageEngine::instance()->update_manager()->apply_thread_pool()->update_max_threads(max_thread_cnt);
         });
+        _config_callback.emplace("get_pindex_worker_count", [&]() {
+            int max_thread_cnt = CpuInfo::num_cores();
+            if (config::get_pindex_worker_count > 0) {
+                max_thread_cnt = config::get_pindex_worker_count;
+            }
+            StorageEngine::instance()->update_manager()->get_pindex_thread_pool()->update_max_threads(max_thread_cnt);
+        });
     });
 
     Status s = config::set_config(name, value);

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2961,10 +2961,6 @@ Status PersistentIndex::_get_from_immutable_index_parallel(size_t n, const Slice
         return Status::OK();
     }
 
-    for (auto& [_, keys_info] : keys_info_by_key_size) {
-        std::sort(keys_info.key_infos.begin(), keys_info.key_infos.end());
-    }
-
     std::unique_lock<std::mutex> ul(_lock);
     std::map<size_t, KeysInfo>::iterator iter;
     std::string error_msg;

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2968,11 +2968,6 @@ Status PersistentIndex::_get_from_immutable_index_parallel(size_t n, const Slice
     std::unique_lock<std::mutex> ul(_lock);
     std::map<size_t, KeysInfo>::iterator iter;
     std::string error_msg;
-    //for (iter = keys_info_by_key_size.begin(); iter != keys_info_by_key_size.end(); iter++) {
-    //    if (iter->second.size() == 0) {
-    //        break;
-    //    }
-    //    size_t key_size = iter->first;
     std::vector<std::vector<uint64_t>> get_values(_l1_vec.size(), std::vector<uint64_t>(n, NullIndexValue));
     _found_keys_info.resize(_l1_vec.size());
     for (size_t i = 0; i < _l1_vec.size(); i++) {
@@ -3002,7 +2997,6 @@ Status PersistentIndex::_get_from_immutable_index_parallel(size_t n, const Slice
             values[key_idx] = get_values[i][key_idx];
         }
     }
-    //}
     _found_keys_info.clear();
 
     return Status::OK();

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -567,8 +567,9 @@ public:
     // |values|: value array for return values
     Status get(size_t n, const Slice* keys, IndexValue* values);
 
-    Status get_from_one_immutable_index(size_t n, const Slice* keys, IndexValue* values, KeysInfo* keys_info,
-                                        KeysInfo* found_keys_info, size_t idx, size_t key_size);
+    Status get_from_one_immutable_index(size_t n, const Slice* keys, IndexValue* values,
+                                        std::map<size_t, KeysInfo>* _keys_info_by_key_size, KeysInfo* found_keys_info,
+                                        size_t idx);
 
     // batch upsert
     // |n|: size of key/value array

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -688,7 +688,6 @@ private:
     bool _need_bloom_filter = false;
 
     mutable std::mutex _lock;
-    std::unique_ptr<ThreadPool> _get_thread_pool;
     std::condition_variable _get_task_finished;
     size_t _running_get_task = 0;
     std::atomic<bool> _error{false};

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1183,33 +1183,37 @@ Status PrimaryIndex::_insert_into_persistent_index(uint32_t rssid, const vector<
     return Status::OK();
 }
 
-void PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
-                                                 uint32_t idx_begin, uint32_t idx_end, DeletesMap* deletes,
-                                                 IOStat* stat) {
+Status PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
+                                                   uint32_t idx_begin, uint32_t idx_end, DeletesMap* deletes,
+                                                   IOStat* stat) {
+    Status st;
     uint32_t n = idx_end - idx_begin;
     std::vector<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(n);
     std::vector<uint64_t> old_values(n, NullIndexValue);
     const Slice* vkeys = _build_persistent_keys(pks, idx_begin, idx_end, &keys);
-    _build_persistent_values(rssid, rowid_start, idx_begin, idx_end, &values);
-    _persistent_index->upsert(n, vkeys, reinterpret_cast<IndexValue*>(values.data()),
-                              reinterpret_cast<IndexValue*>(old_values.data()), stat);
+    RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, idx_begin, idx_end, &values));
+    RETURN_IF_ERROR(_persistent_index->upsert(n, vkeys, reinterpret_cast<IndexValue*>(values.data()),
+                                              reinterpret_cast<IndexValue*>(old_values.data()), stat));
     for (unsigned long old : old_values) {
         if ((old != NullIndexValue) && (old >> 32) == rssid) {
             LOG(ERROR) << "found duplicate in upsert data rssid:" << rssid;
+            st = Status::InternalError("found duplicate in upsert data");
         }
         if (old != NullIndexValue) {
             (*deletes)[(uint32_t)(old >> 32)].push_back((uint32_t)(old & ROWID_MASK));
         }
     }
+    return st;
 }
 
-void PrimaryIndex::_erase_persistent_index(const Column& key_col, DeletesMap* deletes) {
+Status PrimaryIndex::_erase_persistent_index(const Column& key_col, DeletesMap* deletes) {
+    Status st;
     std::vector<Slice> keys;
     std::vector<uint64_t> old_values(key_col.size(), NullIndexValue);
     const Slice* vkeys = _build_persistent_keys(key_col, 0, key_col.size(), &keys);
-    Status st = _persistent_index->erase(key_col.size(), vkeys, reinterpret_cast<IndexValue*>(old_values.data()));
+    st = _persistent_index->erase(key_col.size(), vkeys, reinterpret_cast<IndexValue*>(old_values.data()));
     if (!st.ok()) {
         LOG(WARNING) << "erase persistent index failed";
     }
@@ -1218,42 +1222,46 @@ void PrimaryIndex::_erase_persistent_index(const Column& key_col, DeletesMap* de
             (*deletes)[(uint32_t)(old >> 32)].push_back((uint32_t)(old & ROWID_MASK));
         }
     }
+    return st;
 }
 
-void PrimaryIndex::_get_from_persistent_index(const Column& key_col, std::vector<uint64_t>* rowids) const {
+Status PrimaryIndex::_get_from_persistent_index(const Column& key_col, std::vector<uint64_t>* rowids) const {
     std::vector<Slice> keys;
     const Slice* vkeys = _build_persistent_keys(key_col, 0, key_col.size(), &keys);
     Status st = _persistent_index->get(key_col.size(), vkeys, reinterpret_cast<IndexValue*>(rowids->data()));
     if (!st.ok()) {
         LOG(WARNING) << "failed get value from persistent index";
     }
+    return st;
 }
 
-[[maybe_unused]] void PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
-                                                              const vector<uint32_t>& src_rssid,
-                                                              vector<uint32_t>* deletes) {
+[[maybe_unused]] Status PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
+                                                                const vector<uint32_t>& src_rssid,
+                                                                vector<uint32_t>* deletes) {
     std::vector<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
-    _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
+    RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
     Status st = _persistent_index->try_replace(pks.size(), _build_persistent_keys(pks, 0, pks.size(), &keys),
                                                reinterpret_cast<IndexValue*>(values.data()), src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
     }
+    return st;
 }
 
-void PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
-                                             const uint32_t max_src_rssid, vector<uint32_t>* deletes) {
+Status PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
+                                               const uint32_t max_src_rssid, vector<uint32_t>* deletes) {
     std::vector<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
-    _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
+    RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
     Status st = _persistent_index->try_replace(pks.size(), _build_persistent_keys(pks, 0, pks.size(), &keys),
                                                reinterpret_cast<IndexValue*>(values.data()), max_src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
     }
+    return st;
 }
 
 Status PrimaryIndex::insert(uint32_t rssid, const vector<uint32_t>& rowids, const Column& pks) {
@@ -1272,61 +1280,74 @@ Status PrimaryIndex::insert(uint32_t rssid, uint32_t rowid_start, const Column& 
     return insert(rssid, rids, pks);
 }
 
-void PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, DeletesMap* deletes, IOStat* stat) {
+Status PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, DeletesMap* deletes,
+                            IOStat* stat) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    Status st;
     if (_persistent_index != nullptr) {
-        _upsert_into_persistent_index(rssid, rowid_start, pks, 0, pks.size(), deletes, stat);
+        st = _upsert_into_persistent_index(rssid, rowid_start, pks, 0, pks.size(), deletes, stat);
     } else {
         _pkey_to_rssid_rowid->upsert(rssid, rowid_start, pks, 0, pks.size(), deletes);
     }
+    return st;
 }
 
-void PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin, uint32_t idx_end,
-                          DeletesMap* deletes) {
+Status PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin,
+                            uint32_t idx_end, DeletesMap* deletes) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    Status st;
     if (_persistent_index != nullptr) {
-        _upsert_into_persistent_index(rssid, rowid_start, pks, idx_begin, idx_end, deletes, nullptr);
+        st = _upsert_into_persistent_index(rssid, rowid_start, pks, idx_begin, idx_end, deletes, nullptr);
     } else {
         _pkey_to_rssid_rowid->upsert(rssid, rowid_start, pks, idx_begin, idx_end, deletes);
     }
+    return st;
 }
 
-[[maybe_unused]] void PrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks,
-                                                const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes) {
+[[maybe_unused]] Status PrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks,
+                                                  const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    Status st;
     if (_persistent_index != nullptr) {
-        _replace_persistent_index(rssid, rowid_start, pks, src_rssid, deletes);
+        st = _replace_persistent_index(rssid, rowid_start, pks, src_rssid, deletes);
     } else {
         _pkey_to_rssid_rowid->try_replace(rssid, rowid_start, pks, src_rssid, 0, pks.size(), deletes);
     }
+    return st;
 }
 
-void PrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, const uint32_t max_src_rssid,
-                               vector<uint32_t>* deletes) {
+Status PrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, const uint32_t max_src_rssid,
+                                 vector<uint32_t>* deletes) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    Status st;
     if (_persistent_index != nullptr) {
-        _replace_persistent_index(rssid, rowid_start, pks, max_src_rssid, deletes);
+        st = _replace_persistent_index(rssid, rowid_start, pks, max_src_rssid, deletes);
     } else {
         _pkey_to_rssid_rowid->try_replace(rssid, rowid_start, pks, max_src_rssid, 0, pks.size(), deletes);
     }
+    return st;
 }
 
-void PrimaryIndex::erase(const Column& key_col, DeletesMap* deletes) {
+Status PrimaryIndex::erase(const Column& key_col, DeletesMap* deletes) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    Status st;
     if (_persistent_index != nullptr) {
-        _erase_persistent_index(key_col, deletes);
+        st = _erase_persistent_index(key_col, deletes);
     } else {
         _pkey_to_rssid_rowid->erase(key_col, 0, key_col.size(), deletes);
     }
+    return st;
 }
 
-void PrimaryIndex::get(const Column& key_col, std::vector<uint64_t>* rowids) const {
+Status PrimaryIndex::get(const Column& key_col, std::vector<uint64_t>* rowids) const {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    Status st;
     if (_persistent_index != nullptr) {
-        _get_from_persistent_index(key_col, rowids);
+        st = _get_from_persistent_index(key_col, rowids);
     } else {
         _pkey_to_rssid_rowid->get(key_col, 0, key_col.size(), rowids);
     }
+    return st;
 }
 
 std::size_t PrimaryIndex::memory_usage() const {

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -65,10 +65,10 @@ public:
     // old position to |deletes|.
     //
     // [not thread-safe]
-    void upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, DeletesMap* deletes, IOStat* stat = nullptr);
+    Status upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, DeletesMap* deletes, IOStat* stat = nullptr);
 
-    void upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin, uint32_t idx_end,
-                DeletesMap* deletes);
+    Status upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin, uint32_t idx_end,
+                  DeletesMap* deletes);
 
     // TODO(qzc): maybe unused, remove it or refactor it with the methods in use by template after a period of time
     // used for compaction, try replace input rowsets' rowid with output segment's rowid, if
@@ -81,8 +81,8 @@ public:
     // |failed| rowids of output segment's rows that failed to replace
     //
     // [not thread-safe]
-    [[maybe_unused]] void try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks,
-                                      const vector<uint32_t>& src_rssid, vector<uint32_t>* failed);
+    [[maybe_unused]] Status try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks,
+                                        const vector<uint32_t>& src_rssid, vector<uint32_t>* failed);
 
     // used for compaction, try replace input rowsets' rowid with output segment's rowid, if
     // input rowsets' rowid greater than the max src rssid, this indicates that the row of output rowset is
@@ -94,16 +94,16 @@ public:
     // |failed| rowids of output segment's rows that failed to replace
     //
     // [not thread-safe]
-    void try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, const uint32_t max_src_rssid,
-                     vector<uint32_t>* failed);
+    Status try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, const uint32_t max_src_rssid,
+                       vector<uint32_t>* failed);
 
     // |key_col| contains the *encoded* primary keys to be deleted from this index.
     // The position of deleted keys will be appended into |new_deletes|.
     //
     // [not thread-safe]
-    void erase(const Column& pks, DeletesMap* deletes);
+    Status erase(const Column& pks, DeletesMap* deletes);
 
-    void get(const Column& pks, std::vector<uint64_t>* rowids) const;
+    Status get(const Column& pks, std::vector<uint64_t>* rowids) const;
 
     Status prepare(const EditVersion& version, size_t n);
 
@@ -148,18 +148,18 @@ private:
 
     Status _insert_into_persistent_index(uint32_t rssid, const vector<uint32_t>& rowids, const Column& pks);
 
-    void _upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin,
-                                       uint32_t idx_end, DeletesMap* deletes, IOStat* stat);
+    Status _upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin,
+                                         uint32_t idx_end, DeletesMap* deletes, IOStat* stat);
 
-    void _erase_persistent_index(const Column& key_col, DeletesMap* deletes);
+    Status _erase_persistent_index(const Column& key_col, DeletesMap* deletes);
 
-    void _get_from_persistent_index(const Column& key_col, std::vector<uint64_t>* rowids) const;
+    Status _get_from_persistent_index(const Column& key_col, std::vector<uint64_t>* rowids) const;
 
     // TODO(qzc): maybe unused, remove it or refactor it with the methods in use by template after a period of time
-    [[maybe_unused]] void _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
-                                                    const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes);
-    void _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
-                                   const uint32_t max_src_rssid, vector<uint32_t>* deletes);
+    [[maybe_unused]] Status _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
+                                                      const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes);
+    Status _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const Column& pks,
+                                     const uint32_t max_src_rssid, vector<uint32_t>* deletes);
 
 protected:
     std::mutex _lock;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1052,7 +1052,16 @@ void TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version_i
                     _set_error(msg);
                     return;
                 }
-                _do_update(rowset_id, i, conditional_column, upserts, index, tablet_id, &new_deletes);
+                st = _do_update(rowset_id, i, conditional_column, upserts, index, tablet_id, &new_deletes);
+                if (!st.ok()) {
+                    manager->update_state_cache().remove(state_entry);
+                    std::string msg =
+                            strings::Substitute("_apply_rowset_commit error: apply rowset update state failed: $0 $1",
+                                                st.to_string(), debug_string());
+                    LOG(ERROR) << msg;
+                    _set_error(msg);
+                    return;
+                }
                 manager->index_cache().update_object_size(index_entry, index.memory_usage());
                 if (delete_pks != nullptr) {
                     index.erase(*delete_pks, &new_deletes);
@@ -1102,7 +1111,17 @@ void TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version_i
                         _set_error(msg);
                         return;
                     }
-                    _do_update(rowset_id, loaded_upsert, conditional_column, upserts, index, tablet_id, &new_deletes);
+                    st = _do_update(rowset_id, loaded_upsert, conditional_column, upserts, index, tablet_id,
+                                    &new_deletes);
+                    if (!st.ok()) {
+                        manager->update_state_cache().remove(state_entry);
+                        std::string msg = strings::Substitute(
+                                "_apply_rowset_commit error: apply rowset update state failed: $0 $1", st.to_string(),
+                                debug_string());
+                        LOG(ERROR) << msg;
+                        _set_error(msg);
+                        return;
+                    }
                     manager->index_cache().update_object_size(index_entry, index.memory_usage());
                     if (delete_pks != nullptr) {
                         index.erase(*delete_pks, &new_deletes);
@@ -1366,7 +1385,7 @@ Status TabletUpdates::_do_update(std::uint32_t rowset_id, std::int32_t upsert_id
         read_column_ids.push_back(condition_column);
 
         std::vector<uint64_t> old_rowids(upserts[upsert_idx]->size());
-        index.get(*upserts[upsert_idx], &old_rowids);
+        RETURN_IF_ERROR(index.get(*upserts[upsert_idx], &old_rowids));
         bool non_old_value = std::all_of(old_rowids.begin(), old_rowids.end(), [](int id) { return -1 == id; });
         if (!non_old_value) {
             std::map<uint32_t, std::vector<uint32_t>> old_rowids_by_rssid;
@@ -1377,7 +1396,8 @@ Status TabletUpdates::_do_update(std::uint32_t rowset_id, std::int32_t upsert_id
             auto old_unordered_column =
                     ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
             old_columns[0] = old_unordered_column->clone_empty();
-            get_column_values(read_column_ids, num_default > 0, old_rowids_by_rssid, &old_columns, nullptr);
+            RETURN_IF_ERROR(
+                    get_column_values(read_column_ids, num_default > 0, old_rowids_by_rssid, &old_columns, nullptr));
             auto old_column = ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
             old_column->append_selective(*old_columns[0], idxes.data(), 0, idxes.size());
 
@@ -1390,7 +1410,7 @@ Status TabletUpdates::_do_update(std::uint32_t rowset_id, std::int32_t upsert_id
             std::vector<std::unique_ptr<Column>> new_columns(1);
             auto new_column = ChunkHelper::column_from_field_type(tablet_column.type(), tablet_column.is_nullable());
             new_columns[0] = new_column->clone_empty();
-            get_column_values(read_column_ids, false, new_rowids_by_rssid, &new_columns, nullptr);
+            RETURN_IF_ERROR(get_column_values(read_column_ids, false, new_rowids_by_rssid, &new_columns, nullptr));
 
             int idx_begin = 0;
             int upsert_idx_step = 0;
@@ -1401,8 +1421,8 @@ Status TabletUpdates::_do_update(std::uint32_t rowset_id, std::int32_t upsert_id
                 } else {
                     int r = old_column->compare_at(j, j, *new_columns[0].get(), -1);
                     if (r > 0) {
-                        index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], idx_begin,
-                                     idx_begin + upsert_idx_step, new_deletes);
+                        RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], idx_begin,
+                                                     idx_begin + upsert_idx_step, new_deletes));
 
                         idx_begin = j + 1;
                         upsert_idx_step = 0;
@@ -1416,17 +1436,17 @@ Status TabletUpdates::_do_update(std::uint32_t rowset_id, std::int32_t upsert_id
             }
 
             if (idx_begin < old_column->size()) {
-                index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], idx_begin, idx_begin + upsert_idx_step,
-                             new_deletes);
+                RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], idx_begin,
+                                             idx_begin + upsert_idx_step, new_deletes));
             }
         } else {
-            index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], new_deletes);
+            RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], new_deletes));
         }
     } else {
         std::unique_ptr<IOStat> iostat = std::make_unique<IOStat>();
         MonotonicStopWatch watch;
         watch.start();
-        index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], new_deletes, iostat.get());
+        RETURN_IF_ERROR(index.upsert(rowset_id + upsert_idx, 0, *upserts[upsert_idx], new_deletes, iostat.get()));
         LOG(INFO) << "primary index upsert tid: " << tablet_id << ", cost: " << watch.elapsed_time() << ", "
                   << iostat->print_str();
     }

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -67,6 +67,9 @@ UpdateManager::~UpdateManager() {
         // should be shutdown.
         _apply_thread_pool->shutdown();
     }
+    if (_get_pindex_thread_pool) {
+        _get_pindex_thread_pool->shutdown();
+    }
     clear_cache();
     if (_compaction_state_mem_tracker) {
         _compaction_state_mem_tracker.reset();
@@ -90,8 +93,14 @@ Status UpdateManager::init() {
     if (config::transaction_apply_worker_count > 0) {
         max_thread_cnt = config::transaction_apply_worker_count;
     }
-    auto st = ThreadPoolBuilder("update_apply").set_max_threads(max_thread_cnt).build(&_apply_thread_pool);
-    return st;
+    RETURN_IF_ERROR(ThreadPoolBuilder("update_apply").set_max_threads(max_thread_cnt).build(&_apply_thread_pool));
+
+    int max_get_thread_cnt =
+            config::get_pindex_worker_count > max_thread_cnt ? config::get_pindex_worker_count : max_thread_cnt * 2;
+    RETURN_IF_ERROR(
+            ThreadPoolBuilder("get_pindex").set_max_threads(max_get_thread_cnt).build(&_get_pindex_thread_pool));
+
+    return Status::OK();
 }
 
 Status UpdateManager::get_del_vec_in_meta(KVStore* meta, const TabletSegmentId& tsid, int64_t version,

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -86,6 +86,7 @@ public:
     void on_rowset_cancel(Tablet* tablet, Rowset* rowset);
 
     ThreadPool* apply_thread_pool() { return _apply_thread_pool.get(); }
+    ThreadPool* get_pindex_thread_pool() { return _get_pindex_thread_pool.get(); }
 
     DynamicCache<uint64_t, PrimaryIndex>& index_cache() { return _index_cache; }
 
@@ -156,6 +157,7 @@ private:
     std::unique_ptr<MemTracker> _delta_column_group_cache_mem_tracker;
 
     std::unique_ptr<ThreadPool> _apply_thread_pool;
+    std::unique_ptr<ThreadPool> _get_pindex_thread_pool;
 
     UpdateManager(const UpdateManager&) = delete;
     const UpdateManager& operator=(const UpdateManager&) = delete;

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -5315,7 +5315,6 @@ TEST_F(ArrayFunctionsTest, array_match_nullable) {
     src_column->append_datum(DatumArray{(int8_t)0, Datum()});
     src_column->append_datum(DatumArray{});
 
-
     auto dest_column = ArrayMatch<true>::process(nullptr, {src_column});
     ASSERT_TRUE(dest_column->is_nullable());
     ASSERT_EQ(dest_column->size(), 7);
@@ -5326,7 +5325,6 @@ TEST_F(ArrayFunctionsTest, array_match_nullable) {
     ASSERT_TRUE(dest_column->get(4).get_int8());
     ASSERT_TRUE(dest_column->get(5).is_null());
     ASSERT_FALSE(dest_column->get(6).get_int8());
-
 
     dest_column = ArrayMatch<false>::process(nullptr, {src_column});
     ASSERT_TRUE(dest_column->is_nullable());
@@ -5360,7 +5358,6 @@ TEST_F(ArrayFunctionsTest, array_match_not_null) {
     ASSERT_TRUE(dest_column->get(4).get_int8());
     ASSERT_TRUE(dest_column->get(5).is_null());
     ASSERT_FALSE(dest_column->get(6).get_int8());
-
 
     dest_column = ArrayMatch<false>::process(nullptr, {src_column});
     ASSERT_TRUE(dest_column->is_nullable());

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -344,7 +344,7 @@ TEST_F(LakePrimaryKeyPublishTest, test_write_fail_retry) {
 TEST_F(LakePrimaryKeyPublishTest, test_publish_multi_times) {
     auto saved_max_versions = config::lake_gc_metadata_max_versions;
     // Prevent the old tablet metadata files been removed
-     config::lake_gc_metadata_max_versions = 10;
+    config::lake_gc_metadata_max_versions = 10;
 
     auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true);
     auto txns = std::vector<int64_t>();


### PR DESCRIPTION
There are two major changes:
1. Set a global thread pool `_get_pindex_thread_pool` to support persisent index get. The main purpose is support parallel get among mutiple L1 files to speed up apply.
2. Add return status check to handle the error code. We don't check the return status of primary index's operation before. Even if some errors happened, we still treat it as normal status, this maybe cause serious problem.


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
