### PR TITLE
[BugFix] stream load failed when table with auto increment column(#25301)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -299,8 +299,10 @@ public class Load {
         if (!specifyFileFieldNames) {
             List<Column> columns = tbl.getBaseSchema();
             for (Column column : columns) {
-                ImportColumnDesc columnDesc = new ImportColumnDesc(column.getName());
-                copiedColumnExprs.add(columnDesc);
+                if (!column.isAutoIncrement()) {
+                    ImportColumnDesc columnDesc = new ImportColumnDesc(column.getName());
+                    copiedColumnExprs.add(columnDesc);
+                }
             }
         }
 


### PR DESCRIPTION
Problem:
When use streamload without specifying the column name, auto increment
column
will be treated as a normal column which can be insert by streamload.
This is an unexpected behavior.

Solution:
If user does not specify the column name in streamload, just load the
data by the columns without auto increment column.

Fixes #25301

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
