### PR TITLE
[BugFix] Fix arrow parquet exception handling

### DIFF
--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -377,11 +377,7 @@ Status SyncFileWriter::_flush_row_group() {
             _chunk_writer->close();
         } catch (const ::parquet::ParquetStatusException& e) {
             _chunk_writer.reset();
-
-            // this is to avoid calling ParquetFileWriter.Close which incurs segfault
             _closed = true;
-            _writer.release();
-
             auto st = Status::IOError(fmt::format("{}: {}", "flush rowgroup error", e.what()));
             LOG(WARNING) << st;
             return st;

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -483,6 +483,7 @@ if [[ -d $TP_SOURCE_DIR/$ARROW_SOURCE ]] ; then
         patch -p1 < $TP_PATCH_DIR/arrow-5.0.0-force-use-external-jemalloc.patch
         touch $PATCHED_MARK
     fi
+    # fix arrow parquet exception handling
     if [ ! -f $PATCHED_MARK ] && [ $ARROW_SOURCE = "arrow-apache-arrow-5.0.0" ] ; then
         patch -p1 < $TP_PATCH_DIR/arrow-5.0.0-fix-exception-handling.patch
         touch $PATCHED_MARK

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -475,11 +475,16 @@ fi
 echo "Finished patching $SERDES_SOURCE"
 cd -
 
-# patch arrows to use our built jemalloc
+# patch arrows
 if [[ -d $TP_SOURCE_DIR/$ARROW_SOURCE ]] ; then
     cd $TP_SOURCE_DIR/$ARROW_SOURCE
+    # use our built jemalloc
     if [ ! -f $PATCHED_MARK ] && [ $ARROW_SOURCE = "arrow-apache-arrow-5.0.0" ] ; then
         patch -p1 < $TP_PATCH_DIR/arrow-5.0.0-force-use-external-jemalloc.patch
+        touch $PATCHED_MARK
+    fi
+    if [ ! -f $PATCHED_MARK ] && [ $ARROW_SOURCE = "arrow-apache-arrow-5.0.0" ] ; then
+        patch -p1 < $TP_PATCH_DIR/arrow-5.0.0-fix-exception-handling.patch
         touch $PATCHED_MARK
     fi
     cd -

--- a/thirdparty/patches/arrow-5.0.0-fix-exception-handling.patch
+++ b/thirdparty/patches/arrow-5.0.0-fix-exception-handling.patch
@@ -1,0 +1,21 @@
+diff --git a/cpp/src/parquet/file_writer.cc b/cpp/src/parquet/file_writer.cc
+index deac9586e..836f9e93c 100644
+--- a/cpp/src/parquet/file_writer.cc
++++ b/cpp/src/parquet/file_writer.cc
+@@ -181,15 +181,13 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
+       closed_ = true;
+       CheckRowsWritten();
+ 
++      auto column_writers = std::move(column_writers_);
+       for (size_t i = 0; i < column_writers_.size(); i++) {
+         if (column_writers_[i]) {
+           total_bytes_written_ += column_writers_[i]->Close();
+-          column_writers_[i].reset();
+         }
+       }
+ 
+-      column_writers_.clear();
+-
+       // Ensures all columns have been written
+       metadata_->set_num_rows(num_rows_);
+       metadata_->Finish(total_bytes_written_, row_group_ordinal_);


### PR DESCRIPTION
Fixes #23606, where memory leaks are introduced by `_chunk_writer->release()`

The modification on Arrow is to make sure `RowGroupSerializer::column_writers_` is cleaned up even if exception throws.

You may refer https://github.com/apache/arrow/pull/35520 for more details.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
