### PR TITLE
[BugFix] Adjust sum result type after sync mv's rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -125,7 +125,7 @@ public class Optimizer {
         OptimizerTraceUtil.logOptExpression(connectContext, "origin logicOperatorTree:\n%s", logicOperatorTree);
         TaskContext rootTaskContext =
                 new TaskContext(context, requiredProperty, requiredColumns.clone(), Double.MAX_VALUE);
-        logicOperatorTree = rewriteAndValidatePlan(logicOperatorTree, rootTaskContext);
+        logicOperatorTree = rewriteAndValidatePlan(connectContext, logicOperatorTree, rootTaskContext);
         OptimizerTraceUtil.log(connectContext, "after logical rewrite, new logicOperatorTree:\n%s", logicOperatorTree);
         return logicOperatorTree;
     }
@@ -151,7 +151,7 @@ public class Optimizer {
         TaskContext rootTaskContext =
                 new TaskContext(context, requiredProperty, requiredColumns.clone(), Double.MAX_VALUE);
         try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("Optimizer.RuleBaseOptimize")) {
-            logicOperatorTree = rewriteAndValidatePlan(logicOperatorTree, rootTaskContext);
+            logicOperatorTree = rewriteAndValidatePlan(connectContext, logicOperatorTree, rootTaskContext);
         }
 
         memo.init(logicOperatorTree);
@@ -237,7 +237,9 @@ public class Optimizer {
         }
     }
 
