### PR TITLE
[BugFix] Fix constant order by limit bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitLimitRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitLimitRule.java
@@ -15,7 +15,6 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -49,7 +48,6 @@ public class SplitLimitRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalLimitOperator limit = (LogicalLimitOperator) input.getOp();
-        Preconditions.checkState(!limit.hasOffset());
 
         LogicalLimitOperator global = LogicalLimitOperator.global(limit.getLimit());
         LogicalLimitOperator local = LogicalLimitOperator.local(limit.getLimit());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -782,4 +782,11 @@ public class LimitTest extends PlanTestBase {
         assertContains(planFragment, "tabletRatio=3/3");
         FeConstants.runningUnitTest = flag;
     }
+
+    @Test
+    public void testConstantOrderByLimit() throws Exception {
+        String sql = "select * from t0 order by 'abc' limit 100, 100 ";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "limit: 100");
+    }
 }


### PR DESCRIPTION
Fixes #issue
Fix question:

`order by` with constant will remove...

```
MySQL td> select * from t0 order by 'abc' limit 100, 100
(1064, 'Unknown error')
MySQL td>
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
