### PR TITLE
[BugFix][Cherry-Pick][Branch-2.5] Set _get_pindex_thread_pool as a global thread pool (#24980)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -99,6 +99,8 @@ CONF_Int32(push_worker_count_high_priority, "3");
 // The count of thread to publish version per transaction
 CONF_mInt32(transaction_publish_version_worker_count, "0");
 
+CONF_mInt32(get_pindex_worker_count, "0");
+
 // The count of thread to clear transaction task.
 CONF_Int32(clear_transaction_task_worker_count, "1");
 // The count of thread to delete.

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -102,6 +102,13 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             _exec_env->agent_server()->update_max_thread_by_type(TTaskType::CLONE,
                                                                  config::parallel_clone_task_per_path);
         });
+        _config_callback.emplace("get_pindex_worker_count", [&]() {
+            int max_thread_cnt = CpuInfo::num_cores();
+            if (config::get_pindex_worker_count > 0) {
+                max_thread_cnt = config::get_pindex_worker_count;
+            }
+            StorageEngine::instance()->update_manager()->get_pindex_thread_pool()->update_max_threads(max_thread_cnt);
+        });
     });
 
     Status s = config::set_config(name, value);

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -12,9 +12,11 @@
 #include "storage/chunk_iterator.h"
 #include "storage/primary_key_encoder.h"
 #include "storage/rowset/rowset.h"
+#include "storage/storage_engine.h"
 #include "storage/tablet.h"
 #include "storage/tablet_meta_manager.h"
 #include "storage/tablet_updates.h"
+#include "storage/update_manager.h"
 #include "util/bit_util.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
@@ -2340,9 +2342,6 @@ PersistentIndex::~PersistentIndex() {
             l1->clear();
         }
     }
-    if (_get_thread_pool != nullptr) {
-        _get_thread_pool->shutdown();
-    }
 }
 
 // Create a new empty PersistentIndex
