### PR TITLE
[BugFix] fix access partial-prepared Aggregator

### DIFF
--- a/be/src/exec/aggregate/agg_hash_variant.cpp
+++ b/be/src/exec/aggregate/agg_hash_variant.cpp
@@ -225,7 +225,8 @@ bool AggHashMapVariant::need_expand(size_t increasement) const {
 
 size_t AggHashMapVariant::reserved_memory_usage(const MemPool* pool) const {
     return visit([pool](const auto& hash_map_with_key) {
-        return hash_map_with_key->hash_map.dump_bound() + pool->total_reserved_bytes();
+        size_t pool_bytes = (pool != nullptr) ? pool->total_reserved_bytes() : 0;
+        return hash_map_with_key->hash_map.dump_bound() + pool_bytes;
     });
 }
 
@@ -300,7 +301,8 @@ bool AggHashSetVariant::need_expand(size_t increasement) const {
 
 size_t AggHashSetVariant::reserved_memory_usage(const MemPool* pool) const {
     return visit([&](auto& hash_set_with_key) {
-        return hash_set_with_key->hash_set.dump_bound() + pool->total_reserved_bytes();
+        size_t pool_bytes = pool != nullptr ? pool->total_reserved_bytes() : 0;
+        return hash_set_with_key->hash_set.dump_bound() + pool_bytes;
     });
 }
 


### PR DESCRIPTION
Fixes #25563


Bug:
1. `Aggregator::Prepare` failed since `Invalid agg function plan: sum`
2. After that, `AggHashMapVariant::reserved_memory_usage` will access the `Aggregator::_pool`, which cause SIGSEGV

Fix:
1. When accessing `Aggregator::_pool` through `AggHashMapVariant::reserved_memory_usage`, check the pool pointer
2. Use a temp `Aggregator` in `AggregateBaseNode::prepare()` before prepare succeed


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
