### PR TITLE
[BugFix] Disable in-tablet parallel, add counter and get index timeout for pointer query using pk index

### DIFF
--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -424,6 +424,9 @@ StatusOr<bool> OlapScanNode::_could_tablet_internal_parallel(
         const std::vector<TScanRangeParams>& scan_ranges, int32_t pipeline_dop, size_t num_total_scan_ranges,
         TTabletInternalParallelMode::type tablet_internal_parallel_mode, int64_t* scan_dop,
         int64_t* splitted_scan_rows) const {
+    if (_olap_scan_node.use_pk_index) {
+        return false;
+    }
     bool force_split = tablet_internal_parallel_mode == TTabletInternalParallelMode::type::FORCE_SPLIT;
     // The enough number of tablets shouldn't use tablet internal parallel.
     if (!force_split && num_total_scan_ranges >= pipeline_dop) {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -99,6 +99,7 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     _get_rowsets_timer = ADD_TIMER(_runtime_profile, "GetRowsets");
     _get_delvec_timer = ADD_TIMER(_runtime_profile, "GetDelVec");
     _get_delta_column_group_timer = ADD_TIMER(_runtime_profile, "GetDeltaColumnGroup");
+    _read_pk_index_timer = ADD_TIMER(_runtime_profile, "ReadPKIndex");
 
     // SegmentInit
     _seg_init_timer = ADD_TIMER(_runtime_profile, "SegmentInit");
@@ -431,6 +432,7 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_get_delvec_timer, _reader->stats().get_delvec_ns);
     COUNTER_UPDATE(_get_delta_column_group_timer, _reader->stats().get_delta_column_group_ns);
     COUNTER_UPDATE(_seg_init_timer, _reader->stats().segment_init_ns);
+    COUNTER_UPDATE(_read_pk_index_timer, _reader->stats().read_pk_index_ns);
 
     COUNTER_UPDATE(_raw_rows_counter, _reader->stats().raw_rows_read);
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -140,6 +140,7 @@ private:
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;
     RuntimeProfile::Counter* _segments_read_count = nullptr;
     RuntimeProfile::Counter* _total_columns_data_page_count = nullptr;
+    RuntimeProfile::Counter* _read_pk_index_timer = nullptr;
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -622,7 +622,7 @@ Status DeltaWriter::_fill_auto_increment_id(const Chunk& chunk) {
     rss_rowids.resize(upserts->size());
 
     // 2. probe index
-    _tablet->updates()->get_rss_rowids_by_pk(_tablet.get(), *upserts, nullptr, &rss_rowids);
+    RETURN_IF_ERROR(_tablet->updates()->get_rss_rowids_by_pk(_tablet.get(), *upserts, nullptr, &rss_rowids));
 
     std::vector<uint8_t> filter;
     uint32_t gen_num = 0;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -263,6 +263,8 @@ struct OlapReaderStatistics {
 
     int64_t runtime_stats_filtered = 0;
 
+    int64_t read_pk_index_ns = 0;
+
     // ------ for lake tablet ------
     int64_t pages_from_local_disk = 0;
 

--- a/be/src/storage/range.h
+++ b/be/src/storage/range.h
@@ -173,6 +173,9 @@ public:
     // number of rows covered by this range. it's the sum of all the sub-ranges span size.
     uint32_t span_size() const;
 
+    // only contains single row or empty
+    bool is_single_row_or_empty() const;
+
     // return a new range that represent the intersection of |this| and |r|.
     SparseRange intersection(const SparseRange& rhs) const;
 
@@ -261,6 +264,10 @@ inline uint32_t SparseRange::span_size() const {
         n += r.span_size();
     }
     return n;
+}
+
+inline bool SparseRange::is_single_row_or_empty() const {
+    return _ranges.empty() || (_ranges.size() == 1 && _ranges[0].span_size() == 1);
 }
 
 inline SparseRangeIterator SparseRange::new_iterator() const {

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -147,12 +147,16 @@ Status TabletReader::_init_collector_for_pk_index_read() {
     PrimaryKeyEncoder::encode(*tablet_schema.schema(), *keys, 0, keys->num_rows(), pk_column.get());
 
     // get rowid using pk index
-    EditVersion read_version;
     std::vector<uint64_t> rowids(1);
-    RETURN_IF_ERROR(_tablet->updates()->get_rss_rowids_by_pk(_tablet.get(), *pk_column, &read_version, &rowids));
-    if (rowids.size() != 1) {
-        return Status::InternalError(strings::Substitute("get rowid size not match tablet:$0 $1 != $2",
-                                                         _tablet->tablet_id(), rowids.size(), 1));
+    {
+        SCOPED_RAW_TIMER(&_stats.read_pk_index_ns);
+        EditVersion read_version;
+        RETURN_IF_ERROR(
+                _tablet->updates()->get_rss_rowids_by_pk(_tablet.get(), *pk_column, &read_version, &rowids, 3000));
+        if (rowids.size() != 1) {
+            return Status::InternalError(strings::Substitute("get rowid size not match tablet:$0 $1 != $2",
+                                                             _tablet->tablet_id(), rowids.size(), 1));
+        }
     }
     // do not check read version in use_pk_index mode
     uint32_t rssid = rowids[0] >> 32;
@@ -215,7 +219,8 @@ Status TabletReader::do_get_next(Chunk* chunk) {
     if (UNLIKELY(_collect_iter == nullptr)) {
         auto st = _init_collector_for_pk_index_read();
         if (!st.ok()) {
-            LOG(WARNING) << "using pk index for pointer read failed, fallback to normal read " << st;
+            LOG(WARNING) << "using pk index for pointer read failed, fallback to normal read " << st
+                         << " tablet:" << _tablet->tablet_id();
             RETURN_IF_ERROR(_init_collector(*_reader_params));
         }
     }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -4095,9 +4095,17 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
 }
 
 Status TabletUpdates::get_rss_rowids_by_pk(Tablet* tablet, const Column& keys, EditVersion* read_version,
-                                           std::vector<uint64_t>* rss_rowids) {
-    std::lock_guard lg(_index_lock);
-    return get_rss_rowids_by_pk_unlock(tablet, keys, read_version, rss_rowids);
+                                           std::vector<uint64_t>* rss_rowids, int64_t timeout_ms) {
+    if (timeout_ms <= 0) {
+        _index_lock.lock();
+    } else {
+        if (!_index_lock.try_lock_for(std::chrono::milliseconds(timeout_ms))) {
+            return Status::TimedOut("get_rss_rowids_by_pk try lock timeout");
+        }
+    }
+    auto st = get_rss_rowids_by_pk_unlock(tablet, keys, read_version, rss_rowids);
+    _index_lock.unlock();
+    return st;
 }
 
 Status TabletUpdates::get_rss_rowids_by_pk_unlock(Tablet* tablet, const Column& keys, EditVersion* read_version,

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -284,7 +284,7 @@ public:
                              vector<std::unique_ptr<Column>>* columns, void* state);
 
     Status get_rss_rowids_by_pk(Tablet* tablet, const Column& keys, EditVersion* read_version,
-                                std::vector<uint64_t>* rss_rowids);
+                                std::vector<uint64_t>* rss_rowids, int64_t timeout_ms = 0);
 
     Status get_rss_rowids_by_pk_unlock(Tablet* tablet, const Column& keys, EditVersion* read_version,
                                        std::vector<uint64_t>* rss_rowids);
@@ -437,7 +437,7 @@ private:
     // used for async apply, make sure at most 1 thread is doing applying
     mutable std::mutex _apply_running_lock;
     // make sure at most 1 thread is read or write primary index
-    mutable std::mutex _index_lock;
+    mutable std::timed_mutex _index_lock;
     // apply process is running currently
     bool _apply_running = false;
 


### PR DESCRIPTION
Fixes #25705

This PR disables in-tablet parallel, adds counter and get index timeout for pointer query.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
