### PR TITLE
[BugFix] check subfield not empty when create unamed structType

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
@@ -82,6 +82,8 @@ public class StructType extends Type {
     // Used to construct an unnamed struct type, for example, to create a struct type
     // row(1, 'b') to create an unnamed struct type struct<int, string>
     public StructType(List<Type> fieldTypes) {
+        Preconditions.checkNotNull(fieldTypes);
+        Preconditions.checkArgument(fieldTypes.size() > 0);
         isNamed = false;
         this.fields = new ArrayList<>();
         for (int i = 0; i < fieldTypes.size(); i++) {


### PR DESCRIPTION
Fixes #issue
We encountered structtype fields is empty and lead to structType deserialize error and fe restart failed.
The root reason is on finding out, this pr just give a preventive measure.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
