### PR TITLE
[Enhancement] add disk_spill in runtime query statistics 

### DIFF
--- a/be/src/exec/chunks_sorter.cpp
+++ b/be/src/exec/chunks_sorter.cpp
@@ -153,7 +153,7 @@ ChunksSorter::ChunksSorter(RuntimeState* state, const std::vector<ExprContext*>*
 
 ChunksSorter::~ChunksSorter() = default;
 
-void ChunksSorter::setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
+void ChunksSorter::setup_runtime(RuntimeState* state, RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
     _build_timer = ADD_TIMER(profile, "BuildingTime");
     _sort_timer = ADD_TIMER(profile, "SortingTime");
     _merge_timer = ADD_TIMER(profile, "MergingTime");

--- a/be/src/exec/chunks_sorter.h
+++ b/be/src/exec/chunks_sorter.h
@@ -111,7 +111,7 @@ public:
                                                             const SortExecExprs& sort_exec_exprs,
                                                             const std::vector<OrderByType>& order_by_types);
 
-    virtual void setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker);
+    virtual void setup_runtime(RuntimeState* state, RuntimeProfile* profile, MemTracker* parent_mem_tracker);
 
     void set_spiller(std::shared_ptr<spill::Spiller> spiller) { _spiller = std::move(spiller); }
 

