### PR TITLE
[BugFix] Fix BE hive csv reader OOM and Hang when field_delim=''

### DIFF
--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -49,7 +49,7 @@ public:
 
     Status reset(size_t offset, size_t remain_length);
 
-    Status next_record(Record* record);
+    Status next_record(Record* record) override;
 
 protected:
     Status _fill_buffer() override;
@@ -149,10 +149,10 @@ Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPa
 
     // All delimiters will not be empty.
     // Even if the user has not set it, there will be a default value.
-    DCHECK(!text_file_desc.field_delim.empty());
-    DCHECK(!text_file_desc.line_delim.empty());
-    DCHECK(!text_file_desc.collection_delim.empty());
-    DCHECK(!text_file_desc.mapkey_delim.empty());
+    if (text_file_desc.field_delim.empty() || text_file_desc.line_delim.empty() ||
+        text_file_desc.collection_delim.empty() || text_file_desc.mapkey_delim.empty()) {
+        return Status::InternalError("Hive TEXTFILE's delimiters is missing");
+    }
 
     // _field_delimiter and _record_delimiter should use std::string,
     // because the CSVReader is using std::string type as delimiter.
@@ -163,16 +163,8 @@ Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPa
     // In Hive, users can specify collection delimiter and mapkey delimiter as string type,
     // but in fact, only the first character of the delimiter will take effect.
     // So here, we only use the first character of collection_delim and mapkey_delim.
-    if (text_file_desc.collection_delim.empty() || text_file_desc.mapkey_delim.empty()) {
-        // During the StarRocks upgrade process, collection_delim and mapkey_delim may be empty,
-        // in order to prevent crash, we set _collection_delimiter
-        // and _mapkey_delimiter a default value here.
-        _collection_delimiter = '\002';
-        _mapkey_delimiter = '\003';
-    } else {
-        _collection_delimiter = text_file_desc.collection_delim.front();
-        _mapkey_delimiter = text_file_desc.mapkey_delim.front();
-    }
+    _collection_delimiter = text_file_desc.collection_delim.front();
+    _mapkey_delimiter = text_file_desc.mapkey_delim.front();
 
     // by default it's unknown compression. we will synthesise informaiton from FE and BE(file extension)
     // parse compression type from FE first.

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -49,7 +49,7 @@ public:
 
     Status reset(size_t offset, size_t remain_length);
 
-    Status next_record(Record* record) override;
+    Status next_record(Record* record);
 
 protected:
     Status _fill_buffer() override;

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -151,7 +151,7 @@ Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPa
     // Even if the user has not set it, there will be a default value.
     if (text_file_desc.field_delim.empty() || text_file_desc.line_delim.empty() ||
         text_file_desc.collection_delim.empty() || text_file_desc.mapkey_delim.empty()) {
-        return Status::InternalError("Hive TEXTFILE's delimiters is missing");
+        return Status::Corruption("Hive TEXTFILE's delimiters is missing");
     }
 
     // _field_delimiter and _record_delimiter should use std::string,

