### PR TITLE
[BugFix] Fix load image failed 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1488,8 +1488,10 @@ public class GlobalStateMgr {
         int flag = dis.readInt();
         checksum = checksum ^ flag;
         int starrocksMetaVersion;
+        int metaVersion = 0;
         if (flag < 0) {
-            checksum ^= dis.readInt();
+            metaVersion = dis.readInt();
+            checksum ^= metaVersion;
             starrocksMetaVersion = dis.readInt();
             checksum ^= starrocksMetaVersion;
         } else {
@@ -1504,6 +1506,7 @@ public class GlobalStateMgr {
         }
 
         MetaContext.get().setStarRocksMetaVersion(starrocksMetaVersion);
+        MetaContext.get().setMetaVersion(metaVersion);
 
         return checksum;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1488,7 +1488,7 @@ public class GlobalStateMgr {
         int flag = dis.readInt();
         checksum = checksum ^ flag;
         int starrocksMetaVersion;
-        int metaVersion = 0;
+        int metaVersion = FeConstants.META_VERSION;
         if (flag < 0) {
             metaVersion = dis.readInt();
             checksum ^= metaVersion;


### PR DESCRIPTION
Fixes
```
java.io.EOFException: null
        at java.io.DataInputStream.readFully(DataInputStream.java:197) ~[?:1.8.0_292]
        at com.starrocks.common.io.Text.readString(Text.java:393) ~[starrocks-fe.jar:?]
        at com.starrocks.system.Backend.readFields(Backend.java:337) ~[starrocks-fe.jar:?]
        at com.starrocks.system.Backend.read(Backend.java:303) ~[starrocks-fe.jar:?]
        at com.starrocks.system.SystemInfoService.loadBackends(SystemInfoService.java:888) ~[starrocks-fe.jar:?]
        at com.starrocks.server.NodeMgr.loadBackends(NodeMgr.java:571) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.loadImage(GlobalStateMgr.java:1353) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.initialize(GlobalStateMgr.java:992) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.start(StarRocksFE.java:130) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.main(StarRocksFE.java:82) ~[starrocks-fe.jar:?]
```

This PR #25280 ignores the read of old meta version, which leads to load image crash. To fix this bug, set the old meta version to MetaContext. 

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
