### PR TITLE
[BugFix] The short key index and segment data may not be consistent after vertical compaction of primary key table which sort key  and primary key are separated

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -637,4 +637,12 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_update_file_iterators(const 
     return seg_iterators;
 }
 
+Status Rowset::get_segment_sk_index(std::vector<std::string>* sk_index_values) {
+    RETURN_IF_ERROR(load());
+    for (auto& segment : _segments) {
+        RETURN_IF_ERROR(segment->get_short_key_index(sk_index_values));
+    }
+    return Status::OK();
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -338,6 +338,9 @@ public:
 
     bool is_column_mode_partial_update() const { return _rowset_meta->is_column_mode_partial_update(); }
 
+    // only used in unit test
+    Status get_segment_sk_index(std::vector<std::string>* sk_index_values);
+
 protected:
     friend class RowsetFactory;
 

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -400,4 +400,12 @@ StatusOr<std::shared_ptr<Segment>> Segment::new_dcg_segment(const DeltaColumnGro
                          TabletSchema::create_with_uid(*_tablet_schema, dcg.column_ids()), nullptr);
 }
 
+Status Segment::get_short_key_index(std::vector<std::string>* sk_index_values) {
+    RETURN_IF_ERROR(load_index(false));
+    for (size_t i = 0; i < _sk_index_decoder->num_items(); i++) {
+        sk_index_values->emplace_back(_sk_index_decoder->key(i).to_string());
+    }
+    return Status::OK();
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -169,6 +169,9 @@ public:
 
     int64_t mem_usage() { return _basic_info_mem_usage() + _short_key_index_mem_usage(); }
 
+    // read short_key_index, for data check, just used in unit test now
+    Status get_short_key_index(std::vector<std::string>* sk_index_values);
+
     DISALLOW_COPY_AND_MOVE(Segment);
 
 private:

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -127,7 +127,8 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
     _column_indexes.insert(_column_indexes.end(), column_indexes.begin(), column_indexes.end());
     _column_writers.reserve(_column_indexes.size());
     size_t num_columns = _tablet_schema->num_columns();
-    for (uint32_t column_index : _column_indexes) {
+    for (uint32_t i = 0; i < _column_indexes.size(); i++) {
+        uint32_t column_index = _column_indexes[i];
         if (column_index >= num_columns) {
             return Status::InternalError(
                     strings::Substitute("column index $0 out of range $1", column_index, num_columns));
@@ -179,6 +180,9 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         ASSIGN_OR_RETURN(auto writer, ColumnWriter::create(opts, &column, _wfile.get()));
         RETURN_IF_ERROR(writer->init());
         _column_writers.push_back(std::move(writer));
+        if (column.is_sort_key()) {
+            _sort_column_indexes.emplace_back(i);
+        }
     }
 
     _has_key = has_key;
@@ -324,7 +328,7 @@ Status SegmentWriter::append_chunk(const Chunk& chunk) {
                 size_t keys = _tablet_schema->num_short_key_columns();
                 SeekTuple tuple(*chunk.schema(), chunk.get(i).datums());
                 std::string encoded_key;
-                encoded_key = tuple.short_key_encode(keys, _tablet_schema->sort_key_idxes(), 0);
+                encoded_key = tuple.short_key_encode(keys, _sort_column_indexes, 0);
                 RETURN_IF_ERROR(_index_builder->add_item(encoded_key));
             }
             ++_num_rows_written;

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -59,7 +59,11 @@ extern const char* const k_segment_magic;
 extern const uint32_t k_segment_magic_length;
 
 struct SegmentWriterOptions {
+#ifdef BE_TEST
+    uint32_t num_rows_per_block = 100;
+#else
     uint32_t num_rows_per_block = 1024;
+#endif
     GlobalDictByNameMaps* global_dicts = nullptr;
     std::vector<int32_t> referenced_column_ids;
 };
@@ -144,6 +148,7 @@ private:
     std::vector<std::unique_ptr<ColumnWriter>> _column_writers;
     std::vector<uint32_t> _column_indexes;
     bool _has_key = true;
+    std::vector<uint32_t> _sort_column_indexes;
 
     // num rows written when appending [partial] columns
     uint32_t _num_rows_written = 0;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -1704,6 +1704,29 @@ TEST_F(TabletUpdatesTest, horizontal_compaction_with_sort_key) {
     ASSERT_EQ(best_tablet->updates()->version_history_count(), loop + 2);
     // the time interval is not enough after last compaction
     EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
+
+    auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+    auto sk_chunk = ChunkHelper::new_chunk(schema, loop);
+    auto& cols = sk_chunk->columns();
+    for (int i = 0; i < loop; i++) {
+        int64_t key = sorted_keys[i * 100];
+        cols[0]->append_datum(Datum(key));
+        cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
+        cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+    }
+    std::vector<RowsetSharedPtr> rowsets;
+    ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(loop + 1, &rowsets).ok());
+    std::vector<std::string> sk_index_values;
+    for (auto& rowset : rowsets) {
+        ASSERT_TRUE(rowset->get_segment_sk_index(&sk_index_values).ok());
+    }
+    ASSERT_EQ(sk_index_values.size(), loop);
+    size_t keys = _tablet->tablet_schema().num_short_key_columns();
+    for (size_t i = 0; i < loop; i++) {
+        SeekTuple tuple(schema, sk_chunk->get(i).datums());
+        std::string encoded_key = tuple.short_key_encode(keys, {1, 2}, 0);
+        ASSERT_EQ(encoded_key, sk_index_values[i]);
+    }
 }
 
 TEST_F(TabletUpdatesTest, horizontal_compaction_with_sort_key_error_encode_case) {
@@ -1898,6 +1921,29 @@ TEST_F(TabletUpdatesTest, vertical_compaction_with_sort_key) {
     ASSERT_EQ(best_tablet->updates()->version_history_count(), loop + 2);
     // the time interval is not enough after last compaction
     EXPECT_EQ(best_tablet->updates()->get_compaction_score(), -1);
+
+    auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+    auto sk_chunk = ChunkHelper::new_chunk(schema, loop);
+    auto& cols = sk_chunk->columns();
+    for (int i = 0; i < loop; i++) {
+        int64_t key = sorted_keys[i * 100];
+        cols[0]->append_datum(Datum(key));
+        cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
+        cols[2]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+    }
+    std::vector<RowsetSharedPtr> rowsets;
+    ASSERT_TRUE(_tablet->updates()->get_applied_rowsets(loop + 1, &rowsets).ok());
+    std::vector<std::string> sk_index_values;
+    for (auto& rowset : rowsets) {
+        ASSERT_TRUE(rowset->get_segment_sk_index(&sk_index_values).ok());
+    }
+    ASSERT_EQ(sk_index_values.size(), loop);
+    size_t keys = _tablet->tablet_schema().num_short_key_columns();
+    for (size_t i = 0; i < loop; i++) {
+        SeekTuple tuple(schema, sk_chunk->get(i).datums());
+        std::string encoded_key = tuple.short_key_encode(keys, {1, 2}, 0);
+        ASSERT_EQ(encoded_key, sk_index_values[i]);
+    }
 }
 
 void TabletUpdatesTest::test_compaction_with_empty_rowset(bool enable_persistent_index, bool vertical,


### PR DESCRIPTION
If we create a primary key table separated primary key and sort key, we will write short key index according to sort key columns and we give sort key column id in tablet schema to decide which column should be encoded as short key index.
However, in vertical compaction, we will write all sort key columns data first and we cannot write short key index according to sort key column id.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
