### PR TITLE
[Enhancement] Switching from independently driven polling by a separate thread to polling driven by workers

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -84,7 +84,8 @@ public:
 private:
     using Base = FactoryMethod<DriverExecutor, GlobalDriverExecutor>;
     void _worker_thread();
-    StatusOr<DriverRawPtr> _get_next_driver(std::queue<DriverRawPtr>& local_driver_queue);
+    StatusOr<DriverRawPtr> _get_next_driver();
+    StatusOr<DriverRawPtr> _get_next_driver(bool block);
     void _finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state);
     void _update_profile_by_level(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool done);
     void _remove_non_core_metrics(QueryContext* query_ctx, std::vector<RuntimeProfile*>& driver_profiles);


### PR DESCRIPTION
## Background

Pipeline execution engine uses poller-driven mode, which will perform periodic polling over the blocked driver queue. And in order to get lowest latency, there is no interval between two consecutive polling. But this approach will cause a problem, that the poller thread will always occupy one cpu with 100% utilization, which is unnecessary and will reduce the overall execution performance.

## Enhancement

Based on the observation that it's unnecessary to poll drivers while all workers are busy processing driver. We can switch from indenpendently driven polling by a separate thread to polling driver by workers.

The main process are displayed in the pseudo code down below:

```
// Worker's main process
while(true) {​
    tryPollingBlockedDriverQueue(once=true);​
    Driver driver = tryGetFromReadyQueue();​
    if (driver == null) {​
        // Current thread observes that the ready queue is empty​
        if(tryPollingBlockedDriverQueue(once=false)) {​
            continue;​
        } else {​
            driver = blockGetFromReadyQueue();​
        }​
    }​
    driver.execute();
}
```

Where:
1. `tryPollingBlockedDriverQueue`: try to trigger polling in a preemptive manner.
    * return `true` means successful preemption, otherwise failure.
    * `once=true`: only polling for one time.
    * `once=false`: polling drivers until at least one blocked driver becomes ready.
2.  `tryGetFromReadyQueue`: try to get a driver from ready queue in non-block manner.
3.  `blockGetFromReadyQueue`: try to get a driver form ready queue in a block manner.

## Experiment

Here's expectation:
* For low concurrency scenerio: there is no performance reduction.
* For high concurrency scenerio: we can see some performance improvement.

### machine specification 16c/64g

**Env**
* 1fe/3be with 16c/64G
* tpch-100g

**Outcomes of low concurrency scenerio:**

| Query | before | after | diff(after-before) |
|:-----:|:------:|:-----:|:-----------------:|
|   Q1  |  1952  |  1907 |        -45        |
|   Q2  |   240  |  244  |        +4         |
|   Q3  |  1322  |  1326 |        +4         |
|   Q4  |   508  |  498  |       -10         |
|   Q5  |  1324  |  1286 |       -38         |
|   Q6  |   78   |   79  |        +1         |
|   Q7  |  958   |  935  |       -23         |
|   Q8  |  821   |  802  |       -19         |
|   Q9  |  2920  |  2928 |        +8         |
|  Q10  |  3825  |  3923 |       +98         |
|  Q11  |  197   |  204  |        +7         |
|  Q12  |  210   |  205  |        -5         |
|  Q13  |  1784  |  1842 |       +58         |
|  Q14  |   162  |  161  |        -1         |
|  Q15  |   12   |   12  |        +0         |
|  Q16  |  418   |  402  |       -16         |
|  Q17  |  415   |  402  |       -13         |
|  Q18  |  3070  |  2947 |      -123         |
|  Q19  |  701   |  616  |       -85         |
|  Q20  |  241   |  228  |       -13         |
|  Q21  |  1655  |  1589 |       -66         |
|  Q22  |  379   |  380  |        +1         |

---

**Outcomes of high concurrency scenerio:**

```sh
mysqlslap -u root -h 127.0.0.1 -P 9030 \
     --concurrency=5 \
     --number-of-queries=1000 \
     --create-schema=tpch_100g \
     --delimiter=";" \
     --query="q06.sql"
```