@@ -2766,15 +2765,6 @@ Status PersistentIndex::prepare(const EditVersion& version, size_t n) {
 
     if (config::enable_parallel_get_and_bf) {
         _need_bloom_filter = true;
-        if (n > _size / 4 && n > kMinEnableBFKVNum) {
-            RETURN_IF_ERROR(ThreadPoolBuilder("get_kv_thread")
-                                    .set_min_threads(1)
-                                    .set_max_threads(config::l0_l1_merge_ratio)
-                                    .set_max_queue_size(4096)
-                                    .set_idle_timeout(MonoDelta::FromMilliseconds(/*5 minutes=*/5 * 60 * 1000))
-                                    .build(&_get_thread_pool));
-            LOG(INFO) << "get kv thread num: " << _get_thread_pool->num_threads();
-        }
     }
     _set_error(false, "");
     return Status::OK();
@@ -2859,9 +2849,7 @@ Status PersistentIndex::on_commited() {
     _dump_snapshot = false;
     _flushed = false;
     _need_bloom_filter = false;
-    if (_get_thread_pool != nullptr) {
-        _get_thread_pool->shutdown();
-    }
+
     return Status::OK();
 }
 
@@ -2894,48 +2882,50 @@ Status PersistentIndex::_get_from_immutable_index(size_t n, const Slice* keys, I
 
 class GetFromImmutableIndexTask : public Runnable {
 public:
-    GetFromImmutableIndexTask(size_t num, size_t idx, size_t key_size, const Slice* keys, IndexValue* values,
-                              KeysInfo* keys_info, PersistentIndex* index)
+    GetFromImmutableIndexTask(size_t num, size_t idx, const Slice* keys, IndexValue* values,
+                              std::map<size_t, KeysInfo>* keys_info_by_key_size, PersistentIndex* index)
             : _num(num),
               _idx(idx),
-              _key_size(key_size),
               _keys(keys),
               _values(values),
-              _keys_info(keys_info),
+              _keys_info_by_key_size(keys_info_by_key_size),
               _index(index) {}
 
     void run() override {
-        _index->get_from_one_immutable_index(_num, _keys, _values, _keys_info, &_found_keys_info, _idx, _key_size);
+        _index->get_from_one_immutable_index(_num, _keys, _values, _keys_info_by_key_size, &_found_keys_info, _idx);
     }
 
 private:
     size_t _num;
     size_t _idx;
-    size_t _key_size;
     const Slice* _keys;
     IndexValue* _values;
-    KeysInfo* _keys_info;
+    std::map<size_t, KeysInfo>* _keys_info_by_key_size;
     KeysInfo _found_keys_info;
     PersistentIndex* _index;
 };
 
 Status PersistentIndex::get_from_one_immutable_index(size_t n, const Slice* keys, IndexValue* values,
-                                                     KeysInfo* keys_info, KeysInfo* found_keys_info, size_t idx,
-                                                     size_t key_size) {
+                                                     std::map<size_t, KeysInfo>* _keys_info_by_key_size,
+                                                     KeysInfo* found_keys_info, size_t idx) {
     DCHECK(_l1_vec.size() > idx);
-    auto st = _l1_vec[idx]->get(n, keys, *keys_info, values, found_keys_info, key_size);
-    std::unique_lock<std::mutex> ul(_lock);
-    if (!st.ok()) {
-        std::string msg =
-                strings::Substitute("get from one immutableindex failed, l1 idx: $0, status: $1", idx, st.to_string());
-        LOG(ERROR) << msg;
-        _set_error(true, msg);
+    Status st;
+    for (auto& [key_size, keys_info] : (*_keys_info_by_key_size)) {
+        st = _l1_vec[idx]->get(n, keys, keys_info, values, found_keys_info, key_size);
+        if (!st.ok()) {
+            std::string msg = strings::Substitute("get from one immutableindex failed, l1 idx: $0, status: $1", idx,
+                                                  st.to_string());
+            LOG(ERROR) << msg;
+            _set_error(true, msg);
+            break;
+        }
     }
+    std::unique_lock<std::mutex> ul(_lock);
     _running_get_task--;
+    _found_keys_info[idx].key_infos.swap(found_keys_info->key_infos);
     if (_running_get_task == 0) {
         _get_task_finished.notify_all();
     }
-    _found_keys_info[idx].key_infos.swap(found_keys_info->key_infos);
     return st;
 }
 
@@ -2944,42 +2934,37 @@ Status PersistentIndex::_get_from_immutable_index_parallel(size_t n, const Slice
     if (_l1_vec.empty()) {
         return Status::OK();
     }
-    DCHECK(_get_thread_pool != nullptr);
 
     std::unique_lock<std::mutex> ul(_lock);
     std::map<size_t, KeysInfo>::iterator iter;
     std::string error_msg;
-    for (iter = keys_info_by_key_size.begin(); iter != keys_info_by_key_size.end(); iter++) {
-        if (iter->second.size() == 0) {
-            break;
+    std::vector<std::vector<uint64_t>> get_values(_l1_vec.size(), std::vector<uint64_t>(n, NullIndexValue));
+    _found_keys_info.resize(_l1_vec.size());
+    for (size_t i = 0; i < _l1_vec.size(); i++) {
+        GetFromImmutableIndexTask task(n, i, keys, reinterpret_cast<IndexValue*>(get_values[i].data()),
+                                       &keys_info_by_key_size, this);
+        std::shared_ptr<Runnable> r(std::make_shared<GetFromImmutableIndexTask>(task));
+        auto st = StorageEngine::instance()->update_manager()->get_pindex_thread_pool()->submit(std::move(r));
+        if (!st.ok()) {
+            error_msg = strings::Substitute("get from immutable index failed: $0", st.to_string());
+            LOG(ERROR) << error_msg;
+            return st;
         }
-        size_t key_size = iter->first;
-        std::vector<std::vector<uint64_t>> get_values(_l1_vec.size(), std::vector<uint64_t>(n, NullIndexValue));
-        _found_keys_info.resize(_l1_vec.size());
-        for (size_t i = 0; i < _l1_vec.size(); i++) {
-            GetFromImmutableIndexTask task(n, i, key_size, keys, reinterpret_cast<IndexValue*>(get_values[i].data()),
-                                           &(iter->second), this);
-            std::shared_ptr<Runnable> r(std::make_shared<GetFromImmutableIndexTask>(task));
-            auto st = _get_thread_pool->submit(std::move(r));
-            if (!st.ok()) {
-                error_msg = strings::Substitute("get from immutable index failed: $0", st.to_string());
-                LOG(ERROR) << error_msg;
-                return st;
-            }
-            _running_get_task++;
-        }
-        _get_task_finished.wait(ul, [&] { return _running_get_task == 0; });
-        if (is_error()) {
-            LOG(ERROR) << _error_msg;
-            return Status::InternalError(_error_msg);
-        }
+        _running_get_task++;
+    }
+    while (_running_get_task != 0) {
+        _get_task_finished.wait(ul);
+    }
+    if (is_error()) {
+        LOG(ERROR) << _error_msg;
+        return Status::InternalError(_error_msg);
+    }
 
-        // wait all task finished
-        for (int i = 0; i < _l1_vec.size(); i++) {
-            for (int j = 0; j < _found_keys_info[i].size(); j++) {
-                auto key_idx = _found_keys_info[i].key_infos[j].first;
-                values[key_idx] = get_values[i][key_idx];
-            }
+    // wait all task finished
+    for (int i = 0; i < _l1_vec.size(); i++) {
+        for (int j = 0; j < _found_keys_info[i].size(); j++) {
+            auto key_idx = _found_keys_info[i].key_infos[j].first;
+            values[key_idx] = get_values[i][key_idx];
         }
     }
     _found_keys_info.clear();
@@ -2991,7 +2976,7 @@ Status PersistentIndex::get(size_t n, const Slice* keys, IndexValue* values) {
     std::map<size_t, KeysInfo> not_founds_by_key_size;
     size_t num_found = 0;
     RETURN_IF_ERROR(_l0->get(n, keys, values, &num_found, not_founds_by_key_size));
-    if (_get_thread_pool != nullptr) {
+    if (config::enable_parallel_get_and_bf) {
         return _get_from_immutable_index_parallel(n, keys, values, not_founds_by_key_size);
     }
     return _get_from_immutable_index(n, keys, values, not_founds_by_key_size);
@@ -3068,7 +3053,7 @@ Status PersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue* va
     std::map<size_t, KeysInfo> not_founds_by_key_size;
     size_t num_found = 0;
     RETURN_IF_ERROR(_l0->upsert(n, keys, values, old_values, &num_found, not_founds_by_key_size));
-    if (_get_thread_pool != nullptr) {
+    if (config::enable_parallel_get_and_bf) {
         RETURN_IF_ERROR(_get_from_immutable_index_parallel(n, keys, old_values, not_founds_by_key_size));
     } else {
         RETURN_IF_ERROR(_get_from_immutable_index(n, keys, old_values, not_founds_by_key_size));
@@ -3124,7 +3109,7 @@ Status PersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_value
     size_t num_erased = 0;
     RETURN_IF_ERROR(_l0->erase(n, keys, old_values, &num_erased, not_founds_by_key_size));
     _dump_snapshot |= _can_dump_directly();
-    if (_get_thread_pool != nullptr) {
+    if (config::enable_parallel_get_and_bf) {
         RETURN_IF_ERROR(_get_from_immutable_index_parallel(n, keys, old_values, not_founds_by_key_size));
     } else {
         RETURN_IF_ERROR(_get_from_immutable_index(n, keys, old_values, not_founds_by_key_size));

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -540,8 +540,9 @@ public:
     // |values|: value array for return values
     Status get(size_t n, const Slice* keys, IndexValue* values);
 
-    Status get_from_one_immutable_index(size_t n, const Slice* keys, IndexValue* values, KeysInfo* keys_info,
-                                        KeysInfo* found_keys_info, size_t idx, size_t key_size);
+    Status get_from_one_immutable_index(size_t n, const Slice* keys, IndexValue* values,
+                                        std::map<size_t, KeysInfo>* _keys_info_by_key_size, KeysInfo* found_keys_info,
+                                        size_t idx);
 
     // batch upsert
     // |n|: size of key/value array
@@ -659,7 +660,6 @@ private:
     bool _need_bloom_filter = false;
 
     mutable std::mutex _lock;
-    std::unique_ptr<ThreadPool> _get_thread_pool;
     std::condition_variable _get_task_finished;
     size_t _running_get_task = 0;
     std::atomic<bool> _error{false};

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1178,32 +1178,36 @@ Status PrimaryIndex::_insert_into_persistent_index(uint32_t rssid, const vector<
     return Status::OK();
 }
 
-void PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                                                 uint32_t idx_begin, uint32_t idx_end, DeletesMap* deletes) {
+Status PrimaryIndex::_upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                                   uint32_t idx_begin, uint32_t idx_end, DeletesMap* deletes) {
+    Status st;
     uint32_t n = idx_end - idx_begin;
     std::vector<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(n);
     std::vector<uint64_t> old_values(n, NullIndexValue);
     const Slice* vkeys = _build_persistent_keys(pks, idx_begin, idx_end, &keys);
-    _build_persistent_values(rssid, rowid_start, idx_begin, idx_end, &values);
-    _persistent_index->upsert(n, vkeys, reinterpret_cast<IndexValue*>(values.data()),
-                              reinterpret_cast<IndexValue*>(old_values.data()));
+    RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, idx_begin, idx_end, &values));
+    RETURN_IF_ERROR(_persistent_index->upsert(n, vkeys, reinterpret_cast<IndexValue*>(values.data()),
+                                              reinterpret_cast<IndexValue*>(old_values.data())));
     for (unsigned long old : old_values) {
         if ((old != NullIndexValue) && (old >> 32) == rssid) {
             LOG(ERROR) << "found duplicate in upsert data rssid:" << rssid;
+            st = Status::InternalError("found duplicate in upsert data");
         }
         if (old != NullIndexValue) {
             (*deletes)[(uint32_t)(old >> 32)].push_back((uint32_t)(old & ROWID_MASK));
         }
     }
+    return st;
 }
 
-void PrimaryIndex::_erase_persistent_index(const vectorized::Column& key_col, DeletesMap* deletes) {
+Status PrimaryIndex::_erase_persistent_index(const vectorized::Column& key_col, DeletesMap* deletes) {
+    Status st;
     std::vector<Slice> keys;
     std::vector<uint64_t> old_values(key_col.size(), NullIndexValue);
     const Slice* vkeys = _build_persistent_keys(key_col, 0, key_col.size(), &keys);
-    Status st = _persistent_index->erase(key_col.size(), vkeys, reinterpret_cast<IndexValue*>(old_values.data()));
+    st = _persistent_index->erase(key_col.size(), vkeys, reinterpret_cast<IndexValue*>(old_values.data()));
     if (!st.ok()) {
         LOG(WARNING) << "erase persistent index failed";
     }
@@ -1212,43 +1216,48 @@ void PrimaryIndex::_erase_persistent_index(const vectorized::Column& key_col, De
             (*deletes)[(uint32_t)(old >> 32)].push_back((uint32_t)(old & ROWID_MASK));
         }
     }
+    return st;
 }
 
-void PrimaryIndex::_get_from_persistent_index(const vectorized::Column& key_col, std::vector<uint64_t>* rowids) const {
+Status PrimaryIndex::_get_from_persistent_index(const vectorized::Column& key_col,
+                                                std::vector<uint64_t>* rowids) const {
     std::vector<Slice> keys;
     const Slice* vkeys = _build_persistent_keys(key_col, 0, key_col.size(), &keys);
     Status st = _persistent_index->get(key_col.size(), vkeys, reinterpret_cast<IndexValue*>(rowids->data()));
     if (!st.ok()) {
         LOG(WARNING) << "failed get value from persistent index";
     }
+    return st;
 }
 
-[[maybe_unused]] void PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start,
-                                                              const vectorized::Column& pks,
-                                                              const vector<uint32_t>& src_rssid,
-                                                              vector<uint32_t>* deletes) {
+[[maybe_unused]] Status PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start,
+                                                                const vectorized::Column& pks,
+                                                                const vector<uint32_t>& src_rssid,
+                                                                vector<uint32_t>* deletes) {
     std::vector<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
-    _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
+    RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
     Status st = _persistent_index->try_replace(pks.size(), _build_persistent_keys(pks, 0, pks.size(), &keys),
                                                reinterpret_cast<IndexValue*>(values.data()), src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
     }
+    return st;
 }
 
-void PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                                             const uint32_t max_src_rssid, vector<uint32_t>* deletes) {
+Status PrimaryIndex::_replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                               const uint32_t max_src_rssid, vector<uint32_t>* deletes) {
     std::vector<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
-    _build_persistent_values(rssid, rowid_start, 0, pks.size(), &values);
+    RETURN_IF_ERROR(_build_persistent_values(rssid, rowid_start, 0, pks.size(), &values));
     Status st = _persistent_index->try_replace(pks.size(), _build_persistent_keys(pks, 0, pks.size(), &keys),
                                                reinterpret_cast<IndexValue*>(values.data()), max_src_rssid, deletes);
     if (!st.ok()) {
         LOG(WARNING) << "try replace persistent index failed";
     }
+    return st;
 }
 
 Status PrimaryIndex::insert(uint32_t rssid, const vector<uint32_t>& rowids, const vectorized::Column& pks) {
@@ -1267,61 +1276,73 @@ Status PrimaryIndex::insert(uint32_t rssid, uint32_t rowid_start, const vectoriz
     return insert(rssid, rids, pks);
 }
 
-void PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, DeletesMap* deletes) {
+Status PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, DeletesMap* deletes) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    Status st;
     if (_persistent_index != nullptr) {
-        _upsert_into_persistent_index(rssid, rowid_start, pks, 0, pks.size(), deletes);
+        st = _upsert_into_persistent_index(rssid, rowid_start, pks, 0, pks.size(), deletes);
     } else {
         _pkey_to_rssid_rowid->upsert(rssid, rowid_start, pks, 0, pks.size(), deletes);
     }
+    return st;
 }
 
-void PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, uint32_t idx_begin,
-                          uint32_t idx_end, DeletesMap* deletes) {
+Status PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks uint32_t idx_begin,
+                            uint32_t idx_end, DeletesMap* deletes) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    Status st;
     if (_persistent_index != nullptr) {
-        _upsert_into_persistent_index(rssid, rowid_start, pks, idx_begin, idx_end, deletes);
+        st = _upsert_into_persistent_index(rssid, rowid_start, pks, idx_begin, idx_end, deletes);
     } else {
         _pkey_to_rssid_rowid->upsert(rssid, rowid_start, pks, idx_begin, idx_end, deletes);
     }
+    return st;
 }
 
-[[maybe_unused]] void PrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                                                const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes) {
+[[maybe_unused]] Status PrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                                  const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    Status st;
     if (_persistent_index != nullptr) {
-        _replace_persistent_index(rssid, rowid_start, pks, src_rssid, deletes);
+        st = _replace_persistent_index(rssid, rowid_start, pks, src_rssid, deletes);
     } else {
         _pkey_to_rssid_rowid->try_replace(rssid, rowid_start, pks, src_rssid, 0, pks.size(), deletes);
     }
+    return st;
 }
 
-void PrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                               const uint32_t max_src_rssid, vector<uint32_t>* deletes) {
+Status PrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                 const uint32_t max_src_rssid, vector<uint32_t>* deletes) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    Status st;
     if (_persistent_index != nullptr) {
-        _replace_persistent_index(rssid, rowid_start, pks, max_src_rssid, deletes);
+        st = _replace_persistent_index(rssid, rowid_start, pks, max_src_rssid, deletes);
     } else {
         _pkey_to_rssid_rowid->try_replace(rssid, rowid_start, pks, max_src_rssid, 0, pks.size(), deletes);
     }
+    return st;
 }
 
-void PrimaryIndex::erase(const vectorized::Column& key_col, DeletesMap* deletes) {
+Status PrimaryIndex::erase(const vectorized::Column& key_col, DeletesMap* deletes) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    Status st;
     if (_persistent_index != nullptr) {
-        _erase_persistent_index(key_col, deletes);
+        st = _erase_persistent_index(key_col, deletes);
     } else {
         _pkey_to_rssid_rowid->erase(key_col, 0, key_col.size(), deletes);
     }
+    return st;
 }
 
-void PrimaryIndex::get(const vectorized::Column& key_col, std::vector<uint64_t>* rowids) const {
+Status PrimaryIndex::get(const vectorized::Column& key_col, std::vector<uint64_t>* rowids) const {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
+    Status st;
     if (_persistent_index != nullptr) {
-        _get_from_persistent_index(key_col, rowids);
+        st = _get_from_persistent_index(key_col, rowids);
     } else {
         _pkey_to_rssid_rowid->get(key_col, 0, key_col.size(), rowids);
     }
+    return st;
 }
 
 std::size_t PrimaryIndex::memory_usage() const {

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1287,7 +1287,7 @@ Status PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const vectoriz
     return st;
 }
 
-Status PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks uint32_t idx_begin,
+Status PrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, uint32_t idx_begin,
                             uint32_t idx_end, DeletesMap* deletes) {
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
     Status st;

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -53,10 +53,10 @@ public:
     // old position to |deletes|.
     //
     // [not thread-safe]
-    void upsert(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, DeletesMap* deletes);
+    Status upsert(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, DeletesMap* deletes);
 
-    void upsert(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, uint32_t idx_begin,
-                uint32_t idx_end, DeletesMap* deletes);
+    Status upsert(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, uint32_t idx_begin,
+                  uint32_t idx_end, DeletesMap* deletes);
 
     // TODO(qzc): maybe unused, remove it or refactor it with the methods in use by template after a period of time
     // used for compaction, try replace input rowsets' rowid with output segment's rowid, if
@@ -69,8 +69,8 @@ public:
     // |failed| rowids of output segment's rows that failed to replace
     //
     // [not thread-safe]
-    [[maybe_unused]] void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                                      const vector<uint32_t>& src_rssid, vector<uint32_t>* failed);
+    [[maybe_unused]] Status try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                        const vector<uint32_t>& src_rssid, vector<uint32_t>* failed);
 
     // used for compaction, try replace input rowsets' rowid with output segment's rowid, if
     // input rowsets' rowid greater than the max src rssid, this indicates that the row of output rowset is
@@ -82,16 +82,16 @@ public:
     // |failed| rowids of output segment's rows that failed to replace
     //
     // [not thread-safe]
-    void try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks, const uint32_t max_src_rssid,
-                     vector<uint32_t>* failed);
+    Status try_replace(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                       const uint32_t max_src_rssid, vector<uint32_t>* failed);
 
     // |key_col| contains the *encoded* primary keys to be deleted from this index.
     // The position of deleted keys will be appended into |new_deletes|.
     //
     // [not thread-safe]
-    void erase(const vectorized::Column& pks, DeletesMap* deletes);
+    Status erase(const vectorized::Column& pks, DeletesMap* deletes);
 
-    void get(const vectorized::Column& pks, std::vector<uint64_t>* rowids) const;
+    Status get(const vectorized::Column& pks, std::vector<uint64_t>* rowids) const;
 
     Status prepare(const EditVersion& version, size_t n);
 
@@ -135,18 +135,19 @@ private:
 
     Status _insert_into_persistent_index(uint32_t rssid, const vector<uint32_t>& rowids, const vectorized::Column& pks);
 
-    void _upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                                       uint32_t idx_begin, uint32_t idx_end, DeletesMap* deletes);
+    Status _upsert_into_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                         uint32_t idx_begin, uint32_t idx_end, DeletesMap* deletes);
 
