### PR TITLE
[Feature] Support runtime profile

### DIFF
--- a/be/src/exec/pipeline/adaptive/lazy_instantiate_drivers_operator.cpp
+++ b/be/src/exec/pipeline/adaptive/lazy_instantiate_drivers_operator.cpp
@@ -111,7 +111,7 @@ void LazyInstantiateDriversOperator::close(RuntimeState* state) {
         for (auto& pipeline : pipeline_group.pipelines) {
             auto sink_factory = pipeline->sink_operator_factory();
             if (typeid(*sink_factory) != typeid(ResultSinkOperatorFactory)) {
-                fragment_ctx->count_down_pipeline(state);
+                fragment_ctx->count_down_pipeline();
             } else {
                 // Closing ResultSinkOperator notifies FE not to wait fetch_data anymore.
                 pipeline->source_operator_factory()->set_degree_of_parallelism(1);

--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -42,11 +42,11 @@ std::string to_http_path(const std::string& token, const std::string& file_name)
 
 TReportExecStatusParams ExecStateReporter::create_report_exec_status_params(QueryContext* query_ctx,
                                                                             FragmentContext* fragment_ctx,
+                                                                            RuntimeProfile* profile,
                                                                             const Status& status, bool done) {
     TReportExecStatusParams params;
     auto* runtime_state = fragment_ctx->runtime_state();
     DCHECK(runtime_state != nullptr);
-    auto* profile = runtime_state->runtime_profile();
     DCHECK(profile != nullptr);
     auto* exec_env = fragment_ctx->runtime_state()->exec_env();
     DCHECK(exec_env != nullptr);
@@ -66,7 +66,7 @@ TReportExecStatusParams ExecStateReporter::create_report_exec_status_params(Quer
             runtime_state->update_report_load_status(&params);
             params.__set_load_type(runtime_state->query_options().load_job_type);
         }
-        if (query_ctx->is_report_profile()) {
+        if (query_ctx->enable_profile()) {
             profile->to_thrift(&params.profile);
             params.__isset.profile = true;
         }

--- a/be/src/exec/pipeline/exec_state_reporter.h
+++ b/be/src/exec/pipeline/exec_state_reporter.h
@@ -32,7 +32,8 @@ public:
     ExecStateReporter();
 
     static TReportExecStatusParams create_report_exec_status_params(QueryContext* query_ctx,
-                                                                    FragmentContext* fragment_ctx, const Status& status,
+                                                                    FragmentContext* fragment_ctx,
+                                                                    RuntimeProfile* profile, const Status& status,
                                                                     bool done);
     static Status report_exec_status(const TReportExecStatusParams& params, ExecEnv* exec_env,
                                      const TNetworkAddress& fe_addr);

--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -22,6 +22,7 @@
 #include "runtime/exec_env.h"
 #include "runtime/stream_load/stream_load_context.h"
 #include "runtime/stream_load/transaction_mgr.h"
+#include "util/time.h"
 
 namespace starrocks::pipeline {
 
@@ -80,12 +81,13 @@ void FragmentContext::set_data_sink(std::unique_ptr<DataSink> data_sink) {
     _data_sink = std::move(data_sink);
 }
 
-void FragmentContext::count_down_pipeline(RuntimeState* state, size_t val) {
+void FragmentContext::count_down_pipeline(size_t val) {
     bool all_pipelines_finished = _num_finished_pipelines.fetch_add(val) + val == _pipelines.size();
     if (!all_pipelines_finished) {
         return;
     }
 
+    auto* state = runtime_state();
     auto* query_ctx = state->query_ctx();
 
     state->runtime_profile()->reverse_childs();
@@ -99,11 +101,38 @@ void FragmentContext::count_down_pipeline(RuntimeState* state, size_t val) {
 
     finish();
     auto status = final_status();
-    state->exec_env()->wg_driver_executor()->report_exec_state(query_ctx, this, status, true);
+    state->exec_env()->wg_driver_executor()->report_exec_state(query_ctx, this, status, true, true);
 
     destroy_pass_through_chunk_buffer();
 
     query_ctx->count_down_fragments();
+}
+
+bool FragmentContext::need_report_exec_state() {
+    auto* state = runtime_state();
+    auto* query_ctx = state->query_ctx();
+    if (!query_ctx->enable_profile()) {
+        return false;
+    }
+
+    return (MonotonicNanos() - _last_report_exec_state_ns) >= query_ctx->get_runtime_profile_report_interval_ns();
+}
+
+void FragmentContext::report_exec_state_if_necessary() {
+    auto* state = runtime_state();
+    auto* query_ctx = state->query_ctx();
+    if (!query_ctx->enable_profile()) {
+        return;
+    }
+    auto now = MonotonicNanos();
+    auto last_report_exec_state_ns = _last_report_exec_state_ns.load();
+    if (now - last_report_exec_state_ns < query_ctx->get_runtime_profile_report_interval_ns()) {
+        return;
+    }
+    if (_last_report_exec_state_ns.compare_exchange_strong(last_report_exec_state_ns, now)) {
+        LOG(ERROR) << "report runtime profile, query_id=" << print_id(_query_id);
+        state->exec_env()->wg_driver_executor()->report_exec_state(query_ctx, this, Status::OK(), false, true);
+    }
 }
 
 void FragmentContext::set_final_status(const Status& status) {

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -75,7 +75,10 @@ public:
     size_t num_drivers() const;
 
     bool all_pipelines_finished() const { return _num_finished_pipelines == _pipelines.size(); }
-    void count_down_pipeline(RuntimeState* state, size_t val = 1);
+    void count_down_pipeline(size_t val = 1);
+
+    bool need_report_exec_state();
+    void report_exec_state_if_necessary();
 
     void set_final_status(const Status& status);
 
@@ -190,6 +193,8 @@ private:
     AdaptiveDopParam _adaptive_dop_param;
 
     size_t _expired_log_count = 0;
+
+    std::atomic<int64_t> _last_report_exec_state_ns = MonotonicNanos();
 };
 
 class FragmentContextManager {

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -129,10 +129,13 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const UnifiedExec
     _query_ctx->extend_query_lifetime();
 
     if (query_options.__isset.enable_profile && query_options.enable_profile) {
-        _query_ctx->set_report_profile();
+        _query_ctx->set_enable_profile();
     }
     if (query_options.__isset.pipeline_profile_level) {
         _query_ctx->set_profile_level(query_options.pipeline_profile_level);
+    }
+    if (query_options.__isset.runtime_profile_report_interval) {
+        _query_ctx->set_runtime_profile_report_interval(query_options.runtime_profile_report_interval);
     }
 
     bool enable_query_trace = false;

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -326,7 +326,7 @@ public:
     int32_t plan_node_id() const { return _plan_node_id; }
     virtual Status prepare(RuntimeState* state);
     virtual void close(RuntimeState* state);
-    std::string get_name() const { return _name + "_" + std::to_string(_plan_node_id); }
+    std::string get_name() const { return _name + "_(" + std::to_string(_plan_node_id) + ")"; }
     std::string get_raw_name() const { return _name; }
     // Local rf that take effects on this operator, and operator must delay to schedule to execution on core
     // util the corresponding local rf generated.

--- a/be/src/exec/pipeline/pipeline.cpp
+++ b/be/src/exec/pipeline/pipeline.cpp
@@ -29,7 +29,7 @@ size_t Pipeline::degree_of_parallelism() const {
 void Pipeline::count_down_driver(RuntimeState* state) {
     bool all_drivers_finished = ++_num_finished_drivers == _drivers.size();
     if (all_drivers_finished) {
-        state->fragment_ctx()->count_down_pipeline(state);
+        state->fragment_ctx()->count_down_pipeline();
     }
 }
 

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -416,6 +416,18 @@ void PipelineDriver::check_short_circuit() {
     }
 }
 
+bool PipelineDriver::need_report_exec_state() {
+    return _fragment_ctx->need_report_exec_state();
+}
+
+void PipelineDriver::report_exec_state() {
+    if (_state == DriverState::NOT_READY || _state == DriverState::FINISH || _state == DriverState::CANCELED ||
+        _state == DriverState::INTERNAL_ERROR) {
+        return;
+    }
+    _fragment_ctx->report_exec_state_if_necessary();
+}
+
 void PipelineDriver::mark_precondition_not_ready() {
     for (auto& op : _operators) {
         _operator_stages[op->get_id()] = OperatorStage::PRECONDITION_NOT_READY;

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -410,6 +410,9 @@ public:
     // Check whether an operator can be short-circuited, when is_precondition_block() becomes false from true.
     void check_short_circuit();
 
+    bool need_report_exec_state();
+    void report_exec_state();
+
     std::string to_readable_string() const;
 
     workgroup::WorkGroup* workgroup();

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -179,6 +179,9 @@ void GlobalDriverExecutor::_worker_thread() {
                 }
                 continue;
             }
+
+            driver->report_exec_state();
+
             auto driver_state = maybe_state.value();
             switch (driver_state) {
             case READY:
@@ -279,9 +282,13 @@ void GlobalDriverExecutor::cancel(DriverRawPtr driver) {
 }
 
 void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentContext* fragment_ctx,
-                                             const Status& status, bool done) {
-    _update_profile_by_level(query_ctx, fragment_ctx, done);
-    auto params = ExecStateReporter::create_report_exec_status_params(query_ctx, fragment_ctx, status, done);
+                                             const Status& status, bool done, bool attach_profile) {
+    auto* profile = fragment_ctx->runtime_state()->runtime_profile();
+    if (attach_profile) {
+        profile = _build_merged_instance_profile(query_ctx, fragment_ctx);
+    }
+
+    auto params = ExecStateReporter::create_report_exec_status_params(query_ctx, fragment_ctx, profile, status, done);
     auto fe_addr = fragment_ctx->fe_addr();
     if (fe_addr.hostname.empty()) {
         // query executed by external connectors, like spark and flink connector,
@@ -354,23 +361,19 @@ void GlobalDriverExecutor::iterate_immutable_blocking_driver(const IterateImmuta
     _blocked_driver_poller->iterate_immutable_driver(call);
 }
 
-void GlobalDriverExecutor::_update_profile_by_level(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool done) {
-    if (!done) {
-        return;
-    }
-
-    if (!query_ctx->is_report_profile()) {
-        return;
+RuntimeProfile* GlobalDriverExecutor::_build_merged_instance_profile(QueryContext* query_ctx,
+                                                                     FragmentContext* fragment_ctx) {
+    auto* instance_profile = fragment_ctx->runtime_state()->runtime_profile();
+    if (!query_ctx->enable_profile()) {
+        return instance_profile;
     }
 
     if (query_ctx->profile_level() >= TPipelineProfileLevel::type::DETAIL) {
-        return;
+        return instance_profile;
     }
 
-    auto* profile = fragment_ctx->runtime_state()->runtime_profile();
-
     std::vector<RuntimeProfile*> pipeline_profiles;
-    profile->get_children(&pipeline_profiles);
+    instance_profile->get_children(&pipeline_profiles);
 
     std::vector<RuntimeProfile*> merged_driver_profiles;
     for (auto* pipeline_profile : pipeline_profiles) {
@@ -383,9 +386,8 @@ void GlobalDriverExecutor::_update_profile_by_level(QueryContext* query_ctx, Fra
 
         _remove_non_core_metrics(query_ctx, driver_profiles);
 
-        RuntimeProfile::merge_isomorphic_profiles(driver_profiles);
-        // all the isomorphic profiles will merged into the first profile
-        auto* merged_driver_profile = driver_profiles[0];
+        auto* merged_driver_profile =
+                RuntimeProfile::merge_isomorphic_profiles(query_ctx->object_pool(), driver_profiles);
 
         // use the name of pipeline' profile as pipeline driver's
         merged_driver_profile->set_name(pipeline_profile->name());
@@ -398,12 +400,15 @@ void GlobalDriverExecutor::_update_profile_by_level(QueryContext* query_ctx, Fra
         merged_driver_profiles.push_back(merged_driver_profile);
     }
 
-    // remove pipeline's profile from the hierarchy
-    profile->remove_childs();
+    auto* new_instance_profile = query_ctx->object_pool()->add(new RuntimeProfile(instance_profile->name()));
+    new_instance_profile->copy_all_info_strings_from(instance_profile);
+    new_instance_profile->copy_all_counters_from(instance_profile);
     for (auto* merged_driver_profile : merged_driver_profiles) {
         merged_driver_profile->reset_parent();
-        profile->add_child(merged_driver_profile, true, nullptr);
+        new_instance_profile->add_child(merged_driver_profile, true, nullptr);
     }
+
+    return new_instance_profile;
 }
 
 void GlobalDriverExecutor::_remove_non_core_metrics(QueryContext* query_ctx,

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -48,7 +48,7 @@ public:
     // non-root drivers maybe has pending io task executed in io threads asynchronously has reference
     // to objects owned by FragmentContext.
     virtual void report_exec_state(QueryContext* query_ctx, FragmentContext* fragment_ctx, const Status& status,
-                                   bool done) = 0;
+                                   bool done, bool attach_profile) = 0;
 
     virtual void iterate_immutable_blocking_driver(const IterateImmutableDriverFunc& call) const = 0;
 
@@ -71,8 +71,8 @@ public:
     void change_num_threads(int32_t num_threads) override;
     void submit(DriverRawPtr driver) override;
     void cancel(DriverRawPtr driver) override;
-    void report_exec_state(QueryContext* query_ctx, FragmentContext* fragment_ctx, const Status& status,
-                           bool done) override;
+    void report_exec_state(QueryContext* query_ctx, FragmentContext* fragment_ctx, const Status& status, bool done,
+                           bool attach_profile) override;
 
     void iterate_immutable_blocking_driver(const IterateImmutableDriverFunc& call) const override;
 
@@ -86,7 +86,7 @@ private:
     void _worker_thread();
     StatusOr<DriverRawPtr> _get_next_driver(std::queue<DriverRawPtr>& local_driver_queue);
     void _finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
-    void _update_profile_by_level(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool done);
+    RuntimeProfile* _build_merged_instance_profile(QueryContext* query_ctx, FragmentContext* fragment_ctx);
     void _remove_non_core_metrics(QueryContext* query_ctx, std::vector<RuntimeProfile*>& driver_profiles);
 
     void _finalize_epoch(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -139,7 +139,7 @@ void PipelineDriverPoller::run_internal() {
                 } else if (driver->is_finished()) {
                     remove_blocked_driver(_local_blocked_drivers, driver_it);
                     ready_drivers.emplace_back(driver);
-                } else if (driver->is_not_blocked()) {
+                } else if (driver->is_not_blocked() || driver->need_report_exec_state()) {
                     driver->set_driver_state(DriverState::READY);
                     remove_blocked_driver(_local_blocked_drivers, driver_it);
                     ready_drivers.emplace_back(driver);

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -86,8 +86,12 @@ public:
         _query_deadline =
                 duration_cast<milliseconds>(steady_clock::now().time_since_epoch() + _query_expire_seconds).count();
     }
-    void set_report_profile() { _is_report_profile = true; }
-    bool is_report_profile() { return _is_report_profile; }
+    void set_enable_profile() { _enable_profile = true; }
+    bool enable_profile() { return _enable_profile; }
+    void set_runtime_profile_report_interval(int64_t runtime_profile_report_interval_s) {
+        _runtime_profile_report_interval_ns = 1'000'000'000L * runtime_profile_report_interval_s;
+    }
+    int64_t get_runtime_profile_report_interval_ns() { return _runtime_profile_report_interval_ns; }
     void set_profile_level(const TPipelineProfileLevel::type& profile_level) { _profile_level = profile_level; }
     const TPipelineProfileLevel::type& profile_level() { return _profile_level; }
 
@@ -187,7 +191,8 @@ private:
     bool _is_runtime_filter_coordinator = false;
     std::once_flag _init_mem_tracker_once;
     std::shared_ptr<RuntimeProfile> _profile;
-    bool _is_report_profile = false;
+    bool _enable_profile = false;
+    int64_t _runtime_profile_report_interval_ns = std::numeric_limits<int64_t>::max();
     TPipelineProfileLevel::type _profile_level;
     std::shared_ptr<MemTracker> _mem_tracker;
     ObjectPool _object_pool;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -507,16 +507,15 @@ void ScanOperator::_merge_chunk_source_profiles(RuntimeState* state) {
         query_ctx = state->exec_env()->query_context_mgr()->get(state->query_id());
         DCHECK(query_ctx != nullptr);
     }
-    if (!query_ctx->is_report_profile()) {
+    if (!query_ctx->enable_profile()) {
         return;
     }
     std::vector<RuntimeProfile*> profiles(_chunk_source_profiles.size());
     for (auto i = 0; i < _chunk_source_profiles.size(); i++) {
         profiles[i] = _chunk_source_profiles[i].get();
     }
-    RuntimeProfile::merge_isomorphic_profiles(profiles);
 
-    RuntimeProfile* merged_profile = profiles[0];
+    RuntimeProfile* merged_profile = RuntimeProfile::merge_isomorphic_profiles(query_ctx->object_pool(), profiles);
 
     _unique_metrics->copy_all_info_strings_from(merged_profile);
     _unique_metrics->copy_all_counters_from(merged_profile);

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -556,8 +556,35 @@ void PInternalServiceImplBase<T>::trigger_profile_report(google::protobuf::RpcCo
                                                          PTriggerProfileReportResult* result,
                                                          google::protobuf::Closure* done) {
     ClosureGuard closure_guard(done);
-    auto st = _exec_env->fragment_mgr()->trigger_profile_report(request);
-    st.to_protobuf(result->mutable_status());
+    result->mutable_status()->set_status_code(TStatusCode::OK);
+
+    TUniqueId query_id;
+    DCHECK(request->has_query_id());
+    query_id.__set_hi(request->query_id().hi());
+    query_id.__set_lo(request->query_id().lo());
+
+    auto&& query_ctx = _exec_env->query_context_mgr()->get(query_id);
+    if (query_ctx == nullptr) {
+        LOG(WARNING) << "query context is null, query_id=" << print_id(query_id);
+        result->mutable_status()->set_status_code(TStatusCode::NOT_FOUND);
+        return;
+    }
+
+    for (size_t i = 0; i < request->instance_ids_size(); i++) {
+        TUniqueId instance_id;
+        instance_id.__set_hi(request->instance_ids(i).hi());
+        instance_id.__set_lo(request->instance_ids(i).lo());
+
+        auto&& fragment_ctx = query_ctx->fragment_mgr()->get(instance_id);
+        if (fragment_ctx == nullptr) {
+            LOG(WARNING) << "fragment context is null, query_id=" << print_id(query_id)
+                         << ", instance_id=" << print_id(instance_id);
+            result->mutable_status()->set_status_code(TStatusCode::NOT_FOUND);
+            return;
+        }
+        pipeline::DriverExecutor* driver_executor = _exec_env->wg_driver_executor();
+        driver_executor->report_exec_state(query_ctx.get(), fragment_ctx.get(), Status::OK(), false, true);
+    }
 }
 
 template <typename T>

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -586,7 +586,7 @@ public:
     // Merge all the isomorphic sub profiles and the caller must know for sure
     // that all the children are isomorphic, otherwise, the behavior is undefined
     // The merged result will be stored in the first profile
-    static void merge_isomorphic_profiles(std::vector<RuntimeProfile*>& profiles);
+    static RuntimeProfile* merge_isomorphic_profiles(ObjectPool* obj_pool, std::vector<RuntimeProfile*>& profiles);
 
 private:
     static const std::unordered_set<std::string> NON_MERGE_COUNTER_NAMES;

--- a/be/test/exec/stream/stream_operators_test.cpp
+++ b/be/test/exec/stream/stream_operators_test.cpp
@@ -68,7 +68,7 @@ StatusOr<ChunkPtr> GeneratorStreamSourceOperator::pull_chunk(starrocks::RuntimeS
 }
 
 Status PrinterStreamSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
-    std::cout << "<<<<<<<<< Sink Result: " << chunk->debug_columns() << std::endl;
+    std::cout << "========= Sink Result: " << chunk->debug_columns() << std::endl;
     for (auto& col : chunk->columns()) {
         std::cout << col->debug_string() << std::endl;
     }

--- a/be/test/util/runtime_profile_test.cpp
+++ b/be/test/util/runtime_profile_test.cpp
@@ -28,6 +28,7 @@ static TCounterStrategy create_strategy(TUnit::type type) {
 }
 
 TEST(TestRuntimeProfile, testMergeIsomorphicProfiles1) {
+    std::shared_ptr<ObjectPool> obj_pool = std::make_shared<ObjectPool>();
     std::vector<RuntimeProfile*> profiles;
 
     auto profile1 = std::make_shared<RuntimeProfile>("profile");
@@ -56,9 +57,8 @@ TEST(TestRuntimeProfile, testMergeIsomorphicProfiles1) {
         profiles.push_back(profile2.get());
     }
 
-    RuntimeProfile::merge_isomorphic_profiles(profiles);
+    auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(obj_pool.get(), profiles);
 
-    auto* merged_profile = profiles[0];
     auto* merged_time1 = merged_profile->get_counter("time1");
     ASSERT_EQ(2000000000L, merged_time1->value());
     auto* merged_min_of_time1 = merged_profile->get_counter("__MIN_OF_time1");
@@ -88,6 +88,7 @@ TEST(TestRuntimeProfile, testMergeIsomorphicProfiles1) {
 }
 
 TEST(TestRuntimeProfile, testMergeIsomorphicProfiles2) {
+    std::shared_ptr<ObjectPool> obj_pool = std::make_shared<ObjectPool>();
     std::vector<RuntimeProfile*> profiles;
 
     auto profile1 = std::make_shared<RuntimeProfile>("profile");
@@ -136,9 +137,7 @@ TEST(TestRuntimeProfile, testMergeIsomorphicProfiles2) {
         profiles.push_back(profile2.get());
     }
 
-    RuntimeProfile::merge_isomorphic_profiles(profiles);
-
-    auto* merged_profile = profiles[0];
+    auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(obj_pool.get(), profiles);
     auto* merged_time1 = merged_profile->get_counter("time1");
     ASSERT_EQ(2500000000L, merged_time1->value());
     auto* merged_min_of_time1 = merged_profile->get_counter("__MIN_OF_time1");
@@ -159,6 +158,7 @@ TEST(TestRuntimeProfile, testMergeIsomorphicProfiles2) {
 }
 
 TEST(TestRuntimeProfile, testProfileMergeStrategy) {
+    std::shared_ptr<ObjectPool> obj_pool = std::make_shared<ObjectPool>();
     std::vector<RuntimeProfile*> profiles;
 
     TCounterStrategy strategy1;
@@ -210,9 +210,7 @@ TEST(TestRuntimeProfile, testProfileMergeStrategy) {
         profiles.push_back(profile2.get());
     }
 
-    RuntimeProfile::merge_isomorphic_profiles(profiles);
-
-    auto* merged_profile = profiles[0];
+    auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(obj_pool.get(), profiles);
 
     auto* merged_time1 = merged_profile->get_counter("time1");
     ASSERT_EQ(2000000000L, merged_time1->value());
@@ -248,6 +246,7 @@ TEST(TestRuntimeProfile, testProfileMergeStrategy) {
 }
 
 TEST(TestRuntimeProfile, testConflictInfoString) {
+    std::shared_ptr<ObjectPool> obj_pool = std::make_shared<ObjectPool>();
     std::vector<RuntimeProfile*> profiles;
     auto profile1 = std::make_shared<RuntimeProfile>("profile");
     {
@@ -277,9 +276,7 @@ TEST(TestRuntimeProfile, testConflictInfoString) {
         profiles.push_back(profile5.get());
     }
 
-    RuntimeProfile::merge_isomorphic_profiles(profiles);
-
-    auto* merged_profile = profiles[0];
+    auto* merged_profile = RuntimeProfile::merge_isomorphic_profiles(obj_pool.get(), profiles);
     const std::set<std::string> expected_values{"value1", "value2", "value3", "value4", "value5", "value6"};
     std::set<std::string> actual_values;
     ASSERT_TRUE(merged_profile->get_info_string("key1") != nullptr);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -44,12 +44,9 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Deque;
-import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
@@ -78,27 +75,20 @@ public class ProfileManager {
     public static final String VARIABLES = "Variables";
     public static final String PROFILE_TIME = "Collect Profile Time";
 
-    public static final ArrayList<String> PROFILE_HEADERS = new ArrayList(
+    public static final ArrayList<String> PROFILE_HEADERS = new ArrayList<>(
             Arrays.asList(QUERY_ID, USER, DEFAULT_DB, SQL_STATEMENT, QUERY_TYPE,
                     START_TIME, END_TIME, TOTAL_TIME, QUERY_STATE));
 
-    private class ProfileElement {
+    private static class ProfileElement {
         public Map<String, String> infoStrings = Maps.newHashMap();
         public byte[] profileContent;
     }
 
-    // Only protect profileDeque; profileMap is concurrent, no need to protect
-    private ReentrantReadWriteLock lock;
-    private ReadLock readLock;
-    private WriteLock writeLock;
+    private final ReadLock readLock;
+    private final WriteLock writeLock;
 
-    private Deque<ProfileElement> profileDeque;
-
-    // The frequency of load may be relatively high,
-    // so do not use the same deque and map of the query to reduce the impact on the query
-    private Deque<ProfileElement> loadProfileDeque;
-    private Map<String, ProfileElement> profileMap; // from QueryId to RuntimeProfile
-    private Map<String, ProfileElement> loadProfileMap; // from LoadId to RuntimeProfile
+    private final LinkedHashMap<String, ProfileElement> profileMap; // from QueryId to RuntimeProfile
+    private final LinkedHashMap<String, ProfileElement> loadProfileMap; // from LoadId to RuntimeProfile
 
     public static ProfileManager getInstance() {
         if (INSTANCE == null) {
@@ -108,13 +98,12 @@ public class ProfileManager {
     }
 
     private ProfileManager() {
-        lock = new ReentrantReadWriteLock(true);
+        // Only protect profileDeque; profileMap is concurrent, no need to protect
+        ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
         readLock = lock.readLock();
         writeLock = lock.writeLock();
-        profileDeque = new LinkedList<ProfileElement>();
-        profileMap = new ConcurrentHashMap<String, ProfileElement>();
-        loadProfileDeque = new LinkedList<ProfileElement>();
-        loadProfileMap = new ConcurrentHashMap<String, ProfileElement>();
+        profileMap = new LinkedHashMap<>();
+        loadProfileMap = new LinkedHashMap<>();
     }
 
     public ProfileElement createElement(RuntimeProfile summaryProfile, String profileString) {
@@ -163,14 +152,12 @@ public class ProfileManager {
                     + "may be forget to insert 'QUERY_ID' column into infoStrings");
         }
 
-        profileMap.put(queryId, element);
         writeLock.lock();
         try {
-            if (profileDeque.size() >= Config.profile_info_reserved_num) {
-                profileMap.remove(profileDeque.getFirst().infoStrings.get(QUERY_ID));
-                profileDeque.removeFirst();
+            profileMap.put(queryId, element);
+            if (profileMap.size() >= Config.profile_info_reserved_num) {
+                profileMap.remove(profileMap.keySet().iterator().next());
             }
-            profileDeque.addLast(element);
         } finally {
             writeLock.unlock();
         }
@@ -190,14 +177,12 @@ public class ProfileManager {
                     + "may be forget to insert 'QUERY_ID' column into infoStrings");
         }
 
-        loadProfileMap.put(loadId, element);
         writeLock.lock();
         try {
-            if (loadProfileDeque.size() >= Config.load_profile_info_reserved_num) {
-                loadProfileMap.remove(profileDeque.getFirst().infoStrings.get(loadId));
-                loadProfileDeque.removeFirst();
+            loadProfileMap.put(loadId, element);
+            if (loadProfileMap.size() >= Config.load_profile_info_reserved_num) {
+                loadProfileMap.remove(loadProfileMap.keySet().iterator().next());
             }
-            loadProfileDeque.addLast(element);
         } finally {
             writeLock.unlock();
         }
@@ -205,21 +190,17 @@ public class ProfileManager {
         return profileString;
     }
 
-
     public List<List<String>> getAllQueries() {
-        List<List<String>> result = Lists.newArrayList();
+        List<List<String>> result = Lists.newLinkedList();
         readLock.lock();
         try {
-            Iterator reverse = profileDeque.descendingIterator();
-            while (reverse.hasNext()) {
-                ProfileElement element = (ProfileElement) reverse.next();
+            for (ProfileElement element : profileMap.values()) {
                 Map<String, String> infoStrings = element.infoStrings;
-
                 List<String> row = Lists.newArrayList();
                 for (String str : PROFILE_HEADERS) {
                     row.add(infoStrings.get(str));
                 }
-                result.add(row);
+                result.add(0, row);
             }
         } finally {
             readLock.unlock();

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -98,7 +98,6 @@ public class ProfileManager {
     }
 
     private ProfileManager() {
-        // Only protect profileDeque; profileMap is concurrent, no need to protect
         ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
         readLock = lock.readLock();
         writeLock = lock.writeLock();

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -531,16 +531,15 @@ public class RuntimeProfile {
 
     // Merge all the isomorphic sub profiles and the caller must know for sure
     // that all the children are isomorphic, otherwise, the behavior is undefined
-    // The merged result will be stored in the first profile
-    public static void mergeIsomorphicProfiles(List<RuntimeProfile> profiles) {
+    public static RuntimeProfile mergeIsomorphicProfiles(List<RuntimeProfile> profiles) {
         if (CollectionUtils.isEmpty(profiles)) {
-            return;
+            return null;
         }
 
-        RuntimeProfile profile0 = profiles.get(0);
+        RuntimeProfile mergedProfile = new RuntimeProfile(profiles.get(0).getName());
 
-        for (int i = 1; i < profiles.size(); i++) {
-            profile0.copyAllInfoStringsFrom(profiles.get(i));
+        for (RuntimeProfile runtimeProfile : profiles) {
+            mergedProfile.copyAllInfoStringsFrom(runtimeProfile);
         }
 
         // Find all counters, although these profiles are expected to be isomorphic,
@@ -569,9 +568,6 @@ public class RuntimeProfile {
                     Pair<Counter, String> pair = profile.counterMap.get(name);
                     Preconditions.checkNotNull(pair);
                     Counter counter = pair.first;
-                    if (counter.isSkipMerge()) {
-                        continue;
-                    }
                     String parentName = pair.second;
 
                     while (allLevelCounters.size() <= levelIdx) {
@@ -587,8 +583,8 @@ public class RuntimeProfile {
                     if (!existType.equals(counter.getType())) {
                         LOG.warn(
                                 "find non-isomorphic counter, profileName={}, counterName={}, existType={}, anotherType={}",
-                                profile0.name, name, existType.name(), counter.getType().name());
-                        return;
+                                mergedProfile.name, name, existType.name(), counter.getType().name());
+                        continue;
                     }
                 }
             }
@@ -618,6 +614,8 @@ public class RuntimeProfile {
             long minValue = Long.MAX_VALUE;
             long maxValue = Long.MIN_VALUE;
             boolean alreadyMerged = false;
+            boolean skipMerge = false;
+            Counter skipMergeCounter = null;
             TCounterStrategy strategy = null;
             for (RuntimeProfile profile : profiles) {
                 Counter counter = profile.getCounter(name);
@@ -631,10 +629,15 @@ public class RuntimeProfile {
                 if (!type.equals(counter.getType())) {
                     LOG.warn(
                             "find non-isomorphic counter, profileName={}, counterName={}, existType={}, anotherType={}",
-                            profile0.name, name, type.name(), counter.getType().name());
-                    return;
+                            mergedProfile.name, name, type.name(), counter.getType().name());
+                    continue;
                 }
                 strategy = counter.getStrategy();
+                if (counter.isSkipMerge()) {
+                    skipMerge = true;
+                    skipMergeCounter = counter;
+                    break;
+                }
 
                 Counter minCounter = profile.getCounter(MERGED_INFO_PREFIX_MIN + name);
                 if (minCounter != null) {
@@ -652,56 +655,60 @@ public class RuntimeProfile {
                 }
                 counters.add(counter);
             }
-            Counter.MergedInfo mergedInfo = Counter.mergeIsomorphicCounters(counters);
-            final long mergedValue = mergedInfo.mergedValue;
-            if (!alreadyMerged) {
-                minValue = mergedInfo.minValue;
-                maxValue = mergedInfo.maxValue;
-            }
-
-            Counter counter0 = profile0.getCounter(name);
-            // As stated before, some counters may only attach to one of the isomorphic profiles
-            // and the first profile may not have this counter, so we create a counter here
-            if (counter0 == null) {
-                if (!Objects.equals(ROOT_COUNTER, parentName) && profile0.getCounter(parentName) != null) {
-                    counter0 = profile0.addCounter(name, type, strategy, parentName);
-                } else {
-                    if (!Objects.equals(ROOT_COUNTER, parentName)) {
-                        LOG.warn("missing parent counter, profileName={}, counterName={}, parentCounterName={}",
-                                profile0.name, name, parentName);
-                    }
-                    counter0 = profile0.addCounter(name, type, strategy);
+            Counter mergedCounter = null;
+            if (!Objects.equals(ROOT_COUNTER, parentName) && mergedProfile.getCounter(parentName) != null) {
+                mergedCounter = mergedProfile.addCounter(name, type, strategy, parentName);
+            } else {
+                if (!Objects.equals(ROOT_COUNTER, parentName)) {
+                    LOG.warn("missing parent counter, profileName={}, counterName={}, parentCounterName={}",
+                            mergedProfile.name, name, parentName);
                 }
+                mergedCounter = mergedProfile.addCounter(name, type, strategy);
             }
-            counter0.setValue(mergedValue);
+            if (skipMerge) {
+                mergedCounter.setValue(skipMergeCounter.getValue());
+            } else {
+                Counter.MergedInfo mergedInfo = Counter.mergeIsomorphicCounters(counters);
+                final long mergedValue = mergedInfo.mergedValue;
+                if (!alreadyMerged) {
+                    minValue = mergedInfo.minValue;
+                    maxValue = mergedInfo.maxValue;
+                }
+                mergedCounter.setValue(mergedValue);
 
-            Counter minCounter = profile0.addCounter(MERGED_INFO_PREFIX_MIN + name, type, counter0.getStrategy(), name);
-            Counter maxCounter = profile0.addCounter(MERGED_INFO_PREFIX_MAX + name, type, counter0.getStrategy(), name);
-            minCounter.setValue(minValue);
-            maxCounter.setValue(maxValue);
+                Counter minCounter =
+                        mergedProfile.addCounter(MERGED_INFO_PREFIX_MIN + name, type, mergedCounter.getStrategy(),
+                                name);
+                Counter maxCounter =
+                        mergedProfile.addCounter(MERGED_INFO_PREFIX_MAX + name, type, mergedCounter.getStrategy(),
+                                name);
+                minCounter.setValue(minValue);
+                maxCounter.setValue(maxValue);
+            }
+
         }
 
         // merge children
-        for (int i = 0; i < profile0.childList.size(); i++) {
+        for (int i = 0; i < profiles.get(0).childList.size(); i++) {
             List<RuntimeProfile> subProfiles = Lists.newArrayList();
-            RuntimeProfile child0 = profile0.childList.get(i).first;
-            subProfiles.add(child0);
-            for (int j = 1; j < profiles.size(); j++) {
-                RuntimeProfile profile = profiles.get(j);
+            for (RuntimeProfile profile : profiles) {
                 if (i >= profile.childList.size()) {
                     LOG.warn("find non-isomorphic children, profileName={}, childProfileNames={}" +
                                     ", another profileName={}, another childProfileNames={}",
-                            profile0.name,
-                            profile0.childList.stream().map(p -> p.first.getName()).collect(Collectors.toList()),
+                            mergedProfile.name,
+                            mergedProfile.childList.stream().map(p -> p.first.getName()).collect(Collectors.toList()),
                             profile.name,
                             profile.childList.stream().map(p -> p.first.getName()).collect(Collectors.toList()));
-                    return;
+                    continue;
                 }
                 RuntimeProfile child = profile.childList.get(i).first;
                 subProfiles.add(child);
             }
-            mergeIsomorphicProfiles(subProfiles);
+            RuntimeProfile mergedChild = mergeIsomorphicProfiles(subProfiles);
+            mergedProfile.addChild(mergedChild);
         }
+
+        return mergedProfile;
     }
 
     public static void removeRedundantMinMaxMetrics(RuntimeProfile profile) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -238,8 +238,7 @@ public class LoadLoadingTask extends LoadTask {
                 curCoordinator.getQueryProfile().getCounterTotalTime()
                         .setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
                 curCoordinator.endProfile();
-                curCoordinator.mergeIsomorphicProfiles(null);
-                profile.addChild(curCoordinator.getQueryProfile());
+                profile.addChild(curCoordinator.buildMergedQueryProfile(null));
 
                 StringBuilder builder = new StringBuilder();
                 profile.prettyPrint(builder, "");

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1046,15 +1046,15 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
 
         profile.addChild(summaryProfile);
         if (coord.getQueryProfile() != null) {
-            profile.addChild(coord.getQueryProfile());
             if (!isSyncStreamLoad()) {
                 coord.endProfile();
-                coord.mergeIsomorphicProfiles(null);
+                profile.addChild(coord.buildMergedQueryProfile(null));
+            } else {
+                profile.addChild(coord.getQueryProfile());
             }
         }
 
         ProfileManager.getInstance().pushLoadProfile(profile);
-        return;
     }
 
     public void setLoadState(long loadBytes, long loadRows, long filteredRows, long unselectedRows,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
@@ -183,6 +183,16 @@ public class QueryState {
         return packet;
     }
 
+    public String toProfileString() {
+        if (stateType == MysqlStateType.EOF) {
+            return "Finished";
+        } else if (stateType == MysqlStateType.ERR) {
+            return "Error";
+        } else {
+            return "Running";
+        }
+    }
+
     @Override
     public String toString() {
         return String.valueOf(stateType);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -202,6 +202,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String MAX_PIPELINE_DOP = "max_pipeline_dop";
 
     public static final String PROFILE_TIMEOUT = "profile_timeout";
+    public static final String RUNTIME_PROFILE_REPORT_INTERVAL = "runtime_profile_report_interval";
     public static final String PROFILE_LIMIT_FOLD = "profile_limit_fold";
     public static final String PIPELINE_PROFILE_LEVEL = "pipeline_profile_level";
 
@@ -693,6 +694,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PROFILE_TIMEOUT, flag = VariableMgr.INVISIBLE)
     private int profileTimeout = 2;
+
+    @VariableMgr.VarAttr(name = RUNTIME_PROFILE_REPORT_INTERVAL)
+    private int runtimeProfileReportInterval = 10;
 
     @VariableMgr.VarAttr(name = PROFILE_LIMIT_FOLD, flag = VariableMgr.INVISIBLE)
     private boolean profileLimitFold = true;
@@ -1745,6 +1749,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return profileTimeout;
     }
 
+    public int getRuntimeProfileReportInterval() {
+        return runtimeProfileReportInterval;
+    }
+
     public boolean isProfileLimitFold() {
         return profileLimitFold;
     }
@@ -2214,6 +2222,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setQuery_timeout(Math.min(Integer.MAX_VALUE / 1000, queryTimeoutS));
         tResult.setQuery_delivery_timeout(Math.min(Integer.MAX_VALUE / 1000, queryDeliveryTimeoutS));
         tResult.setEnable_profile(enableProfile);
+        tResult.setRuntime_profile_report_interval(runtimeProfileReportInterval);
         tResult.setBatch_size(chunkSize);
         tResult.setLoad_mem_limit(loadMemLimit);
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -832,7 +832,7 @@ public class StmtExecutor {
                 new QeProcessorImpl.QueryInfo(context, originStmt.originStmt, coord));
 
         coord.exec();
-        coord.setQueryTopLevelProfileGen(this::buildTopLevelProfile);
+        coord.setTopProfileSupplier(this::buildTopLevelProfile);
 
         // send result
         // 1. If this is a query with OUTFILE clause, eg: select * from tbl1 into outfile xxx,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -241,9 +241,8 @@ public class StmtExecutor {
         return this.coord;
     }
 
-    // At the end of query execution, we begin to add up profile
-    public void initProfile(long beginTimeInNanoSecond) {
-        profile = new RuntimeProfile("Query");
+    private RuntimeProfile buildTopLevelProfile() {
+        RuntimeProfile profile = new RuntimeProfile("Query");
         RuntimeProfile summaryProfile = new RuntimeProfile("Summary");
         summaryProfile.addInfoString(ProfileManager.QUERY_ID, DebugUtil.printId(context.getExecutionId()));
         summaryProfile.addInfoString(ProfileManager.START_TIME, TimeUtils.longToTimeString(context.getStartTime()));
@@ -254,7 +253,7 @@ public class StmtExecutor {
         summaryProfile.addInfoString(ProfileManager.TOTAL_TIME, DebugUtil.getPrettyStringMs(totalTimeMs));
 
         summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Query");
-        summaryProfile.addInfoString(ProfileManager.QUERY_STATE, context.getState().toString());
+        summaryProfile.addInfoString(ProfileManager.QUERY_STATE, context.getState().toProfileString());
         summaryProfile.addInfoString("StarRocks Version",
                 String.format("%s-%s", Version.STARROCKS_VERSION, Version.STARROCKS_COMMIT_HASH));
         summaryProfile.addInfoString(ProfileManager.USER, context.getQualifiedUser());
@@ -289,13 +288,17 @@ public class StmtExecutor {
         RuntimeProfile plannerProfile = new RuntimeProfile("Planner");
         profile.addChild(plannerProfile);
         context.getPlannerProfile().build(plannerProfile);
+        return profile;
+    }
 
+    // At the end of query execution, we begin to add up profile
+    private void initProfile(long beginTimeInNanoSecond) {
+        profile = buildTopLevelProfile();
         if (coord != null) {
             if (coord.getQueryProfile() != null) {
                 coord.getQueryProfile().getCounterTotalTime().setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
                 coord.endProfile();
-                coord.mergeIsomorphicProfiles(getQueryStatisticsForAuditLog());
-                profile.addChild(coord.getQueryProfile());
+                profile.addChild(coord.buildMergedQueryProfile(getQueryStatisticsForAuditLog()));
             }
             coord = null;
         }
@@ -829,6 +832,7 @@ public class StmtExecutor {
                 new QeProcessorImpl.QueryInfo(context, originStmt.originStmt, coord));
 
         coord.exec();
+        coord.setQueryTopLevelProfileGen(this::buildTopLevelProfile);
 
         // send result
         // 1. If this is a query with OUTFILE clause, eg: select * from tbl1 into outfile xxx,

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PTriggerProfileReportRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PTriggerProfileReportRequest.java
@@ -20,7 +20,6 @@ package com.starrocks.rpc;
 import com.baidu.bjf.remoting.protobuf.FieldType;
 import com.baidu.bjf.remoting.protobuf.annotation.Protobuf;
 import com.baidu.bjf.remoting.protobuf.annotation.ProtobufClass;
-import com.google.common.collect.Lists;
 import com.starrocks.proto.PUniqueId;
 
 import java.util.List;
@@ -31,11 +30,14 @@ public class PTriggerProfileReportRequest extends AttachmentRequest {
     @Protobuf(fieldType = FieldType.OBJECT, order = 1, required = false)
     List<PUniqueId> instanceIds;
 
+    @Protobuf(order = 2, required = false)
+    PUniqueId queryId;
+
     public PTriggerProfileReportRequest() {
     }
 
-    public PTriggerProfileReportRequest(List<PUniqueId> instanceIds) {
-        this.instanceIds = Lists.newArrayList();
-        this.instanceIds.addAll(instanceIds);
+    public PTriggerProfileReportRequest(List<PUniqueId> instanceIds, PUniqueId queryId) {
+        this.instanceIds = instanceIds;
+        this.queryId = queryId;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
@@ -226,9 +226,9 @@ public class RuntimeProfileTest {
             profiles.add(profile2);
         }
 
-        RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        Assert.assertNotNull(mergedProfile);
 
-        RuntimeProfile mergedProfile = profiles.get(0);
         Counter mergedTime1 = mergedProfile.getCounter("time1");
         Assert.assertEquals(2000000000L, mergedTime1.getValue());
         Counter mergedMinOfTime1 = mergedProfile.getCounter("__MIN_OF_time1");
@@ -299,9 +299,9 @@ public class RuntimeProfileTest {
             profiles.add(profile2);
         }
 
-        RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        Assert.assertNotNull(mergedProfile);
 
-        RuntimeProfile mergedProfile = profiles.get(0);
         Counter mergedTime1 = mergedProfile.getCounter("time1");
         Assert.assertEquals(2500000000L, mergedTime1.getValue());
         Counter mergedMinOfTime1 = mergedProfile.getCounter("__MIN_OF_time1");
@@ -374,9 +374,8 @@ public class RuntimeProfileTest {
             profiles.add(profile2);
         }
 
-        RuntimeProfile.mergeIsomorphicProfiles(profiles);
-
-        RuntimeProfile mergedProfile = profiles.get(0);
+        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        Assert.assertNotNull(mergedProfile);
 
         Counter mergedTime1 = mergedProfile.getCounter("time1");
         Assert.assertEquals(2000000000L, mergedTime1.getValue());
@@ -483,9 +482,9 @@ public class RuntimeProfileTest {
             profiles.add(profile2);
         }
 
-        RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        Assert.assertNotNull(mergedProfile);
 
-        RuntimeProfile mergedProfile = profiles.get(0);
         Assert.assertEquals(13, mergedProfile.getCounterMap().size());
         RuntimeProfile.removeRedundantMinMaxMetrics(mergedProfile);
         Assert.assertEquals(7, mergedProfile.getCounterMap().size());
@@ -539,8 +538,8 @@ public class RuntimeProfileTest {
             profiles.add(profile5);
         }
 
-        RuntimeProfile.mergeIsomorphicProfiles(profiles);
-        RuntimeProfile mergedProfile = profiles.get(0);
+        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        Assert.assertNotNull(mergedProfile);
 
         Set<String> expectedValues = Sets.newHashSet("value1", "value2", "value3", "value4", "value5", "value6");
         Set<String> actualValues = Sets.newHashSet();

--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJournalCursorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJournalCursorTest.java
@@ -139,7 +139,7 @@ public class BDBJournalCursorTest {
         journal.batchWriteCommit();
 
         for (int i = 1; i <= 5; ++ i) {
-            // <<< read from i to 6
+            // read from i to 6
             LOG.info("pretend I'm reading from {} to 6", i);
             BDBJournalCursor bdbJournalCursor = BDBJournalCursor.getJournalCursor(environment, i, -1);
             for (int j = i; j <= 6; ++ j) {
@@ -151,7 +151,7 @@ public class BDBJournalCursorTest {
         }
 
         //
-        // <<< read 6->6
+        // read 6->6
         //
         BDBJournalCursor bdbJournalCursor = BDBJournalCursor.getJournalCursor(environment, 6, -1);
         JournalEntity entity = bdbJournalCursor.next();
@@ -161,14 +161,14 @@ public class BDBJournalCursorTest {
         Assert.assertNull(bdbJournalCursor.next());
 
         //
-        // >>> write 7
+        // write 7
         //
         journal.batchWriteBegin();
         journal.batchWriteAppend(7, makeBuffer(7));
         journal.batchWriteCommit();
 
         //
-        // <<< read 7
+        // read 7
         //
         bdbJournalCursor.refresh();
         entity = bdbJournalCursor.next();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -156,7 +156,7 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
     }
 
     /**
-     * >>>>>>>>> Analyze TPCH MVs Result <<<<<<<<<
+     * ========= Analyze TPCH MVs Result =========
      *
      * TableName:partsupp_mv
      * Columns:n_name,p_mfgr,p_size,p_type,ps_partkey,ps_partvalue,ps_suppkey,ps_supplycost,r_name,s_acctbal,s_address,
@@ -179,7 +179,7 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
      * Columns:c_custkey,o_comment,o_orderkey
      * Queries:13
      *
-     * >>>>>>>>> Analyze TPCH MVs Result <<<<<<<<<
+     * ========= Analyze TPCH MVs Result =========
      */
     @Test
     public void analyzeTPCHMVs() throws Exception {
@@ -206,7 +206,7 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
             }
         }
 
-        System.out.println(">>>>>>>>> Analyze TPCH MVs Result <<<<<<<<<");
+        System.out.println("========= Analyze TPCH MVs Result =========");
         System.out.println();
         int totolQueriesUsedMV = 0;
         for (Map.Entry<String, Set<String>> entry : mvTableColumnsMap.entrySet()) {
@@ -218,7 +218,7 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
             System.out.println();
             totolQueriesUsedMV += mvTableQueryIds.get(mvTableName).size();
         }
-        System.out.println(">>>>>>>>> Analyze TPCH MVs Result <<<<<<<<<");
+        System.out.println("========= Analyze TPCH MVs Result =========");
         Assert.assertTrue(mvTableColumnsMap.size() >= 4);
         Assert.assertTrue(totolQueriesUsedMV >= 19);
     }

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -375,6 +375,7 @@ message PFetchDataResult {
 
 message PTriggerProfileReportRequest {
     repeated PUniqueId instance_ids = 1;
+    optional PUniqueId query_id = 2;
 };
 
 message PTriggerProfileReportResult {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -212,6 +212,8 @@ struct TQueryOptions {
   96: optional i64 spillable_operator_mask;
   // used to judge whether the profile need to report to FE, only meaningful when enable_profile=true
   97: optional i64 load_profile_collect_second;
+
+  101: optional i64 runtime_profile_report_interval = 30;
 }
 
 


### PR DESCRIPTION
## Background

Sometimes, when a query is expected to take a considerable amount of time to execute, such as 10 minutes, we are required to wait until its completion before obtaining any information about the execution process.

Therefore, it is crucial to have a runtime profile available while the query is still in progress.

## How to achieve

We continue to use the existing session variable `enable_profile` to enable/disable this feature. Besides, we introduce another session varaible `runtime_profile_report_interval`, which defines the time interval between two consecutive profile reports, with a default value of 10.

The implementation is quite straightforward:
* Each fragment instance report its execution state and profile with the defined interval `runtime_profile_report_interval`
* Fe receive the state report, and update the final query content with the defined interval `runtime_profile_report_interval`

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
