### PR TITLE
[BugFix] fix load channel crash when add chunk

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -254,6 +254,9 @@ Status LoadChannel::_build_chunk_meta(const ChunkPB& pb_chunk) {
     if (_has_chunk_meta.load(std::memory_order_acquire)) {
         return Status::OK();
     }
+    if (_row_desc == nullptr) {
+        return Status::InternalError(fmt::format("load channel not open yet, load id: {}", _load_id.to_string()));
+    }
     StatusOr<serde::ProtobufChunkMeta> res = serde::build_protobuf_chunk_meta(*_row_desc, pb_chunk);
     if (!res.ok()) return res.status();
     _chunk_meta = std::move(res).value();


### PR DESCRIPTION
When load channel not open yet, the `_row_desc` will be null, avoid dereference it when `add_chunk`. This will happen when rpc packets arrive not in order.

crash stack:
```
(gdb) bt
#0  0x00000000057cd3e2 in starrocks::serde::build_protobuf_chunk_meta(starrocks::RowDescriptor const&, starrocks::ChunkPB const&) ()
#1  0x0000000004d1ee07 in starrocks::LoadChannel::_build_chunk_meta(starrocks::ChunkPB const&) ()
#2  0x0000000004d21816 in starrocks::LoadChannel::add_chunk(starrocks::PTabletWriterAddChunkRequest const&, starrocks::PTabletWriterAddBatchResult*) ()
#3  0x0000000004d1abb2 in starrocks::LoadChannelMgr::add_chunk(starrocks::PTabletWriterAddChunkRequest const&, starrocks::PTabletWriterAddBatchResult*) ()
#4  0x0000000004dd0835 in starrocks::BackendInternalServiceImpldoris::PBackendService::tablet_writer_add_chunk(google::protobuf::RpcController*, starrocks::PTabletWriterAddChunkRequest const*, starrocks::PTabletWriterAddBatchResult*, google::protobuf::Closure*) ()
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
