### PR TITLE
[Refactor] refactor spill trigger strategy for hash join

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -877,7 +877,7 @@ CONF_String(spill_local_storage_dir, "${STARROCKS_HOME}/spill");
 // when spill occurs, whether enable skip synchronous flush
 CONF_mBool(experimental_spill_skip_sync, "true");
 // spill Initial number of partitions
-CONF_mInt32(spill_init_partition, "4");
+CONF_mInt32(spill_init_partition, "16");
 // The maximum size of a single log block container file, this is not a hard limit.
 // If the file size exceeds this limit, a new file will be created to store the block.
 CONF_Int64(spill_max_log_block_container_bytes, "10737418240"); // 10GB

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -521,9 +521,8 @@ Status Aggregator::spill_aggregate_data(RuntimeState* state, std::function<Statu
         auto chunk_with_st = chunk_provider();
         if (chunk_with_st.ok()) {
             if (!chunk_with_st.value()->is_empty()) {
-                RETURN_IF_ERROR(spiller->spill(
-                        state, chunk_with_st.value(), *io_executor,
-                        spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this())));
+                RETURN_IF_ERROR(spiller->spill(state, chunk_with_st.value(), *io_executor,
+                                               RESOURCE_TLS_MEMTRACER_GUARD(state)));
             }
         } else if (chunk_with_st.status().is_end_of_file()) {
             // chunk_provider return eos means provider has output all data from hash_map/hash_set.

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -179,10 +179,7 @@ Status HashJoiner::append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk
 Status HashJoiner::append_chunk_to_spill_buffer(RuntimeState* state, const ChunkPtr& chunk) {
     update_build_rows(chunk->num_rows());
     auto io_executor = spill_channel()->io_executor();
-    RETURN_IF_ERROR(
-            spiller()->spill(state, chunk, *io_executor,
-                             spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this())));
-
+    RETURN_IF_ERROR(spiller()->spill(state, chunk, *io_executor, RESOURCE_TLS_MEMTRACER_GUARD(state)));
     return Status::OK();
 }
 
