### PR TITLE
[BugFix] Fix listTableSatus() NPE when base table is dropped

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationMgr.java
@@ -263,7 +263,6 @@ public class AuthenticationMgr {
                         authenticatedUser = UserIdentity.createEphemeralUserIdent(remoteUser, authMechanism);
                         ConnectContext currentContext = ConnectContext.get();
                         if (currentContext != null) {
-                            // TODO(yiming): set role ids for ephemeral user in connection context
                             currentContext.setCurrentRoleIds(new HashSet<>(
                                     Collections.singletonList(PrivilegeBuiltinConstants.ROOT_ROLE_ID)));
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
@@ -292,7 +292,6 @@ public abstract class BaseAction implements IAction {
     protected void checkActionOnSystem(UserIdentity currentUser, PrivilegeType... systemActions)
             throws UnauthorizedException {
         for (PrivilegeType systemAction : systemActions) {
-            // TODO(yiming): set role ids for ephemeral user
             if (!PrivilegeActions.checkSystemAction(currentUser, null, systemAction)) {
                 throw new UnauthorizedException("Access denied; you need (at least one of) the "
                         + systemAction.name() + " privilege(s) for this operation");

--- a/fe/fe-core/src/main/java/com/starrocks/http/action/WebBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/action/WebBaseAction.java
@@ -190,7 +190,6 @@ public class WebBaseAction extends BaseAction {
             ctx.setRemoteIP(authInfo.remoteIp);
             ctx.setCurrentUserIdentity(currentUser);
             ctx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
-            // TODO(yiming): set role ids for ephemeral user
             ctx.setCurrentRoleIds(currentUser);
 
             ctx.setThreadLocalInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -94,7 +94,6 @@ public class RestBaseAction extends BaseAction {
         ctx.setQueryId(UUIDUtil.genUUID());
         ctx.setRemoteIP(authInfo.remoteIp);
         ctx.setCurrentUserIdentity(currentUser);
-        // TODO(yiming): set role ids for ephemeral user
         ctx.setCurrentRoleIds(currentUser);
         ctx.setThreadLocalInfo();
         executeWithoutPassword(request, response);

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationMgr.java
@@ -877,7 +877,6 @@ public class AuthorizationMgr {
                 roleIds = getRoleIdsByUser(pair.first);
             }
 
-            // TODO(yiming): modify for ephemeral user
             for (long badRoleId : badRoles) {
                 if (roleIds.contains(badRoleId)) {
                     badKeys.add(pair);

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -130,8 +130,6 @@ public class InformationSchemaDataSource {
                 try {
                     List<Table> allTables = db.getTables();
                     for (Table table : allTables) {
-
-                        // TODO(yiming): set role ids for ephemeral user in all the PrivilegeActions.* call in this dir
                         if (!PrivilegeActions.checkAnyActionOnTableLikeObject(result.currentUser, null, dbName, table)) {
                             continue;
                         }
@@ -299,8 +297,6 @@ public class InformationSchemaDataSource {
                 try {
                     List<Table> allTables = db.getTables();
                     for (Table table : allTables) {
-
-                        // TODO(yiming): set role ids for ephemeral user in all the PrivilegeActions.* call in this dir
                         if (!PrivilegeActions.checkAnyActionOnTableLikeObject(result.currentUser, null, dbName, table)) {
                             continue;
                         }


### PR DESCRIPTION
Fixes SR-18423

When the base table of a view is dropped, NPE maybe throwed
when calling FrontendServiceImpl.listTableStatus() to list views
in a database because of privilege checking. In this case, we
should just ignore the privilege checking for the dropped table.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
