### PR TITLE
[BugFix] Primary key table data separated by primary key and sort key may be disordered after compaction

### DIFF
--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -21,7 +21,9 @@ namespace starrocks {
 
 #ifdef BE_TEST
 
-Schema::Schema(Fields fields) : Schema(fields, KeysType::DUP_KEYS, {}) {}
+Schema::Schema(Fields fields) : Schema(fields, KeysType::DUP_KEYS, {}) {
+    _init_sort_key_idxes();
+}
 
 #endif
 
@@ -34,6 +36,7 @@ Schema::Schema(Fields fields, KeysType keys_type, std::vector<ColumnId> sort_key
     auto is_key = [](const FieldPtr& f) { return f->is_key(); };
     _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);
     _build_index_map(_fields);
+    _init_sort_key_idxes();
 }
 
 Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids)
@@ -46,6 +49,7 @@ Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids)
     auto is_key = [](const FieldPtr& f) { return f->is_key(); };
     _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);
     _build_index_map(_fields);
+    _init_sort_key_idxes();
 }
 
 Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids, const std::vector<ColumnId>& scids)
@@ -60,6 +64,7 @@ Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids, const std::vec
     auto is_key = [](const FieldPtr& f) { return f->is_key(); };
     _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);
     _build_index_map(_fields);
+    _init_sort_key_idxes();
 }
 
 // if we use this constructor and share the name_to_index with another schema,
@@ -81,6 +86,7 @@ Schema::Schema(Schema* schema)
         _share_name_to_index = false;
         _build_index_map(_fields);
     }
+    _init_sort_key_idxes();
 }
 
 // if we use this constructor and share the name_to_index with another schema,
@@ -101,6 +107,7 @@ Schema::Schema(const Schema& schema)
         _share_name_to_index = false;
         _build_index_map(_fields);
     }
+    _init_sort_key_idxes();
 }
 
 // if we use this constructor and share the name_to_index with another schema,

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -60,15 +60,6 @@ public:
     const std::vector<ColumnId> sort_key_idxes() const { return _sort_key_idxes; }
     void append_sort_key_idx(ColumnId idx) { _sort_key_idxes.emplace_back(idx); }
 
-    std::vector<ColumnId> get_sort_key_idxes() {
-        if (!_sort_key_idxes.empty()) {
-            return _sort_key_idxes;
-        }
-        std::vector<ColumnId> sort_key_idxes(num_key_fields());
-        std::iota(sort_key_idxes.begin(), sort_key_idxes.end(), 0);
-        return sort_key_idxes;
-    }
-
     void reserve(size_t size) { _fields.reserve(size); }
 
     void append(const FieldPtr& field);
@@ -99,6 +90,12 @@ public:
 
 private:
     void _build_index_map(const Fields& fields);
+    void _init_sort_key_idxes() {
+        if (_sort_key_idxes.empty()) {
+            _sort_key_idxes.resize(num_key_fields());
+            std::iota(_sort_key_idxes.begin(), _sort_key_idxes.end(), 0);
+        }
+    }
 
     Fields _fields;
     size_t _num_keys = 0;

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <numeric>
 #include <string_view>
 #include <utility>
 
@@ -58,6 +59,15 @@ public:
 
     const std::vector<ColumnId> sort_key_idxes() const { return _sort_key_idxes; }
     void append_sort_key_idx(ColumnId idx) { _sort_key_idxes.emplace_back(idx); }
+
+    std::vector<ColumnId> get_sort_key_idxes() {
+        if (!_sort_key_idxes.empty()) {
+            return _sort_key_idxes;
+        }
+        std::vector<ColumnId> sort_key_idxes(num_key_fields());
+        std::iota(sort_key_idxes.begin(), sort_key_idxes.end(), 0);
+        return sort_key_idxes;
+    }
 
     void reserve(size_t size) { _fields.reserve(size); }
 

--- a/be/src/storage/merge_iterator.cpp
+++ b/be/src/storage/merge_iterator.cpp
@@ -324,7 +324,7 @@ inline Status HeapMergeIterator::fill(size_t child) {
             return Status::InternalError(strings::Substitute(
                     "Merge iterator only supports merging chunks with rows less than $0", max_merge_chunk_size));
         }
