### PR TITLE
[BugFix] Fix IllegalState Exception thrown from TabletScheduler

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -569,7 +569,6 @@ public class TabletInvertedIndex {
     public Replica getReplica(long tabletId, long backendId) {
         readLock();
         try {
-            Preconditions.checkState(tabletMetaMap.containsKey(tabletId), tabletId);
             return replicaMetaTable.get(tabletId, backendId);
         } finally {
             readUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -927,7 +927,7 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
 
             if (pathHash != -1) {
                 Replica replica = GlobalStateMgr.getCurrentInvertedIndex().getReplica(tabletId, beId);
-                if (replica.getPathHash() != pathHash) {
+                if (replica == null || replica.getPathHash() != pathHash) {
                     continue;
                 }
             }
@@ -944,7 +944,10 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
         for (Map.Entry<Pair<Long, Long>, Set<Long>> entry : partitionTablets.entrySet()) {
             long totalSize = 0;
             for (Long tabletId : entry.getValue()) {
-                totalSize += GlobalStateMgr.getCurrentInvertedIndex().getReplica(tabletId, beId).getDataSize();
+                Replica replica = GlobalStateMgr.getCurrentInvertedIndex().getReplica(tabletId, beId);
+                if (replica != null) {
+                    totalSize += replica.getDataSize();
+                }
             }
             result.put(entry.getKey(), (double) totalSize / (entry.getValue().size() > 0 ? entry.getValue().size() : 1));
         }
@@ -1894,8 +1897,11 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                 tabletGroups[i] = new ArrayList<>();
             }
             for (long tabletId : tablets) {
-                long pathHash = tabletInvertedIndex.getReplica(tabletId, this.backendId).getPathHash();
-                int sortIndex = pathSortIndex.get(pathHash);
+                Replica replica = tabletInvertedIndex.getReplica(tabletId, this.backendId);
+                if (replica == null) {
+                    continue;
+                }
+                int sortIndex = pathSortIndex.get(replica.getPathHash());
                 if (sortIndex > lastHighLoadIndex) {
                     continue;
                 }


### PR DESCRIPTION
Fixes
```
java.lang.IllegalStateException: 6261562
        at com.google.common.base.Preconditions.checkState(Preconditions.java:510) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.catalog.TabletInvertedIndex.getReplica(TabletInvertedIndex.java:567) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.DiskAndTabletLoadReBalancer.tryToBalanceTablet(DiskAndTabletLoadReBalancer.java:1244) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.DiskAndTabletLoadReBalancer.balanceTablet(DiskAndTabletLoadReBalancer.java:1179) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.DiskAndTabletLoadReBalancer.balanceBackendTablet(DiskAndTabletLoadReBalancer.java:1065) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.DiskAndTabletLoadReBalancer.selectAlternativeTabletsForCluster(DiskAndTabletLoadReBalancer.java:105) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.Rebalancer.selectAlternativeTablets(Rebalancer.java:76) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletScheduler.selectTabletsForBalance(TabletScheduler.java:1281) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletScheduler.runAfterCatalogReady(TabletScheduler.java:377) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.LeaderDaemon.runOneCycle(LeaderDaemon.java:73) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:115) ~[starrocks-fe.jar:?]
```
Remove the assert in `getReplica`, check nullable in the caller.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
