### PR TITLE
[Enhancement] Add two new parameters for routine load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -214,7 +214,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                     long timeToExecuteMs = System.currentTimeMillis() + taskSchedIntervalS * 1000;
                     KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(UUID.randomUUID(), id,
                             taskSchedIntervalS * 1000,
-                            timeToExecuteMs, taskKafkaProgress);
+                            timeToExecuteMs, taskKafkaProgress, taskTimeoutSecond * 1000);
                     routineLoadTaskInfoList.add(kafkaTaskInfo);
                     result.add(kafkaTaskInfo);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -72,19 +72,20 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
     private Map<Integer, Long> latestPartOffset;
 
     public KafkaTaskInfo(UUID id, long jobId, long taskScheduleIntervalMs, long timeToExecuteMs,
-                         Map<Integer, Long> partitionIdToOffset) {
-        super(id, jobId, taskScheduleIntervalMs, timeToExecuteMs);
+                         Map<Integer, Long> partitionIdToOffset, long taskTimeoutMs) {
+        super(id, jobId, taskScheduleIntervalMs, timeToExecuteMs, taskTimeoutMs);
         this.partitionIdToOffset = partitionIdToOffset;
     }
 
     public KafkaTaskInfo(long timeToExecuteMs, KafkaTaskInfo kafkaTaskInfo, Map<Integer, Long> partitionIdToOffset,
                          Map<Integer, Long> latestPartOffset) {
-        this(timeToExecuteMs, kafkaTaskInfo, partitionIdToOffset);
+        this(timeToExecuteMs, kafkaTaskInfo, partitionIdToOffset, kafkaTaskInfo.getTimeoutMs());
     }
 
-    public KafkaTaskInfo(long timeToExecuteMs, KafkaTaskInfo kafkaTaskInfo, Map<Integer, Long> partitionIdToOffset) {
+    public KafkaTaskInfo(long timeToExecuteMs, KafkaTaskInfo kafkaTaskInfo, Map<Integer, Long> partitionIdToOffset,
+                         long tastTimeoutMs) {
         super(UUID.randomUUID(), kafkaTaskInfo.getJobId(),
-                kafkaTaskInfo.getTaskScheduleIntervalMs(), timeToExecuteMs, kafkaTaskInfo.getBeId());
+                kafkaTaskInfo.getTaskScheduleIntervalMs(), timeToExecuteMs, kafkaTaskInfo.getBeId(), tastTimeoutMs);
         this.partitionIdToOffset = partitionIdToOffset;
     }
 
@@ -173,7 +174,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         tRoutineLoadTask.setKafka_load_info(tKafkaLoadInfo);
         tRoutineLoadTask.setType(TLoadSourceType.KAFKA);
         tRoutineLoadTask.setParams(plan(routineLoadJob));
-        tRoutineLoadTask.setMax_interval_s(Config.routine_load_task_consume_second);
+        tRoutineLoadTask.setMax_interval_s(routineLoadJob.getTaskConsumeSecond());
         tRoutineLoadTask.setMax_batch_rows(routineLoadJob.getMaxBatchRows());
         tRoutineLoadTask.setMax_batch_size(Config.max_routine_load_batch_size);
         if (!routineLoadJob.getFormat().isEmpty() && routineLoadJob.getFormat().equalsIgnoreCase("json")) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
