### PR TITLE
[Enhancement] Enable HDFS client's hedged read by default

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -791,6 +791,13 @@ CONF_Int32(connector_io_tasks_slow_io_latency_ms, "50");
 CONF_mDouble(scan_use_query_mem_ratio, "0.25");
 CONF_Double(connector_scan_use_query_mem_ratio, "0.3");
 
+// hdfs hedged read
+CONF_mBool(hdfs_client_enable_hedged_read, "true")
+// dfs.client.hedged.read.threadpool.size
+CONF_Int32(hdfs_client_hedged_read_threadpool_size, "64")
+// dfs.client.hedged.read.threshold.millis
+CONF_Int32(hdfs_client_hedged_read_threshold_millis, "1000")
+
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory
 // following the default naming pattern of aws_sdk_<date>.log.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -796,7 +796,7 @@ CONF_mBool(hdfs_client_enable_hedged_read, "true");
 // dfs.client.hedged.read.threadpool.size
 CONF_Int32(hdfs_client_hedged_read_threadpool_size, "128");
 // dfs.client.hedged.read.threshold.millis
-CONF_Int32(hdfs_client_hedged_read_threshold_millis, "5000");
+CONF_Int32(hdfs_client_hedged_read_threshold_millis, "3000");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -796,7 +796,7 @@ CONF_mBool(hdfs_client_enable_hedged_read, "true");
 // dfs.client.hedged.read.threadpool.size
 CONF_Int32(hdfs_client_hedged_read_threadpool_size, "128");
 // dfs.client.hedged.read.threshold.millis
-CONF_Int32(hdfs_client_hedged_read_threshold_millis, "2000");
+CONF_Int32(hdfs_client_hedged_read_threshold_millis, "2500");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -796,7 +796,7 @@ CONF_mBool(hdfs_client_enable_hedged_read, "true");
 // dfs.client.hedged.read.threadpool.size
 CONF_Int32(hdfs_client_hedged_read_threadpool_size, "128");
 // dfs.client.hedged.read.threshold.millis
-CONF_Int32(hdfs_client_hedged_read_threshold_millis, "3000");
+CONF_Int32(hdfs_client_hedged_read_threshold_millis, "2000");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -796,7 +796,7 @@ CONF_mBool(hdfs_client_enable_hedged_read, "true");
 // dfs.client.hedged.read.threadpool.size
 CONF_Int32(hdfs_client_hedged_read_threadpool_size, "128");
 // dfs.client.hedged.read.threshold.millis
-CONF_Int32(hdfs_client_hedged_read_threshold_millis, "1000");
+CONF_Int32(hdfs_client_hedged_read_threshold_millis, "5000");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -794,7 +794,7 @@ CONF_Double(connector_scan_use_query_mem_ratio, "0.3");
 // hdfs hedged read
 CONF_mBool(hdfs_client_enable_hedged_read, "true");
 // dfs.client.hedged.read.threadpool.size
-CONF_Int32(hdfs_client_hedged_read_threadpool_size, "64");
+CONF_Int32(hdfs_client_hedged_read_threadpool_size, "128");
 // dfs.client.hedged.read.threshold.millis
 CONF_Int32(hdfs_client_hedged_read_threshold_millis, "1000");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -792,11 +792,11 @@ CONF_mDouble(scan_use_query_mem_ratio, "0.25");
 CONF_Double(connector_scan_use_query_mem_ratio, "0.3");
 
 // hdfs hedged read
-CONF_mBool(hdfs_client_enable_hedged_read, "true")
+CONF_mBool(hdfs_client_enable_hedged_read, "true");
 // dfs.client.hedged.read.threadpool.size
-CONF_Int32(hdfs_client_hedged_read_threadpool_size, "64")
+CONF_Int32(hdfs_client_hedged_read_threadpool_size, "64");
 // dfs.client.hedged.read.threshold.millis
-CONF_Int32(hdfs_client_hedged_read_threshold_millis, "1000")
+CONF_Int32(hdfs_client_hedged_read_threshold_millis, "1000");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -124,7 +124,6 @@ StatusOr<std::unique_ptr<io::NumericStatistics>> HdfsInputStream::get_numeric_st
         if (r == -1) {
             return Status::IOError(fmt::format("Fail to get read statistics of {}: {}", r, get_hdfs_err_msg()));
         }
