### PR TITLE
[BugFix] Fix parquet page reader EOF check 

### DIFF
--- a/be/src/exec/pipeline/sink/sink_io_buffer.h
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.h
@@ -84,12 +84,10 @@ public:
     virtual void cancel_one_sinker() { _is_cancelled = true; }
 
     virtual void close(RuntimeState* state) {
+        _is_finished = true;
         if (_exec_queue_id != nullptr) {
             bthread::execution_queue_stop(*_exec_queue_id);
-            bthread::execution_queue_join(*_exec_queue_id); // make sure the stop task has been executed
-            _exec_queue_id.reset();
         }
-        _is_finished = true;
     }
 
     inline void set_io_status(const Status& status) {
@@ -105,9 +103,6 @@ public:
     }
 
     static int execute_io_task(void* meta, bthread::TaskIterator<ChunkPtr>& iter) {
-        if (iter.is_queue_stopped()) {
-            return 0;
-        }
         auto* sink_io_buffer = static_cast<SinkIOBuffer*>(meta);
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(sink_io_buffer->_state->query_mem_tracker_ptr().get());
         for (; iter; ++iter) {

--- a/be/src/exec/pipeline/sink/sink_io_buffer.h
+++ b/be/src/exec/pipeline/sink/sink_io_buffer.h
@@ -84,10 +84,12 @@ public:
     virtual void cancel_one_sinker() { _is_cancelled = true; }
 
     virtual void close(RuntimeState* state) {
-        _is_finished = true;
         if (_exec_queue_id != nullptr) {
             bthread::execution_queue_stop(*_exec_queue_id);
+            bthread::execution_queue_join(*_exec_queue_id); // make sure the stop task has been executed
+            _exec_queue_id.reset();
         }
+        _is_finished = true;
     }
 
     inline void set_io_status(const Status& status) {
@@ -103,6 +105,9 @@ public:
     }
 
     static int execute_io_task(void* meta, bthread::TaskIterator<ChunkPtr>& iter) {
+        if (iter.is_queue_stopped()) {
+            return 0;
+        }
         auto* sink_io_buffer = static_cast<SinkIOBuffer*>(meta);
         SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(sink_io_buffer->_state->query_mem_tracker_ptr().get());
         for (; iter; ++iter) {

--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -45,8 +45,9 @@ Status ColumnChunkReader::init(int chunk_size) {
     } else {
         start_offset = metadata().data_page_offset;
     }
-    size_t size = metadata().total_compressed_size;
-    _page_reader = std::make_unique<PageReader>(_opts.file->stream().get(), start_offset, size);
+    int64_t size = metadata().total_compressed_size;
+    int64_t num_values = metadata().num_values;
+    _page_reader = std::make_unique<PageReader>(_opts.file->stream().get(), start_offset, size, num_values);
 
     // seek to the first page
     _page_reader->seek_to_offset(start_offset);

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -22,8 +22,8 @@ namespace starrocks::parquet {
 
 static constexpr size_t kHeaderInitSize = 1024;
 
-PageReader::PageReader(io::SeekableInputStream* stream, uint64_t start_offset, uint64_t length)
-        : _stream(stream), _finish_offset(start_offset + length) {}
+PageReader::PageReader(io::SeekableInputStream* stream, uint64_t start_offset, uint64_t length, uint64_t num_values)
+        : _stream(stream), _finish_offset(start_offset + length), _num_values_total(num_values) {}
 
 Status PageReader::next_header() {
     if (_offset != _next_header_pos) {
@@ -31,7 +31,9 @@ Status PageReader::next_header() {
                 strings::Substitute("Try to parse parquet column header in wrong position, offset=$0 vs expect=$1",
                                     _offset, _next_header_pos));
     }
-    if (_offset >= _finish_offset) {
+
+    DCHECK(_num_values_read <= _num_values_total);
+    if (_num_values_read == _num_values_total) {
         return Status::EndOfFile("");
     }
 
@@ -61,6 +63,7 @@ Status PageReader::next_header() {
 
     _offset += header_length;
     _next_header_pos = _offset + _cur_header.compressed_page_size;
+    _num_values_read += _cur_header.data_page_header.num_values;
     return Status::OK();
 }
 

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -33,7 +33,9 @@ Status PageReader::next_header() {
     }
 
     DCHECK(_num_values_read <= _num_values_total);
-    if (_num_values_read == _num_values_total) {
+    if (_num_values_read >= _num_values_total) {
+        LOG_IF(WARNING, _num_values_read > _num_values_total)
+                << "Read more values than expected, read=" << _num_values_read << ", expect=" << _num_values_total;
         return Status::EndOfFile("");
     }
 

--- a/be/src/formats/parquet/page_reader.h
+++ b/be/src/formats/parquet/page_reader.h
@@ -25,7 +25,8 @@ namespace starrocks::parquet {
 // Used to parse page header of column chunk. This class don't parse page's type.
 class PageReader {
 public:
-    PageReader(io::SeekableInputStream* stream, size_t start, size_t length);
+    PageReader(io::SeekableInputStream* stream, size_t start, size_t length, size_t num_values);
+
     ~PageReader() = default;
 
     // Try to parse header starts from current _offset. Caller should assure that
@@ -59,6 +60,8 @@ private:
     uint64_t _offset = 0;
     uint64_t _next_header_pos = 0;
     uint64_t _finish_offset = 0;
+    uint64_t _num_values_total = 0;
+    uint64_t _num_values_read = 0;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/page_reader.h
+++ b/be/src/formats/parquet/page_reader.h
@@ -55,13 +55,15 @@ public:
     uint64_t get_offset() const { return _offset; }
 
 private:
-    io::SeekableInputStream* _stream;
+    io::SeekableInputStream* const _stream;
     tparquet::PageHeader _cur_header;
+
     uint64_t _offset = 0;
     uint64_t _next_header_pos = 0;
-    uint64_t _finish_offset = 0;
-    uint64_t _num_values_total = 0;
+    const uint64_t _finish_offset = 0;
+
     uint64_t _num_values_read = 0;
+    const uint64_t _num_values_total = 0;
 };
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/page_reader_test.cpp
+++ b/be/test/formats/parquet/page_reader_test.cpp
@@ -32,74 +32,74 @@ public:
     ~ParquetPageReaderTest() override = default;
 };
 
-TEST_F(ParquetPageReaderTest, Normal) {
-    std::string buffer;
-
-    std::vector<uint8_t> read_buffer;
-    read_buffer.reserve(1024);
-    uint8_t* data = read_buffer.data();
-
-    // page 0
-    {
-        tparquet::PageHeader page_header;
-        page_header.type = tparquet::PageType::DATA_PAGE;
-        page_header.uncompressed_page_size = 100;
-        page_header.compressed_page_size = 100;
-
-        ThriftSerializer ser(true, 100);
-        uint32_t len = 0;
-        uint8_t* header_ser = nullptr;
-        ser.serialize(&page_header, &len, &header_ser);
-        buffer.append((char*)header_ser, len);
-
-        buffer.resize(buffer.size() + page_header.compressed_page_size);
-    }
-
-    size_t page_1_size = buffer.size();
-    // page 1
-    {
-        tparquet::PageHeader page_header;
-        page_header.type = tparquet::PageType::DATA_PAGE;
-        page_header.uncompressed_page_size = 200;
-        page_header.compressed_page_size = 300;
-
-        ThriftSerializer ser(true, 100);
-        uint32_t len = 0;
-        uint8_t* header_ser = nullptr;
-        ser.serialize(&page_header, &len, &header_ser);
-        buffer.append((char*)header_ser, len);
-
-        buffer.resize(buffer.size() + page_header.compressed_page_size);
-    }
-
-    size_t total_size = buffer.size();
-
-    RandomAccessFile file(std::make_shared<io::StringInputStream>(std::move(buffer)), "string-file");
-
-    io::SharedBufferedInputStream stream(file.stream(), file.filename(), file.get_size().value());
-
-    PageReader reader(&stream, 0, total_size);
-
-    // read page 1
-    auto st = reader.next_header();
-    ASSERT_TRUE(st.ok());
-    ASSERT_EQ(100, reader.current_header()->uncompressed_page_size);
-
-    // read page 2
-    reader.seek_to_offset(page_1_size);
-    st = reader.next_header();
-    ASSERT_TRUE(st.ok());
-    ASSERT_EQ(200, reader.current_header()->uncompressed_page_size);
-
-    st = reader.read_bytes(data, 100);
-    ASSERT_TRUE(st.ok());
-
-    st = reader.read_bytes(data, 250);
-    ASSERT_FALSE(st.ok());
-
-    // read out-of-page
-    st = reader.next_header();
-    ASSERT_FALSE(st.ok());
-}
+//TEST_F(ParquetPageReaderTest, Normal) {
+//    std::string buffer;
+//
+//    std::vector<uint8_t> read_buffer;
+//    read_buffer.reserve(1024);
+//    uint8_t* data = read_buffer.data();
+//
+//    // page 0
+//    {
+//        tparquet::PageHeader page_header;
+//        page_header.type = tparquet::PageType::DATA_PAGE;
+//        page_header.uncompressed_page_size = 100;
+//        page_header.compressed_page_size = 100;
+//
+//        ThriftSerializer ser(true, 100);
+//        uint32_t len = 0;
+//        uint8_t* header_ser = nullptr;
+//        ser.serialize(&page_header, &len, &header_ser);
+//        buffer.append((char*)header_ser, len);
+//
+//        buffer.resize(buffer.size() + page_header.compressed_page_size);
+//    }
+//
+//    size_t page_1_size = buffer.size();
+//    // page 1
+//    {
+//        tparquet::PageHeader page_header;
+//        page_header.type = tparquet::PageType::DATA_PAGE;
+//        page_header.uncompressed_page_size = 200;
+//        page_header.compressed_page_size = 300;
+//
+//        ThriftSerializer ser(true, 100);
+//        uint32_t len = 0;
+//        uint8_t* header_ser = nullptr;
+//        ser.serialize(&page_header, &len, &header_ser);
+//        buffer.append((char*)header_ser, len);
+//
+//        buffer.resize(buffer.size() + page_header.compressed_page_size);
+//    }
+//
+//    size_t total_size = buffer.size();
+//
+//    RandomAccessFile file(std::make_shared<io::StringInputStream>(std::move(buffer)), "string-file");
+//
+//    io::SharedBufferedInputStream stream(file.stream(), file.filename(), file.get_size().value());
+//
+//    PageReader reader(&stream, 0, total_size);
+//
+//    // read page 1
+//    auto st = reader.next_header();
+//    ASSERT_TRUE(st.ok());
+//    ASSERT_EQ(100, reader.current_header()->uncompressed_page_size);
+//
+//    // read page 2
+//    reader.seek_to_offset(page_1_size);
+//    st = reader.next_header();
+//    ASSERT_TRUE(st.ok());
+//    ASSERT_EQ(200, reader.current_header()->uncompressed_page_size);
+//
+//    st = reader.read_bytes(data, 100);
+//    ASSERT_TRUE(st.ok());
+//
+//    st = reader.read_bytes(data, 250);
+//    ASSERT_FALSE(st.ok());
+//
+//    // read out-of-page
+//    st = reader.next_header();
+//    ASSERT_FALSE(st.ok());
+//}
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/page_reader_test.cpp
+++ b/be/test/formats/parquet/page_reader_test.cpp
@@ -32,74 +32,149 @@ public:
     ~ParquetPageReaderTest() override = default;
 };
 
-//TEST_F(ParquetPageReaderTest, Normal) {
-//    std::string buffer;
-//
-//    std::vector<uint8_t> read_buffer;
-//    read_buffer.reserve(1024);
-//    uint8_t* data = read_buffer.data();
-//
-//    // page 0
-//    {
-//        tparquet::PageHeader page_header;
-//        page_header.type = tparquet::PageType::DATA_PAGE;
-//        page_header.uncompressed_page_size = 100;
-//        page_header.compressed_page_size = 100;
-//
-//        ThriftSerializer ser(true, 100);
-//        uint32_t len = 0;
-//        uint8_t* header_ser = nullptr;
-//        ser.serialize(&page_header, &len, &header_ser);
-//        buffer.append((char*)header_ser, len);
-//
-//        buffer.resize(buffer.size() + page_header.compressed_page_size);
-//    }
-//
-//    size_t page_1_size = buffer.size();
-//    // page 1
-//    {
-//        tparquet::PageHeader page_header;
-//        page_header.type = tparquet::PageType::DATA_PAGE;
-//        page_header.uncompressed_page_size = 200;
-//        page_header.compressed_page_size = 300;
-//
-//        ThriftSerializer ser(true, 100);
-//        uint32_t len = 0;
-//        uint8_t* header_ser = nullptr;
-//        ser.serialize(&page_header, &len, &header_ser);
-//        buffer.append((char*)header_ser, len);
-//
-//        buffer.resize(buffer.size() + page_header.compressed_page_size);
-//    }
-//
-//    size_t total_size = buffer.size();
-//
-//    RandomAccessFile file(std::make_shared<io::StringInputStream>(std::move(buffer)), "string-file");
-//
-//    io::SharedBufferedInputStream stream(file.stream(), file.filename(), file.get_size().value());
-//
-//    PageReader reader(&stream, 0, total_size);
-//
-//    // read page 1
-//    auto st = reader.next_header();
-//    ASSERT_TRUE(st.ok());
-//    ASSERT_EQ(100, reader.current_header()->uncompressed_page_size);
-//
-//    // read page 2
-//    reader.seek_to_offset(page_1_size);
-//    st = reader.next_header();
-//    ASSERT_TRUE(st.ok());
-//    ASSERT_EQ(200, reader.current_header()->uncompressed_page_size);
-//
-//    st = reader.read_bytes(data, 100);
-//    ASSERT_TRUE(st.ok());
-//
-//    st = reader.read_bytes(data, 250);
-//    ASSERT_FALSE(st.ok());
-//
-//    // read out-of-page
-//    st = reader.next_header();
-//    ASSERT_FALSE(st.ok());
-//}
+TEST_F(ParquetPageReaderTest, Normal) {
+    std::string buffer;
+
+    std::vector<uint8_t> read_buffer;
+    read_buffer.reserve(1024);
+    uint8_t* data = read_buffer.data();
+
+    // page 0
+    {
+        tparquet::PageHeader page_header;
+        page_header.type = tparquet::PageType::DATA_PAGE;
+        page_header.uncompressed_page_size = 100;
+        page_header.compressed_page_size = 100;
+        page_header.data_page_header.num_values = 10;
+
+        ThriftSerializer ser(true, 100);
+        uint32_t len = 0;
+        uint8_t* header_ser = nullptr;
+        ser.serialize(&page_header, &len, &header_ser);
+        buffer.append((char*)header_ser, len);
+
+        buffer.resize(buffer.size() + page_header.compressed_page_size);
+    }
+
+    size_t page_1_size = buffer.size();
+    // page 1
+    {
+        tparquet::PageHeader page_header;
+        page_header.type = tparquet::PageType::DATA_PAGE;
+        page_header.uncompressed_page_size = 200;
+        page_header.compressed_page_size = 300;
+        page_header.data_page_header.num_values = 20;
+
+        ThriftSerializer ser(true, 100);
+        uint32_t len = 0;
+        uint8_t* header_ser = nullptr;
+        ser.serialize(&page_header, &len, &header_ser);
+        buffer.append((char*)header_ser, len);
+
+        buffer.resize(buffer.size() + page_header.compressed_page_size);
+    }
+
+    size_t total_size = buffer.size();
+
+    RandomAccessFile file(std::make_shared<io::StringInputStream>(std::move(buffer)), "string-file");
+
+    io::SharedBufferedInputStream stream(file.stream(), file.filename(), file.get_size().value());
+
+    PageReader reader(&stream, 0, total_size, 30);
+
+    // read page 1
+    auto st = reader.next_header();
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(100, reader.current_header()->uncompressed_page_size);
+
+    // read page 2
+    reader.seek_to_offset(page_1_size);
+    st = reader.next_header();
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(200, reader.current_header()->uncompressed_page_size);
+
+    st = reader.read_bytes(data, 100);
+    ASSERT_TRUE(st.ok());
+
+    st = reader.read_bytes(data, 250);
+    ASSERT_FALSE(st.ok());
+
+    // read out-of-page
+    st = reader.next_header();
+    ASSERT_FALSE(st.ok());
+}
+
+TEST_F(ParquetPageReaderTest, ExtraBytes) {
+    std::string buffer;
+
+    std::vector<uint8_t> read_buffer;
+    read_buffer.reserve(1024);
+    uint8_t* data = read_buffer.data();
+
+    // page 0
+    {
+        tparquet::PageHeader page_header;
+        page_header.type = tparquet::PageType::DATA_PAGE;
+        page_header.uncompressed_page_size = 100;
+        page_header.compressed_page_size = 100;
+        page_header.data_page_header.num_values = 10;
+
+        ThriftSerializer ser(true, 100);
+        uint32_t len = 0;
+        uint8_t* header_ser = nullptr;
+        ser.serialize(&page_header, &len, &header_ser);
+        buffer.append((char*)header_ser, len);
+
+        buffer.resize(buffer.size() + page_header.compressed_page_size);
+    }
+
+    size_t page_1_size = buffer.size();
+    // page 1
+    {
+        tparquet::PageHeader page_header;
+        page_header.type = tparquet::PageType::DATA_PAGE;
+        page_header.uncompressed_page_size = 200;
+        page_header.compressed_page_size = 300;
+        page_header.data_page_header.num_values = 20;
+
+        ThriftSerializer ser(true, 100);
+        uint32_t len = 0;
+        uint8_t* header_ser = nullptr;
+        ser.serialize(&page_header, &len, &header_ser);
+        buffer.append((char*)header_ser, len);
+
+        buffer.resize(buffer.size() + page_header.compressed_page_size);
+    }
+
+    size_t extra_nbytes = 10;
+    size_t total_size = buffer.size() + extra_nbytes;
+
+    RandomAccessFile file(std::make_shared<io::StringInputStream>(std::move(buffer)), "string-file");
+
+    io::SharedBufferedInputStream stream(file.stream(), file.filename(), file.get_size().value());
+
+    PageReader reader(&stream, 0, total_size, 30);
+
+    // read page 1
+    auto st = reader.next_header();
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(100, reader.current_header()->uncompressed_page_size);
+
+    // read page 2
+    reader.seek_to_offset(page_1_size);
+    st = reader.next_header();
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(200, reader.current_header()->uncompressed_page_size);
+
+    st = reader.read_bytes(data, 100);
+    ASSERT_TRUE(st.ok());
+
+    st = reader.read_bytes(data, 250);
+    ASSERT_FALSE(st.ok());
+
+    // read out-of-page
+    st = reader.next_header();
+    ASSERT_FALSE(st.ok());
+}
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/page_reader_test.cpp
+++ b/be/test/formats/parquet/page_reader_test.cpp
@@ -147,7 +147,8 @@ TEST_F(ParquetPageReaderTest, ExtraBytes) {
     }
 
     size_t extra_nbytes = 10;
-    size_t total_size = buffer.size() + extra_nbytes;
+    buffer.resize(buffer.size() + extra_nbytes);
+    size_t total_size = buffer.size();
 
     RandomAccessFile file(std::make_shared<io::StringInputStream>(std::move(buffer)), "string-file");
 


### PR DESCRIPTION
There are parquet files (although rare) where `total_uncompressed_bytes` in column chunk meta is larger than the total uncompressed bytes of all pages.

In this case, the current page reader would try to read an extra page (which is not existent), resulting in a page header decode error.

This PR resorts to `num_values` in column chunk meta, in line with `parquet-mr/parquet-cli`

```java
  private boolean hasMorePages(long valuesCountReadSoFar, int dataPageCountReadSoFar) {
    return offsetIndex == null ? valuesCountReadSoFar < descriptor.metadata.getValueCount()
        : dataPageCountReadSoFar < offsetIndex.getPageCount();
  }
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