--- a/be/src/formats/csv/csv_reader.cpp
+++ b/be/src/formats/csv/csv_reader.cpp
@@ -589,6 +589,7 @@ void CSVReader::split_record(const Record& record, Fields* columns) const {
             }
         }
     } else {
+        DCHECK(_column_delimiter_length > 0);
         const auto* const base = ptr;
 
         do {

--- a/be/src/formats/csv/csv_reader.cpp
+++ b/be/src/formats/csv/csv_reader.cpp
@@ -572,6 +572,8 @@ Status CSVReader::_expand_buffer_loosely() {
 }
 
 void CSVReader::split_record(const Record& record, Fields* columns) const {
+    DCHECK(_column_delimiter_length > 0);
+
     const char* value = record.data;
     const char* ptr = record.data;
     const size_t size = record.size;
@@ -589,7 +591,6 @@ void CSVReader::split_record(const Record& record, Fields* columns) const {
             }
         }
     } else {
-        DCHECK(_column_delimiter_length > 0);
         const auto* const base = ptr;
 
         do {

--- a/be/src/formats/csv/csv_reader.h
+++ b/be/src/formats/csv/csv_reader.h
@@ -174,7 +174,7 @@ public:
 
     virtual ~CSVReader() = default;
 
-    Status next_record(Record* record);
+    virtual Status next_record(Record* record);
 
     Status next_record(CSVRow& row);
 

--- a/be/src/formats/csv/csv_reader.h
+++ b/be/src/formats/csv/csv_reader.h
@@ -174,7 +174,7 @@ public:
 
     virtual ~CSVReader() = default;
 
-    virtual Status next_record(Record* record);
+    Status next_record(Record* record);
 
     Status next_record(CSVRow& row);
 

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -1727,6 +1727,52 @@ TEST_F(HdfsScannerTest, TestCSVWithStructMap) {
     }
 }
 
+TEST_F(HdfsScannerTest, TestCSVWithBlankDelimiter) {
+    const std::string small_file = "./be/test/exec/test_data/csv_scanner/array_struct_map.csv";
+
+    SlotDesc csv_descs[] = {{"id", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)},
+                        {""}};
+
+    auto* tuple_desc = _create_tuple_desc(csv_descs);
+    auto* common_range = _create_scan_range(small_file, 0, 0);
+    auto* param = _create_param(small_file, common_range, tuple_desc);
+    std::vector<std::string> hive_column_names{"id"};
+    param->hive_column_names = &hive_column_names;
+
+    {
+        auto* range = _create_scan_range(small_file, 0, 0);
+        range->text_file_desc.field_delim = "";
+        param->scan_ranges[0] = range;
+        auto scanner = std::make_shared<HdfsTextScanner>();
+        auto status = scanner->init(_runtime_state, *param);
+        EXPECT_FALSE(status.ok());
+    }
+    {
+        auto* range = _create_scan_range(small_file, 0, 0);
+        range->text_file_desc.collection_delim = "";
+        param->scan_ranges[0] = range;
+        auto scanner = std::make_shared<HdfsTextScanner>();
+        auto status = scanner->init(_runtime_state, *param);
+        EXPECT_FALSE(status.ok());
+    }
+    {
+        auto* range = _create_scan_range(small_file, 0, 0);
+        range->text_file_desc.mapkey_delim = "";
+        param->scan_ranges[0] = range;
+        auto scanner = std::make_shared<HdfsTextScanner>();
+        auto status = scanner->init(_runtime_state, *param);
+        EXPECT_FALSE(status.ok());
+    }
+    {
+        auto* range = _create_scan_range(small_file, 0, 0);
+        range->text_file_desc.line_delim = "";
+        param->scan_ranges[0] = range;
+        auto scanner = std::make_shared<HdfsTextScanner>();
+        auto status = scanner->init(_runtime_state, *param);
+        EXPECT_FALSE(status.ok());
+    }
+}
+
 // =============================================================================
 
 /*

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -1730,8 +1730,7 @@ TEST_F(HdfsScannerTest, TestCSVWithStructMap) {
 TEST_F(HdfsScannerTest, TestCSVWithBlankDelimiter) {
     const std::string small_file = "./be/test/exec/test_data/csv_scanner/array_struct_map.csv";
 
-    SlotDesc csv_descs[] = {{"id", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)},
-                        {""}};
+    SlotDesc csv_descs[] = {{"id", TypeDescriptor::from_logical_type(LogicalType::TYPE_INT)}, {""}};
 
     auto* tuple_desc = _create_tuple_desc(csv_descs);
     auto* common_range = _create_scan_range(small_file, 0, 0);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -318,6 +318,12 @@ public class HiveMetastoreApiConverter {
     }
 
     public static TextFileFormatDesc toTextFileFormatDesc(Map<String, String> serdeParams) {
+        final String DEFAULT_FIELD_DELIM = "\001";
+        final String DEFAULT_COLLECTION_DELIM = "\002";
+        final String DEFAULT_MAPKEY_DELIM = "\003";
+        final String DEFAULT_LINE_DELIM = "\n";
+
+
         // Get properties 'field.delim', 'line.delim', 'collection.delim' and 'mapkey.delim' from StorageDescriptor
         // Detail refer to:
         // https://github.com/apache/hive/blob/90428cc5f594bd0abb457e4e5c391007b2ad1cb8/serde/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/serde/serdeConstants.java#L34-L40
@@ -329,14 +335,20 @@ public class HiveMetastoreApiConverter {
         if (serdeParams.containsKey("colelction.delim")) {
             collectionDelim = serdeParams.get("colelction.delim");
         } else {
-            collectionDelim = serdeParams.getOrDefault("collection.delim", "\002");
+            collectionDelim = serdeParams.getOrDefault("collection.delim", DEFAULT_COLLECTION_DELIM);
         }
 
-        return new TextFileFormatDesc(
-                serdeParams.getOrDefault("field.delim", "\001"),
-                serdeParams.getOrDefault("line.delim", "\n"),
-                collectionDelim,
-                serdeParams.getOrDefault("mapkey.delim", "\003"));
+        String fieldDelim = serdeParams.getOrDefault("field.delim", DEFAULT_FIELD_DELIM);
+        String lineDelim = serdeParams.getOrDefault("line.delim", DEFAULT_LINE_DELIM);
+        String mapkeyDelim = serdeParams.getOrDefault("mapkey.delim", DEFAULT_MAPKEY_DELIM);
+
+        // check is empty
+        fieldDelim = fieldDelim.isEmpty() ? DEFAULT_FIELD_DELIM : fieldDelim;
+        lineDelim = lineDelim.isEmpty() ? DEFAULT_LINE_DELIM : lineDelim;
+        collectionDelim = collectionDelim.isEmpty() ? DEFAULT_COLLECTION_DELIM : collectionDelim;
+        mapkeyDelim = mapkeyDelim.isEmpty() ? DEFAULT_MAPKEY_DELIM : mapkeyDelim;
+
+        return new TextFileFormatDesc(fieldDelim, lineDelim, collectionDelim, mapkeyDelim);
     }
 
     public static HiveCommonStats toHiveCommonStats(Map<String, String> params) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.MetaException;
-import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.thrift.TException;
@@ -158,8 +157,19 @@ public class HiveMetaClientTest {
         Assert.assertEquals("\002", emptyDesc.getCollectionDelim());
         Assert.assertEquals("\003", emptyDesc.getMapkeyDelim());
 
+        // Check blank delimiter
+        Map<String, String> blankParameters = new HashMap<>();
+        blankParameters.put("field.delim", "");
+        blankParameters.put("line.delim", "");
+        blankParameters.put("collection.delim", "");
+        blankParameters.put("mapkey.delim", "");
+        TextFileFormatDesc blankDesc = HiveMetastoreApiConverter.toTextFileFormatDesc(blankParameters);
+        Assert.assertEquals("\001", blankDesc.getFieldDelim());
+        Assert.assertEquals("\n", blankDesc.getLineDelim());
+        Assert.assertEquals("\002", blankDesc.getCollectionDelim());
+        Assert.assertEquals("\003", blankDesc.getMapkeyDelim());
+
         // Check is using custom delimiter
-        StorageDescriptor customSd = new StorageDescriptor();
         Map<String, String> parameters = new HashMap<>();
         parameters.put("field.delim", ",");
         parameters.put("line.delim", "\004");


### PR DESCRIPTION
If user create a table in Hive like:
```sql
CREATE TABLE `csv_oom`(
  `id` int,
  `val` int,
  `label` int)
ROW FORMAT SERDE
  'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
WITH SERDEPROPERTIES (
  'field.delim'='',
  'serialization.format'='') stored as textfile;
```

We will pass `field.delim=''` to BE, then BE will into an infinite loop in csv_reader.cpp `CSVReader::split_record`. 
We will add elements into `columns` infinitely until BE OOM.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
