### PR TITLE
[Enhancement] count distinct mv can rewrite when missing group by has equal predicate

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -2685,4 +2685,26 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             "WHERE dt BETWEEN '2023-06-01' AND '2023-06-02' GROUP BY t");
         starRocksAssert.dropTable("t_time_slice");
     }
+
+    @Test
+    public void testCountDistinctRollupAgg() throws Exception {
+        {
+            String mv = "select empid, deptno, locationid, count(distinct name) as s\n"
+                + "from emps group by empid, deptno, locationid";
+            String query = "select empid, count(distinct name) as s\n"
+                + "from emps where deptno=1 and locationid=1 "
+                + "group by empid ";
+            testRewriteOK(mv, query);
+        }
+
+        {
+            String mv = "select empid, deptno, locationid, count(distinct name) as s\n"
+                + "from emps group by empid, deptno, locationid";
+            String query = "select empid, count(distinct name) as s\n"
+                + "from emps where deptno=1 \n"
+                + "group by empid ";
+            testRewriteFail(mv, query);
+        }
+
+    }
 }

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q21.sql
@@ -41,9 +41,6 @@ order by
 [result]
 TOP-N (order by [[71: count DESC NULLS LAST, 2: s_name ASC NULLS FIRST]])
     TOP-N (order by [[71: count DESC NULLS LAST, 2: s_name ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{185: count=sum(185: count)}] group by [[150: s_name]] having [null]
-            EXCHANGE SHUFFLE[150]
-                AGGREGATE ([LOCAL] aggregate [{185: count=sum(153: cnt_star)}] group by [[150: s_name]] having [null]
-                    SCAN (mv[query21_mv] columns[150: s_name, 151: o_orderstatus, 152: n_name, 153: cnt_star] predicate[151: o_orderstatus = F AND 152: n_name = CANADA])
+        SCAN (mv[query21_mv] columns[150: s_name, 151: o_orderstatus, 152: n_name, 153: cnt_star] predicate[151: o_orderstatus = F AND 152: n_name = CANADA])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q21.sql
@@ -41,9 +41,6 @@ order by
 [result]
 TOP-N (order by [[71: count DESC NULLS LAST, 2: s_name ASC NULLS FIRST]])
     TOP-N (order by [[71: count DESC NULLS LAST, 2: s_name ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{189: count=sum(189: count)}] group by [[157: s_name]] having [null]
-            EXCHANGE SHUFFLE[157]
-                AGGREGATE ([LOCAL] aggregate [{189: count=sum(160: cnt_star)}] group by [[157: s_name]] having [null]
-                    SCAN (mv[query21_mv] columns[157: s_name, 158: o_orderstatus, 159: n_name, 160: cnt_star] predicate[158: o_orderstatus = F AND 159: n_name = CANADA])
+        SCAN (mv[query21_mv] columns[157: s_name, 158: o_orderstatus, 159: n_name, 160: cnt_star] predicate[158: o_orderstatus = F AND 159: n_name = CANADA])
 [end]
 


### PR DESCRIPTION
mv: select a, b, c, count(distinct d)  from emps group by a, b, c
query: select a, count(distinct name)  from emps where b=0 and c=0 group by a

this query could rewrite when b/c all have equal predicate, because doesn't have rollup.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
