### PR TITLE
[Refactor] remove _delete_predicates_version from TabletReader

### DIFF
--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -725,7 +725,6 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2_normal(const TAlterTable
 
     // open tablet readers out of lock for open is heavy because of io
     for (auto& tablet_reader : readers) {
-        tablet_reader->set_delete_predicates_version(delete_predicates_version);
         RETURN_IF_ERROR(tablet_reader->open(read_params));
     }
 

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -20,7 +20,6 @@
 #include "common/status.h"
 #include "gen_cpp/tablet_schema.pb.h"
 #include "gutil/stl_util.h"
-#include "service/backend_options.h"
 #include "storage/aggregate_iterator.h"
 #include "storage/chunk_helper.h"
 #include "storage/column_predicate.h"
@@ -39,25 +38,17 @@
 namespace starrocks {
 
 TabletReader::TabletReader(TabletSharedPtr tablet, const Version& version, Schema schema)
-        : ChunkIterator(std::move(schema)),
-          _tablet(std::move(tablet)),
-          _version(version),
-          _delete_predicates_version(version) {}
+        : ChunkIterator(std::move(schema)), _tablet(std::move(tablet)), _version(version) {}
 
 TabletReader::TabletReader(TabletSharedPtr tablet, const Version& version, Schema schema,
                            const std::vector<RowsetSharedPtr>& captured_rowsets)
-        : ChunkIterator(std::move(schema)),
-          _tablet(std::move(tablet)),
-          _version(version),
-          _delete_predicates_version(version),
-          _rowsets(captured_rowsets) {}
+        : ChunkIterator(std::move(schema)), _tablet(std::move(tablet)), _version(version), _rowsets(captured_rowsets) {}
 
 TabletReader::TabletReader(TabletSharedPtr tablet, const Version& version, Schema schema, bool is_key,
                            RowSourceMaskBuffer* mask_buffer)
         : ChunkIterator(std::move(schema)),
           _tablet(std::move(tablet)),
           _version(version),
-          _delete_predicates_version(version),
           _is_vertical_merge(true),
           _is_key(is_key),
           _mask_buffer(mask_buffer) {

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -53,8 +53,6 @@ public:
 
     size_t merged_rows() const override { return _collect_iter->merged_rows(); }
 
-    void set_delete_predicates_version(Version version) { _delete_predicates_version = version; }
-
     Status get_segment_iterators(const TabletReaderParams& params, std::vector<ChunkIteratorPtr>* iters);
 
     static Status parse_seek_range(const TabletSharedPtr& tablet,
@@ -81,9 +79,6 @@ private:
 
     TabletSharedPtr _tablet;
     Version _version;
-    // version of delete predicates, equal as _version by default
-    // _delete_predicates_version will be set as max_version of tablet in schema change vectorized
-    Version _delete_predicates_version;
 
     MemPool _mempool;
     ObjectPool _obj_pool;


### PR DESCRIPTION
Remove `_delete_predicates_version` from `TabletReader`

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