<table>
  <tr>
    <th>Query</th>
    <th>concurrency</th>
    <th>before</th>
    <th>after</th>
    <th>diff</th>
  </tr>
  <tr>
    <td rowspan="5">Q1(-n=100)</td>
    <td>5</td>
    <td>191.406s</td>
    <td>191.588s</td>
    <td>+0.182s</td>
  </tr>
  <tr>
    <td>10</td>
    <td>192.260s</td>
    <td>191.919s</td>
    <td>-0.341s</td>
  </tr>
  <tr>
    <td>20</td>
    <td>197.143s</td>
    <td>194.379s</td>
    <td>-2.764s</td>
  </tr>
  <tr>
    <td>50</td>
    <td>OOM</td>
    <td>OOM</td>
    <td>\</td>
  </tr>
  <tr>
    <td>100</td>
    <td>OOM</td>
    <td>OOM</td>
    <td>\</td>
  </tr>
  <tr>
    <td rowspan="5">Q5(-n=100)</td>
    <td>5</td>
    <td>116.203s</td>
    <td>116.818s</td>
    <td>+0.615s</td>
  </tr>
  <tr>
    <td>10</td>
    <td>120.741s</td>
    <td>117.002s</td>
    <td>-3.739s</td>
  </tr>
  <tr>
    <td>20</td>
    <td>121.323s</td>
    <td>116.410s</td>
    <td>-4.913s</td>
  </tr>
  <tr>
    <td>50</td>
    <td>123.702s</td>
    <td>116.513s</td>
    <td>-7.189s</td>
  </tr>
  <tr>
    <td>100</td>
    <td>134.117s</td>
    <td>131.960s</td>
    <td>-2.157s</td>
  </tr>
  <tr>
    <td rowspan="5">Q6(-n=1000)</td>
    <td>5</td>
    <td>31.842s</td>
    <td>31.213s</td>
    <td>-0.629s</td>
  </tr>
  <tr>
    <td>10</td>
    <td>31.494s</td>
    <td>30.168s</td>
    <td>-1.326s</td>
  </tr>
  <tr>
    <td>20</td>
    <td>31.541s</td>
    <td>30.533s</td>
    <td>-1.008s</td>
  </tr>
  <tr>
    <td>50</td>
    <td>31.542s</td>
    <td>30.650s</td>
    <td>-0.892s</td>
  </tr>
  <tr>
    <td>100</td>
    <td>31.427s</td>
    <td>30.670s</td>
    <td>-0.757s</td>
  </tr>
  <tr>
    <td rowspan="5">Q11(-n=1000)</td>
    <td>5</td>
    <td>123.890s</td>
    <td>123.794s</td>
    <td>-0.096s</td>
  </tr>
  <tr>
    <td>10</td>
    <td>123.890s</td>
    <td>123.826s</td>
    <td>-0.064s</td>
  </tr>
  <tr>
    <td>20</td>
    <td>126.414s</td>
    <td>126.356s</td>
    <td>-0.058s</td>
  </tr>
  <tr>
    <td>50</td>
    <td>131.245s</td>
    <td>130.039s</td>
    <td>-1.206s</td>
  </tr>
  <tr>
    <td>100</td>
    <td>134.723s</td>
    <td>134.793s</td>
    <td>+0.070s</td>
  </tr>
  <tr>
    <td rowspan="5">Q12(-n=1000)</td>
    <td>5</td>
    <td>123.676s</td>
    <td>122.984s</td>
    <td>-0.692s</td>
  </tr>
  <tr>
    <td>10</td>
    <td>123.510s</td>
    <td>123.228s</td>
    <td>-0.282s</td>
  </tr>
  <tr>
    <td>20</td>
    <td>125.491s</td>
    <td>124.925s</td>
    <td>-0.566s</td>
  </tr>
  <tr>
    <td>50</td>
    <td>128.400s</td>
    <td>127.231s</td>
    <td>-1.169s</td>
  </tr>
  <tr>
    <td>100</td>
    <td>131.240s</td>
    <td>129.558s</td>
    <td>-1.682s</td>
  </tr>
  <tr>
    <td rowspan="5">Q14(-n=1000)</td>
    <td>5</td>
    <td>85.153s</td>
    <td>83.791s</td>
    <td>-1.362s</td>
  </tr>
  <tr>
    <td>10</td>
    <td>83.615s</td>
    <td>83.036s</td>
    <td>-0.579s</td>
  </tr>
  <tr>
    <td>20</td>
    <td>84.854s</td>
    <td>84.513s</td>
    <td>-0.341s</td>
  </tr>
  <tr>
    <td>50</td>
    <td>87.089s</td>
    <td>88.165s</td>
    <td>+1.076s</td>
  </tr>
  <tr>
    <td>100</td>
    <td>89.620s</td>
    <td>90.207s</td>
    <td>+0.587s</td>
  </tr>
</table>


### machine specification 4c/64g

**Env**
* 1fe/3be with 4c/64G
* tpch-100g

**Outcomes of low concurrency scenerio:**

| Query | before | after | diff(after-before) |
|:-----:|:------:|:-----:|:-----------------:|
|   Q1  | 6999   | 6925  | -74               |
|   Q2  | 328    | 278   | -50               |
|   Q3  | 3589   | 3511  | -78               |
|   Q4  | 1420   | 1427  | +7                |
|   Q5  | 4428   | 4335  | -93               |
|   Q6  | 137    | 158   | +21               |
|   Q7  | 3009   | 2990  | -19               |
|   Q8  | 2722   | 2770  | +48               |
|   Q9  | 10040  | 9858  | -182              |
|  Q10  | 6410   | 6353  | -57               |
|  Q11  | 487    | 457   | -30               |
|  Q12  | 551    | 504   | -47               |
|  Q13  | 6305   | 6281  | -24               |
|  Q14  | 461    | 423   | -38               |
|  Q15  | 13     | 12    | -1                |
|  Q16  | 1130   | 1124  | -6                |
|  Q17  | 1203   | 1177  | -26               |
|  Q18  | 8636   | 8618  | -18               |
|  Q19  | 2292   | 2256  | -36               |
|  Q20  | 508    | 538   | +30               |
|  Q21  | 5508   | 5433  | -75               |
|  Q22  | 1013   | 972   | -41               |


