### PR TITLE
[BugFix] prevent external table has not null column

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -55,7 +55,9 @@ Status HiveDataSource::_check_all_slots_nullable() {
     for (const auto* slot : _tuple_desc->slots()) {
         if (!slot->is_nullable()) {
             return Status::RuntimeError(fmt::format(
-                    "All columns must be nullable for external table. Column '{}' is not nullable", slot->col_name()));
+                    "All columns must be nullable for external table. Column '{}' is not nullable, You can rebuild the"
+                    "external table and We strongly recommend that you use catalog to access external data.",
+                    slot->col_name()));
         }
     }
     return Status::OK();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -279,7 +279,7 @@ public class CreateTableAnalyzer {
         Set<String> columnSet = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         for (ColumnDef columnDef : columnDefs) {
             try {
-                columnDef.analyze(statement.isOlapEngine());
+                columnDef.analyze(statement.isOlapEngine(), CatalogMgr.isInternalCatalog(catalogName), engineName);
             } catch (AnalysisException e) {
                 LOGGER.error("Column definition analyze failed.", e);
                 throw new SemanticException(e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/EngineType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/EngineType.java
@@ -14,6 +14,10 @@
 
 package com.starrocks.sql.common;
 
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
 public enum EngineType {
     OLAP,
     MYSQL,
@@ -25,7 +29,17 @@ public enum EngineType {
     JDBC,
     FILE;
 
+    public static Set<EngineType> SUPPORT_NOT_NULL_SET = ImmutableSet.of(
+            OLAP,
+            MYSQL,
+            BROKER
+    );
+
     public static EngineType defaultEngine() {
         return OLAP;
+    }
+
+    public static boolean supportNotNullColumn(String engineName) {
+        return SUPPORT_NOT_NULL_SET.contains(EngineType.valueOf(engineName.toUpperCase()));
     }
 }


### PR DESCRIPTION
Users may specify the column is not null but the data is nullable, and this may lead `be` to crash, so we prevent it.

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0 I'll cp it manually.
  - [ ] 2.5 I'll cp it manually.
  - [ ] 2.4
