### PR TITLE
[Enhancement] Add trace log for MV Rewrite to better debug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -316,6 +316,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_MULTI_COLUMNS_ON_GLOBAL_RUNTIME_FILTER =
             "enable_multicolumn_global_runtime_filter";
     public static final String ENABLE_OPTIMIZER_TRACE_LOG = "enable_optimizer_trace_log";
+    public static final String ENABLE_MV_OPTIMIZER_TRACE_LOG = "enable_mv_optimizer_trace_log";
     public static final String JOIN_IMPLEMENTATION_MODE = "join_implementation_mode";
     public static final String JOIN_IMPLEMENTATION_MODE_V2 = "join_implementation_mode_v2";
 
@@ -916,6 +917,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_OPTIMIZER_TRACE_LOG, flag = VariableMgr.INVISIBLE)
     private boolean enableOptimizerTraceLog = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_MV_OPTIMIZER_TRACE_LOG, flag = VariableMgr.INVISIBLE)
+    private boolean enableMVOptimizerTraceLog = false;
 
     @VariableMgr.VarAttr(name = ENABLE_QUERY_DEBUG_TRACE, flag = VariableMgr.INVISIBLE)
     private boolean enableQueryDebugTrace = false;
@@ -1895,6 +1899,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableOptimizerTraceLog(boolean val) {
         this.enableOptimizerTraceLog = val;
+    }
+
+    public boolean isEnableMVOptimizerTraceLog() {
+        return enableMVOptimizerTraceLog || enableOptimizerTraceLog;
+    }
+
+    public void setEnableMVOptimizerTraceLog(boolean val) {
+        this.enableMVOptimizerTraceLog = val;
     }
 
     public boolean isRuntimeFilterOnExchangeNode() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.optimizer;
 import com.starrocks.catalog.Table;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
+import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
 