---

**Outcomes of high concurrency scenerio:**

```sh
mysqlslap -u root -h 127.0.0.1 -P 9030 \
     --concurrency=5 \
     --number-of-queries=128 \
     --create-schema=tpch_100g \
     --delimiter=";" \
     --query="q06.sql"
```

<table>
  <tr>
    <th>Query</th>
    <th>concurrency</th>
    <th>before</th>
    <th>after</th>
    <th>diff</th>
  </tr>
  <tr>
    <td rowspan="4">Q1(-n=32)</td>
    <td>4</td>
    <td>221.117s</td>
    <td>214.257s</td>
    <td>-6.86s</td>
  </tr>
  <tr>
    <td>8</td>
    <td>192.788s</td>
    <td>191.411s</td>
    <td>-1.377s</td>
  </tr>
  <tr>
    <td>16</td>
    <td>177.407s</td>
    <td>178.091s</td>
    <td>+0.684s</td>
  </tr>
  <tr>
    <td>32</td>
    <td>171.040s</td>
    <td>173.080s</td>
    <td>+2.04s</td>
  </tr>
  <tr>
    <td rowspan="4">Q5(-n=32)</td>
    <td>4</td>
    <td>157.982s</td>
    <td>156.095s</td>
    <td>-1.887s</td>
  </tr>
  <tr>
    <td>8</td>
    <td>139.145s</td>
    <td>137.604s</td>
    <td>-1.541s</td>
  </tr>
  <tr>
    <td>16</td>
    <td>126.231s</td>
    <td>125.016s</td>
    <td>-1.215s</td>
  </tr>
  <tr>
    <td>32</td>
    <td>120.570s</td>
    <td>119.245s</td>
    <td>-1.325s</td>
  </tr>
  <tr>
    <td rowspan="4">Q6(-n=128)</td>
    <td>4</td>
    <td>11.997s</td>
    <td>12.267s</td>
    <td>+0.27s</td>
  </tr>
  <tr>
    <td>8</td>
    <td>11.878s</td>
    <td>11.955s</td>
    <td>+0.077s</td>
  </tr>
  <tr>
    <td>16</td>
    <td>11.660s</td>
    <td>11.906s</td>
    <td>+0.246s</td>
  </tr>
  <tr>
    <td>32</td>
    <td>11.782s</td>
    <td>12.053s</td>
    <td>+0.271s</td>
  </tr>
  <tr>
    <td rowspan="4">Q11(-n=128)</td>
    <td>4</td>
    <td>46.882s</td>
    <td>47.087s</td>
    <td>+0.205s</td>
  </tr>
  <tr>
    <td>8</td>
    <td>46.955s</td>
    <td>46.792s</td>
    <td>-0.163s</td>
  </tr>
  <tr>
    <td>16</td>
    <td>47.488s</td>
    <td>47.710s</td>
    <td>+0.222s</td>
  </tr>
  <tr>
    <td>32</td>
    <td>48.245s</td>
    <td>48.416s</td>
    <td>+0.171s</td>
  </tr>
  <tr>
    <td rowspan="4">Q12(-n=128)</td>
    <td>4</td>
    <td>49.755s</td>
    <td>49.331s</td>
    <td>-0.424s</td>
  </tr>
  <tr>
    <td>8</td>
    <td>49.600s</td>
    <td>48.954s</td>
    <td>-0.646s</td>
  </tr>
  <tr>
    <td>16</td>
    <td>48.917s</td>
    <td>47.966s</td>
    <td>-0.951s</td>
  </tr>
  <tr>
    <td>32</td>
    <td>48.700s</td>
    <td>48.036s</td>
    <td>-0.664s</td>
  </tr>
  <tr>
    <td rowspan="4">Q14(-n=128)</td>
    <td>4</td>
    <td>37.683s</td>
    <td>38.307s</td>
    <td>+0.624s</td>
  </tr>
  <tr>
    <td>8</td>
    <td>37.784s</td>
    <td>38.040s</td>
    <td>+0.256s</td>
  </tr>
  <tr>
    <td>16</td>
    <td>38.121s</td>
    <td>39.429s</td>
    <td>+1.308s</td>
  </tr>
  <tr>
    <td>32</td>
    <td>39.174s</td>
    <td>41.022s</td>
    <td>+1.848s</td>
  </tr>
</table>

## performance vs. dop

```sql
select count(*) from lineorder a 
join lineorder b on a.lo_orderkey=b.lo_orderkey and a.lo_shipmode=b.lo_shipmode 
where a.lo_orderkey<=40000000 and b.lo_orderkey<=40000000;
```

| Dop | Before | After |
|:--|:--|:--|
| 0 | 0.495s | 0.484s |
| 15 | 0.495s | 0.484s |
| 16 | 1.010s | 1.214s |

## Summary

The above two experiments show that there are minimal differences between these two different polling-driven methods, which does not accord with the expectations.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
