### PR TITLE
[Enhancement] Opt the memory usage of ordinal index

### DIFF
--- a/be/src/storage/rowset/ordinal_page_index.cpp
+++ b/be/src/storage/rowset/ordinal_page_index.cpp
@@ -101,11 +101,14 @@ Status OrdinalIndexReader::_do_load(const IndexReadOptions& opts, const OrdinalI
     if (meta.root_page().is_root_data_page()) {
         // only one data page, no index page
         _num_pages = 1;
+
         _ordinals = std::make_unique<ordinal_t[]>(2);
         _ordinals[0] = 0;
         _ordinals[1] = num_values;
-        _pages = std::make_unique<PagePointer[]>(1);
-        _pages[0] = meta.root_page().root_page();
+
+        _pages = std::make_unique<uint64_t[]>(2);
+        _pages[0] = meta.root_page().root_page().offset();
+        _pages[1] = meta.root_page().root_page().offset() + meta.root_page().root_page().size();
         return Status::OK();
     }
     // need to read index page
@@ -133,7 +136,7 @@ Status OrdinalIndexReader::_do_load(const IndexReadOptions& opts, const OrdinalI
 
     _num_pages = reader.count();
     _ordinals = std::make_unique<ordinal_t[]>(_num_pages + 1);
-    _pages = std::make_unique<PagePointer[]>(_num_pages);
+    _pages = std::make_unique<uint64_t[]>(_num_pages + 1);
     for (int i = 0; i < _num_pages; i++) {
         Slice key = reader.get_key(i);
         ordinal_t ordinal = 0;
@@ -141,9 +144,10 @@ Status OrdinalIndexReader::_do_load(const IndexReadOptions& opts, const OrdinalI
                                                                                (uint8_t*)&ordinal, nullptr));
 
         _ordinals[i] = ordinal;
-        _pages[i] = reader.get_value(i);
+        _pages[i] = reader.get_value(i).offset;
     }
     _ordinals[_num_pages] = num_values;
+    _pages[_num_pages] = reader.get_value(_num_pages - 1).offset + reader.get_value(_num_pages - 1).size;
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/ordinal_page_index.h
+++ b/be/src/storage/rowset/ordinal_page_index.h
@@ -117,7 +117,7 @@ private:
     void _reset();
 
     size_t _mem_usage() const {
-        return sizeof(OrdinalIndexReader) + (_num_pages + 1) * sizeof(ordinal_t) + _num_pages * sizeof(PagePointer);
+        return sizeof(OrdinalIndexReader) + (_num_pages + 1) * sizeof(ordinal_t) + (_num_pages + 1) * sizeof(uint64_t);
     }
 
     Status _do_load(const IndexReadOptions& opts, const OrdinalIndexPB& meta, ordinal_t num_values);
@@ -127,8 +127,8 @@ private:
     int _num_pages = 0;
     // _ordinals[i] = first ordinal of the i-th data page,
     std::unique_ptr<ordinal_t[]> _ordinals;
-    // _pages[i] = page pointer to the i-th data page
-    std::unique_ptr<PagePointer[]> _pages;
+    // _pages[i] = page pointer to offset of the i-th data page
+    std::unique_ptr<uint64_t[]> _pages;
 };
 
 class OrdinalPageIndexIterator {
@@ -142,7 +142,10 @@ public:
         _cur_idx++;
     }
     int32_t page_index() const { return _cur_idx; };
-    const PagePointer& page() const { return _index->_pages[_cur_idx]; };
+    PagePointer page() const {
+        return {_index->_pages[_cur_idx],
+                static_cast<uint32_t>(_index->_pages[_cur_idx + 1] - _index->_pages[_cur_idx])};
+    };
     ordinal_t first_ordinal() const { return _index->get_first_ordinal(_cur_idx); }
     ordinal_t last_ordinal() const { return _index->get_last_ordinal(_cur_idx); }
 


### PR DESCRIPTION
Fixes #issue

For wide tables or when the amount of data is relatively large, the ordinal index will occupy a large amount of memory.

So we replace `PagePointer` with the offsets array to reduce the memory usage.

According to the actual test results, there is no performance loss.

```
mysql> select count(*) from lineorder;
+-----------+
| count(*)  |
+-----------+
| 143999468 |
+-----------+
```
```
select count(lo_orderkey), count(lo_linenumber), count(lo_custkey), count(lo_partkey), count(lo_suppkey), count(lo_orderdate), count(lo_orderpriority), count(lo_shippriority), count(lo_quantity), count(lo_extendedprice), count(lo_ordtotalprice), count(lo_discount), count(lo_revenue), count(lo_supplycost), count(lo_tax), count(lo_commitdate), count(lo_shipmode) from lineorder;
```

BeforeOpt:

```
ordinal index mem usage:  3744832 bytes
segment init time: 36ms
```

AfterOpt

```
ordinal index mem usage: 2536128 bytes
segment init time: 29ms
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
