### PR TITLE
[BugFix] Fix schema change bug in ASAN mode

### DIFF
--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -237,8 +237,7 @@ bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const
                 }
                 auto new_col = new_col_status.value();
                 // TODO: no need to unpack const column later.
-                new_col = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
-                new_chunk->update_column_by_index(new_col, i);
+                new_chunk->columns()[i] = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
             } else {
                 LogicalType ref_type = base_tablet_meta->tablet_schema().column(ref_column).type();
                 LogicalType new_type = new_tablet_meta->tablet_schema().column(i).type();
@@ -382,8 +381,7 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
                     return false;
                 }
                 auto new_col = new_col_status.value();
-                new_col = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
-                new_chunk->update_column_by_index(new_col, i);
+                new_chunk->columns()[i] = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
             } else {
                 DCHECK(_slot_id_to_index_map.find(ref_column) != _slot_id_to_index_map.end());
                 int base_index = _slot_id_to_index_map[ref_column];


### PR DESCRIPTION
Fixes #2733

`update_column_by_index` will call `check_or_die` after updated in ASAN mode, but `new_chunk `'s columns may have not been initialized yet which will cause broken.

```
void Chunk::update_column_by_index(ColumnPtr column, size_t idx) {
    _columns[idx] = std::move(column);
    check_or_die();
}
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
