### PR TITLE
[BugFix] fix broker jar read permission issue

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -909,6 +909,8 @@ build_broker_thirdparty_jars() {
     # cloudfs-hadoop-with-dependencies will include aws jars, but we already support aws by official sdk, so we don't need it anymore.
     # And it will conflict with Iceberg's S3FileIO, make access S3 files failed.
     rm $TP_INSTALL_DIR/$BROKER_THIRDPARTY_JARS_SOURCE/cloudfs-hadoop-with-dependencies-1.1.21.jar
+    # ensure read permission is granted for all users
+    chmod -R +r $TP_INSTALL_DIR/$BROKER_THIRDPARTY_JARS_SOURCE/
 }
 
 build_aws_cpp_sdk() {


### PR DESCRIPTION
* hadoop-ks3-0.1.jar in broker_thirdparty_jars.tar.gz doesn't have sufficient permission for non-owner users/groups, causes the following error: cp: cannot open '.../installed/broker_thirdparty_jars/hadoop-ks3-0.1.jar' for reading: Permission denied

```
$ tar -tzvf broker_thirdparty_jars.tar.gz
drwxr-xr-x sr/sr             0 2023-01-20 10:58 broker_thirdparty_jars/
-rw-r----- sr/sr       5294932 2021-10-25 19:19 broker_thirdparty_jars/hadoop-ks3-0.1.jar
```

Fixes #issue

## What type of PR is this:
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.1
  - [X] 3.0
  - [ ] 2.5
  - [ ] 2.4
