### PR TITLE
[BugFix] The short key index maybe not order by sort key columns

### DIFF
--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -127,6 +127,7 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
     _column_indexes.insert(_column_indexes.end(), column_indexes.begin(), column_indexes.end());
     _column_writers.reserve(_column_indexes.size());
     size_t num_columns = _tablet_schema->num_columns();
+    std::map<uint32_t, uint32_t> sort_column_idx_by_column_index;
     for (uint32_t i = 0; i < _column_indexes.size(); i++) {
         uint32_t column_index = _column_indexes[i];
         if (column_index >= num_columns) {
@@ -181,7 +182,21 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         RETURN_IF_ERROR(writer->init());
         _column_writers.push_back(std::move(writer));
         if (column.is_sort_key()) {
-            _sort_column_indexes.emplace_back(i);
+            sort_column_idx_by_column_index[column_index] = i;
+        }
+    }
+    for (auto& column_idx : _tablet_schema->sort_key_idxes()) {
+        auto iter = sort_column_idx_by_column_index.find(column_idx);
+        if (iter != sort_column_idx_by_column_index.end()) {
+            _sort_column_indexes.emplace_back(iter->second);
+        } else {
+            // Currently we have the following two scenarios：
+            //  1. data load or horizontal compaction, we will write the whole row data once a time
+            //  2. vertical compaction, we will first write all sort key columns and write value columns by group
+            // So the all sort key columns should be found in `_column_indexes` so far.
+            std::string err_msg =
+                    strings::Substitute("column $0 is sort key but not find while init segment writer", column_idx);
+            return Status::InternalError(err_msg);
         }
     }
 


### PR DESCRIPTION
This bug is introduced by this pr(https://github.com/StarRocks/starrocks/pull/25286), we fix the bug which short key index and segment data may not be consistent after vertical compaction in the pr. But the fix ignores the following scenario:
if we create a table which order by column `c2` and c1 and `c2` is after `c1`,
```
CREATE TABLE pk1sk2_tbl (
    k1 int,
    c1 varchar(20),
    c2 varchar(20)
PRIMARY KEY(k1)
DISTRIBUTED BY HASH(c1) BUCKETS 3
ORDER BY(c2,c1);
```
The data of column `c2` should be the prefix of short key index, but the following code in `segment_writer.cpp`:
```
    for (uint32_t i = 0; i < _column_indexes.size(); i++) {
        uint32_t column_index = _column_indexes[i];
        ....
        if (column.is_sort_key()) {
            _sort_column_indexes.emplace_back(i);
        }
    }
```
When we import data or do horizontal compaction, segment_writer's init schema is tablet schema, and the `_column_indexes` is ordered by table column. At this time, column `c1` and column `c2` are both sort key columns and we check column `c1` first, so the `_sort_column_indexes` keeps the index of `c1` first. And in the following short key index encoding process, the data of `c1` will be written before `c2` and be the prefix of the short key index.

The solution is to check `_sort_column_indexes` and the elements of `_sort_column_indexes` should be ordered by the sort key column index.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
