### PR TITLE
[BugFix] Fix NLJoin crash when enable runtime_adaptive_dop

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_context.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.cpp
@@ -61,6 +61,12 @@ void NJJoinBuildInputChannel::finalize() {
     }
 }
 
+void NJJoinBuildInputChannel::close() {
+    _accumulator.reset();
+    _input_chunks.clear();
+    _spiller.reset();
+}
+
 Status SpillableNLJoinChunkStream::prefetch(RuntimeState* state, spill::IOTaskExecutor& executor) {
     return _reader->trigger_restore(state, executor, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_reader)));
 }
@@ -235,7 +241,10 @@ Status NLJoinContext::finish_one_right_sinker(int32_t sinker_id, RuntimeState* s
         } else {
             _notify_runtime_filter_collector(state);
         }
-        _input_channel.clear();
+
+        for (auto& channel : _input_channel) {
+            channel->close();
+        }
 
         _all_right_finished = true;
     }

--- a/be/src/exec/pipeline/nljoin/nljoin_context.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.h
@@ -64,6 +64,8 @@ public:
 
     void finalize();
 
+    void close();
+
     size_t num_rows() const { return _num_rows; }
 
     // Fragmented chunk. it can only be the last chunk in the chunk_list


### PR DESCRIPTION
output_amplification_factor in NLJoinBuildOperator will be called when enable runtime_adaptive_dop. but _input_channels will be clear when all builder has set_finishing.

so the solution is add a close method for each build channel

Fixes https://github.com/StarRocks/StarRocksTest/issues/2692

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