@@ -193,7 +193,8 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
                     }
                     long timeToExecuteMs = System.currentTimeMillis() + taskSchedIntervalS * 1000;
                     PulsarTaskInfo pulsarTaskInfo = new PulsarTaskInfo(UUID.randomUUID(), id,
-                            taskSchedIntervalS * 1000, timeToExecuteMs, partitions, initialPositions);
+                            taskSchedIntervalS * 1000, timeToExecuteMs, partitions,
+                            initialPositions, getTaskTimeoutSecond() * 1000);
                     LOG.debug("pulsar routine load task created: " + pulsarTaskInfo);
                     routineLoadTaskInfoList.add(pulsarTaskInfo);
                     result.add(pulsarTaskInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
@@ -44,8 +44,8 @@ public class PulsarTaskInfo extends RoutineLoadTaskInfo {
     private Map<String, Long> initialPositions = Maps.newHashMap();
 
     public PulsarTaskInfo(UUID id, long jobId, long taskScheduleIntervalMs, long timeToExecuteMs,
-                          List<String> partitions, Map<String, Long> initialPositions) {
-        super(id, jobId, taskScheduleIntervalMs, timeToExecuteMs);
+                          List<String> partitions, Map<String, Long> initialPositions, long tastTimeoutMs) {
+        super(id, jobId, taskScheduleIntervalMs, timeToExecuteMs, tastTimeoutMs);
         this.partitions = partitions;
         this.initialPositions.putAll(initialPositions);
     }
@@ -139,7 +139,7 @@ public class PulsarTaskInfo extends RoutineLoadTaskInfo {
         tRoutineLoadTask.setPulsar_load_info(tPulsarLoadInfo);
         tRoutineLoadTask.setType(TLoadSourceType.PULSAR);
         tRoutineLoadTask.setParams(plan(routineLoadJob));
-        tRoutineLoadTask.setMax_interval_s(Config.routine_load_task_consume_second);
+        tRoutineLoadTask.setMax_interval_s(routineLoadJob.getTaskConsumeSecond());
         tRoutineLoadTask.setMax_batch_rows(routineLoadJob.getMaxBatchRows());
         tRoutineLoadTask.setMax_batch_size(Config.max_routine_load_batch_size);
         if (!routineLoadJob.getFormat().isEmpty() && routineLoadJob.getFormat().equalsIgnoreCase("json")) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
@@ -37,7 +37,6 @@ package com.starrocks.load.routineload;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
-import com.starrocks.common.Config;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.TimeUtils;
@@ -104,18 +103,18 @@ public abstract class RoutineLoadTaskInfo {
     protected StreamLoadTask streamLoadTask = null;
 
     public RoutineLoadTaskInfo(UUID id, long jobId, long taskScheduleIntervalMs,
-                               long timeToExecuteMs) {
+                               long timeToExecuteMs, long taskTimeoutMs) {
         this.id = id;
         this.jobId = jobId;
         this.createTimeMs = System.currentTimeMillis();
         this.taskScheduleIntervalMs = taskScheduleIntervalMs;
-        this.timeoutMs = 1000 * Config.routine_load_task_timeout_second;
+        this.timeoutMs = taskTimeoutMs;
         this.timeToExecuteMs = timeToExecuteMs;
     }
 
     public RoutineLoadTaskInfo(UUID id, long jobId, long taskSchedulerIntervalMs,
-                               long timeToExecuteMs, long previousBeId) {
-        this(id, jobId, taskSchedulerIntervalMs, timeToExecuteMs);
+                               long timeToExecuteMs, long previousBeId, long taskTimeoutMs) {
+        this(id, jobId, taskSchedulerIntervalMs, timeToExecuteMs, taskTimeoutMs);
         this.previousBeId = previousBeId;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -460,7 +460,7 @@ public class StreamLoadInfo {
         partitions = routineLoadJob.getPartitions();
         strictMode = routineLoadJob.isStrictMode();
         timezone = routineLoadJob.getTimezone();
-        timeout = (int) Config.routine_load_task_timeout_second;
+        timeout = (int) routineLoadJob.getTaskTimeoutSecond();
         if (!routineLoadJob.getJsonPaths().isEmpty()) {
             jsonPaths = routineLoadJob.getJsonPaths();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateRoutineLoadStmt.java
@@ -100,7 +100,9 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final String MAX_BATCH_INTERVAL_SEC_PROPERTY = "max_batch_interval";
     public static final String MAX_BATCH_ROWS_PROPERTY = "max_batch_rows";
     public static final String MAX_BATCH_SIZE_PROPERTY = "max_batch_size";  // deprecated
-
+    public static final String TASK_CONSUME_SECOND = "task_consume_second";
+    public static final String TASK_TIMEOUT_SECOND = "task_timeout_second";
+    public static final int TASK_TIMEOUT_SECOND_TASK_CONSUME_SECOND_RATIO = 4;
     public static final String LOG_REJECTED_RECORD_NUM_PROPERTY = "log_rejected_record_num";
 
     // the value is csv or json, default is csv
@@ -155,6 +157,8 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             .add(ENCLOSE)
             .add(ESCAPE)
             .add(LOG_REJECTED_RECORD_NUM_PROPERTY)
+            .add(TASK_CONSUME_SECOND)
+            .add(TASK_TIMEOUT_SECOND)
             .build();
 
     private static final ImmutableSet<String> KAFKA_PROPERTIES_SET = new ImmutableSet.Builder<String>()
@@ -191,6 +195,8 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     private double maxFilterRatio = 1;
     private long maxBatchIntervalS = -1;
     private long maxBatchRows = -1;
+    private long taskConsumeSecond;
+    private long taskTimeoutSecond;
     private long logRejectedRecordNum = 0;
     private boolean strictMode = true;
     private String timezone = TimeUtils.DEFAULT_TIME_ZONE;
@@ -265,6 +271,14 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
     public void setConfluentSchemaRegistryUrl(String confluentSchemaRegistryUrl) {
         this.confluentSchemaRegistryUrl = confluentSchemaRegistryUrl;
+    }
+
+    public long getTaskConsumeSecond() {
+        return taskConsumeSecond;
+    }
+
+    public long getTaskTimeoutSecond() {
+        return taskTimeoutSecond;
     }
 
     public boolean isTrimspace() {
@@ -588,6 +602,46 @@ public class CreateRoutineLoadStmt extends DdlStmt {
             } else {
                 escape = 0;
             }
+        }
+
+        if (jobProperties.containsKey(TASK_CONSUME_SECOND) && jobProperties.containsKey(TASK_TIMEOUT_SECOND)) {
+            String taskConsumeSecondStr = jobProperties.get(TASK_CONSUME_SECOND);
+            try {
+                taskConsumeSecond = Long.parseLong(taskConsumeSecondStr);
+            } catch (NumberFormatException e) {
+                throw new UserException(e.getMessage());
+            }
+            String taskTimeoutSecondStr = jobProperties.get(TASK_TIMEOUT_SECOND);
+            try {
+                taskTimeoutSecond = Long.parseLong(taskTimeoutSecondStr);
+            } catch (NumberFormatException e) {
+                throw new UserException(e.getMessage());
+            }
+            if (taskConsumeSecond >= taskTimeoutSecond) {
+                throw new UserException("task_timeout_second must be larger than task_consume_second");
+            }
+        } else if (jobProperties.containsKey(TASK_CONSUME_SECOND) || jobProperties.containsKey(TASK_TIMEOUT_SECOND)) {
+            if (jobProperties.containsKey(TASK_CONSUME_SECOND)) {
+                String taskConsumeSecondStr = jobProperties.get(TASK_CONSUME_SECOND);
+                try {
+                    taskConsumeSecond = Long.parseLong(taskConsumeSecondStr);
+                } catch (NumberFormatException e) {
+                    throw new UserException(e.getMessage());
+                }
+                taskTimeoutSecond = taskConsumeSecond * TASK_TIMEOUT_SECOND_TASK_CONSUME_SECOND_RATIO;
+            }
+            if (jobProperties.containsKey(TASK_TIMEOUT_SECOND)) {
+                String taskTimeoutSecondStr = jobProperties.get(TASK_TIMEOUT_SECOND);
+                try {
+                    taskTimeoutSecond = Long.parseLong(taskTimeoutSecondStr);
+                } catch (NumberFormatException e) {
+                    throw new UserException(e.getMessage());
+                }
+                taskConsumeSecond = taskTimeoutSecond / TASK_TIMEOUT_SECOND_TASK_CONSUME_SECOND_RATIO;
+            }
+        } else {
+            taskConsumeSecond = Config.routine_load_task_consume_second;
+            taskTimeoutSecond = Config.routine_load_task_timeout_second;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterRoutineLoadStmtTest.java
@@ -102,6 +102,7 @@ public class AlterRoutineLoadStmtTest {
                 + "\"desired_concurrent_number\"=\"3\",\n"
                 + "\"max_batch_interval\" = \"21\",\n"
                 + "\"strict_mode\" = \"false\",\n"
+                + "\"task_consume_second\" = \"5\",\n"
                 + "\"timezone\" = \"Africa/Abidjan\"\n"
                 + ")\n"
                 + "FROM KAFKA\n"
@@ -115,7 +116,7 @@ public class AlterRoutineLoadStmtTest {
         AlterRoutineLoadStmt stmt = (AlterRoutineLoadStmt)stmts.get(0);
         AlterRoutineLoadAnalyzer.analyze(stmt, connectContext);
 
-        Assert.assertEquals(7, stmt.getAnalyzedJobProperties().size());
+        Assert.assertEquals(9, stmt.getAnalyzedJobProperties().size());
         Assert.assertTrue(
                 stmt.getAnalyzedJobProperties().containsKey(CreateRoutineLoadStmt.MAX_ERROR_NUMBER_PROPERTY));
         Assert.assertTrue(
@@ -123,6 +124,8 @@ public class AlterRoutineLoadStmtTest {
         Assert.assertEquals("0.3", stmt.getAnalyzedJobProperties().get(CreateRoutineLoadStmt.MAX_FILTER_RATIO_PROPERTY));
         Assert.assertTrue(
                 stmt.getAnalyzedJobProperties().containsKey(CreateRoutineLoadStmt.MAX_BATCH_ROWS_PROPERTY));
+        Assert.assertEquals("5", stmt.getAnalyzedJobProperties().get(CreateRoutineLoadStmt.TASK_CONSUME_SECOND));
+        Assert.assertEquals("20", stmt.getAnalyzedJobProperties().get(CreateRoutineLoadStmt.TASK_TIMEOUT_SECOND));
         Assert.assertTrue(stmt.hasDataSourceProperty());
         Assert.assertEquals(1, stmt.getDataSourceProperties().getCustomKafkaProperties().size());
         Assert.assertTrue(stmt.getDataSourceProperties().getCustomKafkaProperties().containsKey("group.id"));

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateRoutineLoadStmtTest.java
@@ -148,6 +148,61 @@ public class CreateRoutineLoadStmtTest {
     }
 
     @Test
+    public void testTaskTimeout() {
+        {
+            String sql = "CREATE ROUTINE LOAD testdb.routine_name ON table1"
+                    + " PROPERTIES( \"desired_concurrent_number\"=\"3\",\n"
+                    + "\"task_consume_second\" = \"5\",\n"
+                    + "\"task_timeout_second\" = \"15\"\n"
+                    + ")\n"
+                    + "FROM KAFKA\n"
+                    + "(\n"
+                    + "\"kafka_broker_list\" = \"kafkahost1:9092,kafkahost2:9092\",\n"
+                    + "\"kafka_topic\" = \"topictest\"\n"
+                    + ");";
+            List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(sql, 32);
+            CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) stmts.get(0);
+            CreateRoutineLoadAnalyzer.analyze(createRoutineLoadStmt, connectContext);
+            Assert.assertEquals(15, createRoutineLoadStmt.getTaskTimeoutSecond());
+            Assert.assertEquals(5, createRoutineLoadStmt.getTaskConsumeSecond());
+        }
+
+        {
+            String sql = "CREATE ROUTINE LOAD testdb.routine_name ON table1"
+                    + " PROPERTIES( \"desired_concurrent_number\"=\"3\",\n"
+                    + "\"timezone\" = \"Asia/Shanghai\"\n"
+                    + ")\n"
+                    + "FROM KAFKA\n"
+                    + "(\n"
+                    + "\"kafka_broker_list\" = \"kafkahost1:9092,kafkahost2:9092\",\n"
+                    + "\"kafka_topic\" = \"topictest\"\n"
+                    + ");";
+            List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(sql, 32);
+            CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) stmts.get(0);
+            CreateRoutineLoadAnalyzer.analyze(createRoutineLoadStmt, connectContext);
+            Assert.assertEquals(Config.routine_load_task_timeout_second, createRoutineLoadStmt.getTaskTimeoutSecond());
+            Assert.assertEquals(Config.routine_load_task_consume_second, createRoutineLoadStmt.getTaskConsumeSecond());
+        }
+
+        {
+            String sql = "CREATE ROUTINE LOAD testdb.routine_name ON table1"
+                    + " PROPERTIES( \"desired_concurrent_number\"=\"3\",\n"
+                    + "\"task_timeout_second\" = \"20\"\n"
+                    + ")\n"
+                    + "FROM KAFKA\n"
+                    + "(\n"
+                    + "\"kafka_broker_list\" = \"kafkahost1:9092,kafkahost2:9092\",\n"
+                    + "\"kafka_topic\" = \"topictest\"\n"
+                    + ");";
+            List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(sql, 32);
+            CreateRoutineLoadStmt createRoutineLoadStmt = (CreateRoutineLoadStmt) stmts.get(0);
+            CreateRoutineLoadAnalyzer.analyze(createRoutineLoadStmt, connectContext);
+            Assert.assertEquals(20, createRoutineLoadStmt.getTaskTimeoutSecond());
+            Assert.assertEquals(5, createRoutineLoadStmt.getTaskConsumeSecond());
+        }
+    }
+
+    @Test
     public void testLoadColumns() {
         String sql = "CREATE ROUTINE LOAD testdb.routine_name ON table1" +
                 " COLUMNS(`k1`, `k2`, `k3`, `k4`, `k5`," +

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaRoutineLoadJobTest.java
@@ -250,7 +250,8 @@ public class KafkaRoutineLoadJobTest {
         Map<Integer, Long> partitionIdsToOffset = Maps.newHashMap();
         partitionIdsToOffset.put(100, 0L);
         KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(new UUID(1, 1), 1L,
-                maxBatchIntervalS * 2 * 1000, System.currentTimeMillis(), partitionIdsToOffset);
+                maxBatchIntervalS * 2 * 1000, System.currentTimeMillis(), partitionIdsToOffset,
+                routineLoadJob.getTaskTimeoutSecond() * 1000);
         kafkaTaskInfo.setExecuteStartTimeMs(System.currentTimeMillis() - maxBatchIntervalS * 2 * 1000 - 1);
         routineLoadTaskInfoList.add(kafkaTaskInfo);
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
@@ -17,6 +17,7 @@ package com.starrocks.load.routineload;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.KafkaUtil;
@@ -59,7 +60,8 @@ public class KafkaTaskInfoTest {
                 1L,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
-                offset1);
+                offset1,
+                Config.routine_load_task_timeout_second * 1000);
         Assert.assertTrue(kafkaTaskInfo1.readyToExecute());
 
         Map<Integer, Long> offset2 = Maps.newHashMap();
@@ -68,7 +70,8 @@ public class KafkaTaskInfoTest {
                 1L,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
-                offset2);
+                offset2,
+                Config.routine_load_task_timeout_second * 1000);
         Assert.assertFalse(kafkaTaskInfo2.readyToExecute());
     }
 
@@ -99,7 +102,8 @@ public class KafkaTaskInfoTest {
                 1L,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
-                offset);
+                offset,
+                Config.routine_load_task_timeout_second * 1000);
         // call readyExecute to cache latestPartOffset
         kafkaTaskInfo.readyToExecute();
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -287,6 +287,8 @@ public class RoutineLoadJobTest {
         String jsonPaths = "[\\\"$.category\\\",\\\"$.author\\\",\\\"$.price\\\",\\\"$.timestamp\\\"]";
         String stripOuterArray = "true";
         String jsonRoot = "$.RECORDS";
+        String taskTimeout = "20";
+        String taskConsumeTime = "3";
         String originStmt = "alter routine load for db.job1 " +
                 "properties (" +
                 "   \"desired_concurrent_number\" = \"" + desiredConcurrentNumber + "\"," +
@@ -294,6 +296,8 @@ public class RoutineLoadJobTest {
                 "   \"max_error_number\" = \"" + maxErrorNumber + "\"," +
                 "   \"max_filter_ratio\" = \"" + maxFilterRatio + "\"," +
                 "   \"max_batch_rows\" = \"" + maxBatchRows + "\"," +
+                "   \"task_consume_second\" = \"" + taskConsumeTime + "\"," +
+                "   \"task_timeout_second\" = \"" + taskTimeout + "\"," +
                 "   \"strict_mode\" = \"" + strictMode + "\"," +
                 "   \"timezone\" = \"" + timeZone + "\"," +
                 "   \"jsonpaths\" = \"" + jsonPaths + "\"," +
@@ -301,6 +305,10 @@ public class RoutineLoadJobTest {
                 "   \"json_root\" = \"" + jsonRoot + "\"" +
                 ")";
         AlterRoutineLoadStmt stmt = (AlterRoutineLoadStmt) UtFrameUtils.parseStmtWithNewParser(originStmt, connectContext);
+        for (String key : stmt.getAnalyzedJobProperties().keySet()) {
+            System.out.println("Key: " + key);
+            System.out.println("Value: " + stmt.getAnalyzedJobProperties().get(key));
+        }
         routineLoadJob.modifyJob(stmt.getRoutineLoadDesc(), stmt.getAnalyzedJobProperties(),
                 stmt.getDataSourceProperties(), new OriginStatement(originStmt, 0), true);
         Assert.assertEquals(Integer.parseInt(desiredConcurrentNumber),
@@ -311,6 +319,10 @@ public class RoutineLoadJobTest {
                 (long) Deencapsulation.getField(routineLoadJob, "maxErrorNum"));
         Assert.assertEquals(Double.parseDouble(maxFilterRatio),
                 (double) Deencapsulation.getField(routineLoadJob, "maxFilterRatio"), 0.01);
+        Assert.assertEquals(Long.parseLong(taskTimeout),
+                (long) Deencapsulation.getField(routineLoadJob, "taskTimeoutSecond"));
+        Assert.assertEquals(Long.parseLong(taskConsumeTime),
+                (long) Deencapsulation.getField(routineLoadJob, "taskConsumeSecond"));
         Assert.assertEquals(Long.parseLong(maxBatchRows),
                 (long) Deencapsulation.getField(routineLoadJob, "maxBatchRows"));
         Assert.assertEquals(Boolean.parseBoolean(strictMode), routineLoadJob.isStrictMode());

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadTaskSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadTaskSchedulerTest.java
@@ -36,6 +36,7 @@ package com.starrocks.load.routineload;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
+import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
 import mockit.Expectations;
@@ -67,7 +68,7 @@ public class RoutineLoadTaskSchedulerTest {
 
         Queue<RoutineLoadTaskInfo> routineLoadTaskInfoQueue = Queues.newLinkedBlockingQueue();
         KafkaTaskInfo routineLoadTaskInfo1 = new KafkaTaskInfo(new UUID(1, 1), 1L, 20000,
-                System.currentTimeMillis(), partitionIdToOffset);
+                System.currentTimeMillis(), partitionIdToOffset, Config.routine_load_task_timeout_second * 1000);
         routineLoadTaskInfoQueue.add(routineLoadTaskInfo1);
 
         Map<Long, RoutineLoadTaskInfo> idToRoutineLoadTask = Maps.newHashMap();

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -352,7 +352,7 @@ public class GlobalTransactionMgrTest {
         partitionIdToOffset.put(1, 0L);
         KafkaTaskInfo routineLoadTaskInfo =
                 new KafkaTaskInfo(UUID.randomUUID(), 1L, 20000, System.currentTimeMillis(),
-                        partitionIdToOffset);
+                        partitionIdToOffset, Config.routine_load_task_timeout_second);
         Deencapsulation.setField(routineLoadTaskInfo, "txnId", 1L);
         routineLoadTaskInfoList.add(routineLoadTaskInfo);
         TransactionState transactionState = new TransactionState(1L, Lists.newArrayList(1L), 1L, "label", null,
@@ -425,7 +425,7 @@ public class GlobalTransactionMgrTest {
         partitionIdToOffset.put(1, 0L);
         KafkaTaskInfo routineLoadTaskInfo =
                 new KafkaTaskInfo(UUID.randomUUID(), 1L, 20000, System.currentTimeMillis(),
-                        partitionIdToOffset);
+                        partitionIdToOffset, Config.routine_load_task_timeout_second);
         Deencapsulation.setField(routineLoadTaskInfo, "txnId", 1L);
         routineLoadTaskInfoList.add(routineLoadTaskInfo);
         TransactionState transactionState = new TransactionState(1L, Lists.newArrayList(1L), 1L, "label", null,


### PR DESCRIPTION
Add two new job parameters for routine load:
+ task_consume_second
+ task_timeout_second

These two parameters are job-level implementations of routine_load_task_consume_second and routine_load_task_timeout_second. You can specify these two parameters when you create a routine load job:
```
CREATE ROUTINE LOAD jobname on tablename 
PROPERTIES (
"task_consume_second"="5",
"task_timeout_second"="20"
) 
FROM KAFKA (
"kafka_broker_list"="addr",
"kafka_topic"="xxx"
)
```
When you do not specify these two parameters when creating a routine load task, SR will use routine_load_task_consume_second and routine_load_task_timeout_second to control the routine load import behavior. A few things to note:
+ task_timeout_second must be greater than task_consume_second.
+ When you configure only task_consume_second, task_timeout_second=task_consume_second*4 by default.
+ When you configure only task_timeout_second, task_consume_second=task_timeout_second/4 by default.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [x] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
