### PR TITLE
[BugFix] Iceberg's RestCatalog credential is case-sensitive, we can't do lowercase, also change iceberg catalog properties' prefix

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -43,7 +43,7 @@ public class IcebergConnector implements Connector {
     @Deprecated
     public static final String ICEBERG_METASTORE_URIS = "iceberg.catalog.hive.metastore.uris";
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
-    public static final String ICEBERG_REST_CATALOG_PREFIX = "iceberg.rest-catalog.";
+    public static final String ICEBERG_CUSTOM_PROPERTIES_PREFIX = "iceberg.catalog.";
     private final Map<String, String> properties;
     private final CloudConfiguration cloudConfiguration;
     private final HdfsEnvironment hdfsEnvironment;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -47,7 +47,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
-import static com.starrocks.connector.iceberg.IcebergConnector.ICEBERG_REST_CATALOG_PREFIX;
+import static com.starrocks.connector.iceberg.IcebergConnector.ICEBERG_CUSTOM_PROPERTIES_PREFIX;
 
 public class IcebergRESTCatalog implements IcebergCatalog {
 
@@ -63,8 +63,8 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
         properties.forEach((key, value) -> {
             String newKey = key.toLowerCase();
-            if (newKey.startsWith(ICEBERG_REST_CATALOG_PREFIX)) {
-                newKey = newKey.substring(ICEBERG_REST_CATALOG_PREFIX.length());
+            if (newKey.startsWith(ICEBERG_CUSTOM_PROPERTIES_PREFIX)) {
+                newKey = newKey.substring(ICEBERG_CUSTOM_PROPERTIES_PREFIX.length());
                 copiedProperties.put(newKey, value);
             }
         });

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -63,10 +63,9 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
         properties.forEach((key, value) -> {
             String newKey = key.toLowerCase();
-            String newValue = value.toLowerCase();
             if (newKey.startsWith(ICEBERG_REST_CATALOG_PREFIX)) {
                 newKey = newKey.substring(ICEBERG_REST_CATALOG_PREFIX.length());
-                copiedProperties.put(newKey, newValue);
+                copiedProperties.put(newKey, value);
             }
         });
 


### PR DESCRIPTION
Iceberg's RestCatalog credential is case-sensitive, we shouldn't do anything about properties' values.
Change iceberg rest catalog prefix from `iceberg.rest-catalog.` -> `iceberg.catalog.`.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
