### PR TITLE
[Enhancement] remove unnecessary dcheck in dynmaic cache

### DIFF
--- a/be/src/util/dynamic_cache.h
+++ b/be/src/util/dynamic_cache.h
@@ -162,8 +162,6 @@ public:
         std::lock_guard<std::mutex> lg(_lock);
         entry->_ref--;
         if (entry->_ref != 1) {
-            LOG(ERROR) << "remove() failed: cache entry ref != 1 " << entry->_value;
-            DCHECK(false);
             return false;
         } else {
             _map.erase(entry->key());


### PR DESCRIPTION
remove unnecessary dcheck in dynmaic cache, it could happen in `remove`.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
