### PR TITLE
[Enhancement] Makes estimating the memory required by the aggregator more accurate

### DIFF
--- a/be/src/exec/aggregate/agg_hash_variant.cpp
+++ b/be/src/exec/aggregate/agg_hash_variant.cpp
@@ -17,6 +17,8 @@
 #include <type_traits>
 #include <variant>
 
+#include "util/phmap/phmap.h"
+
 namespace starrocks {
 
 namespace detail {
@@ -214,6 +216,13 @@ size_t AggHashMapVariant::size() const {
     });
 }
 
+bool AggHashMapVariant::need_expand(size_t increasement) const {
+    // TODO: think about two-level hashmap
+    size_t size = this->size() + increasement;
+    // see detail implement in reset_growth_left
+    return size >= phmap::priv::CapacityToGrowth(this->capacity());
+}
+
 size_t AggHashMapVariant::reserved_memory_usage(const MemPool* pool) const {
     return visit([pool](const auto& hash_map_with_key) {
         return hash_map_with_key->hash_map.dump_bound() + pool->total_reserved_bytes();
@@ -281,6 +290,12 @@ size_t AggHashSetVariant::size() const {
         }
         return sz;
     });
+}
+
+bool AggHashSetVariant::need_expand(size_t increasement) const {
+    size_t size = this->size() + increasement;
+    // see detail implement in reset_growth_left
+    return size >= phmap::priv::CapacityToGrowth(this->capacity());
 }
 
 size_t AggHashSetVariant::reserved_memory_usage(const MemPool* pool) const {

--- a/be/src/exec/aggregate/agg_hash_variant.h
+++ b/be/src/exec/aggregate/agg_hash_variant.h
@@ -482,6 +482,8 @@ struct AggHashMapVariant {
 
     size_t size() const;
 
+    bool need_expand(size_t increasement) const;
+
     size_t reserved_memory_usage(const MemPool* pool) const;
 
     size_t allocated_memory_usage(const MemPool* pool) const;
@@ -581,6 +583,8 @@ struct AggHashSetVariant {
     size_t capacity() const;
 
     size_t size() const;
+
+    bool need_expand(size_t increasement) const;
 
     size_t reserved_memory_usage(const MemPool* pool) const;
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -90,10 +90,7 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_force_preaggregati
 }
 
 Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_auto(const ChunkPtr& chunk, const size_t chunk_size) {
-    // TODO: calc the real capacity of hashtable, will add one interface in the class of habletable
-    size_t real_capacity = _aggregator->hash_set_variant().capacity() - _aggregator->hash_set_variant().capacity() / 8;
-    size_t remain_size = real_capacity - _aggregator->hash_set_variant().size();
-    bool ht_needs_expansion = remain_size < chunk_size;
+    bool ht_needs_expansion = _aggregator->hash_set_variant().need_expand(chunk_size);
     size_t allocated_bytes = _aggregator->hash_set_variant().allocated_memory_usage(_aggregator->mem_pool());
     if (!ht_needs_expansion ||
         _aggregator->should_expand_preagg_hash_tables(_aggregator->num_input_rows(), chunk_size, allocated_bytes,

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -156,10 +156,7 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const ChunkPtr& chunk
     const size_t continuous_limit = _auto_context.get_continuous_limit();
     switch (_auto_state) {
     case AggrAutoState::INIT_PREAGG: {
-        size_t real_capacity =
-                _aggregator->hash_map_variant().capacity() - _aggregator->hash_map_variant().capacity() / 8;
-        size_t remain_size = real_capacity - _aggregator->hash_map_variant().size();
-        bool ht_needs_expansion = remain_size < chunk_size;
+        bool ht_needs_expansion = _aggregator->hash_map_variant().need_expand(chunk_size);
         _auto_context.init_preagg_count++;
         if (!ht_needs_expansion ||
             _aggregator->should_expand_preagg_hash_tables(_aggregator->num_input_rows(), chunk_size, allocated_bytes,

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
@@ -49,11 +49,10 @@ public:
 
     size_t estimated_memory_reserved(const ChunkPtr& chunk) override {
         if (chunk && !chunk->is_empty()) {
-            if (_aggregator->is_hash_set()) {
-                return chunk->memory_usage() + _aggregator->hash_set_memory_usage();
-            } else {
+            if (_aggregator->hash_map_variant().need_expand(chunk->num_rows())) {
                 return chunk->memory_usage() + _aggregator->hash_map_memory_usage();
             }
+            return chunk->memory_usage();
         }
         return 0;
     }

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.h
@@ -48,6 +48,16 @@ public:
         TRACE_SPILL_LOG << "AggregateDistinctBlockingSink, mark spill " << (void*)this;
     }
 
+    size_t estimated_memory_reserved(const ChunkPtr& chunk) override {
+        if (chunk && !chunk->is_empty()) {
+            if (_aggregator->hash_set_variant().need_expand(chunk->num_rows())) {
+                return chunk->memory_usage() + _aggregator->hash_set_memory_usage();
+            }
+            return chunk->memory_usage();
+        }
+        return 0;
+    }
+
 private:
     Status _spill_all_inputs(RuntimeState* state, const ChunkPtr& chunk);
     Status _spill_aggregated_data(RuntimeState* state);


### PR DESCRIPTION
In the past, we have taken a more conservative strategy. We have considered the hashmap/hash_set to have the possibility of expansion every time. Now we only need to reserve memory in advance when the phmap really needs to be expanded

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
