### PR TITLE
[Enhancement]adaptive coalesce active column and lazy column

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -761,6 +761,7 @@ CONF_Bool(parquet_late_materialization_enable, "true");
 
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
+CONF_mBool(io_coalesce_adaptive_lazy_active, "true");
 CONF_Int32(io_tasks_per_scan_operator, "4");
 CONF_Int32(connector_io_tasks_per_scan_operator, "16");
 CONF_Int32(connector_io_tasks_min_size, "2");

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -482,6 +482,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.case_sensitive = _case_sensitive;
     scanner_params.profile = &_profile;
     scanner_params.open_limit = nullptr;
+    scanner_params.lazy_column_colease_counter = get_lazy_column_colease_counter();
     for (const auto& delete_file : scan_range.delete_files) {
         scanner_params.deletes.emplace_back(&delete_file);
     }

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -482,7 +482,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.case_sensitive = _case_sensitive;
     scanner_params.profile = &_profile;
     scanner_params.open_limit = nullptr;
-    scanner_params.lazy_column_colease_counter = get_lazy_column_colease_counter();
+    scanner_params.lazy_column_coalesce_counter = get_lazy_column_coalesce_counter();
     for (const auto& delete_file : scan_range.delete_files) {
         scanner_params.deletes.emplace_back(&delete_file);
     }

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -56,8 +56,8 @@ public:
     void close(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk) override;
     const std::string get_custom_coredump_msg() const override;