-    void _erase_persistent_index(const vectorized::Column& key_col, DeletesMap* deletes);
+    Status _erase_persistent_index(const vectorized::Column& key_col, DeletesMap* deletes);
 
-    void _get_from_persistent_index(const vectorized::Column& key_col, std::vector<uint64_t>* rowids) const;
+    Status _get_from_persistent_index(const vectorized::Column& key_col, std::vector<uint64_t>* rowids) const;
 
     // TODO(qzc): maybe unused, remove it or refactor it with the methods in use by template after a period of time
-    [[maybe_unused]] void _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                                                    const vector<uint32_t>& src_rssid, vector<uint32_t>* deletes);
-    void _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
-                                   const uint32_t max_src_rssid, vector<uint32_t>* deletes);
+    [[maybe_unused]] Status _replace_persistent_index(uint32_t rssid, uint32_t rowid_start,
+                                                      const vectorized::Column& pks, const vector<uint32_t>& src_rssid,
+                                                      vector<uint32_t>* deletes);
+    Status _replace_persistent_index(uint32_t rssid, uint32_t rowid_start, const vectorized::Column& pks,
+                                     const uint32_t max_src_rssid, vector<uint32_t>* deletes);
 
     std::mutex _lock;
     std::atomic<bool> _loaded{false};

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -41,6 +41,9 @@ UpdateManager::~UpdateManager() {
         // should be shutdown.
         _apply_thread_pool->shutdown();
     }
