### PR TITLE
[BugFix] Avoid no queryable replicas error for single replica tablet rebalancing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -297,8 +297,8 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
 
     @Override
     public Long getToDeleteReplicaId(Long tabletId) {
-        Long beId = cachedReplicaId.remove(tabletId);
-        return beId == null ? -1L : beId;
+        Long replicaId = cachedReplicaId.remove(tabletId);
+        return replicaId == null ? -1L : replicaId;
     }
 
     private void setCachedReplicaId(Long tabletId, Long replicaId) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -539,6 +539,10 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         return candidates;
     }
 
+    public Replica getDecommissionedReplica() {
+        return decommissionedReplica;
+    }
+
     // database lock should be held.
     public void chooseSrcReplica(Map<Long, PathSlot> backendsWorkingSlots) throws SchedException {
         /*

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.clone.TabletScheduler;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -82,12 +83,15 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
                 LOG.warn("partition {} is dropped, ignore", partitionId);
                 continue;
             }
+            short replicationNum = table.getPartitionInfo().getReplicationNum(partitionId);
             long version = partitionCommitInfo.getVersion();
             List<MaterializedIndex> allIndices =
                     partition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL);
             for (MaterializedIndex index : allIndices) {
                 for (Tablet tablet : index.getTablets()) {
-                    for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
+                    boolean hasFailedVersion = false;
+                    List<Replica> replicas = ((LocalTablet) tablet).getImmutableReplicas();
+                    for (Replica replica : replicas) {
                         if (txnState.isNewFinish()) {
                             updateReplicaVersion(version, replica, txnState.getFinishState());
                             continue;
@@ -106,25 +110,33 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
                                 // then we will detect this and set C's last failed version to 10 and last success version to 11
                                 // this logic has to be replayed in checkpoint thread
                                 lastFailedVersion = partition.getVisibleVersion();
+                                hasFailedVersion = true;
                                 newVersion = replica.getVersion();
                             }
 
                             // success version always move forward
                             lastSucessVersion = version;
                         } else {
-                            // for example, A,B,C 3 replicas, B,C failed during publish version, then B C will be set abnormal
-                            // all loading will failed, B,C will have to recovery by clone, it is very inefficient and maybe lost data
-                            // Using this method, B,C will publish failed, and fe will publish again, not update their last failed version
-                            // if B is publish successfully in next turn, then B is normal and C will be set abnormal so that quorum is maintained
-                            // and loading will go on.
+                            // for example, A,B,C 3 replicas, B,C failed during publish version,
+                            // then B C will be set abnormal and all loadings will be failed, B,C will have to recover
+                            // by clone, it is very inefficient and may lose data.
+                            // Using this method, B,C will publish failed, and fe will publish again,
+                            // not update their last failed version.
+                            // if B is published successfully in next turn, then B is normal and C will be set
+                            // abnormal so that quorum is maintained and loading will go on.
                             newVersion = replica.getVersion();
                             if (version > lastFailedVersion) {
                                 lastFailedVersion = version;
+                                hasFailedVersion = true;
                             }
                         }
                         replica.updateVersionInfo(newVersion, lastFailedVersion, lastSucessVersion);
+                    } // end for replicas
+
+                    if (hasFailedVersion && replicationNum == 1) {
+                        TabletScheduler.resetDecommStatForSingleReplicaTabletUnlocked(tablet.getId(), replicas);
                     }
-                }
+                } // end for tablets
             } // end for indices
             long versionTime = partitionCommitInfo.getVersionTime();
             partition.updateVisibleVersion(version, versionTime);


### PR DESCRIPTION
Fixes SR-18543

For tablet with single replica set, after re-balancing, the src replica will be set to decommissioned state
to clean redundant replica, but because there may exist loading txns which have run concurrently with
re-balancing process, and the newly cloned replica would have failed versions if the loading txn doesn't
see these new replicas.

So the tablet may in a state where all of its replicas are in an abnormal state, the original replica
has complete versions but is in decommissioned state and the newly cloned replica has failed version.
In this situation, the tablet is not queryable, we should reset the original replica's state to normal ASAP.

Besides, here we reset the state only when the newly cloned replica has failed version to avoid
extra scheduling cost.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
