### PR TITLE
[BugFix] fix wrong consumption in mem_tracker under auto spill mode

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -468,7 +468,7 @@ void PipelineDriver::_adjust_memory_usage(RuntimeState* state, MemTracker* track
     auto& mem_resource_mgr = op->mem_resource_manager();
     if (state->enable_spill() && mem_resource_mgr.releaseable() &&
         op->revocable_mem_bytes() > state->spill_operator_min_bytes()) {
-        auto request_reserved = 0;
+        int64_t request_reserved = 0;
         if (chunk == nullptr) {
             request_reserved = op->estimated_memory_reserved();
         } else {

--- a/be/src/exec/spillable_chunks_sorter_full_sort.cpp
+++ b/be/src/exec/spillable_chunks_sorter_full_sort.cpp
@@ -111,9 +111,9 @@ Status SpillableChunksSorterFullSort::get_next(ChunkPtr* chunk, bool* eos) {
 
 size_t SpillableChunksSorterFullSort::reserved_bytes(const ChunkPtr& chunk) {
     if (chunk) {
-        return chunk->memory_usage() + _unsorted_chunk->memory_usage() * 2;
+        return chunk->memory_usage() + (_unsorted_chunk != nullptr ? _unsorted_chunk->memory_usage() * 2 : 0);
     }
-    return _unsorted_chunk->memory_usage() * 2;
+    return _unsorted_chunk != nullptr ? _unsorted_chunk->memory_usage() * 2 : 0;
 }
 
 size_t SpillableChunksSorterFullSort::get_output_rows() const {

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -218,6 +218,7 @@ public:
 
     // Return prev memory tracker.
     starrocks::MemTracker* set_mem_tracker(starrocks::MemTracker* mem_tracker) {
+        release_reserved();
         mem_tracker_ctx_shift();
         auto* prev = tls_mem_tracker;
         tls_mem_tracker = mem_tracker;


### PR DESCRIPTION
## BackGround
when I test auto spill mode under tpch-1T dataset  in a 16c64g instance, I found Q18 will cancel due to OOM, and the consumption values of some mem tracker are wrong after the query cancels: 

1.  the consumption of chunk_allocator will be a negative number 

2.  the consumption of process mem tracker will be a very large number

these issues were introduced by https://github.com/StarRocks/starrocks/pull/24644

### for the first issue

After the reserved_bytes is introduced, the mem tracker will be updated in advance, and the unused reserved memory will be returned after the push_chunk/set_finishing call ends. So when push_chunk/set_finishing is executed, if the allocated memory size does not exceed reserved bytes in current thread, then the mem tracker will not be updated.

If the tls_mem_tracker doesn't switch during execution, everything is ok. Otherwise there will be problems, take MemChunkAllocator as an example:
![image](https://github.com/StarRocks/starrocks/assets/3675229/1b7de188-7958-48f4-99c9-1beafb2fdfcb)


consider the following operations:
1.  first, reserving memory in PipelineDriver::_adjust_memory_usage, tls_mem_tracker is fragment instance tracker, if we reserve 10 bytes, fragment->query->wg->query_pool->process will be updated.
4. then executing MemChunkAllocator::allocate, tls_mem_tracker will switch to chunk_allocator, if we allocate 5 bytes, chunk_allocator tracker won't be really update because of the existence of reserved_bytes in current thread
5. in the defer op, because of the existence of reserve bytes, we cannot know how much the consumption of chunk_allocator tracker has been updated. At this time, we still release 5 bytes, which is wrong.

The solution is to release the reserved memory every time the tracker is switched.


### for the second issue

![image](https://github.com/StarRocks/starrocks/assets/3675229/ac4f77bc-61b4-49d4-a1fd-4defa3733198)

the type of request_reserved is wrong. auto type means int32_t, we should use int64_t instead.
otherwise, if the reserved bytes larger than int32, something will be wrong.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
