### PR TITLE
[BugFix][Cherry-Pick] Fix forward to leader failed when current node's meta is far behind leader's meta

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/BDBHA.java
@@ -127,6 +127,12 @@ public class BDBHA implements HAProtocol {
     }
 
     @Override
+    public String getLeaderNodeName() {
+        ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
+        return replicationGroupAdmin.getMasterNodeName();
+    }
+
+    @Override
     public List<InetSocketAddress> getObserverNodes() {
         ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
         if (replicationGroupAdmin == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/ha/HAProtocol.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/HAProtocol.java
@@ -27,6 +27,8 @@ public interface HAProtocol {
     // increase epoch number by one
     public boolean fencing();
 
+    String getLeaderNodeName();
+
     // get observer nodes in the current group
     public List<InetSocketAddress> getObserverNodes();
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -23,6 +23,7 @@ package com.starrocks.http.rest;
 
 import com.starrocks.analysis.UserIdentity;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseAction;
@@ -126,8 +127,9 @@ public class RestBaseAction extends BaseAction {
         if (globalStateMgr.isMaster()) {
             return false;
         }
+        Pair<String, Integer> leaderIpAndPort = globalStateMgr.getLeaderIpAndHttpPort();
         redirectTo(request, response,
-                new TNetworkAddress(globalStateMgr.getMasterIp(), globalStateMgr.getMasterHttpPort()));
+                new TNetworkAddress(leaderIpAndPort.first, leaderIpAndPort.second));
         return true;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -60,6 +60,7 @@ import com.starrocks.catalog.TabletMeta;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.load.DeleteJob;
 import com.starrocks.load.loadv2.SparkLoadJob;

--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -1202,9 +1202,8 @@ public class MasterImpl {
     }
 
     public TNetworkAddress masterAddr() {
-        String masterHost = GlobalStateMgr.getCurrentState().getMasterIp();
-        int masterRpcPort = GlobalStateMgr.getCurrentState().getMasterRpcPort();
-        return new TNetworkAddress(masterHost, masterRpcPort);
+        Pair<String, Integer> ipAndPort = GlobalStateMgr.getCurrentState().getLeaderIpAndRpcPort();
+        return new TNetworkAddress(ipAndPort.first, ipAndPort.second);
     }
 
     public TBeginRemoteTxnResponse beginRemoteTxn(TBeginRemoteTxnRequest request) throws TException {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/MasterOpExecutor.java
@@ -26,10 +26,12 @@ import com.starrocks.analysis.SetStmt;
 import com.starrocks.analysis.StatementBase;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.mysql.MysqlChannel;
 import com.starrocks.qe.QueryState.MysqlStateType;
 import com.starrocks.rpc.FrontendServiceProxy;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TMasterOpRequest;
 import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.thrift.TNetworkAddress;
@@ -111,9 +113,8 @@ public class MasterOpExecutor {
 
     // Send request to Master
     private void forward() throws Exception {
-        String masterHost = ctx.getGlobalStateMgr().getMasterIp();
-        int masterRpcPort = ctx.getGlobalStateMgr().getMasterRpcPort();
-        TNetworkAddress thriftAddress = new TNetworkAddress(masterHost, masterRpcPort);
+        Pair<String, Integer> ipAndPort = GlobalStateMgr.getCurrentState().getLeaderIpAndRpcPort();
+        TNetworkAddress thriftAddress = new TNetworkAddress(ipAndPort.first, ipAndPort.second);
         TMasterOpRequest params = new TMasterOpRequest();
         params.setCluster(ctx.getClusterName());
         params.setSql(originStmt.originStmt);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2460,12 +2460,12 @@ public class GlobalStateMgr {
         return this.feType;
     }
 
-    public int getMasterRpcPort() {
-        return nodeMgr.getMasterRpcPort();
+    public Pair<String, Integer> getLeaderIpAndRpcPort() {
+        return nodeMgr.getLeaderIpAndRpcPort();
     }
 
-    public int getMasterHttpPort() {
-        return nodeMgr.getMasterHttpPort();
+    public Pair<String, Integer> getLeaderIpAndHttpPort() {
+        return nodeMgr.getLeaderIpAndHttpPort();
     }
 
     public String getMasterIp() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -835,25 +835,33 @@ public class NodeMgr {
         return this.nodeName;
     }
 
-    public int getMasterRpcPort() {
-        if (!stateMgr.isReady()) {
-            return 0;
+    public Pair<String, Integer> getLeaderIpAndRpcPort() {
+        if (stateMgr.isReady()) {
+            return new Pair<>(this.masterIp, this.masterRpcPort);
+        } else {
+            String leaderNodeName = stateMgr.getHaProtocol().getLeaderNodeName();
+            Frontend frontend = frontends.get(leaderNodeName);
+            return new Pair<>(frontend.getHost(), frontend.getRpcPort());
         }
-        return this.masterRpcPort;
     }
 
-    public int getMasterHttpPort() {
-        if (!stateMgr.isReady()) {
-            return 0;
+    public Pair<String, Integer> getLeaderIpAndHttpPort() {
+        if (stateMgr.isReady()) {
+            return new Pair<>(this.masterIp, this.masterHttpPort);
+        } else {
+            String leaderNodeName = stateMgr.getHaProtocol().getLeaderNodeName();
+            Frontend frontend = frontends.get(leaderNodeName);
+            return new Pair<>(frontend.getHost(), Config.http_port);
         }
-        return this.masterHttpPort;
     }
 
     public String getMasterIp() {
-        if (!stateMgr.isReady()) {
-            return "";
+        if (stateMgr.isReady()) {
+            return this.masterIp;
+        } else {
+            String leaderNodeName = stateMgr.getHaProtocol().getLeaderNodeName();
+            return frontends.get(leaderNodeName).getHost();
         }
-        return this.masterIp;
     }
 
     public void setMaster(MasterInfo info) {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockJournal.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockJournal.java
@@ -138,20 +138,27 @@ public class MockJournal implements Journal {
 
         @Override
         public List<InetSocketAddress> getNoneLeaderNodes() {
-            return Lists.newArrayList();
+            return null;
         }
 
         @Override
         public void transferToMaster() {
+
         }
 
         @Override
         public void transferToNonMaster() {
+
         }
 
         @Override
         public boolean isLeader() {
-            return true;
+            return false;
+        }
+
+        @Override
+        public String getLeaderNodeName() {
+            return "";
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockJournal.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockJournal.java
@@ -138,22 +138,20 @@ public class MockJournal implements Journal {
 
         @Override
         public List<InetSocketAddress> getNoneLeaderNodes() {
-            return null;
+            return Lists.newArrayList();
         }
 
         @Override
         public void transferToMaster() {
-
         }
 
         @Override
         public void transferToNonMaster() {
-
         }
 
         @Override
         public boolean isLeader() {
-            return false;
+            return true;
         }
 
         @Override


### PR DESCRIPTION
Fixes #17575 #17928
If the isReady is false, (if follower's meta is far behind leader's meta, or read from bdb timeout, isReady will be false), NodeMgr.getLeaderIp will return an empty string. It will cause the query which forwards to leader failed. 

To fix this bug, we should get leader info through bdb rpc if follower's meta is far behind leader's meta.

Signed-off-by: gengjun-git <gengjun@starrocks.com>
