### PR TITLE
[Enhancemnent] Support date_add function for trino parser

### DIFF
--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -659,6 +659,10 @@ TimestampValue timestamp_add(TimestampValue tsv, int count) {
 // years_sub
 DEFINE_TIME_ADD_AND_SUB_FN(years, TimeUnit::YEAR);
 
+// quarters_add
+// quarters_sub
+DEFINE_TIME_ADD_AND_SUB_FN(quarters, TimeUnit::QUARTER);
+
 // months_add
 // months_sub
 DEFINE_TIME_ADD_AND_SUB_FN(months, TimeUnit::MONTH);
@@ -682,6 +686,10 @@ DEFINE_TIME_ADD_AND_SUB_FN(minutes, TimeUnit::MINUTE);
 // seconds_add
 // seconds_sub
 DEFINE_TIME_ADD_AND_SUB_FN(seconds, TimeUnit::SECOND);
+
+// millis_add
+// millis_sub
+DEFINE_TIME_ADD_AND_SUB_FN(millis, TimeUnit::MILLISECOND);
 
 // micros_add
 // micros_sub

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -346,6 +346,14 @@ public:
     DEFINE_VECTORIZED_FN(years_sub);
 
     /**
+     * @param: [timestmap, quarter]
+     * @paramType columns: [TimestampColumn, IntColumn]
+     * @return TimestampColumn
+     */
+    DEFINE_VECTORIZED_FN(quarters_add);
+    DEFINE_VECTORIZED_FN(quarters_sub);
+
+    /**
      * @param: [timestmap, month]
      * @paramType columns: [TimestampColumn, IntColumn]
      * @return TimestampColumn
@@ -400,6 +408,14 @@ public:
      */
     DEFINE_VECTORIZED_FN(micros_add);
     DEFINE_VECTORIZED_FN(micros_sub);
+
+    /**
+     * @param: [timestmap, millis]
+     * @paramType columns: [TimestampColumn, IntColumn]
+     * @return TimestampColumn
+     */
+    DEFINE_VECTORIZED_FN(millis_add);
+    DEFINE_VECTORIZED_FN(millis_sub);
 
     /**
      * @param: [timestmap, timestamp]

--- a/be/src/runtime/datetime_value.cpp
+++ b/be/src/runtime/datetime_value.cpp
@@ -1466,6 +1466,7 @@ bool DateTimeValue::date_add_interval(const TimeInterval& interval, TimeUnit uni
     int sign = interval.is_neg ? -1 : 1;
     switch (unit) {
     case MICROSECOND:
+    case MILLISECOND:
     case SECOND:
     case MINUTE:
     case HOUR:

--- a/be/src/runtime/time_types.h
+++ b/be/src/runtime/time_types.h
@@ -35,6 +35,7 @@ static const Timestamp TIMESTAMP_BITS_TIME{UINT64_MAX >> 24};
 // TimeUnit
 enum TimeUnit {
     MICROSECOND,
+    MILLISECOND,
     SECOND,
     MINUTE,
     HOUR,
@@ -69,6 +70,7 @@ static const int64_t USECS_PER_DAY = 86400000000;
 static const int64_t USECS_PER_HOUR = 3600000000;
 static const int64_t USECS_PER_MINUTE = 60000000;
 static const int64_t USECS_PER_SEC = 1000000;
+static const int64_t USECS_PER_MILLIS = 1000;
 
 static const int64_t NANOSECS_PER_USEC = 1000;
 static const int64_t NANOSECS_PER_SEC = 1000000000;
@@ -76,6 +78,7 @@ static const int64_t NANOSECS_PER_SEC = 1000000000;
 // Corresponding to TimeUnit
 static constexpr int64_t USECS_PER_UNIT[] = {
         1,                // Microsecond
+        USECS_PER_MILLIS, // Millisecond
         USECS_PER_SEC,    // Second
         USECS_PER_MINUTE, // Minute
         USECS_PER_HOUR,   // Hour
@@ -229,10 +232,13 @@ JulianDate date::add(JulianDate date, int count) {
         return date + count;
     } else if constexpr (UNIT == TimeUnit::WEEK) {
         return date + 7 * count;
-    } else if constexpr (UNIT == TimeUnit::MONTH) {
+    } else if constexpr (UNIT == TimeUnit::MONTH || UNIT == TimeUnit::QUARTER) {
         int year, month, day;
         to_date_with_cache(date, &year, &month, &day);
 
+        if (UNIT == TimeUnit::QUARTER) {
+            count = 3 * count;
+        }
         int months = year * 12 + month - 1 + count;
         if (months < 0) {
             // @INFO: NOT SUPPORT BCE

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -137,6 +137,49 @@ TEST_F(TimeFunctionsTest, yearAddTest) {
     }
 }
 
+TEST_F(TimeFunctionsTest, quarterAddTest) {
+    Columns columns;
+
+    auto tc = TimestampColumn::create();
+    auto quarter = Int32Column::create();
+
+    tc->append(TimestampValue::create(2000, 1, 1, 0, 30, 30));
+    quarter->append(2);
+
+    columns.emplace_back(tc);
+    columns.emplace_back(quarter);
+
+    ColumnPtr result = TimeFunctions::quarters_add(_utils->get_fn_ctx(), columns).value();
+    ASSERT_TRUE(result->is_nullable());
+    auto v = ColumnHelper::cast_to<TYPE_DATETIME>(ColumnHelper::as_column<NullableColumn>(result)->data_column());
+
+    ASSERT_EQ(TimestampValue::create(2000, 7, 1, 0, 30, 30), v->get_data()[0]);
+    ASSERT_FALSE(result->is_null(0));
+}
+
+TEST_F(TimeFunctionsTest, millisAddTest) {
+    Columns columns;
+
+    auto tc = TimestampColumn::create();
+    auto millis = Int32Column::create();
+
+    tc->append(TimestampValue::create(2000, 1, 1, 0, 30, 30));
+    millis->append(200);
+
+    columns.emplace_back(tc);
+    columns.emplace_back(millis);
+
+    ColumnPtr result = TimeFunctions::millis_add(_utils->get_fn_ctx(), columns).value();
+    ASSERT_TRUE(result->is_nullable());
+    auto v = ColumnHelper::cast_to<TYPE_DATETIME>(ColumnHelper::as_column<NullableColumn>(result)->data_column());
+
+    TimestampValue check_ts;
+    check_ts.from_timestamp(2000, 1, 1, 0, 30, 30, 200 * 1000);
+
+    ASSERT_EQ(check_ts, v->get_data()[0]);
+    ASSERT_FALSE(result->is_null(0));
+}
+
 TEST_F(TimeFunctionsTest, yearOverflowTest) {
     Columns columns;
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -176,6 +176,18 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
 
         sql = "select date_add('year', 2, th) from tall;";
         assertPlanContains(sql, "years_add(8: th, 2)");
+
+        sql = "select date_add('quarter', 2, TIMESTAMP '2014-03-08 09:00:00');";
+        assertPlanContains(sql, "quarters_add('2014-03-08 09:00:00', 2)");
+
+        sql = "select date_add('quarter', -1, TIMESTAMP '2014-03-08 09:00:00');";
+        assertPlanContains(sql, "quarters_add('2014-03-08 09:00:00', -1)");
+
+        sql = "select date_add('millisecond', 20, TIMESTAMP '2014-03-08 09:00:00');";
+        assertPlanContains(sql, "milliseconds_add('2014-03-08 09:00:00', 20)");
+
+        sql = "select date_add('millisecond', -100, TIMESTAMP '2014-03-08 09:00:00');";
+        assertPlanContains(sql, "milliseconds_add('2014-03-08 09:00:00', -100)");
     }
 
     @Test

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -359,6 +359,8 @@ vectorized_functions = [
 
     [50110, 'years_add', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::years_add'],
     [50111, 'years_sub', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::years_sub'],
+    [50115, 'quarters_add', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::quarters_add'],
+    [50116, 'quarters_sub', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::quarters_sub'],
     [50120, 'months_add', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::months_add'],
     [50121, 'months_sub', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::months_sub'],
     [50122, 'add_months', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::months_add'],
@@ -379,6 +381,8 @@ vectorized_functions = [
     [50161, 'minutes_sub', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::minutes_sub'],
     [50170, 'seconds_add', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::seconds_add'],
     [50171, 'seconds_sub', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::seconds_sub'],
+    [50175, 'milliseconds_add', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::millis_add'],
+    [50176, 'milliseconds_sub', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::millis_sub'],
     [50180, 'microseconds_add', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::micros_add'],
     [50181, 'microseconds_sub', 'DATETIME', ['DATETIME', 'INT'], 'TimeFunctions::micros_sub'],
     [50190, 'years_diff', 'BIGINT', ['DATETIME', 'DATETIME'], 'TimeFunctions::years_diff'],


### PR DESCRIPTION
Fixes #issue
#14825 
we need to implent milliseconds_add, quarters_add function in starrocks， so we can mapping all time unit supported by trino date_add function (https://trino.io/docs/current/functions/datetime.html?highlight=date_add#date_add)

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
