### PR TITLE
[Enhancement][Cherry-pick][Branch-2.5] Support delete sql for primary key table with sort key (#22799)

### DIFF
--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -141,6 +141,7 @@ private:
     Status _flush_memtable();
     const char* _state_name(State state) const;
     const char* _replica_state_name(ReplicaState state) const;
+    Status _check_partial_update_with_sort_key(const Chunk& chunk);
 
     void _garbage_collection();
 
@@ -171,6 +172,7 @@ private:
     bool _with_rollback_log;
     // initial value is max value
     size_t _memtable_buffer_row = -1;
+    bool _partial_schema_with_sort_key = false;
 };
 
 } // namespace vectorized

--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -54,6 +54,10 @@ public:
 
     void set_write_buffer_row(size_t max_buffer_row) { _max_buffer_row = max_buffer_row; }
 
+    void set_partial_schema_with_sort_key(bool partial_schema_with_sort_key) {
+        _partial_schema_with_sort_key = partial_schema_with_sort_key;
+    }
+
     static Schema convert_schema(const TabletSchema* tablet_schema, const std::vector<SlotDescriptor*>* slot_descs);
 
 private:
@@ -108,6 +112,7 @@ private:
     size_t _chunk_bytes_usage = 0;
     size_t _aggregator_memory_usage = 0;
     size_t _aggregator_bytes_usage = 0;
+    bool _partial_schema_with_sort_key = false;
 };
 
 } // namespace vectorized


### PR DESCRIPTION
Primary key table with sort key does not support partial update so far, so we need to provide all columns data when we doing data import. But the delete sql only provide primary key columns and the delete request will be reject because the request is consider as partial update request. This pr will support the delete request for primary key table with sort key.
