### PR TITLE
[Enhancement] Limit the block_size for block cache.

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -33,6 +33,12 @@ namespace starrocks {
 
 namespace fs = std::filesystem;
 
+// The cachelib doesn't support a item (key+valueu+attribute) larger than 4 MB without chain.
+// So, we check and limit the block_size configured by users to avoid unexpected errors.
+// For starcache, in theory we doesn't have a hard limitation for block size, but a very large
+// block_size may cause heavy read amplification. So, we also limit it to 2 MB as an empirical value.
+const size_t BlockCache::MAX_BLOCK_SIZE = 2 * 1024 * 1024;
+
 BlockCache* BlockCache::instance() {
     static BlockCache cache;
     return &cache;
@@ -57,17 +63,17 @@ Status BlockCache::init(const CacheOptions& options) {
             }
         }
     }
-    _block_size = options.block_size;
+    _block_size = std::min(options.block_size, MAX_BLOCK_SIZE);
 #ifdef WITH_CACHELIB
     if (options.engine == "cachelib") {
         _kv_cache = std::make_unique<CacheLibWrapper>();
-        LOG(INFO) << "init cachelib block engine";
+        LOG(INFO) << "init cachelib engine, block_size: " << _block_size;
     }
 #endif
 #ifdef WITH_STARCACHE
     if (options.engine == "starcache") {
         _kv_cache = std::make_unique<StarCacheWrapper>();
-        LOG(INFO) << "init starcache block engine";
+        LOG(INFO) << "init starcache engine, block_size: " << _block_size;
     }
 #endif
     if (!_kv_cache) {

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -49,6 +49,8 @@ public:
 
     size_t block_size() const { return _block_size; }
 
+    static const size_t MAX_BLOCK_SIZE;
+
 private:
 #ifndef BE_TEST
     BlockCache() = default;


### PR DESCRIPTION

The cachelib doesn't support a item (key+valueu+attribute) larger than 4 MB without chain. So, we check and limit the block_size configured by users to avoid unexpected errors. For starcache, in theory we doesn't have a hard limitation for block size, but a very large block_size may cause heavy read amplification. So, we also limit it to 2 MB as an empirical value.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