-    private OptExpression logicalRuleRewrite(OptExpression tree, TaskContext rootTaskContext) {
+    private OptExpression logicalRuleRewrite(ConnectContext connectContext,
+                                             OptExpression tree,
+                                             TaskContext rootTaskContext) {
         tree = OptExpression.create(new LogicalTreeAnchorOperator(), tree);
         ColumnRefSet requiredColumns = rootTaskContext.getRequiredColumns().clone();
         deriveLogicalProperty(tree);
@@ -313,9 +315,14 @@ public class Optimizer {
             }
         }
 
-        if (!optimizerConfig.isRuleDisable(TF_MATERIALIZED_VIEW) && sessionVariable.isEnableSyncMaterializedViewRewrite()) {
+        if (!optimizerConfig.isRuleDisable(TF_MATERIALIZED_VIEW)
+                && sessionVariable.isEnableSyncMaterializedViewRewrite()) {
             // Add a config to decide whether to rewrite sync mv.
+
+            OptimizerTraceUtil.logOptExpression(connectContext, "before MaterializedViewRule:\n%s", tree);
             tree = new MaterializedViewRule().transform(tree, context).get(0);
+            OptimizerTraceUtil.logOptExpression(connectContext, "after MaterializedViewRule:\n%s", tree);
+
             deriveLogicalProperty(tree);
         }
 
@@ -392,8 +399,10 @@ public class Optimizer {
         return true;
     }
 
-    private OptExpression rewriteAndValidatePlan(OptExpression tree, TaskContext rootTaskContext) {
-        OptExpression result = logicalRuleRewrite(tree, rootTaskContext);
+    private OptExpression rewriteAndValidatePlan(ConnectContext connectContext,
+                                                 OptExpression tree,
+                                                 TaskContext rootTaskContext) {
+        OptExpression result = logicalRuleRewrite(connectContext, tree, rootTaskContext);
         OptExpressionValidator validator = new OptExpressionValidator();
         validator.validate(result);
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
@@ -21,6 +21,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -110,18 +111,27 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
                                               Column mvColumn,
                                               CallOperator queryAggFunc) {
         String functionName = queryAggFunc.getFnName();
-        if ((functionName.equals(FunctionSet.COUNT) || functionName.equals(FunctionSet.SUM))
-                && !queryAggFunc.isDistinct()) {
+        if (functionName.equals(FunctionSet.COUNT) && !queryAggFunc.isDistinct()) {
             CallOperator callOperator = new CallOperator(FunctionSet.SUM,
                     queryAggFunc.getType(),
                     queryAggFunc.getChildren(),
                     Expr.getBuiltinFunction(FunctionSet.SUM, new Type[] {Type.BIGINT}, IS_IDENTICAL));
-
             return (CallOperator) replaceColumnRefRewriter.rewrite(callOperator);
-        } else if (
-                ((functionName.equals(FunctionSet.COUNT) && queryAggFunc.isDistinct())
-                        || functionName.equals(FunctionSet.MULTI_DISTINCT_COUNT)) &&
-                        mvColumn.getAggregationType() == AggregateType.BITMAP_UNION) {
+        } else if (functionName.equals(FunctionSet.SUM) && !queryAggFunc.isDistinct()) {
+            CallOperator callOperator = new CallOperator(FunctionSet.SUM,
+                    queryAggFunc.getType(),
+                    queryAggFunc.getChildren(),
+                    Expr.getBuiltinFunction(FunctionSet.SUM, new Type[] {mvColumn.getType()}, IS_IDENTICAL));
+            if (mvColumn.getType().isDecimalV3()) {
+                ScalarType decimal128Type =
+                        ScalarType.createDecimalV3NarrowestType(38, 0);
+                callOperator.getFunction().setArgsType(new Type[] {mvColumn.getType()});
+                callOperator.getFunction().setRetType(decimal128Type);
+            }
+            return (CallOperator) replaceColumnRefRewriter.rewrite(callOperator);
+        } else if (((functionName.equals(FunctionSet.COUNT) && queryAggFunc.isDistinct())
+                || functionName.equals(FunctionSet.MULTI_DISTINCT_COUNT)) &&
+                mvColumn.getAggregationType() == AggregateType.BITMAP_UNION) {
             CallOperator callOperator = new CallOperator(FunctionSet.BITMAP_UNION_COUNT,
                     queryAggFunc.getType(),
                     queryAggFunc.getChildren(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
@@ -124,7 +124,7 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
                     Expr.getBuiltinFunction(FunctionSet.SUM, new Type[] {mvColumn.getType()}, IS_IDENTICAL));
             if (mvColumn.getType().isDecimalV3()) {
                 ScalarType decimal128Type =
-                        ScalarType.createDecimalV3NarrowestType(38, 0);
+                        ScalarType.createDecimalV3NarrowestType(38, mvColumn.getScale());
                 callOperator.getFunction().setArgsType(new Type[] {mvColumn.getType()});
                 callOperator.getFunction().setRetType(decimal128Type);
             }

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite
@@ -55,6 +55,14 @@ function: wait_materialized_view_finish()
 -- result:
 None
 -- !result
+CREATE MATERIALIZED VIEW mv_4
+AS SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
 insert into duplicate_tbl values 
     ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
     ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
@@ -78,6 +86,11 @@ select k1, count(k6 + 1) as c_k6, min(k7 * 10) as m_k7 from duplicate_tbl group 
 2023-06-15	6	10
 2023-06-16	2	10
 -- !result
+SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1 order by 1;
+-- result:
+2023-06-15	1	1	1	6	1	1.0	1.0	6000000000
+2023-06-16	1	1	1	2	1	1.0	1.0	2000000000
+-- !result
 drop materialized view mv_1;
 -- result:
 -- !result
@@ -85,5 +98,8 @@ drop materialized view mv_2;
 -- result:
 -- !result
 drop materialized view mv_3;
+-- result:
+-- !result
+drop materialized view mv_4;
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite
@@ -88,8 +88,8 @@ select k1, count(k6 + 1) as c_k6, min(k7 * 10) as m_k7 from duplicate_tbl group 
 -- !result
 SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1 order by 1;
 -- result:
-2023-06-15	1	1	1	6	1	1.0	1.0	6000000000
-2023-06-16	1	1	1	2	1	1.0	1.0	2000000000
+2023-06-15	1	1	1	6	1	1.0	1.0	6.000000000
+2023-06-16	1	1	1	2	1	1.0	1.0	2.000000000
 -- !result
 drop materialized view mv_1;
 -- result:

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite
@@ -41,6 +41,10 @@ function: wait_materialized_view_finish()
 create materialized view mv_3 as select k1, count(k6 + 1) as c_k6, min(k7 * 10) as m_k7 from duplicate_tbl group by 1;
 function: wait_materialized_view_finish()
 
+CREATE MATERIALIZED VIEW mv_4
+AS SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1;
+function: wait_materialized_view_finish()
+
 insert into duplicate_tbl values 
     ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
     ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
@@ -51,7 +55,9 @@ insert into duplicate_tbl values
 select k1, sum(k6) as k6, max(k7) as k7 from duplicate_tbl group by 1 order by 1;
 select k1, sum(k6 + 1) as k6, max(k7 * 10) as k7 from duplicate_tbl group by 1 order by 1;
 select k1, count(k6 + 1) as c_k6, min(k7 * 10) as m_k7 from duplicate_tbl group by 1 order by 1;
+SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1 order by 1;
 
 drop materialized view mv_1;
 drop materialized view mv_2;
 drop materialized view mv_3;
+drop materialized view mv_4;


### PR DESCRIPTION
Fixes #issue

Before PR([#24966](https://github.com/StarRocks/starrocks/pull/24444)）,  `SUM` no needs to use `MaterializedViewRewriter` rewrite because its mv column name is the same with base name.

```
mysql> explain verbose SELECT SUM(k13) FROM duplicate_tbl;
+--------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                   |
+--------------------------------------------------------------------------------------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                                                                                                       |
|                                                                                                                                                  |
| PLAN FRAGMENT 0(F01)                                                                                                                             |
|   Output Exprs:14: sum                                                                                                                           |
|   Input Partition: UNPARTITIONED                                                                                                                 |
|   RESULT SINK                                                                                                                                    |
|                                                                                                                                                  |
|   3:AGGREGATE (merge finalize)                                                                                                                   |
|   |  aggregate: sum[([14: sum, DECIMAL128(38,9), true]); args: DECIMAL128; result: DECIMAL128(38,9); args nullable: true; result nullable: true] |
|   |  cardinality: 1                                                                                                                              |
|   |                                                                                                                                              |
|   2:EXCHANGE                                                                                                                                     |
|      distribution type: GATHER                                                                                                                   |
|      cardinality: 1                                                                                                                              |
|                                                                                                                                                  |
| PLAN FRAGMENT 1(F00)                                                                                                                             |
|                                                                                                                                                  |
|   Input Partition: RANDOM                                                                                                                        |
|   OutPut Partition: UNPARTITIONED                                                                                                                |
|   OutPut Exchange Id: 02                                                                                                                         |
|                                                                                                                                                  |
|   1:AGGREGATE (update serialize)                                                                                                                 |
|   |  aggregate: sum[([13: k13, DECIMAL128(27,9), true]); args: DECIMAL128; result: DECIMAL128(38,9); args nullable: true; result nullable: true] |
|   |  cardinality: 1                                                                                                                              |
|   |                                                                                                                                              |
|   0:OlapScanNode                                                                                                                                 |
|      table: duplicate_tbl, rollup: mv_4                                                                                                          |
|      preAggregation: off. Reason: Aggregate Operator not match: SUM <--> NONE                                                                    |
|      partitionsRatio=1/1, tabletsRatio=3/3                                                                                                       |
|      tabletList=40042,40044,40046                                                                                                                |
|      actualRows=2, avgRowSize=16.0                                                                                                               |
|      cardinality: 4                                                                                                                              |
+--------------------------------------------------------------------------------------------------------------------------------------------------+
32 rows in set (57.84 sec)
```

However, after that pr `MaterializedViewRewriter` needs to support `SUM` rewrites because we treat `SUM` 's mv column as other aggregate function, eg sum(a)  mv column name  is mv_sum_a not a.


```
mysql> explain verbose SELECT SUM(k13) FROM duplicate_tbl;
+---------------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                          |
+---------------------------------------------------------------------------------------------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                                                                                                              |
|                                                                                                                                                         |
| PLAN FRAGMENT 0(F01)                                                                                                                                    |
|   Output Exprs:22: sum                                                                                                                                  |
|   Input Partition: UNPARTITIONED                                                                                                                        |
|   RESULT SINK                                                                                                                                           |
|                                                                                                                                                         |
|   3:AGGREGATE (merge finalize)                                                                                                                          |
|   |  aggregate: sum[([22: sum, DECIMAL128(38,9), true]); args: DECIMAL128; result: DECIMAL128(38,9); args nullable: true; result nullable: true]        |
|   |  cardinality: 1                                                                                                                                     |
|   |                                                                                                                                                     |
|   2:EXCHANGE                                                                                                                                            |
|      distribution type: GATHER                                                                                                                          |
|      cardinality: 1                                                                                                                                     |
|                                                                                                                                                         |
| PLAN FRAGMENT 1(F00)                                                                                                                                    |
|                                                                                                                                                         |
|   Input Partition: RANDOM                                                                                                                               |
|   OutPut Partition: UNPARTITIONED                                                                                                                       |
|   OutPut Exchange Id: 02                                                                                                                                |
|                                                                                                                                                         |
|   1:AGGREGATE (update serialize)                                                                                                                        |
|   |  aggregate: sum[([21: mv_sum_k13, DECIMAL128(27,9), true]); args: DECIMAL128; result: DECIMAL128(38,9); args nullable: true; result nullable: true] |
|   |  cardinality: 1                                                                                                                                     |
|   |                                                                                                                                                     |
|   0:OlapScanNode                                                                                                                                        |
|      table: duplicate_tbl, rollup: mv_4                                                                                                                 |
|      preAggregation: on                                                                                                                                 |
|      partitionsRatio=1/1, tabletsRatio=3/3                                                                                                              |
|      tabletList=69048,69050,69052                                                                                                                       |
|      actualRows=0, avgRowSize=1.0                                                                                                                       |
|      cardinality: 4                                                                                                                                     |
+---------------------------------------------------------------------------------------------------------------------------------------------------------+
32 rows in set (0.01 sec)

```




## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
