### PR TITLE
[Enhancement] Optimize `select count(*)` query pattern for external table

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -207,6 +207,9 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
     if (hdfs_scan_node.__isset.case_sensitive) {
         _case_sensitive = hdfs_scan_node.case_sensitive;
     }
+    if (hdfs_scan_node.__isset.can_use_any_column) {
+        _can_use_any_column = hdfs_scan_node.can_use_any_column;
+    }
 }
 
 Status HiveDataSource::_decompose_conjunct_ctxs(RuntimeState* state) {
@@ -483,6 +486,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     }
     scanner_params.use_block_cache = _use_block_cache;
     scanner_params.enable_populate_block_cache = _enable_populate_block_cache;
+    scanner_params.can_use_any_column = _can_use_any_column;
 
     HdfsScanner* scanner = nullptr;
     auto format = scan_range.file_format;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -127,6 +127,7 @@ private:
 
     std::vector<std::string> _hive_column_names;
     bool _case_sensitive = false;
+    bool _can_use_any_column = false;
     const HiveTableDescriptor* _hive_table = nullptr;
 
     // ======================================

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -128,6 +128,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.min_max_conjunct_ctxs = _scanner_params.min_max_conjunct_ctxs;
     ctx.min_max_tuple_desc = _scanner_params.min_max_tuple_desc;
     ctx.case_sensitive = _scanner_params.case_sensitive;
