### PR TITLE
[Refactor] compatibly read parquet files from arrow for nested types

### DIFF
--- a/be/src/exec/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/arrow_to_starrocks_converter.cpp
@@ -200,9 +200,9 @@ void offsets_copy(const T* arrow_offsets_data, T arrow_base_offset, size_t num_e
 }
 
 template <LogicalType LT, typename = StringOrBinaryGaurd<LT>>
-static inline constexpr uint32_t binary_max_length =
-        (LT == TYPE_VARCHAR || LT == TYPE_VARBINARY) ? TypeDescriptor::MAX_VARCHAR_LENGTH
-                                                     : TypeDescriptor::MAX_CHAR_LENGTH;
+static inline constexpr uint32_t binary_max_length = (LT == TYPE_VARCHAR || LT == TYPE_VARBINARY)
+                                                             ? TypeDescriptor::MAX_VARCHAR_LENGTH
+                                                             : TypeDescriptor::MAX_CHAR_LENGTH;
 
 template <ArrowTypeId AT, LogicalType LT, bool is_nullable, bool is_strict>
 struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringOrBinaryGaurd<LT>> {

--- a/be/src/exec/arrow_to_starrocks_converter.cpp
+++ b/be/src/exec/arrow_to_starrocks_converter.cpp
@@ -129,7 +129,7 @@ struct ArrowConverter {
     static Status apply(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
                         size_t column_start_idx, [[maybe_unused]] uint8_t* null_data,
                         [[maybe_unused]] Filter* chunk_filter, ArrowConvertContext* ctx,
-                        [[maybe_unused]] const TypeDescriptor* type_desc) {
+                        [[maybe_unused]] ConvertFuncTree* conv_func) {
         auto concrete_array = down_cast<const ArrowArrayType*>(array);
         auto concrete_column = down_cast<ColumnType*>(column);
         concrete_column->resize(column->size() + num_elements);
@@ -200,9 +200,9 @@ void offsets_copy(const T* arrow_offsets_data, T arrow_base_offset, size_t num_e
 }
 
 template <LogicalType LT, typename = StringOrBinaryGaurd<LT>>
-static inline constexpr uint32_t binary_max_length = (LT == TYPE_VARCHAR || LT == TYPE_VARBINARY)
-                                                             ? TypeDescriptor::MAX_VARCHAR_LENGTH
-                                                             : TypeDescriptor::MAX_CHAR_LENGTH;
+static inline constexpr uint32_t binary_max_length =
+        (LT == TYPE_VARCHAR || LT == TYPE_VARBINARY) ? TypeDescriptor::MAX_VARCHAR_LENGTH
+                                                     : TypeDescriptor::MAX_CHAR_LENGTH;
 
 template <ArrowTypeId AT, LogicalType LT, bool is_nullable, bool is_strict>
 struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringOrBinaryGaurd<LT>> {
@@ -287,7 +287,7 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, BinaryATGuard<AT>, StringO
 
     static Status apply(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
                         size_t column_start_idx, [[maybe_unused]] uint8_t* null_data, Filter* chunk_filter,
-                        ArrowConvertContext* ctx, [[maybe_unused]] const TypeDescriptor* type_desc) {
+                        ArrowConvertContext* ctx, [[maybe_unused]] ConvertFuncTree* conv_func) {
         auto concrete_array = down_cast<const ArrowArrayType*>(array);
         auto concrete_column = down_cast<ColumnType*>(column);
         auto* filter_data = (&chunk_filter->front()) + column_start_idx;
@@ -491,7 +491,7 @@ struct ArrowConverter<ArrowTypeId::DECIMAL, LT, is_nullable, is_strict, guard::G
     static Status apply(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
                         size_t column_start_idx, [[maybe_unused]] uint8_t* null_data,
                         [[maybe_unused]] Filter* chunk_filter, ArrowConvertContext* ctx,
-                        [[maybe_unused]] const TypeDescriptor* type_desc) {
+                        [[maybe_unused]] ConvertFuncTree* conv_func) {
         auto concrete_array = down_cast<const ArrowArrayType*>(array);
         auto concrete_type = std::static_pointer_cast<ArrowType>(array->type());
         auto concrete_column = down_cast<ColumnType*>(column);
@@ -633,7 +633,7 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, DateOrDateTimeATGuard<AT>,
     static Status apply(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
                         size_t column_start_idx, [[maybe_unused]] uint8_t* null_data,
                         [[maybe_unused]] Filter* chunk_filter, ArrowConvertContext* ctx,
-                        [[maybe_unused]] const TypeDescriptor* type_desc) {
+                        [[maybe_unused]] ConvertFuncTree* conv_func) {
         auto* concrete_array = down_cast<const ArrowArrayType*>(array);
         auto concrete_type = std::static_pointer_cast<ArrowType>(array->type());
         auto* concrete_column = down_cast<ColumnType*>(column);
@@ -688,7 +688,7 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, JsonGuard<LT>> {
     static Status apply(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
                         size_t column_start_idx, [[maybe_unused]] uint8_t* null_data,
                         [[maybe_unused]] Filter* chunk_filter, ArrowConvertContext* ctx,
-                        [[maybe_unused]] const TypeDescriptor* type_desc) {
+                        [[maybe_unused]] ConvertFuncTree* conv_func) {
         auto* json_column = down_cast<JsonColumn*>(column);
         json_column->reserve(column->size() + num_elements);
 
@@ -783,7 +783,7 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, ArrayGuard<LT>> {
 
     static Status apply(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
                         size_t chunk_start_idx, [[maybe_unused]] uint8_t* null_data, Filter* chunk_filter,
-                        ArrowConvertContext* ctx, const TypeDescriptor* type_desc) {
+                        ArrowConvertContext* ctx, ConvertFuncTree* conv_func) {
         auto* col_array = down_cast<ArrayColumn*>(column);
         UInt32Column* col_offsets = col_array->offsets_column().get();
 
@@ -798,7 +798,6 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, ArrayGuard<LT>> {
             return Status::InternalError(strings::Substitute("Invalid arrow list type($0)", array->type()->name()));
         }
 
-        const TypeDescriptor& child_type = type_desc->children[0];
         size_t child_array_start_idx;
         size_t child_array_num_elements;
         const auto* child_array = get_child_array_position(array, array_start_idx, num_elements, &child_array_start_idx,
@@ -806,14 +805,11 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, ArrayGuard<LT>> {
         if (!child_array) {
             return Status::InternalError(fmt::format("Unnest arrow list type({}) fail", array->type()->name()));
         }
-        auto conv_func = get_arrow_converter(child_array->type()->id(), child_type.type, true, false);
-        if (!conv_func) {
-            return illegal_converting_error(child_array->type()->name(), child_type.debug_string());
-        }
+
         Filter child_chunk_filter;
         child_chunk_filter.resize(col_array->elements_column()->size() + child_array_num_elements, 1);
-        return ParquetScanner::convert_array_to_column(conv_func, child_array_num_elements, child_array, &child_type,
-                                                       col_array->elements_column(), child_array_start_idx,
+        return ParquetScanner::convert_array_to_column(conv_func->children[0].get(), child_array_num_elements,
+                                                       child_array, col_array->elements_column(), child_array_start_idx,
                                                        col_array->elements_column()->size(), &child_chunk_filter, ctx);
     }
 };
@@ -822,7 +818,7 @@ template <ArrowTypeId AT, LogicalType LT, bool is_nullable, bool is_strict>
 struct ArrowConverter<AT, LT, is_nullable, is_strict, MapGuard<LT>> {
     static Status apply(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
                         size_t chunk_start_idx, [[maybe_unused]] uint8_t* null_data, Filter* chunk_filter,
-                        ArrowConvertContext* ctx, const TypeDescriptor* type_desc) {
+                        ArrowConvertContext* ctx, ConvertFuncTree* conv_func) {
         // offset
         auto* col_map = down_cast<MapColumn*>(column);
         UInt32Column* col_offsets = col_map->offsets_column().get();
@@ -831,7 +827,6 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, MapGuard<LT>> {
         size_t kv_size[] = {col_map->keys().size(), col_map->values().size()};
         ColumnPtr kv_columns[] = {col_map->keys_column(), col_map->values_column()};
         for (auto i = 0; i < 2; ++i) {
-            const TypeDescriptor& child_type = type_desc->children[i];
             size_t child_array_start_idx;
             size_t child_array_num_elements;
             const auto* child_array = get_list_map_array_child<arrow::MapType>(
@@ -839,15 +834,12 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, MapGuard<LT>> {
             if (!child_array) {
                 return Status::InternalError(fmt::format("Unnest arrow array type({}) fail", array->type()->name()));
             }
-            auto conv_func = get_arrow_converter(child_array->type()->id(), child_type.type, true, false);
-            if (!conv_func) {
-                return illegal_converting_error(child_array->type()->name(), child_type.debug_string());
-            }
+
             Filter child_chunk_filter;
             child_chunk_filter.resize(kv_size[i] + child_array_num_elements, 1);
-            RETURN_IF_ERROR(ParquetScanner::convert_array_to_column(conv_func, child_array_num_elements, child_array,
-                                                                    &child_type, kv_columns[i], child_array_start_idx,
-                                                                    kv_size[i], &child_chunk_filter, ctx));
+            RETURN_IF_ERROR(ParquetScanner::convert_array_to_column(
+                    conv_func->children[i].get(), child_array_num_elements, child_array, kv_columns[i],
+                    child_array_start_idx, kv_size[i], &child_chunk_filter, ctx));
         }
         return Status::OK();
     }
@@ -857,14 +849,13 @@ template <ArrowTypeId AT, LogicalType LT, bool is_nullable, bool is_strict>
 struct ArrowConverter<AT, LT, is_nullable, is_strict, StructGurad<LT>> {
     static Status apply(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
                         size_t chunk_start_idx, [[maybe_unused]] uint8_t* null_data, Filter* chunk_filter,
-                        ArrowConvertContext* ctx, const TypeDescriptor* type_desc) {
+                        ArrowConvertContext* ctx, ConvertFuncTree* conv_func) {
         auto* struct_col = down_cast<StructColumn*>(column);
         auto* struct_array = down_cast<const arrow::StructArray*>(array);
 
-        DCHECK_EQ(type_desc->field_names.size(), type_desc->children.size());
-        for (size_t i = 0; i < type_desc->field_names.size(); i++) {
-            const auto& child_type = type_desc->children[i];
-            const auto& child_name = type_desc->field_names[i];
+        DCHECK_EQ(conv_func->field_names.size(), conv_func->children.size());
+        for (size_t i = 0; i < conv_func->field_names.size(); i++) {
+            const auto& child_name = conv_func->field_names[i];
 
             auto child_col = struct_col->field_column(child_name);
             auto child_array = struct_array->GetFieldByName(child_name);
@@ -876,13 +867,8 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, StructGurad<LT>> {
                 continue;
             }
 
-            auto conv_func = get_arrow_converter(child_array->type()->id(), child_type.type, true, false);
-            if (!conv_func) {
-                return illegal_converting_error(child_array->type()->name(), child_type.debug_string());
-            }
-
-            RETURN_IF_ERROR(ParquetScanner::convert_array_to_column(conv_func, num_elements, child_array.get(),
-                                                                    &child_type, child_col, array_start_idx,
+            RETURN_IF_ERROR(ParquetScanner::convert_array_to_column(conv_func->children[i].get(), num_elements,
+                                                                    child_array.get(), child_col, array_start_idx,
                                                                     chunk_start_idx, chunk_filter, ctx));
         }
 
@@ -893,7 +879,7 @@ struct ArrowConverter<AT, LT, is_nullable, is_strict, StructGurad<LT>> {
 // Convert Arrow null to any types
 Status null_converter(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
                       size_t column_start_idx, uint8_t* null_data, [[maybe_unused]] Filter* chunk_filter,
-                      ArrowConvertContext* ctx, [[maybe_unused]] const TypeDescriptor* type_desc) {
+                      ArrowConvertContext* ctx, [[maybe_unused]] ConvertFuncTree* conv_func) {
     if (null_data == nullptr) {
         return Status::InvalidArgument(fmt::format("The column ({}) must be nullable", ctx->current_slot->col_name()));
     }
@@ -938,6 +924,9 @@ static const std::unordered_map<ArrowTypeId, LogicalType> global_strict_arrow_co
         STRICT_ARROW_CONV_ENTRY_R(TYPE_DATETIME, ArrowTypeId::DATE64, ArrowTypeId::TIMESTAMP),
         STRICT_ARROW_CONV_ENTRY_R(TYPE_DECIMAL128, ArrowTypeId::DECIMAL),
         STRICT_ARROW_CONV_ENTRY_R(TYPE_JSON, ArrowTypeId::STRUCT, ArrowTypeId::MAP, ArrowTypeId::LIST),
+        STRICT_ARROW_CONV_ENTRY_R(TYPE_ARRAY, ArrowTypeId::LIST, ArrowTypeId::LARGE_LIST, ArrowTypeId::FIXED_SIZE_LIST),
+        STRICT_ARROW_CONV_ENTRY_R(TYPE_MAP, ArrowTypeId::MAP),
+        STRICT_ARROW_CONV_ENTRY_R(TYPE_STRUCT, ArrowTypeId::STRUCT),
 };
 
 static const std::unordered_map<int32_t, ConvertFunc> global_optimized_arrow_conv_table{
@@ -951,7 +940,7 @@ static const std::unordered_map<int32_t, ConvertFunc> global_optimized_arrow_con
         ARROW_CONV_ENTRY(ArrowTypeId::INT16, TYPE_FLOAT, TYPE_DOUBLE, TYPE_JSON),
         ARROW_CONV_ENTRY(ArrowTypeId::UINT16, TYPE_SMALLINT, TYPE_INT, TYPE_BIGINT, TYPE_LARGEINT, TYPE_JSON),
         ARROW_CONV_ENTRY(ArrowTypeId::UINT16, TYPE_FLOAT, TYPE_DOUBLE, TYPE_JSON),
-        ARROW_CONV_ENTRY(ArrowTypeId::INT32, TYPE_INT, TYPE_BIGINT, TYPE_LARGEINT, TYPE_DOUBLE, TYPE_JSON, TYPE_JSON),
+        ARROW_CONV_ENTRY(ArrowTypeId::INT32, TYPE_INT, TYPE_BIGINT, TYPE_LARGEINT, TYPE_DOUBLE, TYPE_JSON),
         ARROW_CONV_ENTRY(ArrowTypeId::UINT32, TYPE_INT, TYPE_BIGINT, TYPE_LARGEINT, TYPE_DOUBLE, TYPE_JSON),
         ARROW_CONV_ENTRY(ArrowTypeId::INT64, TYPE_BIGINT, TYPE_LARGEINT, TYPE_JSON),
         ARROW_CONV_ENTRY(ArrowTypeId::UINT64, TYPE_BIGINT, TYPE_LARGEINT, TYPE_JSON),
@@ -972,7 +961,9 @@ static const std::unordered_map<int32_t, ConvertFunc> global_optimized_arrow_con
 
         // JSON converters
         ARROW_CONV_ENTRY(ArrowTypeId::MAP, TYPE_MAP, TYPE_JSON),
-        ARROW_CONV_ENTRY(ArrowTypeId::LIST, TYPE_ARRAY, TYPE_JSON), // NOTE: FixedSizeListType, LargeListType, ListType
+        ARROW_CONV_ENTRY(ArrowTypeId::LIST, TYPE_ARRAY, TYPE_JSON),
+        ARROW_CONV_ENTRY(ArrowTypeId::LARGE_LIST, TYPE_ARRAY, TYPE_JSON),
+        ARROW_CONV_ENTRY(ArrowTypeId::FIXED_SIZE_LIST, TYPE_ARRAY, TYPE_JSON),
         ARROW_CONV_ENTRY(ArrowTypeId::STRUCT, TYPE_STRUCT, TYPE_JSON),
 };
 
@@ -980,7 +971,6 @@ ConvertFunc get_arrow_converter(ArrowTypeId at, LogicalType lt, bool is_nullable
     if (at == ArrowTypeId::NA) {
         return null_converter;
     }
-    at = ArrowConverter<ArrowTypeId::LIST, TYPE_ARRAY, false, false>::is_any_list(at) ? ArrowTypeId::LIST : at;
     auto optimized_idx = convert_idx(at, lt, is_nullable, is_strict);
     auto it = global_optimized_arrow_conv_table.find(optimized_idx);
     if (it != global_optimized_arrow_conv_table.end()) {

--- a/be/src/exec/arrow_to_starrocks_converter.h
+++ b/be/src/exec/arrow_to_starrocks_converter.h
@@ -44,7 +44,6 @@ struct ArrowConvertContext {
     void report_error_message(const std::string& reason, const std::string& raw_data);
 };
 
-
 // fill null_column's range [column_start_idx, column_start_idx + num_elements) with
 // array's range [array_start_idx, array_start_idx + num_elements).
 size_t fill_null_column(const arrow::Array* array, size_t array_start_idx, size_t num_elements, NullColumn*,

--- a/be/src/exec/arrow_to_starrocks_converter.h
+++ b/be/src/exec/arrow_to_starrocks_converter.h
@@ -32,7 +32,7 @@
 namespace starrocks {
 class RuntimeState;
 class SlotDescriptor;
-
+struct ConvertFuncTree;
 } // namespace starrocks
 namespace starrocks {
 
@@ -43,6 +43,7 @@ struct ArrowConvertContext {
     int error_message_counter = 0;
     void report_error_message(const std::string& reason, const std::string& raw_data);
 };
+
 
 // fill null_column's range [column_start_idx, column_start_idx + num_elements) with
 // array's range [array_start_idx, array_start_idx + num_elements).
@@ -60,7 +61,7 @@ void fill_filter(const arrow::Array* array, size_t array_start_idx, size_t num_e
 // filter_data[i - column_start_idx] == DATUM_NULL, slot marked as 1 is filtered out
 typedef Status (*ConvertFunc)(const arrow::Array* array, size_t array_start_idx, size_t num_elements, Column* column,
                               size_t column_start_idx, uint8_t* null_data, Filter* chunk_filter,
-                              ArrowConvertContext* ctx, const TypeDescriptor* type_desc);
+                              ArrowConvertContext* ctx, ConvertFuncTree* conv_func);
 
 // invoked when a arrow type fail to convert to StarRocks type.
 Status illegal_converting_error(const std::string& arrow_type_name, const std::string& type_name);
@@ -74,5 +75,13 @@ ConvertFunc get_arrow_converter(ArrowTypeId at, LogicalType lt, bool is_nullable
 // phase1: convert at->lt0 by converter determined by the triple [at, lt0, is_nullable]
 // phase2: convert lt0->lt by VectorCastExpr.
 LogicalType get_strict_type(ArrowTypeId at);
+
+struct ConvertFuncTree {
+    ConvertFuncTree(ConvertFunc f) : func(f){};
+    ConvertFuncTree() : func(nullptr){};
+    ConvertFunc func = nullptr;
+    std::vector<std::string> field_names; // used in struct
+    std::vector<std::unique_ptr<ConvertFuncTree>> children;
+};
 
 } // namespace starrocks

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -14,6 +14,8 @@
 
 #include "exec/parquet_scanner.h"
 
+#include <fmt/format.h>
+
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/vectorized_fwd.h"
@@ -54,7 +56,9 @@ Status ParquetScanner::open() {
                                         ? implicit_cast<int>(range.num_of_columns_from_file)
                                         : implicit_cast<int>(_src_slot_descriptors.size());
 
-    _conv_funcs.resize(_num_of_columns_from_file, nullptr);
+    for (auto i = 0; i < _num_of_columns_from_file; ++i) {
+        _conv_funcs.emplace_back(std::make_unique<ConvertFuncTree>());
+    }
     _cast_exprs.resize(_num_of_columns_from_file, nullptr);
 
     // column from path
@@ -82,7 +86,8 @@ Status ParquetScanner::initialize_src_chunk(ChunkPtr* chunk) {
         }
         auto* array = _batch->column(column_pos++).get();
         ColumnPtr column;
-        RETURN_IF_ERROR(new_column(array->type().get(), slot_desc, &column, &_conv_funcs[i], &_cast_exprs[i]));
+        RETURN_IF_ERROR(new_column(array->type().get(), slot_desc, &column, _conv_funcs[i].get(), &_cast_exprs[i],
+                                   _pool, _strict_mode));
         column->reserve(_max_chunk_size);
         (*chunk)->append_column(column, slot_desc->id());
     }
@@ -111,8 +116,8 @@ Status ParquetScanner::append_batch_to_src_chunk(ChunkPtr* chunk) {
             auto& mutable_timezone = (std::string&)timestamp_type->timezone();
             mutable_timezone = _state->timezone();
         }
-        RETURN_IF_ERROR(convert_array_to_column(_conv_funcs[i], num_elements, array, &slot_desc->type(), column,
-                                                _batch_start_idx, _chunk_start_idx, &_chunk_filter, &_conv_ctx));
+        RETURN_IF_ERROR(convert_array_to_column(_conv_funcs[i].get(), num_elements, array, column, _batch_start_idx,
+                                                _chunk_start_idx, &_chunk_filter, &_conv_ctx));
     }
 
     _chunk_start_idx += num_elements;
@@ -160,9 +165,7 @@ Status ParquetScanner::finalize_src_chunk(ChunkPtr* chunk) {
 // 2. inter-column convertible:  a column can convert to another column, e.g. BinaryColumn -> FloatColumn
 // An arrow type AT loading into column type LT is undergoes this steps:
 // AT ===[arrow-column convert]===> LT0 ===[inter-column convert]===> LT
-//
-// case#0: if LT is TYPE_ARRAY, then convert AT to LT directly
-//  ListArray ===[array_conv] ===> TYPE_ARRAY === [ColumnRef expr] ===> TYPE_ARRAY
+// case#0: convert recursively for nested types: TYPE_ARRAY, TYPE_MAP, TYPE_STRUCT
 // case#1: if an optimized conv_func provided for AT converting to LT, then convert AT to LT directly
 //  AT ===[conv_func] ===> LT ===[ColumnRef expr]===> LT
 // case#2: if no optimized conv_func is provided, then convert AT to a strict LT, then use CastExpr for
@@ -170,76 +173,146 @@ Status ParquetScanner::finalize_src_chunk(ChunkPtr* chunk) {
 //  AT ===[conv_func]===> strict LT ===[VectorizedCastExpr]===> LT
 // case#3: otherwise, AT to LT is inconvertible and InterError is reported.
 
-Status ParquetScanner::new_column(const arrow::DataType* arrow_type, const SlotDescriptor* slot_desc, ColumnPtr* column,
-                                  ConvertFunc* conv_func, Expr** expr) {
-    auto& type_desc = slot_desc->type();
+// build convert function tree, raw type desc to get cast function and create dest column,
+Status ParquetScanner::build_dest(const arrow::DataType* arrow_type, const TypeDescriptor* type_desc, bool is_nullable,
+                                  TypeDescriptor* raw_type_desc, ConvertFuncTree* conv_func, bool& need_cast,
+                                  bool strict_mode) {
     auto at = arrow_type->id();
-    auto lt = type_desc.type;
+    auto lt = type_desc->type;
+    conv_func->func = get_arrow_converter(at, lt, is_nullable, strict_mode);
 
-    auto optimized_conv_func = get_arrow_converter(at, lt, slot_desc->is_nullable(), _strict_mode);
-    if (optimized_conv_func != nullptr) {
-        (*column) = ColumnHelper::create_column(type_desc, slot_desc->is_nullable());
-        *expr = _pool.add(new ColumnRef(slot_desc));
-        *conv_func = optimized_conv_func;
-        return Status::OK();
-    }
-
-    Status error = illegal_converting_error(arrow_type->name(), type_desc.debug_string());
-    auto strict_pt = get_strict_type(at);
-    if (strict_pt == TYPE_UNKNOWN) {
-        return error;
-    }
-
-    auto strict_conv_func = get_arrow_converter(at, strict_pt, slot_desc->is_nullable(), _strict_mode);
-    if (strict_conv_func == nullptr) {
-        return error;
-    }
-
-    auto* strict_type_desc = _pool.add(new TypeDescriptor());
-    strict_type_desc->type = strict_pt;
-    switch (strict_pt) {
-    case TYPE_DECIMAL128: {
-        const auto* discrete_type = down_cast<const arrow::Decimal128Type*>(arrow_type);
-        auto precision = discrete_type->precision();
-        auto scale = discrete_type->scale();
-        if (precision < 1 || precision > decimal_precision_limit<int128_t> || scale < 0 || scale > precision) {
-            return Status::InternalError(strings::Substitute("Decimal($0, $1) is out of range.", precision, scale));
+    switch (lt) {
+    case TYPE_ARRAY: {
+        if (at != ArrowTypeId::LIST && at != ArrowTypeId::LARGE_LIST && at != ArrowTypeId::FIXED_SIZE_LIST) {
+            return Status::InternalError(
+                    fmt::format("Apache Arrow type (nested) {} does not match the type {} in StarRocks",
+                                arrow_type->name(), type_to_string(lt)));
         }
-        strict_type_desc->precision = precision;
-        strict_type_desc->scale = scale;
-        break;
-    }
-    case TYPE_VARCHAR: {
-        strict_type_desc->len = TypeDescriptor::MAX_VARCHAR_LENGTH;
-        break;
-    }
-    case TYPE_CHAR: {
-        strict_type_desc->len = TypeDescriptor::MAX_CHAR_LENGTH;
-        break;
-    }
-    case TYPE_DECIMALV2:
-    case TYPE_DECIMAL32:
-    case TYPE_DECIMAL64: {
-        return Status::InternalError(
-                strings::Substitute("Apache Arrow type($0) does not match the type($1) in StarRocks",
-                                    arrow_type->name(), type_to_string(strict_pt)));
-    }
-    default:
-        break;
-    }
+        raw_type_desc->type = TYPE_ARRAY;
+        TypeDescriptor type;
+        auto cf = std::make_unique<ConvertFuncTree>();
+        auto sub_at = arrow_type->field(0)->type();
+        RETURN_IF_ERROR(
+                build_dest(sub_at.get(), &type_desc->children[0], true, &type, cf.get(), need_cast, strict_mode));
+        raw_type_desc->children.emplace_back(std::move(type));
+        conv_func->children.emplace_back(std::move(cf));
+    } break;
+    case TYPE_MAP: {
+        if (at != ArrowTypeId::MAP) {
+            return Status::InternalError(
+                    fmt::format("Apache Arrow type (nested) {} does not match the type {} in StarRocks",
+                                arrow_type->name(), type_to_string(lt)));
+        }
 
-    auto slot = _pool.add(new ColumnRef(slot_desc));
-    *expr = VectorizedCastExprFactory::from_type(*strict_type_desc, slot_desc->type(), slot, &_pool);
-    if ((*expr) == nullptr) {
-        return illegal_converting_error(arrow_type->name(), type_desc.debug_string());
+        raw_type_desc->type = TYPE_MAP;
+        for (auto i = 0; i < 2; i++) {
+            TypeDescriptor type;
+            auto cf = std::make_unique<ConvertFuncTree>();
+            auto sub_at = i == 0 ? down_cast<const arrow::MapType*>(arrow_type)->key_type()
+                                 : down_cast<const arrow::MapType*>(arrow_type)->item_type();
+            RETURN_IF_ERROR(
+                    build_dest(sub_at.get(), &type_desc->children[i], true, &type, cf.get(), need_cast, strict_mode));
+            raw_type_desc->children.emplace_back(std::move(type));
+            conv_func->children.emplace_back(std::move(cf));
+        }
+    } break;
+    case TYPE_STRUCT: {
+        if (at != ArrowTypeId::STRUCT) {
+            return Status::InternalError(
+                    fmt::format("Apache Arrow type (nested) {} does not match the type {} in StarRocks",
+                                arrow_type->name(), type_to_string(lt)));
+        }
+        auto field_size = type_desc->children.size();
+        auto arrow_field_size = arrow_type->num_fields();
+
+        raw_type_desc->type = TYPE_STRUCT;
+        conv_func->field_names = type_desc->field_names;
+        for (auto i = 0; i < field_size; i++) {
+            TypeDescriptor type;
+            auto cf = std::make_unique<ConvertFuncTree>();
+            auto sub_at = i >= arrow_field_size ? arrow::null() : arrow_type->field(i)->type();
+            RETURN_IF_ERROR(
+                    build_dest(sub_at.get(), &type_desc->children[i], true, &type, cf.get(), need_cast, strict_mode));
+            raw_type_desc->children.emplace_back(std::move(type));
+            conv_func->children.emplace_back(std::move(cf));
+        }
+    } break;
+    default: {
+        if (conv_func->func == nullptr) {
+            need_cast = true;
+            Status error = illegal_converting_error(arrow_type->name(), type_desc->debug_string());
+            auto strict_pt = get_strict_type(at);
+            if (strict_pt == TYPE_UNKNOWN) {
+                return error;
+            }
+            auto strict_conv_func = get_arrow_converter(at, strict_pt, is_nullable, strict_mode);
+            if (strict_conv_func == nullptr) {
+                return error;
+            }
+            conv_func->func = strict_conv_func;
+            raw_type_desc->type = strict_pt;
+            switch (strict_pt) {
+            case TYPE_DECIMAL128: {
+                const auto* discrete_type = down_cast<const arrow::Decimal128Type*>(arrow_type);
+                auto precision = discrete_type->precision();
+                auto scale = discrete_type->scale();
+                if (precision < 1 || precision > decimal_precision_limit<int128_t> || scale < 0 || scale > precision) {
+                    return Status::InternalError(
+                            strings::Substitute("Decimal($0, $1) is out of range.", precision, scale));
+                }
+                raw_type_desc->precision = precision;
+                raw_type_desc->scale = scale;
+                break;
+            }
+            case TYPE_VARCHAR: {
+                raw_type_desc->len = TypeDescriptor::MAX_VARCHAR_LENGTH;
+                break;
+            }
+            case TYPE_CHAR: {
+                raw_type_desc->len = TypeDescriptor::MAX_CHAR_LENGTH;
+                break;
+            }
+            case TYPE_DECIMALV2:
+            case TYPE_DECIMAL32:
+            case TYPE_DECIMAL64: {
+                return Status::InternalError(
+                        strings::Substitute("Apache Arrow type($0) does not match the type($1) in StarRocks",
+                                            arrow_type->name(), type_to_string(strict_pt)));
+            }
+            default:
+                break;
+            }
+        } else {
+            *raw_type_desc = *type_desc;
+        }
     }
-    *column = ColumnHelper::create_column(*strict_type_desc, slot_desc->is_nullable());
-    *conv_func = strict_conv_func;
+    }
     return Status::OK();
 }
 
-Status ParquetScanner::convert_array_to_column(ConvertFunc conv_func, size_t num_elements, const arrow::Array* array,
-                                               const TypeDescriptor* type_desc, const ColumnPtr& column,
+Status ParquetScanner::new_column(const arrow::DataType* arrow_type, const SlotDescriptor* slot_desc, ColumnPtr* column,
+                                  ConvertFuncTree* conv_func, Expr** expr, ObjectPool& pool, bool strict_mode) {
+    auto& type_desc = slot_desc->type();
+    auto* raw_type_desc = pool.add(new TypeDescriptor());
+    bool need_cast = false;
+    build_dest(arrow_type, &type_desc, slot_desc->is_nullable(), raw_type_desc, conv_func, need_cast, strict_mode);
+    if (!need_cast) {
+        *expr = pool.add(new ColumnRef(slot_desc));
+        (*column) = ColumnHelper::create_column(type_desc, slot_desc->is_nullable());
+    } else {
+        auto slot = pool.add(new ColumnRef(slot_desc));
+        *expr = VectorizedCastExprFactory::from_type(*raw_type_desc, slot_desc->type(), slot, &pool);
+        if ((*expr) == nullptr) {
+            return illegal_converting_error(arrow_type->name(), type_desc.debug_string());
+        }
+        *column = ColumnHelper::create_column(*raw_type_desc, slot_desc->is_nullable());
+    }
+
+    return Status::OK();
+}
+
+Status ParquetScanner::convert_array_to_column(ConvertFuncTree* conv_func, size_t num_elements,
+                                               const arrow::Array* array, const ColumnPtr& column,
                                                size_t batch_start_idx, size_t chunk_start_idx, Filter* chunk_filter,
                                                ArrowConvertContext* conv_ctx) {
     uint8_t* null_data;
@@ -258,8 +331,8 @@ Status ParquetScanner::convert_array_to_column(ConvertFunc conv_func, size_t num
         data_column = column.get();
     }
 
-    auto st = conv_func(array, batch_start_idx, num_elements, data_column, chunk_start_idx, null_data, chunk_filter,
-                        conv_ctx, type_desc);
+    auto st = conv_func->func(array, batch_start_idx, num_elements, data_column, chunk_start_idx, null_data,
+                              chunk_filter, conv_ctx, conv_func);
     if (st.ok() && column->is_nullable()) {
         // in some scene such as string length exceeds limit, the column will be set NULL, so we need reset has_null
         down_cast<NullableColumn*>(column.get())->update_has_null();

--- a/be/src/exec/parquet_scanner.h
+++ b/be/src/exec/parquet_scanner.h
@@ -50,10 +50,15 @@ public:
 
     void close() override;
 
-    static Status convert_array_to_column(ConvertFunc func, size_t num_elements, const arrow::Array* array,
-                                          const TypeDescriptor* type_desc, const ColumnPtr& column,
-                                          size_t batch_start_idx, size_t column_start_idx, Filter* chunk_filter,
-                                          ArrowConvertContext* conv_ctx);
+    static Status convert_array_to_column(ConvertFuncTree* func, size_t num_elements, const arrow::Array* array,
+                                          const ColumnPtr& column, size_t batch_start_idx, size_t column_start_idx,
+                                          Filter* chunk_filter, ArrowConvertContext* conv_ctx);
+
+    static Status new_column(const arrow::DataType* arrow_type, const SlotDescriptor* slot_desc, ColumnPtr* column,
+                             ConvertFuncTree* conv_func, Expr** expr, ObjectPool& pool, bool strict_mode);
+
+    static Status build_dest(const arrow::DataType* arrow_type, const TypeDescriptor* type_desc, bool is_nullable,
+                             TypeDescriptor* raw_type_desc, ConvertFuncTree* conv_func, bool& need_cast, bool strict_mode);
 
 private:
     // Read next buffer from reader
@@ -65,9 +70,6 @@ private:
     bool batch_is_exhausted();
     Status finalize_src_chunk(ChunkPtr* chunk);
 
-    Status new_column(const arrow::DataType* arrow_type, const SlotDescriptor* slot_desc, ColumnPtr* column,
-                      ConvertFunc* conv_func, Expr** expr);
-
     const TBrokerScanRange& _scan_range;
     int _next_file;
     std::shared_ptr<ParquetChunkReader> _curr_file_reader;
@@ -77,7 +79,7 @@ private:
     size_t _batch_start_idx;
     size_t _chunk_start_idx;
     int _num_of_columns_from_file = 0;
-    std::vector<ConvertFunc> _conv_funcs;
+    std::vector<std::unique_ptr<ConvertFuncTree>> _conv_funcs;
     std::vector<Expr*> _cast_exprs;
     ObjectPool _pool;
     Filter _chunk_filter;

--- a/be/src/exec/parquet_scanner.h
+++ b/be/src/exec/parquet_scanner.h
@@ -58,7 +58,8 @@ public:
                              ConvertFuncTree* conv_func, Expr** expr, ObjectPool& pool, bool strict_mode);
 
     static Status build_dest(const arrow::DataType* arrow_type, const TypeDescriptor* type_desc, bool is_nullable,
-                             TypeDescriptor* raw_type_desc, ConvertFuncTree* conv_func, bool& need_cast, bool strict_mode);
+                             TypeDescriptor* raw_type_desc, ConvertFuncTree* conv_func, bool& need_cast,
+                             bool strict_mode);
 
 private:
     // Read next buffer from reader

--- a/be/src/util/arrow/row_batch.cpp
+++ b/be/src/util/arrow/row_batch.cpp
@@ -45,8 +45,8 @@
 #include <arrow/type.h>
 #include <arrow/visitor.h>
 #include <arrow/visitor_inline.h>
-
 #include <fmt/format.h>
+
 #include <memory>
 
 #include "common/logging.h"

--- a/be/src/util/arrow/row_batch.cpp
+++ b/be/src/util/arrow/row_batch.cpp
@@ -46,6 +46,7 @@
 #include <arrow/visitor.h>
 #include <arrow/visitor_inline.h>
 
+#include <fmt/format.h>
 #include <memory>
 
 #include "common/logging.h"
@@ -103,6 +104,35 @@ Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::
     case TYPE_DECIMAL128:
         *result = std::make_shared<arrow::Decimal128Type>(type.precision, type.scale);
         break;
+    case TYPE_ARRAY: {
+        std::shared_ptr<arrow::DataType> type0;
+        convert_to_arrow_type(type.children[0], &type0);
+        *result = arrow::list(type0);
+        break;
+    }
+    case TYPE_MAP: {
+        std::shared_ptr<arrow::DataType> type0;
+        convert_to_arrow_type(type.children[0], &type0);
+        std::shared_ptr<arrow::DataType> type1;
+        convert_to_arrow_type(type.children[1], &type1);
+        *result = arrow::map(type0, type1);
+        break;
+    }
+    case TYPE_STRUCT: {
+        std::vector<std::shared_ptr<arrow::Field>> fields;
+        if (type.field_names.size() != type.children.size()) {
+            return Status::InternalError(
+                    fmt::format("Struct filed names' size {} mismatch children size {} in convert_to_arrow_type()",
+                                type.field_names.size(), type.children.size()));
+        }
+        for (auto i = 0; i < type.children.size(); ++i) {
+            std::shared_ptr<arrow::DataType> type0;
+            convert_to_arrow_type(type.children[i], &type0);
+            fields.push_back(std::move(arrow::field(type.field_names[i], type0)));
+        }
+        *result = arrow::struct_(fields);
+        break;
+    }
     default:
         return Status::InvalidArgument(strings::Substitute("Unknown logical type($0)", type.type));
     }

--- a/be/src/util/arrow/row_batch.h
+++ b/be/src/util/arrow/row_batch.h
@@ -44,7 +44,7 @@
 // each execute node.
 
 namespace arrow {
-
+class DataType;
 class RecordBatch;
 class Schema;
 
@@ -53,6 +53,8 @@ class Schema;
 namespace starrocks {
 
 class RowDescriptor;
+
+Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::DataType>* result);
 
 // Convert StarRocks RowDescriptor to Arrow Schema.
 Status convert_to_arrow_schema(const RowDescriptor& row_desc,

--- a/be/test/exec/arrow_converter_test.cpp
+++ b/be/test/exec/arrow_converter_test.cpp
@@ -30,6 +30,7 @@
 #include "exec/arrow_to_starrocks_converter.h"
 #include "exec/parquet_scanner.h"
 #include "runtime/datetime_value.h"
+#include "util/arrow/row_batch.h"
 
 #define ASSERT_STATUS_OK(stmt)    \
     do {                          \
@@ -43,6 +44,16 @@ class ArrowConverterTest : public ::testing::Test {
 public:
     void SetUp() override { date::init_date_cache(); }
 };
+
+std::tuple<bool, Status> get_conv_func(const TypeDescriptor& type, const TypeDescriptor& to_arrow_type,
+                                       ConvertFuncTree& cf, bool is_nullable = false) {
+    std::shared_ptr<arrow::DataType> arrow_type;
+    convert_to_arrow_type(to_arrow_type, &arrow_type);
+    TypeDescriptor raw_type;
+    bool need_cast;
+    auto st = ParquetScanner::build_dest(arrow_type.get(), &type, is_nullable, &raw_type, &cf, need_cast, false);
+    return {need_cast, st};
+}
 
 template <typename ArrowType, bool is_nullable = false, typename CType = typename arrow::TypeTraits<ArrowType>::CType,
           typename BuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType>
@@ -1340,7 +1351,7 @@ PARALLEL_TEST(ArrowConverterTest, test_map_to_json) {
 }
 
 static std::shared_ptr<arrow::Array> create_list_array(int64_t num_elements, ssize_t& counter, bool add_null = false) {
-    auto value_builder = std::make_shared<arrow::UInt64Builder>();
+    auto value_builder = std::make_shared<arrow::Int32Builder>();
     int fix_size = 10;
     arrow::TypeTraits<arrow::FixedSizeListType>::BuilderType builder(arrow::default_memory_pool(), value_builder,
                                                                      fix_size);
@@ -1359,25 +1370,55 @@ static std::shared_ptr<arrow::Array> create_list_array(int64_t num_elements, ssi
 
 PARALLEL_TEST(ArrowConverterTest, test_convert_list_array) {
     TypeDescriptor array_type(TYPE_ARRAY);
-    array_type.children.push_back(TypeDescriptor(LogicalType::TYPE_BIGINT));
+    array_type.children.push_back(TypeDescriptor(LogicalType::TYPE_INT));
+
+    ConvertFuncTree cf;
+    auto [need_cast, st] = get_conv_func(array_type, array_type, cf);
+    ASSERT_STATUS_OK(st);
+    ASSERT_FALSE(need_cast);
+
     auto column = ColumnHelper::create_column(array_type, false);
     column->reserve(4096);
     ssize_t counter = 0;
     int num = 100;
     auto array = create_list_array(num, counter);
-    auto conv_func = get_arrow_converter(ArrowTypeId::LIST, TYPE_ARRAY, false, false);
-    ASSERT_TRUE(conv_func != nullptr);
     ASSERT_EQ(num, counter);
     Filter filter;
     filter.resize(array->length() + column->size(), 1);
-    ASSERT_STATUS_OK(conv_func(array.get(), 0, array->length(), column.get(), column->size(), nullptr, &filter, nullptr,
-                               &array_type));
+    ASSERT_STATUS_OK(
+            cf.func(array.get(), 0, array->length(), column.get(), column->size(), nullptr, &filter, nullptr, &cf));
+    ASSERT_EQ(column->size(), 10);
+}
+
+PARALLEL_TEST(ArrowConverterTest, test_convert_list_array_cast) {
+    TypeDescriptor array_type(TYPE_ARRAY);
+    array_type.children.push_back(TypeDescriptor(LogicalType::TYPE_INT));
+    std::shared_ptr<arrow::DataType> arrow_type;
+    convert_to_arrow_type(array_type, &arrow_type);
+    array_type.children[0].type = LogicalType::TYPE_FLOAT; // hack type here
+    TypeDescriptor raw_type;
+    ConvertFuncTree cf;
+    bool need_cast;
+    auto st = ParquetScanner::build_dest(arrow_type.get(), &array_type, false, &raw_type, &cf, need_cast, false);
+    ASSERT_STATUS_OK(st);
+    ASSERT_TRUE(need_cast);
+    ASSERT_EQ(raw_type.children[0].type, LogicalType::TYPE_INT);
+    auto column = ColumnHelper::create_column(raw_type, false);
+    column->reserve(4096);
+    ssize_t counter = 0;
+    int num = 100;
+    auto array = create_list_array(num, counter);
+    ASSERT_EQ(num, counter);
+    Filter filter;
+    filter.resize(array->length() + column->size(), 1);
+    ASSERT_STATUS_OK(
+            cf.func(array.get(), 0, array->length(), column.get(), column->size(), nullptr, &filter, nullptr, &cf));
     ASSERT_EQ(column->size(), 10);
 }
 
 static std::shared_ptr<arrow::Array> create_nest_list_array(int64_t num_parents, int64_t num_children,
                                                             int64_t num_child_values, ssize_t& counter) {
-    auto value_builder = std::make_shared<arrow::UInt64Builder>();
+    auto value_builder = std::make_shared<arrow::Int64Builder>();
     auto builder = std::make_shared<arrow::FixedSizeListBuilder>(arrow::default_memory_pool(), value_builder,
                                                                  num_child_values);
     arrow::TypeTraits<arrow::FixedSizeListType>::BuilderType builder1(arrow::default_memory_pool(), builder,
@@ -1402,35 +1443,42 @@ PARALLEL_TEST(ArrowConverterTest, test_convert_nest_list_array) {
     TypeDescriptor array_type(TYPE_ARRAY);
     array_type.children.push_back(array_type0);
 
+    ConvertFuncTree cf;
+    auto [need_cast, st] = get_conv_func(array_type, array_type, cf);
+    ASSERT_STATUS_OK(st);
+    ASSERT_FALSE(need_cast);
+
     auto column = ColumnHelper::create_column(array_type, false);
     column->reserve(4096);
     ssize_t counter = 0;
     auto array = create_nest_list_array(10, 2, 5, counter);
-    auto conv_func = get_arrow_converter(ArrowTypeId::LIST, TYPE_ARRAY, false, false);
-    ASSERT_TRUE(conv_func != nullptr);
     ASSERT_EQ(10 * 2 * 5, counter);
     Filter filter;
     filter.resize(array->length() + column->size(), 1);
-    ASSERT_STATUS_OK(conv_func(array.get(), 0, array->length(), column.get(), column->size(), nullptr, &filter, nullptr,
-                               &array_type));
+    ASSERT_STATUS_OK(
+            cf.func(array.get(), 0, array->length(), column.get(), column->size(), nullptr, &filter, nullptr, &cf));
     ASSERT_EQ(column->size(), 10);
 }
 
 PARALLEL_TEST(ArrowConverterTest, test_convert_nullable_list_array) {
     TypeDescriptor array_type(TYPE_ARRAY);
-    array_type.children.push_back(TypeDescriptor(LogicalType::TYPE_BIGINT));
+    array_type.children.push_back(TypeDescriptor(LogicalType::TYPE_INT));
+
+    ConvertFuncTree cf;
+    auto [need_cast, st] = get_conv_func(array_type, array_type, cf, true);
+    ASSERT_STATUS_OK(st);
+    ASSERT_FALSE(need_cast);
+
     auto column = ColumnHelper::create_column(array_type, true);
     column->reserve(4096);
     ssize_t counter = 0;
     int num = 100;
     auto array = create_list_array(num, counter, true);
-    auto conv_func = get_arrow_converter(ArrowTypeId::LIST, TYPE_ARRAY, true, false);
-    ASSERT_TRUE(conv_func != nullptr);
     ASSERT_EQ(num, counter);
     Filter filter;
     filter.resize(array->length() + column->size(), 1);
-    ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(conv_func, array->length(), array.get(), &array_type,
-                                                             column, 0, column->size(), &filter, nullptr));
+    ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(&cf, array->length(), array.get(), column, 0,
+                                                             column->size(), &filter, nullptr));
     ASSERT_EQ(column->size(), 20);
     ASSERT_EQ(down_cast<NullableColumn*>(column.get())->null_count(), 10);
 }
@@ -1439,13 +1487,14 @@ void convert_arrow_map_to_map_column(Column* column, size_t num_elements, const 
                                      size_t& counter, const TypeDescriptor& type) {
     ASSERT_EQ(column->size(), counter);
     auto array = create_map_array(num_elements, value, counter);
-    auto conv_func = get_arrow_converter(ArrowTypeId::MAP, TYPE_MAP, false, false);
-    ASSERT_TRUE(conv_func != nullptr);
+    ConvertFuncTree cf;
+    auto [need_cast, st] = get_conv_func(type, type, cf);
+    ASSERT_STATUS_OK(st);
+    ASSERT_FALSE(need_cast);
 
     Filter filter;
     filter.resize(array->length() + column->size(), 1);
-    ASSERT_STATUS_OK(
-            conv_func(array.get(), 0, array->length(), column, column->size(), nullptr, &filter, nullptr, &type));
+    ASSERT_STATUS_OK(cf.func(array.get(), 0, array->length(), column, column->size(), nullptr, &filter, nullptr, &cf));
     ASSERT_EQ(column->size(), counter);
 }
 
@@ -1480,13 +1529,15 @@ PARALLEL_TEST(ArrowConverterTest, test_convert_nullable_map) {
     };
     int num_elements = 10;
     auto array = create_map_array(num_elements, map_value, counter, true);
-    auto conv_func = get_arrow_converter(ArrowTypeId::MAP, TYPE_MAP, true, false);
-    ASSERT_TRUE(conv_func != nullptr);
+    ConvertFuncTree cf;
+    auto [need_cast, st] = get_conv_func(map_type, map_type, cf, true);
+    ASSERT_STATUS_OK(st);
+    ASSERT_FALSE(need_cast);
 
     Filter filter;
     filter.resize(array->length() + map_column->size(), 1);
-    ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(conv_func, array->length(), array.get(), &map_type,
-                                                             map_column, 0, map_column->size(), &filter, nullptr));
+    ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(&cf, array->length(), array.get(), map_column, 0,
+                                                             map_column->size(), &filter, nullptr));
     ASSERT_EQ(map_column->size(), counter);
     ASSERT_EQ(down_cast<NullableColumn*>(map_column.get())->null_count(), num_elements);
     ASSERT_EQ(map_column->debug_item(0), "{'haha':2,'haha':2,'hehe':1,'hehe':1}");
@@ -1505,13 +1556,16 @@ PARALLEL_TEST(ArrowConverterTest, test_convert_struct) {
     auto st_col = ColumnHelper::create_column(struct_type, true);
 
     auto array = create_struct_array(10, false);
-    auto conv_func = get_arrow_converter(ArrowTypeId::STRUCT, TYPE_STRUCT, true, false);
-    ASSERT_TRUE(conv_func != nullptr);
+
+    ConvertFuncTree cf;
+    auto [need_cast, st] = get_conv_func(struct_type, struct_type, cf, true);
+    ASSERT_STATUS_OK(st);
+    ASSERT_FALSE(need_cast);
 
     Filter filter;
     filter.resize(array->length(), 1);
-    ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(conv_func, array->length(), array.get(), &struct_type,
-                                                             st_col, 0, st_col->size(), &filter, nullptr));
+    ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(&cf, array->length(), array.get(), st_col, 0,
+                                                             st_col->size(), &filter, nullptr));
     ASSERT_EQ(st_col->size(), 10);
     ASSERT_EQ(down_cast<NullableColumn*>(st_col.get())->null_count(), 0);
 
@@ -1532,13 +1586,15 @@ PARALLEL_TEST(ArrowConverterTest, test_convert_struct_null) {
     auto st_col = ColumnHelper::create_column(struct_type, true);
 
     auto array = create_struct_array(10, true);
-    auto conv_func = get_arrow_converter(ArrowTypeId::STRUCT, TYPE_STRUCT, true, false);
-    ASSERT_TRUE(conv_func != nullptr);
+    ConvertFuncTree cf;
+    auto [need_cast, st] = get_conv_func(struct_type, struct_type, cf, true);
+    ASSERT_STATUS_OK(st);
+    ASSERT_FALSE(need_cast);
 
     Filter filter;
     filter.resize(array->length(), 1);
-    ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(conv_func, array->length(), array.get(), &struct_type,
-                                                             st_col, 0, st_col->size(), &filter, nullptr));
+    ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(&cf, array->length(), array.get(), st_col, 0,
+                                                             st_col->size(), &filter, nullptr));
     ASSERT_EQ(st_col->size(), 10);
     ASSERT_EQ(down_cast<NullableColumn*>(st_col.get())->null_count(), 5);
     ASSERT_EQ(st_col->debug_item(0), "NULL");
@@ -1559,16 +1615,27 @@ PARALLEL_TEST(ArrowConverterTest, test_convert_struct_less_column) {
     struct_type.field_names.emplace_back("col3");
     struct_type.field_names.emplace_back("col4");
 
-    auto st_col = ColumnHelper::create_column(struct_type, true);
+    TypeDescriptor struct_type1(TYPE_STRUCT);
+    struct_type1.children.emplace_back(TYPE_INT);
+    struct_type1.children.emplace_back(TYPE_VARCHAR);
+    struct_type1.children.emplace_back(TYPE_INT);
+
+    struct_type1.field_names.emplace_back("col1");
+    struct_type1.field_names.emplace_back("col2");
+    struct_type1.field_names.emplace_back("col3");
 
     auto array = create_struct_array(10, true);
-    auto conv_func = get_arrow_converter(ArrowTypeId::STRUCT, TYPE_STRUCT, true, false);
-    ASSERT_TRUE(conv_func != nullptr);
+    ConvertFuncTree cf;
+    auto [need_cast, st] = get_conv_func(struct_type, struct_type1, cf, true);
+    ASSERT_STATUS_OK(st);
+    ASSERT_FALSE(need_cast);
+
+    auto st_col = ColumnHelper::create_column(struct_type, true);
 
     Filter filter;
     filter.resize(array->length(), 1);
-    ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(conv_func, array->length(), array.get(), &struct_type,
-                                                             st_col, 0, st_col->size(), &filter, nullptr));
+    ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(&cf, array->length(), array.get(), st_col, 0,
+                                                             st_col->size(), &filter, nullptr));
     ASSERT_EQ(st_col->size(), 10);
     ASSERT_EQ(down_cast<NullableColumn*>(st_col.get())->null_count(), 5);
     ASSERT_EQ(st_col->debug_item(3), "{col1:3,col2:'char-3',col3:30,col4:NULL}");
@@ -1586,13 +1653,15 @@ PARALLEL_TEST(ArrowConverterTest, test_convert_struct_more_column) {
     auto st_col = ColumnHelper::create_column(struct_type, true);
 
     auto array = create_struct_array(10, false);
-    auto conv_func = get_arrow_converter(ArrowTypeId::STRUCT, TYPE_STRUCT, true, false);
-    ASSERT_TRUE(conv_func != nullptr);
+    ConvertFuncTree cf;
+    auto [need_cast, st] = get_conv_func(struct_type, struct_type, cf, true);
+    ASSERT_STATUS_OK(st);
+    ASSERT_FALSE(need_cast);
 
     Filter filter;
     filter.resize(array->length(), 1);
-    ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(conv_func, array->length(), array.get(), &struct_type,
-                                                             st_col, 0, st_col->size(), &filter, nullptr));
+    ASSERT_STATUS_OK(ParquetScanner::convert_array_to_column(&cf, array->length(), array.get(), st_col, 0,
+                                                             st_col->size(), &filter, nullptr));
     ASSERT_EQ(st_col->size(), 10);
     ASSERT_EQ(down_cast<NullableColumn*>(st_col.get())->null_count(), 0);
     ASSERT_EQ(st_col->debug_item(0), "{col1:0,col2:'char-0'}");


### PR DESCRIPTION
read compatible data types for parquet, for example cast int to char or boolean.
```
mysql> Create table tmapp ( c1 int, c2 map<string, boolean>,c3 map<string,map<string, float>>,c4 map<string, array<string>>) ENGINE=OLAP DUPLICATE KEY(c1)  DISTRIBUTED BY HASH(c1) BUCKETS 2 PROPERTIES("replication_num" = "1");
Query OK, 0 rows affected (0.00 sec)

mysql> LOAD LABEL tmapp2(DATA INFILE("hdfs://172.26.194.238:9000/starrocks/test_data/map/file_reader_test_map.parquet") INTO TABLE tmapp FORMAT AS "parquet" (c1,c2,c3,c4))WITH BROKER;
Query OK, 0 rows affected (0.01 sec)

mysql> SHOW LOAD where label =  "tmapp2";
+-------+--------+----------+---------------------+--------+----------+----------+--------------+----------------+----------+---------+------------------------------------------------------+----------+---------------------+---------------------+---------------------+---------------------+---------------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| JobId | Label  | State    | Progress            | Type   | Priority | ScanRows | FilteredRows | UnselectedRows | SinkRows | EtlInfo | TaskInfo                                             | ErrorMsg | CreateTime          | EtlStartTime        | EtlFinishTime       | LoadStartTime       | LoadFinishTime      | TrackingSQL | JobDetails                                                                                                                                                                                                                                                              |
+-------+--------+----------+---------------------+--------+----------+----------+--------------+----------------+----------+---------+------------------------------------------------------+----------+---------------------+---------------------+---------------------+---------------------+---------------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 85146 | tmapp2 | FINISHED | ETL:100%; LOAD:100% | BROKER | NORMAL   | 8        | 0            | 0              | 8        | NULL    | resource:N/A; timeout(s):14400; max_filter_ratio:0.0 | NULL     | 2023-06-20 09:59:02 | 2023-06-20 09:59:04 | 2023-06-20 09:59:04 | 2023-06-20 09:59:04 | 2023-06-20 09:59:04 |             | {"All backends":{"8d5574ac-a379-489a-ae16-3e267e0c206a":[10006]},"FileNumber":1,"FileSize":1727,"InternalTableLoadBytes":1098,"InternalTableLoadRows":8,"ScanBytes":1727,"ScanRows":8,"TaskNumber":1,"Unfinished backends":{"8d5574ac-a379-489a-ae16-3e267e0c206a":[]}} |
+-------+--------+----------+---------------------+--------+----------+----------+--------------+----------------+----------+---------+------------------------------------------------------+----------+---------------------+---------------------+---------------------+---------------------+---------------------+-------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql> select * from tmapp;
+------+------------------------+---------------------------------------------+-------------------------+
| c1   | c2                     | c3                                          | c4                      |
+------+------------------------+---------------------------------------------+-------------------------+
|    3 | {"k2":1,"k3":1,"k5":1} | {"e1":{"f1":1,"f2":2,"f3":3}}               | {"g1":["1","2","3"]}    |
|    5 | {"k3":1}               | {"e2":{"f2":2}}                             | {"g1":[null]}           |
|    6 | {"k1":null}            | {"e2":{"f2":null}}                          | {"g1":["1"]}            |
|    1 | {"k1":0,"k2":1}        | {"e1":{"f1":1,"f2":2}}                      | {"g1":["1","2"]}        |
|    2 | {"k1":1,"k3":1,"k4":1} | {"e1":{"f1":1,"f2":2},"e2":{"f1":1,"f2":2}} | {"g1":["1"],"g3":["2"]} |
|    4 | {"k1":1,"k2":1,"k3":1} | {"e2":{"f2":2}}                             | {"g1":["1"]}            |
|    7 | {"k1":1,"k2":1}        | {"e2":{"f2":2}}                             | {"g1":["1","2","3"]}    |
|    8 | {"k3":1}               | {"e1":{"f1":1,"f2":2,"f3":3}}               | {"g2":["1"],"g3":["2"]} |
+------+------------------------+---------------------------------------------+-------------------------+
8 rows in set (0.02 sec)

```

raw parquet schema
```
c1: int32
c2: map<string, int32>
c3: map<string, map<string, int32>>
c4: map<string, list<array_element: int32>>

```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
