### PR TITLE
[Enhancement]Use inferred storage medium and cooldown time if not provided 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DataProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DataProperty.java
@@ -98,6 +98,8 @@ public class DataProperty implements Writable {
 
         Preconditions.checkState(mediumSet.size() <= 2, "current medium set: " + mediumSet);
         TStorageMedium m = TStorageMedium.SSD;
+        long cooldownTimeMs = MAX_COOLDOWN_TIME_MS;
+
         // When storage_medium property is not explicitly specified on creating table, we infer the storage medium type
         // based on the types of storage paths reported by backends. Here is the rules,
         //   1. If the storage paths reported by all the backends all have storage medium type HDD,
@@ -111,7 +113,20 @@ public class DataProperty implements Writable {
             m = TStorageMedium.HDD;
         }
 
-        return new DataProperty(m);
+        if (mediumSet.size() == 2) {
+            cooldownTimeMs = getSsdCooldownTimeMs();
+        }
+
+        return new DataProperty(m, cooldownTimeMs);
+    }
+
+    public static long getSsdCooldownTimeMs() {
+        long currentTimeMs = System.currentTimeMillis();
+        return ((Config.tablet_sched_storage_cooldown_second <= 0) ||
+                ((DataProperty.MAX_COOLDOWN_TIME_MS - currentTimeMs) / 1000L <
+                        Config.tablet_sched_storage_cooldown_second)) ?
+                DataProperty.MAX_COOLDOWN_TIME_MS :
+                currentTimeMs + Config.tablet_sched_storage_cooldown_second * 1000L;
     }
 
     public TStorageMedium getStorageMedium() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -57,7 +57,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.catalog.UniqueConstraint;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.qe.ConnectContext;
@@ -165,7 +164,7 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_DEFAULT_PREFIX = "default.";
 
-    public static DataProperty analyzeDataProperty(Map<String, String> properties, DataProperty oldDataProperty,
+    public static DataProperty analyzeDataProperty(Map<String, String> properties, DataProperty inferredDataProperty,
                                                    boolean isDefault)
             throws AnalysisException {
         String mediumKey = PROPERTIES_STORAGE_MEDIUM;
@@ -176,7 +175,7 @@ public class PropertyAnalyzer {
         }
 
         if (properties == null) {
-            return oldDataProperty;
+            return inferredDataProperty;
         }
 
         TStorageMedium storageMedium = null;
@@ -204,7 +203,7 @@ public class PropertyAnalyzer {
         } // end for properties
 
         if (!hasCooldown && !hasMedium) {
-            return oldDataProperty;
+            return inferredDataProperty;
         }
 
         properties.remove(mediumKey);
@@ -227,11 +226,7 @@ public class PropertyAnalyzer {
 
         if (storageMedium == TStorageMedium.SSD && !hasCooldown) {
             // set default cooldown time
-            coolDownTimeStamp = ((Config.tablet_sched_storage_cooldown_second <= 0) ||
-                    ((DataProperty.MAX_COOLDOWN_TIME_MS - currentTimeMs) / 1000L <
-                            Config.tablet_sched_storage_cooldown_second)) ?
-                    DataProperty.MAX_COOLDOWN_TIME_MS :
-                    currentTimeMs + Config.tablet_sched_storage_cooldown_second * 1000L;
+            coolDownTimeStamp = DataProperty.getSsdCooldownTimeMs();
         }
 
         Preconditions.checkNotNull(storageMedium);

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -162,6 +162,22 @@ public class PropertyAnalyzerTest {
         // avoid UT fail because time zone different
         DateLiteral dateLiteral = new DateLiteral(tomorrowTimeStr, Type.DATETIME);
         Assert.assertEquals(dateLiteral.unixTimestamp(TimeUtils.getTimeZone()), dataProperty.getCooldownTimeMs());
+
+        Map<String, String> properties1 = Maps.newHashMap();
+        properties1.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, "HDD");
+        Config.tablet_sched_storage_cooldown_second = 60;
+        dataProperty =
+                PropertyAnalyzer.analyzeDataProperty(properties1, new DataProperty(TStorageMedium.SSD), false);
+        // Use specified storage medium even if SSD is inferred.
+        Assert.assertEquals(TStorageMedium.HDD, dataProperty.getStorageMedium());
+
+        Map<String, String> properties2 = Maps.newHashMap();
+        Config.tablet_sched_storage_cooldown_second = 60;
+        DataProperty defaultDP = new DataProperty(TStorageMedium.SSD, DataProperty.getSsdCooldownTimeMs());
+        dataProperty =
+                PropertyAnalyzer.analyzeDataProperty(properties2, defaultDP, false);
+        // If not specified, the default value should be used
+        Assert.assertEquals(dataProperty, defaultDP);
     }
 
     @Test


### PR DESCRIPTION
If there are both HDD and SSD，and also storage_cooldown_second > 0, the table's storage_mediam should be ssd and cooldown time should also set accordingly. So far(3.0), if not providing storage_mediam when creating table，the cooldown_time is set as 9999-12-31 23:59:59, so that    the partition would not be transferred to hdd after storage_cooldown_second.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