-    std::atomic<int32_t>* get_lazy_column_colease_counter() {
-        return _provider->_scan_node->get_lazy_column_colease_counter();
+    std::atomic<int32_t>* get_lazy_column_coalesce_counter() {
+        return _provider->_scan_node->get_lazy_column_coalesce_counter();
     }
 
     int64_t raw_rows_read() const override;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -16,6 +16,7 @@
 
 #include "column/vectorized_fwd.h"
 #include "connector/connector.h"
+#include "exec/connector_scan_node.h"
 #include "exec/hdfs_scanner.h"
 
 namespace starrocks::connector {
@@ -55,6 +56,9 @@ public:
     void close(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk) override;
     const std::string get_custom_coredump_msg() const override;
+    std::atomic<int32_t>* get_lazy_column_colease_counter() {
+        return _provider->_scan_node->get_lazy_column_colease_counter();
+    }
 
     int64_t raw_rows_read() const override;
     int64_t num_rows_read() const override;

--- a/be/src/exec/connector_scan_node.h
+++ b/be/src/exec/connector_scan_node.h
@@ -48,6 +48,7 @@ public:
     connector::DataSourceProvider* data_source_provider() { return _data_source_provider.get(); }
     connector::ConnectorType connector_type() { return _connector_type; }
     bool always_shared_scan() const override;
+    std::atomic<int32_t>* get_lazy_column_colease_counter() { return &_lazy_column_colease_counter; }
 
 private:
     RuntimeState* _runtime_state = nullptr;
@@ -81,6 +82,7 @@ private:
     std::atomic<int32_t> _scanner_submit_count = 0;
     std::atomic<int32_t> _running_threads = 0;
     std::atomic<int32_t> _closed_scanners = 0;
+    std::atomic<int32_t> _lazy_column_colease_counter = 0;
 
 private:
     template <typename T>

--- a/be/src/exec/connector_scan_node.h
+++ b/be/src/exec/connector_scan_node.h
@@ -48,7 +48,7 @@ public:
     connector::DataSourceProvider* data_source_provider() { return _data_source_provider.get(); }
     connector::ConnectorType connector_type() { return _connector_type; }
     bool always_shared_scan() const override;
-    std::atomic<int32_t>* get_lazy_column_colease_counter() { return &_lazy_column_colease_counter; }
+    std::atomic<int32_t>* get_lazy_column_coalesce_counter() { return &_lazy_column_coalesce_counter; }
 
 private:
     RuntimeState* _runtime_state = nullptr;
@@ -82,7 +82,7 @@ private:
     std::atomic<int32_t> _scanner_submit_count = 0;
     std::atomic<int32_t> _running_threads = 0;
     std::atomic<int32_t> _closed_scanners = 0;
-    std::atomic<int32_t> _lazy_column_colease_counter = 0;
+    std::atomic<int32_t> _lazy_column_coalesce_counter = 0;
 
 private:
     template <typename T>

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -131,6 +131,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.timezone = _runtime_state->timezone();
     ctx.iceberg_schema = _scanner_params.iceberg_schema;
     ctx.stats = &_stats;
+    ctx.lazy_column_coalesce_counter = _scanner_params.lazy_column_colease_counter;
 
     return Status::OK();
 }

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -131,7 +131,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.timezone = _runtime_state->timezone();
     ctx.iceberg_schema = _scanner_params.iceberg_schema;
     ctx.stats = &_stats;
-    ctx.lazy_column_coalesce_counter = _scanner_params.lazy_column_colease_counter;
+    ctx.lazy_column_coalesce_counter = _scanner_params.lazy_column_coalesce_counter;
 
     return Status::OK();
 }

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -171,7 +171,7 @@ struct HdfsScannerParams {
     bool use_block_cache = false;
     bool enable_populate_block_cache = false;
 
-    std::atomic<int32_t>* lazy_column_colease_counter;
+    std::atomic<int32_t>* lazy_column_coalesce_counter;
 };
 
 struct HdfsScannerContext {

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -65,6 +65,9 @@ struct HdfsScanStats {
     int64_t build_iceberg_pos_filter_ns = 0;
     // late materialization
     int64_t skip_read_rows = 0;
+    // io coalesce
+    int64_t group_active_lazy_coalesce_together = 0;
+    int64_t group_active_lazy_coalesce_seperately = 0;
 
     // ORC only!
     int64_t delete_build_ns = 0;
@@ -167,6 +170,8 @@ struct HdfsScannerParams {
 
     bool use_block_cache = false;
     bool enable_populate_block_cache = false;
+
+    std::atomic<int32_t>* lazy_column_colease_counter;
 };
 
 struct HdfsScannerContext {
@@ -213,6 +218,8 @@ struct HdfsScannerContext {
     const TIcebergSchema* iceberg_schema = nullptr;
 
     HdfsScanStats* stats = nullptr;
+
+    std::atomic<int32_t>* lazy_column_coalesce_counter;
 
     // set column names from file.
     // and to update not_existed slots and conjuncts.

--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -53,6 +53,10 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile::Counter* group_dict_decode_timer = nullptr;
     RuntimeProfile::Counter* build_iceberg_pos_filter_timer = nullptr;
 
+    // io coalesce
+    RuntimeProfile::Counter* group_active_lazy_coalesce_together = nullptr;
+    RuntimeProfile::Counter* group_active_lazy_coalesce_seperately = nullptr;
+
     RuntimeProfile* root = profile->runtime_profile;
     ADD_COUNTER(root, kParquetProfileSectionPrefix, TUnit::UNIT);
     request_bytes_read = ADD_CHILD_COUNTER(root, "RequestBytesRead", TUnit::BYTES, kParquetProfileSectionPrefix);
@@ -71,6 +75,11 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
     build_iceberg_pos_filter_timer = ADD_CHILD_TIMER(root, "BuildIcebergPosFilter", kParquetProfileSectionPrefix);
 
+    group_active_lazy_coalesce_together =
+            ADD_CHILD_COUNTER(root, "GroupActiveLazyCoalesceTogether", TUnit::UNIT, kParquetProfileSectionPrefix);
+    group_active_lazy_coalesce_seperately =
+            ADD_CHILD_COUNTER(root, "GroupActiveLazyCoalesceSeperately", TUnit::UNIT, kParquetProfileSectionPrefix);
+
     COUNTER_UPDATE(request_bytes_read, _stats.request_bytes_read);
     COUNTER_UPDATE(request_bytes_read_uncompressed, _stats.request_bytes_read_uncompressed);
     COUNTER_UPDATE(value_decode_timer, _stats.value_decode_ns);
@@ -82,6 +91,8 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     COUNTER_UPDATE(group_dict_filter_timer, _stats.group_dict_filter_ns);
     COUNTER_UPDATE(group_dict_decode_timer, _stats.group_dict_decode_ns);
     COUNTER_UPDATE(build_iceberg_pos_filter_timer, _stats.build_iceberg_pos_filter_ns);
+    COUNTER_UPDATE(group_active_lazy_coalesce_together, _stats.group_active_lazy_coalesce_together);
+    COUNTER_UPDATE(group_active_lazy_coalesce_seperately, _stats.group_active_lazy_coalesce_seperately);
 }
 
 Status HdfsParquetScanner::do_open(RuntimeState* runtime_state) {

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -450,6 +450,7 @@ Status FileReader::_init_group_readers() {
     _group_reader_param.file = _file;
     _group_reader_param.file_metadata = _file_metadata.get();
     _group_reader_param.case_sensitive = fd_scanner_ctx.case_sensitive;
+    _group_reader_param.lazy_column_coalesce_counter = fd_scanner_ctx.lazy_column_coalesce_counter;
 
     int64_t row_group_first_row = 0;
     // select and create row group readers.
@@ -477,26 +478,42 @@ Status FileReader::_init_group_readers() {
     }
     _row_group_size = _row_group_readers.size();
 
-    // if coalesce read enabled, we have to
-    // 1. allocate shared buffered input stream and
-    // 2. collect io ranges of every row group reader.
-    // 3. set io ranges to the stream.
-    if (config::parquet_coalesce_read_enable && _sb_stream != nullptr) {
-        std::vector<io::SharedBufferedInputStream::IORange> ranges;
-        for (auto& r : _row_group_readers) {
-            int64_t end_offset = 0;
-            r->collect_io_ranges(&ranges, &end_offset);
-            r->set_end_offset(end_offset);
-        }
-        _sb_stream->set_io_ranges(ranges);
-        _group_reader_param.sb_stream = _sb_stream;
-    }
-
     // initialize row group readers.
     for (auto& r : _row_group_readers) {
         RETURN_IF_ERROR(r->init());
     }
+
+    if (!_row_group_readers.empty()) {
+        // collect io range of the first rowgroup
+        _collect_io_range_of_cur_group();
+    }
+
     return Status::OK();
+}
+
+void FileReader::_collect_io_range_of_cur_group() {
+    // if coalesce read enabled, we have to
+    // 0. clear last group memory
+    // 1. allocate shared buffered input stream and
+    // 2. collect io ranges of every row group reader.
+    // 3. set io ranges to the stream.
+    if (config::parquet_coalesce_read_enable && _sb_stream != nullptr) {
+        // clear last group memory;
+        _sb_stream->release();
+        std::vector<io::SharedBufferedInputStream::IORange> ranges;
+        auto& r = _row_group_readers[_cur_row_group_idx];
+        int64_t end_offset = 0;
+        r->collect_io_ranges(&ranges, &end_offset);
+        int32_t counter = _scanner_ctx->lazy_column_coalesce_counter->load(std::memory_order_relaxed);
+        if (counter >= 0 || !config::io_coalesce_adaptive_lazy_active) {
+            _scanner_ctx->stats->group_active_lazy_coalesce_together += 1;
+        } else {
+            _scanner_ctx->stats->group_active_lazy_coalesce_seperately += 1;
+        }
+        r->set_end_offset(end_offset);
+        _sb_stream->set_io_ranges(ranges, counter >= 0);
+        _group_reader_param.sb_stream = _sb_stream;
+    }
 }
 
 Status FileReader::get_next(ChunkPtr* chunk) {
@@ -520,6 +537,10 @@ Status FileReader::get_next(ChunkPtr* chunk) {
             if (status.is_end_of_file()) {
                 _row_group_readers[_cur_row_group_idx]->close();
                 _cur_row_group_idx++;
+                if (_cur_row_group_idx < _row_group_size) {
+                    // collect io of new group
+                    _collect_io_range_of_cur_group();
+                }
                 return Status::OK();
             }
         } else {

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -92,6 +92,8 @@ private:
     // Validate the magic bytes and get the length of metadata
     StatusOr<uint32_t> _parse_metadata_length(const std::vector<char>& footer_buff) const;
 
+    void _collect_io_range_of_cur_group();
+
     // decode min/max value from row group stats
     static Status _decode_min_max_column(const ParquetField& field, const std::string& timezone,
                                          const TypeDescriptor& type, const tparquet::ColumnMetaData& column_meta,

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -92,7 +92,7 @@ private:
     // Validate the magic bytes and get the length of metadata
     StatusOr<uint32_t> _parse_metadata_length(const std::vector<char>& footer_buff) const;
 
-    void _collect_io_range_of_cur_group();
+    Status _prepare_cur_row_group();
 
     // decode min/max value from row group stats
     static Status _decode_min_max_column(const ParquetField& field, const std::string& timezone,

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -42,9 +42,7 @@ Status GroupReader::init() {
     RETURN_IF_ERROR(_init_column_readers());
     _dict_filter_ctx.init(_param.read_cols.size());
     _process_columns_and_conjunct_ctxs();
-    RETURN_IF_ERROR(_dict_filter_ctx.rewrite_conjunct_ctxs_to_predicates(_param, _column_readers, &_obj_pool,
-                                                                         &_is_group_filtered));
-    _init_read_chunk();
+
     return Status::OK();
 }
 

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -123,6 +123,7 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
 
     size_t active_rows = active_chunk->num_rows();
     if (active_rows > 0 && !_lazy_column_indices.empty()) {
+        _lazy_column_needed = true;
         ChunkPtr lazy_chunk = _create_read_chunk(_lazy_column_indices);
         RETURN_IF_ERROR(_lazy_skip_rows(_lazy_column_indices, lazy_chunk, *row_count));
 
@@ -163,6 +164,11 @@ Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
 void GroupReader::close() {
     if (_param.sb_stream) {
         _param.sb_stream->release_to_offset(_end_offset);
+    }
+    if (_lazy_column_needed) {
+        _param.lazy_column_coalesce_counter->fetch_add(1, std::memory_order_relaxed);
+    } else {
+        _param.lazy_column_coalesce_counter->fetch_sub(1, std::memory_order_relaxed);
     }
     _column_readers.clear();
 }
@@ -258,19 +264,33 @@ ChunkPtr GroupReader::_create_read_chunk(const std::vector<int>& column_indices)
 
 void GroupReader::collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset) {
     int64_t end = 0;
-    for (const auto& column : _param.read_cols) {
+    // collect io of active column
+    for (const auto& index : _active_column_indices) {
+        const auto& column = _param.read_cols[index];
         auto schema_node = _param.file_metadata->schema().get_stored_column_by_field_idx(column.field_idx_in_parquet);
         if (column.t_iceberg_schema_field == nullptr) {
-            _collect_field_io_range(*schema_node, column.col_type_in_chunk, ranges, &end);
+            _collect_field_io_range(*schema_node, column.col_type_in_chunk, true, ranges, &end);
         } else {
-            _collect_field_io_range(*schema_node, column.col_type_in_chunk, column.t_iceberg_schema_field, ranges,
+            _collect_field_io_range(*schema_node, column.col_type_in_chunk, column.t_iceberg_schema_field, true, ranges,
                                     &end);
+        }
+    }
+
+    // collect io of lazy column
+    for (const auto& index : _lazy_column_indices) {
+        const auto& column = _param.read_cols[index];
+        auto schema_node = _param.file_metadata->schema().get_stored_column_by_field_idx(column.field_idx_in_parquet);
+        if (column.t_iceberg_schema_field == nullptr) {
+            _collect_field_io_range(*schema_node, column.col_type_in_chunk, false, ranges, &end);
+        } else {
+            _collect_field_io_range(*schema_node, column.col_type_in_chunk, column.t_iceberg_schema_field, false,
+                                    ranges, &end);
         }
     }
     *end_offset = end;
 }
 
-void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeDescriptor& col_type,
+void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeDescriptor& col_type, bool active,
                                           std::vector<io::SharedBufferedInputStream::IORange>* ranges,
                                           int64_t* end_offset) {
     // 1. We collect column io ranges for each row group to make up the shared buffer, so we get column
@@ -280,7 +300,7 @@ void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeD
     // we need to iterate the children and collect their io ranges.
     // 3. For subfield pruning, we collect io range based on col_type which is pruned by fe.
     if (field.type.type == LogicalType::TYPE_ARRAY) {
-        _collect_field_io_range(field.children[0], col_type.children[0], ranges, end_offset);
+        _collect_field_io_range(field.children[0], col_type.children[0], active, ranges, end_offset);
     } else if (field.type.type == LogicalType::TYPE_STRUCT) {
         std::vector<int32_t> subfield_pos(col_type.children.size());
         ColumnReader::get_subfield_pos_with_pruned_type(field, col_type, _param.case_sensitive, subfield_pos);
@@ -289,7 +309,7 @@ void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeD
             if (subfield_pos[i] == -1) {
                 continue;
             }
-            _collect_field_io_range(field.children[subfield_pos[i]], col_type.children[i], ranges, end_offset);
+            _collect_field_io_range(field.children[subfield_pos[i]], col_type.children[i], active, ranges, end_offset);
         }
     } else if (field.type.type == LogicalType::TYPE_MAP) {
         // ParquetFiled Map -> Map<Struct<key,value>>
@@ -297,7 +317,7 @@ void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeD
         auto index = 0;
         for (auto& child : field.children[0].children) {
             if ((!col_type.children[index].is_unknown_type())) {
-                _collect_field_io_range(child, col_type.children[index], ranges, end_offset);
+                _collect_field_io_range(child, col_type.children[index], active, ranges, end_offset);
             }
             ++index;
         }
@@ -310,20 +330,20 @@ void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeD
             offset = column.data_page_offset;
         }
         int64_t size = column.total_compressed_size;
-        auto r = io::SharedBufferedInputStream::IORange{.offset = offset, .size = size};
+        auto r = io::SharedBufferedInputStream::IORange{.offset = offset, .size = size, .active = active};
         ranges->emplace_back(r);
         *end_offset = std::max(*end_offset, offset + size);
     }
 }
 
 void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeDescriptor& col_type,
-                                          const TIcebergSchemaField* iceberg_schema_field,
+                                          const TIcebergSchemaField* iceberg_schema_field, bool active,
                                           std::vector<io::SharedBufferedInputStream::IORange>* ranges,
                                           int64_t* end_offset) {
     // Logically same with _collect_filed_io_range, just support schema change.
     if (field.type.type == LogicalType::TYPE_ARRAY) {
-        _collect_field_io_range(field.children[0], col_type.children[0], &iceberg_schema_field->children[0], ranges,
-                                end_offset);
+        _collect_field_io_range(field.children[0], col_type.children[0], &iceberg_schema_field->children[0], active,
+                                ranges, end_offset);
     } else if (field.type.type == LogicalType::TYPE_STRUCT) {
         std::vector<int32_t> subfield_pos(col_type.children.size());
         std::vector<const TIcebergSchemaField*> iceberg_schema_subfield(col_type.children.size());
@@ -335,7 +355,7 @@ void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeD
                 continue;
             }
             _collect_field_io_range(field.children[subfield_pos[i]], col_type.children[i], iceberg_schema_subfield[i],
-                                    ranges, end_offset);
+                                    active, ranges, end_offset);
         }
     } else if (field.type.type == LogicalType::TYPE_MAP) {
         // ParquetFiled Map -> Map<Struct<key,value>>
@@ -343,8 +363,8 @@ void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeD
         auto index = 0;
         for (auto& child : field.children[0].children) {
             if ((!col_type.children[index].is_unknown_type())) {
-                _collect_field_io_range(child, col_type.children[index], &iceberg_schema_field->children[index], ranges,
-                                        end_offset);
+                _collect_field_io_range(child, col_type.children[index], &iceberg_schema_field->children[index], active,
+                                        ranges, end_offset);
             }
             ++index;
         }
@@ -357,7 +377,7 @@ void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeD
             offset = column.data_page_offset;
         }
         int64_t size = column.total_compressed_size;
-        auto r = io::SharedBufferedInputStream::IORange{.offset = offset, .size = size};
+        auto r = io::SharedBufferedInputStream::IORange{.offset = offset, .size = size, .active = active};
         ranges->emplace_back(r);
         *end_offset = std::max(*end_offset, offset + size);
     }

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -48,6 +48,13 @@ Status GroupReader::init() {
     return Status::OK();
 }
 
+Status GroupReader::prepare() {
+    RETURN_IF_ERROR(_dict_filter_ctx.rewrite_conjunct_ctxs_to_predicates(_param, _column_readers, &_obj_pool,
+                                                                         &_is_group_filtered));
+    _init_read_chunk();
+    return Status::OK();
+}
+
 Status GroupReader::get_next(ChunkPtr* chunk, size_t* row_count) {
     if (_is_group_filtered) {
         *row_count = 0;

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -82,7 +82,10 @@ public:
                 int64_t row_group_first_row);
     ~GroupReader() = default;
 
+    // init used to init column reader, init dict_filter_ctx and devide active/lazy
     Status init();
+    // we need load dict for dict_filter, so prepare should be after collec_io_range
+    Status prepare();
     Status get_next(ChunkPtr* chunk, size_t* row_count);
     void close();
     void collect_io_ranges(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset);

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -71,6 +71,9 @@ struct GroupReaderParam {
     FileMetaData* file_metadata = nullptr;
 
     bool case_sensitive = false;
+
+    // used to identify io coalesce
+    std::atomic<int32_t>* lazy_column_coalesce_counter = nullptr;
 };
 
 class GroupReader {
@@ -133,10 +136,10 @@ private:
 
     Status _read(const std::vector<int>& read_columns, size_t* row_count, ChunkPtr* chunk);
     Status _lazy_skip_rows(const std::vector<int>& read_columns, const ChunkPtr& chunk, size_t chunk_size);
-    void _collect_field_io_range(const ParquetField& field, const TypeDescriptor& col_type,
+    void _collect_field_io_range(const ParquetField& field, const TypeDescriptor& col_type, bool active,
                                  std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset);
     void _collect_field_io_range(const ParquetField& field, const TypeDescriptor& col_type,
-                                 const TIcebergSchemaField* iceberg_schema_field,
+                                 const TIcebergSchemaField* iceberg_schema_field, bool active,
                                  std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset);
 
     // row group meta
@@ -155,6 +158,8 @@ private:
     std::vector<int> _active_column_indices;
     // lazy conlumns that hold read_col index
     std::vector<int> _lazy_column_indices;
+    // load lazy column or not
+    bool _lazy_column_needed = false;
 
     // dict value is empty after conjunct eval, file group can be skipped
     bool _is_group_filtered = false;

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -14,6 +14,7 @@
 
 #include "io/shared_buffered_input_stream.h"
 
+#include "common/config.h"
 #include "gutil/strings/fastmem.h"
 #include "util/runtime_profile.h"
 namespace starrocks::io {
@@ -33,15 +34,10 @@ void SharedBufferedInputStream::SharedBuffer::align(int64_t align_size, int64_t 
     }
 }
 
-Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& ranges) {
-    if (ranges.size() == 0) {
-        return Status::OK();
-    }
-
+Status SharedBufferedInputStream::_sort_and_check_overlap(std::vector<IORange>& ranges) {
     // specify compare function is important. suppose we have zero range like [351,351],[351,356].
     // If we don't specify compare function, we may have [351,356],[351,351] which is bad order.
-    std::vector<IORange> check(ranges);
-    std::sort(check.begin(), check.end(), [](const IORange& a, const IORange& b) {
+    std::sort(ranges.begin(), ranges.end(), [](const IORange& a, const IORange& b) {
         if (a.offset != b.offset) {
             return a.offset < b.offset;
         }
@@ -49,23 +45,16 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
     });
 
     // check io range is not overlapped.
-    for (size_t i = 1; i < check.size(); i++) {
-        if (check[i].offset < (check[i - 1].offset + check[i - 1].size)) {
+    for (size_t i = 1; i < ranges.size(); i++) {
+        if (ranges[i].offset < (ranges[i - 1].offset + ranges[i - 1].size)) {
             return Status::RuntimeError("io ranges are overalpped");
         }
     }
 
-    std::vector<IORange> small_ranges;
-    for (const IORange& r : check) {
-        if (r.size > _options.max_buffer_size) {
-            SharedBuffer sb = SharedBuffer{.raw_offset = r.offset, .raw_size = r.size, .ref_count = 1};
-            sb.align(_align_size, _file_size);
-            _map.insert(std::make_pair(sb.raw_offset + sb.raw_size, sb));
-        } else {
-            small_ranges.emplace_back(r);
-        }
-    }
+    return Status::OK();
+}
 
+void SharedBufferedInputStream::_merge_small_ranges(const std::vector<IORange>& small_ranges) {
     if (small_ranges.size() > 0) {
         auto update_map = [&](size_t from, size_t to) {
             // merge from [unmerge, i-1]
@@ -94,8 +83,103 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
         }
         update_map(unmerge, small_ranges.size() - 1);
     }
+}
+
+Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& ranges) {
+    if (ranges.size() == 0) {
+        return Status::OK();
+    }
+
+    std::vector<IORange> check(ranges);
+    RETURN_IF_ERROR(_sort_and_check_overlap(check));
+
+    std::vector<IORange> small_ranges;
+    for (const IORange& r : check) {
+        if (r.size > _options.max_buffer_size) {
+            SharedBuffer sb = SharedBuffer{.raw_offset = r.offset, .raw_size = r.size, .ref_count = 1};
+            sb.align(_align_size, _file_size);
+            _map.insert(std::make_pair(sb.raw_offset + sb.raw_size, sb));
+        } else {
+            small_ranges.emplace_back(r);
+        }
+    }
+
+    _merge_small_ranges(small_ranges);
     _update_estimated_mem_usage();
     return Status::OK();
+}
+
+Status SharedBufferedInputStream::_set_io_ranges_separately(const std::vector<IORange>& ranges) {
+    if (ranges.size() == 0) {
+        return Status::OK();
+    }
+
+    // specify compare function is important. suppose we have zero range like [351,351],[351,356].
+    // If we don't specify compare function, we may have [351,356],[351,351] which is bad order.
+    std::vector<IORange> check(ranges);
+    RETURN_IF_ERROR(_sort_and_check_overlap(check));
+
+    std::vector<IORange> small_active_ranges;
+    std::vector<bool> small_lazy_flag(ranges.size());
+    small_lazy_flag.assign(ranges.size(), false);
+    for (auto index = 0; index < check.size(); ++index) {
+        const IORange& r = check[index];
+        if (r.size > _options.max_buffer_size) {
+            SharedBuffer sb = SharedBuffer{.raw_offset = r.offset, .raw_size = r.size, .ref_count = 1};
+            sb.align(_align_size, _file_size);
+            _map.insert(std::make_pair(sb.raw_offset + sb.raw_size, sb));
+        } else {
+            if (r.active) {
+                small_active_ranges.emplace_back(r);
+            } else {
+                small_lazy_flag[index] = true;
+            }
+        }
+    }
+
+    if (small_active_ranges.size() > 0) {
+        _merge_small_ranges(small_active_ranges);
+    }
+
+    std::vector<IORange> small_lazy_batch_ranges;
+    for (auto index = 0; index < small_lazy_flag.size(); ++index) {
+        if (!small_lazy_flag[index]) {
+            // active column or big column
+            continue;
+        } else {
+            // 1. there may be lazy_column locate in the middle of two active_columns,
+            // such as active_column, lazy_column, active_column,
+            // that two active_columns have merged and the lazy_column had be contained.
+            const IORange& r = check[index];
+            auto iter = _map.upper_bound(r.offset);
+            if (iter != _map.end()) {
+                SharedBuffer& sb = iter->second;
+                if (sb.offset <= r.offset && sb.offset + sb.size >= r.offset + r.size) {
+                    sb.ref_count++;
+                    continue;
+                }
+            }
+            small_lazy_batch_ranges.emplace_back(r);
+            // 2. there also may be active_column locate in the middle of two lazy_columns,
+            // in this case active_column may be contained in two shared_buffer，
+            // we should prevent that
+            if (index + 1 >= small_lazy_flag.size() || !small_lazy_flag[index + 1]) {
+                _merge_small_ranges(small_lazy_batch_ranges);
+                small_lazy_batch_ranges.clear();
+            }
+        }
+    }
+
+    _update_estimated_mem_usage();
+    return Status::OK();
+}
+
+Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& ranges, bool coalesce_together) {
+    if (coalesce_together || !config::io_coalesce_adaptive_lazy_active) {
+        return set_io_ranges(ranges);
+    } else {
+        return _set_io_ranges_separately(ranges);
+    }
 }
 
 StatusOr<SharedBufferedInputStream::SharedBuffer*> SharedBufferedInputStream::_find_shared_buffer(size_t offset,

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -28,6 +28,7 @@ public:
     struct IORange {
         int64_t offset;
         int64_t size;
+        bool active = true;
         bool operator<(const IORange& x) const { return offset < x.offset; }
     };
     struct CoalesceOptions {
@@ -58,6 +59,7 @@ public:
     }
 
     Status set_io_ranges(const std::vector<IORange>& ranges);
+    Status set_io_ranges(const std::vector<IORange>& ranges, bool coalesce_together);
     void release_to_offset(int64_t offset);
     void release();
     void set_coalesce_options(const CoalesceOptions& options) { _options = options; }
@@ -89,6 +91,9 @@ private:
 
     void _update_estimated_mem_usage();
     Status _get_bytes(const uint8_t** buffer, size_t offset, size_t nbytes);
+    Status _sort_and_check_overlap(std::vector<IORange>& ranges);
+    void _merge_small_ranges(const std::vector<IORange>& ranges);
+    Status _set_io_ranges_separately(const std::vector<IORange>& ranges);
     StatusOr<SharedBuffer*> _find_shared_buffer(size_t offset, size_t count);
     const std::shared_ptr<SeekableInputStream> _stream;
     const std::string _filename;

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -107,7 +107,7 @@ THdfsScanRange* HdfsScannerTest::_create_scan_range(const std::string& file, uin
 HdfsScannerParams* HdfsScannerTest::_create_param(const std::string& file, THdfsScanRange* range,
                                                   const TupleDescriptor* tuple_desc) {
     auto* param = _pool.add(new HdfsScannerParams());
-    auto* lazy_column_colease_counter = _pool.add(new std::atomic<int32_t>(0));
+    auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
     param->fs = FileSystem::Default();
     param->path = file;
     param->file_size = range->file_length;
@@ -133,7 +133,7 @@ HdfsScannerParams* HdfsScannerTest::_create_param(const std::string& file, THdfs
     param->materialize_index_in_chunk = materialize_index_in_chunk;
     param->materialize_slots = mat_slots;
     param->partition_slots = part_slots;
-    param->lazy_column_colease_counter = lazy_column_colease_counter;
+    param->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
     return param;
 }
 

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -107,6 +107,7 @@ THdfsScanRange* HdfsScannerTest::_create_scan_range(const std::string& file, uin
 HdfsScannerParams* HdfsScannerTest::_create_param(const std::string& file, THdfsScanRange* range,
                                                   const TupleDescriptor* tuple_desc) {
     auto* param = _pool.add(new HdfsScannerParams());
+    auto* lazy_column_colease_counter = _pool.add(new std::atomic<int32_t>(0));
     param->fs = FileSystem::Default();
     param->path = file;
     param->file_size = range->file_length;
@@ -132,6 +133,7 @@ HdfsScannerParams* HdfsScannerTest::_create_param(const std::string& file, THdfs
     param->materialize_index_in_chunk = materialize_index_in_chunk;
     param->materialize_slots = mat_slots;
     param->partition_slots = part_slots;
+    param->lazy_column_colease_counter = lazy_column_colease_counter;
     return param;
 }
 

--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -44,6 +44,8 @@ protected:
 
     HdfsScannerContext* _create_scan_context() {
         auto* ctx = _pool.add(new HdfsScannerContext());
+        auto* lazy_column_colease_counter = _pool.add(new std::atomic<int32_t>(0));
+        ctx->lazy_column_coalesce_counter = lazy_column_colease_counter;
         ctx->timezone = "Asia/Shanghai";
         ctx->stats = &g_hdfs_scan_stats;
         return ctx;

--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -44,8 +44,8 @@ protected:
 
     HdfsScannerContext* _create_scan_context() {
         auto* ctx = _pool.add(new HdfsScannerContext());
-        auto* lazy_column_colease_counter = _pool.add(new std::atomic<int32_t>(0));
-        ctx->lazy_column_coalesce_counter = lazy_column_colease_counter;
+        auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
+        ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
         ctx->timezone = "Asia/Shanghai";
         ctx->stats = &g_hdfs_scan_stats;
         return ctx;

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -216,8 +216,8 @@ std::unique_ptr<RandomAccessFile> FileReaderTest::_create_file(const std::string
 
 HdfsScannerContext* FileReaderTest::_create_scan_context() {
     auto* ctx = _pool.add(new HdfsScannerContext());
-    auto* lazy_column_colease_counter = _pool.add(new std::atomic<int32_t>(0));
-    ctx->lazy_column_coalesce_counter = lazy_column_colease_counter;
+    auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
+    ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
     ctx->timezone = "Asia/Shanghai";
     ctx->stats = &g_hdfs_scan_stats;
     return ctx;

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -216,6 +216,8 @@ std::unique_ptr<RandomAccessFile> FileReaderTest::_create_file(const std::string
 
 HdfsScannerContext* FileReaderTest::_create_scan_context() {
     auto* ctx = _pool.add(new HdfsScannerContext());
+    auto* lazy_column_colease_counter = _pool.add(new std::atomic<int32_t>(0));
+    ctx->lazy_column_coalesce_counter = lazy_column_colease_counter;
     ctx->timezone = "Asia/Shanghai";
     ctx->stats = &g_hdfs_scan_stats;
     return ctx;

--- a/be/test/formats/parquet/file_writer_test.cpp
+++ b/be/test/formats/parquet/file_writer_test.cpp
@@ -47,6 +47,8 @@ public:
 protected:
     HdfsScannerContext* _create_scan_context(const std::vector<TypeDescriptor>& type_descs) {
         auto ctx = _pool.add(new HdfsScannerContext());
+        auto* lazy_column_colease_counter = _pool.add(new std::atomic<int32_t>(0));
+        ctx->lazy_column_coalesce_counter = lazy_column_colease_counter;
 
         std::vector<Utils::SlotDesc> slot_descs;
         for (auto& type_desc : type_descs) {

--- a/be/test/formats/parquet/file_writer_test.cpp
+++ b/be/test/formats/parquet/file_writer_test.cpp
@@ -47,8 +47,8 @@ public:
 protected:
     HdfsScannerContext* _create_scan_context(const std::vector<TypeDescriptor>& type_descs) {
         auto ctx = _pool.add(new HdfsScannerContext());
-        auto* lazy_column_colease_counter = _pool.add(new std::atomic<int32_t>(0));
-        ctx->lazy_column_coalesce_counter = lazy_column_colease_counter;
+        auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
+        ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
 
         std::vector<Utils::SlotDesc> slot_descs;
         for (auto& type_desc : type_descs) {

--- a/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
@@ -70,6 +70,8 @@ protected:
 
     HdfsScannerContext* _create_scan_context() {
         auto* ctx = _pool.add(new HdfsScannerContext());
+        auto* lazy_column_colease_counter = _pool.add(new std::atomic<int32_t>(0));
+        ctx->lazy_column_coalesce_counter = lazy_column_colease_counter;
         ctx->stats = &g_hdfs_scan_stats;
         return ctx;
     }

--- a/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
@@ -70,8 +70,8 @@ protected:
 
     HdfsScannerContext* _create_scan_context() {
         auto* ctx = _pool.add(new HdfsScannerContext());
-        auto* lazy_column_colease_counter = _pool.add(new std::atomic<int32_t>(0));
-        ctx->lazy_column_coalesce_counter = lazy_column_colease_counter;
+        auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
+        ctx->lazy_column_coalesce_counter = lazy_column_coalesce_counter;
         ctx->stats = &g_hdfs_scan_stats;
         return ctx;
     }


### PR DESCRIPTION
In some cases, active and lazy column will be coalesced together, When requeting io, their io will be requested together, in case of low-pass filter, lazy column is useless, we adaptivly coalesce them.
On each scan node, there is a counter, when lazy_columns are needed counter++ else counter--, of course it's atomic.
when counter>0, so we know lazy_columns are needed has a greater possibility, so we coalesce them with active_columns.

Fixes #issue
a case: 100columns, 1.3M/column/rowgroup, 1/8 row_group need lazy column.
<img width="335" alt="截屏2023-06-26 10 27 38" src="https://github.com/StarRocks/starrocks/assets/28446271/a61ae6d4-6c2d-4ea2-b9b0-cfb10c4c629c">
to 
<img width="355" alt="截屏2023-06-26 10 29 10" src="https://github.com/StarRocks/starrocks/assets/28446271/01c47f7d-ad45-453b-a82c-44d4ec397961">


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
