### PR TITLE
[BugFix] Remove the invalid d_check for LocalTabletsChannel::_open_all_writers

### DIFF
--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -515,7 +515,6 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
         }
     }
     _s_tablet_writer_count += _delta_writers.size();
-    DCHECK_EQ(_delta_writers.size(), params.tablets_size());
     // In order to get sorted index for each tablet
     std::sort(tablet_ids.begin(), tablet_ids.end());
     for (size_t i = 0; i < tablet_ids.size(); ++i) {

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -5315,7 +5315,6 @@ TEST_F(ArrayFunctionsTest, array_match_nullable) {
     src_column->append_datum(DatumArray{(int8_t)0, Datum()});
     src_column->append_datum(DatumArray{});
 
-
     auto dest_column = ArrayMatch<true>::process(nullptr, {src_column});
     ASSERT_TRUE(dest_column->is_nullable());
     ASSERT_EQ(dest_column->size(), 7);
@@ -5326,7 +5325,6 @@ TEST_F(ArrayFunctionsTest, array_match_nullable) {
     ASSERT_TRUE(dest_column->get(4).get_int8());
     ASSERT_TRUE(dest_column->get(5).is_null());
     ASSERT_FALSE(dest_column->get(6).get_int8());
-
 
     dest_column = ArrayMatch<false>::process(nullptr, {src_column});
     ASSERT_TRUE(dest_column->is_nullable());
@@ -5360,7 +5358,6 @@ TEST_F(ArrayFunctionsTest, array_match_not_null) {
     ASSERT_TRUE(dest_column->get(4).get_int8());
     ASSERT_TRUE(dest_column->get(5).is_null());
     ASSERT_FALSE(dest_column->get(6).get_int8());
-
 
     dest_column = ArrayMatch<false>::process(nullptr, {src_column});
     ASSERT_TRUE(dest_column->is_nullable());

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -344,7 +344,7 @@ TEST_F(LakePrimaryKeyPublishTest, test_write_fail_retry) {
 TEST_F(LakePrimaryKeyPublishTest, test_publish_multi_times) {
     auto saved_max_versions = config::lake_gc_metadata_max_versions;
     // Prevent the old tablet metadata files been removed
-     config::lake_gc_metadata_max_versions = 10;
+    config::lake_gc_metadata_max_versions = 10;
 
     auto [chunk0, indexes] = gen_data_and_index(kChunkSize, 0, true);
     auto txns = std::vector<int64_t>();


### PR DESCRIPTION
Fixes https://github.com/StarRocks/StarRocksTest/issues/2656

If `enable_replicated_storage_as_default_engine` is true, and `AsyncDeltaWriter` open failed, `_delta_writers.size()` is not equal to `params.tablets_size()`.

So remove the dcheck;

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
