### PR TITLE
[Enhancement] add metrics for some thread pool queue

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -169,6 +169,8 @@ void AgentServer::Impl::init_or_die() {
         BUILD_DYNAMIC_TASK_THREAD_POOL("publish_version", MIN_TRANSACTION_PUBLISH_WORKER_COUNT,
                                        max_publish_version_worker_count, DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE,
                                        _thread_pool_publish_version);
+        REGISTER_GAUGE_STARROCKS_METRIC(publish_version_queue_count,
+                                        [this]() { return _thread_pool_publish_version->num_queued_tasks(); });
 #endif
 
         BUILD_DYNAMIC_TASK_THREAD_POOL("drop", config::drop_tablet_worker_count, config::drop_tablet_worker_count,

--- a/be/src/storage/segment_flush_executor.h
+++ b/be/src/storage/segment_flush_executor.h
@@ -72,6 +72,8 @@ public:
             const std::shared_ptr<starrocks::DeltaWriter>& delta_writer,
             ThreadPool::ExecutionMode execution_mode = ThreadPool::ExecutionMode::CONCURRENT);
 
+    ThreadPool* get_thread_pool() { return _flush_pool.get(); }
+
 private:
     std::unique_ptr<ThreadPool> _flush_pool;
 };

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -147,6 +147,8 @@ public:
 
     Status update_max_threads(int max_threads);
 
+    ThreadPool* get_thread_pool() { return _replicate_pool.get(); }
+
     // NOTE: we use SERIAL mode here to ensure all segment from one tablet are synced in order.
     std::unique_ptr<ReplicateToken> create_replicate_token(
             const DeltaWriterOptions* opt,

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -203,15 +203,29 @@ Status StorageEngine::_open(const EngineOptions& options) {
 
     _async_delta_writer_executor =
             std::make_unique<bthreads::ThreadPoolExecutor>(thread_pool.release(), kTakesOwnership);
+    REGISTER_GAUGE_STARROCKS_METRIC(async_delta_writer_queue_count, [this]() {
+        return static_cast<bthreads::ThreadPoolExecutor*>(_async_delta_writer_executor.get())
+                ->get_thread_pool()
+                ->num_queued_tasks();
+    });
 
     _memtable_flush_executor = std::make_unique<MemTableFlushExecutor>();
     RETURN_IF_ERROR_WITH_WARN(_memtable_flush_executor->init(dirs), "init MemTableFlushExecutor failed");
+    REGISTER_GAUGE_STARROCKS_METRIC(memtable_flush_queue_count, [this]() {
+        return _memtable_flush_executor->get_thread_pool()->num_queued_tasks();
+    });
 
     _segment_flush_executor = std::make_unique<SegmentFlushExecutor>();
     RETURN_IF_ERROR_WITH_WARN(_segment_flush_executor->init(dirs), "init SegmentFlushExecutor failed");
+    REGISTER_GAUGE_STARROCKS_METRIC(segment_flush_queue_count, [this]() {
+        return _segment_flush_executor->get_thread_pool()->num_queued_tasks();
+    });
 
     _segment_replicate_executor = std::make_unique<SegmentReplicateExecutor>();
     RETURN_IF_ERROR_WITH_WARN(_segment_replicate_executor->init(dirs), "init SegmentReplicateExecutor failed");
+    REGISTER_GAUGE_STARROCKS_METRIC(segment_replicate_queue_count, [this]() {
+        return _segment_replicate_executor->get_thread_pool()->num_queued_tasks();
+    });
 
     return Status::OK();
 }

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -94,6 +94,8 @@ Status UpdateManager::init() {
         max_thread_cnt = config::transaction_apply_worker_count;
     }
     RETURN_IF_ERROR(ThreadPoolBuilder("update_apply").set_max_threads(max_thread_cnt).build(&_apply_thread_pool));
+    REGISTER_GAUGE_STARROCKS_METRIC(update_apply_queue_count,
+                                    [this]() { return _apply_thread_pool->num_queued_tasks(); });
 
     int max_get_thread_cnt =
             config::get_pindex_worker_count > max_thread_cnt ? config::get_pindex_worker_count : max_thread_cnt * 2;

--- a/be/src/util/bthreads/executor.h
+++ b/be/src/util/bthreads/executor.h
@@ -53,6 +53,8 @@ public:
         _thread_pool = thread_pool;
     }
 
+    ThreadPool* get_thread_pool() { return _thread_pool; }
+
     void set_ownership(Ownership ownership) { _ownership = ownership; }
 
     void set_busy_sleep_ms(int64_t value) { _busy_sleep_ms = value; }

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -239,6 +239,14 @@ public:
     METRIC_DEFINE_UINT_GAUGE(brpc_endpoint_stub_count, MetricUnit::NOUNIT);
     METRIC_DEFINE_UINT_GAUGE(tablet_writer_count, MetricUnit::NOUNIT);
 
+    // queue task count of thread pool
+    METRIC_DEFINE_UINT_GAUGE(publish_version_queue_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_UINT_GAUGE(async_delta_writer_queue_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_UINT_GAUGE(memtable_flush_queue_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_UINT_GAUGE(segment_replicate_queue_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_UINT_GAUGE(segment_flush_queue_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_UINT_GAUGE(update_apply_queue_count, MetricUnit::NOUNIT);
+
     static StarRocksMetrics* instance() {
         static StarRocksMetrics instance;
         return &instance;


### PR DESCRIPTION
Add metrics for some thread pool's task queue count, used for detect data loading bottleneck easily.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
