### PR TITLE
[Enhancement] Make forward compatibility easier when adding new priv obj

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -105,6 +105,7 @@ import com.starrocks.persist.RangePartitionPersistInfo;
 import com.starrocks.persist.SinglePartitionPersistInfo;
 import com.starrocks.privilege.CatalogPEntryObject;
 import com.starrocks.privilege.DbPEntryObject;
+import com.starrocks.privilege.ForwardCompatiblePEntryObject;
 import com.starrocks.privilege.FunctionPEntryObject;
 import com.starrocks.privilege.GlobalFunctionPEntryObject;
 import com.starrocks.privilege.MaterializedViewPEntryObject;
@@ -254,7 +255,8 @@ public class GsonUtils {
                     .registerSubtype(FunctionPEntryObject.class, FunctionPEntryObject.class.getSimpleName())
                     .registerSubtype(CatalogPEntryObject.class, CatalogPEntryObject.class.getSimpleName())
                     .registerSubtype(ResourceGroupPEntryObject.class,
-                            ResourceGroupPEntryObject.class.getSimpleName());
+                            ResourceGroupPEntryObject.class.getSimpleName())
+                    .registerSubtype(ForwardCompatiblePEntryObject.class, "StorageVolumePEntryObject");
 
     private static final RuntimeTypeAdapterFactory<Warehouse> WAREHOUSE_TYPE_ADAPTER_FACTORY = RuntimeTypeAdapterFactory
             .of(Warehouse.class, "clazz")

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ForwardCompatiblePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ForwardCompatiblePEntryObject.java
@@ -1,0 +1,68 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.privilege;
+
+import com.starrocks.server.GlobalStateMgr;
+
+/**
+ * This class is existed for forward compatibility so that when we add a new type of {@link PEntryObject}
+ * in newer version and rollback to older version, the older version can still read the image file and edit log.
+ * <p>
+ * We achieve this by registering the new type as {@link ForwardCompatiblePEntryObject} in
+ * {@link com.starrocks.persist.gson.GsonUtils} and remove the privilege entry in corresponding
+ * {@link PrivilegeCollection} when deserializing.
+ */
+public class ForwardCompatiblePEntryObject implements PEntryObject {
+    @Override
+    public boolean match(Object obj) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isFuzzyMatching() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean validate(GlobalStateMgr globalStateMgr) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareTo(PEntryObject obj) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PEntryObject clone() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int hashCode() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
Fixes SR-18210

Adding a new compatibility PEntryObject class to keep forward compatibility
so that when we add a new type of {@link PEntryObject}
in newer version and rollback to older version, the older version can still
read the image file and edit log.

We achieve this by registering the new type as {@link ForwardCompatiblePEntryObject} in
{@link com.starrocks.persist.gson.GsonUtils} and remove the privilege entry in corresponding
{@link PrivilegeCollection} when deserializing.

Also fixes the following problem:

```
 [StarRocksFE.start():184] StarRocksFE start failed
com.google.gson.JsonParseException: cannot deserialize interface com.starrocks.privilege.PEntryObject subtype named StorageVolumePEntryObject; did you forget to register a subtype?
        at com.starrocks.persist.gson.RuntimeTypeAdapterFactory$1.read(RuntimeTypeAdapterFactory.java:377) ~[starrocks-fe.jar:?]
        at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:199) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:548) ~[starrocks-fe.jar:?]
        at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:41) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:82) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:61) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:548) ~[starrocks-fe.jar:?]
        at com.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.read(TypeAdapterRuntimeTypeWrapper.java:41) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:187) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.read(MapTypeAdapterFactory.java:145) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:548) ~[starrocks-fe.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:548) ~[starrocks-fe.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:963) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:928) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:877) ~[spark-dpp-1.0.0.jar:?]
        at com.google.gson.Gson.fromJson(Gson.java:848) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.persist.metablock.SRMetaBlockReader.readJson(SRMetaBlockReader.java:83) ~[starrocks-fe.jar:?]
        at com.starrocks.privilege.AuthorizationManager.load(AuthorizationManager.java:1592) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.loadRBACPrivilege(GlobalStateMgr.java:1556) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.loadImage(GlobalStateMgr.java:1399) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.initialize(GlobalStateMgr.java:989) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.start(StarRocksFE.java:130) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.main(StarRocksFE.java:82) ~[starrocks-fe.jar:?]
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
