### PR TITLE
[Enhancement] Make forward compatibility easier when adding new priv obj

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ForwardCompatiblePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ForwardCompatiblePEntryObject.java
@@ -1,0 +1,68 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.privilege;
+
+import com.starrocks.server.GlobalStateMgr;
+
+/**
+ * This class is existed for forward compatibility so that when we add a new type of {@link PEntryObject}
+ * in newer version and rollback to older version, the older version can still read the image file and edit log.
+ * <p>
+ * We achieve this by registering the new type as {@link ForwardCompatiblePEntryObject} in
+ * {@link com.starrocks.persist.gson.GsonUtils} and remove the privilege entry in corresponding
+ * {@link PrivilegeCollection} when deserializing.
+ */
+public class ForwardCompatiblePEntryObject implements PEntryObject {
+    @Override
+    public boolean match(Object obj) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isFuzzyMatching() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean validate(GlobalStateMgr globalStateMgr) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int compareTo(PEntryObject obj) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PEntryObject clone() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int hashCode() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
Fixes SR-18210

Adding a new compatibility PEntryObject class to keep forward compatibility
so that when we add a new type of {@link PEntryObject} in newer version and
rollback to older version, the older version can still read the image file and edit log.

We achieve this by registering the new type as {@link ForwardCompatiblePEntryObject} in
{@link com.starrocks.persist.gson.GsonUtils} and remove the privilege entry in corresponding
{@link PrivilegeCollection} when deserializing.


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
