### PR TITLE
[BugFix] Fix CTAS profile bugs when profile is enabled

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -261,15 +261,16 @@ public class InsertOverwriteJobRunner {
         long insertStartTimestamp = System.currentTimeMillis();
         // should replan here because prepareInsert has changed the targetPartitionNames of insertStmt
         ExecPlan newPlan = StatementPlanner.plan(insertStmt, context);
-        // Use `handleDMLStmtImpl` instead of `handleDMLStmt` because cannot call `writeProfile` in InsertOverwriteJobRunner.
+        // Use `handleDMLStmt` instead of `handleDMLStmtWithProfile` because cannot call `writeProfile` in
+        // InsertOverwriteJobRunner.
         // InsertOverWriteJob is executed as below:
-        // - StmtExecutor#handleDMLStmt
+        // - StmtExecutor#handleDMLStmtWithProfile
         //    - StmtExecutor#executeInsert
         //  - StmtExecutor#handleInsertOverwrite#InsertOverwriteJobMgr#run
         //  - InsertOverwriteJobRunner#executeInsert
-        //  - StmtExecutor#handleDMLStmtImpl <- no call `handleDMLStmt` again.
+        //  - StmtExecutor#handleDMLStmt <- no call `handleDMLStmt` again.
         // `writeProfile` is called in `handleDMLStmt`, and no need call it again later.
-        stmtExecutor.handleDMLStmtImpl(newPlan, insertStmt);
+        stmtExecutor.handleDMLStmt(newPlan, insertStmt);
         insertElapse = System.currentTimeMillis() - insertStartTimestamp;
         if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {
             LOG.warn("insert overwrite failed. error message:{}", context.getState().getErrorMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -262,11 +262,12 @@ public class InsertOverwriteJobRunner {
         // should replan here because prepareInsert has changed the targetPartitionNames of insertStmt
         ExecPlan newPlan = StatementPlanner.plan(insertStmt, context);
         // Use `handleDMLStmtImpl` instead of `handleDMLStmt` because cannot call `writeProfile` in InsertOverwriteJobRunner.
-        // InsertOver is executed as:
+        // InsertOverWriteJob is executed as below:
         // - StmtExecutor#handleDMLStmt
         //    - StmtExecutor#executeInsert
         //  - StmtExecutor#handleInsertOverwrite#InsertOverwriteJobMgr#run
         //  - InsertOverwriteJobRunner#executeInsert
+        //  - StmtExecutor#handleDMLStmtImpl <- no call `handleDMLStmt` again.
         // `writeProfile` is called in `handleDMLStmt`, and no need call it again later.
         stmtExecutor.handleDMLStmtImpl(newPlan, insertStmt);
         insertElapse = System.currentTimeMillis() - insertStartTimestamp;

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -261,7 +261,7 @@ public class InsertOverwriteJobRunner {
         long insertStartTimestamp = System.currentTimeMillis();
         // should replan here because prepareInsert has changed the targetPartitionNames of insertStmt
         ExecPlan newPlan = StatementPlanner.plan(insertStmt, context);
-        stmtExecutor.handleDMLStmt(newPlan, insertStmt);
+        stmtExecutor.handleDMLStmt(newPlan, insertStmt, insertStartTimestamp);
         insertElapse = System.currentTimeMillis() - insertStartTimestamp;
         if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {
             LOG.warn("insert overwrite failed. error message:{}", context.getState().getErrorMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -660,8 +660,6 @@ public class StmtExecutor {
             LOG.warn("handle create table as select stmt fail", t);
             ((CreateTableAsSelectStmt) parsedStmt).dropTable(context);
             throw t;
-        } finally {
-            QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1379,6 +1379,10 @@ public class StmtExecutor {
         manager.executeJob(context, this, job);
     }
 
+    /**
+     * `handleDMLStmt` executes DML statement and write profile at the end.
+     * NOTE: `writeProfile` can only be called once, otherwise the profile detail will be lost.
+     */
     public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt, long beginTimeInNanoSecond) throws Exception {
         try {
             handleDMLStmtImpl(execPlan, stmt);
@@ -1394,6 +1398,9 @@ public class StmtExecutor {
         }
     }
 
+    /**
+     * `handleDMLStmtImpl` only executes DML statement and no write profile at the end.
+     */
     public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
         if (stmt.isExplain()) {
             handleExplainStmt(buildExplainString(execPlan, ResourceGroupClassifier.QueryType.INSERT));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1394,7 +1394,7 @@ public class StmtExecutor {
         }
     }
 
-    private void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+    public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
         if (stmt.isExplain()) {
             handleExplainStmt(buildExplainString(execPlan, ResourceGroupClassifier.QueryType.INSERT));
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -979,7 +979,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         ctx.setStmtId(new AtomicInteger().incrementAndGet());
         ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
         try {
-            executor.handleDMLStmt(execPlan, insertStmt, beginTimeInNanoSecond);
+            executor.handleDMLStmtWithProfile(execPlan, insertStmt, beginTimeInNanoSecond);
         } finally {
             auditAfterExec(mvContext, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -978,8 +978,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
         ctx.setStmtId(new AtomicInteger().incrementAndGet());
         ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
+        long beginTimeInNanoSecond = TimeUtils.getStartTime();
         try {
-            executor.handleDMLStmt(execPlan, insertStmt);
+            executor.handleDMLStmt(execPlan, insertStmt, beginTimeInNanoSecond);
         } finally {
             QeProcessorImpl.INSTANCE.unregisterQuery(ctx.getExecutionId());
             auditAfterExec(mvContext, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -60,7 +60,6 @@ import com.starrocks.planner.HdfsScanNode;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
@@ -967,6 +966,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     @VisibleForTesting
     public void refreshMaterializedView(MvTaskRunContext mvContext, ExecPlan execPlan, InsertStmt insertStmt)
             throws Exception {
+        long beginTimeInNanoSecond = TimeUtils.getStartTime();
         Preconditions.checkNotNull(execPlan);
         Preconditions.checkNotNull(insertStmt);
         ConnectContext ctx = mvContext.getCtx();
@@ -978,11 +978,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
         ctx.setStmtId(new AtomicInteger().incrementAndGet());
         ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
-        long beginTimeInNanoSecond = TimeUtils.getStartTime();
         try {
             executor.handleDMLStmt(execPlan, insertStmt, beginTimeInNanoSecond);
         } finally {
-            QeProcessorImpl.INSTANCE.unregisterQuery(ctx.getExecutionId());
             auditAfterExec(mvContext, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -34,7 +34,6 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.util.DebugUtil;
-import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.hive.MockedHiveMetadata;
 import com.starrocks.qe.ConnectContext;
@@ -260,7 +259,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testUnionAllMvWithPartition() {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -305,7 +304,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testWithPartition() {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -410,7 +409,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testMvWithoutPartition() {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -452,7 +451,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testRangePartitionRefresh() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -587,7 +586,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testRefreshWithHiveTableJoin() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -622,7 +621,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testAutoPartitionRefreshWithHiveTable() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -654,7 +653,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testAutoPartitionRefreshWithPartitionChanged() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -1134,7 +1133,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testRangePartitionRefreshWithHiveTable() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -1181,7 +1180,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testRefreshPartitionWithMulParColumnsHiveTable1() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -1220,7 +1219,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testRefreshPartitionWithMulParColumnsHiveTable2() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -1260,7 +1259,7 @@ public class PartitionBasedMvRefreshProcessorTest {
         final AtomicInteger taskRunCounter = new AtomicInteger();
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 taskRunCounter.incrementAndGet();
             }
         };
@@ -1287,7 +1286,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testClearQueryInfo() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 UUID uuid = UUID.randomUUID();
                 TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
                 System.out.println("register query id: " + DebugUtil.printId(connectContext.getExecutionId()));
@@ -1532,7 +1531,6 @@ public class PartitionBasedMvRefreshProcessorTest {
             throws Exception {
         // mv need refresh with base table partition p3, add partition p99 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        long beginTimeInNanoSecond = TimeUtils.getStartTime();
         new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public void refreshMaterializedView(MvTaskRunContext mvContext, ExecPlan execPlan,
@@ -1552,7 +1550,7 @@ public class PartitionBasedMvRefreshProcessorTest {
                 ctx.setThreadLocalInfo();
                 ctx.setStmtId(new AtomicInteger().incrementAndGet());
                 ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
-                executor.handleDMLStmt(execPlan, insertStmt, beginTimeInNanoSecond);
+                executor.handleDMLStmtImpl(execPlan, insertStmt);
             }
         };
 
@@ -1620,7 +1618,6 @@ public class PartitionBasedMvRefreshProcessorTest {
             throws Exception {
         // drop partition p4 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        long beginTimeInNanoSecond = TimeUtils.getStartTime();
         new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public void refreshMaterializedView(MvTaskRunContext mvContext, ExecPlan execPlan,
@@ -1638,7 +1635,7 @@ public class PartitionBasedMvRefreshProcessorTest {
                 ctx.setThreadLocalInfo();
                 ctx.setStmtId(new AtomicInteger().incrementAndGet());
                 ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
-                executor.handleDMLStmt(execPlan, insertStmt, beginTimeInNanoSecond);
+                executor.handleDMLStmtImpl(execPlan, insertStmt);
             }
         };
 
@@ -1696,7 +1693,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testSyncPartitionWithSsdStorage() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -1746,7 +1743,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testSyncPartitionWithSsdStorageAndCooldownTime() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -259,7 +259,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testUnionAllMvWithPartition() {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -304,7 +304,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testWithPartition() {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -409,7 +409,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testMvWithoutPartition() {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -451,7 +451,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testRangePartitionRefresh() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -586,7 +586,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testRefreshWithHiveTableJoin() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -621,7 +621,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testAutoPartitionRefreshWithHiveTable() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -653,7 +653,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testAutoPartitionRefreshWithPartitionChanged() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -1133,7 +1133,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testRangePartitionRefreshWithHiveTable() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -1180,7 +1180,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testRefreshPartitionWithMulParColumnsHiveTable1() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -1219,7 +1219,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testRefreshPartitionWithMulParColumnsHiveTable2() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -1259,7 +1259,7 @@ public class PartitionBasedMvRefreshProcessorTest {
         final AtomicInteger taskRunCounter = new AtomicInteger();
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 taskRunCounter.incrementAndGet();
             }
         };
@@ -1286,7 +1286,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testClearQueryInfo() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 UUID uuid = UUID.randomUUID();
                 TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
                 System.out.println("register query id: " + DebugUtil.printId(connectContext.getExecutionId()));
@@ -1550,7 +1550,7 @@ public class PartitionBasedMvRefreshProcessorTest {
                 ctx.setThreadLocalInfo();
                 ctx.setStmtId(new AtomicInteger().incrementAndGet());
                 ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
-                executor.handleDMLStmtImpl(execPlan, insertStmt);
+                executor.handleDMLStmt(execPlan, insertStmt);
             }
         };
 
@@ -1635,7 +1635,7 @@ public class PartitionBasedMvRefreshProcessorTest {
                 ctx.setThreadLocalInfo();
                 ctx.setStmtId(new AtomicInteger().incrementAndGet());
                 ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
-                executor.handleDMLStmtImpl(execPlan, insertStmt);
+                executor.handleDMLStmt(execPlan, insertStmt);
             }
         };
 
@@ -1693,7 +1693,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testSyncPartitionWithSsdStorage() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();
@@ -1743,7 +1743,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testSyncPartitionWithSsdStorageAndCooldownTime() throws Exception {
         new MockUp<StmtExecutor>() {
             @Mock
-            public void handleDMLStmtImpl(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
                 if (stmt instanceof InsertStmt) {
                     InsertStmt insertStmt = (InsertStmt) stmt;
                     TableName tableName = insertStmt.getTableName();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -34,6 +34,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.hive.MockedHiveMetadata;
 import com.starrocks.qe.ConnectContext;
@@ -1531,6 +1532,7 @@ public class PartitionBasedMvRefreshProcessorTest {
             throws Exception {
         // mv need refresh with base table partition p3, add partition p99 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
+        long beginTimeInNanoSecond = TimeUtils.getStartTime();
         new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public void refreshMaterializedView(MvTaskRunContext mvContext, ExecPlan execPlan,
@@ -1550,7 +1552,7 @@ public class PartitionBasedMvRefreshProcessorTest {
                 ctx.setThreadLocalInfo();
                 ctx.setStmtId(new AtomicInteger().incrementAndGet());
                 ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
-                executor.handleDMLStmt(execPlan, insertStmt);
+                executor.handleDMLStmt(execPlan, insertStmt, beginTimeInNanoSecond);
             }
         };
 
@@ -1618,6 +1620,7 @@ public class PartitionBasedMvRefreshProcessorTest {
             throws Exception {
         // drop partition p4 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
+        long beginTimeInNanoSecond = TimeUtils.getStartTime();
         new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public void refreshMaterializedView(MvTaskRunContext mvContext, ExecPlan execPlan,
@@ -1635,7 +1638,7 @@ public class PartitionBasedMvRefreshProcessorTest {
                 ctx.setThreadLocalInfo();
                 ctx.setStmtId(new AtomicInteger().incrementAndGet());
                 ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
-                executor.handleDMLStmt(execPlan, insertStmt);
+                executor.handleDMLStmt(execPlan, insertStmt, beginTimeInNanoSecond);
             }
         };
 


### PR DESCRIPTION
Fix bugs introduced by https://github.com/StarRocks/starrocks/pull/25261

- `handleDMLStmt ` has already `writeProfile `, ignore `writeProfile ` in handleCreateTableAsSelectStmt and InsertOverwriteJobRunner

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
