### PR TITLE
[BugFix] Fix CpuUsageRecorderTest failure

### DIFF
--- a/be/test/util/cpu_usage_info_test.cpp
+++ b/be/test/util/cpu_usage_info_test.cpp
@@ -27,7 +27,6 @@ PARALLEL_TEST(CpuUsageRecorderTest, normal) {
     recorder.update_interval();
     int cpu_used_permille = recorder.cpu_used_permille();
     ASSERT_GE(cpu_used_permille, 0);
-    ASSERT_LE(cpu_used_permille, 1000);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
Fixes #25263

CpuUsageRecorder cannot sample cpu time and realtime in exactly the same time, so it's possible the cpu_used_permille be greater than 1000, remove the related assert

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