@@ -191,9 +188,8 @@ Status HashJoiner::append_spill_task(RuntimeState* state, std::function<StatusOr
     while (!spiller()->is_full()) {
         auto chunk_st = spill_task();
         if (chunk_st.ok()) {
-            RETURN_IF_ERROR(spiller()->spill(
-                    state, chunk_st.value(), io_executor(),
-                    spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this())));
+            RETURN_IF_ERROR(
+                    spiller()->spill(state, chunk_st.value(), io_executor(), RESOURCE_TLS_MEMTRACER_GUARD(state)));
         } else if (chunk_st.status().is_end_of_file()) {
             return Status::OK();
         } else {

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -158,7 +158,7 @@ Status SpillableAggregateBlockingSinkOperatorFactory::prepare(RuntimeState* stat
     // init spill options
     _spill_options = std::make_shared<spill::SpilledOptions>(&_sort_exprs, &_sort_desc);
 
-    _spill_options->spill_file_size = state->spill_mem_table_size();
+    _spill_options->spill_mem_table_bytes_size = state->spill_mem_table_size();
     _spill_options->mem_table_pool_size = state->spill_mem_table_num();
     _spill_options->spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
     _spill_options->block_manager = state->query_ctx()->spill_manager()->block_manager();

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -98,11 +98,8 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::_pull_spilled_chunk
 
     if (!_aggregator->is_spilled_eos()) {
         auto executor = _aggregator->spill_channel()->io_executor();
-        ASSIGN_OR_RETURN(auto chunk, _aggregator->spiller()->restore(
-                                             state, *executor,
-                                             spill::ResourceMemTrackerGuard(tls_mem_tracker,
-                                                                            state->query_ctx()->weak_from_this())));
-
+        ASSIGN_OR_RETURN(auto chunk,
+                         _aggregator->spiller()->restore(state, *executor, RESOURCE_TLS_MEMTRACER_GUARD(state)));
         if (chunk->is_empty()) {
             return chunk;
         }

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -121,7 +121,7 @@ Status SpillableAggregateDistinctBlockingSinkOperatorFactory::prepare(RuntimeSta
     // init spill options
     _spill_options = std::make_shared<spill::SpilledOptions>(&_sort_exprs, &_sort_desc);
 
-    _spill_options->spill_file_size = state->spill_mem_table_size();
+    _spill_options->spill_mem_table_bytes_size = state->spill_mem_table_size();
     _spill_options->mem_table_pool_size = state->spill_mem_table_num();
     _spill_options->spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
     _spill_options->block_manager = state->query_ctx()->spill_manager()->block_manager();

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -78,6 +78,7 @@ Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
     }
 
     auto io_executor = _join_builder->spill_channel()->io_executor();
+    RETURN_IF_ERROR(_join_builder->spiller()->flush(state, *io_executor, RESOURCE_TLS_MEMTRACER_GUARD(state)));
     auto set_call_back_function = [this](RuntimeState* state, auto io_executor) {
         return _join_builder->spiller()->set_flush_all_call_back(
                 [this]() {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -30,6 +30,7 @@
 #include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "runtime/runtime_state.h"
+#include "util/bit_util.h"
 #include "util/defer_op.h"
 
 namespace starrocks::pipeline {
@@ -48,6 +49,17 @@ Status SpillableHashJoinBuildOperator::prepare(RuntimeState* state) {
 
 void SpillableHashJoinBuildOperator::close(RuntimeState* state) {
     HashJoinBuildOperator::close(state);
+}
+
+size_t SpillableHashJoinBuildOperator::estimated_memory_reserved(const ChunkPtr& chunk) {
+    if (chunk && !chunk->is_empty()) {
+        return chunk->memory_usage() + _join_builder->hash_join_builder()->hash_table().mem_usage();
+    }
+    return 0;
+}
+
+size_t SpillableHashJoinBuildOperator::estimated_memory_reserved() {
+    return _join_builder->hash_join_builder()->hash_table().mem_usage() * 2;
 }
 
 bool SpillableHashJoinBuildOperator::need_input() const {
@@ -153,9 +165,14 @@ Status SpillableHashJoinBuildOperator::push_chunk(RuntimeState* state, const Chu
         return Status::OK();
     }
 
-    // TODO: materialize chunk (const/nullable)
-
     auto& ht = _join_builder->hash_join_builder()->hash_table();
+    // Estimate the appropriate number of partitions
+    if (_is_first_time_spill && ht.get_row_count() > 0) {
+        // We estimate the size of the hash table to be twice the size of the already input hash table
+        auto num_partitions = ht.mem_usage() * 2 / _join_builder->spiller()->options().spill_mem_table_bytes_size;
+        _join_builder->spiller()->set_partition(state, num_partitions);
+    }
+
     ASSIGN_OR_RETURN(auto spill_chunk, ht.convert_to_spill_schema(chunk));
     RETURN_IF_ERROR(append_hash_columns(spill_chunk));
 
@@ -200,11 +217,10 @@ Status SpillableHashJoinBuildOperatorFactory::prepare(RuntimeState* state) {
 
     // no order by, init with 4 partitions
     _spill_options = std::make_shared<spill::SpilledOptions>(config::spill_init_partition);
-    _spill_options->spill_file_size = state->spill_mem_table_size();
+    _spill_options->spill_mem_table_bytes_size = state->spill_mem_table_size();
     _spill_options->mem_table_pool_size = state->spill_mem_table_num();
     _spill_options->spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
     _spill_options->min_spilled_size = state->spill_operator_min_bytes();
-    _spill_options->max_memory_size_each_partition = state->spill_operator_max_bytes();
     _spill_options->block_manager = state->query_ctx()->spill_manager()->block_manager();
     _spill_options->name = "hash-join-build";
     _spill_options->plan_node_id = _plan_node_id;

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -170,7 +170,7 @@ Status SpillableHashJoinBuildOperator::push_chunk(RuntimeState* state, const Chu
     if (_is_first_time_spill && ht.get_row_count() > 0) {
         // We estimate the size of the hash table to be twice the size of the already input hash table
         auto num_partitions = ht.mem_usage() * 2 / _join_builder->spiller()->options().spill_mem_table_bytes_size;
-        _join_builder->spiller()->set_partition(state, num_partitions);
+        RETURN_IF_ERROR(_join_builder->spiller()->set_partition(state, num_partitions));
     }
 
     ASSIGN_OR_RETURN(auto spill_chunk, ht.convert_to_spill_schema(chunk));

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
@@ -48,6 +48,9 @@ public:
     bool spillable() const override { return true; }
     void set_execute_mode(int performance_level) override;
 
+    size_t estimated_memory_reserved(const ChunkPtr& chunk) override;
+    size_t estimated_memory_reserved() override;
+
 private:
     void set_spill_strategy(spill::SpillStrategy strategy) { _join_builder->set_spill_strategy(strategy); }
     spill::SpillStrategy spill_strategy() const { return _join_builder->spill_strategy(); }

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -56,7 +56,7 @@ void SpillableHashJoinProbeOperator::close(RuntimeState* state) {
 }
 
 bool SpillableHashJoinProbeOperator::has_output() const {
-    if (spill_strategy() == spill::SpillStrategy::NO_SPILL) {
+    if (!spilled()) {
         return HashJoinProbeOperator::has_output();
     }
 
@@ -114,7 +114,7 @@ bool SpillableHashJoinProbeOperator::has_output() const {
 }
 
 bool SpillableHashJoinProbeOperator::need_input() const {
-    if (spill_strategy() == spill::SpillStrategy::NO_SPILL) {
+    if (!spilled()) {
         return HashJoinProbeOperator::need_input();
     }
 
@@ -142,7 +142,7 @@ bool SpillableHashJoinProbeOperator::need_input() const {
 }
 
 bool SpillableHashJoinProbeOperator::is_finished() const {
-    if (spill_strategy() == spill::SpillStrategy::NO_SPILL) {
+    if (!spilled()) {
         return HashJoinProbeOperator::is_finished();
     }
 
@@ -158,7 +158,7 @@ bool SpillableHashJoinProbeOperator::is_finished() const {
 }
 
 Status SpillableHashJoinProbeOperator::set_finishing(RuntimeState* state) {
-    if (spill_strategy() == spill::SpillStrategy::NO_SPILL) {
+    if (!spilled()) {
         return HashJoinProbeOperator::set_finishing(state);
     }
     if (state->is_cancelled()) {
@@ -175,7 +175,7 @@ Status SpillableHashJoinProbeOperator::set_finished(RuntimeState* state) {
 
 Status SpillableHashJoinProbeOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
     RETURN_IF_ERROR(_status());
-    if (spill_strategy() == spill::SpillStrategy::NO_SPILL) {
+    if (!spilled()) {
         return HashJoinProbeOperator::push_chunk(state, chunk);
     }
 
@@ -346,7 +346,7 @@ Status SpillableHashJoinProbeOperator::_restore_probe_partition(RuntimeState* st
 
 StatusOr<ChunkPtr> SpillableHashJoinProbeOperator::pull_chunk(RuntimeState* state) {
     RETURN_IF_ERROR(_status());
-    if (spill_strategy() == spill::SpillStrategy::NO_SPILL) {
+    if (!spilled()) {
         return HashJoinProbeOperator::pull_chunk(state);
     }
 

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
@@ -79,8 +79,7 @@ public:
     void set_probe_spiller(std::shared_ptr<spill::Spiller> spiller) { _probe_spiller = std::move(spiller); }
 
 private:
-    void set_spill_strategy(spill::SpillStrategy strategy) { _join_builder->set_spill_strategy(strategy); }
-    spill::SpillStrategy spill_strategy() const { return _join_builder->spill_strategy(); }
+    bool spilled() const { return _join_builder->spiller()->spilled(); }
 
     SpillableHashJoinProbeOperator* as_mutable() const { return const_cast<SpillableHashJoinProbeOperator*>(this); }
 

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
@@ -88,11 +88,10 @@ Status SpillableNLJoinBuildOperatorFactory::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
 
     _spill_options = std::make_shared<spill::SpilledOptions>();
-    _spill_options->spill_file_size = state->spill_mem_table_size();
+    _spill_options->spill_mem_table_bytes_size = state->spill_mem_table_size();
     _spill_options->mem_table_pool_size = state->spill_mem_table_num();
     _spill_options->spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
     _spill_options->min_spilled_size = state->spill_operator_min_bytes();
-    _spill_options->max_memory_size_each_partition = state->spill_operator_max_bytes();
     _spill_options->block_manager = state->query_ctx()->spill_manager()->block_manager();
     _spill_options->name = "spillable-nestloop-join-build";
     _spill_options->plan_node_id = _plan_node_id;

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -464,7 +464,6 @@ void PipelineDriver::_close_operators(RuntimeState* runtime_state) {
 
 void PipelineDriver::_adjust_memory_usage(RuntimeState* state, MemTracker* tracker, OperatorPtr& op,
                                           const ChunkPtr& chunk) {
-    // TODO: FIXME
     // a simple spill stragety
     auto& mem_resource_mgr = op->mem_resource_manager();
     if (state->enable_spill() && mem_resource_mgr.releaseable() &&

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -140,7 +140,7 @@ Status SpillablePartitionSortSinkOperatorFactory::prepare(RuntimeState* state) {
 
     // init spill parameters
     _spill_options = std::make_shared<spill::SpilledOptions>(&_sort_exec_exprs, sort_desc);
-    _spill_options->spill_file_size = state->spill_mem_table_size();
+    _spill_options->spill_mem_table_bytes_size = state->spill_mem_table_size();
     _spill_options->mem_table_pool_size = state->spill_mem_table_num();
     _spill_options->spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
     _spill_options->block_manager = state->query_ctx()->spill_manager()->block_manager();

--- a/be/src/exec/pipeline/spill_process_operator.cpp
+++ b/be/src/exec/pipeline/spill_process_operator.cpp
@@ -47,9 +47,8 @@ StatusOr<ChunkPtr> SpillProcessOperator::pull_chunk(RuntimeState* state) {
     if (chunk_st.status().ok() && !state->is_cancelled()) {
         auto chunk = chunk_st.value();
         if (chunk != nullptr && !chunk->is_empty()) {
-            RETURN_IF_ERROR(_channel->spiller()->spill(
-                    state, std::move(chunk_st.value()), *_channel->io_executor(),
-                    spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this())));
+            RETURN_IF_ERROR(_channel->spiller()->spill(state, std::move(chunk_st.value()), *_channel->io_executor(),
+                                                       RESOURCE_TLS_MEMTRACER_GUARD(state)));
         }
     } else if (chunk_st.status().is_end_of_file()) {
         _channel->current_task().reset();

--- a/be/src/exec/spill/operator_mem_resource_manager.cpp
+++ b/be/src/exec/spill/operator_mem_resource_manager.cpp
@@ -38,9 +38,19 @@ void OperatorMemoryResourceManager::to_low_memory_mode() {
     }
 }
 
+size_t OperatorMemoryResourceManager::operator_avaliable_memory_bytes() {
+    // TODO: think about multi-operators
+    auto* runtime_state = _op->runtime_state();
+    size_t avaliable = runtime_state->spill_mem_table_size() * runtime_state->spill_mem_table_num();
+    avaliable = std::max<size_t>(avaliable, runtime_state->spill_operator_min_bytes());
+    avaliable = std::min<size_t>(avaliable, runtime_state->spill_operator_max_bytes());
+    return avaliable;
+}
+
 void OperatorMemoryResourceManager::close() {
     if (_performance_level == MEM_RESOURCE_LOW_MEMORY && _query_spill_manager != nullptr) {
         _query_spill_manager->decrease_spilling_operators();
+        _query_spill_manager->decrease_spillable_operators();
     }
 }
 

--- a/be/src/exec/spill/operator_mem_resource_manager.h
+++ b/be/src/exec/spill/operator_mem_resource_manager.h
@@ -38,6 +38,9 @@ public:
 
     void to_low_memory_mode();
 
+    // For the current operator available memory (estimated value)
+    size_t operator_avaliable_memory_bytes();
+
 private:
     // performance level. Determine the execution mode and whether memory can be freed early
     // A higher performance level will allow the operator to execute with less memory, which will reduce performance

--- a/be/src/exec/spill/options.h
+++ b/be/src/exec/spill/options.h
@@ -77,7 +77,7 @@ struct SpilledOptions {
 
     // max mem table size for each spiller
     size_t mem_table_pool_size{};
-    // the spilled file size
+    // memory table peak mem usage
     size_t spill_mem_table_bytes_size{};
     // spilled format type
     SpillFormaterType spill_type{};

--- a/be/src/exec/spill/options.h
+++ b/be/src/exec/spill/options.h
@@ -78,7 +78,7 @@ struct SpilledOptions {
     // max mem table size for each spiller
     size_t mem_table_pool_size{};
     // the spilled file size
-    size_t spill_file_size{};
+    size_t spill_mem_table_bytes_size{};
     // spilled format type
     SpillFormaterType spill_type{};
 
@@ -88,7 +88,6 @@ struct SpilledOptions {
 
     CompressionTypePB compress_type = CompressionTypePB::LZ4;
 
-    size_t max_memory_size_each_partition = 2 * 1024 * 1024;
     size_t min_spilled_size = 1 * 1024 * 1024;
 
     bool read_shared = false;

--- a/be/src/exec/spill/query_spill_manager.h
+++ b/be/src/exec/spill/query_spill_manager.h
@@ -34,6 +34,7 @@ public:
     size_t spilling_operators() { return _spilling_operators; }
 
     void increase_spillable_operators() { _spillable_operators++; }
+    void decrease_spillable_operators() { _spillable_operators--; }
     size_t spillable_operators() { return _spillable_operators; }
 
     BlockManager* block_manager() const { return _block_manager.get(); }

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -234,6 +234,8 @@ public:
 
     Status reset_partition(const std::vector<const SpillPartitionInfo*>& partitions);
 
+    Status reset_partition(RuntimeState* state, size_t num_partitions);
+
     void cancel() override {}
 
     void shuffle(std::vector<uint32_t>& dst, const SpillHashColumn* hash_column);
@@ -279,6 +281,8 @@ public:
 
 private:
     Status _init_with_partition_nums(RuntimeState* state, int num_partitions);
+    // prepare and acquire mem_table for each partition in _id_to_partitions
+    Status _prepare_partitions(RuntimeState* state);
 
     // split partition by hash
     // hash-based partitioning can have significant degradation in the case of heavily skewed data.

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -97,6 +97,11 @@ Status Spiller::set_partition(const std::vector<const SpillPartitionInfo*>& pari
     return Status::OK();
 }
 
+Status Spiller::set_partition(RuntimeState* state, size_t num_partitions) {
+    RETURN_IF_ERROR(down_cast<PartitionedSpillerWriter*>(_writer.get())->reset_partition(state, num_partitions));
+    return Status::OK();
+}
+
 void Spiller::update_spilled_task_status(Status&& st) {
     std::lock_guard guard(_mutex);
     if (_spilled_task_status.ok() && !st.ok()) {

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -101,8 +101,10 @@ public:
 
     const SpillProcessMetrics& metrics() { return _metrics; }
 
-    // set partition
+    // set partitions for spiller only works when spiller has partitioned spill writer
     Status set_partition(const std::vector<const SpillPartitionInfo*>& parititons);
+    // init partition by `num_partitions`
+    Status set_partition(RuntimeState* state, size_t num_partitions);
 
     // no thread-safe
     // TaskExecutor: Executor for runing io tasks

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -547,11 +547,6 @@ Status PartitionedSpillerWriter::flush(RuntimeState* state, TaskExecutor&& execu
             }
         }
 
-        if (!splitting_partitions.empty()) {
-            LOG(INFO) << "memtracker consumption:" << _mem_tracker->consumption()
-                      << ",instance:" << state->instance_mem_tracker()->consumption();
-        }
-
         return Status::OK();
     };
 

--- a/be/src/exec/spillable_chunks_sorter_full_sort.cpp
+++ b/be/src/exec/spillable_chunks_sorter_full_sort.cpp
@@ -35,9 +35,7 @@ Status SpillableChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr
     bool first_time_spill = _spiller->spilled_append_rows() == 0;
     CHECK(!_spill_channel->has_task());
 
-    RETURN_IF_ERROR(
-            _spiller->spill(state, chunk, io_executor(),
-                            spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this())));
+    RETURN_IF_ERROR(_spiller->spill(state, chunk, io_executor(), RESOURCE_TLS_MEMTRACER_GUARD(state)));
 
     if (first_time_spill) {
         auto process_task = _spill_process_task();
@@ -45,9 +43,8 @@ Status SpillableChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr
             auto chunk_st = process_task();
             if (chunk_st.ok()) {
                 if (!chunk_st.value()->is_empty()) {
-                    RETURN_IF_ERROR(_spiller->spill(
-                            state, chunk_st.value(), io_executor(),
-                            spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this())));
+                    RETURN_IF_ERROR(_spiller->spill(state, chunk_st.value(), io_executor(),
+                                                    RESOURCE_TLS_MEMTRACER_GUARD(state)));
                 }
             } else if (chunk_st.status().is_end_of_file()) {
                 return Status::OK();
@@ -68,21 +65,16 @@ Status SpillableChunksSorterFullSort::do_done(RuntimeState* state) {
 
     if (_sorted_chunks.empty() && _unsorted_chunk == nullptr) {
         // force flush
-        RETURN_IF_ERROR(
-                _spiller->flush(state, io_executor(),
-                                spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this())));
+        RETURN_IF_ERROR(_spiller->flush(state, io_executor(), RESOURCE_TLS_MEMTRACER_GUARD(state)));
     } else {
         // TODO: avoid sort multi times
         // spill sorted chunks
         auto spill_process_task = _spill_process_task();
         _spill_channel->add_spill_task({std::move(spill_process_task)});
         std::function<StatusOr<ChunkPtr>()> flush_task = [this, state]() -> StatusOr<ChunkPtr> {
-            RETURN_IF_ERROR(_spiller->flush(
-                    state, io_executor(),
-                    spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this())));
+            RETURN_IF_ERROR(_spiller->flush(state, io_executor(), RESOURCE_TLS_MEMTRACER_GUARD(state)));
             return Status::EndOfFile("eos");
         };
-
         _spill_channel->add_spill_task({std::move(flush_task)});
     }
 
@@ -163,9 +155,7 @@ std::function<StatusOr<ChunkPtr>()> SpillableChunksSorterFullSort::_spill_proces
 }
 
 Status SpillableChunksSorterFullSort::_get_result_from_spiller(ChunkPtr* chunk, bool* eos) {
-    auto chunk_st =
-            _spiller->restore(_state, io_executor(),
-                              spill::ResourceMemTrackerGuard(tls_mem_tracker, _state->query_ctx()->weak_from_this()));
+    auto chunk_st = _spiller->restore(_state, io_executor(), RESOURCE_TLS_MEMTRACER_GUARD(_state));
     if (chunk_st.status().is_end_of_file()) {
         *eos = true;
     }

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -290,7 +290,7 @@ TEST_F(SpillTest, unsorted_process) {
     // 4 buffer chunk
     spill_options.mem_table_pool_size = 4;
     // file size: 1M
-    spill_options.spill_file_size = 1 * 1024 * 1024;
+    spill_options.spill_mem_table_bytes_size = 1 * 1024 * 1024;
     // spill format type
     spill_options.spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
 
@@ -384,7 +384,7 @@ TEST_F(SpillTest, order_by_process) {
     // 4 buffer chunk
     spill_options.mem_table_pool_size = 2;
     // file size: 1M
-    spill_options.spill_file_size = 1 * 1024 * 1024;
+    spill_options.spill_mem_table_bytes_size = 1 * 1024 * 1024;
     // spill format type
     spill_options.spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
 


### PR DESCRIPTION
We try to reserve a large amount of memory (1G per operator) when restoring the partition hash table. In this PR, we modify the memory table size to memory_table_num * memory_table_bytes_size. If each partition is currently small, but the overall memory table exceeds the memory_table_bytes_size, we will flush half of the memory table to ensure that the memory table is smaller than the expected size.

this PR also fix a bug for auto-spill mode (rows unmatched)

case for SSB-100G 1BE
set enable_spill=true;
set spill_mode="force";
set pipeline_dop=1;
select count(*) from lineorder l join [colocate] lineorder r on l.lo_orderkey=r.lo_orderkey;

baseline:
```
  Execution Profile 057f1fbe-0e4a-11ee-a0e0-162d24e49988:
     - QueryAllocatedMemoryUsage: 233.00 GB
     - QueryCumulativeCpuTime: 52s407ms
     - QueryCumulativeOperatorTime: 51s994ms
     - QueryDeallocatedMemoryUsage: 232.52 GB
     - QueryExecutionWallTime: 1m12s
     - QueryPeakMemoryUsage: 2.69 GB
```


patched:
```
  Execution Profile b7f0682c-0e67-11ee-a0e0-162d24e49988:
     - QueryAllocatedMemoryUsage: 133.21 GB
     - QueryCumulativeCpuTime: 37s773ms
     - QueryCumulativeOperatorTime: 37s384ms
     - QueryDeallocatedMemoryUsage: 132.75 GB
     - QueryExecutionWallTime: 1m4s
     - QueryPeakMemoryUsage: 503.38 MB
```


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
