### PR TITLE
[Enhancement] Add retry operation when getting kafka info time out

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -186,16 +186,23 @@ public class KafkaUtil {
                 address = new TNetworkAddress(be.getHost(), be.getBrpcPort());
 
                 // get info
-                request.timeout = Config.routine_load_kafka_timeout_second;
-                Future<PProxyResult> future = BackendServiceClient.getInstance().getInfo(address, request);
-                PProxyResult result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
-                TStatusCode code = TStatusCode.findByValue(result.status.statusCode);
-                if (code != TStatusCode.OK) {
-                    LOG.warn("failed to send proxy request to " + address + " err " + result.status.errorMsgs);
-                    throw new UserException(
-                            "failed to send proxy request to " + address + " err " + result.status.errorMsgs);
-                } else {
-                    return result;
+                int retryTimes = 0;
+                while (true) {
+                    request.timeout = Config.routine_load_kafka_timeout_second;
+                    Future<PProxyResult> future = BackendServiceClient.getInstance().getInfo(address, request);
+                    PProxyResult result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
+                    TStatusCode code = TStatusCode.findByValue(result.status.statusCode);
+                    if (code != TStatusCode.OK) {
+                        LOG.warn("failed to send proxy request to " + address + " err " + result.status.errorMsgs);
+                        // When getting kafka info timed out, we tried again three times.
+                        if (++retryTimes > 3 || (retryTimes + 1) * Config.routine_load_kafka_timeout_second >
+                                                                        Config.routine_load_task_timeout_second) {
+                            throw new UserException(
+                                    "failed to send proxy request to " + address + " err " + result.status.errorMsgs);
+                        }
+                    } else {
+                        return result;
+                    }
                 }
             } catch (InterruptedException ie) {
                 LOG.warn("got interrupted exception when sending proxy request to " + address);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -194,14 +194,18 @@ public class KafkaUtil {
                     PProxyResult result;
                     try {
                         result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
-                    } catch (TimeoutException e) {
+                    } catch (Exception e) {
                         LOG.warn("failed to send proxy request to " + address + " err " + e.getMessage());
-                        // When getting kafka info timed out, we tried again three times.
-                        if (++retryTimes > 3 || (retryTimes + 1) * Config.routine_load_kafka_timeout_second >
-                                                                        Config.routine_load_task_timeout_second) {
+                        if (e instanceof TimeoutException) {
+                            // When getting kafka info timed out, we tried again three times.
+                            if (++retryTimes > 3 || (retryTimes + 1) * Config.routine_load_kafka_timeout_second >
+                                                                            Config.routine_load_task_timeout_second) {
+                                throw e;
+                            }
+                            continue;
+                        } else {
                             throw e;
                         }
-                        continue;
                     }
                     TStatusCode code = TStatusCode.findByValue(result.status.statusCode);
                     if (code != TStatusCode.OK) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class KafkaUtil {
     private static final Logger LOG = LogManager.getLogger(KafkaUtil.class);
@@ -190,16 +191,23 @@ public class KafkaUtil {
                 while (true) {
                     request.timeout = Config.routine_load_kafka_timeout_second;
                     Future<PProxyResult> future = BackendServiceClient.getInstance().getInfo(address, request);
-                    PProxyResult result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
-                    TStatusCode code = TStatusCode.findByValue(result.status.statusCode);
-                    if (code != TStatusCode.OK) {
-                        LOG.warn("failed to send proxy request to " + address + " err " + result.status.errorMsgs);
+                    PProxyResult result;
+                    try {
+                        result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
+                    } catch (TimeoutException e) {
+                        LOG.warn("failed to send proxy request to " + address + " err " + e.getMessage());
                         // When getting kafka info timed out, we tried again three times.
                         if (++retryTimes > 3 || (retryTimes + 1) * Config.routine_load_kafka_timeout_second >
                                                                         Config.routine_load_task_timeout_second) {
-                            throw new UserException(
-                                    "failed to send proxy request to " + address + " err " + result.status.errorMsgs);
+                            throw e;
                         }
+                        continue;
+                    }
+                    TStatusCode code = TStatusCode.findByValue(result.status.statusCode);
+                    if (code != TStatusCode.OK) {
+                        LOG.warn("failed to send proxy request to " + address + " err " + result.status.errorMsgs);
+                        throw new UserException(
+                                "failed to send proxy request to " + address + " err " + result.status.errorMsgs);
                     } else {
                         return result;
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -61,7 +61,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class KafkaUtil {
     private static final Logger LOG = LogManager.getLogger(KafkaUtil.class);
@@ -196,7 +195,9 @@ public class KafkaUtil {
                         result = future.get(Config.routine_load_kafka_timeout_second, TimeUnit.SECONDS);
                     } catch (Exception e) {
                         LOG.warn("failed to send proxy request to " + address + " err " + e.getMessage());
-                        if (e instanceof TimeoutException) {
+                        // Jprotobuf-rpc-socket throws an ExecutionException when an exception occurs.
+                        // We use the error message to identify the type of exception.
+                        if (e.getMessage().contains("Ocurrs time out")) {
                             // When getting kafka info timed out, we tried again three times.
                             if (++retryTimes > 3 || (retryTimes + 1) * Config.routine_load_kafka_timeout_second >
                                                                             Config.routine_load_task_timeout_second) {


### PR DESCRIPTION
Fixes #issue
Add retry operation to avoid the routine load job be paused when getting kafka info timeout.
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
