### PR TITLE
[Enhancement] Clear expired_versions from index `_apply_version_idx - 1`

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1945,7 +1945,7 @@ void TabletUpdates::remove_expired_versions(int64_t expire_time) {
         // only keep at most one version which is before expire_time
         // also to prevent excessive memory usage of editversion array, limit edit version count to be less than
         // config::tablet_max_versions
-        size_t keep_index_min = _apply_version_idx;
+        size_t keep_index_min = _apply_version_idx - 1;
         while (keep_index_min > 0) {
             if (_edit_version_infos[keep_index_min]->creation_time <= expire_time ||
                 keep_index_min + config::tablet_max_versions < _edit_version_infos.size()) {


### PR DESCRIPTION
If an load job has committed successfully, but publish task can not be executed successfully for a long time, it is possible that the latest applied version has been deleted, making it not queryable.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
