### PR TITLE
[Doc] add up starrocks_audit_tbl__ stmt from string to VARCHAR(1048576) aft…

### DIFF
--- a/docs/administration/audit_loader.md
+++ b/docs/administration/audit_loader.md
@@ -36,7 +36,7 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__ (
   `stmtId`         INT                    COMMENT "Incremental SQL statement ID",
   `isQuery`        TINYINT                COMMENT "If the SQL is a query (0 and 1)",
   `feIp`           VARCHAR(32)            COMMENT "IP address of FE that executes the SQL",
-  `stmt`           STRING                 COMMENT "SQL statement",
+  `stmt`           VARCHAR(1048576)       COMMENT "SQL statement",
   `digest`         VARCHAR(32)            COMMENT "SQL fingerprint",
   `planCpuCosts`   DOUBLE                 COMMENT "CPU resources consumption time for planning in nanoseconds",
   `planMemCosts`   DOUBLE                 COMMENT "Memory cost for planning in bytes"
@@ -78,7 +78,7 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__ (
   `stmtId`         INT                    COMMENT "Incremental SQL statement ID",
   `isQuery`        TINYINT                COMMENT "If the SQL is a query (0 and 1)",
   `feIp`           VARCHAR(32)            COMMENT "IP address of FE that executes the SQL",
-  `stmt`           STRING                 COMMENT "SQL statement",
+  `stmt`           VARCHAR(1048576)       COMMENT "SQL statement",
   `digest`         VARCHAR(32)            COMMENT "SQL fingerprint",
   `planCpuCosts`   DOUBLE                 COMMENT "CPU resources consumption time for planning in nanoseconds",
   `planMemCosts`   DOUBLE                 COMMENT "Memory cost for planning in bytes"
@@ -119,7 +119,7 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__
     stmt_id          INT                    COMMENT "Incremental SQL statement ID",
     is_query         TINYINT                COMMENT "If the SQL is a query (0 and 1)",
     frontend_ip      VARCHAR(32)            COMMENT "IP address of FE that executes the SQL",
-    stmt             STRING                 COMMENT "SQL statement",
+    stmt             VARCHAR(1048576)       COMMENT "SQL statement",
     digest           VARCHAR(32)            COMMENT "SQL fingerprint"
 ) engine=OLAP
 duplicate key(query_id, time, client_ip)
@@ -155,7 +155,7 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__
     stmt_id         INT                   COMMENT "Incremental SQL statement ID",
     is_query        TINYINT               COMMENT "If the SQL is a query (0 and 1)",
     frontend_ip     VARCHAR(32)           COMMENT "IP address of FE that executes the SQL",
-    stmt            STRING                COMMENT "SQL statement",
+    stmt            VARCHAR(1048576)      COMMENT "SQL statement",
     digest          VARCHAR(32)           COMMENT "SQL fingerprint"
 ) engine=OLAP
 DUPLICATE KEY(query_id, time, client_ip)


### PR DESCRIPTION
…er version 2.1 because string default length is 65533, it will cause stmt truncated if sql stmt's length exceed 65533

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
