### PR TITLE
[Enhancement][Cherry-Pick][Branch-3.0] Support delete sql for primary key table with sort key (#22799)

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -217,8 +217,7 @@ Status DeltaWriter::_init() {
         std::sort(sort_key_idxes.begin(), sort_key_idxes.end());
         if (!std::includes(writer_context.referenced_column_ids.begin(), writer_context.referenced_column_ids.end(),
                            sort_key_idxes.begin(), sort_key_idxes.end())) {
-            LOG(WARNING) << "table with sort key do not support partial update";
-            return Status::NotSupported("table with sort key do not support partial update");
+            _partial_schema_with_sort_key = true;
         }
         writer_context.tablet_schema = writer_context.partial_update_tablet_schema.get();
     } else {
@@ -297,8 +296,25 @@ void DeltaWriter::_set_state(State state, const Status& st) {
     }
 }
 
+Status DeltaWriter::_check_partial_update_with_sort_key(const Chunk& chunk) {
+    if (_tablet->updates() != nullptr && _partial_schema_with_sort_key && _opt.slots != nullptr &&
+        _opt.slots->back()->col_name() == "__op") {
+        size_t op_column_id = chunk.num_columns() - 1;
+        auto op_column = chunk.get_column_by_index(op_column_id);
+        auto* ops = reinterpret_cast<const uint8_t*>(op_column->raw_data());
+        for (size_t i = 0; i < chunk.num_rows(); i++) {
+            if (ops[i] == TOpType::UPSERT) {
+                LOG(WARNING) << "table with sort key do not support partial update";
+                return Status::NotSupported("table with sort key do not support partial update");
+            }
+        }
+    }
+    return Status::OK();
+}
+
 Status DeltaWriter::write(const Chunk& chunk, const uint32_t* indexes, uint32_t from, uint32_t size) {
     SCOPED_THREAD_LOCAL_MEM_SETTER(_mem_tracker, false);
+    RETURN_IF_ERROR(_check_partial_update_with_sort_key(chunk));
     // Delay the creation memtables until we write data.
     // Because for the tablet which doesn't have any written data, we will not use their memtables.
     if (_mem_table == nullptr) {
@@ -439,6 +455,7 @@ void DeltaWriter::_reset_mem_table() {
                                                 _mem_table_sink.get(), "", _mem_tracker);
     }
     _mem_table->set_write_buffer_row(_memtable_buffer_row);
+    _mem_table->set_partial_schema_with_sort_key(_partial_schema_with_sort_key);
 }
 
 Status DeltaWriter::commit() {

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -153,6 +153,7 @@ private:
     const char* _state_name(State state) const;
     const char* _replica_state_name(ReplicaState state) const;
     Status _fill_auto_increment_id(const Chunk& chunk);
+    Status _check_partial_update_with_sort_key(const Chunk& chunk);
 
     void _garbage_collection();
 
@@ -183,6 +184,7 @@ private:
     bool _with_rollback_log;
     // initial value is max value
     size_t _memtable_buffer_row = -1;
+    bool _partial_schema_with_sort_key = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -64,6 +64,10 @@ public:
 
     void set_write_buffer_row(size_t max_buffer_row) { _max_buffer_row = max_buffer_row; }
 
+    void set_partial_schema_with_sort_key(bool partial_schema_with_sort_key) {
+        _partial_schema_with_sort_key = partial_schema_with_sort_key;
+    }
+
     static Schema convert_schema(const TabletSchema* tablet_schema, const std::vector<SlotDescriptor*>* slot_descs);
 
     ChunkPtr get_result_chunk() { return _result_chunk; }
@@ -120,6 +124,7 @@ private:
     size_t _chunk_bytes_usage = 0;
     size_t _aggregator_memory_usage = 0;
     size_t _aggregator_bytes_usage = 0;
+    bool _partial_schema_with_sort_key = false;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const MemTable& table) {


### PR DESCRIPTION
Primary key table with sort key does not support partial update so far, so we need to provide all columns data when we doing data import. But the delete sql only provide primary key columns and the delete request will be reject because the request is consider as partial update request. This pr will support the delete request for primary key table with sort key.
