### PR TITLE
[BugFix] Fix replay create table throws NPE bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/CreateTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/CreateTableInfo.java
@@ -35,6 +35,7 @@
 package com.starrocks.persist;
 
 import com.google.common.base.Objects;
+import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Table;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.FeMetaVersion;
@@ -51,7 +52,9 @@ import java.io.IOException;
 public class CreateTableInfo implements Writable {
     public static final Logger LOG = LoggerFactory.getLogger(CreateTableInfo.class);
 
+    @SerializedName(value = "d")
     private String dbName;
+    @SerializedName(value = "t")
     private Table table;
 
     public CreateTableInfo() {


### PR DESCRIPTION
Fixes 
```
com.starrocks.journal.JournalInconsistentException: failed to load journal type 13000
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:1054) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.replayJournalInner(GlobalStateMgr.java:2134) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.replayJournal(GlobalStateMgr.java:2086) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.transferToLeader(GlobalStateMgr.java:1131) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.access$100(GlobalStateMgr.java:324) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$1.transferToLeader(GlobalStateMgr.java:720) ~[starrocks-fe.jar:?]
        at com.starrocks.ha.StateChangeExecutor.runOneCycle(StateChangeExecutor.java:103) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:115) ~[starrocks-fe.jar:?]
Caused by: java.lang.NullPointerException
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:221) ~[starrocks-fe.jar:?]
        ... 7 more
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