+    if (_get_pindex_thread_pool) {
+        _get_pindex_thread_pool->shutdown();
+    }
     clear_cache();
     if (_compaction_state_mem_tracker) {
         _compaction_state_mem_tracker.reset();
@@ -57,8 +60,15 @@ UpdateManager::~UpdateManager() {
 }
 
 Status UpdateManager::init() {
-    auto st = ThreadPoolBuilder("update_apply").build(&_apply_thread_pool);
-    return st;
+    RETURN_IF_ERROR(ThreadPoolBuilder("update_apply").build(&_apply_thread_pool));
+
+    int max_thread_cnt = CpuInfo::num_cores();
+    int max_get_thread_cnt =
+            config::get_pindex_worker_count > max_thread_cnt ? config::get_pindex_worker_count : max_thread_cnt * 2;
+    RETURN_IF_ERROR(
+            ThreadPoolBuilder("get_pindex").set_max_threads(max_get_thread_cnt).build(&_get_pindex_thread_pool));
+
+    return Status::OK();
 }
 
 Status UpdateManager::get_del_vec_in_meta(KVStore* meta, const TabletSegmentId& tsid, int64_t version,

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -53,6 +53,7 @@ public:
     void on_rowset_cancel(Tablet* tablet, Rowset* rowset);
 
     ThreadPool* apply_thread_pool() { return _apply_thread_pool.get(); }
+    ThreadPool* get_pindex_thread_pool() { return _get_pindex_thread_pool.get(); }
 
     DynamicCache<uint64_t, PrimaryIndex>& index_cache() { return _index_cache; }
 
@@ -105,6 +106,7 @@ private:
     std::unique_ptr<MemTracker> _del_vec_cache_mem_tracker;
 
     std::unique_ptr<ThreadPool> _apply_thread_pool;
+    std::unique_ptr<ThreadPool> _get_pindex_thread_pool;
 
     UpdateManager(const UpdateManager&) = delete;
     const UpdateManager& operator=(const UpdateManager&) = delete;


### PR DESCRIPTION
There are two major changes:
1. Set a global thread pool `_get_pindex_thread_pool` to support persisent index get. The main purpose is support parallel get among mutiple L1 files to speed up apply.
2. Add return status check to handle the error code. We don't check the return status of primary index's operation before. Even if some errors happened, we still treat it as normal status, this maybe cause serious
