### PR TITLE
[Enhancement] Using PK index to handle pointer query with hint

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -161,6 +161,7 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
     _params.profile = _runtime_profile;
     _params.runtime_state = _runtime_state;
     _params.use_page_cache = _runtime_state->use_page_cache();
+    _params.use_pk_index = thrift_olap_scan_node.use_pk_index;
     if (thrift_olap_scan_node.__isset.sorted_by_keys_per_tablet) {
         _params.sorted_by_keys_per_tablet = thrift_olap_scan_node.sorted_by_keys_per_tablet;
     }

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -622,7 +622,7 @@ Status DeltaWriter::_fill_auto_increment_id(const Chunk& chunk) {
     rss_rowids.resize(upserts->size());
 
     // 2. probe index
-    _tablet->updates()->prepare_partial_update_states(_tablet.get(), upserts, nullptr, &rss_rowids);
+    _tablet->updates()->get_rss_rowids_by_pk(_tablet.get(), *upserts, nullptr, &rss_rowids);
 
     std::vector<uint8_t> filter;
     uint32_t gen_num = 0;

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -265,8 +265,8 @@ Status UpdateManager::_handle_index_op(Tablet* tablet, const TabletMetadata& met
     _index_cache.update_object_size(index_entry, index.memory_usage());
     if (!st.ok()) {
         _index_cache.remove(index_entry);
-        std::string msg = strings::Substitute("prepare_partial_update_states error: load primary index failed: $0",
-                                              st.to_string());
+        std::string msg =
+                strings::Substitute("get_rss_rowids_by_pk error: load primary index failed: $0", st.to_string());
         LOG(ERROR) << msg;
         return Status::InternalError(msg);
     }

--- a/be/src/storage/local_tablet_reader.cpp
+++ b/be/src/storage/local_tablet_reader.cpp
@@ -123,8 +123,7 @@ Status LocalTabletReader::multi_get(const Chunk& keys, const std::vector<uint32_
     // search pks in pk index to get rowids
     EditVersion edit_version;
     std::vector<uint64_t> rowids(n);
-    RETURN_IF_ERROR(
-            _tablet->updates()->prepare_partial_update_states(_tablet.get(), pk_column, &edit_version, &rowids));
+    RETURN_IF_ERROR(_tablet->updates()->get_rss_rowids_by_pk(_tablet.get(), *pk_column, &edit_version, &rowids));
     if (edit_version.major() != _version) {
         return Status::InternalError(
                 strings::Substitute("multi_get version not match tablet:$0 current_version:$1 read_version:$2",

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -206,13 +206,13 @@ Status RowsetColumnUpdateState::_prepare_partial_update_states(Tablet* tablet, R
 
     int64_t t_read_rss = MonotonicMillis();
     if (need_lock) {
-        RETURN_IF_ERROR(tablet->updates()->prepare_partial_update_states(
-                tablet, _upserts[idx], &(_partial_update_states[idx].read_version),
-                &(_partial_update_states[idx].src_rss_rowids)));
+        RETURN_IF_ERROR(tablet->updates()->get_rss_rowids_by_pk(tablet, *_upserts[idx],
+                                                                &(_partial_update_states[idx].read_version),
+                                                                &(_partial_update_states[idx].src_rss_rowids)));
     } else {
-        RETURN_IF_ERROR(tablet->updates()->prepare_partial_update_states_unlock(
-                tablet, _upserts[idx], &(_partial_update_states[idx].read_version),
-                &(_partial_update_states[idx].src_rss_rowids)));
+        RETURN_IF_ERROR(tablet->updates()->get_rss_rowids_by_pk_unlock(tablet, *_upserts[idx],
+                                                                       &(_partial_update_states[idx].read_version),
+                                                                       &(_partial_update_states[idx].src_rss_rowids)));
     }
     // build `rss_rowid_to_update_rowid`
     _partial_update_states[idx].build_rss_rowid_to_update_rowid();

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -343,13 +343,13 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
 
     int64_t t_read_index = MonotonicMillis();
     if (need_lock) {
-        RETURN_IF_ERROR(tablet->updates()->prepare_partial_update_states(
-                tablet, _upserts[idx], &(_partial_update_states[idx].read_version),
-                &(_partial_update_states[idx].src_rss_rowids)));
+        RETURN_IF_ERROR(tablet->updates()->get_rss_rowids_by_pk(tablet, *_upserts[idx],
+                                                                &(_partial_update_states[idx].read_version),
+                                                                &(_partial_update_states[idx].src_rss_rowids)));
     } else {
-        RETURN_IF_ERROR(tablet->updates()->prepare_partial_update_states_unlock(
-                tablet, _upserts[idx], &(_partial_update_states[idx].read_version),
-                &(_partial_update_states[idx].src_rss_rowids)));
+        RETURN_IF_ERROR(tablet->updates()->get_rss_rowids_by_pk_unlock(tablet, *_upserts[idx],
+                                                                       &(_partial_update_states[idx].read_version),
+                                                                       &(_partial_update_states[idx].src_rss_rowids)));
     }
 
     int64_t t_read_values = MonotonicMillis();
@@ -407,8 +407,8 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(Tablet* 
     read_column[0] = column->clone_empty();
     _auto_increment_partial_update_states[idx].write_column = column->clone_empty();
 
-    tablet->updates()->prepare_partial_update_states_unlock(tablet, _upserts[idx], nullptr,
-                                                            &_auto_increment_partial_update_states[idx].src_rss_rowids);
+    tablet->updates()->get_rss_rowids_by_pk_unlock(tablet, *_upserts[idx], nullptr,
+                                                   &_auto_increment_partial_update_states[idx].src_rss_rowids);
 
     std::vector<uint32_t> rowids;
     uint32_t n = _auto_increment_partial_update_states[idx].src_rss_rowids.size();

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -20,6 +20,8 @@
 #include "common/status.h"
 #include "gen_cpp/tablet_schema.pb.h"
 #include "gutil/stl_util.h"
+#include "primary_key_encoder.h"
+#include "service/backend_options.h"
 #include "storage/aggregate_iterator.h"
 #include "storage/chunk_helper.h"
 #include "storage/column_predicate.h"
@@ -32,6 +34,7 @@
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/seek_range.h"
 #include "storage/tablet.h"
+#include "storage/tablet_updates.h"
 #include "storage/types.h"
 #include "storage/union_iterator.h"
 
@@ -95,12 +98,124 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
         read_params.reader_type != ReaderType::READER_ALTER_TABLE && !is_compaction(read_params.reader_type)) {
         return Status::NotSupported("reader type not supported now");
     }
+    if (read_params.use_pk_index) {
+        // defer init collector to IO scanner thread when calling do_get_next()
+        _reader_params = &read_params;
+        return Status::OK();
+    }
     Status st = _init_collector(read_params);
     return st;
 }
 
+Status TabletReader::_init_collector_for_pk_index_read() {
+    DCHECK(_reader_params != nullptr);
+    // get pk eq predicates, and convert these predicates to encoded pk column
+    const auto& tablet_schema = _tablet->tablet_schema();
+    vector<ColumnId> pk_column_ids;
+    for (size_t i = 0; i < tablet_schema.num_key_columns(); i++) {
+        pk_column_ids.emplace_back(i);
+    }
+    auto pk_schema = ChunkHelper::convert_schema(tablet_schema, pk_column_ids);
+    auto keys = ChunkHelper::new_chunk(pk_schema, 1);
+    PredicateMap pushdown_predicates;
+    size_t num_pk_eq_predicates = 0;
+    for (const ColumnPredicate* pred : _reader_params->predicates) {
+        auto column_id = pred->column_id();
+        if (column_id < tablet_schema.num_key_columns() && pred->type() == PredicateType::kEQ) {
+            auto& column = keys->get_column_by_id(column_id);
+            if (column->size() != 0) {
+                return Status::NotSupported(
+                        strings::Substitute("multiple eq predicates on same pk column columnId=$0", column_id));
+            }
+            column->append_datum(pred->value());
+            num_pk_eq_predicates++;
+        } else {
+            pushdown_predicates[pred->column_id()].emplace_back(pred);
+        }
+    }
+    if (num_pk_eq_predicates != tablet_schema.num_key_columns()) {
+        return Status::NotSupported(strings::Substitute("should have eq predicates on all pk columns current: $0 < $1",
+                                                        num_pk_eq_predicates, tablet_schema.num_key_columns()));
+    }
+    std::unique_ptr<Column> pk_column;
+    if (!PrimaryKeyEncoder::create_column(*tablet_schema.schema(), &pk_column).ok()) {
+        CHECK(false) << "create column for primary key encoder failed tablet_id:" << _tablet->tablet_id();
+    }
+    PrimaryKeyEncoder::encode(*tablet_schema.schema(), *keys, 0, keys->num_rows(), pk_column.get());
+
+    // get rowid using pk index
+    EditVersion read_version;
+    std::vector<uint64_t> rowids(1);
+    RETURN_IF_ERROR(_tablet->updates()->get_rss_rowids_by_pk(_tablet.get(), *pk_column, &read_version, &rowids));
+    if (rowids.size() != 1) {
+        return Status::InternalError(strings::Substitute("get rowid size not match tablet:$0 $1 != $2",
+                                                         _tablet->tablet_id(), rowids.size(), 1));
+    }
+    // do not check read version in use_pk_index mode
+    uint32_t rssid = rowids[0] >> 32;
+    uint32_t rowid = rowids[0] & 0xffffffff;
+    if (rssid == (uint32_t)-1) {
+        _collect_iter = new_empty_iterator(_schema, _reader_params->chunk_size);
+        return Status::OK();
+    }
+
+    RowsetSharedPtr rowset;
+    uint32_t segment_idx = 0;
+    RETURN_IF_ERROR(_tablet->updates()->get_rowset_and_segment_idx_by_rssid(rssid, &rowset, &segment_idx));
+
+    RowsetReadOptions rs_opts;
+    rs_opts.predicates = pushdown_predicates;
+    rs_opts.sorted = false;
+    rs_opts.reader_type = _reader_params->reader_type;
+    rs_opts.chunk_size = _reader_params->chunk_size;
+    rs_opts.delete_predicates = &_delete_predicates;
+    rs_opts.stats = &_stats;
+    rs_opts.runtime_state = _reader_params->runtime_state;
+    rs_opts.profile = _reader_params->profile;
+    rs_opts.use_page_cache = _reader_params->use_page_cache;
+    rs_opts.tablet_schema = &_tablet->tablet_schema();
+    rs_opts.global_dictmaps = _reader_params->global_dictmaps;
+    rs_opts.unused_output_column_ids = _reader_params->unused_output_column_ids;
+    rs_opts.runtime_range_pruner = _reader_params->runtime_range_pruner;
+    // single row fetch, no need to use delvec
+    rs_opts.is_primary_keys = false;
+
+    rs_opts.rowid_range_option = std::make_shared<RowidRangeOption>();
+    auto rowid_range = std::make_shared<SparseRange>();
+    rowid_range->add({rowid, rowid + 1});
+    if (segment_idx >= rowset->num_segments()) {
+        return Status::InternalError(strings::Substitute("segment_idx out of range tablet:$0 $1 >= $2",
+                                                         _tablet->tablet_id(), segment_idx, rowset->num_segments()));
+    }
+    rs_opts.rowid_range_option->add(rowset.get(), rowset->segments()[segment_idx].get(), rowid_range);
+
+    std::vector<ChunkIteratorPtr> iters;
+    RETURN_IF_ERROR(rowset->get_segment_iterators(schema(), rs_opts, &iters));
+
+    if (iters.size() != 1) {
+        return Status::InternalError(
+                strings::Substitute("get_segment_iterators for pointer query should return single iter tablet:$0 $1",
+                                    _tablet->tablet_id(), iters.size()));
+    }
+
+    _collect_iter = iters[0];
+
+    // other collector setup
+    RETURN_IF_ERROR(_collect_iter->init_encoded_schema(*_reader_params->global_dictmaps));
+    RETURN_IF_ERROR(_collect_iter->init_output_schema(*_reader_params->unused_output_column_ids));
+
+    return Status::OK();
+}
+
 Status TabletReader::do_get_next(Chunk* chunk) {
     DCHECK(!_is_vertical_merge);
+    if (UNLIKELY(_collect_iter == nullptr)) {
+        auto st = _init_collector_for_pk_index_read();
+        if (!st.ok()) {
+            LOG(WARNING) << "using pk index for pointer read failed, fallback to normal read " << st;
+            RETURN_IF_ERROR(_init_collector(*_reader_params));
+        }
+    }
     RETURN_IF_ERROR(_collect_iter->get_next(chunk));
     return Status::OK();
 }

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -77,6 +77,8 @@ private:
     static Status _to_seek_tuple(const TabletSchema& tablet_schema, const OlapTuple& input, SeekTuple* tuple,
                                  MemPool* mempool);
 
+    Status _init_collector_for_pk_index_read();
+
     TabletSharedPtr _tablet;
     Version _version;
 
@@ -96,6 +98,9 @@ private:
     bool _is_vertical_merge = false;
     bool _is_key = false;
     RowSourceMaskBuffer* _mask_buffer = nullptr;
+
+    // used for pk index based pointer read
+    const TabletReaderParams* _reader_params = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -83,6 +83,7 @@ struct TabletReaderParams {
     OlapRuntimeScanRangePruner runtime_range_pruner;
 
     std::unordered_map<uint32_t, ColumnAccessPathPtr>* column_access_paths = nullptr;
+    bool use_pk_index = false;
 
 public:
     std::string to_string() const;

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -283,11 +283,11 @@ public:
                              std::map<uint32_t, std::vector<uint32_t>>& rowids_by_rssid,
                              vector<std::unique_ptr<Column>>* columns, void* state);
 
-    Status prepare_partial_update_states(Tablet* tablet, const ColumnUniquePtr& upserts, EditVersion* read_version,
-                                         std::vector<uint64_t>* rss_rowids);
+    Status get_rss_rowids_by_pk(Tablet* tablet, const Column& keys, EditVersion* read_version,
+                                std::vector<uint64_t>* rss_rowids);
 
-    Status prepare_partial_update_states_unlock(Tablet* tablet, const ColumnUniquePtr& upserts,
-                                                EditVersion* read_version, std::vector<uint64_t>* rss_rowids);
+    Status get_rss_rowids_by_pk_unlock(Tablet* tablet, const Column& keys, EditVersion* read_version,
+                                       std::vector<uint64_t>* rss_rowids);
 
     Status get_missing_version_ranges(std::vector<int64_t>& missing_version_ranges);
 
@@ -312,6 +312,8 @@ public:
                                          std::vector<uint32_t>* rowset_ids);
 
     bool check_delta_column_generate_from_version(EditVersion begin_version);
+
+    Status get_rowset_and_segment_idx_by_rssid(uint32_t rssid, RowsetSharedPtr* rowset, uint32_t* segment_idx);
 
 private:
     friend class Tablet;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -278,6 +278,7 @@ set(EXEC_FILES
         ./storage/binlog_reader_test.cpp
         ./storage/tablet_binlog_test.cpp
         ./storage/publish_version_task_test.cpp
+        ./storage/get_use_pk_index_test.cpp
         ./runtime/buffer_control_block_test.cpp
         ./runtime/datetime_value_test.cpp
         ./runtime/decimalv2_value_test.cpp

--- a/be/test/storage/get_use_pk_index_test.cpp
+++ b/be/test/storage/get_use_pk_index_test.cpp
@@ -1,0 +1,347 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "column/datum_tuple.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/runtime_state.h"
+#include "storage/chunk_helper.h"
+#include "storage/empty_iterator.h"
+#include "storage/kv_store.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/schema_change.h"
+#include "storage/snapshot_manager.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_meta_manager.h"
+#include "storage/tablet_reader.h"
+#include "storage/tablet_updates.h"
+#include "storage/update_manager.h"
+#include "testutil/assert.h"
+#include "util/defer_op.h"
+
+namespace starrocks {
+
+class GetUsePkIndexTest : public testing::Test {
+public:
+    using Row = std::vector<Datum>;
+    RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const std::vector<std::vector<Row>>& segments,
+                                  SegmentsOverlapPB overlap) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = &tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = overlap;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        for (size_t i = 0; i < segments.size(); i++) {
+            auto& segment = segments[i];
+            auto chunk = ChunkHelper::new_chunk(schema, segment.size());
+            auto& cols = chunk->columns();
+            for (auto& row : segment) {
+                CHECK(cols.size() == row.size());
+                for (size_t j = 0; j < row.size(); j++) {
+                    cols[j]->append_datum(row[j]);
+                }
+            }
+            CHECK_OK(writer->flush_chunk(*chunk));
+        }
+        return *writer->build();
+    }
+
+    static int64_t get_pk1(int64_t key) { return key % 100; }
+
+    static int64_t get_pk2(int64_t key) { return key / 100; }
+
+    static int64_t get_v1(int64_t key) { return static_cast<int64_t>((key * 7919) % 7883); }
+
+    static int64_t get_v2(int64_t key) { return static_cast<int64_t>((key * 6361) % 6373); }
+
+    void generate_data(int64_t key_start, size_t num_row, size_t num_segment, bool multi_column_pk, bool sort_key,
+                       std::vector<std::vector<Row>>& segments) {
+        size_t num_row_per_segment = (num_row + num_segment - 1) / num_segment;
+        std::vector<int64_t> keys(num_row, 0);
+        for (size_t i = 0; i < num_row; i++) {
+            keys[i] = key_start + i;
+        }
+        std::random_shuffle(keys.begin(), keys.end());
+        for (size_t i = 0; i < num_segment; i++) {
+            auto& segment = segments.emplace_back();
+            size_t start = i * num_row_per_segment;
+            size_t end = std::min((i + 1) * num_row_per_segment, num_row);
+            std::sort(keys.begin() + start, keys.begin() + end);
+            for (size_t j = start; j < end; j++) {
+                auto& row = segment.emplace_back();
+                auto key = keys[j];
+                if (multi_column_pk) {
+                    row.push_back(Datum(get_pk1(key)));
+                    row.push_back(Datum(get_pk2(key)));
+                } else {
+                    row.push_back(Datum(key));
+                }
+                row.push_back(Datum(get_v1(key)));
+                row.push_back(Datum(get_v2(key)));
+            }
+            if (sort_key) {
+                const size_t sort_key_idx = multi_column_pk ? 2 : 1;
+                std::vector<size_t> ind(segment.size());
+                std::iota(ind.begin(), ind.end(), 0);
+                std::sort(ind.begin(), ind.end(), [&](size_t a, size_t b) {
+                    return segment[a][sort_key_idx].get_int64() < segment[b][sort_key_idx].get_int64();
+                });
+                std::vector<Row> sorted_segment;
+                sorted_segment.reserve(segment.size());
+                for (auto idx : ind) {
+                    sorted_segment.emplace_back(segment[idx]);
+                }
+                std::swap(segment, sorted_segment);
+            }
+        }
+    }
+
+    void print_data(const std::vector<std::vector<Row>>& segments) {
+        for (size_t i = 0; i < segments.size(); i++) {
+            std::cout << "segment " << i << std::endl;
+            for (auto& row : segments[i]) {
+                for (auto& datum : row) {
+                    std::cout << "  " << datum.get_int64();
+                }
+                std::cout << std::endl;
+            }
+        }
+    }
+
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash, bool multi_column_pk, bool sort_key) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+        if (sort_key) {
+            if (multi_column_pk) {
+                request.tablet_schema.sort_key_idxes.push_back(2);
+            } else {
+                request.tablet_schema.sort_key_idxes.push_back(1);
+            }
+        }
+
+        if (multi_column_pk) {
+            TColumn pk1;
+            pk1.column_name = "pk1";
+            pk1.__set_is_key(true);
+            pk1.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(pk1);
+            TColumn pk2;
+            pk2.column_name = "pk2";
+            pk2.__set_is_key(true);
+            pk2.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(pk2);
+        } else {
+            TColumn k1;
+            k1.column_name = "pk";
+            k1.__set_is_key(true);
+            k1.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(k1);
+        }
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k3);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    void wait_for_version(int64_t version, int64_t timeout_ms = 10000) {
+        while (true) {
+            timeout_ms -= 200;
+            if (timeout_ms <= 0) {
+                ASSERT_TRUE(false) << "timeout";
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            std::vector<RowsetSharedPtr> rowsets;
+            EditVersion full_version;
+            ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(version, &rowsets, &full_version).ok());
+            if (full_version.major() >= version) {
+                break;
+            }
+            std::cerr << "waiting for version " << version << std::endl;
+        }
+    }
+
+    void read_using_pk_index(int64_t key, int64_t version, bool multi_column_pk, bool expect_exist) {
+        const Schema& schema = *_tablet->tablet_schema().schema();
+        TabletReader reader(_tablet, Version(0, version), schema);
+        TabletReaderParams params;
+        params.is_pipeline = true;
+        params.reader_type = READER_QUERY;
+        params.use_page_cache = false;
+        params.use_pk_index = true;
+        std::string pk_str = std::to_string(key);
+        std::unique_ptr<ColumnPredicate> pk_eq(
+                new_column_eq_predicate(get_type_info(LogicalType::TYPE_BIGINT), 0, pk_str));
+        std::string pk1_str = std::to_string(get_pk1(key));
+        std::unique_ptr<ColumnPredicate> pk1_eq(
+                new_column_eq_predicate(get_type_info(LogicalType::TYPE_BIGINT), 0, pk1_str));
+        std::string pk2_str = std::to_string(get_pk2(key));
+        std::unique_ptr<ColumnPredicate> pk2_eq(
+                new_column_eq_predicate(get_type_info(LogicalType::TYPE_BIGINT), 1, pk2_str));
+        if (multi_column_pk) {
+            params.predicates.emplace_back(pk2_eq.get());
+            params.predicates.emplace_back(pk1_eq.get());
+        } else {
+            params.predicates.emplace_back(pk_eq.get());
+        }
+        ASSERT_OK(reader.prepare());
+        ASSERT_OK(reader.open(params));
+        auto chunk = ChunkHelper::new_chunk(reader.schema(), 1);
+        if (expect_exist) {
+            ASSERT_OK(reader.do_get_next(chunk.get()));
+            ASSERT_EQ(1, chunk->num_rows());
+            if (multi_column_pk) {
+                ASSERT_EQ(get_pk1(key), chunk->get_column_by_index(0)->get(0).get_int64());
+                ASSERT_EQ(get_pk2(key), chunk->get_column_by_index(1)->get(0).get_int64());
+                ASSERT_EQ(get_v1(key), chunk->get_column_by_index(2)->get(0).get_int64());
+                ASSERT_EQ(get_v2(key), chunk->get_column_by_index(3)->get(0).get_int64());
+            } else {
+                ASSERT_EQ(key, chunk->get_column_by_index(0)->get(0).get_int64());
+                ASSERT_EQ(get_v1(key), chunk->get_column_by_index(1)->get(0).get_int64());
+                ASSERT_EQ(get_v2(key), chunk->get_column_by_index(2)->get(0).get_int64());
+            }
+            chunk->reset();
+            ASSERT_TRUE(reader.do_get_next(chunk.get()).is_end_of_file());
+        } else {
+            ASSERT_TRUE(reader.do_get_next(chunk.get()).is_end_of_file());
+        }
+        reader.close();
+    }
+
+    void test_single_rowset_read(int32_t seed, bool multi_column_pk, bool sort_key) {
+        const int64_t key_start = 0;
+        const int num_row = _num_row;
+        const int num_get = std::min(20, num_row / 1000);
+        LOG(INFO) << "seed=" << seed << ", rowset=1, segment=" << _num_segment
+                  << ", multi_column_pk=" << multi_column_pk << ", sort_key=" << sort_key << ", "
+                  << "num_row=" << num_row << ", num_get=" << num_get;
+        srand(GetCurrentTimeMicros());
+        _tablet = create_tablet(rand(), rand(), multi_column_pk, sort_key);
+        std::vector<std::vector<Row>> segments;
+        std::srand(seed);
+        generate_data(key_start, num_row, _num_segment, multi_column_pk, sort_key, segments);
+        auto rs = create_rowset(_tablet, segments, SegmentsOverlapPB::OVERLAPPING);
+        ASSERT_TRUE(_tablet->rowset_commit(2, rs).ok());
+        wait_for_version(2);
+        ASSERT_EQ(2, _tablet->updates()->max_version());
+        for (int i = 0; i < num_get; i++) {
+            int64_t get_key = std::rand() % num_row + key_start;
+            read_using_pk_index(get_key, 2, multi_column_pk, true);
+        }
+        read_using_pk_index(key_start - 1, 2, multi_column_pk, false);
+        read_using_pk_index(key_start + num_row, 2, multi_column_pk, false);
+    }
+
+    void test_multi_rowset_read(int32_t seed, bool multi_column_pk, bool sort_key) {
+        const int64_t key_start = 0;
+        const int num_row = _num_row;
+        const int num_get = std::min(20, num_row / 1000);
+        LOG(INFO) << "seed=" << seed << ", rowset=2, segment=" << _num_segment
+                  << ", multi_column_pk=" << multi_column_pk << ", sort_key=" << sort_key << ", "
+                  << "num_row=" << num_row << ", num_get=" << num_get;
+        srand(GetCurrentTimeMicros());
+        _tablet = create_tablet(rand(), rand(), multi_column_pk, sort_key);
+        std::srand(seed);
+        std::vector<std::vector<Row>> segments1;
+        generate_data(key_start, num_row / 2, _num_segment, multi_column_pk, sort_key, segments1);
+        auto rs1 = create_rowset(_tablet, segments1, SegmentsOverlapPB::OVERLAPPING);
+        ASSERT_TRUE(_tablet->rowset_commit(2, rs1).ok());
+        std::vector<std::vector<Row>> segments2;
+        generate_data(key_start + num_row / 2, num_row - num_row / 2, _num_segment, multi_column_pk, sort_key,
+                      segments2);
+        auto rs2 = create_rowset(_tablet, segments2, SegmentsOverlapPB::OVERLAPPING);
+        ASSERT_TRUE(_tablet->rowset_commit(3, rs2).ok());
+        wait_for_version(3);
+        ASSERT_EQ(3, _tablet->updates()->max_version());
+        for (int i = 0; i < num_get; i++) {
+            int64_t get_key = std::rand() % num_row + key_start;
+            read_using_pk_index(get_key, 2, multi_column_pk, true);
+        }
+        read_using_pk_index(key_start - 1, 2, multi_column_pk, false);
+        read_using_pk_index(key_start + num_row, 2, multi_column_pk, false);
+    }
+
+protected:
+    TabletSharedPtr _tablet;
+    size_t _num_segment = 1;
+    size_t _num_row = 10000;
+};
+
+TEST_F(GetUsePkIndexTest, single_segment) {
+    const int32_t seed = 0;
+    _num_row = 10000;
+    _num_segment = 1;
+    test_single_rowset_read(seed, false, false);
+    test_single_rowset_read(seed, true, false);
+    test_single_rowset_read(seed, false, true);
+    test_single_rowset_read(seed, true, true);
+}
+
+TEST_F(GetUsePkIndexTest, multi_segment) {
+    const int32_t seed = 0;
+    _num_row = 10000;
+    _num_segment = 3;
+    test_single_rowset_read(seed, false, false);
+    test_single_rowset_read(seed, true, false);
+    test_single_rowset_read(seed, false, true);
+    test_single_rowset_read(seed, true, true);
+}
+
+TEST_F(GetUsePkIndexTest, multi_segment_multi_rowset) {
+    const int32_t seed = 0;
+    _num_row = 10000;
+    _num_segment = 3;
+    test_multi_rowset_read(seed, false, false);
+    test_multi_rowset_read(seed, true, false);
+    test_multi_rowset_read(seed, false, true);
+    test_multi_rowset_read(seed, true, true);
+}
+
+}; // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
@@ -34,7 +34,8 @@ public class TableRelation extends Relation {
     public enum TableHint {
         _META_,
         _BINLOG_,
-        _SYNC_MV_
+        _SYNC_MV_,
+        _USE_PK_INDEX_,
     }
 
     private final TableName name;
@@ -91,7 +92,7 @@ public class TableRelation extends Relation {
 
     // Check whether the table has some table hints, some rules should not be applied.
     public boolean hasTableHints() {
-        return partitionNames != null || isSyncMVQuery() ||  (tabletIds != null && !tabletIds.isEmpty());
+        return partitionNames != null || isSyncMVQuery() || (tabletIds != null && !tabletIds.isEmpty());
     }
 
     public List<Long> getTabletIds() {
@@ -158,8 +159,13 @@ public class TableRelation extends Relation {
     public boolean isBinlogQuery() {
         return tableHints.contains(TableHint._BINLOG_) && table.isOlapTable();
     }
+
     public boolean isSyncMVQuery() {
         return tableHints.contains(TableHint._SYNC_MV_);
+    }
+
+    public boolean isUsePkIndex() {
+        return tableHints.contains(TableHint._USE_PK_INDEX_);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -333,6 +333,7 @@ public class MvRewritePreprocessor {
                 .setSelectedTabletId(selectTabletIds)
                 .setHintsTabletIds(Collections.emptyList())
                 .setHasTableHints(false)
+                .setUsePkIndex(false)
                 .build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalOlapScanOperator.java
@@ -43,6 +43,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
     private List<Long> hintsTabletIds;
 
     private List<ScalarOperator> prunedPartitionPredicates;
+    private boolean usePkIndex;
 
     // record if this scan is derived from SplitScanORToUnionRule
     private boolean fromSplitOR;
@@ -65,7 +66,8 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
                 null,
                 false,
                 Lists.newArrayList(),
-                Lists.newArrayList());
+                Lists.newArrayList(),
+                false);
     }
 
     public LogicalOlapScanOperator(
@@ -80,7 +82,8 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
             PartitionNames partitionNames,
             boolean hasTableHints,
             List<Long> selectedTabletId,
-            List<Long> hintsTabletIds) {
+            List<Long> hintsTabletIds,
+            boolean usePkIndex) {
         super(OperatorType.LOGICAL_OLAP_SCAN, table, colRefToColumnMetaMap, columnMetaToColRefMap, limit, predicate,
                 null);
 
@@ -93,6 +96,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
         this.selectedTabletId = selectedTabletId;
         this.hintsTabletIds = hintsTabletIds;
         this.prunedPartitionPredicates = Lists.newArrayList();
+        this.usePkIndex = usePkIndex;
     }
 
     private LogicalOlapScanOperator() {
@@ -126,6 +130,10 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
 
     public boolean hasTableHints() {
         return hasTableHints;
+    }
+
+    public boolean isUsePkIndex() {
+        return usePkIndex;
     }
 
     public List<ScalarOperator> getPrunedPartitionPredicates() {
@@ -189,6 +197,7 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
             builder.selectedTabletId = scanOperator.selectedTabletId;
             builder.hintsTabletIds = scanOperator.hintsTabletIds;
             builder.prunedPartitionPredicates = scanOperator.prunedPartitionPredicates;
+            builder.usePkIndex = scanOperator.usePkIndex;
             return this;
         }
 
@@ -234,6 +243,11 @@ public final class LogicalOlapScanOperator extends LogicalScanOperator {
 
         public Builder setFromSplitOR(boolean fromSplitOR) {
             builder.fromSplitOR = fromSplitOR;
+            return this;
+        }
+
+        public Builder setUsePkIndex(boolean usePkIndex) {
+            builder.usePkIndex = usePkIndex;
             return this;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalOlapScanOperator.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.operator.physical;
 
 import com.google.common.collect.Lists;
@@ -47,6 +46,8 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
     private String turnOffReason;
     protected boolean needSortedByKeyPerTablet = false;
 
+    private boolean usePkIndex = false;
+
     private List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
     // TODO: remove this
     private Map<Integer, Integer> dictStringIdToIntIds = Maps.newHashMap();
@@ -62,13 +63,15 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
                                     List<Long> selectedPartitionId,
                                     List<Long> selectedTabletId,
                                     List<ScalarOperator> prunedPartitionPredicates,
-                                    Projection projection) {
+                                    Projection projection,
+                                    boolean usePkIndex) {
         super(OperatorType.PHYSICAL_OLAP_SCAN, table, colRefToColumnMetaMap, limit, predicate, projection);
         this.distributionSpec = distributionDesc;
         this.selectedIndexId = selectedIndexId;
         this.selectedPartitionId = selectedPartitionId;
         this.selectedTabletId = selectedTabletId;
         this.prunedPartitionPredicates = prunedPartitionPredicates;
+        this.usePkIndex = usePkIndex;
     }
 
     public long getSelectedIndexId() {
@@ -130,6 +133,10 @@ public class PhysicalOlapScanOperator extends PhysicalScanOperator {
 
     public void setNeedSortedByKeyPerTablet(boolean needSortedByKeyPerTablet) {
         this.needSortedByKeyPerTablet = needSortedByKeyPerTablet;
+    }
+
+    public boolean isUsePkIndex() {
+        return usePkIndex;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/OlapScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/OlapScanImplementationRule.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.implementation;
 
 import com.google.common.collect.Lists;
@@ -45,7 +44,8 @@ public class OlapScanImplementationRule extends ImplementationRule {
                 scan.getSelectedPartitionId(),
                 scan.getSelectedTabletId(),
                 scan.getPrunedPartitionPredicates(),
-                scan.getProjection());
+                scan.getProjection(),
+                scan.isUsePkIndex());
 
         physicalOlapScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalOlapScan);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MVProjectAggProjectScanRewrite.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MVProjectAggProjectScanRewrite.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.mv;
 
 import com.google.common.base.Preconditions;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.tree;
 
 import com.google.common.base.Preconditions;
@@ -249,7 +248,8 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                     if (!usedCols.isEmpty()) {
                         Set<Integer> dictCols = usedCols.stream().map(e -> context.stringColumnIdToDictColumnIds.get(e))
                                 .collect(Collectors.toSet());
-                        if (!(globalDictIds.containsAll(dictCols) && couldApplyDictOptimize(operator, encodedStringCols))) {
+                        if (!(globalDictIds.containsAll(dictCols) &&
+                                couldApplyDictOptimize(operator, encodedStringCols))) {
                             return false;
                         }
                     }
@@ -257,7 +257,6 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
             }
             return true;
         }
-
 
         // create a new dictionary column and assign the same property except for the type and column id
         // the input column maybe a dictionary column or a string column
@@ -457,7 +456,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                                     scanOperator.getDistributionSpec(), scanOperator.getLimit(), newPredicate,
                                     scanOperator.getSelectedIndexId(), scanOperator.getSelectedPartitionId(),
                                     scanOperator.getSelectedTabletId(), scanOperator.getPrunedPartitionPredicates(),
-                                    scanOperator.getProjection());
+                                    scanOperator.getProjection(), scanOperator.isUsePkIndex());
                     newOlapScan.setPreAggregation(scanOperator.isPreAggregation());
                     newOlapScan.setGlobalDicts(globalDicts);
                     // set output columns because of the projection is not encoded but the colRefToColumnMetaMap has encoded.
@@ -965,7 +964,8 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
         result.setStatistics(childExpr.get(0).getStatistics());
 
         LogicalProperty decodeProperty = new LogicalProperty(childExpr.get(0).getLogicalProperty());
-        result.setLogicalProperty(DecodeVisitor.rewriteLogicProperty(decodeProperty, decodeOperator.getDictToStrings()));
+        result.setLogicalProperty(
+                DecodeVisitor.rewriteLogicProperty(decodeProperty, decodeOperator.getDictToStrings()));
         context.clear();
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -496,6 +496,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
                         .setSelectedTabletId(Lists.newArrayList())
                         .setHintsTabletIds(node.getTabletIds())
                         .setHasTableHints(node.hasTableHints())
+                        .setUsePkIndex(node.isUsePkIndex())
                         .build();
             } else {
                 scanOperator = new LogicalBinlogScanOperator(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -778,6 +778,8 @@ public class PlanFragmentBuilder {
             scanNode.updateAppliedDictStringColumns(node.getGlobalDicts().stream().
                     map(entry -> entry.first).collect(Collectors.toSet()));
 
+            scanNode.setUsePkIndex(node.isUsePkIndex());
+
             context.getScanNodes().add(scanNode);
             PlanFragment fragment =
                     new PlanFragment(context.getNextFragmentId(), scanNode, DataPartition.RANDOM);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/implementation/OlapScanImplementationRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/implementation/OlapScanImplementationRuleTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.implementation;
 
 import com.google.common.collect.Lists;
@@ -39,7 +38,7 @@ public class OlapScanImplementationRuleTest {
         LogicalOlapScanOperator logical = new LogicalOlapScanOperator(table, Maps.newHashMap(), Maps.newHashMap(),
                 null, -1, ConstantOperator.createBoolean(true),
                 1, Lists.newArrayList(1L, 2L, 3L), null,
-                false, Lists.newArrayList(4L), null);
+                false, Lists.newArrayList(4L), null, false);
 
         List<OptExpression> output =
                 new OlapScanImplementationRule().transform(new OptExpression(logical), new OptimizerContext(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPrunerRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPrunerRuleTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.collect.Lists;
@@ -147,7 +146,7 @@ public class DistributionPrunerRuleTest {
                         inPredicateOperator2, inPredicateOperator3, inPredicateOperator4);
         LogicalOlapScanOperator operator =
                 new LogicalOlapScanOperator(olapTable, scanColumnMap, Maps.newHashMap(), null, -1, predicate,
-                        1, Lists.newArrayList(1L), null, false, Lists.newArrayList(), Lists.newArrayList());
+                        1, Lists.newArrayList(1L), null, false, Lists.newArrayList(), Lists.newArrayList(), false);
         operator.setPredicate(predicate);
 
         new Expectations() {
@@ -183,7 +182,6 @@ public class DistributionPrunerRuleTest {
                         .get(0);
 
         assertEquals(20, ((LogicalOlapScanOperator) optExpression.getOp()).getSelectedTabletId().size());
-
 
         LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) optExpression.getOp();
         LogicalOlapScanOperator newScanOperator = new LogicalOlapScanOperator.Builder()

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PartitionPruneRuleTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.collect.Lists;
@@ -367,7 +366,7 @@ public class PartitionPruneRuleTest {
 
     @Test
     public void transformForSingleItemListPartitionWithTemp(@Mocked OlapTable olapTable,
-                                                    @Mocked ListPartitionInfo partitionInfo)
+                                                            @Mocked ListPartitionInfo partitionInfo)
             throws AnalysisException {
         FeConstants.runningUnitTest = true;
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
@@ -382,7 +381,7 @@ public class PartitionPruneRuleTest {
         LogicalOlapScanOperator operator =
                 new LogicalOlapScanOperator(olapTable, scanColumnMap, columnMetaToColRefMap,
                         null, -1, null, olapTable.getBaseIndexId(),
-                        null, partitionNames, false, Lists.newArrayList(), Lists.newArrayList());
+                        null, partitionNames, false, Lists.newArrayList(), Lists.newArrayList(), false);
 
         Partition part1 = new Partition(10001L, "p1", null, null);
         Partition part2 = new Partition(10002L, "p2", null, null);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.collect.ImmutableMap;
@@ -253,7 +252,8 @@ public class StatisticsCalculatorTest {
                     null,
                     false,
                     Lists.newArrayList(),
-                    Lists.newArrayList());
+                    Lists.newArrayList(),
+                    false);
 
             GroupExpression groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
             groupExpression.setGroup(new Group(0));
@@ -316,7 +316,8 @@ public class StatisticsCalculatorTest {
                         null,
                         false,
                         Lists.newArrayList(),
-                        Lists.newArrayList());
+                        Lists.newArrayList(),
+                        false);
 
         GroupExpression groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
@@ -372,7 +373,8 @@ public class StatisticsCalculatorTest {
                         null,
                         false,
                         Lists.newArrayList(),
-                        Lists.newArrayList());
+                        Lists.newArrayList(),
+                        false);
 
         GroupExpression groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
@@ -400,7 +402,8 @@ public class StatisticsCalculatorTest {
                         null,
                         false,
                         Lists.newArrayList(),
-                        Lists.newArrayList());
+                        Lists.newArrayList(),
+                        false);
         olapScanOperator.setPredicate(new BinaryPredicateOperator(BinaryType.GE,
                 idDate, ConstantOperator.createDate(LocalDateTime.of(2014, 5, 1, 0, 0, 0))));
 
@@ -459,7 +462,8 @@ public class StatisticsCalculatorTest {
                         null,
                         false,
                         Lists.newArrayList(),
-                        Lists.newArrayList());
+                        Lists.newArrayList(),
+                        false);
 
         GroupExpression groupExpression = new GroupExpression(olapScanOperator, Lists.newArrayList());
         groupExpression.setGroup(new Group(0));
@@ -489,7 +493,8 @@ public class StatisticsCalculatorTest {
                         null,
                         false,
                         Lists.newArrayList(),
-                        Lists.newArrayList());
+                        Lists.newArrayList(),
+                        false);
         olapScanOperator.setPredicate(new BinaryPredicateOperator(BinaryType.GE,
                 idDate, ConstantOperator.createDate(LocalDateTime.of(2020, 04, 24, 0, 0, 0))));
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -480,6 +480,7 @@ struct TOlapScanNode {
   27: optional list<string> sort_key_column_names
   28: optional i32 max_parallel_scan_instance_num
   29: optional list<TColumnAccessPath> column_access_paths
+  30: optional bool use_pk_index
 }
 
 struct TJDBCScanNode {


### PR DESCRIPTION
Resolves: #23006

This PR adds a hint to use primary index for pointer query. If the hint is present, TabletReader will defer reader init to pipe IO thread and check whether all the key columns have an equal predicate, if so, it will look up PK from pk index to get rowset&segment&rowid, then init segment iterator to only read that row.

This feature is especially useful for table whose sort key and primary key are different. When data is stored in sort key, query by primary key will result in a full table scan. So using pk index to support pointer query will greatly boost performance.

Note that looking up index requires locking the index, this operation may get blocked during index update, this issue will be optimized later when index supports MVCC.

```
mysql> select * from test [_USE_PK_INDEX_] where pk = 3;
+------+------+
| pk   | v1   |
+------+------+
|    3 |    3 |
+------+------+
1 row in set (0.01 sec)

```
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
