### PR TITLE
[BugFix] Release client from cache directly if not found (#25037)

### DIFF
--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -50,7 +50,7 @@ Status ClientCacheHelper::get_client(const TNetworkAddress& hostport, const clie
                                      void** client_key, int timeout_ms) {
     std::lock_guard<std::mutex> lock(_lock);
     //VLOG_RPC << "get_client(" << hostport << ")";
-    ClientCacheMap::iterator cache_entry = _client_cache.find(hostport);
+    auto cache_entry = _client_cache.find(hostport);
 
     if (cache_entry == _client_cache.end()) {
         cache_entry = _client_cache.insert(std::make_pair(hostport, std::list<void*>())).first;
@@ -79,7 +79,7 @@ Status ClientCacheHelper::get_client(const TNetworkAddress& hostport, const clie
 
 Status ClientCacheHelper::reopen_client(const client_factory& factory_method, void** client_key, int timeout_ms) {
     std::lock_guard<std::mutex> lock(_lock);
-    ClientMap::iterator i = _client_map.find(*client_key);
+    auto i = _client_map.find(*client_key);
     DCHECK(i != _client_map.end());
     ThriftClientImpl* info = i->second;
     const std::string ipaddress = info->ipaddress();
@@ -134,13 +134,21 @@ Status ClientCacheHelper::create_client(const TNetworkAddress& hostport, const c
 void ClientCacheHelper::release_client(void** client_key) {
     DCHECK(*client_key != nullptr) << "Trying to release NULL client";
     std::lock_guard<std::mutex> lock(_lock);
-    ClientMap::iterator client_map_entry = _client_map.find(*client_key);
-    DCHECK(client_map_entry != _client_map.end());
-    ThriftClientImpl* info = client_map_entry->second;
-    ClientCacheMap::iterator j = _client_cache.find(make_network_address(info->ipaddress(), info->port()));
-    DCHECK(j != _client_cache.end());
 
-    if (_max_cache_size_per_host >= 0 && j->second.size() >= _max_cache_size_per_host) {
+    auto client_map_entry = _client_map.find(*client_key);
+    if (client_map_entry == _client_map.end()) {
+        *client_key = nullptr;
+        return;
+    }
+
+    ThriftClientImpl* info = client_map_entry->second;
+    auto iter = _client_cache.find(make_network_address(info->ipaddress(), info->port()));
+    if (iter == _client_cache.end()) {
+        *client_key = nullptr;
+        return;
+    }
+
+    if (_max_cache_size_per_host >= 0 && iter->second.size() >= _max_cache_size_per_host) {
         // cache of this host is full, close this client connection and remove if from _client_map
         info->close();
         _client_map.erase(*client_key);
@@ -150,7 +158,7 @@ void ClientCacheHelper::release_client(void** client_key) {
             _opened_clients->increment(-1);
         }
     } else {
-        j->second.push_back(*client_key);
+        iter->second.push_back(*client_key);
     }
 
     if (_metrics_enabled) {
@@ -162,14 +170,14 @@ void ClientCacheHelper::release_client(void** client_key) {
 
 void ClientCacheHelper::close_connections(const TNetworkAddress& hostport) {
     std::lock_guard<std::mutex> lock(_lock);
-    ClientCacheMap::iterator cache_entry = _client_cache.find(hostport);
+    auto cache_entry = _client_cache.find(hostport);
     if (cache_entry == _client_cache.end()) {
         return;
     }
 
     auto& client_keys = cache_entry->second;
     for (void* client_key : client_keys) {
-        ClientMap::iterator client_map_entry = _client_map.find(client_key);
+        auto client_map_entry = _client_map.find(client_key);
         DCHECK(client_map_entry != _client_map.end());
         ThriftClientImpl* info = client_map_entry->second;
         info->close();
@@ -183,7 +191,7 @@ std::string ClientCacheHelper::debug_string() {
     std::stringstream out;
     out << "ClientCacheHelper(#hosts=" << _client_cache.size() << " [";
 
-    for (ClientCacheMap::iterator i = _client_cache.begin(); i != _client_cache.end(); ++i) {
+    for (auto i = _client_cache.begin(); i != _client_cache.end(); ++i) {
         if (i != _client_cache.begin()) {
             out << " ";
         }
@@ -193,20 +201,6 @@ std::string ClientCacheHelper::debug_string() {
 
     out << "])";
     return out.str();
-}
-
-void ClientCacheHelper::test_shutdown() {
-    std::vector<TNetworkAddress> hostports;
-    {
-        std::lock_guard<std::mutex> lock(_lock);
-        for (const ClientCacheMap::value_type& i : _client_cache) {
-            hostports.push_back(i.first);
-        }
-    }
-
-    for (auto& hostport : hostports) {
-        close_connections(hostport);
-    }
 }
 
 void ClientCacheHelper::init_metrics(MetricRegistry* metrics, const std::string& key_prefix) {

--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -85,8 +85,6 @@ public:
 
     std::string debug_string();
 
-    void test_shutdown();
-
     void init_metrics(MetricRegistry* metrics, const std::string& key_prefix);
 
 private:
@@ -206,9 +204,6 @@ public:
 
     // Helper method which returns a debug string
     std::string debug_string() { return _client_cache_helper.debug_string(); }
-
-    // For testing only: shutdown all clients
-    void test_shutdown() { return _client_cache_helper.test_shutdown(); }
 
     // Adds metrics for this cache to the supplied MetricRegistry instance. The
     // metrics have keys that are prefixed by the key_prefix argument


### PR DESCRIPTION
If create client with fe failed, all the client in cache for the fe will be closed and removed from cache, so the client maybe already released from cache when close the connection.

```
            FrontendServiceConnection fe_connection(exec_env->frontend_client_cache(), fe_addr, &fe_connection_status);
            if (!fe_connection_status.ok()) {
                std::stringstream ss;
                ss << "couldn't get a client for " << fe_addr;
                LOG(WARNING) << ss.str();
                starrocks::ExecEnv::GetInstance()->profile_report_worker()->unregister_pipeline_load(
                        fragment_ctx->query_id(), fragment_ctx->fragment_instance_id());
                exec_env->frontend_client_cache()->close_connections(fe_addr);
                continue;
            }
```

```
*** SIGSEGV (@0x48) received by PID 3293592 (TID 0x7fddaf4c1700) from PID 72; stack trace: ***
    @          0x6240182 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fdec2089cf0 (unknown)
    @          0x4e5bbfb starrocks::ClientCacheHelper::release_client()
    @          0x5704c5c starrocks::pipeline::ExecStateReporter::report_exec_status()
    @          0x56fa41a _ZNSt17_Function_handlerIFvvEZN9starrocks8pipeline20GlobalDriverExecutor17report_exec_stateEPNS2_12QueryContextEPNS2_15FragmentContextERKNS1_6StatusEbEUlvE_E9_M_invokeERKSt9_Any_data
    @          0x506b022 starrocks::ThreadPool::dispatch_thread()
    @          0x5065b1a starrocks::Thread::supervise_thread()
    @     0x7fdec207f1ca start_thread
    @     0x7fdec155ce73 __GI___clone
    @                0x0 (unknown)
```
