### PR TITLE
[BugFix] Fix create view with lateral join bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -22,9 +22,11 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Table;
 import com.starrocks.sql.ast.CTERelation;
 import com.starrocks.sql.ast.FieldReference;
+import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.TableFunctionRelation;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.ViewRelation;
 import org.apache.commons.collections4.CollectionUtils;
@@ -32,6 +34,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 
@@ -242,6 +245,60 @@ public class AstToSQLBuilder {
                 sqlBuilder.append(" AS ");
                 sqlBuilder.append("`").append(node.getAlias().getTbl()).append("`");
             }
+            return sqlBuilder.toString();
+        }
+
+        @Override
+        public String visitTableFunction(TableFunctionRelation node, Void scope) {
+            StringBuilder sqlBuilder = new StringBuilder();
+
+            sqlBuilder.append(node.getFunctionName());
+            sqlBuilder.append("(");
+
+            List<String> childSql = node.getChildExpressions().stream().map(this::visit).collect(toList());
+            sqlBuilder.append(Joiner.on(",").join(childSql));
+
+            sqlBuilder.append(")");
+            if (node.getAlias() != null) {
+                sqlBuilder.append(" ").append(node.getAlias().getTbl());
+
+                if (node.getColumnOutputNames() != null) {
+                    sqlBuilder.append("(");
+                    String names = node.getColumnOutputNames().stream().map(c -> "`" + c + "`")
+                            .collect(Collectors.joining(","));
+                    sqlBuilder.append(names);
+                    sqlBuilder.append(")");
+                }
+            }
+
+            return sqlBuilder.toString();
+        }
+
+        @Override
+        public String visitNormalizedTableFunction(NormalizedTableFunctionRelation node, Void scope) {
+            StringBuilder sqlBuilder = new StringBuilder();
+            sqlBuilder.append("TABLE(");
+
+            TableFunctionRelation tableFunction = (TableFunctionRelation) node.getRight();
+            sqlBuilder.append(tableFunction.getFunctionName());
+            sqlBuilder.append("(");
+            sqlBuilder.append(
+                    tableFunction.getChildExpressions().stream().map(this::visit).collect(Collectors.joining(",")));
+            sqlBuilder.append(")");
+            sqlBuilder.append(")"); // TABLE(
+
+            if (tableFunction.getAlias() != null) {
+                sqlBuilder.append(" ").append(tableFunction.getAlias().getTbl());
+
+                if (node.getColumnOutputNames() != null) {
+                    sqlBuilder.append("(");
+                    String names = node.getColumnOutputNames().stream().map(c -> "`" + c + "`")
+                            .collect(Collectors.joining(","));
+                    sqlBuilder.append(names);
+                    sqlBuilder.append(")");
+                }
+            }
+
             return sqlBuilder.toString();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -289,10 +289,9 @@ public class AstToSQLBuilder {
 
             if (tableFunction.getAlias() != null) {
                 sqlBuilder.append(" ").append(tableFunction.getAlias().getTbl());
-
-                if (node.getColumnOutputNames() != null) {
+                if (tableFunction.getColumnOutputNames() != null) {
                     sqlBuilder.append("(");
-                    String names = node.getColumnOutputNames().stream().map(c -> "`" + c + "`")
+                    String names = tableFunction.getColumnOutputNames().stream().map(c -> "`" + c + "`")
                             .collect(Collectors.joining(","));
                     sqlBuilder.append(names);
                     sqlBuilder.append(")");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ViewPlanTest.java
@@ -1727,4 +1727,35 @@ public class ViewPlanTest extends PlanTestBase {
         viewPlan = getFragmentPlan("select * from " + viewName);
         Assert.assertEquals(sqlPlan, viewPlan);
     }
+
+
+    @Test
+    public void testLateralJoin() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE json_test (" +
+                " v_id INT," +
+                " v_json json, " +
+                " v_SMALLINT SMALLINT" +
+                ") DUPLICATE KEY (v_id) " +
+                "DISTRIBUTED BY HASH (v_id) " +
+                "properties(\"replication_num\"=\"1\") ;"
+        );
+        String sql = "    SELECT\n" +
+                "         v_id\n" +
+                "        , get_json_string(ie.value,'$.b') as b\n" +
+                "        ,get_json_string(ie.value,'$.c') as c\n" +
+                "    FROM\n" +
+                "      json_test ge\n" +
+                "      ,lateral json_each(cast (ge.v_json as json) -> '$.')ie";
+
+        testView(sql);
+
+        sql = "    SELECT\n" +
+                "         v_id\n" +
+                "        , get_json_string(ie.value,'$.b') as b\n" +
+                "        ,get_json_string(ie.value,'$.c') as c\n" +
+                "    FROM\n" +
+                "      json_test ge\n" +
+                "      ,lateral json_each(cast (ge.v_json as json) -> '$.') ie(`key`, `value`)";
+        testView(sql);
+    }
 }


### PR DESCRIPTION
Fixes #issue

lateral join to sql print output column `ie(key,value) `: 

`KEY`,`VALUE` is keywords, we should print sql use quota, like ```ie(`key`,`value`)```

the origin SQL:
```
SELECT `test`.`ge`.`v_id`, get_json_string(`ie`.`value`, '$.b') AS `b`, get_json_string(`ie`.`value`, '$.c') AS `c`
FROM `test`.`json_test` AS `ge` , LATERAL json_each(CAST(`test`.`ge`.`v_json` AS JSON)->'$.') ie
```

but the view SQL:
```
SELECT `test`.`ge`.`v_id`, get_json_string(`ie`.`value`, '$.b') AS `b`, get_json_string(`ie`.`value`, '$.c') AS `c`
FROM `test`.`json_test` AS `ge` , LATERAL json_each(CAST(`test`.`ge`.`v_json` AS JSON)->'$.') ie(key,value) 
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
