### PR TITLE
[BugFix] Fix drop FE failed when the target FE is using FQDN bug the leader node is not

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/CheckDecommissionAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/CheckDecommissionAction.java
@@ -90,7 +90,7 @@ public class CheckDecommissionAction extends RestBaseAction {
         for (String hostPort : hostPortArr) {
             Pair<String, Integer> pair;
             try {
-                pair = SystemInfoService.validateHostAndPort(hostPort);
+                pair = SystemInfoService.validateHostAndPort(hostPort, false);
             } catch (AnalysisException e) {
                 throw new DdlException(e.getMessage());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -622,7 +622,7 @@ public class NodeMgr {
         if (helpers != null) {
             String[] splittedHelpers = helpers.split(",");
             for (String helper : splittedHelpers) {
-                Pair<String, Integer> helperHostPort = SystemInfoService.validateHostAndPort(helper);
+                Pair<String, Integer> helperHostPort = SystemInfoService.validateHostAndPort(helper, false);
                 if (helperHostPort.equals(selfNode)) {
                     /*
                      * If user specified the helper node to this FE itself,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterSystemStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterSystemStmtAnalyzer.java
@@ -19,6 +19,11 @@ import com.google.common.base.Strings;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.service.FrontendOptions;
+import com.starrocks.sql.ast.AddBackendClause;
+import com.starrocks.sql.ast.AddComputeNodeClause;
+import com.starrocks.sql.ast.AddFollowerClause;
+import com.starrocks.sql.ast.AddObserverClause;
 import com.starrocks.sql.ast.AlterSystemStmt;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.BackendClause;
@@ -48,7 +53,7 @@ public class AlterSystemStmtAnalyzer {
             CancelAlterSystemStmt stmt = (CancelAlterSystemStmt) ddlStmt;
             try {
                 for (String hostPort : stmt.getHostPorts()) {
-                    Pair<String, Integer> pair = SystemInfoService.validateHostAndPort(hostPort);
+                    Pair<String, Integer> pair = SystemInfoService.validateHostAndPort(hostPort, false);
                     stmt.getHostPortPairs().add(pair);
                 }
             } catch (AnalysisException e) {
@@ -66,7 +71,8 @@ public class AlterSystemStmtAnalyzer {
         public Void visitComputeNodeClause(ComputeNodeClause computeNodeClause, ConnectContext context) {
             try {
                 for (String hostPort : computeNodeClause.getHostPorts()) {
-                    Pair<String, Integer> pair = SystemInfoService.validateHostAndPort(hostPort);
+                    Pair<String, Integer> pair = SystemInfoService.validateHostAndPort(hostPort,
+                            computeNodeClause instanceof AddComputeNodeClause && !FrontendOptions.isUseFqdn());
                     computeNodeClause.getHostPortPairs().add(pair);
                 }
                 Preconditions.checkState(!computeNodeClause.getHostPortPairs().isEmpty());
@@ -80,7 +86,8 @@ public class AlterSystemStmtAnalyzer {
         public Void visitBackendClause(BackendClause backendClause, ConnectContext context) {
             try {
                 for (String hostPort : backendClause.getHostPorts()) {
-                    Pair<String, Integer> pair = SystemInfoService.validateHostAndPort(hostPort);
+                    Pair<String, Integer> pair = SystemInfoService.validateHostAndPort(hostPort,
+                            backendClause instanceof AddBackendClause && !FrontendOptions.isUseFqdn());
                     backendClause.getHostPortPairs().add(pair);
                 }
                 Preconditions.checkState(!backendClause.getHostPortPairs().isEmpty());
@@ -93,7 +100,11 @@ public class AlterSystemStmtAnalyzer {
         @Override
         public Void visitFrontendClause(FrontendClause frontendClause, ConnectContext context) {
             try {
-                Pair<String, Integer> pair = SystemInfoService.validateHostAndPort(frontendClause.getHostPort());
+                Pair<String, Integer> pair = SystemInfoService
+                        .validateHostAndPort(frontendClause.getHostPort(),
+                                (frontendClause instanceof AddFollowerClause
+                                        || frontendClause instanceof AddObserverClause)
+                                        && !FrontendOptions.isUseFqdn());
                 frontendClause.setHost(pair.first);
                 frontendClause.setPort(pair.second);
                 Preconditions.checkState(!Strings.isNullOrEmpty(frontendClause.getHost()));
@@ -150,7 +161,7 @@ public class AlterSystemStmtAnalyzer {
             try {
                 if (clause.getOp() != ModifyBrokerClause.ModifyOp.OP_DROP_ALL) {
                     for (String hostPort : clause.getHostPorts()) {
-                        Pair<String, Integer> pair = SystemInfoService.validateHostAndPort(hostPort);
+                        Pair<String, Integer> pair = SystemInfoService.validateHostAndPort(hostPort, false);
                         clause.getHostPortPairs().add(pair);
                     }
                     Preconditions.checkState(!clause.getHostPortPairs().isEmpty());

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -64,7 +64,6 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
-import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.ast.DropBackendClause;
 import com.starrocks.sql.ast.ModifyBackendAddressClause;
 import com.starrocks.system.Backend.BackendState;

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -860,7 +860,7 @@ public class SystemInfoService implements GsonPostProcessable {
         this.idToReportVersionRef = ImmutableMap.of();
     }
 
-    public static Pair<String, Integer> validateHostAndPort(String hostPort) throws AnalysisException {
+    public static Pair<String, Integer> validateHostAndPort(String hostPort, boolean resolveHost) throws AnalysisException {
         hostPort = hostPort.replaceAll("\\s+", "");
         if (hostPort.isEmpty()) {
             throw new AnalysisException("Invalid host port: " + hostPort);
@@ -879,7 +879,7 @@ public class SystemInfoService implements GsonPostProcessable {
         int heartbeatPort = -1;
         try {
             // validate host
-            if (!InetAddressValidator.getInstance().isValid(host) && !FrontendOptions.isUseFqdn()) {
+            if (resolveHost && !InetAddressValidator.getInstance().isValid(host)) {
                 // maybe this is a hostname
                 // if no IP address for the host could be found, 'getByName'
                 // will throw

--- a/fe/fe-core/src/test/java/com/starrocks/cluster/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/cluster/SystemInfoServiceTest.java
@@ -198,19 +198,19 @@ public class SystemInfoServiceTest {
     @Test(expected = AnalysisException.class)
     public void validHostAndPortTest1() throws Exception {
         createHostAndPort(1);
-        systemInfoService.validateHostAndPort(hostPort);
+        systemInfoService.validateHostAndPort(hostPort, false);
     }
 
     @Test(expected = AnalysisException.class)
     public void validHostAndPortTest3() throws Exception {
         createHostAndPort(3);
-        systemInfoService.validateHostAndPort(hostPort);
+        systemInfoService.validateHostAndPort(hostPort, false);
     }
 
     @Test
     public void validHostAndPortTest4() throws Exception {
         createHostAndPort(4);
-        systemInfoService.validateHostAndPort(hostPort);
+        systemInfoService.validateHostAndPort(hostPort, false);
     }
 
     @Test


### PR DESCRIPTION
Fixes SR-18292
Currently, the leader will resolve the host to IP when dropping FE if the leader is not using FQDN mode. But if the target node is using FQDN, the operation will fail because the host stored in meta is FQDN.
To fix this bug, only resolve host to IP when adding node (FE or BE), and remain the host unchanged when dropping node.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
