### PR TITLE
Revert "[Enhancement] Change Sort Key Order for AirByte tables"

### DIFF
--- a/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/SqlUtil.java
+++ b/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/SqlUtil.java
@@ -77,11 +77,11 @@ public class SqlUtil {
 
     public static void createTableIfNotExist(Connection conn, String tableName) throws SQLException {
         String sql = "CREATE TABLE IF NOT EXISTS " + tableName + " ( \n"
-                + "`" + JavaBaseConstants.COLUMN_NAME_EMITTED_AT + "` BIGINT,\n"
                 + "`" + JavaBaseConstants.COLUMN_NAME_AB_ID + "` varchar(40),\n"
+                + "`" + JavaBaseConstants.COLUMN_NAME_EMITTED_AT + "` BIGINT,\n"
                 + "`" + JavaBaseConstants.COLUMN_NAME_DATA + "` String)\n"
-                + "DUPLICATE KEY(`" + JavaBaseConstants.COLUMN_NAME_EMITTED_AT + "`,`"
-                + JavaBaseConstants.COLUMN_NAME_AB_ID + "`) \n"
+                + "DUPLICATE KEY(`" + JavaBaseConstants.COLUMN_NAME_AB_ID + "`,`"
+                + JavaBaseConstants.COLUMN_NAME_EMITTED_AT + "`) \n"
                 + "DISTRIBUTED BY HASH(`" + JavaBaseConstants.COLUMN_NAME_AB_ID + "`) BUCKETS 16 \n"
                 + "PROPERTIES ( \n"
                 + "\"replication_num\" = \"1\" \n"


### PR DESCRIPTION
## Description

https://github.com/StarRocks/starrocks/pull/25026 introduced a bug which I mentioned here - https://github.com/StarRocks/starrocks/pull/25026#issuecomment-1595699817

For now, I'm reverting the change.

Basically during data load to StarRocks, we end up inserting _airbyte_emitted_at value into _airbyte_ab_id and vice-versa.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

