### PR TITLE
[BugFix] Ensure SinkIOBuffer outlives execution queue

### DIFF
--- a/be/src/exec/pipeline/sink/sink_io_buffer.h
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.h
@@ -85,8 +85,17 @@ public:
 
     virtual void close(RuntimeState* state) {
         if (_exec_queue_id != nullptr) {
-            bthread::execution_queue_stop(*_exec_queue_id);
-            bthread::execution_queue_join(*_exec_queue_id); // make sure the stop task has been executed
+            int ret = bthread::execution_queue_stop(*_exec_queue_id);
+            if (ret != 0) {
+                auto error_msg = fmt::format("Fail to stop execution queue: {}", std::strerror(errno));
+                LOG(WARNING) << error_msg;
+            }
+
+            ret = bthread::execution_queue_join(*_exec_queue_id); // make sure the stop task has been executed
+            if (ret != 0) {
+                auto error_msg = fmt::format("Fail to join execution queue: {}", std::strerror(errno));
+                LOG(WARNING) << error_msg;
+            }
             _exec_queue_id.reset();
         }
         _is_finished = true;

--- a/be/src/exec/pipeline/sink/sink_io_buffer.h
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.h
@@ -84,10 +84,12 @@ public:
     virtual void cancel_one_sinker() { _is_cancelled = true; }
 
     virtual void close(RuntimeState* state) {
-        _is_finished = true;
         if (_exec_queue_id != nullptr) {
             bthread::execution_queue_stop(*_exec_queue_id);
+            bthread::execution_queue_join(*_exec_queue_id); // make sure the stop task has been executed
+            _exec_queue_id.reset();
         }
+        _is_finished = true;
     }
 
     inline void set_io_status(const Status& status) {
@@ -103,6 +105,9 @@ public:
     }
 
     static int execute_io_task(void* meta, bthread::TaskIterator<ChunkPtr>& iter) {
+        if (iter.is_queue_stopped()) {
+            return 0;
+        }
         auto* sink_io_buffer = static_cast<SinkIOBuffer*>(meta);
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(sink_io_buffer->_state->query_mem_tracker_ptr().get());
         for (; iter; ++iter) {


### PR DESCRIPTION
Fix [SinkIOBuffer use-after-free in execution queue caused by pending task](https://github.com/StarRocks/StarRocksTest/issues/2691)


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