-        _heap.push(ComparableChunk{chunk, child, _schema.num_key_fields(), std::move(_schema.get_sort_key_idxes()),
+        _heap.push(ComparableChunk{chunk, child, _schema.num_key_fields(), std::move(_schema.sort_key_idxes()),
                                    merge_condition});
     } else if (st.is_end_of_file()) {
         // ignore Status::EndOfFile.

--- a/be/src/storage/merge_iterator.cpp
+++ b/be/src/storage/merge_iterator.cpp
@@ -27,11 +27,11 @@
 namespace starrocks {
 
 // Compare the row of index |m| in |lhs|, with the row of index |n| in |rhs|.
-inline int compare_chunk(size_t key_columns, const Chunk& lhs, size_t m, const Chunk& rhs, size_t n,
-                         const std::string& merge_condition) {
-    for (size_t i = 0; i < key_columns; i++) {
-        const ColumnPtr& lc = lhs.get_column_by_index(i);
-        const ColumnPtr& rc = rhs.get_column_by_index(i);
+inline int compare_chunk(size_t key_columns, const std::vector<uint32_t>& sort_key_idxes, const Chunk& lhs, size_t m,
+                         const Chunk& rhs, size_t n, const std::string& merge_condition) {
+    for (size_t i = 0; i < sort_key_idxes.size(); i++) {
+        const ColumnPtr& lc = lhs.get_column_by_index(sort_key_idxes[i]);
+        const ColumnPtr& rc = rhs.get_column_by_index(sort_key_idxes[i]);
         if (int r = lc->compare_at(m, n, *rc, -1); r != 0) {
             return r;
         }
@@ -75,15 +75,18 @@ protected:
 // Compare two chunks by the one specific row of each other.
 class ComparableChunk : public MergingChunk {
 public:
-    explicit ComparableChunk(Chunk* chunk, size_t order, size_t key_columns, std::string merge_condition)
+    explicit ComparableChunk(Chunk* chunk, size_t order, size_t key_columns, std::vector<uint32_t> sort_key_idxes,
+                             std::string merge_condition)
             : MergingChunk(chunk),
               _order(order),
               _key_columns(key_columns),
+              _sort_key_idxes(std::move(sort_key_idxes)),
               _merge_condition(std::move(merge_condition)) {}
 
     bool operator>(const ComparableChunk& rhs) const {
         DCHECK_EQ(_key_columns, rhs._key_columns);
-        int r = compare_chunk(_key_columns, *_chunk, _compared_row, *rhs._chunk, rhs._compared_row, _merge_condition);
+        int r = compare_chunk(_key_columns, _sort_key_idxes, *_chunk, _compared_row, *rhs._chunk, rhs._compared_row,
+                              _merge_condition);
         return (r > 0) | ((r == 0) & (_order > rhs._order));
     }
 
@@ -108,7 +111,8 @@ public:
     }
 
     bool less_than(size_t lhs_row, const ComparableChunk& rhs) {
-        int r = compare_chunk(_key_columns, *_chunk, lhs_row, *rhs._chunk, rhs._compared_row, _merge_condition);
+        int r = compare_chunk(_key_columns, _sort_key_idxes, *_chunk, lhs_row, *rhs._chunk, rhs._compared_row,
+                              _merge_condition);
         return (r < 0) | ((r == 0) & (_order < rhs._order));
     }
 
@@ -118,6 +122,7 @@ private:
     // used to determinate the order of two rows when their key columns are all equals.
     uint16_t _order;
     uint16_t _key_columns;
+    std::vector<uint32_t> _sort_key_idxes;
     std::string _merge_condition;
 };
 
@@ -319,7 +324,8 @@ inline Status HeapMergeIterator::fill(size_t child) {
             return Status::InternalError(strings::Substitute(
                     "Merge iterator only supports merging chunks with rows less than $0", max_merge_chunk_size));
         }
-        _heap.push(ComparableChunk{chunk, child, _schema.num_key_fields(), merge_condition});
+        _heap.push(ComparableChunk{chunk, child, _schema.num_key_fields(), std::move(_schema.get_sort_key_idxes()),
+                                   merge_condition});
     } else if (st.is_end_of_file()) {
         // ignore Status::EndOfFile.
         close_child(child);

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1674,29 +1674,34 @@ TEST_F(TabletUpdatesTest, horizontal_compaction_with_sort_key) {
     DeferOp unset_config([&] { config::vertical_compaction_max_columns_per_group = orig; });
 
     int N = 100;
+    int loop = 4;
     srand(GetCurrentTimeMicros());
     _tablet = create_tablet_with_sort_key(rand(), rand(), {1, 2});
-    std::vector<int64_t> keys;
-    for (int i = 0; i < N; i++) {
-        keys.push_back(i);
+
+    std::vector<int64_t> sorted_keys;
+    for (int i = 0; i < 100; i++) {
+        for (int j = 0; j < loop; j++) {
+            sorted_keys.emplace_back(100 * j + i);
+        }
     }
-    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys)).ok());
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset(_tablet, keys)).ok());
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset(_tablet, keys)).ok());
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    ASSERT_EQ(_tablet->updates()->version_history_count(), 4);
-    ASSERT_EQ(N, read_tablet(_tablet, 4));
+    for (int i = 0; i < loop; i++) {
+        std::vector<int64_t> keys;
+        for (int j = 0; j < N; j++) {
+            keys.push_back(i * 100 + j);
+        }
+        ASSERT_TRUE(_tablet->rowset_commit(2 + i, create_rowset(_tablet, keys)).ok());
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+    ASSERT_EQ(N * loop, read_tablet(_tablet, loop + 1));
     const auto& best_tablet =
             StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
     EXPECT_EQ(best_tablet->tablet_id(), _tablet->tablet_id());
     EXPECT_GT(best_tablet->updates()->get_compaction_score(), 0);
     ASSERT_TRUE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    EXPECT_EQ(100, read_tablet_and_compare(best_tablet, 4, keys));
+    EXPECT_EQ(N * loop, read_tablet_and_compare(best_tablet, loop + 1, sorted_keys));
     ASSERT_EQ(best_tablet->updates()->num_rowsets(), 1);
-    ASSERT_EQ(best_tablet->updates()->version_history_count(), 5);
+    ASSERT_EQ(best_tablet->updates()->version_history_count(), loop + 2);
     // the time interval is not enough after last compaction
     EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
 }
@@ -1862,29 +1867,35 @@ TEST_F(TabletUpdatesTest, vertical_compaction_with_sort_key) {
     DeferOp unset_config([&] { config::vertical_compaction_max_columns_per_group = orig; });
 
     int N = 100;
+    int loop = 4;
     srand(GetCurrentTimeMicros());
-    _tablet = create_tablet_with_sort_key(rand(), rand(), {1});
-    std::vector<int64_t> keys;
-    for (int i = 0; i < N; i++) {
-        keys.push_back(i);
+    _tablet = create_tablet_with_sort_key(rand(), rand(), {1, 2});
+    std::vector<int64_t> sorted_keys;
+    for (int i = 0; i < 100; i++) {
+        for (int j = 0; j < loop; j++) {
+            sorted_keys.emplace_back(100 * j + i);
+        }
     }
-    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys)).ok());
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    ASSERT_TRUE(_tablet->rowset_commit(3, create_rowset(_tablet, keys)).ok());
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    ASSERT_TRUE(_tablet->rowset_commit(4, create_rowset(_tablet, keys)).ok());
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    ASSERT_EQ(_tablet->updates()->version_history_count(), 4);
-    ASSERT_EQ(N, read_tablet(_tablet, 4));
+
+    for (int i = 0; i < loop; i++) {
+        std::vector<int64_t> keys;
+        for (int j = 0; j < N; j++) {
+            keys.push_back(i * 100 + j);
+        }
+        ASSERT_TRUE(_tablet->rowset_commit(2 + i, create_rowset(_tablet, keys)).ok());
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    ASSERT_EQ(N * loop, read_tablet(_tablet, loop + 1));
     const auto& best_tablet =
             StorageEngine::instance()->tablet_manager()->find_best_tablet_to_do_update_compaction(_tablet->data_dir());
     EXPECT_EQ(best_tablet->tablet_id(), _tablet->tablet_id());
     EXPECT_GT(best_tablet->updates()->get_compaction_score(), 0);
     ASSERT_TRUE(best_tablet->updates()->compaction(_compaction_mem_tracker.get()).ok());
     std::this_thread::sleep_for(std::chrono::seconds(1));
-    EXPECT_EQ(N, read_tablet_and_compare(best_tablet, 4, keys));
+    EXPECT_EQ(N * loop, read_tablet_and_compare(best_tablet, loop + 1, sorted_keys));
     ASSERT_EQ(best_tablet->updates()->num_rowsets(), 1);
-    ASSERT_EQ(best_tablet->updates()->version_history_count(), 5);
+    ASSERT_EQ(best_tablet->updates()->version_history_count(), loop + 2);
     // the time interval is not enough after last compaction
     EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
 }


### PR DESCRIPTION
If we create a primary key table that separates the primary key and the sort key, we should order segment data by the sort key but not the primary key. But when compaction is finished, the segment data may be out of order because in the heap merge of segment data, the `HeapMergeIterator` use the primary key as the basis for sorting data.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
