### PR TITLE
[Enhancement] fill delvec to meta cache advance in lake primary table

### DIFF
--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -52,7 +52,10 @@ public:
     bool has_update_index() const { return _has_update_index; }
 
 private:
+    // update delvec in tablet meta
     Status _finalize_delvec(int64_t version, int64_t txn_id);
+    // fill delvec cache, for better reading latency
+    void _fill_delvec_cache();
 
 private:
     Tablet _tablet;
@@ -64,13 +67,20 @@ private:
     bool _has_finalized = false;
     // whether update the state of pk index.
     bool _has_update_index = false;
+    // from segment id to delvec, used for fill cache in finalize stage.
+    std::unordered_map<uint32_t, DelVectorPtr> _segmentid_to_delvec;
+    // from cache key to segment id
+    std::unordered_map<std::string, uint32_t> _cache_key_to_segment_id;
 };
 
 class MetaFileReader {
 public:
     explicit MetaFileReader(const std::string& filepath, bool fill_cache);
     ~MetaFileReader() {}
+    // load tablet meta from file
     Status load();
+    // try to load tablet meta from cache first, if not exist then load from file
+    Status load_by_cache(const std::string& filepath, TabletManager* tablet_mgr);
     Status get_del_vec(TabletManager* tablet_mgr, uint32_t segment_id, DelVector* delvec);
     StatusOr<TabletMetadataPtr> get_meta();
 

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -413,7 +413,7 @@ Status UpdateManager::get_del_vec(const TabletSegmentId& tsid, int64_t version, 
 Status UpdateManager::get_del_vec_in_meta(const TabletSegmentId& tsid, int64_t meta_ver, DelVector* delvec) {
     std::string filepath = _location_provider->tablet_metadata_location(tsid.tablet_id, meta_ver);
     MetaFileReader reader(filepath, false);
-    RETURN_IF_ERROR(reader.load());
+    RETURN_IF_ERROR(reader.load_by_cache(filepath, _tablet_mgr));
     RETURN_IF_ERROR(reader.get_del_vec(_tablet_mgr, tsid.segment_id, delvec));
     return Status::OK();
 }

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -64,7 +64,7 @@ public:
         s_location_provider = std::make_unique<FixedLocationProvider>(kTestDir);
         s_update_manager = std::make_unique<lake::UpdateManager>(s_location_provider.get());
         s_tablet_manager =
-                std::make_unique<lake::TabletManager>(s_location_provider.get(), s_update_manager.get(), 16384);
+                std::make_unique<lake::TabletManager>(s_location_provider.get(), s_update_manager.get(), 1638400000);
     }
 
     static void TearDownTestCase() { (void)FileSystem::Default()->delete_dir_recursive(kTestDir); }
@@ -207,6 +207,94 @@ TEST_F(MetaFileTest, test_delvec_rw) {
 
     iter2 = version_to_file_map.find(new_version);
     EXPECT_TRUE(iter2 != version_to_file_map.end());
+}
+
+TEST_F(MetaFileTest, test_delvec_read_meta_cache) {
+    // 1. generate metadata
+    const int64_t tablet_id = 10003;
+    const uint32_t segment_id = 1234;
+    const int64_t version = 11;
+    auto tablet = std::make_shared<Tablet>(s_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(version);
+    metadata->set_next_rowset_id(110);
+    metadata->mutable_schema()->set_keys_type(PRIMARY_KEYS);
+
+    // 2. write pk meta & delvec
+    MetaFileBuilder builder(*tablet, metadata);
+    DelVector dv;
+    dv.set_empty();
+    EXPECT_TRUE(dv.empty());
+
+    std::shared_ptr<DelVector> ndv;
+    std::vector<uint32_t> dels = {1, 3, 5, 7, 90000};
+    dv.add_dels_as_new_version(dels, version, &ndv);
+    EXPECT_FALSE(ndv->empty());
+    std::string before_delvec = ndv->save();
+    builder.append_delvec(ndv, segment_id);
+    Status st = builder.finalize(next_id());
+    EXPECT_TRUE(st.ok());
+
+    // 3. read delvec
+    MetaFileReader reader(s_tablet_manager->tablet_metadata_location(tablet_id, version), false);
+    auto tablet_meta_ptr =
+            s_tablet_manager->lookup_tablet_metadata(s_tablet_manager->tablet_metadata_location(tablet_id, version));
+    EXPECT_TRUE(tablet_meta_ptr != nullptr);
+    EXPECT_EQ(tablet_meta_ptr->id(), tablet_id);
+    // call load_by cache for test
+    EXPECT_TRUE(
+            reader.load_by_cache(s_tablet_manager->tablet_metadata_location(tablet_id, version), s_tablet_manager.get())
+                    .ok());
+    DelVector after_delvec;
+    EXPECT_TRUE(reader.get_del_vec(s_tablet_manager.get(), segment_id, &after_delvec).ok());
+    EXPECT_EQ(before_delvec, after_delvec.save());
+}
+
+TEST_F(MetaFileTest, test_delvec_read_loop) {
+    // 1. generate metadata
+    const int64_t tablet_id = 10002;
+    const int64_t version = 11;
+    auto tablet = std::make_shared<Tablet>(s_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(version);
+    metadata->set_next_rowset_id(110);
+    metadata->mutable_schema()->set_keys_type(PRIMARY_KEYS);
+
+    // 2. test delvec
+    auto test_delvec = [&](uint32_t segment_id) {
+        MetaFileBuilder builder(*tablet, metadata);
+        DelVector dv;
+        dv.set_empty();
+        EXPECT_TRUE(dv.empty());
+
+        std::shared_ptr<DelVector> ndv;
+        std::vector<uint32_t> dels;
+        for (int i = 0; i < 10; i++) {
+            dels.push_back(rand() % 1000);
+        }
+        dv.add_dels_as_new_version(dels, version, &ndv);
+        EXPECT_FALSE(ndv->empty());
+        std::string before_delvec = ndv->save();
+        builder.append_delvec(ndv, segment_id);
+        Status st = builder.finalize(next_id());
+        EXPECT_TRUE(st.ok());
+
+        // 3. read delvec
+        MetaFileReader reader(s_tablet_manager->tablet_metadata_location(tablet_id, version), false);
+        EXPECT_TRUE(reader.load().ok());
+        DelVector after_delvec;
+        EXPECT_TRUE(reader.get_del_vec(s_tablet_manager.get(), segment_id, &after_delvec).ok());
+        EXPECT_EQ(before_delvec, after_delvec.save());
+    };
+    for (uint32_t segment_id = 1000; segment_id < 1200; segment_id++) {
+        test_delvec(segment_id);
+    }
+    // test twice
+    for (uint32_t segment_id = 1000; segment_id < 1200; segment_id++) {
+        test_delvec(segment_id);
+    }
 }
 
 } // namespace starrocks::lake


### PR DESCRIPTION
This PR is aim to improve the read performance of lake primary table. It contains two parts:
1. When load `delvec`, try to seek tablet meta from meta cache first.
2. Try to fill `delvec` to meta cache in finalize stage.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
