### PR TITLE
[Enhancement] improve the readability for parser error msg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
@@ -28,11 +28,11 @@ public interface ParserErrorMsg {
     @BaseMessage("No viable statement for input ''{0}''")
     String noViableStatement(String a0);
 
-    @BaseMessage("Input ''{0}'' is not valid at this position")
-    String inputMismatch(String a0);
-
     @BaseMessage("Input ''{0}'' is valid only for ''{1}''")
     String failedPredicate(String a0, String a1);
+
+    @BaseMessage("unexpected input ''{0}'', expecting {1}")
+    String unexpectedInput(String a0, String a1);
 
     @BaseMessage("Statement exceeds maximum length limit, please consider modify ''parse_tokens_limit'' session variable")
     String tokenExceedLimit();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
@@ -31,7 +31,7 @@ public interface ParserErrorMsg {
     @BaseMessage("Input ''{0}'' is valid only for ''{1}''")
     String failedPredicate(String a0, String a1);
 
-    @BaseMessage("unexpected input ''{0}'', expecting {1}")
+    @BaseMessage("Unexpected input ''{0}'', the most similar input is {1}")
     String unexpectedInput(String a0, String a1);
 
     @BaseMessage("Statement exceeds maximum length limit, please consider modify ''parse_tokens_limit'' session variable")

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/ErrorHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/ErrorHandler.java
@@ -16,9 +16,6 @@ package com.starrocks.sql.parser;
 
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.FailedPredicateException;
-import org.antlr.v4.runtime.InputMismatchException;
-import org.antlr.v4.runtime.LexerNoViableAltException;
-import org.antlr.v4.runtime.NoViableAltException;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 
@@ -33,15 +30,7 @@ class ErrorHandler extends BaseErrorListener {
         NodePosition pos = new NodePosition(line, charPositionInLine);
         String tokenName;
 
-        if (e instanceof NoViableAltException || e instanceof LexerNoViableAltException) {
-            // it means parser cannot find a suitable rule for the input.
-            tokenName = SqlParser.getTokenDisplay(e.getOffendingToken());
-            detailMsg = PARSER_ERROR_MSG.noViableStatement(tokenName);
-        } else if (e instanceof InputMismatchException) {
-            // it means parser find the input only partially matches the rule.
-            tokenName = SqlParser.getTokenDisplay(e.getOffendingToken());
-            detailMsg = PARSER_ERROR_MSG.inputMismatch(tokenName);
-        } else if (e instanceof FailedPredicateException) {
+        if (e instanceof FailedPredicateException) {
             tokenName = SqlParser.getTokenDisplay(e.getOffendingToken());
             detailMsg = PARSER_ERROR_MSG.failedPredicate(tokenName, ((FailedPredicateException) e).getPredicate());
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -28,14 +28,25 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.DefaultErrorStrategy;
 import org.antlr.v4.runtime.InputMismatchException;
+import org.antlr.v4.runtime.NoViableAltException;
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.runtime.Vocabulary;
+import org.antlr.v4.runtime.misc.Interval;
+import org.antlr.v4.runtime.misc.IntervalSet;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.similarity.JaroWinklerDistance;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 import static com.starrocks.sql.common.ErrorMsgProxy.PARSER_ERROR_MSG;
 
@@ -148,24 +159,99 @@ public class SqlParser {
             }
 
             @Override
-            protected void reportMissingToken(Parser recognizer) {
-                reportMissMatchedToken(recognizer);
+            public void reportNoViableAlternative(Parser recognizer, NoViableAltException e) {
+                TokenStream tokens = recognizer.getInputStream();
+                String input;
+                if (tokens != null) {
+                    if (e.getStartToken().getType() == Token.EOF) {
+                        input = "<EOF>";
+                    } else {
+                        input = tokens.getText(e.getStartToken(), e.getOffendingToken());
+                    }
+                } else {
+                    input = "<unknown input>";
+                }
+                String msg = PARSER_ERROR_MSG.noViableStatement(input);
+                recognizer.notifyErrorListeners(e.getOffendingToken(), msg, e);
             }
 
             @Override
-            protected void reportUnwantedToken(Parser recognizer) {
-                reportMissMatchedToken(recognizer);
+            public void reportInputMismatch(Parser recognizer, InputMismatchException e) {
+                Token t = e.getOffendingToken();
+                String tokenName = getTokenDisplay(t);
+                IntervalSet expecting = getExpectedTokens(recognizer);
+                String expects = filterExpectingToken(tokenName, expecting, recognizer.getVocabulary());
+                String msg = PARSER_ERROR_MSG.unexpectedInput(tokenName, expects);
+                recognizer.notifyErrorListeners(e.getOffendingToken(), msg, e);
             }
 
-            private void reportMissMatchedToken(Parser recognizer) {
+            @Override
+            public void reportUnwantedToken(Parser recognizer) {
                 if (inErrorRecoveryMode(recognizer)) {
                     return;
                 }
-
                 beginErrorCondition(recognizer);
                 Token t = recognizer.getCurrentToken();
                 String tokenName = getTokenDisplay(t);
-                recognizer.notifyErrorListeners(t, PARSER_ERROR_MSG.inputMismatch(tokenName), null);
+                IntervalSet expecting = getExpectedTokens(recognizer);
+                String expects = filterExpectingToken(tokenName, expecting, recognizer.getVocabulary());
+                String msg = PARSER_ERROR_MSG.unexpectedInput(tokenName, expects);
+                recognizer.notifyErrorListeners(t, msg, null);
+            }
+
+            private String filterExpectingToken(String token, IntervalSet expecting, Vocabulary vocabulary) {
+                List<String> symbols = Lists.newArrayList();
+                List<String> words = Lists.newArrayList();
+
+                List<String> result = Lists.newArrayList();
+                StringJoiner joiner = new StringJoiner(", ", "{", "}");
+                JaroWinklerDistance jaroWinklerDistance = new JaroWinklerDistance();
+
+                if (expecting.isNil()) {
+                    return joiner.toString();
+                }
+
+                Iterator<Interval> iter = expecting.getIntervals().iterator();
+                while (iter.hasNext()) {
+                    Interval I = iter.next();
+                    int a = I.a;
+                    int b = I.b;
+                    if (a == b) {
+                        addToken(vocabulary, a, symbols, words);
+                    } else {
+                        for (int i = a; i <= b; i++) {
+                            addToken(vocabulary, i, symbols, words);
+                        }
+                    }
+                }
+                String upperToken = StringUtils.upperCase(token);
+                Collections.sort(words, Comparator.comparingDouble(s -> jaroWinklerDistance.apply(s, upperToken)));
+                int limit = Math.min(5, words.size());
+                result.addAll(words.subList(0, limit));
+                result.addAll(symbols);
+                // if there exists an expect word in nonReserved words, there should be a legal identifier.
+                if (result.contains("'ACCESS'")) {
+                    result.clear();
+                    result.add("a legal identifier");
+                }
+
+                result.forEach(e -> joiner.add(e));
+                return joiner.toString();
+            }
+
+            private void addToken(Vocabulary vocabulary, int a, List<String> symbols, List<String> words) {
+                if (a == Token.EOF) {
+                    symbols.add("<EOF>");
+                } else if (a == Token.EPSILON) {
+                    // do nothing
+                } else {
+                    String token = vocabulary.getDisplayName(a);
+                    if (token.matches(".*[a-zA-Z]+.*")) {
+                        words.add(token);
+                    } else {
+                        symbols.add(token);
+                    }
+                }
             }
         });
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -213,9 +213,9 @@ public class SqlParser {
 
                 Iterator<Interval> iter = expecting.getIntervals().iterator();
                 while (iter.hasNext()) {
-                    Interval I = iter.next();
-                    int a = I.a;
-                    int b = I.b;
+                    Interval interval = iter.next();
+                    int a = interval.a;
+                    int b = interval.b;
                     if (a == b) {
                         addToken(vocabulary, a, symbols, words);
                     } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -53,6 +53,8 @@ import static com.starrocks.sql.common.ErrorMsgProxy.PARSER_ERROR_MSG;
 public class SqlParser {
     private static final Logger LOG = LogManager.getLogger(SqlParser.class);
 
+    private static final String EOF = "<EOF>";
+
     public static List<StatementBase> parse(String sql, SessionVariable sessionVariable) {
         if (sessionVariable.getSqlDialect().equalsIgnoreCase("trino")) {
             return parseWithTrinoDialect(sql, sessionVariable);
@@ -164,7 +166,7 @@ public class SqlParser {
                 String input;
                 if (tokens != null) {
                     if (e.getStartToken().getType() == Token.EOF) {
-                        input = "<EOF>";
+                        input = EOF;
                     } else {
                         input = tokens.getText(e.getStartToken(), e.getOffendingToken());
                     }
@@ -235,13 +237,13 @@ public class SqlParser {
                     result.add("a legal identifier");
                 }
 
-                result.forEach(e -> joiner.add(e));
+                result.forEach(joiner::add);
                 return joiner.toString();
             }
 
             private void addToken(Vocabulary vocabulary, int a, List<String> symbols, List<String> words) {
                 if (a == Token.EOF) {
-                    symbols.add("<EOF>");
+                    symbols.add(EOF);
                 } else if (a == Token.EPSILON) {
                     // do nothing
                 } else {
@@ -272,7 +274,7 @@ public class SqlParser {
         String s = t.getText();
         if (s == null) {
             if (t.getType() == Token.EOF) {
-                s = "<EOF>";
+                s = EOF;
             } else {
                 s = "<" + t.getType() + ">";
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -246,7 +246,8 @@ public class SqlParser {
                     // do nothing
                 } else {
                     String token = vocabulary.getDisplayName(a);
-                    if (token.matches(".*[a-zA-Z]+.*")) {
+                    // ensure it's a word
+                    if (token.length() > 1 && token.charAt(1) >= 'A' && token.charAt(1) <= 'Z') {
                         words.add(token);
                     } else {
                         symbols.add(token);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1725,7 +1725,7 @@ public class CreateMaterializedViewTest {
             currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage()
-                    .contains("No viable statement for input '('."));
+                    .contains("No viable statement for input 'distributed by hash(date_trunc('."));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/StorageVolumeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/StorageVolumeTest.java
@@ -59,7 +59,7 @@ public class StorageVolumeTest {
     @Test
     public void testAlterStorageVolumeParserAndAnalyzer() {
         String sql = "ALTER STORAGE VOLUME storage_volume_1";
-        AnalyzeTestUtil.analyzeFail(sql, "Input '<EOF>' is not valid at this position");
+        AnalyzeTestUtil.analyzeFail(sql, "Unexpected input '<EOF>', the most similar input is {'SET', 'COMMENT'}");
 
         sql = "ALTER STORAGE VOLUME storage_volume_1 COMMENT = 'comment', " +
                 "SET (\"aws.s3.region\"=\"us-west-2\", \"enabled\"=\"false\")";

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -366,15 +366,15 @@ public class CreateTableTest {
                         + "Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES"
                         + " ('replication_num' = '1');\n"));
 
-        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Input 'AS' is not "
-                        + "valid at this position.",
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Unexpected input 'AS', " +
+                        "the most similar input is {',', ')'}.",
                 () -> createTable("CREATE TABLE test.atbl17 ( id BIGINT NOT NULL,  array_data ARRAY<int> NOT NULL, \n"
                         + "mc DOUBLE AUTO_INCREMENT AS (array_avg(array_data)) ) \n"
                         + "Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES"
                         + "('replication_num' = '1');\n"));
 
-        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Input 'AS' is not "
-                        + "valid at this position.",
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Unexpected input 'AS', " +
+                        "the most similar input is {',', ')'}.",
                 () -> createTable("CREATE TABLE test.atbl18 ( id BIGINT NOT NULL,  array_data ARRAY<int> NOT NULL, \n"
                         + "mc DOUBLE DEFAULT '1.0' AS (array_avg(array_data)) ) \n"
                         + "Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES"

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminSetTest.java
@@ -34,7 +34,7 @@ public class AdminSetTest {
     public void testAdminSetConfig() {
         analyzeSuccess("admin set frontend config(\"alter_table_timeout_second\" = \"60\");");
         analyzeFail("admin set frontend config;", "Getting syntax error at line 1, column 25. " +
-                "Detail message: Input ';' is not valid at this position");
+                "Detail message: Unexpected input ';', expecting {'('}.");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminSetTest.java
@@ -34,7 +34,7 @@ public class AdminSetTest {
     public void testAdminSetConfig() {
         analyzeSuccess("admin set frontend config(\"alter_table_timeout_second\" = \"60\");");
         analyzeFail("admin set frontend config;", "Getting syntax error at line 1, column 25. " +
-                "Detail message: Unexpected input ';', expecting {'('}.");
+                "Detail message: Unexpected input ';', the most similar input is {'('}.");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
@@ -89,7 +89,8 @@ public class AnalyzeJoinTest {
 
         analyzeSuccess("select * from (t0 join tnotnull using(v1)) , t1");
         analyzeFail("select * from (t0 join tnotnull using(v1)) t , t1",
-                "Getting syntax error at line 1, column 43. Detail message: Input 't' is not valid at this position");
+                "Getting syntax error at line 1, column 43. Detail message: Unexpected input 't', " +
+                        "the most similar input is {<EOF>, ';'}.");
         analyzeFail("select v1 from (t0 join tnotnull using(v1)), t1", "Column 'v1' is ambiguous");
         analyzeSuccess("select a.v1 from (t0 a join tnotnull b using(v1)), t1");
     }
@@ -190,7 +191,7 @@ public class AnalyzeJoinTest {
 
         sql = "select * from (t0 a, (t1) b)";
         analyzeFail(sql, "Getting syntax error at line 1, column 26. " +
-                "Detail message: Input 'b' is not valid at this position");
+                "Detail message: Unexpected input 'b', the most similar input is {')'}.");
 
         sql = "select * from (t0 a, t1 a)";
         analyzeFail(sql, "Not unique table/alias: 'a'");
@@ -206,7 +207,7 @@ public class AnalyzeJoinTest {
 
         sql = "select * from (t0 join t1) t,t1";
         analyzeFail(sql, "Getting syntax error at line 1, column 27. " +
-                "Detail message: Input 't' is not valid at this position");
+                "Detail message: Unexpected input 't', the most similar input is {<EOF>, ';'}.");
 
         sql = "select * from (t0 join t1 t) ,t1";
         analyzeSuccess(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -679,7 +679,7 @@ public class AnalyzeSingleTest {
     @Test
     public void testColumnAlias() {
         analyzeFail("select * from test.t0 as t(a,b,c)", "Getting syntax error at line 1, column 26. " +
-                "Detail message: Input '(' is not valid at this position.");
+                "Detail message: Unexpected input '(', expecting {<EOF>, ';'}");
         analyzeSuccess("select * from (select * from test.t0) as t(a,b,c)");
         QueryRelation query = ((QueryStatement) analyzeSuccess("select t.a from (select * from test.t0) as t(a,b,c)"))
                 .getQueryRelation();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -679,7 +679,7 @@ public class AnalyzeSingleTest {
     @Test
     public void testColumnAlias() {
         analyzeFail("select * from test.t0 as t(a,b,c)", "Getting syntax error at line 1, column 26. " +
-                "Detail message: Unexpected input '(', expecting {<EOF>, ';'}");
+                "Detail message: Unexpected input '(', the most similar input is {<EOF>, ';'}");
         analyzeSuccess("select * from (select * from test.t0) as t(a,b,c)");
         QueryRelation query = ((QueryStatement) analyzeSuccess("select t.a from (select * from test.t0) as t(a,b,c)"))
                 .getQueryRelation();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSubqueryTest.java
@@ -74,9 +74,9 @@ public class AnalyzeSubqueryTest {
                 "In Predicate only support literal expression list");
 
         analyzeFail("SELECT * FROM T WHERE A IN 1, 2", "Getting syntax error at line 1, column 24." +
-                " Detail message: Input 'IN' is not valid at this position");
+                " Detail message: Unexpected input 'IN', the most similar input is {<EOF>, ';'}.");
         analyzeFail("SELECT * FROM T WHERE A IN 1", "Getting syntax error at line 1, column 24." +
-                " Detail message: Input 'IN' is not valid at this position");
+                " Detail message: Unexpected input 'IN', the most similar input is {<EOF>, ';'}.");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzerV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeStmtAnalyzerV2Test.java
@@ -477,7 +477,7 @@ public class PrivilegeStmtAnalyzerV2Test {
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Getting syntax error at line 1, column 35. " +
-                    "Detail message: Input 'tables' is not valid at this position."));
+                    "Detail message: Unexpected input 'tables', the most similar input is {'DATABASES'}."));
         }
 
         sql = "revoke select on ALL tables IN ALL tables from test_user";
@@ -486,7 +486,7 @@ public class PrivilegeStmtAnalyzerV2Test {
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Getting syntax error at line 1, column 35. " +
-                    "Detail message: Input 'tables' is not valid at this position"));
+                    "Detail message: Unexpected input 'tables', the most similar input is {'DATABASES'}"));
         }
 
         sql = "grant create table on ALL databases in database db1 to test_user";
@@ -578,7 +578,7 @@ public class PrivilegeStmtAnalyzerV2Test {
     }
 
     @Test
-    public void testViewException() throws Exception {
+    public void testViewException() {
         String sql;
         sql = "grant alter, select on view db1 to test_user";
         try {
@@ -618,7 +618,7 @@ public class PrivilegeStmtAnalyzerV2Test {
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Getting syntax error at line 1, column 34. " +
-                    "Detail message: Input 'views' is not valid at this position."));
+                    "Detail message: Unexpected input 'views', the most similar input is {'DATABASES'}."));
         }
 
         sql = "revoke select on ALL views IN ALL views from test_user";
@@ -627,7 +627,7 @@ public class PrivilegeStmtAnalyzerV2Test {
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("Getting syntax error at line 1, column 34. " +
-                    "Detail message: Input 'views' is not valid at this position"));
+                    "Detail message: Unexpected input 'views', the most similar input is {'DATABASES'}"));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -68,7 +68,7 @@ class ParserTest {
             fail("sql should fail to parse.");
         } catch (Exception e) {
             assertContains(e.getMessage(), "Getting syntax error at line 1, column 14. " +
-                    "Detail message: Input 'tbl' is not valid at this position.");
+                    "Detail message: Unexpected input 'tbl', the most similar input is {<EOF>, ';'}.");
         }
     }
 
@@ -353,6 +353,7 @@ class ParserTest {
         List<Arguments> arguments = Lists.newArrayList();
 
         arguments.add(Arguments.of("selct * from tbl", "SELECT"));
+        arguments.add(Arguments.of("select , from tbl", "SELECT"));
         arguments.add(Arguments.of("CREATE TABLE IF NOT EXISTS timetest (\n" +
                 "  `v1` int(11) NOT NULL,\n" +
                 "  `v2` int(11) NOT NULL,\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -279,7 +279,19 @@ class ParserTest {
         }
     }
 
-    
+    @ParameterizedTest
+    @MethodSource("unexpectedTokenSqls")
+    void testUnexpectedTokenSqls(String sql, String expecting) {
+        SessionVariable sessionVariable = new SessionVariable();
+        try {
+            SqlParser.parse(sql, sessionVariable).get(0);
+            fail("sql should fail.");
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            assertContains(e.getMessage(), expecting);
+        }
+    }
+
     private static Stream<Arguments> keyWordSqls() {
         List<String> sqls = Lists.newArrayList();
         sqls.add("select current_role()");
@@ -335,6 +347,38 @@ class ParserTest {
         sqls.add(Pair.create("select abs(distinct v1) from t1", false));
         return sqls.stream().map(e -> Arguments.of(e.first, e.second));
     }
+
+
+    private static Stream<Arguments> unexpectedTokenSqls() {
+        List<Arguments> arguments = Lists.newArrayList();
+
+        arguments.add(Arguments.of("selct * from tbl", "SELECT"));
+        arguments.add(Arguments.of("CREATE TABLE IF NOT EXISTS timetest (\n" +
+                "  `v1` int(11) NOT NULL,\n" +
+                "  `v2` int(11) NOT NULL,\n" +
+                "  `v3` int(11) NOT NULL\n" +
+                " ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                " \"replication_num\" = \"1\"\n" +
+                ");", ")"));
+        arguments.add(Arguments.of("analyze table tt abc", "';'"));
+        arguments.add(Arguments.of("select 1,, from tbl", "a legal identifier"));
+        arguments.add(Arguments.of("INSTALL PLUGIN FRO xxx", "FROM"));
+        arguments.add(Arguments.of("select (1 + 1) + 1) from tbl", "';'"));
+        arguments.add(Arguments.of("CREATE TABLE IF NOT EXISTS timetest (\n" +
+                "  `v1` int(11) NOT NULL,\n" +
+                "  `v2` int(11) NOT NULL,\n" +
+                "  `v3` int(11) NOT NULL\n" +
+                ")ENGINE=OLAPDUPLICATE KEY(`v1`)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                " \"replication_num\" = \"1\"\n" +
+                ");", "expecting {<EOF>, ';'}"));
+        return arguments.stream();
+    }
+
 }
 
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -353,7 +353,7 @@ class ParserTest {
         List<Arguments> arguments = Lists.newArrayList();
 
         arguments.add(Arguments.of("selct * from tbl", "SELECT"));
-        arguments.add(Arguments.of("select , from tbl", "SELECT"));
+        arguments.add(Arguments.of("select , from tbl", "a legal identifier"));
         arguments.add(Arguments.of("CREATE TABLE IF NOT EXISTS timetest (\n" +
                 "  `v1` int(11) NOT NULL,\n" +
                 "  `v2` int(11) NOT NULL,\n" +
@@ -376,7 +376,7 @@ class ParserTest {
                 "DISTRIBUTED BY HASH(`v1`) BUCKETS 10\n" +
                 "PROPERTIES (\n" +
                 " \"replication_num\" = \"1\"\n" +
-                ");", "expecting {<EOF>, ';'}"));
+                ");", "the most similar input is {<EOF>, ';'}"));
         return arguments.stream();
     }
 

--- a/test/sql/test_array_fn/R/test_array_fn
+++ b/test/sql/test_array_fn/R/test_array_fn
@@ -3945,7 +3945,7 @@ E: (1064, 'Getting analyzing error. Detail message: Lambda arguments should equa
 -- !result
 select all_match((x,y) -> x < y, [],{});
 -- result:
-E: (1064, "Getting syntax error at line 1, column 37. Detail message: Input '}' is not valid at this position.")
+E: (1064, "Getting syntax error at line 1, column 37. Detail message: Unexpected input '}', the most similar input is {'FN'}.")
 -- !result
 select all_match([],null);
 -- result:
@@ -3953,7 +3953,7 @@ E: (1064, 'Getting analyzing error from line 1, column 7 to line 1, column 24. D
 -- !result
 select all_match({});
 -- result:
-E: (1064, "Getting syntax error at line 1, column 18. Detail message: Input '}' is not valid at this position.")
+E: (1064, "Getting syntax error at line 1, column 18. Detail message: Unexpected input '}', the most similar input is {'FN'}.")
 -- !result
 select all_match();
 -- result:
@@ -3973,7 +3973,7 @@ E: (1064, 'Getting analyzing error. Detail message: Lambda arguments should equa
 -- !result
 select any_match((x,y) -> x < y, [],{});
 -- result:
-E: (1064, "Getting syntax error at line 1, column 37. Detail message: Input '}' is not valid at this position.")
+E: (1064, "Getting syntax error at line 1, column 37. Detail message: Unexpected input '}', the most similar input is {'FN'}.")
 -- !result
 select any_match([],null);
 -- result:
@@ -3981,7 +3981,7 @@ E: (1064, 'Getting analyzing error from line 1, column 7 to line 1, column 24. D
 -- !result
 select any_match({});
 -- result:
-E: (1064, "Getting syntax error at line 1, column 18. Detail message: Input '}' is not valid at this position.")
+E: (1064, "Getting syntax error at line 1, column 18. Detail message: Unexpected input '}', the most similar input is {'FN'}.")
 -- !result
 select any_match();
 -- result:

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -11,7 +11,7 @@ E: (1064, 'Getting syntax error at line 1, column 17. Detail message: AUTO_INCRE
 -- !result
 CREATE TABLE t ( id BIGINT NOT NULL AUTO_INCREMENT DEFAULT "100",  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
 -- result:
-E: (1064, "Getting syntax error at line 1, column 51. Detail message: Input 'DEFAULT' is not valid at this position.")
+E: (1064, "Getting syntax error at line 1, column 51. Detail message: Unexpected input 'DEFAULT', the most similar input is {',', ')'}.")
 -- !result
 CREATE TABLE t ( id INT NOT NULL AUTO_INCREMENT,  name BIGINT NOT NULL, job1 BIGINT NOT NULL, job2 BIGINT NOT NULL) Primary KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1", "replicated_storage" = "true");
 -- result:

--- a/test/sql/test_automatic_partition/R/test_insert_overwrite
+++ b/test/sql/test_automatic_partition/R/test_insert_overwrite
@@ -96,7 +96,7 @@ VALUES
 ('2020-08-01', '2020-08-01 00:00:00', 'char2', 'varchar2', false)
 insert overwrite duplicate_table_with_null1 select * from duplicate_table_with_null2;
 -- result:
-E: (1064, "Getting syntax error at line 5, column 0. Detail message: Input 'insert' is not valid at this position.")
+E: (1064, "Getting syntax error at line 5, column 0. Detail message: Unexpected input 'insert', the most similar input is {<EOF>, ';'}.")
 -- !result
 select * from duplicate_table_with_null1;
 -- result:

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -15,11 +15,11 @@ E: (1064, 'Getting syntax error. Detail message: Materialized Column must be nul
 -- !result
 CREATE TABLE t ( id BIGINT NOT NULL,  array_data ARRAY<int> NOT NULL, mc DOUBLE AUTO_INCREMENT AS (array_avg(array_data)) ) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1");
 -- result:
-E: (1064, "Getting syntax error at line 1, column 95. Detail message: Input 'AS' is not valid at this position.")
+E: (1064, "Getting syntax error at line 1, column 95. Detail message: Unexpected input 'AS', the most similar input is {',', ')'}.")
 -- !result
 CREATE TABLE t ( id BIGINT NOT NULL,  array_data ARRAY<int> NOT NULL, mc DOUBLE DEFAULT "1.0" AS (array_avg(array_data)) ) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1");
 -- result:
-E: (1064, "Getting syntax error at line 1, column 94. Detail message: Input 'AS' is not valid at this position.")
+E: (1064, "Getting syntax error at line 1, column 94. Detail message: Unexpected input 'AS', the most similar input is {',', ')'}.")
 -- !result
 CREATE TABLE t ( id BIGINT NOT NULL,  incr BIGINT AUTO_INCREMENT, array_data ARRAY<int> NOT NULL, mc BIGINT AS (incr) ) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1");
 -- result:
@@ -351,7 +351,7 @@ E: (1064, 'Getting analyzing error. Detail message: Illege expression type for M
 -- !result
 ALTER TABLE t ADD COLUMN mc_3 DOUBLE AS NOT NULL (array_avg(array_data));
 -- result:
-E: (1064, "Getting syntax error at line 1, column 49. Detail message: Input '(' is not valid at this position.")
+E: (1064, "Getting syntax error at line 1, column 49. Detail message: Unexpected input '(', the most similar input is {<EOF>, ';'}.")
 -- !result
 ALTER TABLE t ADD COLUMN mc_3 DOUBLE AS AUTO_INCREMENT (array_avg(array_data));
 -- result:
@@ -359,7 +359,7 @@ E: (1064, 'Getting analyzing error from line 1, column 40 to line 1, column 77. 
 -- !result
 ALTER TABLE t ADD COLUMN mc_3 DOUBLE AS DEFAULT "1.0" (array_avg(array_data));
 -- result:
-E: (1064, "Getting syntax error at line 1, column 40. Detail message: Input 'DEFAULT' is not valid at this position.")
+E: (1064, "Getting syntax error at line 1, column 40. Detail message: Unexpected input 'DEFAULT', the most similar input is {'LEFT', DECIMAL_VALUE, 'DUPLICATE', 'FALSE', 'FILTER', '(', '[', '{', '+', '-', '!', '~', '@', '...'}.")
 -- !result
 ALTER TABLE t ADD COLUMN mc_3 DOUBLE AS (mc_1);
 -- result:
@@ -390,7 +390,7 @@ E: (1064, 'Getting analyzing error. Detail message: Illege expression type for M
 -- !result
 ALTER TABLE t MODIFY COLUMN mc_1 DOUBLE AS NOT NULL (array_avg(array_data));
 -- result:
-E: (1064, "Getting syntax error at line 1, column 52. Detail message: Input '(' is not valid at this position.")
+E: (1064, "Getting syntax error at line 1, column 52. Detail message: Unexpected input '(', the most similar input is {<EOF>, ';'}.")
 -- !result
 ALTER TABLE t MODIFY COLUMN mc_1 DOUBLE AS AUTO_INCREMENT (array_avg(array_data));
 -- result:
@@ -398,7 +398,7 @@ E: (1064, 'Getting analyzing error from line 1, column 43 to line 1, column 80. 
 -- !result
 ALTER TABLE t MODIFY COLUMN mc_1 DOUBLE AS DEFAULT "1.0" (array_avg(array_data));
 -- result:
-E: (1064, "Getting syntax error at line 1, column 43. Detail message: Input 'DEFAULT' is not valid at this position.")
+E: (1064, "Getting syntax error at line 1, column 43. Detail message: Unexpected input 'DEFAULT', the most similar input is {'LEFT', DECIMAL_VALUE, 'DUPLICATE', 'FALSE', 'FILTER', '(', '[', '{', '+', '-', '!', '~', '@', '...'}.")
 -- !result
 ALTER TABLE t MODIFY COLUMN mc_1 DOUBLE AS (mc_2);
 -- result:

--- a/test/sql/test_materialized_view/R/test_materialized_view_status
+++ b/test/sql/test_materialized_view/R/test_materialized_view_status
@@ -114,7 +114,7 @@ PROPERTIES(
 )
 insert into t1 values (1,1,1),(1,2,2),(2,3,3),(2,3,4),(2,5,5);
 -- result:
-E: (1064, "Getting syntax error at line 10, column 0. Detail message: Input 'insert' is not valid at this position.")
+E: (1064, "Getting syntax error at line 10, column 0. Detail message: Unexpected input 'insert', the most similar input is {<EOF>, ';'}.")
 -- !result
 CREATE MATERIALIZED VIEW mv2
 DISTRIBUTED BY HASH(k1) BUCKETS 10

--- a/test/sql/test_sorted_streaming_agg/R/sorted_streaming_agg_spill
+++ b/test/sql/test_sorted_streaming_agg/R/sorted_streaming_agg_spill
@@ -39,7 +39,7 @@ insert into test_basic (id_int, id_tinyint, id_smallint, id_bigint, id_largeint,
         (8, 80, 400, 8000, 40000, 400000.1, 4000000.1, 'test_char4', 'testvarchar4', '2020-07-21', '1999-07-24', 2367.34)
 select sum(id_int) from test_basic group by id_int order by id_int;
 -- result:
-E: (1064, "Getting syntax error at line 3, column 80. Detail message: Input '', '' is not valid at this position.")
+E: (1064, "Getting syntax error at line 3, column 80. Detail message: Unexpected input '', '', the most similar input is {',', ')'}.")
 -- !result
 select sum(id_int) from test_basic group by id_int order by id_int;
 -- result:


### PR DESCRIPTION
Previously, our parser did not provide enough info for user how to change the input clause when encountering incorrect input. When handling tokens that do not conform to the rules, Antlr records expecting tokens. However, the expecting tokens include all possible tokens, which leads to excessive information and can even mislead the user. To address this, we compare the customer's input with the expected input and return the top 5 most similar expected words by comparing their [jaroWinklerDistance](https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance) .
For example:
```
CREATE TABLE IF NOT EXISTS timetest (
  `v1` int(11) NOT NULL,
  `v2` int(11) NOT NULL,
  `v3` int(11) NOT NULL
ENGINE=OLAPDUPLICATE KEY(`v1`)
DISTRIBUTED BY HASH(`v1`) BUCKETS 10
PROPERTIES (
 "replication_num" = "1"
);

# the create table clause misses a ')' before the 'ENGINE', now the error message is:
Getting syntax error at line 5, column 1. Detail message: Unexpected input 'ENGINE', the most similar input is {',', ')'}

select , from tbl

# the select clause misses a identifier in the select list
Getting syntax error at line 1, column 7. Detail message: Unexpected input ',', the most similar input is {a legal identifier}.
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
