### PR TITLE
[Enhancement] optimize limit

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -106,9 +106,6 @@ Status HiveDataSource::open(RuntimeState* state) {
 
 void HiveDataSource::_update_has_any_predicate() {
     auto f = [&]() {
-        if (_conjunct_ctxs.size() > 0) return true;
-        if (_min_max_conjunct_ctxs.size() > 0) return true;
-        if (_partition_conjunct_ctxs.size() > 0) return true;
         if (_runtime_filters != nullptr && _runtime_filters->size() > 0) return true;
         return false;
     };

--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -282,14 +282,15 @@ pipeline::OpFactories AggregateBlockingNode::decompose_to_pipeline(pipeline::Pip
         ops_with_source = try_interpolate_local_shuffle(ops_with_source);
     }
 
-    if (!_tnode.conjuncts.empty() || ops_with_source.back()->has_runtime_filters()) {
-        may_add_chunk_accumulate_operator(ops_with_source, context, id());
-    }
-
     if (limit() != -1) {
         ops_with_source.emplace_back(
                 std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
+
+    if (!_tnode.conjuncts.empty() || ops_with_source.back()->has_runtime_filters()) {
+        may_add_chunk_accumulate_operator(ops_with_source, context, id());
+    }
+
     return ops_with_source;
 }
 

--- a/be/src/exec/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/aggregate/distinct_blocking_node.cpp
@@ -222,14 +222,15 @@ pipeline::OpFactories DistinctBlockingNode::decompose_to_pipeline(pipeline::Pipe
         ops_with_source = try_interpolate_local_shuffle(ops_with_source);
     }
 
-    if (!_tnode.conjuncts.empty() || ops_with_source.back()->has_runtime_filters()) {
-        may_add_chunk_accumulate_operator(ops_with_source, context, id());
-    }
-
     if (limit() != -1) {
         ops_with_source.emplace_back(
                 std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
+
+    if (!_tnode.conjuncts.empty() || ops_with_source.back()->has_runtime_filters()) {
+        may_add_chunk_accumulate_operator(ops_with_source, context, id());
+    }
+
     return ops_with_source;
 }
 

--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -692,12 +692,12 @@ std::vector<std::shared_ptr<pipeline::OperatorFactory>> CrossJoinNode::_decompos
                                                                               context->degree_of_parallelism());
     left_ops.emplace_back(std::move(left_factory));
 
-    if constexpr (std::is_same_v<BuildFactory, SpillableNLJoinBuildOperatorFactory>) {
-        may_add_chunk_accumulate_operator(left_ops, context, id());
-    }
-
     if (limit() != -1) {
         left_ops.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
+    }
+
+    if constexpr (std::is_same_v<BuildFactory, SpillableNLJoinBuildOperatorFactory>) {
+        may_add_chunk_accumulate_operator(left_ops, context, id());
     }
 
     // return as the following pipeline

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -277,12 +277,12 @@ pipeline::OpFactories ExchangeNode::decompose_to_pipeline(pipeline::PipelineBuil
     // Initialize OperatorFactory's fields involving runtime filters.
     this->init_runtime_filter_for_operator(operators.back().get(), context, rc_rf_probe_collector);
 
-    if (operators.back()->has_runtime_filters()) {
-        may_add_chunk_accumulate_operator(operators, context, id());
-    }
-
     if (limit() != -1) {
         operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
+    }
+
+    if (operators.back()->has_runtime_filters()) {
+        may_add_chunk_accumulate_operator(operators, context, id());
     }
 
     operators = context->maybe_interpolate_collect_stats(runtime_state(), operators);

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -517,6 +517,10 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
     }
     lhs_operators.emplace_back(std::move(probe_op));
 
+    if (limit() != -1) {
+        lhs_operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
+    }
+
     // Use ChunkAccumulateOperator, when any following condition occurs:
     // - not left outer join,
     // - left outer join, with conjuncts or runtime filters.
@@ -524,10 +528,6 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
                                  !_other_join_conjunct_ctxs.empty() || lhs_operators.back()->has_runtime_filters();
     if (need_accumulate_chunk) {
         may_add_chunk_accumulate_operator(lhs_operators, context, id());
-    }
-
-    if (limit() != -1) {
-        lhs_operators.emplace_back(std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
 
     return lhs_operators;

--- a/be/src/exec/pipeline/scan/chunk_source.h
+++ b/be/src/exec/pipeline/scan/chunk_source.h
@@ -65,6 +65,8 @@ public:
     void pin_chunk_token(ChunkBufferTokenPtr chunk_token);
     void unpin_chunk_token();
 
+    virtual bool reach_limit() { return false; }
+
     // Used to print custom error msg in be.out when coredmp
     // Don't do heavey work, it calls frequently
     virtual const std::string get_custom_coredump_msg() const { return ""; }
@@ -96,6 +98,7 @@ protected:
     BalancedChunkBuffer& _chunk_buffer;
     Status _status = Status::OK();
     ChunkBufferTokenPtr _chunk_token;
+    std::atomic<bool> _reach_limit = false;
 
 private:
     // _scan_timer = _io_task_wait_timer + _io_task_exec_timer

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -539,6 +539,7 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
 
         // Improve for select * from table limit x, x is small
         if (_reach_eof()) {
+            _reach_limit.store(true);
             return Status::EndOfFile("limit reach");
         }
 

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -108,6 +108,8 @@ public:
     void close(RuntimeState* state) override;
     const std::string get_custom_coredump_msg() const override;
 
+    bool reach_limit() override { return _limit != -1 && _reach_limit.load(); }
+
 protected:
     virtual bool _reach_eof() const { return _limit != -1 && _rows_read >= _limit; }
     Status _open_data_source(RuntimeState* state);

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -283,6 +283,9 @@ Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
             total_cnt -= 1;
             continue;
         }
+        if (_chunk_sources[i] != nullptr && _chunk_sources[i]->reach_limit()) {
+            return Status::OK();
+        }
         if (_chunk_sources[i] != nullptr && _chunk_sources[i]->has_next_chunk()) {
             RETURN_IF_ERROR(_trigger_next_scan(state, i));
             total_cnt -= 1;
@@ -559,14 +562,14 @@ pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperat
 
     ops.emplace_back(std::move(scan_operator));
 
-    if ((!scan_node->conjunct_ctxs().empty() || ops.back()->has_runtime_filters()) && !ops.back()->has_topn_filter()) {
-        ExecNode::may_add_chunk_accumulate_operator(ops, context, scan_node->id());
-    }
-
     size_t limit = scan_node->limit();
     if (limit != -1) {
         ops.emplace_back(
                 std::make_shared<pipeline::LimitOperatorFactory>(context->next_operator_id(), scan_node->id(), limit));
+    }
+
+    if ((!scan_node->conjunct_ctxs().empty() || ops.back()->has_runtime_filters()) && !ops.back()->has_topn_filter()) {
+        ExecNode::may_add_chunk_accumulate_operator(ops, context, scan_node->id());
     }
 
     ops = context->maybe_interpolate_collect_stats(context->runtime_state(), ops);


### PR DESCRIPTION
Fixes #issue

I had made several optimize on limit:
1. move limitOperator ahead of chunk accumulate operator, so that we can quickly finish when reach limit.
2. for external table, we can push down limit to chunk accumulate on scan when there is no runtime filter(bloom filter), because other filter has pushed down to scanner.
3. we should have an atomic flag, so that we won't trigger new scan when any io task read limit.
result:
2.6s vs 1min, 460Mvs2.6G (FSIO > AppIO because we don't need all the group then we finished)
before:
<img width="1185" alt="截屏2023-06-15 12 08 30" src="https://github.com/StarRocks/starrocks/assets/28446271/9678b084-6572-49b4-b5fa-f3e6e1f1d0e2">
<img width="274" alt="截屏2023-06-15 12 08 19" src="https://github.com/StarRocks/starrocks/assets/28446271/80d56a21-32b7-4974-bf2a-c2ed314441c9">
after:
<img width="1183" alt="截屏2023-06-15 13 52 13" src="https://github.com/StarRocks/starrocks/assets/28446271/76114501-b0d3-4834-97d2-4e7742d16737">
<img width="270" alt="截屏2023-06-15 13 51 24" src="https://github.com/StarRocks/starrocks/assets/28446271/e9d461a8-9644-465e-94e0-96accd66779b">


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
