### PR TITLE
[Refactor] Make casts of enum class to int explicit in fmt::format().

### DIFF
--- a/be/src/io/s3_input_stream.cpp
+++ b/be/src/io/s3_input_stream.cpp
@@ -28,8 +28,9 @@
 namespace starrocks::io {
 
 inline Status make_error_status(const Aws::S3::S3Error& error) {
-    return Status::IOError(fmt::format("code={}(SdkErrorType:{}), message={}", error.GetResponseCode(),
-                                       error.GetErrorType(), error.GetMessage()));
+    return Status::IOError(fmt::format("code={}(SdkErrorType:{}), message={}",
+                                       static_cast<int>(error.GetResponseCode()),
+                                       static_cast<int>(error.GetErrorType()), error.GetMessage()));
 }
 
 StatusOr<int64_t> S3InputStream::read(void* out, int64_t count) {

--- a/be/src/util/json_converter.cpp
+++ b/be/src/util/json_converter.cpp
@@ -143,7 +143,8 @@ private:
             break;
         }
         default:
-            return Status::InternalError(fmt::format("unsupported json number: {}", num.get_number_type()));
+            return Status::InternalError(
+                    fmt::format("unsupported json number: {}", static_cast<int>(num.get_number_type())));
         }
         return Status::OK();
     }


### PR DESCRIPTION
Fixes #issue

The old fmt-7.0.3 being used in Starrocks converted enum class to int implicitly.
But it is not allowed anymore in the recent fmt library and will cause a compile error.
So this explicit cast is a prerequisite for fmt library upgrade which I'm planning to request in a separate PR.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
