### PR TITLE
[BugFix] Upgrade s3 sdk to v1.11.61 to avoid deadlock in aws InstanceProfile

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -409,7 +409,7 @@ else
 fi
 
 cd $TP_SOURCE_DIR/$AWS_SDK_CPP_SOURCE
-if [ ! -f $PATCHED_MARK ] && [ $AWS_SDK_CPP_SOURCE = "aws-sdk-cpp-1.10.36" ]; then
+if [ ! -f $PATCHED_MARK ] && [ $AWS_SDK_CPP_SOURCE = "aws-sdk-cpp-1.11.61" ]; then
     if [ ! -f prefetch_crt_dep_ok ]; then
         bash ./prefetch_crt_dependency.sh
         touch prefetch_crt_dep_ok

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -313,10 +313,10 @@ GCS_CONNECTOR_SOURCE="gcs-connector-hadoop3-2.2.11-shaded"
 GCS_CONNECTOR_MD5SUM="51fd0eb5cb913a84e4ad8a5ed2069e21"
 
 # aws-sdk-cpp
-AWS_SDK_CPP_DOWNLOAD="https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.10.36.tar.gz"
-AWS_SDK_CPP_NAME="aws-sdk-cpp-1.10.36.tar.gz"
-AWS_SDK_CPP_SOURCE="aws-sdk-cpp-1.10.36"
-AWS_SDK_CPP_MD5SUM="8fed635c5ac98b448bc1a98cf7c97c70"
+AWS_SDK_CPP_DOWNLOAD="https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.11.61.tar.gz"
+AWS_SDK_CPP_NAME="aws-sdk-cpp-1.11.61.tar.gz"
+AWS_SDK_CPP_SOURCE="aws-sdk-cpp-1.11.61"
+AWS_SDK_CPP_MD5SUM="a2c7ed268436f7e2344f1c7e666fbc71"
 
 # velocypack: A fast and compact format for serialization and storage
 VPACK_DOWNLOAD="https://github.com/arangodb/velocypack/archive/refs/tags/XYZ1.0.tar.gz"


### PR DESCRIPTION
In #24129, we upgrade aws SDK to 1.10.36, but it introduces InstanceProfile deadlock bug, which will occur BE query timeout when the user is using InstanceProfile.

AWS report this bug in: https://github.com/aws/aws-sdk-cpp/issues/2251

So in this pr, we upgrade aws SDK to v1.11.61, the same as ClickHouse.  https://github.com/ClickHouse/ClickHouse/pull/50037

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
