### PR TITLE
[BugFix] fix connector scan local exchange bug

### DIFF
--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -196,7 +196,7 @@ pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::Pipelin
 
     auto operators = pipeline::decompose_scan_node_to_pipeline(scan_op, this, context);
 
-    if (!_data_source_provider->insert_local_exchange_operator()) {
+    if (_data_source_provider->insert_local_exchange_operator()) {
         operators = context->maybe_interpolate_local_passthrough_exchange(context->fragment_context()->runtime_state(),
                                                                           operators, context->degree_of_parallelism());
     }


### PR DESCRIPTION
```
CREATE TABLE `t1` (
              `k0` int(11) NULL COMMENT "",
              `c1` bigint(20) NOT NULL COMMENT ""
            ) ENGINE=OLAP
            DUPLICATE KEY(`k0`)
            COMMENT "OLAP"
            DISTRIBUTED BY HASH(`k0`) BUCKETS 1
            PROPERTIES (
            "replication_num" = "1"
            );

insert into t1 (NULL, 1), (NULL, 1), ..., (NULL, 1), (1,1); // (NULL, 1) repeats 4097 times

select k0, sum(c1) as sum_c1 from t1 group by k0 order by k0; // result is ok
((None, 4097), (1, 1))

select /*+ SET_VAR(enable_sort_aggregate=true) */ k0, sum(c1) as sum_c1 from t1 group by k0 order by k0; // result is wrong
((None, 1), (None, 4096), (1, 1))

the first chunk is (NULL, 1), ... (NULL, 1), // repeats 4096 times
the second chunk is (NULL, 1), (1, 1),
if inserts a local exchange here, the second chunk would be processed earlier, so the order is wrong.

the case is already in daily ci.
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
