### PR TITLE
[Enhancement] Support specific endpoint in Azure Blob Storage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationConstants.java
@@ -58,6 +58,9 @@ public class CloudConfigurationConstants {
 
     // Credential for Azure storage
     // For Azure Blob Storage
+
+    // Endpoint already contains storage account, so if user set endpoint, they don't need to set storage account anymore
+    public static final String AZURE_BLOB_ENDPOINT = "azure.blob.endpoint";
     public static final String AZURE_BLOB_STORAGE_ACCOUNT = "azure.blob.storage_account";
     public static final String AZURE_BLOB_SHARED_KEY = "azure.blob.shared_key";
     public static final String AZURE_BLOB_CONTAINER = "azure.blob.container";

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfigurationFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfigurationFactory.java
@@ -33,6 +33,7 @@ import static com.starrocks.credential.CloudConfigurationConstants.AZURE_ADLS2_O
 import static com.starrocks.credential.CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY;
 import static com.starrocks.credential.CloudConfigurationConstants.AZURE_ADLS2_STORAGE_ACCOUNT;
 import static com.starrocks.credential.CloudConfigurationConstants.AZURE_BLOB_CONTAINER;
+import static com.starrocks.credential.CloudConfigurationConstants.AZURE_BLOB_ENDPOINT;
 import static com.starrocks.credential.CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN;
 import static com.starrocks.credential.CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY;
 import static com.starrocks.credential.CloudConfigurationConstants.AZURE_BLOB_STORAGE_ACCOUNT;
@@ -58,6 +59,7 @@ public class AzureCloudConfigurationFactory extends CloudConfigurationFactory {
 
         // Try to build azure blob storage
         AzureBlobCloudCredential blob = new AzureBlobCloudCredential(
+                properties.getOrDefault(AZURE_BLOB_ENDPOINT, ""),
                 properties.getOrDefault(AZURE_BLOB_STORAGE_ACCOUNT, storageAccount),
                 properties.getOrDefault(AZURE_BLOB_SHARED_KEY, ""),
                 properties.getOrDefault(AZURE_BLOB_CONTAINER, container),

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
@@ -62,16 +62,19 @@ abstract class AzureStorageCloudCredential implements CloudCredential {
 }
 
 class AzureBlobCloudCredential extends AzureStorageCloudCredential {
+    private final String endpoint;
     private final String storageAccount;
     private final String sharedKey;
     private final String container;
     private final String sasToken;
 
-    AzureBlobCloudCredential(String storageAccount, String sharedKey, String container, String sasToken) {
+    AzureBlobCloudCredential(String endpoint, String storageAccount, String sharedKey, String container, String sasToken) {
+        Preconditions.checkNotNull(endpoint);
         Preconditions.checkNotNull(storageAccount);
         Preconditions.checkNotNull(sharedKey);
         Preconditions.checkNotNull(container);
         Preconditions.checkNotNull(sasToken);
+        this.endpoint = endpoint;
         this.storageAccount = storageAccount;
         this.sharedKey = sharedKey;
         this.container = container;
@@ -81,13 +84,25 @@ class AzureBlobCloudCredential extends AzureStorageCloudCredential {
 
     @Override
     void tryGenerateConfigurationMap() {
-        if (!storageAccount.isEmpty() && !sharedKey.isEmpty()) {
-            String key = String.format("fs.azure.account.key.%s.blob.core.windows.net", storageAccount);
-            generatedConfigurationMap.put(key, sharedKey);
-        } else if (!storageAccount.isEmpty() && !container.isEmpty() && !sasToken.isEmpty()) {
-            String key =
-                    String.format("fs.azure.sas.%s.%s.blob.core.windows.net", container, storageAccount);
-            generatedConfigurationMap.put(key, sasToken);
+        if (!endpoint.isEmpty()) {
+            // If user specific endpoint, they don't need to specific storage account anymore
+            // Like if user is using Azurite, they need to specific endpoint
+            if (!sharedKey.isEmpty()) {
+                String key = String.format("fs.azure.account.key.%s", endpoint);
+                generatedConfigurationMap.put(key, sharedKey);
+            } else if (!container.isEmpty() && !sasToken.isEmpty()) {
+                String key = String.format("fs.azure.sas.%s.%s", container, endpoint);
+                generatedConfigurationMap.put(key, sasToken);
+            }
+        } else {
+            if (!storageAccount.isEmpty() && !sharedKey.isEmpty()) {
+                String key = String.format("fs.azure.account.key.%s.blob.core.windows.net", storageAccount);
+                generatedConfigurationMap.put(key, sharedKey);
+            } else if (!storageAccount.isEmpty() && !container.isEmpty() && !sasToken.isEmpty()) {
+                String key =
+                        String.format("fs.azure.sas.%s.%s.blob.core.windows.net", container, storageAccount);
+                generatedConfigurationMap.put(key, sasToken);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
@@ -109,7 +109,8 @@ class AzureBlobCloudCredential extends AzureStorageCloudCredential {
     @Override
     public String getCredentialString() {
         return "AzureBlobCloudCredential{" +
-                "storageAccount='" + storageAccount + '\'' +
+                "endpoint='" + endpoint + '\'' +
+                ", storageAccount='" + storageAccount + '\'' +
                 ", sharedKey='" + sharedKey + '\'' +
                 ", container='" + container + '\'' +
                 ", sasToken='" + sasToken + '\'' +


### PR DESCRIPTION
Now we support to specific endpoint  in Azure Blob Storage
Grammar just like below:
```sql
CREATE EXTERNAL CATALOG blob_key_hive_test
PROPERTIES(
  "type"="hive", 
  "hive.metastore.uris"="thrift://10.1.0.18:9083",
  "azure.blob.endpoint"="hello.blob.core.windows.net",
  "azure.blob.shared_key"="XXR2YL69y+pllPz+ASt1nxZlQ=="
);
```

```sql
CREATE EXTERNAL CATALOG blob_key_hive_test
PROPERTIES(
  "type"="hive", 
  "hive.metastore.uris"="thrift://10.1.0.18:9083",
  "azure.blob.endpoint"="hello.blob.core.windows.net",
  "azure.blob.container"="sr",
  "azure.blob.sas_token"="XXR2YL69y+pllPz+ASt1nxZlQ=="
);
```

Because endpoint contains `storage_account` already, so we don't need to specific storage account anymore. Endpoint will be helpful for user who is using Azure.
```sql
CREATE EXTERNAL TABLE file_table
(
  ACTIVITY string
) 
ENGINE=FILE
PROPERTIES
(
  "path" = "wasbs://blob@root.local.azurite:8000/foo.parquet",
  "format" = "parquet",
  "azure.blob.endpoint"="root.local.azurite:8000",
  "azure.blob.shared_key"="sp=r&stZ&spr=https&sv=22BABuUQYQx8k%3D"
);
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
