### PR TITLE
[BugFix] Fix concurrent read/write conflicts for persistent index

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2445,9 +2445,12 @@ Status PersistentIndex::_load(const PersistentIndexMetaPB& index_meta, bool relo
     const MutableIndexMetaPB& l0_meta = index_meta.l0_meta();
     DCHECK(_l0 != nullptr);
     RETURN_IF_ERROR(_l0->load(l0_meta));
-    _l1_vec.clear();
-    _l1_merged_num.clear();
-    _has_l1 = false;
+    {
+        std::unique_lock wrlock(_lock);
+        _l1_vec.clear();
+        _l1_merged_num.clear();
+        _has_l1 = false;
+    }
     std::unique_ptr<RandomAccessFile> l1_rfile;
     if (index_meta.has_l1_version()) {
         _l1_version = index_meta.l1_version();
@@ -2457,9 +2460,12 @@ Status PersistentIndex::_load(const PersistentIndexMetaPB& index_meta, bool relo
         if (!l1_st.ok()) {
             return l1_st.status();
         }
-        _l1_vec.emplace_back(std::move(l1_st).value());
-        _l1_merged_num.emplace_back(-1);
-        _has_l1 = true;
+        {
+            std::unique_lock wrlock(_lock);
+            _l1_vec.emplace_back(std::move(l1_st).value());
+            _l1_merged_num.emplace_back(-1);
+            _has_l1 = true;
+        }
     }
     // if reload, don't update _usage_and_size_by_key_length
     if (!reload) {
@@ -2696,9 +2702,12 @@ Status PersistentIndex::load_from_tablet(Tablet* tablet) {
     _dump_snapshot = true;
 
     // clear l1
-    _l1_vec.clear();
-    _usage_and_size_by_key_length.clear();
-    _l1_merged_num.clear();
+    {
+        std::unique_lock wrlock(_lock);
+        _l1_vec.clear();
+        _usage_and_size_by_key_length.clear();
+        _l1_merged_num.clear();
+    }
     _has_l1 = false;
     for (const auto& [key_size, shard_info] : _l0->_shard_info_by_key_size) {
         auto [l0_shard_offset, l0_shard_size] = shard_info;
@@ -2945,7 +2954,7 @@ Status PersistentIndex::get_from_one_immutable_index(size_t n, const Slice* keys
             break;
         }
     }
-    std::unique_lock<std::mutex> ul(_lock);
+    std::unique_lock<std::mutex> ul(_get_lock);
     _running_get_task--;
     _found_keys_info[idx].key_infos.swap(found_keys_info->key_infos);
     if (_running_get_task == 0) {
@@ -2960,7 +2969,7 @@ Status PersistentIndex::_get_from_immutable_index_parallel(size_t n, const Slice
         return Status::OK();
     }
 
-    std::unique_lock<std::mutex> ul(_lock);
+    std::unique_lock<std::mutex> ul(_get_lock);
     std::map<size_t, KeysInfo>::iterator iter;
     std::string error_msg;
     std::vector<std::vector<uint64_t>> get_values(_l1_vec.size(), std::vector<uint64_t>(n, NullIndexValue));
@@ -3235,9 +3244,12 @@ Status PersistentIndex::flush_advance() {
     if (!l1_st.ok()) {
         return l1_st.status();
     }
-    _l1_vec.emplace_back(std::move(l1_st).value());
-    _l1_merged_num.emplace_back(1);
-    _l1_vec.back()->_bf_map.swap(bf_map);
+    {
+        std::unique_lock wrlock(_lock);
+        _l1_vec.emplace_back(std::move(l1_st).value());
+        _l1_merged_num.emplace_back(1);
+        _l1_vec.back()->_bf_map.swap(bf_map);
+    }
 
     // clear l0
     _l0->clear();
@@ -3813,10 +3825,6 @@ Status PersistentIndex::_merge_compaction_advance() {
         new_l1_merged_num.emplace_back(_l1_merged_num[i]);
     }
 
-    for (int i = merge_l1_start_idx; i < _l1_vec.size(); i++) {
-        _l1_vec[i]->destroy();
-    }
-
     const std::string idx_file_path = strings::Substitute("$0/index.l1.$1.$2.$3.tmp", _path, _version.major(),
                                                           _version.minor(), new_l1_vec.size());
     RETURN_IF_ERROR(FileSystem::Default()->rename_file(idx_file_path_tmp, idx_file_path));
@@ -3831,8 +3839,14 @@ Status PersistentIndex::_merge_compaction_advance() {
         new_l1_vec.back()->_bf_map.swap(bf_map);
     }
     new_l1_merged_num.emplace_back((merge_l1_end_idx - merge_l1_start_idx) * merge_num);
-    _l1_vec.swap(new_l1_vec);
-    _l1_merged_num.swap(new_l1_merged_num);
+    {
+        std::unique_lock wrlock(_lock);
+        for (int i = merge_l1_start_idx; i < _l1_vec.size(); i++) {
+            _l1_vec[i]->destroy();
+        }
+        _l1_vec.swap(new_l1_vec);
+        _l1_merged_num.swap(new_l1_merged_num);
+    }
     _l0->clear();
     return Status::OK();
 }

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -529,6 +529,10 @@ public:
     size_t size() const { return _size; }
     size_t capacity() const { return _l0 ? _l0->capacity() : 0; }
     size_t memory_usage() const {
+        // commit thread will update primary index memory usage and get index memory usage
+        // apply thread maybe clear or modify _l1_vec
+        // add lock to avoid read/write conflicts
+        std::shared_lock rdlock(_lock);
         size_t memory_usage = _l0 ? _l0->memory_usage() : 0;
         for (int i = 0; i < _l1_vec.size(); i++) {
             memory_usage += _l1_vec[i]->memory_usage();
@@ -664,6 +668,10 @@ private:
 
     Status _update_usage_and_size_by_key_length(std::vector<std::pair<int64_t, int64_t>>& add_usage_and_size);
 
+    // prevent concurrent operations
+    // Currently there are only concurrent read/write conflicts for _l1_vec between apply_thread and commit_thread
+    mutable std::shared_mutex _lock;
+
     // index storage directory
     std::string _path;
     size_t _key_size = 0;
@@ -688,7 +696,7 @@ private:
     bool _flushed = false;
     bool _need_bloom_filter = false;
 
-    mutable std::mutex _lock;
+    mutable std::mutex _get_lock;
     std::condition_variable _get_task_finished;
     size_t _running_get_task = 0;
     std::atomic<bool> _error{false};


### PR DESCRIPTION
During the execution of apply on the primary key table, the apply thread maybe clear or modify `_l1_vec` of persistent index. 
And during the execution commit, the commit thread will update primary index memory usage and need to access `_l1_vec`.
So there are read/write conflicts between apply thread and commit thread which may cause BE crash.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
