### PR TITLE
[BugFix] columns of information schema should not return tinyint for boolean type

### DIFF
--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -95,7 +95,7 @@ Status SchemaColumnsScanner::start(RuntimeState* state) {
 std::string SchemaColumnsScanner::to_mysql_data_type_string(TColumnDesc& desc) {
     switch (desc.columnType) {
     case TPrimitiveType::BOOLEAN:
-        return "tinyint";
+        return "boolean";
     case TPrimitiveType::TINYINT:
         return "tinyint";
     case TPrimitiveType::SMALLINT:
@@ -141,7 +141,7 @@ std::string SchemaColumnsScanner::to_mysql_data_type_string(TColumnDesc& desc) {
 std::string SchemaColumnsScanner::type_to_string(TColumnDesc& desc) {
     switch (desc.columnType) {
     case TPrimitiveType::BOOLEAN:
-        return "tinyint(1)";
+        return "boolean";
     case TPrimitiveType::TINYINT:
         return "tinyint(4)";
     case TPrimitiveType::SMALLINT:


### PR DESCRIPTION
Boolean type should keep the same in information_schema.columns.

For example When use cdas, the connector will get tablet schema and columns information from information_schema.columns.

However the connector will get tinyint for boolean will is not same with column type in flink, and exception will be thrown

```
Caused by: java.lang.ClassCastException: java.lang.Boolean cannot be cast to java.lang.Byte
        at org.apache.flink.table.data.GenericRowData.getByte(GenericRowData.java:139) ~[flink-table-api-java-uber-1.15-vvr-6.0.6-SNAPSHOT.jar:1.15-vvr-6.0.6-SNAPSHOT]
        at com.starrocks.connector.flink.row.sink.StarRocksTableRowTransformer.lambda$createFieldGetter$245ca7d1$4(StarRocksTableRowTransformer.java:169) ~[?:?]
        at com.starrocks.connector.flink.row.sink.StarRocksTableRowTransformer.lambda$createFieldGetter$25774257$1(StarRocksTableRowTransformer.java:262) ~[?:?]
        at org.apache.flink.table.runtime.typeutils.RowDataSerializer.toGenericRow(RowDataSerializer.java:221) ~[flink-table-runtime-1.15-vvr-6.0.6-SNAPSHOT.jar:1.15-vvr-6.0.6-SNAPSHOT]
        at org.apache.flink.table.runtime.typeutils.RowDataSerializer.toGenericRow(RowDataSerializer.java:207) ~[flink-table-runtime-1.15-vvr-6.0.6-SNAPSHOT.jar:1.15-vvr-6.0.6-SNAPSHOT]
        at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copy(RowDataSerializer.java:174) ~[flink-table-runtime-1.15-vvr-6.0.6-SNAPSHOT.jar:1.15-vvr-6.0.6-SNAPSHOT]
        at org.apache.flink.table.runtime.typeutils.RowDataSerializer.copy(RowDataSerializer.java:50) ~[flink-table-runtime-1.15-vvr-6.0.6-SNAPSHOT.jar:1.15-vvr-6.0.6-SNAPSHOT]
        at com.starrocks.connector.flink.row.sink.StarRocksTableRowTransformer.transform(StarRocksTableRowTransformer.java:268) ~[?:?]
        at com.starrocks.connector.flink.row.sink.StarRocksSinkRecordTransformer.transform(StarRocksSinkRecordTransformer.java:37) ~[?:?]
        at com.starrocks.connector.flink.row.sink.StarRocksSinkRecordTransformer.transform(StarRocksSinkRecordTransformer.java:12) ~[?:?]
        at com.starrocks.connector.flink.table.sink.StarRocksDynamicSinkFunctionV2.invoke(StarRocksDynamicSinkFunctionV2.java:169) ~[?:?]
        at org.apache.flink.table.runtime.operators.sink.SinkOperator.processElement
```

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
