### PR TITLE
[BugFix] Release client from cache directly if not found

### DIFF
--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -98,8 +98,6 @@ public:
 
     std::string debug_string();
 
-    void test_shutdown();
-
     void init_metrics(MetricRegistry* metrics, const std::string& key_prefix);
 
 private:
@@ -218,9 +216,6 @@ public:
 
     // Helper method which returns a debug string
     std::string debug_string() { return _client_cache_helper.debug_string(); }
-
-    // For testing only: shutdown all clients
-    void test_shutdown() { return _client_cache_helper.test_shutdown(); }
 
     // Adds metrics for this cache to the supplied MetricRegistry instance. The
     // metrics have keys that are prefixed by the key_prefix argument


### PR DESCRIPTION
Fix https://starrocks.atlassian.net/browse/SR-15675

If create client with fe failed, all the client in cache for the fe will be closed and removed from cache, so the client maybe already released from cache when close the connection.

```
            FrontendServiceConnection fe_connection(exec_env->frontend_client_cache(), fe_addr, &fe_connection_status);
            if (!fe_connection_status.ok()) {
                std::stringstream ss;
                ss << "couldn't get a client for " << fe_addr;
                LOG(WARNING) << ss.str();
                starrocks::ExecEnv::GetInstance()->profile_report_worker()->unregister_pipeline_load(
                        fragment_ctx->query_id(), fragment_ctx->fragment_instance_id());
                exec_env->frontend_client_cache()->close_connections(fe_addr);
                continue;
            }
```

```
*** SIGSEGV (@0x48) received by PID 3293592 (TID 0x7fddaf4c1700) from PID 72; stack trace: ***
    @          0x6240182 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fdec2089cf0 (unknown)
    @          0x4e5bbfb starrocks::ClientCacheHelper::release_client()
    @          0x5704c5c starrocks::pipeline::ExecStateReporter::report_exec_status()
    @          0x56fa41a _ZNSt17_Function_handlerIFvvEZN9starrocks8pipeline20GlobalDriverExecutor17report_exec_stateEPNS2_12QueryContextEPNS2_15FragmentContextERKNS1_6StatusEbEUlvE_E9_M_invokeERKSt9_Any_data
    @          0x506b022 starrocks::ThreadPool::dispatch_thread()
    @          0x5065b1a starrocks::Thread::supervise_thread()
    @     0x7fdec207f1ca start_thread
    @     0x7fdec155ce73 __GI___clone
    @                0x0 (unknown)
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
