### PR TITLE
[BugFix] Load Problem for generated column (#25828)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
@@ -531,6 +531,11 @@ public class SparkLoadPendingTask extends LoadTask {
         } catch (UserException e) {
             throw new LoadException(e.getMessage());
         }
+        // add generated column mapping
+        for (ImportColumnDesc columnDesc : Load.getMaterializedShadowColumnDesc(table, db.getFullName(), false)) {
+            copiedColumnExprList.add(columnDesc);
+            exprByName.put(columnDesc.getColumnName(), columnDesc.getExpr());
+        }
         // add shadow column mapping when schema change
         for (ImportColumnDesc columnDesc : Load.getSchemaChangeShadowColumnDesc(table, exprByName)) {
             copiedColumnExprList.add(columnDesc);


### PR DESCRIPTION
Problem:
1. Streamload and Broker load will failed if generated column
ref some mapping column
2. spark load fail

Solution:
1. remove the restriction and allow the generated column ref the 
mapping column
2. add the generated column column desc when planning spark load job

Fixes #25828

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
