### PR TITLE
[BugFix] Fix CTAS profile bugs when profile is enabled (#25687)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -261,6 +261,15 @@ public class InsertOverwriteJobRunner {
         long insertStartTimestamp = System.currentTimeMillis();
         // should replan here because prepareInsert has changed the targetPartitionNames of insertStmt
         ExecPlan newPlan = StatementPlanner.plan(insertStmt, context);
+        // Use `handleDMLStmt` instead of `handleDMLStmtWithProfile` because cannot call `writeProfile` in
+        // InsertOverwriteJobRunner.
+        // InsertOverWriteJob is executed as below:
+        // - StmtExecutor#handleDMLStmtWithProfile
+        //    - StmtExecutor#executeInsert
+        //  - StmtExecutor#handleInsertOverwrite#InsertOverwriteJobMgr#run
+        //  - InsertOverwriteJobRunner#executeInsert
+        //  - StmtExecutor#handleDMLStmt <- no call `handleDMLStmt` again.
+        // `writeProfile` is called in `handleDMLStmt`, and no need call it again later.
         stmtExecutor.handleDMLStmt(newPlan, insertStmt);
         insertElapse = System.currentTimeMillis() - insertStartTimestamp;
         if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMaterializedViewRefreshProcessor.java
@@ -58,7 +58,6 @@ import com.starrocks.planner.HdfsScanNode;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
@@ -929,6 +928,7 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
     @VisibleForTesting
     public void refreshMaterializedView(MvTaskRunContext mvContext, ExecPlan execPlan, InsertStmt insertStmt)
             throws Exception {
+        long beginTimeInNanoSecond = TimeUtils.getStartTime();
         Preconditions.checkNotNull(execPlan);
         Preconditions.checkNotNull(insertStmt);
         ConnectContext ctx = mvContext.getCtx();
@@ -937,9 +937,8 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         ctx.setStmtId(new AtomicInteger().incrementAndGet());
         ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
         try {
-            executor.handleDMLStmt(execPlan, insertStmt);
+            executor.handleDMLStmtWithProfile(execPlan, insertStmt, beginTimeInNanoSecond);
         } finally {
-            QeProcessorImpl.INSTANCE.unregisterQuery(ctx.getExecutionId());
             auditAfterExec(mvContext, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
         }
     }


### PR DESCRIPTION
Fix bugs introduced by https://github.com/StarRocks/starrocks/pull/25261

- `handleDMLStmt ` has already `writeProfile `, ignore `writeProfile ` in handleCreateTableAsSelectStmt and InsertOverwriteJobRunner

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
