### PR TITLE
[BugFix] Fix metadata downgrade bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -1988,6 +1988,7 @@ public class Auth implements Writable {
     }
 
     public void load(SRMetaBlockReader reader) throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
+        LOG.info("version is {}", GlobalStateMgr.getCurrentStateJournalVersion());
         byte[] s = reader.readJson(byte[].class);
         DataInputStream dataInputStream = new DataInputStream(new ByteArrayInputStream(s));
         readFields(dataInputStream);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/privilege/Auth.java
@@ -1988,7 +1988,6 @@ public class Auth implements Writable {
     }
 
     public void load(SRMetaBlockReader reader) throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
-        LOG.info("version is {}", GlobalStateMgr.getCurrentStateJournalVersion());
         byte[] s = reader.readJson(byte[].class);
         DataInputStream dataInputStream = new DataInputStream(new ByteArrayInputStream(s));
         readFields(dataInputStream);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -548,15 +548,10 @@ public class EditLog {
                 }
                 case OperationType.OP_META_VERSION_V2: {
                     MetaVersion metaVersion = (MetaVersion) journal.getData();
-                    if (metaVersion.getCommunityVersion() > FeConstants.META_VERSION) {
-                        throw new JournalInconsistentException("invalid meta data version found, cat not bigger than "
-                                + "FeConstants.meta_version. please update FeConstants.meta_version bigger or equal to "
-                                + metaVersion.getCommunityVersion() + "and restart.");
-                    }
-                    if (metaVersion.getStarRocksVersion() > FeConstants.STARROCKS_META_VERSION) {
-                        throw new JournalInconsistentException("invalid meta data version found, cat not bigger than "
-                                + "FeConstants.starrocks_meta_version. please update FeConstants.starrocks_meta_version"
-                                + " bigger or equal to " + metaVersion.getStarRocksVersion() + "and restart.");
+                    if (!MetaVersion.isCompatible(metaVersion.getStarRocksVersion(), FeConstants.STARROCKS_META_VERSION)) {
+                        throw new JournalInconsistentException("Not compatible with meta version "
+                                + metaVersion.getStarRocksVersion()
+                                + ", current version is " + FeConstants.STARROCKS_META_VERSION);
                     }
                     MetaContext.get().setMetaVersion(metaVersion.getCommunityVersion());
                     MetaContext.get().setStarRocksMetaVersion(metaVersion.getStarRocksVersion());

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1603,6 +1603,7 @@ public class GlobalStateMgr {
         } else {
             // when flag is positive, this is new version format
             starrocksMetaVersion = flag;
+            MetaContext.get().setMetaVersion(FeConstants.META_VERSION);
         }
 
         if (!MetaVersion.isCompatible(starrocksMetaVersion, FeConstants.STARROCKS_META_VERSION)) {


### PR DESCRIPTION
Fixes 
```
[GlobalStateMgr.loadImage():1512] load image eof.
java.io.EOFException: null
        at java.io.DataInputStream.readFully(DataInputStream.java:197) ~[?:1.8.0_292]
        at com.starrocks.common.io.Text.readString(Text.java:393) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.privilege.PrivTable.read(PrivTable.java:248) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.privilege.Auth.readFields(Auth.java:1935) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.privilege.Auth.load(Auth.java:1993) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.loadImage(GlobalStateMgr.java:1425) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.initialize(GlobalStateMgr.java:1017) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.start(StarRocksFE.java:130) ~[starrocks-fe.jar:?]
        at com.starrocks.StarRocksFE.main(StarRocksFE.java:82) ~[starrocks-fe.jar:?]
```
```
com.starrocks.journal.JournalInconsistentException: failed to load journal type 10000
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:1059) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.replayJournalInner(GlobalStateMgr.java:2133) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.replayJournal(GlobalStateMgr.java:2085) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.transferToLeader(GlobalStateMgr.java:1131) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.access$100(GlobalStateMgr.java:324) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$1.transferToLeader(GlobalStateMgr.java:720) ~[starrocks-fe.jar:?]
        at com.starrocks.ha.StateChangeExecutor.runOneCycle(StateChangeExecutor.java:103) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:115) ~[starrocks-fe.jar:?]
Caused by: com.starrocks.journal.JournalInconsistentException: invalid meta data version found, cat not bigger than FeConstants.starrocks_meta_version. please update FeConstants.starrocks_meta_version bigger or equal to 4and restart.
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:559) ~[starrocks-fe.jar:?]
```


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
