### PR TITLE
[BugFix] Fix down_cast<ConnectorScanOperator*> failed in ~ConnectorChunkSource()

### DIFF
--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -461,7 +461,6 @@ ConnectorChunkSource::ConnectorChunkSource(ScanOperator* op, RuntimeProfile* run
     _data_source->set_read_limit(_limit);
     _data_source->set_runtime_profile(runtime_profile);
     _data_source->update_has_any_predicate();
-    _op = down_cast<ConnectorScanOperator*>(op);
 }
 
 ConnectorChunkSource::~ConnectorChunkSource() {
@@ -482,8 +481,7 @@ const std::string ConnectorChunkSource::get_custom_coredump_msg() const {
 }
 
 ConnectorScanOperatorIOTasksMemLimiter* ConnectorChunkSource::_get_io_tasks_mem_limiter() const {
-    ConnectorScanOperator* op = down_cast<ConnectorScanOperator*>(_scan_op);
-    ConnectorScanOperatorFactory* f = down_cast<ConnectorScanOperatorFactory*>(op->get_factory());
+    auto* f = down_cast<ConnectorScanOperatorFactory*>(_scan_op->get_factory());
     return f->_io_tasks_mem_limiter;
 }
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -27,7 +27,7 @@ class ScanNode;
 
 namespace pipeline {
 
-class ConnectorScanOperatorIOTasksMemLimiter;
+struct ConnectorScanOperatorIOTasksMemLimiter;
 
 class ConnectorScanOperatorFactory : public ScanOperatorFactory {
 public:
@@ -61,7 +61,7 @@ public:
     ConnectorScanOperatorIOTasksMemLimiter* _io_tasks_mem_limiter;
 };
 
-class ConnectorScanOperatorAdaptiveProcessor;
+struct ConnectorScanOperatorAdaptiveProcessor;
 class ConnectorScanOperator : public ScanOperator {
 public:
     ConnectorScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_sequence, int32_t dop,
@@ -135,7 +135,6 @@ private:
     bool _opened = false;
     bool _closed = false;
     uint64_t _rows_read = 0;
-    ConnectorScanOperator* _op = nullptr;
 };
 
 } // namespace pipeline


### PR DESCRIPTION
Fix below DECHECK failed msg:

```bash
start time: Wed Jun 14 01:48:36 PM CST 2023
starrocks_be: /home/disk1/code/starrocks-bak/be/src/gutil/casts.h:79: To down_cast(From *) [To = starrocks::pipeline::ConnectorScanOperator *, From = starrocks::pipeline::ScanOperator]: Assertion `f == NULL || dynamic_cast<To>(f) != NULL' failed.
UNKNOWN ASAN (build UNKNOWN)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
tracker:process consumption: 0
tracker:query_pool consumption: 0
tracker:load consumption: 0
tracker:metadata consumption: 56652
tracker:tablet_metadata consumption: 49762
tracker:rowset_metadata consumption: 6890
tracker:segment_metadata consumption: 0
tracker:column_metadata consumption: 0
tracker:tablet_schema consumption: 3362
tracker:segment_zonemap consumption: 0
tracker:short_key_index consumption: 0
tracker:column_zonemap_index consumption: 0
tracker:ordinal_index consumption: 0
tracker:bitmap_index consumption: 0
tracker:bloom_filter_index consumption: 0
tracker:compaction consumption: 0
tracker:schema_change consumption: 0
tracker:column_pool consumption: 0
tracker:page_cache consumption: 0
tracker:update consumption: 0
tracker:chunk_allocator consumption: 0
tracker:clone consumption: 0
tracker:consistency consumption: 0
*** Aborted at 1686721770 (unix time) try "date -d @1686721770" if you are using GNU date ***
PC: @     0x7eff412f6a7c pthread_kill
*** SIGABRT (@0x4010020f0c1) received by PID 2158785 (TID 0x7efc4fb63640) from PID 2158785; stack trace: ***
    @         0x175ae49a google::(anonymous namespace)::FailureSignalHandler()
    @     0x7eff412a2520 (unknown)
    @     0x7eff412f6a7c pthread_kill
    @     0x7eff412a2476 raise
    @     0x7eff412887f3 abort
    @     0x7eff4128871b (unknown)
    @     0x7eff41299e96 __assert_fail
    @          0xc96a884 down_cast<>()
    @          0xc961e8e starrocks::pipeline::ConnectorChunkSource::_get_io_tasks_mem_limiter()
    @          0xc961f4e starrocks::pipeline::ConnectorChunkSource::close()
    @          0xa6f9341 starrocks::pipeline::ScanOperator::_close_chunk_source_unlocked()
    @          0xa6f1939 starrocks::pipeline::ScanOperator::_close_chunk_source()
    @          0xa6f16f5 starrocks::pipeline::ScanOperator::~ScanOperator()
    @          0xc96ad95 starrocks::pipeline::ConnectorScanOperator::~ConnectorScanOperator()
    @          0xc96caed std::_Destroy<>()
    @          0xc96ca29 std::allocator_traits<>::destroy<>()
    @          0xc96c636 std::_Sp_counted_ptr_inplace<>::_M_dispose()
    @          0xa099341 std::_Sp_counted_base<>::_M_release()
    @          0xa099186 std::__shared_count<>::~__shared_count()
    @          0xa640639 std::__shared_ptr<>::~__shared_ptr()
    @          0xa63edc5 std::shared_ptr<>::~shared_ptr()
    @          0xa6410b5 std::_Destroy<>()
    @          0xa641087 std::_Destroy_aux<>::__destroy<>()
    @          0xa64104d std::_Destroy<>()
    @          0xa640f51 std::_Destroy<>()
    @          0xa63cb9f std::vector<>::~vector()
    @          0xa6b61d3 starrocks::pipeline::PipelineDriver::~PipelineDriver()
    @          0xa6b417d std::_Destroy<>()
    @          0xa6b40d9 std::allocator_traits<>::destroy<>()
    @          0xa6b2886 std::_Sp_counted_ptr_inplace<>::_M_dispose()
    @          0xa099341 std::_Sp_counted_base<>::_M_release()
    @          0xa099186 std::__shared_count<>::~__shared_count()

```

When ConnectorChunkSource has put in the task queue, but not be executed, then user cancels the query, we will run the following process:
```bash
~ConnectorScanOperator()
~ConnectorChunkSource()
# In ~ConnectorChunkSource(), we will try to down_cast<ConnectorScanOperator*>(_scan_op);
# But ConnectorScanOperator already deconstructed, so here we will down cast failed.
```


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