--- a/be/src/exec/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/chunks_sorter_full_sort.cpp
@@ -37,8 +37,9 @@ ChunksSorterFullSort::ChunksSorterFullSort(RuntimeState* state, const std::vecto
           _early_materialized_slots(early_materialized_slots.begin(), early_materialized_slots.end()) {}
 
 ChunksSorterFullSort::~ChunksSorterFullSort() = default;
-void ChunksSorterFullSort::setup_runtime(starrocks::RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
-    ChunksSorter::setup_runtime(profile, parent_mem_tracker);
+
+void ChunksSorterFullSort::setup_runtime(RuntimeState* state, RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
+    ChunksSorter::setup_runtime(state, profile, parent_mem_tracker);
     _runtime_profile = profile;
     _parent_mem_tracker = parent_mem_tracker;
     _object_pool = std::make_unique<ObjectPool>();
@@ -46,6 +47,7 @@ void ChunksSorterFullSort::setup_runtime(starrocks::RuntimeProfile* profile, Mem
     _runtime_profile->add_info_string("MaxBufferedBytes", strings::Substitute("$0", max_buffered_bytes));
     _profiler = _object_pool->add(new ChunksSorterFullSortProfiler(profile, parent_mem_tracker));
 }
+
 Status ChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr& chunk) {
     RETURN_IF_ERROR(_merge_unsorted(state, chunk));
     RETURN_IF_ERROR(_partial_sort(state, false));

--- a/be/src/exec/chunks_sorter_full_sort.h
+++ b/be/src/exec/chunks_sorter_full_sort.h
@@ -56,7 +56,8 @@ public:
 
     int64_t mem_usage() const override;
 
-    void setup_runtime(starrocks::RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
+    void setup_runtime(RuntimeState* state, starrocks::RuntimeProfile* profile,
+                       MemTracker* parent_mem_tracker) override;
 
 private:
     // Three stages of sorting procedure:

--- a/be/src/exec/chunks_sorter_heap_sort.cpp
+++ b/be/src/exec/chunks_sorter_heap_sort.cpp
@@ -290,8 +290,8 @@ int ChunksSorterHeapSort::_filter_data(detail::ChunkHolder* chunk_holder, int ro
     return chunk_holder->value()->chunk->filter(filter);
 }
 
-void ChunksSorterHeapSort::setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
-    ChunksSorter::setup_runtime(profile, parent_mem_tracker);
+void ChunksSorterHeapSort::setup_runtime(RuntimeState* state, RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
+    ChunksSorter::setup_runtime(state, profile, parent_mem_tracker);
     _sort_filter_costs = ADD_TIMER(profile, "SortFilterCost");
     _sort_filter_rows = ADD_COUNTER(profile, "SortFilterRows", TUnit::UNIT);
 }

--- a/be/src/exec/chunks_sorter_heap_sort.h
+++ b/be/src/exec/chunks_sorter_heap_sort.h
@@ -249,7 +249,7 @@ public:
 
     size_t get_output_rows() const override;
 
-    void setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
+    void setup_runtime(RuntimeState* state, RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
 
 private:
     size_t _number_of_rows_to_sort() const { return _offset + _limit; }

--- a/be/src/exec/chunks_sorter_topn.cpp
+++ b/be/src/exec/chunks_sorter_topn.cpp
@@ -47,8 +47,8 @@ ChunksSorterTopn::ChunksSorterTopn(RuntimeState* state, const std::vector<ExprCo
 
 ChunksSorterTopn::~ChunksSorterTopn() = default;
 
-void ChunksSorterTopn::setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
-    ChunksSorter::setup_runtime(profile, parent_mem_tracker);
+void ChunksSorterTopn::setup_runtime(RuntimeState* state, RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
+    ChunksSorter::setup_runtime(state, profile, parent_mem_tracker);
     _sort_filter_timer = ADD_TIMER(profile, "SortFilterTime");
     _sort_filter_rows = ADD_COUNTER(profile, "SortFilterRows", TUnit::UNIT);
 }

--- a/be/src/exec/chunks_sorter_topn.h
+++ b/be/src/exec/chunks_sorter_topn.h
@@ -76,7 +76,7 @@ public:
 
     int64_t mem_usage() const override { return _raw_chunks.mem_usage() + _merged_segment.mem_usage(); }
 
-    void setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
+    void setup_runtime(RuntimeState* state, RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
 
     std::vector<JoinRuntimeFilter*>* runtime_filters(ObjectPool* pool) override;
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -98,7 +98,8 @@ void SpillableAggregateBlockingSinkOperator::close(RuntimeState* state) {
 Status SpillableAggregateBlockingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(AggregateBlockingSinkOperator::prepare(state));
     DCHECK(!_aggregator->is_none_group_by_exprs());
-    _aggregator->spiller()->set_metrics(spill::SpillProcessMetrics(_unique_metrics.get()));
+    _aggregator->spiller()->set_metrics(
+            spill::SpillProcessMetrics(_unique_metrics.get(), state->mutable_total_spill_bytes()));
 
     if (state->spill_mode() == TSpillMode::FORCE) {
         _spill_strategy = spill::SpillStrategy::SPILL_ALL;

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -65,7 +65,8 @@ void SpillableAggregateDistinctBlockingSinkOperator::close(RuntimeState* state) 
 Status SpillableAggregateDistinctBlockingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(AggregateDistinctBlockingSinkOperator::prepare(state));
     DCHECK(!_aggregator->is_none_group_by_exprs());
-    _aggregator->spiller()->set_metrics(spill::SpillProcessMetrics(_unique_metrics.get()));
+    _aggregator->spiller()->set_metrics(
+            spill::SpillProcessMetrics(_unique_metrics.get(), state->mutable_total_spill_bytes()));
     if (state->spill_mode() == TSpillMode::FORCE) {
         _spill_strategy = spill::SpillStrategy::SPILL_ALL;
     }

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -36,7 +36,8 @@ namespace starrocks::pipeline {
 
 Status SpillableHashJoinBuildOperator::prepare(RuntimeState* state) {
     HashJoinBuildOperator::prepare(state);
-    _join_builder->spiller()->set_metrics(spill::SpillProcessMetrics(_unique_metrics.get()));
+    _join_builder->spiller()->set_metrics(
+            spill::SpillProcessMetrics(_unique_metrics.get(), state->mutable_total_spill_bytes()));
     RETURN_IF_ERROR(_join_builder->spiller()->prepare(state));
     if (state->spill_mode() == TSpillMode::FORCE) {
         set_spill_strategy(spill::SpillStrategy::SPILL_ALL);

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -40,7 +40,7 @@ namespace starrocks::pipeline {
 Status SpillableHashJoinProbeOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(HashJoinProbeOperator::prepare(state));
     _need_post_probe = has_post_probe(_join_prober->join_type());
-    _probe_spiller->set_metrics(spill::SpillProcessMetrics(_unique_metrics.get()));
+    _probe_spiller->set_metrics(spill::SpillProcessMetrics(_unique_metrics.get(), state->mutable_total_spill_bytes()));
     metrics.hash_partitions = ADD_COUNTER(_unique_metrics.get(), "SpillPartitions", TUnit::UNIT);
     metrics.build_partition_peak_memory_usage = _unique_metrics->AddHighWaterMarkCounter(
             "SpillBuildPartitionPeakMemoryUsage", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TUnit::BYTES));

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
@@ -23,7 +23,8 @@
 namespace starrocks::pipeline {
 Status SpillableNLJoinBuildOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(NLJoinBuildOperator::prepare(state));
-    _spill_channel->spiller()->set_metrics(spill::SpillProcessMetrics(_unique_metrics.get()));
+    _spill_channel->spiller()->set_metrics(
+            spill::SpillProcessMetrics(_unique_metrics.get(), state->mutable_total_spill_bytes()));
     RETURN_IF_ERROR(_spill_channel->spiller()->prepare(state));
     _cross_join_context->input_channel(_driver_sequence).set_spiller(_spill_channel->spiller());
     if (state->spill_mode() == TSpillMode::FORCE) {

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
@@ -126,7 +126,7 @@ Status SpillableNLJoinProbeOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(_prober.prepare(state, _unique_metrics.get()));
     _spill_factory = std::make_shared<spill::SpillerFactory>();
     _spiller = _spill_factory->create({});
-    _spiller->set_metrics(spill::SpillProcessMetrics(_unique_metrics.get()));
+    _spiller->set_metrics(spill::SpillProcessMetrics(_unique_metrics.get(), state->mutable_total_spill_bytes()));
     _cross_join_context->incr_prober();
     return Status::OK();
 }

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -455,6 +455,7 @@ void QueryContextManager::collect_query_statistics(const PCollectQueryStatistics
             query_statistics->set_scan_rows(scan_rows);
             query_statistics->set_scan_bytes(scan_bytes);
             query_statistics->set_mem_usage_bytes(mem_usage_bytes);
+            query_statistics->set_spill_bytes(query_ctx->get_spill_bytes());
         }
     }
 }

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -139,6 +139,8 @@ public:
     int64_t cpu_cost() const { return _total_cpu_cost_ns; }
     int64_t cur_scan_rows_num() const { return _total_scan_rows_num; }
     int64_t get_scan_bytes() const { return _total_scan_bytes; }
+    std::atomic_int64_t* mutable_total_spill_bytes() { return &_total_spill_bytes; }
+    int64_t get_spill_bytes() { return _total_spill_bytes; }
 
     // Query start time, used to check how long the query has been running
     // To ensure that the minimum run time of the query will not be killed by the big query checking mechanism
@@ -198,6 +200,7 @@ private:
     std::atomic<int64_t> _total_cpu_cost_ns = 0;
     std::atomic<int64_t> _total_scan_rows_num = 0;
     std::atomic<int64_t> _total_scan_bytes = 0;
+    std::atomic<int64_t> _total_spill_bytes = 0;
     std::atomic<int64_t> _delta_cpu_cost_ns = 0;
     std::atomic<int64_t> _delta_scan_rows_num = 0;
     std::atomic<int64_t> _delta_scan_bytes = 0;

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.cpp
@@ -42,7 +42,7 @@ Status PartitionSortSinkOperator::prepare(RuntimeState* state) {
     _sort_context->ref();
     _sort_context->incr_sinker();
 
-    _chunks_sorter->setup_runtime(_unique_metrics.get(), this->mem_tracker());
+    _chunks_sorter->setup_runtime(state, _unique_metrics.get(), this->mem_tracker());
 
     return Status::OK();
 }

--- a/be/src/exec/spill/serde.cpp
+++ b/be/src/exec/spill/serde.cpp
@@ -155,6 +155,7 @@ Status ColumnarSerde::serialize(SerdeContext& ctx, const ChunkPtr& chunk, BlockP
         RETURN_IF_ERROR(block->append(data));
     }
     COUNTER_UPDATE(_parent->metrics().flush_bytes, meta_len + serialize_buffer.size());
+    _parent->metrics().total_spill_bytes->fetch_add(meta_len + serialize_buffer.size());
     TRACE_SPILL_LOG << "serialize chunk to block: " << block->debug_string()
                     << ", original size: " << chunk->bytes_usage() << ", encoded size: " << serialize_buffer.size();
     return Status::OK();

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -18,6 +18,7 @@
 #include <fmt/core.h>
 #include <glog/logging.h>
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -38,8 +39,10 @@
 #include "serde/column_array_serde.h"
 
 namespace starrocks::spill {
-SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile) {
+
+SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile, std::atomic_int64_t* total_spill_bytes_) {
     _spiller_metrics = std::make_shared<RuntimeProfile>("SpillerMetrics");
+    total_spill_bytes = total_spill_bytes_;
     profile->add_child(_spiller_metrics.get(), true, nullptr);
 
     append_data_timer = ADD_TIMER(_spiller_metrics.get(), "AppendDataTime");

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -43,10 +43,16 @@ namespace starrocks::spill {
 
 // some metrics for spill
 struct SpillProcessMetrics {
-    SpillProcessMetrics() = default;
-    SpillProcessMetrics(RuntimeProfile* profile);
-
+private:
+    // For profile
     std::shared_ptr<RuntimeProfile> _spiller_metrics;
+
+public:
+    SpillProcessMetrics() = default;
+    SpillProcessMetrics(RuntimeProfile* profile, std::atomic_int64_t* total_spill_bytes);
+
+    // For query statistics
+    std::atomic_int64_t* total_spill_bytes;
 
     // time spent to append data into Spiller
     RuntimeProfile::Counter* append_data_timer = nullptr;

--- a/be/src/exec/spillable_chunks_sorter_full_sort.cpp
+++ b/be/src/exec/spillable_chunks_sorter_full_sort.cpp
@@ -19,9 +19,10 @@
 #include "exec/spillable_chunks_sorter_sort.h"
 
 namespace starrocks {
-void SpillableChunksSorterFullSort::setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) {
-    ChunksSorterFullSort::setup_runtime(profile, parent_mem_tracker);
-    _spiller->set_metrics(spill::SpillProcessMetrics(profile));
+void SpillableChunksSorterFullSort::setup_runtime(RuntimeState* state, RuntimeProfile* profile,
+                                                  MemTracker* parent_mem_tracker) {
+    ChunksSorterFullSort::setup_runtime(state, profile, parent_mem_tracker);
+    _spiller->set_metrics(spill::SpillProcessMetrics(profile, state->mutable_total_spill_bytes()));
 }
 
 Status SpillableChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr& chunk) {

--- a/be/src/exec/spillable_chunks_sorter_sort.h
+++ b/be/src/exec/spillable_chunks_sorter_sort.h
@@ -28,7 +28,7 @@ public:
     bool is_full() override { return (_spiller != nullptr && _spiller->is_full()) || _spill_channel->has_task(); }
 
     bool has_pending_data() override { return _spiller != nullptr && _spiller->has_pending_data(); }
-    void setup_runtime(RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
+    void setup_runtime(RuntimeState* state, RuntimeProfile* profile, MemTracker* parent_mem_tracker) override;
 
     Status update(RuntimeState* state, const ChunkPtr& chunk) override;
     Status do_done(RuntimeState* state) override;

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -236,7 +236,7 @@ Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {
     }
 
     bool eos = false;
-    _chunks_sorter->setup_runtime(runtime_profile(), runtime_state()->instance_mem_tracker());
+    _chunks_sorter->setup_runtime(state, runtime_profile(), runtime_state()->instance_mem_tracker());
     do {
         RETURN_IF_CANCELLED(state);
         ChunkPtr chunk;

--- a/be/src/runtime/query_statistics.h
+++ b/be/src/runtime/query_statistics.h
@@ -56,6 +56,7 @@ public:
     void add_scan_stats(int64_t scan_rows, int64_t scan_bytes);
     void add_cpu_costs(int64_t cpu_ns) { this->cpu_ns += cpu_ns; }
     void add_mem_costs(int64_t bytes) { mem_cost_bytes += bytes; }
+    void add_spill_bytes(int64_t bytes) { spill_bytes += bytes; }
 
     void to_pb(PQueryStatistics* statistics);
 
@@ -72,6 +73,7 @@ private:
     std::atomic_int64_t scan_bytes{0};
     std::atomic_int64_t cpu_ns{0};
     std::atomic_int64_t mem_cost_bytes{0};
+    std::atomic_int64_t spill_bytes{0};
 
     // number rows returned by query.
     // only set once by result sink when closing.

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -476,6 +476,10 @@ std::shared_ptr<QueryStatisticsRecvr> RuntimeState::query_recv() {
     return _query_ctx->maintained_query_recv();
 }
 
+std::atomic_int64_t* RuntimeState::mutable_total_spill_bytes() {
+    return _query_ctx->mutable_total_spill_bytes();
+}
+
 Status RuntimeState::reset_epoch() {
     std::lock_guard<std::mutex> l(_tablet_infos_lock);
     _tablet_commit_infos.clear();

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -292,6 +292,8 @@ public:
         load_params->__set_source_scan_bytes(num_bytes_scan_from_source());
     }
 
+    std::atomic_int64_t* mutable_total_spill_bytes();
+
     void set_per_fragment_instance_idx(int idx) { _per_fragment_instance_idx = idx; }
 
     int per_fragment_instance_idx() const { return _per_fragment_instance_idx; }

--- a/be/test/exec/chunks_sorter_heap_sort_test.cpp
+++ b/be/test/exec/chunks_sorter_heap_sort_test.cpp
@@ -178,7 +178,7 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_notnull_test) {
             ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
             ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+            sorter.setup_runtime(_runtime_state.get(), _pool.add(new RuntimeProfile("")),
                                  _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(1024));
             sorter.done(nullptr);
@@ -199,7 +199,7 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_notnull_test) {
             ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
             ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+            sorter.setup_runtime(_runtime_state.get(), _pool.add(new RuntimeProfile("")),
                                  _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
@@ -223,7 +223,7 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_notnull_test) {
             ASSERT_OK(Expr::prepare(sort_exprs, _runtime_state.get()));
             ASSERT_OK(Expr::open(sort_exprs, _runtime_state.get()));
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, 1024);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+            sorter.setup_runtime(_runtime_state.get(), _pool.add(new RuntimeProfile("")),
                                  _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(1024));
             sorter.update(nullptr, fake_chunks.next_chunk(1023));
@@ -259,7 +259,7 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_nullable_test) {
             // limit 5
             int limit_sz = 5;
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+            sorter.setup_runtime(_runtime_state.get(), _pool.add(new RuntimeProfile("")),
                                  _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
@@ -285,7 +285,7 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_nullable_test) {
             // limit 5
             int limit_sz = 10;
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+            sorter.setup_runtime(_runtime_state.get(), _pool.add(new RuntimeProfile("")),
                                  _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);
@@ -312,7 +312,7 @@ TEST_F(ChunksSorterHeapSortTest, single_column_order_by_nullable_test) {
             // limit 5
             int limit_sz = 5;
             ChunksSorterHeapSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &null_first, "", 0, limit_sz);
-            sorter.setup_runtime(_pool.add(new RuntimeProfile("")),
+            sorter.setup_runtime(_runtime_state.get(), _pool.add(new RuntimeProfile("")),
                                  _pool.add(new MemTracker(1L << 62, "parent", nullptr)));
             sorter.update(nullptr, fake_chunks.next_chunk(10));
             sorter.done(nullptr);

--- a/be/test/exec/chunks_sorter_test.cpp
+++ b/be/test/exec/chunks_sorter_test.cpp
@@ -318,7 +318,8 @@ TEST_F(ChunksSorterTest, full_sort_incremental) {
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
     ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
                                 slots);
-    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
+    sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
+                         pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -527,7 +528,8 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_first) {
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
     ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
                                 slots);
-    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
+    sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
+                         pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -566,7 +568,8 @@ TEST_F(ChunksSorterTest, full_sort_by_2_columns_null_last) {
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
     ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
                                 slots);
-    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
+    sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
+                         pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -608,7 +611,8 @@ TEST_F(ChunksSorterTest, full_sort_by_3_columns) {
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
     ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
                                 slots);
-    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
+    sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
+                         pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);
@@ -653,7 +657,8 @@ TEST_F(ChunksSorterTest, full_sort_by_4_columns) {
     std::vector<SlotId> slots{_expr_region->slot_id(), _expr_cust_key->slot_id()};
     ChunksSorterFullSort sorter(_runtime_state.get(), &sort_exprs, &is_asc, &is_null_first, "", 1024000, 16777216,
                                 slots);
-    sorter.setup_runtime(pool->add(new RuntimeProfile("", false)), pool->add(new MemTracker(1L << 62, "", nullptr)));
+    sorter.setup_runtime(_runtime_state.get(), pool->add(new RuntimeProfile("", false)),
+                         pool->add(new MemTracker(1L << 62, "", nullptr)));
     size_t total_rows = _chunk_1->num_rows() + _chunk_2->num_rows() + _chunk_3->num_rows();
     sorter.update(_runtime_state.get(), _chunk_1);
     sorter.update(_runtime_state.get(), _chunk_2);

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -180,7 +180,7 @@ public:
 
         dummy_rt_st.set_chunk_size(config::vector_chunk_size);
 
-        metrics = SpillProcessMetrics(&dummy_profile);
+        metrics = SpillProcessMetrics(&dummy_profile, &spill_bytes);
     }
     void TearDown() override {}
     std::unique_ptr<spill::DirManager> dummy_dir_mgr;
@@ -188,6 +188,7 @@ public:
     RuntimeState dummy_rt_st;
     RuntimeProfile dummy_profile{"dummy"};
     std::vector<std::string> clean_up;
+    std::atomic_int64_t spill_bytes;
     SpillProcessMetrics metrics;
 };
 
@@ -297,6 +298,7 @@ TEST_F(SpillTest, unsorted_process) {
     spill_options.block_manager = dummy_block_mgr.get();
 
     auto chunk_empty = chunk_builder.gen(tuple, nullables);
+    std::atomic_int64_t spill_bytes;
 
     auto spiller = factory->create(spill_options);
     spiller->set_metrics(metrics);

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -298,7 +298,6 @@ TEST_F(SpillTest, unsorted_process) {
     spill_options.block_manager = dummy_block_mgr.get();
 
     auto chunk_empty = chunk_builder.gen(tuple, nullables);
-    std::atomic_int64_t spill_bytes;
 
     auto spiller = factory->create(spill_options);
     spiller->set_metrics(metrics);

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryBackendInstanceProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryBackendInstanceProcDir.java
@@ -66,7 +66,7 @@ public class CurrentQueryBackendInstanceProcDir implements ProcDirInterface {
                         .toString();
                 content.setHost(address);
                 content.setInstanceId(DebugUtil.printId(info.getInstanceId()));
-                content.setExecTime(item.getQueryExecTime());
+                content.setExecTime(String.valueOf(item.getQueryExecTime()));
                 final String hostWithPort = info.getAddress().toString();
                 List<RowData> list = hostInstances.get(hostWithPort);
                 if (list == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryHostProcNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryHostProcNode.java
@@ -52,7 +52,7 @@ public class CurrentQueryHostProcNode implements ProcNodeInterface {
             rowData.add(host);
             rowData.add(QueryStatisticsFormatter.getBytes(statistics.scanBytes));
             rowData.add(QueryStatisticsFormatter.getRowsReturned(statistics.scanRows));
-            rowData.add(QueryStatisticsFormatter.getCPUCostSeconds(statistics.cpuCostNs));
+            rowData.add(QueryStatisticsFormatter.getSecondsFromNano(statistics.cpuCostNs));
             rowData.add(QueryStatisticsFormatter.getBytes(statistics.memUsageBytes));
             sortedRowDatas.add(rowData);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryInfoProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryInfoProvider.java
@@ -73,7 +73,7 @@ public class CurrentQueryInfoProvider {
     }
 
     public Map<String, QueryStatistics> getQueryStatistics(Collection<QueryStatisticsItem> items)
-        throws AnalysisException {
+            throws AnalysisException {
         return collectQueryStatistics(items);
     }
 
@@ -261,9 +261,13 @@ public class CurrentQueryInfoProvider {
             memUsageBytes += value;
         }
 
-        public void updateSpillBytes(long value) { spillBytes += value; }
+        public void updateSpillBytes(long value) {
+            spillBytes += value;
+        }
 
-        public long getSpillBytes() { return spillBytes; }
+        public long getSpillBytes() {
+            return spillBytes;
+        }
     }
 
     private static class Request {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryInfoProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryInfoProvider.java
@@ -115,6 +115,9 @@ public class CurrentQueryInfoProvider {
                     statistics.updateScanBytes(queryStatistics.scanBytes);
                     statistics.updateScanRows(queryStatistics.scanRows);
                     statistics.updateMemUsageBytes(queryStatistics.memUsageBytes);
+                    if (queryStatistics.spillBytes != null) {
+                        statistics.updateSpillBytes(queryStatistics.spillBytes);
+                    }
                     final Request request = pair.first;
                     String host = String.format("%s:%d",
                             request.getAddress().getHostname(), request.getAddress().getPort());
@@ -199,6 +202,9 @@ public class CurrentQueryInfoProvider {
                         statistics.updateScanBytes(queryStatistics.scanBytes);
                         statistics.updateScanRows(queryStatistics.scanRows);
                         statistics.updateMemUsageBytes(queryStatistics.memUsageBytes);
+                        if (queryStatistics.spillBytes != null) {
+                            statistics.updateSpillBytes(queryStatistics.spillBytes);
+                        }
                     }
                 }
             } catch (InterruptedException e) {
@@ -217,6 +223,7 @@ public class CurrentQueryInfoProvider {
         long scanBytes = 0;
         long scanRows = 0;
         long memUsageBytes = 0;
+        long spillBytes = 0;
 
         public QueryStatistics() {
 
@@ -253,6 +260,10 @@ public class CurrentQueryInfoProvider {
         public void updateMemUsageBytes(long value) {
             memUsageBytes += value;
         }
+
+        public void updateSpillBytes(long value) { spillBytes += value; }
+
+        public long getSpillBytes() { return spillBytes; }
     }
 
     private static class Request {

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/CurrentQueryStatisticsProcDir.java
@@ -54,9 +54,17 @@ import java.util.Map;
 public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
     private static final Logger LOG = LogManager.getLogger(CurrentQueryStatisticsProcDir.class);
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("QueryId").add("ConnectionId").add("Database").add("User")
-            .add("ScanBytes").add("ProcessRows").add("CPUCostSeconds").add("MemoryUsageBytes")
-            .add("ExecTime").build();
+                                                                    .add("QueryId")
+                                                                    .add("ConnectionId")
+                                                                    .add("Database")
+                                                                    .add("User")
+                                                                    .add("ScanBytes")
+                                                                    .add("ScanRows")
+                                                                    .add("MemoryUsage")
+                                                                    .add("DiskSpillSize")
+                                                                    .add("CPUTime")
+                                                                    .add("ExecTime")
+                                                                    .build();
 
     private static final int EXEC_TIME_INDEX = 8;
 
@@ -99,13 +107,12 @@ public class CurrentQueryStatisticsProcDir implements ProcDirInterface {
             values.add(item.getConnId());
             values.add(item.getDb());
             values.add(item.getUser());
-            values.add(QueryStatisticsFormatter.getBytes(
-                    statistics.getScanBytes()));
-            values.add(QueryStatisticsFormatter.getRowsReturned(
-                    statistics.getScanRows()));
-            values.add(QueryStatisticsFormatter.getCPUCostSeconds(statistics.getCpuCostNs()));
+            values.add(QueryStatisticsFormatter.getBytes(statistics.getScanBytes()));
+            values.add(QueryStatisticsFormatter.getRowsReturned(statistics.getScanRows()));
             values.add(QueryStatisticsFormatter.getBytes(statistics.getMemUsageBytes()));
-            values.add(item.getQueryExecTime());
+            values.add(QueryStatisticsFormatter.getBytes(statistics.getSpillBytes()));
+            values.add(QueryStatisticsFormatter.getSecondsFromNano(statistics.getCpuCostNs()));
+            values.add(QueryStatisticsFormatter.getSecondsFromMilli(item.getQueryExecTime()));
             sortedRowData.add(values);
         }
         // sort according to ExecTime

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/QueryStatisticsFormatter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/QueryStatisticsFormatter.java
@@ -30,7 +30,9 @@ public class QueryStatisticsFormatter {
         }
     }
 
-    public static String getRowsReturned(long rowsReturned) { return rowsReturned + " rows"; }
+    public static String getRowsReturned(long rowsReturned) {
+        return rowsReturned + " rows";
+    }
 
     public static String getSecondsFromNano(long nano) {
         final StringBuilder builder = new StringBuilder();

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/QueryStatisticsFormatter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/QueryStatisticsFormatter.java
@@ -26,22 +26,24 @@ public class QueryStatisticsFormatter {
     public static String getBytes(long bytes) {
         final Pair<Double, String> pair = DebugUtil.getByteUint(bytes);
         try (final Formatter fmt = new Formatter()) {
-            final StringBuilder builder = new StringBuilder();
-            builder.append(fmt.format("%.2f", pair.first)).append(" ").append(pair.second);
-            return builder.toString();
+            return fmt.format("%.3f", pair.first) + " " + pair.second;
         }
     }
 
-    public static String getRowsReturned(long rowsReturned) {
+    public static String getRowsReturned(long rowsReturned) { return rowsReturned + " rows"; }
+
+    public static String getSecondsFromNano(long nano) {
         final StringBuilder builder = new StringBuilder();
-        builder.append(rowsReturned).append(" Rows");
+        try (final Formatter fmt = new Formatter()) {
+            builder.append(fmt.format("%.3f", nano * 1.0 / 1000_000_000)).append(" s");
+        }
         return builder.toString();
     }
 
-    public static String getCPUCostSeconds(long cpuCostNs) {
+    public static String getSecondsFromMilli(long milli) {
         final StringBuilder builder = new StringBuilder();
         try (final Formatter fmt = new Formatter()) {
-            builder.append(fmt.format("%.2f", cpuCostNs * 1.0 / 1000000000)).append(" ").append("Seconds");
+            builder.append(fmt.format("%.3f", milli * 1.0 / 1000)).append(" s");
         }
         return builder.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryStatisticsItem.java
@@ -65,9 +65,9 @@ public final class QueryStatisticsItem {
         return connId;
     }
 
-    public String getQueryExecTime() {
-        final long currentTime = System.currentTimeMillis();
-        return String.valueOf(currentTime - queryStartTime);
+    public long getQueryExecTime() {
+        long currentTime = System.currentTimeMillis();
+        return currentTime - queryStartTime;
     }
 
     public String getQueryId() {

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -45,6 +45,7 @@ message PQueryStatistics {
     optional int64 returned_rows = 3;
     optional int64 cpu_cost_ns = 4;
     optional int64 mem_cost_bytes = 5;
+    optional int64 spill_bytes = 6;
     repeated QueryStatisticsItemPB stats_items = 10;
 }
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -391,6 +391,7 @@ message PCollectQueryStatistics {
     optional int64 scan_bytes = 3;
     optional int64 scan_rows = 4;
     optional int64 mem_usage_bytes = 5;
+    optional int64 spill_bytes = 6;
 }
 
 message PCollectQueryStatisticsResult {


### PR DESCRIPTION
Fixes #issue

```sql
> show proc '/current_queries'
+--------------------------------------+--------------+----------+------+------------+---------------+-------------+---------------+----------+----------+
| QueryId                              | ConnectionId | Database | User | ScanBytes  | ScanRows      | MemoryUsage | DiskSpillSize | CPUTime  | ExecTime |
+--------------------------------------+--------------+----------+------+------------+---------------+-------------+---------------+----------+----------+
| 6e770804-0c22-11ee-92dc-162d24e49988 | 2            | ssb_1g   | root | 321.250 MB | 67371008 rows | 902.750 MB  | 113.523 MB    | 10.362 s | 7.501 s  |
+--------------------------------------+--------------+----------+------+------------+---------------+-------------+---------------+----------+----------+
```



## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