@@ -43,20 +44,22 @@ public class MvRewriteContext {
     private ScalarOperator mvPruneConjunct;
 
     private final List<ScalarOperator> onPredicates;
+    private final Rule rule;
 
-    public MvRewriteContext(
-            MaterializationContext materializationContext,
-            List<Table> queryTables,
-            OptExpression queryExpression,
-            ReplaceColumnRefRewriter queryColumnRefRewriter,
-            PredicateSplit queryPredicateSplit,
-            List<ScalarOperator> onPredicates) {
+    public MvRewriteContext(MaterializationContext materializationContext,
+                            List<Table> queryTables,
+                            OptExpression queryExpression,
+                            ReplaceColumnRefRewriter queryColumnRefRewriter,
+                            PredicateSplit queryPredicateSplit,
+                            List<ScalarOperator> onPredicates,
+                            Rule rule) {
         this.materializationContext = materializationContext;
         this.queryTables = queryTables;
         this.queryExpression = queryExpression;
         this.queryColumnRefRewriter = queryColumnRefRewriter;
         this.queryPredicateSplit = queryPredicateSplit;
         this.onPredicates = onPredicates;
+        this.rule = rule;
     }
 
     public MaterializationContext getMaterializationContext() {
@@ -104,5 +107,9 @@ public class MvRewriteContext {
 
     public List<ScalarOperator> getOnPredicates() {
         return onPredicates;
+    }
+
+    public Rule getRule() {
+        return rule;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -229,9 +229,11 @@ public class Optimizer {
             }
             if (connectContext.getSessionVariable().isEnableSyncMaterializedViewRewrite()) {
                 try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("Optimizer.preprocessSyncMvs")) {
-                    preprocessor.prepareSyncMvCandidatesForPlan(connectContext);
+                    preprocessor.prepareSyncMvCandidatesForPlan();
                 }
             }
+            OptimizerTraceUtil.logMVPrepare(connectContext, "There are %d candidate MVs after prepare phase",
+                    context.getCandidateMvs().size());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -131,6 +131,35 @@ public class OptimizerTraceUtil {
         }
     }
 
+    public static void logMVPrepare(ConnectContext ctx, String format, Object... object) {
+        if (ctx.getSessionVariable().isEnableMVOptimizerTraceLog()) {
+            LOG.info("[MV TRACE] [PREPARE {}] {}", ctx.getQueryId(), String.format(format, object));
+        }
+    }
+
+    public static void logMVRewrite(MvRewriteContext mvRewriteContext, String format, Object... object) {
+        MaterializationContext mvContext = mvRewriteContext.getMaterializationContext();
+        if (mvContext.getOptimizerContext().getSessionVariable().isEnableMVOptimizerTraceLog()) {
+            // QueryID-Rule-MVName log
+            LOG.info("[MV TRACE] [REWRITE {} {} {}] {}",
+                    mvContext.getOptimizerContext().getTraceInfo().getQueryId(),
+                    mvRewriteContext.getRule().type().name(),
+                    mvContext.getMv().getName(),
+                    String.format(format, object));
+        }
+    }
+
+    public static void logMVRewrite(OptimizerContext optimizerContext, Rule rule,
+                                     String format, Object... object) {
+        if (optimizerContext.getSessionVariable().isEnableMVOptimizerTraceLog()) {
+            // QueryID-Rule log
+            LOG.info("[MV TRACE] [REWRITE {} {}] {}",
+                    optimizerContext.getTraceInfo().getQueryId(),
+                    rule.type().name(),
+                    String.format(format, object));
+        }
+    }
+
     private static void log(ConnectContext ctx, String message) {
         Preconditions.checkState(ctx.getSessionVariable().isEnableOptimizerTraceLog());
         LOG.info("[TRACE QUERY {}] {}", ctx.getQueryId(), message);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MVUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MVUtils.java
@@ -161,4 +161,5 @@ public class MVUtils {
         }
         return false;
     }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.Function.CompareMode.IS_IDENTICAL;
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 
 /**
  * SPJG materialized view rewriter, based on
@@ -126,6 +127,8 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
 
         // Cannot ROLLUP distinct
         if (isRollup && mvAggOp.getAggregations().values().stream().anyMatch(callOp -> callOp.isDistinct())) {
+            logMVRewrite(mvRewriteContext, "Rewrite aggregate failed: don't support distinct aggregate functions for rollup " +
+                    "aggregate");
             return null;
         }
 
@@ -147,6 +150,8 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                 ScalarOperator rewrittenPred =
                         queryExprToMvExprRewriter.replaceExprWithTarget(queryAggOp.getPredicate());
                 if (rewrittenPred == null || rewrittenPred.equals(queryAggOp.getPredicate())) {
+                    logMVRewrite(mvRewriteContext, "Rewrite aggregate failed, " +
+                            "cannot compensate aggregate having predicates: %s", queryAggOp.getPredicate().toString());
                     return null;
                 }
                 mvOptExpr = OptExpression.create(new LogicalFilterOperator(rewrittenPred), mvOptExpr);
@@ -189,6 +194,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             }
 
             if (rewritten == null) {
+                logMVRewrite(mvRewriteContext, "Rewrite aggregate group-by/agg expr failed: %s", scalarOp.toString());
                 return null;
             }
             newQueryProjection.put(entry.getKey(), rewritten);
@@ -331,6 +337,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                 queryGroupingKeys, queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
                 new ColumnRefSet(rewriteContext.getQueryColumnSet()));
         if (newQueryGroupKeys == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite rollup aggregate failed: cannot rewrite group by keys");
             return null;
         }
         List<ColumnRefOperator> queryGroupKeys = queryAggOp.getGroupingKeys();
@@ -355,6 +362,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                 queryAggregation, queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
                 new ColumnRefSet(rewriteContext.getQueryColumnSet()), queryColumnRefToScalarMap);
         if (newAggregations == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite rollup aggregate failed: cannot rewrite aggregate functions");
             return null;
         }
 
@@ -416,6 +424,8 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         LogicalAggregationOperator queryAgg = (LogicalAggregationOperator) rewriteContext.getQueryExpression().getOp();
         if (queryAgg.getProjection() != null) {
             // if query has projection, is not supported now
+            logMVRewrite(mvRewriteContext, "Rewrite aggregate with union failed: aggregate with projection is " +
+                    "still not supported");
             return null;
         }
         List<ColumnRefOperator> originalGroupKeys = queryAgg.getGroupingKeys();
@@ -434,6 +444,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         Map<ColumnRefOperator, CallOperator> newAggregations = rewriteAggregatesForUnion(
                 queryAgg.getAggregations(), columnMapping, aggregateMapping);
         if (newAggregations == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite aggregate with union failed: rewrite aggregate for union failed");
             return null;
         }
         return createNewAggregate(rewriteContext, queryAgg, newAggregations, aggregateMapping, unionExpr);
@@ -536,10 +547,12 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         for (ScalarOperator key : groupKeys) {
             ScalarOperator newGroupByKey = replaceExprWithTarget(key, queryExprToMvExprRewriter, mapping);
             if (key.isVariable() && key == newGroupByKey) {
+                logMVRewrite(mvRewriteContext, "Rewrite group by key %s failed", key.toString());
                 return null;
             }
             if (newGroupByKey == null || !isAllExprReplaced(newGroupByKey, queryColumnSet)) {
                 // it means there is some column that can not be rewritten by outputs of mv
+                logMVRewrite(mvRewriteContext, "Rewrite group by key %s failed: partially rewrite", key.toString());
                 return null;
             }
             newGroupByKeys.add(newGroupByKey);
@@ -562,15 +575,20 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             ScalarOperator targetColumn = replaceExprWithTarget(aggCall, normalizedViewMap, mapping);
             if (targetColumn == null || !isAllExprReplaced(targetColumn, queryColumnSet)) {
                 // it means there is some column that can not be rewritten by outputs of mv
+                logMVRewrite(mvRewriteContext, "Rewrite aggregate %s failed: partially rewrite", aggCall.toString());
                 return null;
             }
             // TODO: Support non column-ref agg function.
             if (!(targetColumn instanceof ColumnRefOperator)) {
+                logMVRewrite(mvRewriteContext, "Rewrite aggregate %s failed: only column-ref is supported after rewrite",
+                        aggCall.toString());
                 return null;
             }
             // Aggregate must be CallOperator
             CallOperator newAggregate = getRollupAggregate(aggCall, (ColumnRefOperator) targetColumn);
             if (newAggregate == null) {
+                logMVRewrite(mvRewriteContext, "Rewrite aggregate %s failed: cannot get rollup aggregate",
+                        aggCall.toString());
                 return null;
             }
             ColumnRefOperator oldColRef = (ColumnRefOperator) aggregateMapping.get(entry.getKey());
@@ -590,11 +608,15 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             CallOperator aggCall = entry.getValue();
             ColumnRefOperator targetColumn = mapping.get(entry.getKey());
             if (targetColumn == null) {
+                logMVRewrite(mvRewriteContext, "Rewrite aggregate %s for union failed: target column is null",
+                        aggCall.toString());
                 return null;
             }
             // Aggregate must be CallOperator
             CallOperator newAggregate = getRollupAggregate(aggCall, targetColumn);
             if (newAggregate == null) {
+                logMVRewrite(mvRewriteContext, "Rewrite aggregate %s failed: cannot get rollup aggregate",
+                        aggCall.toString());
                 return null;
             }
             rewrittens.put((ColumnRefOperator) aggregateMapping.get(entry.getKey()), newAggregate);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -43,6 +43,7 @@ import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -78,6 +79,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
+
 /*
  * SPJG materialized view rewriter, based on
  * 《Optimizing Queries Using Materialized Views: A Practical, Scalable Solution》
@@ -88,6 +91,7 @@ public class MaterializedViewRewriter {
     protected static final Logger LOG = LogManager.getLogger(MaterializedViewRewriter.class);
     protected final MvRewriteContext mvRewriteContext;
     protected final MaterializationContext materializationContext;
+    protected final OptimizerContext optimizerContext;
 
     protected enum MatchMode {
         // all tables and join types match
@@ -104,6 +108,7 @@ public class MaterializedViewRewriter {
     public MaterializedViewRewriter(MvRewriteContext mvRewriteContext) {
         this.mvRewriteContext = mvRewriteContext;
         this.materializationContext = mvRewriteContext.getMaterializationContext();
+        this.optimizerContext = materializationContext.getOptimizerContext();
     }
 
     /**
@@ -178,6 +183,8 @@ public class MaterializedViewRewriter {
 
         // Check whether mv can be applicable for the query.
         if (!isMVApplicable(mvExpression, queryTables, mvTables, matchMode, queryExpression)) {
+            logMVRewrite(mvRewriteContext, "MV is not applicable for this query: %s",
+                    materializationContext.getMv().getName());
             return null;
         }
 
@@ -222,10 +229,12 @@ public class MaterializedViewRewriter {
         // do not support external table now
         if (queryTableScanDescs.stream().anyMatch(
                 tableScanDesc -> !isSupportViewDeltaJoin(tableScanDesc.getTable()))) {
+            logMVRewrite(mvRewriteContext, "Rewrite view delta failed: query tables are not supported for rewrite");
             return null;
         }
         if (mvTableScanDescs.stream().anyMatch(
                 tableScanDesc -> !isSupportViewDeltaJoin(tableScanDesc.getTable()))) {
+            logMVRewrite(mvRewriteContext, "Rewrite view delta failed: mv tables are not supported for rewrite");
             return null;
         }
 
@@ -274,6 +283,7 @@ public class MaterializedViewRewriter {
             if (!compensateViewDelta(viewEquivalenceClasses, mvTableScanDescs, mvExtraTableScanDescs,
                     compensationJoinColumns, compensationRelations, expectedExtraQueryToMVRelationIds,
                     materializationContext)) {
+                logMVRewrite(mvRewriteContext, "Rewrite ViewDelta failed: cannot compensate query by using PK/FK constraints");
                 continue;
             }
 
@@ -281,6 +291,9 @@ public class MaterializedViewRewriter {
                     MatchMode.VIEW_DELTA, mvPredicateSplit, mvColumnRefRewriter,
                     compensationJoinColumns, compensationRelations, expectedExtraQueryToMVRelationIds);
             if (rewritten != null) {
+                logMVRewrite(mvRewriteContext, "Rewrite ViewDelta Succeed:\n Original Expression:\n %s,\nNew Expression:\n %s",
+                        queryExpression.explain(),
+                        rewritten.explain());
                 return rewritten;
             }
         }
@@ -311,6 +324,7 @@ public class MaterializedViewRewriter {
                 queryTables, queryExpression, materializationContext.getMvColumnRefFactory(),
                 mvTables, mvExpression, matchMode, compensationRelations, expectedExtraQueryToMVRelationIds);
         if (relationIdMappings.isEmpty()) {
+            logMVRewrite(mvRewriteContext, "Rewrite complete failed: relation id mapping is empty");
             return null;
         }
 
@@ -334,6 +348,7 @@ public class MaterializedViewRewriter {
         // used to prune partition and buckets after mv rewrite
         ScalarOperator mvPrunePredicate = collectMvPrunePredicate(materializationContext);
 
+        logMVRewrite(mvRewriteContext, "There are %d relation id mappings to rewrite query", relationIdMappings.size());
         for (BiMap<Integer, Integer> relationIdMapping : relationIdMappings) {
             mvRewriteContext.setMvPruneConjunct(mvPrunePredicate);
             rewriteContext.setQueryToMvRelationIdMapping(relationIdMapping);
@@ -345,6 +360,8 @@ public class MaterializedViewRewriter {
                 // convert mv-based compensation join columns into query based after we get relationId mapping
                 if (!addCompensationJoinColumnsIntoEquivalenceClasses(columnRewriter, newQueryEc,
                         compensationJoinColumns)) {
+                    logMVRewrite(mvRewriteContext, "Rewrite view delta failed: cannot add compensation join columns into " +
+                            "equivalence classes");
                     return null;
                 }
                 rewriteContext.setQueryEquivalenceClasses(newQueryEc);
@@ -354,6 +371,7 @@ public class MaterializedViewRewriter {
             final EquivalenceClasses queryBasedViewEqualPredicate =
                     createQueryBasedEquivalenceClasses(columnRewriter, mvEqualPredicate);
             if (queryBasedViewEqualPredicate == null) {
+                logMVRewrite(mvRewriteContext, "Rewrite complete failed: cannot construct query based equivalence classes");
                 return null;
             }
             rewriteContext.setQueryBasedViewEquivalenceClasses(queryBasedViewEqualPredicate);
@@ -365,6 +383,10 @@ public class MaterializedViewRewriter {
                 if (rewriteContext.getQueryExpression().getOp().hasLimit()) {
                     rewrittenExpression.getOp().setLimit(rewriteContext.getQueryExpression().getOp().getLimit());
                 }
+                logMVRewrite(mvRewriteContext, "Rewrite Succeed:\n Original Expression:\n %s,\nNew Expression:\n %s",
+                        relationIdMappings.size(),
+                        queryExpression.explain(),
+                        rewrittenExpression.explain());
                 return rewrittenExpression;
             }
         }
@@ -743,8 +765,9 @@ public class MaterializedViewRewriter {
         final PredicateSplit compensationPredicates = getCompensationPredicatesQueryToView(columnRewriter,
                 rewriteContext, compensationJoinColumns);
         if (compensationPredicates == null) {
-            if (!materializationContext.getOptimizerContext().getSessionVariable()
-                    .isEnableMaterializedViewUnionRewrite()) {
+            logMVRewrite(mvRewriteContext, "Rewrite query failed: cannot get compensation predicates from MV, " +
+                    "Try to use union rewrite.");
+            if (!optimizerContext.getSessionVariable().isEnableMaterializedViewUnionRewrite()) {
                 return null;
             }
             return tryUnionRewrite(rewriteContext, mvScanOptExpression, compensationJoinColumns);
@@ -757,6 +780,8 @@ public class MaterializedViewRewriter {
             final ScalarOperator compensationPredicate = getMVCompensationPredicate(rewriteContext,
                     columnRewriter, mvColumnRefToScalarOp, equalPredicates, otherPredicates);
             if (compensationPredicate == null) {
+                logMVRewrite(mvRewriteContext, "Rewrite query failed: get compensation predicates from MV but " +
+                        " rewrite compensation failed");
                 return null;
             }
 
@@ -782,8 +807,8 @@ public class MaterializedViewRewriter {
         }
     }
 
-    // Rewrite non-inner/cross join's on-predicates, all on-predicates should not compensated.
-    // For non inner/cross join, we must ensure all on-predicates are not compensated, otherwise there may
+    // Rewrite non-inner/cross join's on-predicates, all on-predicates should not compensate.
+    // For non-inner/cross join, we must ensure all on-predicates are not compensated, otherwise there may
     // be some correctness bugs.
     private ScalarOperator rewriteJoinOnPredicates(ColumnRewriter columnRewriter,
                                                    Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns,
@@ -914,6 +939,7 @@ public class MaterializedViewRewriter {
         final PredicateSplit mvCompensationToQuery = getCompensationPredicatesViewToQuery(columnRewriter,
                 rewriteContext, compensationJoinColumns);
         if (mvCompensationToQuery == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite union failed: cannot get compensation from view to query");
             return null;
         }
         Preconditions.checkState(mvCompensationToQuery.getPredicates()
@@ -961,6 +987,8 @@ public class MaterializedViewRewriter {
                     rewriteScalarOperatorToTarget(mvOtherPreds, queryExprMap, rewriteContext, mvToQueryRefSet, false);
         }
         if (mvEqualPreds == null || mvOtherPreds == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite union failed: cannot rewrite compensations from view to query, " +
+                    "mvEqualPreds:%d, mvOtherPreds:%d", (mvEqualPreds == null), (mvOtherPreds == null));
             return null;
         }
         final ScalarOperator mvCompensationPredicates = Utils.compoundAnd(mvEqualPreds, mvOtherPreds);
@@ -972,12 +1000,14 @@ public class MaterializedViewRewriter {
         final OptExpression queryInput = queryBasedRewrite(rewriteContext,
                 mvCompensationPredicates, mvRewriteContext.getQueryExpression());
         if (queryInput == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite union failed: cannot rewrite MV based on query");
             return null;
         }
 
         // viewBasedRewrite will return the tree of "select a, b from t where a < 10" based on mv expression
         final OptExpression viewInput = viewBasedRewrite(rewriteContext, mvOptExpr);
         if (viewInput == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite union failed: cannot rewrite query based on MV");
             return null;
         }
 
@@ -1129,7 +1159,7 @@ public class MaterializedViewRewriter {
                 if (partitionRelatedPredicates.size() != 1) {
                     // has other partition predicates except partition column is null
                     // do not support now
-                    // can it happend?
+                    // can it happened?
                     return null;
                 }
                 predicates.addAll(partitionRelatedPredicates);
@@ -1405,10 +1435,14 @@ public class MaterializedViewRewriter {
             ScalarOperator rewritten = replaceExprWithTarget(entry.getValue(),
                     queryExprToMvExprRewriter, outputMapping);
             if (rewritten == null) {
+                logMVRewrite(mvRewriteContext, "Rewrite projection failed: cannot rewrite expr %s",
+                        entry.getValue().toString());
                 return null;
             }
             if (!isAllExprReplaced(rewritten, new ColumnRefSet(rewriteContext.getQueryColumnSet()))) {
                 // it means there is some column that can not be rewritten by outputs of mv
+                logMVRewrite(mvRewriteContext, "Rewrite projection failed: cannot totally rewrite expr %s",
+                        entry.getValue().toString());
                 return null;
             }
             newQueryProjection.put(entry.getKey(), rewritten);
@@ -1635,6 +1669,8 @@ public class MaterializedViewRewriter {
                 rewriteJoinOnPredicates(columnRewriter, compensationJoinColumns,
                         queryJoinOnPredicates, mvJoinOnPredicates, true);
         if (queryJoinOnPredicateCompensations == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite query to view failed: on-predicates cannot be compensated and " +
+                    "should be totally the same");
             return null;
         }
 
@@ -1656,6 +1692,8 @@ public class MaterializedViewRewriter {
                 rewriteJoinOnPredicates(columnRewriter, compensationJoinColumns,
                         mvJoinOnPredicates, queryJoinOnPredicates, false);
         if (queryJoinOnPredicateCompensations == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite view to query failed: on-predicates cannot be compensated and " +
+                    "should be totally the same");
             return null;
         }
 
@@ -1679,6 +1717,7 @@ public class MaterializedViewRewriter {
         final ScalarOperator compensationEqualPredicate =
                 getCompensationEqualPredicate(sourceEquivalenceClasses, targetEquivalenceClasses);
         if (compensationEqualPredicate == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite query failed: get equal compensation predicates failed");
             return null;
         }
 
@@ -1688,6 +1727,8 @@ public class MaterializedViewRewriter {
         ScalarOperator compensationPr =
                 getCompensationPredicate(srcPr, targetPr, columnRewriter, true, isQueryToMV);
         if (compensationPr == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite query failed: get range compensation predicates failed," +
+                    "srcPr:%s, targetPr:%s", MvUtils.toString(srcPr), MvUtils.toString(targetPr));
             return null;
         }
 
@@ -1708,6 +1749,8 @@ public class MaterializedViewRewriter {
         ScalarOperator compensationPu =
                 getCompensationPredicate(srcPu, targetPu, columnRewriter, false, isQueryToMV);
         if (compensationPu == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite query failed: get residual compensation predicates failed," +
+                    "srcPr:%s, targetPr:%s", MvUtils.toString(srcPu), MvUtils.toString(targetPu));
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -988,7 +988,7 @@ public class MaterializedViewRewriter {
         }
         if (mvEqualPreds == null || mvOtherPreds == null) {
             logMVRewrite(mvRewriteContext, "Rewrite union failed: cannot rewrite compensations from view to query, " +
-                    "mvEqualPreds:%d, mvOtherPreds:%d", (mvEqualPreds == null), (mvOtherPreds == null));
+                    "mvEqualPreds:%s, mvOtherPreds:%s", (mvEqualPreds == null), (mvOtherPreds == null));
             return null;
         }
         final ScalarOperator mvCompensationPredicates = Utils.compoundAnd(mvEqualPreds, mvOtherPreds);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -879,4 +879,11 @@ public class MvUtils {
                     map(Map.Entry::getValue).collect(Collectors.toList());
         }
     }
+
+    public static String toString(Object o) {
+        if (o == null) {
+            return "";
+        }
+        return o.toString();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -41,6 +41,8 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.Predicate
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
+
 public abstract class BaseMaterializedViewRewriteRule extends TransformationRule {
 
     protected BaseMaterializedViewRewriteRule(RuleType type, Pattern pattern) {
@@ -95,6 +97,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         final ScalarOperator queryPartitionPredicate =
                 MvUtils.compensatePartitionPredicate(queryExpression, queryColumnRefFactory);
         if (queryPartitionPredicate == null) {
+            logMVRewrite(context, this, "Query partition compensate from partition prune failed.");
             return Lists.newArrayList();
         }
         ScalarOperator queryPredicate = MvUtils.rewriteOptExprCompoundPredicate(queryExpression, queryColumnRefRewriter);
@@ -106,8 +109,8 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         onPredicates = onPredicates.stream().map(MvUtils::canonizePredicate).collect(Collectors.toList());
         List<Table> queryTables = MvUtils.getAllTables(queryExpression);
         for (MaterializationContext mvContext : mvCandidateContexts) {
-            MvRewriteContext mvRewriteContext = new MvRewriteContext(
-                    mvContext, queryTables, queryExpression, queryColumnRefRewriter, queryPredicateSplit, onPredicates);
+            MvRewriteContext mvRewriteContext = new MvRewriteContext(mvContext, queryTables, queryExpression,
+                    queryColumnRefRewriter, queryPredicateSplit, onPredicates, this);
             MaterializedViewRewriter mvRewriter = getMaterializedViewRewrite(mvRewriteContext);
             OptExpression candidate = mvRewriter.rewrite();
             if (candidate == null) {
@@ -122,6 +125,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             results.add(candidate);
             mvContext.updateMVUsedCount();
         }
+        logMVRewrite(context, this, "Generate %d candidate plans after this rule rewrite", results.size());
 
         return results;
     }


### PR DESCRIPTION
Introduce mv trace log to better debug mv rewrite.

Further:
- We may add more informations for MV Rewrite.

### Case1: MV is outdated
```
./fe.log:2023-06-16 14:49:41,155 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE f81a89b5-0c11-11ee-98b1-162d24e49988] No Related Async MVs for plan
./fe.log:2023-06-16 14:49:41,155 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE f81a89b5-0c11-11ee-98b1-162d24e49988] No Related Sync MVs
./fe.log:2023-06-16 14:49:41,155 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE f81a89b5-0c11-11ee-98b1-162d24e49988] There are 0 candidate MVs after prepare phase
./fe.log:2023-06-16 14:49:42,716 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE f908ba46-0c11-11ee-98b1-162d24e49988] MV user_tags_mv1 is outdated, partitionNamesToRefresh:[user_tags_mv1]
./fe.log:2023-06-16 14:49:42,716 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE f908ba46-0c11-11ee-98b1-162d24e49988] RelatedMVs: [user_tags_mv1], CandidateMVs: []
./fe.log:2023-06-16 14:49:42,716 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE f908ba46-0c11-11ee-98b1-162d24e49988] No Related Sync MVs
./fe.log:2023-06-16 14:49:42,716 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE f908ba46-0c11-11ee-98b1-162d24e49988] There are 0 candidate MVs after prepare phase
```

### Case2: Expr cannot be rewritten

```
./fe.log:2023-06-16 14:49:10,603 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE e5e4ac30-0c11-11ee-98b1-162d24e49988] Add MV user_tags_mv1 as a candidate
./fe.log:2023-06-16 14:49:10,603 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE e5e4ac30-0c11-11ee-98b1-162d24e49988] RelatedMVs: [user_tags_mv1], CandidateMVs: [user_tags_mv1]
./fe.log:2023-06-16 14:49:10,603 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE e5e4ac30-0c11-11ee-98b1-162d24e49988] No Related Sync MVs
./fe.log:2023-06-16 14:49:10,603 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE e5e4ac30-0c11-11ee-98b1-162d24e49988] There are 1 candidate MVs after prepare phase
./fe.log:2023-06-16 14:49:10,604 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVRewrite():144] [MV TRACE] [REWRITE e5e4ac30-0c11-11ee-98b1-162d24e49988 TF_MV_AGGREGATE_SCAN_RULE user_tags_mv1] There are 1 relation id mappings to rewrite query
./fe.log:2023-06-16 14:49:10,605 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVRewrite():144] [MV TRACE] [REWRITE e5e4ac30-0c11-11ee-98b1-162d24e49988 TF_MV_AGGREGATE_SCAN_RULE user_tags_mv1] Rewrite aggregate group-by/agg expr failed: count(distinct add(cast(4: tag_id as bigint(20)), 1))
./fe.log:2023-06-16 14:49:10,605 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVRewrite():156] [MV TRACE] [REWRITE e5e4ac30-0c11-11ee-98b1-162d24e49988 TF_MV_AGGREGATE_SCAN_RULE] Generate 0 candidate plans after this rule rewrite
./fe.log:2023-06-16 14:49:10,605 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVRewrite():144] [MV TRACE] [REWRITE e5e4ac30-0c11-11ee-98b1-162d24e49988 TF_MV_ONLY_SCAN_RULE user_tags_mv1] MV is not applicable for this query: user_tags_mv1
./fe.log:2023-06-16 14:49:10,605 INFO (starrocks-mysql-nio-pool-2|268) [OptimizerTraceUtil.logMVRewrite():156] [MV TRACE] [REWRITE e5e4ac30-0c11-11ee-98b1-162d24e49988 TF_MV_ONLY_SCAN_RULE] Generate 0 candidate plans after this rule rewrite
```

### Case3: Rewrite Success
```
./fe.log:2023-06-16 14:47:55,933 INFO (starrocks-mysql-nio-pool-1|229) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE b9616896-0c11-11ee-98b1-162d24e49988] Add MV user_tags_mv1 as a candidate
./fe.log:2023-06-16 14:47:55,933 INFO (starrocks-mysql-nio-pool-1|229) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE b9616896-0c11-11ee-98b1-162d24e49988] RelatedMVs: [user_tags_mv1], CandidateMVs: [user_tags_mv1]
./fe.log:2023-06-16 14:47:55,934 INFO (starrocks-mysql-nio-pool-1|229) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE b9616896-0c11-11ee-98b1-162d24e49988] No Related Sync MVs
./fe.log:2023-06-16 14:47:55,934 INFO (starrocks-mysql-nio-pool-1|229) [OptimizerTraceUtil.logMVPrepare():136] [MV TRACE] [PREPARE b9616896-0c11-11ee-98b1-162d24e49988] There are 1 candidate MVs after prepare phase
./fe.log:2023-06-16 14:47:55,949 INFO (starrocks-mysql-nio-pool-1|229) [OptimizerTraceUtil.logMVRewrite():144] [MV TRACE] [REWRITE b9616896-0c11-11ee-98b1-162d24e49988 TF_MV_AGGREGATE_SCAN_RULE user_tags_mv1] There are 1 relation id mappings to rewrite query
./fe.log:2023-06-16 14:47:55,955 INFO (starrocks-mysql-nio-pool-1|229) [OptimizerTraceUtil.logMVRewrite():144] [MV TRACE] [REWRITE b9616896-0c11-11ee-98b1-162d24e49988 TF_MV_AGGREGATE_SCAN_RULE user_tags_mv1] Rewrite Succeed:
./fe.log:2023-06-16 14:47:55,957 INFO (starrocks-mysql-nio-pool-1|229) [OptimizerTraceUtil.logMVRewrite():156] [MV TRACE] [REWRITE b9616896-0c11-11ee-98b1-162d24e49988 TF_MV_AGGREGATE_SCAN_RULE] Generate 1 candidate plans after this rule rewrite
./fe.log:2023-06-16 14:47:55,957 INFO (starrocks-mysql-nio-pool-1|229) [OptimizerTraceUtil.logMVRewrite():144] [MV TRACE] [REWRITE b9616896-0c11-11ee-98b1-162d24e49988 TF_MV_ONLY_SCAN_RULE user_tags_mv1] MV is not applicable for this query: user_tags_mv1
./fe.log:2023-06-16 14:47:55,957 INFO (starrocks-mysql-nio-pool-1|229) [OptimizerTraceUtil.logMVRewrite():156] [MV TRACE] [REWRITE b9616896-0c11-11ee-98b1-162d24e49988 TF_MV_ONLY_SCAN_RULE] Generate 0 candidate plans after this rule rewrite
./fe.log:2023-06-16 14:47:55,957 INFO (starrocks-mysql-nio-pool-1|229) [OptimizerTraceUtil.logMVRewrite():144] [MV TRACE] [REWRITE b9616896-0c11-11ee-98b1-162d24e49988 TF_MV_ONLY_SCAN_RULE user_tags_mv1] MV is not applicable for this query: user_tags_mv1
./fe.log:2023-06-16 14:47:55,957 INFO (starrocks-mysql-nio-pool-1|229) [OptimizerTraceUtil.logMVRewrite():156] [MV TRACE] [REWRITE b9616896-0c11-11ee-98b1-162d24e49988 TF_MV_ONLY_SCAN_RULE] Generate 0 candidate plans after this rule rewrite
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
