### PR TITLE
[BugFix] Fix OutOfBound Exception when balancing distribution of tablet

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -1119,6 +1119,7 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
         for (Pair<Long, Long> partition : partitions) {
             PartitionStat pStat = partitionStats.get(partition);
             // skew <= 1 means partition is balanced
+            // break all partitions because they are sorted by skew in desc order.
             if (pStat.skew <= 1) {
                 break;
             }
@@ -1131,6 +1132,11 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
             } else {
                 tablets = getPartitionTablets(pStat.dbId, pStat.tableId, partition.first, partition.second, null,
                         Pair.create(beId, paths));
+            }
+
+            // partition may be dropped or materializedIndex may be replaced.
+            if (tablets.size() <= 1) {
+                continue;
             }
             boolean tabletFound = false;
             do {


### PR DESCRIPTION
Fixes
```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at java.util.ArrayList.rangeCheck(ArrayList.java:659) ~[?:1.8.0_322]
        at java.util.ArrayList.get(ArrayList.java:435) ~[?:1.8.0_322]
        at com.starrocks.clone.DiskAndTabletLoadReBalancer.balanceTablet(DiskAndTabletLoadReBalancer.java:1160) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.DiskAndTabletLoadReBalancer.balanceBackendTablet(DiskAndTabletLoadReBalancer.java:1065) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.DiskAndTabletLoadReBalancer.selectAlternativeTabletsForCluster(DiskAndTabletLoadReBalancer.java:105) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.Rebalancer.selectAlternativeTablets(Rebalancer.java:76) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletScheduler.selectTabletsForBalance(TabletScheduler.java:1281) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletScheduler.runAfterCatalogReady(TabletScheduler.java:377) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.LeaderDaemon.runOneCycle(LeaderDaemon.java:73) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:115) ~[starrocks-fe.jar:?]
```
Partition may be dropped or materializedIndex may be replaced when balancing, so the tablets may be an empty array.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
