### PR TITLE
[BugFix] Fix listTableSatus() NPE when base table is dropped (#25472)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -141,9 +141,7 @@ public class InformationSchemaDataSource {
                 try {
                     List<Table> allTables = db.getTables();
                     for (Table table : allTables) {
-
                         if (GlobalStateMgr.getCurrentState().isUsingNewPrivilege()) {
-                            // TODO(yiming): set role ids for ephemeral user in all the PrivilegeActions.* call in this dir
                             if (!PrivilegeActions.checkAnyActionOnTableLikeObject(result.currentUser, null, dbName, table)) {
                                 continue;
                             }
@@ -319,9 +317,7 @@ public class InformationSchemaDataSource {
                 try {
                     List<Table> allTables = db.getTables();
                     for (Table table : allTables) {
-
                         if (GlobalStateMgr.getCurrentState().isUsingNewPrivilege()) {
-                            // TODO(yiming): set role ids for ephemeral user in all the PrivilegeActions.* call in this dir
                             if (!PrivilegeActions.checkAnyActionOnTableLikeObject(result.currentUser, null, dbName, table)) {
                                 continue;
                             }


### PR DESCRIPTION
Fixes SR-18423

When the base table of a view is dropped, NPE maybe throwed when
calling FrontendServiceImpl.listTableStatus() to list views in a
database because of privilege checking. In this case, we should
just ignore the privilege checking for the dropped table.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
