### PR TITLE
[BugFix] Patch AWS s3 sdk to avoid InstanceProfile deadlock

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -415,7 +415,7 @@ if [ ! -f $PATCHED_MARK ] && [ $AWS_SDK_CPP_SOURCE = "aws-sdk-cpp-1.10.36" ]; th
         touch prefetch_crt_dep_ok
     fi
     # Fix InstanceProfile deadlock, refer to https://github.com/aws/aws-sdk-cpp/issues/2251
-    patch -p0 < $TP_PATCH_DIR/aws-sdk-cpp-1.10.36-instance-profile-deadlock.patch   
+    patch -p1 < $TP_PATCH_DIR/aws-sdk-cpp-1.10.36-instance-profile-deadlock.patch   
     touch $PATCHED_MARK
     echo "Finished patching $AWS_SDK_CPP_SOURCE"
 else

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -414,6 +414,8 @@ if [ ! -f $PATCHED_MARK ] && [ $AWS_SDK_CPP_SOURCE = "aws-sdk-cpp-1.10.36" ]; th
         bash ./prefetch_crt_dependency.sh
         touch prefetch_crt_dep_ok
     fi
+    # Fix InstanceProfile deadlock, refer to https://github.com/aws/aws-sdk-cpp/issues/2251
+    patch -p0 < $TP_PATCH_DIR/aws-sdk-cpp-1.10.36-instance-profile-deadlock.patch   
     touch $PATCHED_MARK
     echo "Finished patching $AWS_SDK_CPP_SOURCE"
 else

--- a/thirdparty/patches/aws-sdk-cpp-1.10.36-instance-profile-deadlock.patch
+++ b/thirdparty/patches/aws-sdk-cpp-1.10.36-instance-profile-deadlock.patch
@@ -1,0 +1,10 @@
+--- AWSCredentialsProvider.cpp.bak	2023-06-19 14:40:17
++++ AWSCredentialsProvider.cpp	2023-06-19 14:40:35
+@@ -259,7 +259,6 @@
+ 
+ bool InstanceProfileCredentialsProvider::ExpiresSoon() const
+ {
+-    ReaderLockGuard guard(m_reloadLock);
+     auto profileIter = m_ec2MetadataConfigLoader->GetProfiles().find(Aws::Config::INSTANCE_PROFILE_KEY);
+     AWSCredentials credentials;
+ 

--- a/thirdparty/patches/aws-sdk-cpp-1.10.36-instance-profile-deadlock.patch
+++ b/thirdparty/patches/aws-sdk-cpp-1.10.36-instance-profile-deadlock.patch
@@ -1,6 +1,8 @@
---- AWSCredentialsProvider.cpp.bak	2023-06-19 14:40:17
-+++ AWSCredentialsProvider.cpp	2023-06-19 14:40:35
-@@ -259,7 +259,6 @@
+diff --git a/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp b/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
+index 084e4bca6e..6c8b059b2d 100644
+--- a/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
++++ b/aws-cpp-sdk-core/source/auth/AWSCredentialsProvider.cpp
+@@ -259,7 +259,6 @@ AWSCredentials InstanceProfileCredentialsProvider::GetAWSCredentials()
  
  bool InstanceProfileCredentialsProvider::ExpiresSoon() const
  {
@@ -8,3 +10,10 @@
      auto profileIter = m_ec2MetadataConfigLoader->GetProfiles().find(Aws::Config::INSTANCE_PROFILE_KEY);
      AWSCredentials credentials;
  
+diff --git a/crt/aws-crt-cpp b/crt/aws-crt-cpp
+index 0a9e0ad7ab..cb474daeea 160000
+--- a/crt/aws-crt-cpp
++++ b/crt/aws-crt-cpp
+@@ -1 +1 @@
+-Subproject commit 0a9e0ad7ab07113c65b4846ece3a386407c9c0d3
++Subproject commit cb474daeeaf5c025bd3408103adf61b97b74e600

--- a/thirdparty/patches/aws-sdk-cpp-1.10.36-instance-profile-deadlock.patch
+++ b/thirdparty/patches/aws-sdk-cpp-1.10.36-instance-profile-deadlock.patch
@@ -10,10 +10,3 @@ index 084e4bca6e..6c8b059b2d 100644
      auto profileIter = m_ec2MetadataConfigLoader->GetProfiles().find(Aws::Config::INSTANCE_PROFILE_KEY);
      AWSCredentials credentials;
  
-diff --git a/crt/aws-crt-cpp b/crt/aws-crt-cpp
-index 0a9e0ad7ab..cb474daeea 160000
---- a/crt/aws-crt-cpp
-+++ b/crt/aws-crt-cpp
-@@ -1 +1 @@
--Subproject commit 0a9e0ad7ab07113c65b4846ece3a386407c9c0d3
-+Subproject commit cb474daeeaf5c025bd3408103adf61b97b74e600


### PR DESCRIPTION
In https://github.com/StarRocks/starrocks/pull/24129, we upgrade aws SDK to 1.10.36, but it introduces InstanceProfile deadlock bug, which will occur BE query timeout when the user is using InstanceProfile.

AWS report this bug in: https://github.com/aws/aws-sdk-cpp/issues/2251

So we just patch https://github.com/aws/aws-sdk-cpp/commit/5d2aea0f2f7c4713898b4312e487bdbb5c6925a2 instead of upgrading s3 sdk version https://github.com/StarRocks/starrocks/pull/25535. It's safier.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
