### PR TITLE
[BugFix] Add local shuffle exchange before hash-based partition operator

### DIFF
--- a/be/src/exec/analytic_node.cpp
+++ b/be/src/exec/analytic_node.cpp
@@ -340,6 +340,8 @@ pipeline::OpFactories AnalyticNode::decompose_to_pipeline(pipeline::PipelineBuil
         // prepend local shuffle to PartitionSortSinkOperator
         ops_with_sink = context->maybe_interpolate_local_shuffle_exchange(runtime_state(), ops_with_sink,
                                                                           _hash_partition_exprs);
+        upstream_source_op = context->source_operator(ops_with_sink);
+
         ops_with_sink.emplace_back(std::make_shared<HashPartitionSinkOperatorFactory>(
                 context->next_operator_id(), pseudo_plan_node_id, hash_partition_ctx_factory));
         context->add_pipeline(ops_with_sink);

--- a/be/src/exec/analytic_node.cpp
+++ b/be/src/exec/analytic_node.cpp
@@ -64,6 +64,13 @@ AnalyticNode::AnalyticNode(ObjectPool* pool, const TPlanNode& tnode, const Descr
 
 Status AnalyticNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::init(tnode, state));
+    _use_hash_based_partition = _tnode.analytic_node.order_by_exprs.empty() &&
+                                _tnode.analytic_node.__isset.use_hash_based_partition &&
+                                _tnode.analytic_node.use_hash_based_partition;
+    if (_use_hash_based_partition) {
+        RETURN_IF_ERROR(
+                Expr::create_expr_trees(_pool, tnode.analytic_node.partition_exprs, &_hash_partition_exprs, state));
+    }
     DCHECK(_conjunct_ctxs.empty());
 
     return Status::OK();
@@ -321,17 +328,18 @@ pipeline::OpFactories AnalyticNode::decompose_to_pipeline(pipeline::PipelineBuil
     OpFactories ops_with_sink = _children[0]->decompose_to_pipeline(context);
     auto* upstream_source_op = context->source_operator(ops_with_sink);
 
-    const bool use_hash_based_partition = _tnode.analytic_node.order_by_exprs.empty() &&
-                                          _tnode.analytic_node.__isset.use_hash_based_partition &&
-                                          _tnode.analytic_node.use_hash_based_partition;
     if (_tnode.analytic_node.partition_exprs.empty()) {
         // analytic's dop must be 1 if with no partition clause
         ops_with_sink = context->maybe_interpolate_local_passthrough_exchange(runtime_state(), ops_with_sink);
-    } else if (use_hash_based_partition) {
+    } else if (_use_hash_based_partition) {
         // analytic has only partition by columns but no order by columns
         auto pseudo_plan_node_id = context->next_pseudo_plan_node_id();
         HashPartitionContextFactoryPtr hash_partition_ctx_factory =
                 std::make_shared<HashPartitionContextFactory>(_tnode.analytic_node.partition_exprs);
+
+        // prepend local shuffle to PartitionSortSinkOperator
+        ops_with_sink = context->maybe_interpolate_local_shuffle_exchange(runtime_state(), ops_with_sink,
+                                                                          _hash_partition_exprs);
         ops_with_sink.emplace_back(std::make_shared<HashPartitionSinkOperatorFactory>(
                 context->next_operator_id(), pseudo_plan_node_id, hash_partition_ctx_factory));
         context->add_pipeline(ops_with_sink);
@@ -347,7 +355,7 @@ pipeline::OpFactories AnalyticNode::decompose_to_pipeline(pipeline::PipelineBuil
     auto degree_of_parallelism = upstream_source_op->degree_of_parallelism();
 
     AnalytorFactoryPtr analytor_factory = std::make_shared<AnalytorFactory>(
-            degree_of_parallelism, _tnode, child(0)->row_desc(), _result_tuple_desc, use_hash_based_partition);
+            degree_of_parallelism, _tnode, child(0)->row_desc(), _result_tuple_desc, _use_hash_based_partition);
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(2, std::move(this->runtime_filter_collector()));
 
     ops_with_sink.emplace_back(

--- a/be/src/exec/analytic_node.h
+++ b/be/src/exec/analytic_node.h
@@ -44,6 +44,8 @@ private:
     // Tuple descriptor for storing results of analytic fn evaluation.
     const TupleDescriptor* _result_tuple_desc;
     AnalytorPtr _analytor = nullptr;
+    bool _use_hash_based_partition = false;
+    std::vector<ExprContext*> _hash_partition_exprs;
 
     Status _get_next_for_unbounded_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos);
     Status _get_next_for_unbounded_preceding_range_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos);


### PR DESCRIPTION
Add local shuffle exchange before hash-based partition operator just as sorted-based partitioner does. Because in scene of separation of storage and computation, the output data flow of `CONNECTOR_SCAN` is not distributed according to partition by columns

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
