### PR TITLE
[Enhancement] optimize the mem usage of serialize for bitmap_agg

### DIFF
--- a/be/src/exprs/agg/bitmap_agg.h
+++ b/be/src/exprs/agg/bitmap_agg.h
@@ -74,8 +74,8 @@ public:
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         auto* col = down_cast<BitmapColumn*>(to);
-        auto& bitmap = this->data(state);
-        col->append(bitmap);
+        auto& bitmap = const_cast<BitmapValue&>(this->data(state));
+        col->append(std::move(bitmap));
     }
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,


### PR DESCRIPTION
Fixes #issue

No need to do deep copy from AggHashTable, just move it.

```
insert into t5 select lo_supplycost%1000 as c1, bitmap_agg(lo_orderkey) from lineorder group by c1;
```

Before Opt (mem_usage): 1.39G
After Opt (mem_usage): 1.07G

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
