### PR TITLE
[BugFix] update error when table with generate column (#25600)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -84,8 +84,10 @@ public class UpdatePlanner {
             long tableId = table.getId();
             List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
             for (Column column : table.getFullSchema()) {
-                if (updateStmt.usePartialUpdate() && !updateStmt.isAssignmentColumn(column.getName()) && !column.isKey()) {
-                    // When using partial update, skip columns which aren't key column and not be assign
+                if (updateStmt.usePartialUpdate() && !column.isMaterializedColumn() &&
+                        !updateStmt.isAssignmentColumn(column.getName()) && !column.isKey()) {
+                    // When using partial update, skip columns which aren't key column and not be assign, except for
+                    // generated column
                     continue;
                 }
                 SlotDescriptor slotDescriptor = descriptorTable.addSlotDescriptor(olapTuple);

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -595,6 +595,89 @@ ALTER TABLE t ADD COLUMN (newcol5 BIGINT DEFAULT "0", newcol6 BIGINT AS id * 100
 -- result:
 E: (1064, 'Getting analyzing error. Detail message: Can not add normal column and Materialized Column in the same time.')
 -- !result
-DROP DATABASE test_add_multiple_column
+DROP DATABASE test_add_multiple_column;
+-- result:
+-- !result
+-- name: test_update
+CREATE DATABASE test_update;
+-- result:
+-- !result
+USE test_update;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL, v1 BIGINT NOT NULL, v2 BIGINT NOT NULL, v3 BIGINT AS v2) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t VALUES (1, 2, 3);
+-- result:
+-- !result
+SET partial_update_mode = "row";
+-- result:
+-- !result
+UPDATE t SET v1 = 100 where id = 1;
+-- result:
+-- !result
+SELECT * FROM t;
+-- result:
+1	100	3	3
+-- !result
+UPDATE t SET v1 = 200 where v3 = 3;
+-- result:
+-- !result
+SELECT * FROM t;
+-- result:
+1	200	3	3
+-- !result
+UPDATE t SET v2 = 300 where v3 = 3;
+-- result:
+-- !result
+SELECT * FROM t;
+-- result:
+1	200	300	300
+-- !result
+UPDATE t SET v2 = 400 where v3 = 300;
+-- result:
+-- !result
+SELECT * FROM t;
+-- result:
+1	200	400	400
+-- !result
+INSERT INTO t VALUES (1, 2, 3);
+-- result:
+-- !result
+SET partial_update_mode = "column";
+-- result:
+-- !result
+UPDATE t SET v1 = 100 where id = 1;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: All ref Column must be sepecfied in partial update mode.')
+-- !result
+SELECT * FROM t;
+-- result:
+1	2	3	3
+-- !result
+UPDATE t SET v1 = 200 where v3 = 3;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: All ref Column must be sepecfied in partial update mode.')
+-- !result
+SELECT * FROM t;
+-- result:
+1	2	3	3
+-- !result
+UPDATE t SET v2 = 300 where v3 = 3;
+-- result:
+-- !result
+SELECT * FROM t;
+-- result:
+1	2	300	300
+-- !result
+UPDATE t SET v2 = 400 where v3 = 300;
+-- result:
+-- !result
+SELECT * FROM t;
+-- result:
+1	2	400	400
+-- !result
+DROP DATABASE test_update;
 -- result:
 -- !result

--- a/test/sql/test_materialized_column/T/test_materialized_column
+++ b/test/sql/test_materialized_column/T/test_materialized_column
@@ -193,4 +193,34 @@ SHOW CREATE TABLE t;
 
 ALTER TABLE t ADD COLUMN (newcol5 BIGINT DEFAULT "0", newcol6 BIGINT AS id * 1000);
 
-DROP DATABASE test_add_multiple_column
+DROP DATABASE test_add_multiple_column;
+
+-- name: test_update
+CREATE DATABASE test_update;
+USE test_update;
+
+CREATE TABLE t ( id BIGINT NOT NULL, v1 BIGINT NOT NULL, v2 BIGINT NOT NULL, v3 BIGINT AS v2) Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1");
+INSERT INTO t VALUES (1, 2, 3);
+
+SET partial_update_mode = "row";
+UPDATE t SET v1 = 100 where id = 1;
+SELECT * FROM t;
+UPDATE t SET v1 = 200 where v3 = 3;
+SELECT * FROM t;
+UPDATE t SET v2 = 300 where v3 = 3;
+SELECT * FROM t;
+UPDATE t SET v2 = 400 where v3 = 300;
+SELECT * FROM t;
+
+INSERT INTO t VALUES (1, 2, 3);
+SET partial_update_mode = "column";
+UPDATE t SET v1 = 100 where id = 1;
+SELECT * FROM t;
+UPDATE t SET v1 = 200 where v3 = 3;
+SELECT * FROM t;
+UPDATE t SET v2 = 300 where v3 = 3;
+SELECT * FROM t;
+UPDATE t SET v2 = 400 where v3 = 300;
+SELECT * FROM t;
+
+DROP DATABASE test_update;


### PR DESCRIPTION
Fix the following Problems:
1. The variable selectlist in the update analyzer miss for generated column causing NPE problem
2. The update stmt with partial update mode will write the partial segment file
    and does not need all slotDescriptor except for generated column.
    Because generated can not be set in the assignment list but it must 
    be computed and written in the OlapTableSink phase.
4. partial update for update stmt could not miss all ref columns for all generated columns.

Fixes #25600

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
