### PR TITLE
[BugFix] fix top node cannot ref agg output when it has grouping set

### DIFF
--- a/be/src/exec/aggregate/agg_hash_variant.cpp
+++ b/be/src/exec/aggregate/agg_hash_variant.cpp
@@ -218,11 +218,10 @@ size_t AggHashMapVariant::size() const {
 
 bool AggHashMapVariant::need_expand(size_t increasement) const {
     size_t capacity = this->capacity();
-    if (capacity == 0) return true;
     // TODO: think about two-level hashmap
     size_t size = this->size() + increasement;
     // see detail implement in reset_growth_left
-    return size >= phmap::priv::CapacityToGrowth(capacity);
+    return size >= capacity - capacity / 8;
 }
 
 size_t AggHashMapVariant::reserved_memory_usage(const MemPool* pool) const {
@@ -296,9 +295,10 @@ size_t AggHashSetVariant::size() const {
 }
 
 bool AggHashSetVariant::need_expand(size_t increasement) const {
+    size_t capacity = this->capacity();
     size_t size = this->size() + increasement;
     // see detail implement in reset_growth_left
-    return size >= phmap::priv::CapacityToGrowth(this->capacity());
+    return size >= capacity - capacity / 8;
 }
 
 size_t AggHashSetVariant::reserved_memory_usage(const MemPool* pool) const {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/QueryTransformer.java
@@ -365,15 +365,20 @@ class QueryTransformer {
         // e.g:
         // before: select sum(a) from xx group by rollup(a);
         // after: select sum(clone(a)) from xx group by rollup(a);
+        List<FunctionCallExpr> copyAggregates;
         if (groupingSetsList != null) {
+            copyAggregates = aggregates.stream().map(e -> (FunctionCallExpr) e.clone())
+                    .collect(Collectors.toList());
             for (Expr groupBy : groupByExpressions) {
-                aggregates.replaceAll(
+                copyAggregates.replaceAll(
                         root -> (FunctionCallExpr) replaceExprBottomUp(root, groupBy, new CloneExpr(groupBy)));
             }
+        } else {
+            copyAggregates = aggregates;
         }
 
         ImmutableList.Builder<Expr> arguments = ImmutableList.builder();
-        aggregates.stream().filter(f -> !f.getParams().isStar())
+        copyAggregates.stream().filter(f -> !f.getParams().isStar())
                 .map(TreeNode::getChildren).flatMap(List::stream)
                 .filter(e -> !(e.isConstant())).forEach(arguments::add);
 
@@ -411,15 +416,19 @@ class QueryTransformer {
         }
 
         Map<ColumnRefOperator, CallOperator> aggregationsMap = Maps.newHashMap();
-        for (FunctionCallExpr aggregate : aggregates) {
+        for (int i = 0; i < aggregates.size(); i++) {
+            FunctionCallExpr copyAggregate = copyAggregates.get(i);
             ScalarOperator aggCallOperator =
-                    SqlToScalarOperatorTranslator.translate(aggregate, subOpt.getExpressionMapping(), columnRefFactory);
+                    SqlToScalarOperatorTranslator.translate(copyAggregate, subOpt.getExpressionMapping(), columnRefFactory);
             CallOperator aggOperator = (CallOperator) aggCallOperator;
 
             ColumnRefOperator colRef =
-                    columnRefFactory.create(aggOperator.getFnName(), aggregate.getType(), aggregate.isNullable());
+                    columnRefFactory.create(aggOperator.getFnName(), copyAggregate.getType(), copyAggregate.isNullable());
             aggregationsMap.put(colRef, aggOperator);
-            groupingTranslations.put(aggregate, colRef);
+
+            // the output key -> value pair must use the original aggregate expr as key, because
+            // the top node may ref the original aggregate expr
+            groupingTranslations.put(aggregates.get(i), colRef);
         }
 
         //Add repeatOperator to support grouping sets

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GroupingSetTest.java
@@ -253,6 +253,27 @@ public class GroupingSetTest extends PlanTestBase {
     }
 
     @Test
+    public void testSameGroupingAggIF1() throws Exception {
+        String sql = "select xx, v2, max(v2 + 1), max(if(xx > 1, v2, v3)) / sum(if(xx < 1, v2, v1)) from " +
+                "(select if(v1=1, 2, 3) as xx, * from t0) ff group by grouping sets ((xx, v2))";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, ":REPEAT_NODE\n" +
+                "  |  repeat: repeat 0 lines [[2, 4]]\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 4> : 14: if\n" +
+                "  |  <slot 5> : clone(2: v2) + 1\n" +
+                "  |  <slot 6> : if(clone(14: if) > 1, clone(2: v2), 3: v3)\n" +
+                "  |  <slot 7> : if(clone(14: if) < 1, clone(2: v2), 1: v1)",
+                "6:Project\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 4> : 4: if\n" +
+                "  |  <slot 8> : 8: max\n" +
+                "  |  <slot 12> : CAST(9: max AS DOUBLE) / CAST(10: sum AS DOUBLE)");
+    }
+
+    @Test
     public void testSameGroupingAggIF2() throws Exception {
         String sql = "select xx, x2, max(xx + 1) from (" +
                 "select if(x1=1, 2, 3) as xx, * from (" +

--- a/test/sql/test_agg/R/test_grouping_set
+++ b/test/sql/test_agg/R/test_grouping_set
@@ -1,0 +1,111 @@
+-- name: test_grouping_set
+CREATE TABLE `t0` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT "",
+  `v4` varchar NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`, `v2`, `v3`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t0 values(1, 2, 3, 'a'), (1, 3, 4, 'b'), (2, 3, 4, 'a'), (null, 1, null, 'c'), (4, null, 1 , null),
+(5, 1 , 3, 'c'), (2, 2, null, 'a'), (4, null, 4, 'c'), (null, null, 2, null);
+-- result:
+-- !result
+select v1, sum(v2), min(v2 + v3) from t0 group by grouping sets((v1, v2));
+-- result:
+1	2	5
+2	2	None
+2	3	7
+None	None	None
+4	None	None
+1	3	7
+None	1	None
+5	1	4
+-- !result
+select v1, sum(v2), min(v2 + v3) from t0 group by grouping sets((v1, v2), (v3));
+-- result:
+None	None	None
+None	None	None
+None	1	None
+4	None	None
+5	1	4
+2	3	7
+2	2	None
+None	3	4
+None	None	None
+None	6	7
+None	3	None
+1	3	7
+1	2	5
+-- !result
+select xx, v2, max(v2 + v3) / sum(if(xx < 1, v2, v1 + 1)) from (select if(v1=1, 2, 3) as xx, * from t0) ff group by grouping sets ((xx, v2), (v2));
+-- result:
+2	3	3.5
+None	None	None
+None	3	1.4
+3	3	2.3333333333333335
+3	1	0.6666666666666666
+None	1	0.6666666666666666
+2	2	2.5
+3	None	None
+3	2	None
+None	2	1.0
+-- !result
+select v2, sum(if(xx < 1, v2, v1 + 1)), max(v2 + v3) / sum(if(xx < 1, v2, v1 + 1)) from (select if(v1=1, 2, 3) as xx, * from t0) ff group by grouping sets ((xx, v2), (v2, v4));
+-- result:
+None	5	None
+3	2	3.5
+None	5	None
+2	5	1.0
+2	2	2.5
+None	10	None
+3	3	2.3333333333333335
+2	3	None
+1	6	0.6666666666666666
+3	3	2.3333333333333335
+1	6	0.6666666666666666
+3	2	3.5
+-- !result
+select v2, min(if(xx < 1, v2, v1 + 1)), sum(if(xx < 1, v2, v1 + 1)), max(v2 + v3) / sum(if(xx < 1, v2, v1 + 1)) from (select if(v1=1, 2, 3) as xx, * from t0) ff group by grouping sets ((xx, v2), (v2, v4));
+-- result:
+3	3	3	2.3333333333333335
+3	3	3	2.3333333333333335
+2	3	3	None
+2	2	2	2.5
+3	2	2	3.5
+None	5	10	None
+3	2	2	3.5
+1	6	6	0.6666666666666666
+1	6	6	0.6666666666666666
+None	5	5	None
+2	2	5	1.0
+None	5	5	None
+-- !result
+select v2, sum(if(xx < 1, v2, v1 + 1)), max(v2 + v3) / sum(if(xx < 1, v2, v1 + 1)) from (select if(v1=1, 2, 3) as xx, * from t0) ff group by rollup(xx, v2, v4);
+-- result:
+3	2	3.5
+None	26	0.2692307692307692
+None	5	None
+None	5	None
+1	6	0.6666666666666666
+2	2	2.5
+2	2	2.5
+2	3	None
+1	6	0.6666666666666666
+2	3	None
+None	4	1.75
+3	3	2.3333333333333335
+None	22	0.3181818181818182
+None	10	None
+3	3	2.3333333333333335
+3	2	3.5
+-- !result

--- a/test/sql/test_agg/T/test_grouping_set
+++ b/test/sql/test_agg/T/test_grouping_set
@@ -1,0 +1,27 @@
+-- name: test_grouping_set
+
+CREATE TABLE `t0` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT "",
+  `v4` varchar NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`, `v2`, `v3`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+insert into t0 values(1, 2, 3, 'a'), (1, 3, 4, 'b'), (2, 3, 4, 'a'), (null, 1, null, 'c'), (4, null, 1 , null),
+(5, 1 , 3, 'c'), (2, 2, null, 'a'), (4, null, 4, 'c'), (null, null, 2, null);
+
+select v1, sum(v2), min(v2 + v3) from t0 group by grouping sets((v1, v2));
+select v1, sum(v2), min(v2 + v3) from t0 group by grouping sets((v1, v2), (v3));
+select xx, v2, max(v2 + v3) / sum(if(xx < 1, v2, v1 + 1)) from (select if(v1=1, 2, 3) as xx, * from t0) ff group by grouping sets ((xx, v2), (v2));
+select v2, sum(if(xx < 1, v2, v1 + 1)), max(v2 + v3) / sum(if(xx < 1, v2, v1 + 1)) from (select if(v1=1, 2, 3) as xx, * from t0) ff group by grouping sets ((xx, v2), (v2, v4));
+select v2, min(if(xx < 1, v2, v1 + 1)), sum(if(xx < 1, v2, v1 + 1)), max(v2 + v3) / sum(if(xx < 1, v2, v1 + 1)) from (select if(v1=1, 2, 3) as xx, * from t0) ff group by grouping sets ((xx, v2), (v2, v4));
+select v2, sum(if(xx < 1, v2, v1 + 1)), max(v2 + v3) / sum(if(xx < 1, v2, v1 + 1)) from (select if(v1=1, 2, 3) as xx, * from t0) ff group by rollup(xx, v2, v4);


### PR DESCRIPTION
Fixes #issue
For sql like
```
select v1, v2, max(v2 + 1), max(v2 + 1) / min(v2 + 1) from t0 group by groupings set ((v1, v2), (v1));
```
we will rewrite these aggregations to `max(clone(v2) + 1)`, `min(clone(v2) + 1)`and add a projection of `v1, v2, clone(v2) + 1` before the agg. While the node above the agg node depends the original aggregation expr to transform, it cannot obtain `max(v2+1)` from the `ExpressionMapping` only contains `max(clone(v2) + 1)` -> `scalarOperator`, so the top node cannot be transformed correctly.
We have to retain the orginal aggregation epxrs and use them as the key in `ExpressionMapping`. After the pr, the plan is 
```
mysql> explain select v1, v2, max(v2 + 1), max(v2 + 1) / min(v2 + 1) from t0 group by grouping sets ((v1, v2), (v1));
+------------------------------------------------------------------+
| Explain String                                                   |
+------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                  |
|  OUTPUT EXPRS:1: v1 | 2: v2 | 7: max | 10: expr                  |
|   PARTITION: UNPARTITIONED                                       |
|                                                                  |
|   RESULT SINK                                                    |
|                                                                  |
|   7:EXCHANGE                                                     |
|                                                                  |
| PLAN FRAGMENT 1                                                  |
|  OUTPUT EXPRS:                                                   |
|   PARTITION: HASH_PARTITIONED: 1: v1, 2: v2, 9: GROUPING_ID      |
|                                                                  |
|   STREAM DATA SINK                                               |
|     EXCHANGE ID: 07                                              |
|     UNPARTITIONED                                                |
|                                                                  |
|   6:Project                                                      |
|   |  <slot 1> : 1: v1                                            |
|   |  <slot 2> : 2: v2                                            |
|   |  <slot 7> : 7: max                                           |
|   |  <slot 10> : CAST(7: max AS DOUBLE) / CAST(8: min AS DOUBLE) |
|   |                                                              |
|   5:AGGREGATE (merge finalize)                                   |
|   |  output: max(7: max), min(8: min)                            |
|   |  group by: 1: v1, 2: v2, 9: GROUPING_ID                      |
|   |                                                              |
|   4:EXCHANGE                                                     |
|                                                                  |
| PLAN FRAGMENT 2                                                  |
|  OUTPUT EXPRS:                                                   |
|   PARTITION: RANDOM                                              |
|                                                                  |
|   STREAM DATA SINK                                               |
|     EXCHANGE ID: 04                                              |
|     HASH_PARTITIONED: 1: v1, 2: v2, 9: GROUPING_ID               |
|                                                                  |
|   3:AGGREGATE (update serialize)                                 |
|   |  STREAMING                                                   |
|   |  output: max(6: expr), min(6: expr)                          |
|   |  group by: 1: v1, 2: v2, 9: GROUPING_ID                      |
|   |                                                              |
|   2:REPEAT_NODE                                                  |
|   |  repeat: repeat 1 lines [[1, 2], [1]]                        |
|   |                                                              |
|   1:Project                                                      |
|   |  <slot 1> : 1: v1                                            |
|   |  <slot 2> : 2: v2                                            |
|   |  <slot 6> : clone(2: v2) + 1                                 |
|   |                                                              |
|   0:OlapScanNode                                                 |
|      TABLE: t0                                                   |
|      PREAGGREGATION: ON                                          |
|      partitions=1/1                                              |
|      rollup: t0                                                  |
|      tabletRatio=3/3                                             |
|      tabletList=112056,112058,112060                             |
|      cardinality=9                                               |
|      avgRowSize=17.0                                             |
+------------------------------------------------------------------+
58 rows in set (0.00 sec)
```
Another chages is about the check `IsValidCapacity(capacity)` in `CapacityToGrowth(capacity)`. Becuase `capcity()` in `parallel_hash_set` may retain n*set_.capacity() which may fail in the check. So directly use `capacity - capacity / 8` to calculate the loads in the map.
```
size_t capacity() const {
        size_t c = 0;
        for (const auto& inner : sets_) c += inner.set_.capacity();
        return c;
    }
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
