### PR TITLE
[BugFix] Remove the tailing row delimeter for csv files which contain windows line break.

### DIFF
--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -54,6 +54,8 @@ public:
 protected:
     Status _fill_buffer() override;
 
+    void _trim_row_delimeter(Record* record);
+
 private:
     RandomAccessFile* _file;
     size_t _offset = 0;
@@ -87,6 +89,7 @@ Status HdfsScannerCSVReader::next_record(Record* record) {
     } else {
         _remain_length -= consume;
     }
+    _trim_row_delimeter(record);
     return Status::OK();
 }
 
@@ -129,6 +132,16 @@ Status HdfsScannerCSVReader::_fill_buffer() {
     }
 
     return Status::OK();
+}
+
+void HdfsScannerCSVReader::_trim_row_delimeter(Record* record) {
+    // For default row delemiter which is line break, we need to trim the windows line break
+    // if the file was written in windows platfom.
+    if (_parse_options.row_delimiter == "\n") {
+        while (record->size > 0 && record->data[record->size - 1] == '\r') {
+            record->size--;
+        }
+    }
 }
 
 Status HdfsTextScanner::do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -1560,6 +1560,38 @@ TEST_F(HdfsScannerTest, TestCSVWithoutEndDelemeter) {
     }
 }
 
+TEST_F(HdfsScannerTest, TestCSVWithWindowsEndDelemeter) {
+    SlotDesc csv_descs[] = {{"uuid", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR, 22)}, {""}};
+
+    const std::string windows_file = "./be/test/exec/test_data/csv_scanner/windows.csv";
+    Status status;
+
+    {
+        auto* range = _create_scan_range(windows_file, 0, 0);
+        auto* tuple_desc = _create_tuple_desc(csv_descs);
+        auto* param = _create_param(windows_file, range, tuple_desc);
+        build_hive_column_names(param, tuple_desc);
+        auto scanner = std::make_shared<HdfsTextScanner>();
+
+        status = scanner->init(_runtime_state, *param);
+        ASSERT_TRUE(status.ok()) << status.get_error_msg();
+
+        status = scanner->open(_runtime_state);
+        ASSERT_TRUE(status.ok()) << status.get_error_msg();
+
+        ChunkPtr chunk = ChunkHelper::new_chunk(*tuple_desc, 4096);
+
+        status = scanner->get_next(_runtime_state, &chunk);
+        EXPECT_TRUE(status.ok());
+        EXPECT_EQ(3, chunk->num_rows());
+
+        EXPECT_EQ("['hello']", chunk->debug_row(0));
+        EXPECT_EQ("['world']", chunk->debug_row(1));
+        EXPECT_EQ("['starrocks']", chunk->debug_row(2));
+        scanner->close(_runtime_state);
+    }
+}
+
 TEST_F(HdfsScannerTest, TestCSVNewlyAddColumn) {
     SlotDesc csv_descs[] = {{"name1", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR, 22)},
                             {"age", TypeDescriptor::from_logical_type(LogicalType::TYPE_VARCHAR, 22)},

--- a/be/test/exec/test_data/csv_scanner/windows.csv
+++ b/be/test/exec/test_data/csv_scanner/windows.csv
@@ -1,0 +1,3 @@
+hello
+world
+starrocks


### PR DESCRIPTION
If the csv file was written in windows platform, it may contain the windows CR LF line break types. When parsing the record by default row delimiter ("\n"), the record data may contain the '\r' tail, which cause the unexpected query result with the text comparision.

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [x] 2.5
  - [ ] 2.4
