### PR TITLE
[BugFix] Ensure workgroup is always set in BE

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -172,12 +172,6 @@ Status FragmentExecutor::_prepare_fragment_ctx(const UnifiedExecPlanFragmentPara
 }
 
 Status FragmentExecutor::_prepare_workgroup(const UnifiedExecPlanFragmentParams& request) {
-    bool enable_resource_group =
-            request.common().__isset.enable_resource_group && request.common().enable_resource_group;
-    if (!enable_resource_group) {
-        return Status::OK();
-    }
-
     WorkGroupPtr wg = nullptr;
     if (!request.common().__isset.workgroup || request.common().workgroup.id == WorkGroup::DEFAULT_WG_ID) {
         wg = WorkGroupManager::instance()->get_default_workgroup();
@@ -699,7 +693,6 @@ Status FragmentExecutor::execute(ExecEnv* exec_env) {
     DCHECK(_fragment_ctx->enable_resource_group());
     auto* executor = exec_env->wg_driver_executor();
     _fragment_ctx->iterate_drivers([executor, fragment_ctx = _fragment_ctx.get()](const DriverPtr& driver) {
-        DCHECK(!fragment_ctx->enable_resource_group() || driver->workgroup() != nullptr);
         executor->submit(driver.get());
         return Status::OK();
     });


### PR DESCRIPTION
The change introduced in #24421 removes the non-resource-group executor and always utilizes the resource-group executor.

However, if the FE passes a false value for `query_options.enable_resource_group` to the BE, the BE will fail to set a workgroup for this fragment instance, leading to a crash. This situation may arise when the FE version is older than #24421, but the BE version is newer than #24421.

```
*** Aborted at 1687683443 (unix time) try "date -d @1687683443" if you are using GNU date ***
PC: @          0x28847dc starrocks::pipeline::WorkGroupDriverQueue::put_back()
*** SIGSEGV (@0x98) received by PID 22145 (TID 0x7f3877eca700) from PID 152; stack trace: ***
    @          0x5f8b522 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f38eb7cc630 (unknown)
    @          0x28847dc starrocks::pipeline::WorkGroupDriverQueue::put_back()
    @          0x52596a9 _ZNSt17_Function_handlerIFN9starrocks6StatusERKSt10shared_ptrINS0_8pipeline14PipelineDriverEEEZNS3_16FragmentExecutor7executeEPNS0_7ExecEnvEEUlS7_E1_E9_M_invokeERKSt9_Any_dataS7_
    @          0x28903c9 starrocks::pipeline::FragmentContext::iterate_drivers()
    @          0x525a8b6 starrocks::pipeline::FragmentExecutor::execute()
    @          0x5550d60 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment_by_pipeline()
    @          0x555207e starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()
    @          0x555d472 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()
    @          0x49a0f60 starrocks::PriorityThreadPool::work_thread()
    @          0x5f4af47 thread_proxy
    @     0x7f38eb7c4ea5 start_thread
    @     0x7f38eaddfb0d __clone
    @                0x0 (unknown)
```


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
