### PR TITLE
[BugFix] Fix statistcs collect bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDumpAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/QueryDumpAction.java
@@ -100,7 +100,7 @@ public class QueryDumpAction extends RestBaseAction {
 
         StatementBase parsedStmt;
         try {
-            parsedStmt = SqlParser.parseFirstStatement(query, context.getSessionVariable().getSqlMode());
+            parsedStmt = SqlParser.parse(query, context.getSessionVariable()).get(0);
             StmtExecutor executor = new StmtExecutor(context, parsedStmt);
             executor.execute();
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -182,6 +182,8 @@ public class ConnectContext {
     // set true when user dump query through HTTP
     protected boolean isQueryDump = false;
 
+    protected boolean isStatisticsConnection = false;
+
     protected DumpInfo dumpInfo;
 
     // The related db ids for current sql
@@ -599,6 +601,14 @@ public class ConnectContext {
 
     public void setParentConnectContext(ConnectContext parent) {
         this.parent = parent;
+    }
+
+    public boolean isStatisticsConnection() {
+        return isStatisticsConnection;
+    }
+
+    public void setStatisticsConnection(boolean statisticsConnection) {
+        isStatisticsConnection = statisticsConnection;
     }
 
     public ConnectContext getParent() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -768,7 +768,7 @@ public class DDLStmtExecutor {
                 // from current session, may execute analyze stmt
                 statsConnectCtx.getSessionVariable().setStatisticCollectParallelism(
                         context.getSessionVariable().getStatisticCollectParallelism());
-
+                statsConnectCtx.setStatisticsConnection(true);
                 Thread thread = new Thread(() -> {
                     statsConnectCtx.setThreadLocalInfo();
                     StatisticExecutor statisticExecutor = new StatisticExecutor();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1007,6 +1007,7 @@ public class StmtExecutor {
         statsConnectCtx.getSessionVariable().setStatisticCollectParallelism(
                 context.getSessionVariable().getStatisticCollectParallelism());
         statsConnectCtx.setThreadLocalInfo();
+        statsConnectCtx.setStatisticsConnection(true);
         executeAnalyze(statsConnectCtx, analyzeStmt, analyzeStatus, db, table);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableLikeAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableLikeAnalyzer.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.analyzer;
 
 import com.google.common.collect.Lists;
@@ -26,6 +25,7 @@ import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.sql.parser.SqlParser;
 
 import java.util.List;
 
@@ -46,8 +46,8 @@ public class CreateTableLikeAnalyzer {
             ErrorReport.reportSemanticException(ErrorCode.ERROR_CREATE_TABLE_LIKE_EMPTY, "CREATE");
         }
 
-        StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parseFirstStatement(createTableStmt.get(0),
-                context.getSessionVariable().getSqlMode());
+        StatementBase statementBase =
+                SqlParser.parseOneWithStarRocksDialect(createTableStmt.get(0), context.getSessionVariable());
         com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, context);
         if (statementBase instanceof CreateTableStmt) {
             CreateTableStmt parsedCreateTableStmt = (CreateTableStmt) statementBase;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -102,8 +102,16 @@ public class SqlParser {
         return parse(originSql, sessionVariable);
     }
 
+    /**
+     * Please use {@link #parse(String, SessionVariable)}
+     */
+    @Deprecated
     public static StatementBase parseFirstStatement(String originSql, long sqlMode) {
         return parse(originSql, sqlMode).get(0);
+    }
+
+    public static StatementBase parseOneWithStarRocksDialect(String originSql, SessionVariable sessionVariable) {
+        return parseWithStarRocksDialect(originSql, sessionVariable).get(0);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -288,6 +288,7 @@ public class AnalyzeMgr implements Writable {
 
         ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
         statsConnectCtx.setThreadLocalInfo();
+        statsConnectCtx.setStatisticsConnection(true);
 
         dropBasicStatsMetaAndData(statsConnectCtx, tableIdHasDeleted);
         dropHistogramStatsMetaAndData(statsConnectCtx, tableIdHasDeleted);
@@ -309,6 +310,7 @@ public class AnalyzeMgr implements Writable {
 
         ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
         statsConnectCtx.setThreadLocalInfo();
+        statsConnectCtx.setStatisticsConnection(true);
 
         List<Long> pids = dropPartitionIds.stream().limit(Config.expr_children_limit / 2).collect(Collectors.toList());
 
@@ -346,6 +348,7 @@ public class AnalyzeMgr implements Writable {
         List<Pair<Long, Long>> checkDbTableIds = Lists.newArrayList();
         List<Long> checkPartitionIds = Lists.newArrayList();
         ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+        statsConnectCtx.setStatisticsConnection(true);
 
         int exprLimit = Config.expr_children_limit / 2;
         for (Pair<Long, Long> dbTableId : checkTableIds) {
@@ -368,7 +371,6 @@ public class AnalyzeMgr implements Writable {
                 checkPartitionIds.clear();
                 checkDbTableIds.add(dbTableId);
                 checkPartitionIds.addAll(pids);
-                statsConnectCtx.getSessionVariable().setExprChildrenLimit(pids.size() * 3);
                 break;
             } else if ((checkDbTableIds.size() + checkPartitionIds.size() + pids.size()) > exprLimit) {
                 break;
@@ -386,6 +388,7 @@ public class AnalyzeMgr implements Writable {
         StatisticExecutor executor = new StatisticExecutor();
         List<Long> tables = checkDbTableIds.stream().map(p -> p.second).collect(Collectors.toList());
 
+        statsConnectCtx.getSessionVariable().setExprChildrenLimit(checkPartitionIds.size() * 3);
         if (executor.dropTableInvalidPartitionStatistics(statsConnectCtx, tables, checkPartitionIds)) {
             checkDbTableIds.forEach(checkTableIds::remove);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
@@ -82,6 +82,7 @@ public class StatisticAutoCollector extends FrontendDaemon {
                 GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
 
                 ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+                statsConnectCtx.setStatisticsConnection(true);
                 statsConnectCtx.setThreadLocalInfo();
                 STATISTIC_EXECUTOR.collectStatistics(statsConnectCtx, statsJob, analyzeStatus, true);
             }
@@ -94,6 +95,7 @@ public class StatisticAutoCollector extends FrontendDaemon {
             LOG.info("auto collect statistic on analyze job[{}] start", jobIds);
             for (AnalyzeJob analyzeJob : allAnalyzeJobs) {
                 ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
+                statsConnectCtx.setStatisticsConnection(true);
                 statsConnectCtx.setThreadLocalInfo();
                 analyzeJob.run(statsConnectCtx, STATISTIC_EXECUTOR);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -35,8 +35,6 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.StarRocksPlannerException;
-import com.starrocks.sql.optimizer.Utils;
-import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TResultBatch;
@@ -177,7 +175,7 @@ public class StatisticExecutor {
 
         ConnectContext context = StatisticUtils.buildConnectContext();
         context.setThreadLocalInfo();
-        StatementBase parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
+        StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
 
         ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, TResultSinkType.STATISTIC);
         StmtExecutor executor = new StmtExecutor(context, parsedStmt);
@@ -303,26 +301,8 @@ public class StatisticExecutor {
     }
 
     private List<TResultBatch> executeDQL(ConnectContext context, String sql) {
-        StatementBase parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
+        StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
         ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, TResultSinkType.STATISTIC);
-
-        if (LOG.isDebugEnabled()) {
-            List<PhysicalOlapScanOperator> pos = Utils.extractPhysicalOlapScanOperator(execPlan.getPhysicalPlan());
-            StringBuilder stringBuilder = new StringBuilder();
-            for (PhysicalOlapScanOperator scan : pos) {
-                Table table = scan.getTable();
-                stringBuilder.append("[table: ").append(table.getName()).append(", ");
-                for (Partition partition : table.getPartitions()) {
-                    stringBuilder.append(partition.getName()).append(": ");
-                    stringBuilder.append(partition.getCommittedVersion()).append(", ");
-                    stringBuilder.append(partition.getVisibleVersion()).append(", ");
-                    stringBuilder.append(partition.getVisibleVersionTime());
-                }
-                stringBuilder.append("]");
-            }
-            LOG.debug("statistics DQL plan tables: " + stringBuilder);
-        }
-
         StmtExecutor executor = new StmtExecutor(context, parsedStmt);
         context.setExecutor(executor);
         context.setQueryId(UUIDUtil.genUUID());
@@ -338,7 +318,7 @@ public class StatisticExecutor {
     private boolean executeDML(ConnectContext context, String sql) {
         StatementBase parsedStmt;
         try {
-            parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
+            parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             StmtExecutor executor = new StmtExecutor(context, parsedStmt);
             context.setExecutor(executor);
             context.setQueryId(UUIDUtil.genUUID());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -110,7 +110,7 @@ public abstract class StatisticsCollectJob {
         int maxRetryTimes = 5;
         do {
             LOG.debug("statistics collect sql : {}", sql);
-            StatementBase parsedStmt = SqlParser.parseFirstStatement(sql, context.getSessionVariable().getSqlMode());
+            StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             StmtExecutor executor = new StmtExecutor(context, parsedStmt);
             SessionVariable sessionVariable = context.getSessionVariable();
             // Statistics collecting is not user-specific, which means response latency is not that important.

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1495,8 +1495,6 @@ public class DatabaseTransactionMgr {
             TransactionLogApplier applier = txnLogApplierFactory.create(table);
             applier.applyCommitLog(transactionState, tableCommitInfo);
         }
-
-        GlobalStateMgr.getCurrentAnalyzeMgr().updateLoadRows(transactionState);
     }
 
     private boolean updateCatalogAfterVisible(TransactionState transactionState, Database db) {
@@ -1510,6 +1508,7 @@ public class DatabaseTransactionMgr {
             TransactionLogApplier applier = txnLogApplierFactory.create(table);
             applier.applyVisibleLog(transactionState, tableCommitInfo, db);
         }
+        GlobalStateMgr.getCurrentAnalyzeMgr().updateLoadRows(transactionState);
         return true;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/DeleteHandlerTest.java
@@ -252,13 +252,6 @@ public class DeleteHandlerTest {
             }
         };
 
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentAnalyzeMgr().updateLoadRows((TransactionState) any);
-                minTimes = 0;
-            }
-        };
-
         try {
             com.starrocks.sql.analyzer.Analyzer.analyze(deleteStmt, connectContext);
         } catch (Exception e) {
@@ -305,13 +298,6 @@ public class DeleteHandlerTest {
                 TransactionState transactionState = new TransactionState();
                 transactionState.setTransactionStatus(TransactionStatus.VISIBLE);
                 return transactionState;
-            }
-        };
-
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentAnalyzeMgr().updateLoadRows((TransactionState) any);
-                minTimes = 0;
             }
         };
 
@@ -433,13 +419,6 @@ public class DeleteHandlerTest {
 
         new Expectations() {
             {
-                GlobalStateMgr.getCurrentAnalyzeMgr().updateLoadRows((TransactionState) any);
-                minTimes = 0;
-            }
-        };
-
-        new Expectations() {
-            {
                 AgentTaskExecutor.submit((AgentBatchTask) any);
                 minTimes = 0;
             }
@@ -482,13 +461,6 @@ public class DeleteHandlerTest {
             @Mock
             public Collection<TabletDeleteInfo> getTabletDeleteInfo() {
                 return Lists.newArrayList(tabletDeleteInfo);
-            }
-        };
-
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentAnalyzeMgr().updateLoadRows((TransactionState) any);
-                minTimes = 0;
             }
         };
 


### PR DESCRIPTION
Fixes #issue

1. bug: drop invalid partition statistics overflow SqlParse.expr_children_limit bug
the reason because SqlParse.parseFirstStatment doesn't use sessionVariables

Fix: SqlParse.parseFirstStatement -> SqlParse.parseOneWithStarRocksDialect

2. bug: will query statistics table when collect statistics, it's unnecessary
Fix: add `isStatisticsConnection` in `ConnectContext`, and will check it in `statisticTableBlackListCheck`

3. bug: the statistic collector will query old version data (commmited but doesn't publish)
StatisticsMeta updated `updateRows` when the transaction commits (may be doesn't publish when high-concurrency load), then trigger statistics collector work

Fix: StatisticsMeta will update `updateRows` when the transaction publish

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