-        stats->reserve(4);
         stats->append("TotalBytesRead", hdfs_statistics->totalBytesRead);
         stats->append("TotalLocalBytesRead", hdfs_statistics->totalLocalBytesRead);
         stats->append("TotalShortCircuitBytesRead", hdfs_statistics->totalShortCircuitBytesRead);
@@ -134,10 +133,10 @@ StatusOr<std::unique_ptr<io::NumericStatistics>> HdfsInputStream::get_numeric_st
         struct hdfsHedgedReadMetrics* hdfs_hedged_read_statistics = nullptr;
         r = hdfsGetHedgedReadMetrics(_fs, &hdfs_hedged_read_statistics);
         if (r == 0) {
-            stats->reserve(7);
             stats->append("TotalHedgedReadOps", hdfs_hedged_read_statistics->hedgedReadOps);
             stats->append("TotalHedgedReadOpsInCurThread", hdfs_hedged_read_statistics->hedgedReadOpsInCurThread);
             stats->append("TotalHedgedReadOpsWin", hdfs_hedged_read_statistics->hedgedReadOpsWin);
+            hdfsFreeHedgedReadMetrics(hdfs_hedged_read_statistics);
         }
         return Status::OK();
     });

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -130,6 +130,15 @@ StatusOr<std::unique_ptr<io::NumericStatistics>> HdfsInputStream::get_numeric_st
         stats->append("TotalShortCircuitBytesRead", hdfs_statistics->totalShortCircuitBytesRead);
         stats->append("TotalZeroCopyBytesRead", hdfs_statistics->totalZeroCopyBytesRead);
         hdfsFileFreeReadStatistics(hdfs_statistics);
+
+        struct hdfsHedgedReadMetrics* hdfs_hedged_read_statistics = nullptr;
+        r = hdfsGetHedgedReadMetrics(_fs, &hdfs_hedged_read_statistics);
+        if (r == 0) {
+            stats->reserve(7);
+            stats->append("TotalHedgedReadOps", hdfs_hedged_read_statistics->hedgedReadOps);
+            stats->append("TotalHedgedReadOpsInCurThread", hdfs_hedged_read_statistics->hedgedReadOpsInCurThread);
+            stats->append("TotalHedgedReadOpsWin", hdfs_hedged_read_statistics->hedgedReadOpsWin);
+        }
         return Status::OK();
     });
     Status st = ret->get_future().get();

--- a/be/src/fs/hdfs/hdfs_fs_cache.cpp
+++ b/be/src/fs/hdfs/hdfs_fs_cache.cpp
@@ -71,11 +71,13 @@ static Status create_hdfs_fs_handle(const std::string& namenode, const std::shar
     }
 
     // Set for hdfs client hedged read
+    std::string hedged_read_threadpool_size = std::to_string(config::hdfs_client_hedged_read_threadpool_size);
+    std::string hedged_read_threshold_millis = std::to_string(config::hdfs_client_hedged_read_threshold_millis);
     if (config::hdfs_client_enable_hedged_read) {
         hdfsBuilderConfSetStr(hdfs_builder, "dfs.client.hedged.read.threadpool.size",
-                              std::to_string(config::hdfs_client_hedged_read_threadpool_size).data());
+                              hedged_read_threadpool_size.data());
         hdfsBuilderConfSetStr(hdfs_builder, "dfs.client.hedged.read.threshold.millis",
-                              std::to_string(config::hdfs_client_hedged_read_threshold_millis).data());
+                              hedged_read_threshold_millis.data());
     }
 
     hdfs_client->hdfs_fs = hdfsBuilderConnect(hdfs_builder);

--- a/be/src/fs/hdfs/hdfs_fs_cache.cpp
+++ b/be/src/fs/hdfs/hdfs_fs_cache.cpp
@@ -16,9 +16,9 @@
 
 #include <memory>
 
