### PR TITLE
[Enhancement] Consider number of segment files in pk compaction score calculation

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -306,6 +306,7 @@ CONF_mInt32(update_compaction_num_threads_per_disk, "1");
 CONF_Int32(update_compaction_per_tablet_min_interval_seconds, "120"); // 2min
 CONF_mInt64(max_update_compaction_num_singleton_deltas, "1000");
 CONF_mInt64(update_compaction_size_threshold, "268435456");
+CONF_mInt64(update_compaction_result_bytes, "1073741824");
 
 CONF_mInt32(repair_compaction_interval_seconds, "600"); // 10 min
 CONF_Int32(manual_compaction_threads, "4");


### PR DESCRIPTION
Fixes #24979, #25222

Currently, compaction score only consider rowset's total size and ratio of deletion, if a rowset's size is greater than compaction threshold and it doesn't contain deletes, it won't be compacted. But this rowset may contain a large number of small segment files(may due to early memtable flush when memory pressure is high). These small segment files needs to be compacted, or query performance will be impacted.
This PR changes compaction score calculation to consider the number of segment files. It also separate out a config `update_compaction_result_bytes` from `update_compaction_size_threshold`. 

`update_compaction_size_threshold` is used to pick compaction input rowsets
`update_compaction_result_bytes` is used to indicate the preferred compaction output size and rows, so to prevent very large compaction tasks.

Also `compaction_result_rows_threashold` is removed, to fix #25222. If the row of table is very small, a compaction will generate rowset with small segments(each contains rows whose number > `compaction_result_rows_threashold`), those compaction result is still valid for compaction(because they are too small), so this PR removes it.

Note: this PR may cause unintended compaction behavior change, so it needs further evaluation

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
  - [ ] 2.3
