### PR TITLE
[BugFix] Fix assert error in phmap::CapacityToGrowth

### DIFF
--- a/be/src/exec/aggregate/agg_hash_variant.cpp
+++ b/be/src/exec/aggregate/agg_hash_variant.cpp
@@ -217,10 +217,12 @@ size_t AggHashMapVariant::size() const {
 }
 
 bool AggHashMapVariant::need_expand(size_t increasement) const {
+    size_t capacity = this->capacity();
+    if (capacity == 0) return true;
     // TODO: think about two-level hashmap
     size_t size = this->size() + increasement;
     // see detail implement in reset_growth_left
-    return size >= phmap::priv::CapacityToGrowth(this->capacity());
+    return size >= phmap::priv::CapacityToGrowth(capacity);
 }
 
 size_t AggHashMapVariant::reserved_memory_usage(const MemPool* pool) const {


### PR DESCRIPTION
introduce by #25234
capacity 0 will cause a assert error
```
*** Aborted at 1687172299 (unix time) try "date -d @1687172299" if you are using GNU date ***
starrocks_be: /root/starrocks/be/src/util/phmap/phmap.h:493: size_t phmap::priv::CapacityToGrowth(s
ize_t): Assertion `IsValidCapacity(capacity)' failed.
PC: @     0x7fef66b85a7c pthread_kill
*** SIGABRT (@0x3eb001c2fd0) received by PID 1847248 (TID 0x7fee45771640) from PID 1847248; stack t
race: ***
    @         0x1493b06a google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fef66b31520 (unknown)
    @     0x7fef66b85a7c pthread_kill
    @     0x7fef66b31476 raise
    @     0x7fef66b177f3 abort
    @     0x7fef66b1771b (unknown)
    @     0x7fef66b28e96 __assert_fail
    @          0x9885764 phmap::priv::CapacityToGrowth()
    @          0xb905075 starrocks::AggHashMapVariant::need_expand()
    @          0xb05ade3 starrocks::pipeline::AggregateStreamingSinkOperator::_push_chunk_by_auto()
    @          0xb0565c7 starrocks::pipeline::AggregateStreamingSinkOperator::push_chunk()
    @          0x9dca867 starrocks::pipeline::PipelineDriver::process()
    @         0x135ecf73 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x135eb3fa _ZZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiENKUlvE2_clEv
    @         0x135f58fa _ZSt13__invoke_implIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE2_JEET_St14__invoke_otherOT0_DpOT1_
    @         0x135f4d55 _ZSt10__invoke_rIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE2_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES6_E4typeEOS7_DpOS8_
    @         0x135f3fba _ZNSt17_Function_handlerIFvvEZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE2_E9_M_invokeERKSt9_Any_data
    @          0x99b783a std::function<>::operator()()
    @         0x121717f8 starrocks::FunctionRunnable::run()
    @         0x1216e02c starrocks::ThreadPool::dispatch_thread()
    @         0x1218c818 std::__invoke_impl<>()
    @         0x1218c0d5 std::__invoke<>()
    @         0x1218b3d0 _ZNSt5_BindIFMN9starrocks10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @         0x12189a3f std::_Bind<>::operator()<>()
    @         0x121867ec std::__invoke_impl<>()
    @         0x121838a4 _ZSt10__invoke_rIvRSt5_BindIFMN9starrocks10ThreadPoolEFvvEPS2_EEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESA_E4typeEOSB_DpOSC_
    @         0x1217f413 std::_Function_handler<>::_M_invoke()
    @          0x99b783a std::function<>::operator()()
    @         0x12153d16 starrocks::Thread::supervise_thread()
    @     0x7fef66b83b43 (unknown)
    @     0x7fef66c15a00 (unknown)
    @                0x0 (unknown)
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