+#include "common/config.h"
 #include "gutil/strings/substitute.h"
 #include "util/hdfs_util.h"
-#include "common/config.h"
 
 namespace starrocks {
 
@@ -72,8 +72,10 @@ static Status create_hdfs_fs_handle(const std::string& namenode, const std::shar
 
     // Set for hdfs client hedged read
     if (config::hdfs_client_enable_hedged_read) {
-        hdfsBuilderConfSetStr(hdfs_builder, "dfs.client.hedged.read.threadpool.size", std::to_string(config::hdfs_client_hedged_read_threadpool_size).data());
-        hdfsBuilderConfSetStr(hdfs_builder, "dfs.client.hedged.read.threshold.millis", std::to_string(config::hdfs_client_hedged_read_threshold_millis).data());
+        hdfsBuilderConfSetStr(hdfs_builder, "dfs.client.hedged.read.threadpool.size",
+                              std::to_string(config::hdfs_client_hedged_read_threadpool_size).data());
+        hdfsBuilderConfSetStr(hdfs_builder, "dfs.client.hedged.read.threshold.millis",
+                              std::to_string(config::hdfs_client_hedged_read_threshold_millis).data());
     }
 
     hdfs_client->hdfs_fs = hdfsBuilderConnect(hdfs_builder);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -237,6 +237,11 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths, bool as_cn) {
     int connector_num_io_threads = int(config::pipeline_connector_scan_thread_num_per_cpu * CpuInfo::num_cores());
     CHECK_GT(connector_num_io_threads, 0) << "pipeline_connector_scan_thread_num_per_cpu should greater than 0";
 
+    if (config::hdfs_client_enable_hedged_read) {
+        // Set hdfs client hedged read pool size
+        config::hdfs_client_hedged_read_threadpool_size = connector_num_io_threads * 2;
+    }
+
     std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_with_workgroup;
     RETURN_IF_ERROR(ThreadPoolBuilder("con_wg_scan_io")
                             .set_min_threads(0)

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -239,7 +239,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths, bool as_cn) {
 
     if (config::hdfs_client_enable_hedged_read) {
         // Set hdfs client hedged read pool size
-        config::hdfs_client_hedged_read_threadpool_size = std::min(connector_num_io_threads * 2, 128);
+        config::hdfs_client_hedged_read_threadpool_size =
+                std::min(connector_num_io_threads * 2, config::hdfs_client_hedged_read_threadpool_size);
         CHECK_GT(config::hdfs_client_hedged_read_threadpool_size, 0)
                 << "hdfs_client_hedged_read_threadpool_size should greater than 0";
     }

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -240,7 +240,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths, bool as_cn) {
     if (config::hdfs_client_enable_hedged_read) {
         // Set hdfs client hedged read pool size
         config::hdfs_client_hedged_read_threadpool_size = std::min(connector_num_io_threads * 2, 128);
-        CHECK_GT(config::hdfs_client_hedged_read_threadpool_size, 0) << "hdfs_client_hedged_read_threadpool_size should greater than 0";
+        CHECK_GT(config::hdfs_client_hedged_read_threadpool_size, 0)
+                << "hdfs_client_hedged_read_threadpool_size should greater than 0";
     }
 
     std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_with_workgroup;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -239,7 +239,8 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths, bool as_cn) {
 
     if (config::hdfs_client_enable_hedged_read) {
         // Set hdfs client hedged read pool size
-        config::hdfs_client_hedged_read_threadpool_size = connector_num_io_threads * 2;
+        config::hdfs_client_hedged_read_threadpool_size = std::min(connector_num_io_threads * 2, 128);
+        CHECK_GT(config::hdfs_client_hedged_read_threadpool_size, 0) << "hdfs_client_hedged_read_threadpool_size should greater than 0";
     }
 
     std::unique_ptr<ThreadPool> connector_scan_worker_thread_pool_with_workgroup;


### PR DESCRIPTION
Enable HDFS client hedged read by default, avoid straggler node in HDFS cluster.
If user want to configure it in `hdfs-site.xml`, they should set `"hdfs_client_enable_hedged_read"="false"` in `be.conf`.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
