### PR TITLE
[BugFix] csv scanner will return wrong result when _row_delimiter_length lager than 1

### DIFF
--- a/be/src/formats/csv/csv_reader.cpp
+++ b/be/src/formats/csv/csv_reader.cpp
@@ -526,6 +526,12 @@ Status CSVReader::next_record(Record* record) {
         }
         // fill_buffer does a memory copy: it reads the data from the file and writes it to _buff
         RETURN_IF_ERROR(_fill_buffer());
+        // When _row_delimiter_length larger than 1, for example $$$
+        // we may read $$ first and _buff.find will return nullptr, after
+        // filling buffer we read $, however we will find from $ and skip $$
+        // so we may get wrong result here. we can always set pos = 0, but
+        // for single char _row_delimiter we keep the same logic as before.
+        pos = _row_delimiter_length > 1 ? 0 : pos;
     }
     size_t l = d - _buff.position();
     *record = Record(_buff.position(), l);


### PR DESCRIPTION


Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
