### PR TITLE
[Enhancement] auto release local exchange buffer data under spill mode

### DIFF
--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -31,7 +31,9 @@ public:
                          << config::local_exchange_buffer_mem_limit_per_driver;
         }
         size_t res = max_input_dop * _max_memory_usage_per_driver;
-        _max_memory_usage = (res > _max_memory_usage || res <= 0) ? _max_memory_usage : res;
+        if (res < _max_memory_usage) {
+            _max_memory_usage = res;
+        }
     }
 
     void update_memory_usage(size_t memory_usage) { _memory_usage += memory_usage; }
@@ -42,9 +44,11 @@ public:
 
     bool is_full() const { return _memory_usage >= _max_memory_usage; }
 
+    void update_max_memory_usage(size_t limit) { _max_memory_usage = limit; }
+
 private:
-    size_t _max_memory_usage = 128 * 1024 * 1024 * 1024UL;     // 128GB
-    size_t _max_memory_usage_per_driver = 128 * 1024 * 1024UL; // 128MB
+    std::atomic<size_t> _max_memory_usage{128UL * 1024 * 1024 * 1024}; // 128GB
+    size_t _max_memory_usage_per_driver = 128 * 1024 * 1024UL;         // 128MB
     std::atomic<size_t> _memory_usage{0};
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -23,7 +23,7 @@ namespace starrocks::pipeline {
 // Manage the memory usage for local exchange
 class LocalExchangeMemoryManager {
 public:
-    LocalExchangeMemoryManager(size_t max_input_dop) {
+    LocalExchangeMemoryManager(size_t max_input_dop) : _max_input_dop(max_input_dop) {
         if (config::local_exchange_buffer_mem_limit_per_driver > 0) {
             _max_memory_usage_per_driver = config::local_exchange_buffer_mem_limit_per_driver;
         } else {
@@ -44,11 +44,14 @@ public:
 
     bool is_full() const { return _memory_usage >= _max_memory_usage; }
 
-    void update_max_memory_usage(size_t limit) { _max_memory_usage = limit; }
+    size_t get_max_input_dop() const { return _max_input_dop; }
+
+    void update_max_memory_usage(size_t max_memory_usage) { _max_memory_usage = max_memory_usage; }
 
 private:
     std::atomic<size_t> _max_memory_usage{128UL * 1024 * 1024 * 1024}; // 128GB
     size_t _max_memory_usage_per_driver = 128 * 1024 * 1024UL;         // 128MB
     std::atomic<size_t> _memory_usage{0};
+    size_t _max_input_dop;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_memory_manager.h
@@ -46,7 +46,10 @@ public:
 
     size_t get_max_input_dop() const { return _max_input_dop; }
 
-    void update_max_memory_usage(size_t max_memory_usage) { _max_memory_usage = max_memory_usage; }
+    void update_max_memory_usage(size_t max_memory_usage) {
+        DCHECK(max_memory_usage > 0);
+        _max_memory_usage = max_memory_usage;
+    }
 
 private:
     std::atomic<size_t> _max_memory_usage{128UL * 1024 * 1024 * 1024}; // 128GB

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -141,11 +141,8 @@ const size_t min_local_memory_limit = 1LL * 1024 * 1024;
 void LocalExchangeSourceOperator::enter_release_memory_mode() {
     // limit the memory limit to a very small value so that the upstream will not write new data until all the data has been pushed to the downstream operators
     _local_memory_limit = min_local_memory_limit;
-    _memory_manager->update_max_memory_usage(min_local_memory_limit);
-}
-
-bool LocalExchangeSourceOperator::release_memory_mode_done() const {
-    return _local_memory_usage <= min_local_memory_limit;
+    size_t max_memory_usage = min_local_memory_limit * _memory_manager->get_max_input_dop();
+    _memory_manager->update_max_memory_usage(max_memory_usage);
 }
 
 void LocalExchangeSourceOperator::set_execute_mode(int performance_level) {

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -136,6 +136,21 @@ StatusOr<ChunkPtr> LocalExchangeSourceOperator::pull_chunk(RuntimeState* state) 
     return std::move(chunk);
 }
 
+const size_t min_local_memory_limit = 1LL * 1024 * 1024;
+
+void LocalExchangeSourceOperator::enter_release_memory_mode() {
+    _local_memory_limit = min_local_memory_limit;
+    _memory_manager->update_max_memory_usage(min_local_memory_limit);
+}
+
+bool LocalExchangeSourceOperator::release_memory_mode_done() const {
+    return _local_memory_usage <= min_local_memory_limit;
+}
+
+void LocalExchangeSourceOperator::set_execute_mode(int performance_level) {
+    enter_release_memory_mode();
+}
+
 ChunkPtr LocalExchangeSourceOperator::_pull_passthrough_chunk(RuntimeState* state) {
     std::lock_guard<std::mutex> l(_chunk_lock);
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -139,6 +139,7 @@ StatusOr<ChunkPtr> LocalExchangeSourceOperator::pull_chunk(RuntimeState* state) 
 const size_t min_local_memory_limit = 1LL * 1024 * 1024;
 
 void LocalExchangeSourceOperator::enter_release_memory_mode() {
+    // limit the memory limit to a very small value so that the upstream will not write new data until all the data has been pushed to the downstream operators
     _local_memory_limit = min_local_memory_limit;
     _memory_manager->update_max_memory_usage(min_local_memory_limit);
 }

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -146,9 +146,7 @@ private:
 
     PendingPartitionChunks& _max_row_partition_chunks();
 
-    bool _local_buffer_almost_full() const {
-        return _local_memory_usage >= _local_memory_limit;
-    }
+    bool _local_buffer_almost_full() const { return _local_memory_usage >= _local_memory_limit; }
 
     bool _key_partition_pending_chunk_empty() const {
         for (const auto& pending_chunks : _partitions) {

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -147,7 +147,7 @@ private:
     PendingPartitionChunks& _max_row_partition_chunks();
 
     bool _local_buffer_almost_full() const {
-        return _local_memory_usage >= _memory_manager->get_memory_limit_per_driver() * 0.8;
+        return _local_memory_usage >= _local_memory_limit;
     }
 
     bool _key_partition_pending_chunk_empty() const {

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -133,7 +133,6 @@ public:
     bool releaseable() const override { return true; }
 
     void enter_release_memory_mode() override;
-    bool release_memory_mode_done() const override;
     void set_execute_mode(int performance_level) override;
 
 private:

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -90,7 +90,9 @@ public:
     LocalExchangeSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
                                 const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager)
             : SourceOperator(factory, id, "local_exchange_source", plan_node_id, driver_sequence),
-              _memory_manager(memory_manager) {}
+              _memory_manager(memory_manager) {
+        _local_memory_limit = _memory_manager->get_memory_limit_per_driver() * 0.8;
+    }
 
     Status add_chunk(ChunkPtr chunk);
 
@@ -128,6 +130,12 @@ public:
 
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
 
+    bool releaseable() const override { return true; }
+
+    void enter_release_memory_mode() override;
+    bool release_memory_mode_done() const override;
+    void set_execute_mode(int performance_level) override;
+
 private:
     ChunkPtr _pull_passthrough_chunk(RuntimeState* state);
 
@@ -157,6 +165,7 @@ private:
     std::queue<PartitionChunk> _partition_chunk_queue;
     size_t _partition_rows_num = 0;
     size_t _local_memory_usage = 0;
+    size_t _local_memory_limit = 0;
 
     // TODO(KKS): make it lock free
     mutable std::mutex _chunk_lock;

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -228,6 +228,8 @@ public:
     virtual bool spillable() const { return false; }
     // Operator can free memory/buffer early
     virtual bool releaseable() const { return false; }
+    virtual void enter_release_memory_mode() {}
+    virtual bool release_memory_mode_done() const { return true; }
     spill::OperatorMemoryResourceManager& mem_resource_manager() { return _mem_resource_manager; }
 
     // the memory that can be freed by the current operator

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -225,6 +225,10 @@ public:
 
     // Adjusts the execution mode of the operator (will only be called by the OperatorMemoryResourceManager component)
     virtual void set_execute_mode(int performance_level) {}
+    // @TODO(silverbullet233): for an operator, the way to reclaim memory is either spill
+    // or push the buffer data to the downstream operator.
+    // Maybe we don’t need to have the concepts of spillable and releasable, and we can use reclaimable instead.
+    // Later, we need to refactor here.
     virtual bool spillable() const { return false; }
     // Operator can free memory/buffer early
     virtual bool releaseable() const { return false; }

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -233,7 +233,6 @@ public:
     // Operator can free memory/buffer early
     virtual bool releaseable() const { return false; }
     virtual void enter_release_memory_mode() {}
-    virtual bool release_memory_mode_done() const { return true; }
     spill::OperatorMemoryResourceManager& mem_resource_manager() { return _mem_resource_manager; }
 
     // the memory that can be freed by the current operator

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -525,7 +525,7 @@ void PipelineDriver::_adjust_memory_usage(RuntimeState* state, MemTracker* track
     }
 }
 
-const double release_buffer_mem_threshold = 0.8;
+const double release_buffer_mem_ratio = 0.8;
 
 void PipelineDriver::_try_to_release_buffer(RuntimeState* state, OperatorPtr& op) {
     if (state->enable_spill() && op->releaseable()) {
@@ -537,12 +537,12 @@ void PipelineDriver::_try_to_release_buffer(RuntimeState* state, OperatorPtr& op
         auto query_mem_limit = query_mem_tracker->limit();
         auto query_consumption = query_mem_tracker->consumption();
         auto spill_mem_threshold = query_mem_limit * state->spill_mem_limit_threshold();
-        if (query_consumption >= spill_mem_threshold * release_buffer_mem_threshold) {
+        if (query_consumption >= spill_mem_threshold * release_buffer_mem_ratio) {
             // if the currently used memory is very close to the threshold that triggers spill,
             // try to release buffer first
             TRACE_SPILL_LOG << "release operator due to mem pressure, consumption: " << query_consumption
                             << ", release buffer threshold: "
-                            << static_cast<int64_t>(spill_mem_threshold * release_buffer_mem_threshold)
+                            << static_cast<int64_t>(spill_mem_threshold * release_buffer_mem_ratio)
                             << ", spill mem threshold: " << static_cast<int64_t>(spill_mem_threshold);
             mem_resource_mgr.to_low_memory_mode();
         }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -264,6 +264,7 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                     continue;
                 }
 
+                _try_to_release_buffer(runtime_state, curr_op);
                 // try successive operator pairs
                 if (!curr_op->has_output() || !next_op->need_input()) {
                     continue;
@@ -503,10 +504,19 @@ void PipelineDriver::_close_operators(RuntimeState* runtime_state) {
 
 void PipelineDriver::_adjust_memory_usage(RuntimeState* state, MemTracker* tracker, OperatorPtr& op,
                                           const ChunkPtr& chunk) {
+    _try_to_release_buffer(state, op);
+    // TODO: FIXME
     // a simple spill stragety
     auto& mem_resource_mgr = op->mem_resource_manager();
     if (state->enable_spill() && mem_resource_mgr.releaseable() &&
         op->revocable_mem_bytes() > state->spill_operator_min_bytes()) {
+        auto releasing_operators = mem_resource_mgr.query_spill_manager()->releasing_operators();
+        if (releasing_operators > 0) {
+            // if there are some operators that are releasing memory,
+            // wait until all release operations are over before attempting to spill
+            return;
+        }
+
         int64_t request_reserved = 0;
         if (chunk == nullptr) {
             request_reserved = op->estimated_memory_reserved();
@@ -522,8 +532,42 @@ void PipelineDriver::_adjust_memory_usage(RuntimeState* state, MemTracker* track
     }
 }
 
-void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state, int64_t schedule_count,
-                              int64_t execution_time) {
+const double release_buffer_mem_threshold = 0.8;
+
+void PipelineDriver::_try_to_release_buffer(RuntimeState* state, OperatorPtr& op) {
+    if (state->enable_spill()) {
+        auto& mem_resource_mgr = op->mem_resource_manager();
+        if (mem_resource_mgr.is_releasing()) {
+            if (op->release_memory_mode_done()) {
+                mem_resource_mgr.set_release_done();
+                LOG(INFO) << "operator release memory done, op: " << op->get_name() << ", " << op.get()
+                                << ", res releasing opeartors: "
+                                << mem_resource_mgr.query_spill_manager()->releasing_operators();
+            }
+            return;
+        }
+        if (mem_resource_mgr.release_done()) {
+            return;
+        }
+        auto query_mem_tracker = _query_ctx->mem_tracker();
+        auto query_mem_limit = query_mem_tracker->limit();
+        auto query_consumption = query_mem_tracker->consumption();
+        auto spill_mem_threshold = query_mem_limit * state->spill_mem_limit_threshold();
+        if (query_consumption >= spill_mem_threshold * release_buffer_mem_threshold) {
+            // if the currently used memory is very close to the threshold that triggers spill,
+            // try to release buffer first
+            if (op->releaseable()) {
+                LOG(INFO) << "release operator due to mem pressure, consumption: " << query_consumption
+                                << ", release buffer threshold: "
+                                << static_cast<int64_t>(spill_mem_threshold * release_buffer_mem_threshold)
+                                << ", spill mem threshold: " << static_cast<int64_t>(spill_mem_threshold);
+                mem_resource_mgr.to_low_memory_mode();
+            }
+        }
+    }
+}
+
+void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state, int64_t schedule_count, int64_t execution_time) {
     if (schedule_count > 0) {
         _global_schedule_counter->set(schedule_count - _global_schedule_counter->value());
     } else {
@@ -534,7 +578,6 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state, in
     } else {
         _global_schedule_timer->set((int64_t)-1);
     }
-
     int64_t time_spent = 0;
     // The driver may be destructed after finalizing, so use a temporal driver to record
     // the information about the driver queue and workgroup.

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -540,7 +540,7 @@ void PipelineDriver::_try_to_release_buffer(RuntimeState* state, OperatorPtr& op
         if (mem_resource_mgr.is_releasing()) {
             if (op->release_memory_mode_done()) {
                 mem_resource_mgr.set_release_done();
-                LOG(INFO) << "operator release memory done, op: " << op->get_name() << ", " << op.get()
+                TRACE_SPILL_LOG << "operator release memory done, op: " << op->get_name() << ", " << op.get()
                                 << ", res releasing opeartors: "
                                 << mem_resource_mgr.query_spill_manager()->releasing_operators();
             }
@@ -557,7 +557,7 @@ void PipelineDriver::_try_to_release_buffer(RuntimeState* state, OperatorPtr& op
             // if the currently used memory is very close to the threshold that triggers spill,
             // try to release buffer first
             if (op->releaseable()) {
-                LOG(INFO) << "release operator due to mem pressure, consumption: " << query_consumption
+                TRACE_SPILL_LOG << "release operator due to mem pressure, consumption: " << query_consumption
                                 << ", release buffer threshold: "
                                 << static_cast<int64_t>(spill_mem_threshold * release_buffer_mem_threshold)
                                 << ", spill mem threshold: " << static_cast<int64_t>(spill_mem_threshold);

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -467,6 +467,7 @@ protected:
     void _close_operators(RuntimeState* runtime_state);
 
     void _adjust_memory_usage(RuntimeState* state, MemTracker* tracker, OperatorPtr& op, const ChunkPtr& chunk);
+    void _try_to_release_buffer(RuntimeState* state, OperatorPtr& op);
 
     // Update metrics when the driver yields.
     void _update_driver_acct(size_t total_chunks_moved, size_t total_rows_moved, size_t time_spent);

--- a/be/src/exec/spill/operator_mem_resource_manager.cpp
+++ b/be/src/exec/spill/operator_mem_resource_manager.cpp
@@ -37,15 +37,7 @@ void OperatorMemoryResourceManager::to_low_memory_mode() {
         }
         if (_op->releaseable()) {
             set_releasing();
-            _query_spill_manager->increase_releasing_operators();
         }
-    }
-}
-
-void OperatorMemoryResourceManager::set_release_done() {
-    if (_release_state != MEM_RELEASE_STATE::RELEASE_DONE) {
-        _release_state = MEM_RELEASE_STATE::RELEASE_DONE;
-        _query_spill_manager->decrease_releasing_operators();
     }
 }
 

--- a/be/src/exec/spill/operator_mem_resource_manager.cpp
+++ b/be/src/exec/spill/operator_mem_resource_manager.cpp
@@ -35,6 +35,17 @@ void OperatorMemoryResourceManager::to_low_memory_mode() {
         if (_spillable) {
             _query_spill_manager->increase_spilling_operators();
         }
+        if (_op->releaseable()) {
+            set_releasing();
+            _query_spill_manager->increase_releasing_operators();
+        }
+    }
+}
+
+void OperatorMemoryResourceManager::set_release_done() {
+    if (_release_state != MEM_RELEASE_STATE::RELEASE_DONE) {
+        _release_state = MEM_RELEASE_STATE::RELEASE_DONE;
+        _query_spill_manager->decrease_releasing_operators();
     }
 }
 

--- a/be/src/exec/spill/operator_mem_resource_manager.h
+++ b/be/src/exec/spill/operator_mem_resource_manager.h
@@ -24,12 +24,6 @@ enum MEM_RESOURCE {
     MEM_RESOURCE_LOW_MEMORY = 2,
 };
 
-enum MEM_RELEASE_STATE {
-    NOT_RELEASE = 0,
-    RELEASING = 1,
-    RELEASE_DONE = 2,
-};
-
 class OperatorMemoryResourceManager {
 public:
     using OP = pipeline::Operator;
@@ -47,13 +41,9 @@ public:
     // For the current operator available memory (estimated value)
     size_t operator_avaliable_memory_bytes();
 
-    void set_releasing() { _release_state = MEM_RELEASE_STATE::RELEASING; }
+    void set_releasing() { _is_releasing = true; }
 
-    void set_release_done();
-
-    bool is_releasing() const { return _release_state == MEM_RELEASE_STATE::RELEASING; }
-
-    bool release_done() const { return _release_state == MEM_RELEASE_STATE::RELEASE_DONE; }
+    bool is_releasing() const { return _is_releasing; }
 
     QuerySpillManager* query_spill_manager() const { return _query_spill_manager; }
 
@@ -65,6 +55,6 @@ private:
     bool _releaseable = false;
     OP* _op = nullptr;
     QuerySpillManager* _query_spill_manager = nullptr;
-    int _release_state = MEM_RELEASE_STATE::NOT_RELEASE;
+    bool _is_releasing = false;
 };
 } // namespace starrocks::spill

--- a/be/src/exec/spill/operator_mem_resource_manager.h
+++ b/be/src/exec/spill/operator_mem_resource_manager.h
@@ -24,6 +24,12 @@ enum MEM_RESOURCE {
     MEM_RESOURCE_LOW_MEMORY = 2,
 };
 
+enum MEM_RELEASE_STATE {
+    NOT_RELEASE = 0,
+    RELEASING = 1,
+    RELEASE_DONE = 2,
+};
+
 class OperatorMemoryResourceManager {
 public:
     using OP = pipeline::Operator;
@@ -41,6 +47,16 @@ public:
     // For the current operator available memory (estimated value)
     size_t operator_avaliable_memory_bytes();
 
+    void set_releasing() { _release_state = MEM_RELEASE_STATE::RELEASING; }
+
+    void set_release_done();
+
+    bool is_releasing() const { return _release_state == MEM_RELEASE_STATE::RELEASING; }
+
+    bool release_done() const { return _release_state == MEM_RELEASE_STATE::RELEASE_DONE; }
+
+    QuerySpillManager* query_spill_manager() const { return _query_spill_manager; }
+
 private:
     // performance level. Determine the execution mode and whether memory can be freed early
     // A higher performance level will allow the operator to execute with less memory, which will reduce performance
@@ -49,5 +65,6 @@ private:
     bool _releaseable = false;
     OP* _op = nullptr;
     QuerySpillManager* _query_spill_manager = nullptr;
+    int _release_state = MEM_RELEASE_STATE::NOT_RELEASE;
 };
 } // namespace starrocks::spill

--- a/be/src/exec/spill/query_spill_manager.h
+++ b/be/src/exec/spill/query_spill_manager.h
@@ -39,17 +39,10 @@ public:
 
     BlockManager* block_manager() const { return _block_manager.get(); }
 
-    void increase_releasing_operators() { _releasing_operators++; }
-    void decrease_releasing_operators() { _releasing_operators--; }
-
-    size_t releasing_operators() { return _releasing_operators; }
-
 private:
     TUniqueId _uid;
     std::unique_ptr<BlockManager> _block_manager;
     std::atomic_size_t _spilling_operators = 0;
     size_t _spillable_operators = 0;
-
-    std::atomic_size_t _releasing_operators = 0;
 };
 } // namespace starrocks::spill

--- a/be/src/exec/spill/query_spill_manager.h
+++ b/be/src/exec/spill/query_spill_manager.h
@@ -39,10 +39,17 @@ public:
 
     BlockManager* block_manager() const { return _block_manager.get(); }
 
+    void increase_releasing_operators() { _releasing_operators++; }
+    void decrease_releasing_operators() { _releasing_operators--; }
+
+    size_t releasing_operators() { return _releasing_operators; }
+
 private:
     TUniqueId _uid;
     std::unique_ptr<BlockManager> _block_manager;
     std::atomic_size_t _spilling_operators = 0;
     size_t _spillable_operators = 0;
+
+    std::atomic_size_t _releasing_operators = 0;
 };
 } // namespace starrocks::spill


### PR DESCRIPTION

In order to reduce the scheduling overhead, some operators will buffer data internally, and only when the buffer is almost full, they will be scheduled downstream. These buffers may eat a lot of memory, especially the local exchange operator, which allows each operator at most buffer 128MB of data.

So here is an obvious optimization strategy. When the query enables spill, we should release the data in the buffer first to reduce memory and try to avoid the occurrence of spill.

This change supports the automatic release of the buffer in the local exchange operator. The same strategy is also applicable to other operators, such as scan and exchange, but their buffer occupy less memory than local exchange. I think we can support them later if necessary.

here is my test result as an example. I test it in a machine with 104 cores, data set is tpch 100g and query mem limit is 45.5GB.

```sql
select l_comment,l_shipmode,count() from lineitem group by l_comment,l_shipmode order by count() limit 100;
```
this query has a local exchange operator and a spillable aggregate blocking operator, plan like this
![image](https://github.com/StarRocks/starrocks/assets/3675229/27178b24-0886-47be-a690-73c0d3890002)

we focus on the following metrics in query profile:

* PeakRevocableMemoryBytes of SpillableAggregateBlockingOperator: the amount of data in memory before spilling
* LocalExchangePeakMemoryUsage of LocalExchangeOperator: the max data buffered in local exchange operator.

| version |  PeakRevocableMemoryBytes | LocalExchangePeakMemoryUsage |
| --- | --- | --- |
| baseline | 9.98 GB |  6.50 GB | 
| patched | 17.15 GB | 202.98 MB | 

It means that our strategy is effective, allowing the agg operator to store more data in memory to avoid spilling as much as possible



## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