+    ctx.can_use_any_column = _scanner_params.can_use_any_column;
     ctx.timezone = _runtime_state->timezone();
     ctx.iceberg_schema = _scanner_params.iceberg_schema;
     ctx.stats = &_stats;

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -172,6 +172,7 @@ struct HdfsScannerParams {
     bool enable_populate_block_cache = false;
 
     std::atomic<int32_t>* lazy_column_coalesce_counter;
+    bool can_use_any_column = false;
 };
 
 struct HdfsScannerContext {
@@ -212,6 +213,8 @@ struct HdfsScannerContext {
     const RuntimeFilterProbeCollector* runtime_filter_collector = nullptr;
 
     bool case_sensitive = false;
+
+    bool can_use_any_column = false;
 
     std::string timezone;
 

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -579,7 +579,7 @@ Status HdfsOrcScanner::_build_chunk_on_use_any_column(ChunkPtr* chunk, size_t* r
     ctx.row_count -= count;
     *row_count = count;
 
-    ColumnPtr c = ColumnHelper::create_const_null_column(count);
+    ColumnPtr c = ColumnHelper::create_column(ctx.slot_desc->type(), ctx.slot_desc->is_nullable(), true, count);
     (*chunk)->update_column(c, ctx.slot_desc->id());
 
     _scanner_ctx.append_not_existed_columns_to_chunk(chunk, count);

--- a/be/src/exec/hdfs_scanner_orc.h
+++ b/be/src/exec/hdfs_scanner_orc.h
@@ -53,6 +53,15 @@ private:
     Filter _dict_filter;
     Filter _chunk_filter;
     std::set<int64_t> _need_skip_rowids;
+
+    struct UseAnyColumnContext {
+        size_t row_count = 0;
+        SlotDescriptor* slot_desc = nullptr;
+    };
+    bool _can_use_any_column() const;
+    void _init_use_any_column();
+    Status _build_chunk_on_use_any_column(ChunkPtr* chunk, size_t* row_count);
+    UseAnyColumnContext _use_any_column_ctx;
 };
 
 } // namespace starrocks

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -451,6 +451,7 @@ Status FileReader::_init_group_readers() {
     _group_reader_param.file_metadata = _file_metadata.get();
     _group_reader_param.case_sensitive = fd_scanner_ctx.case_sensitive;
     _group_reader_param.lazy_column_coalesce_counter = fd_scanner_ctx.lazy_column_coalesce_counter;
+    _group_reader_param.can_use_any_column = fd_scanner_ctx.can_use_any_column;
 
     int64_t row_group_first_row = 0;
     // select and create row group readers.

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -68,7 +68,6 @@ bool GroupReader::_can_use_any_column() const {
 }
 
 void GroupReader::_init_use_any_column() {
-    VLOG_FILE << "[xxx] init_use_any_column = OK";
     UseAnyColumnContext& ctx = _use_any_column_ctx;
     ctx.row_count = _row_group_metadata->num_rows;
 

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -90,7 +90,7 @@ Status GroupReader::_build_chunk_on_use_any_column(ChunkPtr* chunk, size_t* row_
     ctx.row_count -= count;
     *row_count = count;
 
-    ColumnPtr c = ColumnHelper::create_const_null_column(count);
+    ColumnPtr c = ColumnHelper::create_column(ctx.slot_desc->type(), ctx.slot_desc->is_nullable(), true, count);
     (*chunk)->update_column(c, ctx.slot_desc->id());
     return Status::OK();
 }

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <sstream>
 
+#include "column/column.h"
 #include "column/column_helper.h"
 #include "common/status.h"
 #include "exec/exec_node.h"
@@ -42,6 +43,11 @@ GroupReader::GroupReader(GroupReaderParam& param, int row_group_number, const st
 }
 
 Status GroupReader::init() {
+    if (_can_use_any_column()) {
+        _init_use_any_column();
+        return Status::OK();
+    }
+
     // the calling order matters, do not change unless you know why.
     RETURN_IF_ERROR(_init_column_readers());
     _dict_filter_ctx.init(_param.read_cols.size());
@@ -57,7 +63,42 @@ Status GroupReader::prepare() {
     return Status::OK();
 }
 
+bool GroupReader::_can_use_any_column() const {
+    return _param.can_use_any_column && (_need_skip_rowids == nullptr || _need_skip_rowids->empty());
+}
+
+void GroupReader::_init_use_any_column() {
+    VLOG_FILE << "[xxx] init_use_any_column = OK";
+    UseAnyColumnContext& ctx = _use_any_column_ctx;
+    ctx.row_count = _row_group_metadata->num_rows;
+
+    DCHECK_EQ(_param.read_cols.size(), 1);
+    const auto& c = _param.read_cols[0];
+    const auto& slots = _param.tuple_desc->slots();
+    ctx.slot_desc = slots[c.col_idx_in_chunk];
+}
+
+Status GroupReader::_build_chunk_on_use_any_column(ChunkPtr* chunk, size_t* row_count) {
+    UseAnyColumnContext& ctx = _use_any_column_ctx;
+    if (ctx.row_count == 0) {
+        *row_count = 0;
+        return Status::EndOfFile("");
+    }
+
+    size_t count = std::min(ctx.row_count, *row_count);
+    ctx.row_count -= count;
+    *row_count = count;
+    
+    ColumnPtr c = ColumnHelper::create_const_null_column(count);
+    (*chunk)->update_column(c, ctx.slot_desc->id());
+    return Status::OK();
+}
+
 Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
+    if (_can_use_any_column()) {
+        return _build_chunk_on_use_any_column(chunk, row_count);
+    }
+
     if (_is_group_filtered) {
         *row_count = 0;
         return Status::EndOfFile("");
@@ -65,7 +106,6 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
 
     _read_chunk->reset();
     size_t count = *row_count;
-    bool has_more_filter = !_left_conjunct_ctxs.empty();
     Status status;
 
     ChunkPtr active_chunk = _create_read_chunk(_active_column_indices);
@@ -112,6 +152,7 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
         }
     }
 
+    bool has_more_filter = !_left_conjunct_ctxs.empty();
     // other filter that not dict
     if (has_more_filter) {
         SCOPED_RAW_TIMER(&_param.stats->expr_filter_ns);

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -74,6 +74,7 @@ struct GroupReaderParam {
 
     // used to identify io coalesce
     std::atomic<int32_t>* lazy_column_coalesce_counter = nullptr;
+    bool can_use_any_column = false;
 };
 
 class GroupReader {
@@ -179,6 +180,17 @@ private:
     int64_t _end_offset = 0;
 
     DictFilterContext _dict_filter_ctx;
+
+
+    struct UseAnyColumnContext {
+        size_t row_count = 0;
+        SlotDescriptor* slot_desc = nullptr;
+    };
+
+    bool _can_use_any_column() const;
+    Status _build_chunk_on_use_any_column(ChunkPtr* chunk, size_t* row_count);
+    void _init_use_any_column();
+    UseAnyColumnContext _use_any_column_ctx;    
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -181,7 +181,6 @@ private:
 
     DictFilterContext _dict_filter_ctx;
 
-
     struct UseAnyColumnContext {
         size_t row_count = 0;
         SlotDescriptor* slot_desc = nullptr;
@@ -190,7 +189,7 @@ private:
     bool _can_use_any_column() const;
     Status _build_chunk_on_use_any_column(ChunkPtr* chunk, size_t* row_count);
     void _init_use_any_column();
-    UseAnyColumnContext _use_any_column_ctx;    
+    UseAnyColumnContext _use_any_column_ctx;
 };
 
 } // namespace starrocks::parquet

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -208,6 +208,7 @@ public class HdfsScanNode extends ScanNode {
             cloudConfiguration.toThrift(tCloudConfiguration);
             msg.hdfs_scan_node.setCloud_configuration(tCloudConfiguration);
         }
+        msg.hdfs_scan_node.setCan_use_any_column(canUseAnyColumn);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -58,6 +58,7 @@ public abstract class ScanNode extends PlanNode {
     protected String sortColumn = null;
     protected List<ColumnAccessPath> columnAccessPaths;
     protected boolean canUseAnyColumn;
+    protected boolean canUseMinMaxCountOpt;
 
     public ScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
         super(id, desc.getId().asList(), planNodeName);
@@ -76,8 +77,16 @@ public abstract class ScanNode extends PlanNode {
         this.canUseAnyColumn = canUseAnyColumn;
     }
 
+    public void setCanUseMinMaxCountOpt(boolean canUseMinMaxCountOpt) {
+        this.canUseMinMaxCountOpt = canUseMinMaxCountOpt;
+    }
+
     public boolean getCanUseAnyColumn() {
         return canUseAnyColumn;
+    }
+
+    public boolean getCanUseMinMaxCountOpt() {
+        return canUseMinMaxCountOpt;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -57,6 +57,7 @@ public abstract class ScanNode extends PlanNode {
     protected Map<String, PartitionColumnFilter> columnFilters;
     protected String sortColumn = null;
     protected List<ColumnAccessPath> columnAccessPaths;
+    protected boolean canUseAnyColumn;
 
     public ScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
         super(id, desc.getId().asList(), planNodeName);
@@ -69,6 +70,14 @@ public abstract class ScanNode extends PlanNode {
 
     public void setColumnAccessPaths(List<ColumnAccessPath> columnAccessPaths) {
         this.columnAccessPaths = columnAccessPaths;
+    }
+
+    public void setCanUseAnyColumn(boolean canUseAnyColumn) {
+        this.canUseAnyColumn = canUseAnyColumn;
+    }
+
+    public boolean getCanUseAnyColumn() {
+        return canUseAnyColumn;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -35,6 +35,7 @@ import com.starrocks.sql.optimizer.rule.join.ReorderJoinRule;
 import com.starrocks.sql.optimizer.rule.mv.MaterializedViewRule;
 import com.starrocks.sql.optimizer.rule.transformation.ApplyExceptionRule;
 import com.starrocks.sql.optimizer.rule.transformation.GroupByCountDistinctRewriteRule;
+import com.starrocks.sql.optimizer.rule.transformation.LabelMinMaxCountOnScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.LimitPruneTabletsRule;
 import com.starrocks.sql.optimizer.rule.transformation.MergeProjectWithChildRule;
 import com.starrocks.sql.optimizer.rule.transformation.MergeTwoAggRule;
@@ -48,7 +49,6 @@ import com.starrocks.sql.optimizer.rule.transformation.PushDownProjectLimitRule;
 import com.starrocks.sql.optimizer.rule.transformation.PushLimitAndFilterToCTEProduceRule;
 import com.starrocks.sql.optimizer.rule.transformation.RemoveAggregationFromAggTable;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteGroupingSetsByCTERule;
-import com.starrocks.sql.optimizer.rule.transformation.RewriteMinMaxCountOnScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToMetaScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.SemiReorderRule;
 import com.starrocks.sql.optimizer.rule.transformation.SeparateProjectRule;
@@ -391,7 +391,7 @@ public class Optimizer {
         ruleRewriteIterative(tree, rootTaskContext, new PruneEmptyWindowRule());
         ruleRewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
         ruleRewriteIterative(tree, rootTaskContext, new RewriteSimpleAggToMetaScanRule());
-        ruleRewriteOnlyOnce(tree, rootTaskContext, new RewriteMinMaxCountOnScanRule());
+        ruleRewriteOnlyOnce(tree, rootTaskContext, new LabelMinMaxCountOnScanRule());
 
         // After this rule, we shouldn't generate logical project operator
         ruleRewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
@@ -58,6 +58,7 @@ public abstract class LogicalScanOperator extends LogicalOperator {
     protected Set<String> partitionColumns = Sets.newHashSet();
     protected ImmutableList<ColumnAccessPath> columnAccessPaths;
     protected boolean canUseAnyColumn;
+    protected boolean canUseMinMaxCountOpt;
 
     public LogicalScanOperator(
             OperatorType type,
@@ -117,6 +118,14 @@ public abstract class LogicalScanOperator extends LogicalOperator {
 
     public boolean getCanUseAnyColumn() {
         return canUseAnyColumn;
+    }
+
+    public void setCanUseMinMaxCountOpt(boolean canUseMinMaxCountOpt) {
+        this.canUseMinMaxCountOpt = canUseMinMaxCountOpt;
+    }
+
+    public boolean getCanUseMinMaxCountOpt() {
+        return canUseMinMaxCountOpt;
     }
 
     @Override
@@ -209,6 +218,7 @@ public abstract class LogicalScanOperator extends LogicalOperator {
             builder.columnFilters = scanOperator.columnFilters;
             builder.columnAccessPaths = scanOperator.columnAccessPaths;
             builder.canUseAnyColumn = scanOperator.canUseAnyColumn;
+            builder.canUseMinMaxCountOpt = scanOperator.canUseMinMaxCountOpt;
             return (B) this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
@@ -208,6 +208,7 @@ public abstract class LogicalScanOperator extends LogicalOperator {
             builder.columnMetaToColRefMap = scanOperator.columnMetaToColRefMap;
             builder.columnFilters = scanOperator.columnFilters;
             builder.columnAccessPaths = scanOperator.columnAccessPaths;
+            builder.canUseAnyColumn = scanOperator.canUseAnyColumn;
             return (B) this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalScanOperator.java
@@ -57,6 +57,7 @@ public abstract class LogicalScanOperator extends LogicalOperator {
     protected ImmutableMap<String, PartitionColumnFilter> columnFilters;
     protected Set<String> partitionColumns = Sets.newHashSet();
     protected ImmutableList<ColumnAccessPath> columnAccessPaths;
+    protected boolean canUseAnyColumn;
 
     public LogicalScanOperator(
             OperatorType type,
@@ -108,6 +109,14 @@ public abstract class LogicalScanOperator extends LogicalOperator {
                 .collect(Collectors.toMap(e -> e.getKey().getName(), Map.Entry::getValue));
         cachedColumnNameToColRefMap = Optional.of(columnRefOperatorMap);
         return columnRefOperatorMap;
+    }
+
+    public void setCanUseAnyColumn(boolean canUseAnyColumn) {
+        this.canUseAnyColumn = canUseAnyColumn;
+    }
+
+    public boolean getCanUseAnyColumn() {
+        return canUseAnyColumn;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
@@ -45,6 +45,7 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
     protected final ImmutableMap<ColumnRefOperator, Column> colRefToColumnMetaMap;
     protected ImmutableList<ColumnAccessPath> columnAccessPaths;
     protected boolean canUseAnyColumn;
+    protected boolean canUseMinMaxCountOpt;
 
     public PhysicalScanOperator(OperatorType type, Table table,
                                 Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
@@ -102,6 +103,14 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
 
     public void setCanUseAnyColumn(boolean canUseAnyColumn) {
         this.canUseAnyColumn = canUseAnyColumn;
+    }
+
+    public boolean getCanUseMinMaxCountOpt() {
+        return canUseMinMaxCountOpt;
+    }
+
+    public void setCanUseMinMaxCountOpt(boolean canUseMinMaxCountOpt) {
+        this.canUseMinMaxCountOpt = canUseMinMaxCountOpt;
     }
 
     public Table getTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalScanOperator.java
@@ -44,6 +44,7 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
      */
     protected final ImmutableMap<ColumnRefOperator, Column> colRefToColumnMetaMap;
     protected ImmutableList<ColumnAccessPath> columnAccessPaths;
+    protected boolean canUseAnyColumn;
 
     public PhysicalScanOperator(OperatorType type, Table table,
                                 Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
@@ -93,6 +94,14 @@ public abstract class PhysicalScanOperator extends PhysicalOperator {
 
     public Map<ColumnRefOperator, Column> getColRefToColumnMetaMap() {
         return colRefToColumnMetaMap;
+    }
+
+    public boolean getCanUseAnyColumn() {
+        return canUseAnyColumn;
+    }
+
+    public void setCanUseAnyColumn(boolean canUseAnyColumn) {
+        this.canUseAnyColumn = canUseAnyColumn;
     }
 
     public Table getTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -131,7 +131,6 @@ import com.starrocks.sql.optimizer.rule.transformation.ReorderIntersectRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteBitmapCountDistinctRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteDuplicateAggregateFnRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteHllCountDistinctRule;
-import com.starrocks.sql.optimizer.rule.transformation.RewriteMinMaxCountOnScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteMultiDistinctByCTERule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteMultiDistinctRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToMetaScanRule;
@@ -338,8 +337,7 @@ public class RuleSet {
                 new RewriteHllCountDistinctRule(),
                 new RewriteDuplicateAggregateFnRule(),
                 new RewriteSimpleAggToMetaScanRule(),
-                new RewriteSumByAssociativeRule(),
-                new RewriteMinMaxCountOnScanRule()
+                new RewriteSumByAssociativeRule()
         ));
 
         REWRITE_RULES.put(RuleSetType.MULTI_DISTINCT_REWRITE, ImmutableList.of(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleSet.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule;
 
 import com.google.common.collect.ImmutableList;
@@ -132,6 +131,7 @@ import com.starrocks.sql.optimizer.rule.transformation.ReorderIntersectRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteBitmapCountDistinctRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteDuplicateAggregateFnRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteHllCountDistinctRule;
+import com.starrocks.sql.optimizer.rule.transformation.RewriteMinMaxCountOnScanRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteMultiDistinctByCTERule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteMultiDistinctRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToMetaScanRule;
@@ -338,7 +338,8 @@ public class RuleSet {
                 new RewriteHllCountDistinctRule(),
                 new RewriteDuplicateAggregateFnRule(),
                 new RewriteSimpleAggToMetaScanRule(),
-                new RewriteSumByAssociativeRule()
+                new RewriteSumByAssociativeRule(),
+                new RewriteMinMaxCountOnScanRule()
         ));
 
         REWRITE_RULES.put(RuleSetType.MULTI_DISTINCT_REWRITE, ImmutableList.of(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule;
 
 public enum RuleType {
@@ -128,6 +127,7 @@ public enum RuleType {
     TF_REMOVE_AGGREGATION_BY_AGG_TABLE,
     TF_REWRITE_GROUPING_SET,
     TF_REWRITE_SIMPLE_AGG,
+    TF_REWRITE_MIN_MAX_COUNT_AGG,
     TF_REWRITE_SUM_BY_ASSOCIATIVE_RULE,
 
     TF_INTERSECT_REORDER,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HiveScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HiveScanImplementationRule.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.implementation;
 
 import com.google.common.collect.Lists;
@@ -44,7 +43,7 @@ public class HiveScanImplementationRule extends ImplementationRule {
                     scan.getLimit(),
                     scan.getPredicate(),
                     scan.getProjection());
-
+            physicalHiveScan.setCanUseAnyColumn(scan.getCanUseAnyColumn());
             result = new OptExpression(physicalHiveScan);
         }
         return Lists.newArrayList(result);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
@@ -61,10 +61,11 @@ public class PruneScanColumnRule extends TransformationRule {
                 scanOperator.getColRefToColumnMetaMap().keySet().stream().filter(requiredOutputColumns::contains)
                         .collect(Collectors.toSet());
         outputColumns.addAll(Utils.extractColumnRef(scanOperator.getPredicate()));
-
+        boolean canUseAnyColumn = false;
         if (outputColumns.size() == 0) {
             outputColumns.add(Utils.findSmallestColumnRef(
                     new ArrayList<>(scanOperator.getColRefToColumnMetaMap().keySet())));
+            canUseAnyColumn = true;
         }
 
         if (scanOperator.getColRefToColumnMetaMap().keySet().equals(outputColumns)) {
@@ -78,12 +79,13 @@ public class PruneScanColumnRule extends TransformationRule {
                 LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
                 LogicalOlapScanOperator newScanOperator = builder.withOperator(olapScanOperator)
                         .setColRefToColumnMetaMap(newColumnRefMap).build();
+                newScanOperator.setCanUseAnyColumn(canUseAnyColumn);
                 return Lists.newArrayList(new OptExpression(newScanOperator));
             } else {
                 LogicalScanOperator.Builder builder = OperatorBuilderFactory.build(scanOperator);
+                scanOperator.setCanUseAnyColumn(canUseAnyColumn);
                 Operator newScanOperator =
                         builder.withOperator(scanOperator).setColRefToColumnMetaMap(newColumnRefMap).build();
-
                 return Lists.newArrayList(new OptExpression(newScanOperator));
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMinMaxCountOnScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMinMaxCountOnScanRule.java
@@ -1,0 +1,130 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+
+import java.util.List;
+import java.util.Set;
+
+// for a simple min/max/count aggregation query like
+// 'select min(c1),max(c2),count(*),count(not-null column) from olap_table',
+// we can use MetaScan directly to avoid reading a large amount of data.
+public class RewriteMinMaxCountOnScanRule extends TransformationRule {
+    public RewriteMinMaxCountOnScanRule() {
+        // agg -> project -> scan[checked in `check`]
+        super(RuleType.TF_REWRITE_MIN_MAX_COUNT_AGG,
+                Pattern.create(OperatorType.LOGICAL_AGGR).addChildren(Pattern.create(OperatorType.LOGICAL_PROJECT)));
+    }
+
+    private void mark(LogicalAggregationOperator aggregationOperator, LogicalScanOperator scanOperator,
+                      OptimizerContext context) {
+    }
+
+    @Override
+    public boolean check(final OptExpression input, OptimizerContext context) {
+        LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) input.getOp();
+        Operator operator = input.getInputs().get(0).getInputs().get(0).getOp();
+        if (!(operator instanceof LogicalScanOperator)) {
+            return false;
+        }
+        LogicalScanOperator scanOperator = (LogicalScanOperator) operator;
+
+        // we can only apply this rule to the queries met all the following conditions:
+        // 1. no group by key
+        // 2. no `having` condition or other filters
+        // 3. no limit(???)        // 5. only contain MIN/MAX/COUNT agg functions, no distinct
+        //        //        // 6. all arguments to agg functions are primitive columns
+        // 5. only contain MIN/MAX/COUNT agg functions, no distinct
+        // 6. all arguments to agg functions are primitive columns
+        // 7. no expr in arguments to agg functions
+
+        // no limit
+        if (scanOperator.getLimit() != -1) {
+            return false;
+        }
+
+        // no materialized column in predicate of scan
+        if (isMaterializedColumnInPredicate(scanOperator, scanOperator.getPredicate())) {
+            return false;
+        }
+
+        List<ColumnRefOperator> groupingKeys = aggregationOperator.getGroupingKeys();
+        if (groupingKeys != null && !groupingKeys.isEmpty()) {
+            return false;
+        }
+
+        // no materialized column in predicate of aggregation
+        if (isMaterializedColumnInPredicate(scanOperator, aggregationOperator.getPredicate())) {
+            return false;
+        }
+
+        boolean allValid = aggregationOperator.getAggregations().values().stream().allMatch(aggregator -> {
+            AggregateFunction aggregateFunction = (AggregateFunction) aggregator.getFunction();
+            String functionName = aggregateFunction.functionName();
+            ColumnRefSet usedColumns = aggregator.getUsedColumns();
+            Type type = aggregator.getType();
+
+            // primitive type.
+            if (type.isComplexType()) {
+                return false;
+            }
+
+            // min/max/count(a)
+            if (functionName.equals(FunctionSet.MAX) || functionName.equals(FunctionSet.MIN) ||
+                    (functionName.equals(FunctionSet.COUNT) && !aggregator.isDistinct())) {
+                return (usedColumns.size() == 1);
+            }
+            return false;
+        });
+        return allValid;
+    }
+
+    private static boolean isMaterializedColumnInPredicate(LogicalScanOperator scanOperator, ScalarOperator predicate) {
+        if (predicate == null) {
+            return false;
+        }
+        List<ColumnRefOperator> columnRefOperators = predicate.getColumnRefs();
+        Set<String> partitionColumns = scanOperator.getPartitionColumns();
+        for (ColumnRefOperator c : columnRefOperators) {
+            if (!partitionColumns.contains(c.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) input.getOp();
+        LogicalScanOperator scanOperator = (LogicalScanOperator) input.getInputs().get(0).getInputs().get(0).getOp();
+        mark(aggregationOperator, scanOperator, context);
+        return Lists.newArrayList(input);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -913,6 +913,7 @@ public class PlanFragmentBuilder {
 
             HdfsScanNode hdfsScanNode =
                     new HdfsScanNode(context.getNextNodeId(), tupleDescriptor, "HdfsScanNode");
+            hdfsScanNode.setCanUseAnyColumn(node.getCanUseAnyColumn());
             hdfsScanNode.computeStatistics(optExpression.getStatistics());
             try {
                 HDFSScanNodePredicates scanNodePredicates = hdfsScanNode.getScanNodePredicates();

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1002,6 +1002,8 @@ struct THdfsScanNode {
     13: optional CloudConfiguration.TCloudConfiguration cloud_configuration;
 
     14: optional bool can_use_any_column;
+
+    15: optional bool can_use_min_max_count_opt;
 }
 
 struct TProjectNode {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1000,6 +1000,8 @@ struct THdfsScanNode {
     12: optional bool case_sensitive;
 
     13: optional CloudConfiguration.TCloudConfiguration cloud_configuration;
+
+    14: optional bool can_use_any_column;
 }
 
 struct TProjectNode {


### PR DESCRIPTION
Fixes #issue

## Summary

This pattern can be observed during pruning columns from scan operator. When there is no materialized column required from a table, which means any column could suffice(and any value could suffice).

So I add a `canUseAnyColumn` attached to scan operator and scan node.

And if a scan node has an attribute that `can_use_any_column = true`, I can just return any const column with the expected size.

Right now the optimization works for parquet only. It should be very easy to extend them to other formats and other data sources.

## Benchmark

Use tpch-1t parquet on a single node for example. With this optimization, the following query `select count(*) from lineitem` reads about 
- data: 133MB
- count: 8.5K
- takes: 5.7s

<img width="317" alt="image" src="https://github.com/StarRocks/starrocks/assets/1081215/f674f71a-1808-4fd4-93dd-88be35cf7a49">


```
MySQL [tpch_parquet]> select count(*) from lineitem;
+------------+
| count(*)   |
+------------+
| 5699989709 |
+------------+
1 row in set (5.760 sec)
```

If we use `select count(l_partkey) from lineitem`, it reads about
- data: 21GB
- count: 14K
- takes: 10.4s

<img width="367" alt="image" src="https://github.com/StarRocks/starrocks/assets/1081215/817622f5-42e0-4f5e-bdd1-f1a9870859f7">


```
MySQL [tpch_parquet]> select count(l_partkey) from lineitem;
+------------------+
| count(l_partkey) |
+------------------+
|       5699989709 |
+------------------+
1 row in set (10.422 sec)
```


## Test Cases

Since `select count(*)` is a very common pattern, there is no need to add test cases for that optimization.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
