### PR TITLE
[Enhancement] set empty delta column group when new segment generate

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1302,6 +1302,8 @@ void TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version_i
         for (auto& delvec_pair : new_del_vecs) {
             tsid.segment_id = delvec_pair.first;
             manager->set_cached_del_vec(tsid, delvec_pair.second);
+            // try to set empty dcg cache, for improving latency when reading
+            manager->set_cached_empty_delta_column_group(_tablet.data_dir()->get_meta(), tsid);
         }
         // 5. apply memory
         _next_log_id++;
@@ -1836,6 +1838,8 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
         for (auto& delvec_pair : delvecs) {
             tsid.segment_id = delvec_pair.first;
             manager->set_cached_del_vec(tsid, delvec_pair.second);
+            // try to set empty dcg cache, for improving latency when reading
+            manager->set_cached_empty_delta_column_group(_tablet.data_dir()->get_meta(), tsid);
         }
         // 5. apply memory
         _next_log_id++;

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -101,6 +101,10 @@ public:
 
     Status set_cached_delta_column_group(KVStore* meta, const TabletSegmentId& tsid, const DeltaColumnGroupPtr& dcg);
 
+    Status set_cached_empty_delta_column_group(KVStore* meta, const TabletSegmentId& tsid);
+
+    bool get_cached_delta_column_group(const TabletSegmentId& tsid, int64_t version, DeltaColumnGroupList* dcgs);
+
     void clear_cache();
 
     void clear_cached_del_vec(const std::vector<TabletSegmentId>& tsids);

--- a/be/test/storage/update_manager_test.cpp
+++ b/be/test/storage/update_manager_test.cpp
@@ -196,4 +196,20 @@ TEST_F(UpdateManagerTest, testExpireEntry) {
     ASSERT_EQ(peak_size - expiring_size, remaining_size);
 }
 
+TEST_F(UpdateManagerTest, testSetEmptyCachedDeltaColumnGroup) {
+    srand(time(nullptr));
+    create_tablet(rand(), rand());
+    TabletSegmentId tsid;
+    tsid.tablet_id = _tablet->tablet_id();
+    tsid.segment_id = 1;
+    _update_manager->set_cached_empty_delta_column_group(_tablet->data_dir()->get_meta(), tsid);
+    // search this empty dcg
+    DeltaColumnGroupList dcgs;
+    // search in cache
+    ASSERT_TRUE(_update_manager->get_cached_delta_column_group(tsid, 1, &dcgs));
+    ASSERT_TRUE(dcgs.empty());
+    _update_manager->get_delta_column_group(_tablet->data_dir()->get_meta(), tsid, 1, &dcgs);
+    ASSERT_TRUE(dcgs.empty());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
Fixes #20436
Set empty delta column group when new segment generate

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
