### PR TITLE
[BugFix] Fix MetaVersion compatibility bug where read in lower version will throw NPE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MetaVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MetaVersion.java
@@ -17,6 +17,7 @@ package com.starrocks.catalog;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.StarRocksFEMetaVersion;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -26,6 +27,8 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 public class MetaVersion implements Writable {
+    private static final String KEY_COMMUNITY_VERSION = "communityVersion";
+
     // Before version 1.19, the json key for storing starrocksVersion is KEY_DORISDB_VERSION,
     // and the later versions are KEY_STARROCKS_VERSION
     private static final String KEY_STARROCKS_VERSION = "starrocksVersion";
@@ -44,6 +47,9 @@ public class MetaVersion implements Writable {
     @Override
     public void write(DataOutput out) throws IOException {
         JsonObject jsonObject = new JsonObject();
+        // For rollback compatibility
+        jsonObject.addProperty(KEY_COMMUNITY_VERSION, FeConstants.META_VERSION);
+
         // For rollback compatibility, save the starrocksVersion both to
         // KEY_STARROCKS_VERSION and KEY_DORISDB_VERSION
         jsonObject.addProperty(KEY_STARROCKS_VERSION, starrocksVersion);


### PR DESCRIPTION
Fixes 
```
java.lang.NullPointerException: null
        at com.starrocks.catalog.MetaVersion.read(MetaVersion.java:70) ~[classes/:?]
        at com.starrocks.journal.JournalEntity.readFields(JournalEntity.java:438) ~[classes/:?]
        at com.starrocks.journal.bdbje.BDBJournalCursor.deserializeData(BDBJournalCursor.java:251) ~[classes/:?]
        at com.starrocks.journal.bdbje.BDBJournalCursor.next(BDBJournalCursor.java:295) ~[classes/:?]
        at com.starrocks.server.GlobalStateMgr.replayJournalInner(GlobalStateMgr.java:2005) ~[classes/:?]
        at com.starrocks.server.GlobalStateMgr.replayJournal(GlobalStateMgr.java:1965) ~[classes/:?]
        at com.starrocks.server.GlobalStateMgr.transferToLeader(GlobalStateMgr.java:1106) ~[classes/:?]
        at com.starrocks.server.GlobalStateMgr.access$100(GlobalStateMgr.java:316) ~[classes/:?]
        at com.starrocks.server.GlobalStateMgr$1.transferToLeader(GlobalStateMgr.java:691) ~[classes/:?]
        at com.starrocks.ha.StateChangeExecutor.runOneCycle(StateChangeExecutor.java:103) ~[classes/:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:115) ~[classes/:?]
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
