### PR TITLE
[Feature][CherryPick] support sync refresh mv for 3.0 (#24049)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -37,7 +37,6 @@ import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.DropPartitionClause;
 import com.starrocks.sql.ast.DropTableStmt;
-import com.starrocks.sql.ast.PartitionRangeDesc;
 import com.starrocks.sql.ast.PartitionRenameClause;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.sql.ast.TableRenameClause;
@@ -200,14 +199,7 @@ public interface ConnectorMetadata {
             throws DdlException, MetaNotFoundException, AnalysisException {
     }
 
-    default String refreshMaterializedView(String dbName, String mvName, boolean force, PartitionRangeDesc range,
-                                           int priority, boolean mergeRedundant, boolean isManual)
-            throws DdlException, MetaNotFoundException {
-        return null;
-    }
-
-    default String refreshMaterializedView(RefreshMaterializedViewStatement refreshMaterializedViewStatement,
-                                           int priority)
+    default String refreshMaterializedView(RefreshMaterializedViewStatement refreshMaterializedViewStatement)
             throws DdlException, MetaNotFoundException {
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -197,6 +197,8 @@ public class ConnectContext {
 
     protected SSLContext sslContext;
 
+    private ConnectContext parent;
+
     public StmtExecutor getExecutor() {
         return executor;
     }
@@ -494,7 +496,7 @@ public class ConnectContext {
     }
 
     public boolean isKilled() {
-        return isKilled;
+        return (parent != null && parent.isKilled()) || isKilled;
     }
 
     // Set kill flag to true;
@@ -603,6 +605,14 @@ public class ConnectContext {
 
     public void setStatisticsConnection(boolean statisticsConnection) {
         isStatisticsConnection = statisticsConnection;
+    }
+
+    public void setParentConnectContext(ConnectContext parent) {
+        this.parent = parent;
+    }
+
+    public ConnectContext getParent() {
+        return parent;
     }
 
     // kill operation with no protect.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -293,9 +293,8 @@ public class DDLStmtExecutor {
             List<String> info = Lists.newArrayList();
             ErrorReport.wrapWithRuntimeException(() -> {
                 // The priority of manual refresh is higher than that of general refresh
-                String taskId = context.getGlobalStateMgr().getLocalMetastore()
-                        .refreshMaterializedView(stmt, Constants.TaskRunPriority.HIGH.value());
-                info.add(taskId);
+                String taskRunId = context.getGlobalStateMgr().getLocalMetastore().refreshMaterializedView(stmt);
+                info.add(taskRunId);
             });
 
             return new ShowResultSet(RefreshMaterializedViewStatement.META_DATA, Arrays.asList(info));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1485,6 +1485,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return transactionVisibleWaitTimeout;
     }
 
+    public void setTransactionVisibleWaitTimeout(long transactionVisibleWaitTimeout) {
+        this.transactionVisibleWaitTimeout = transactionVisibleWaitTimeout;
+    }
+
     public boolean getForceScheduleLocal() {
         return forceScheduleLocal;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -206,6 +206,7 @@ public class StmtExecutor {
     private List<ByteBuffer> proxyResultBuffer = null;
     private ShowResultSet proxyResultSet = null;
     private PQueryStatistics statisticsForAuditLog;
+    private List<StmtExecutor> subStmtExecutors;
 
     // this constructor is mainly for proxy
     public StmtExecutor(ConnectContext context, OriginStatement originStmt, boolean isProxy) {
@@ -726,6 +727,13 @@ public class StmtExecutor {
 
     }
 
+    public void registerSubStmtExecutor(StmtExecutor subStmtExecutor) {
+        if (subStmtExecutors == null) {
+            subStmtExecutors = Lists.newArrayList();
+        }
+        subStmtExecutors.add(subStmtExecutor);
+    }
+
     // Because this is called by other thread
     public void cancel() {
         if (parsedStmt instanceof DeleteStmt && ((DeleteStmt) parsedStmt).shouldHandledByDeleteHandler()) {
@@ -735,6 +743,11 @@ public class StmtExecutor {
                 GlobalStateMgr.getCurrentState().getDeleteMgr().killJob(jobId);
             }
         } else {
+            if (subStmtExecutors != null && !subStmtExecutors.isEmpty()) {
+                for (StmtExecutor sub : subStmtExecutors) {
+                    sub.cancel();
+                }
+            }
             Coordinator coordRef = coord;
             if (coordRef != null) {
                 coordRef.cancel();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
@@ -24,6 +24,7 @@ public class ExecuteOption {
     private Map<String, String> taskRunProperties;
     // indicates whether the current execution is manual
     private boolean isManual = false;
+    private boolean isSync = false;
 
     public ExecuteOption() {
     }
@@ -64,5 +65,13 @@ public class ExecuteOption {
 
     public void setManual() {
         this.isManual = true;
+    }
+
+    public boolean getIsSync() {
+        return isSync;
+    }
+
+    public void setSync(boolean isSync) {
+        this.isSync = isSync;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -103,11 +103,11 @@ import java.util.stream.Collectors;
 
 /**
  * Core logic of materialized view refresh task run
- * PartitionBasedMaterializedViewRefreshProcessor is not thread safe for concurrent runs of the same materialized view
+ * PartitionBasedMvRefreshProcessor is not thread safe for concurrent runs of the same materialized view
  */
-public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunProcessor {
+public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
-    private static final Logger LOG = LogManager.getLogger(PartitionBasedMaterializedViewRefreshProcessor.class);
+    private static final Logger LOG = LogManager.getLogger(PartitionBasedMvRefreshProcessor.class);
 
     public static final String MV_ID = "mvId";
 
@@ -118,6 +118,8 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
     private MvTaskRunContext mvContext;
     // table id -> <base table info, snapshot table>
     private Map<Long, Pair<BaseTableInfo, Table>> snapshotBaseTables;
+
+    private long oldTransactionVisibleWaitTimeout;
 
     @VisibleForTesting
     public MvTaskRunContext getMvContext() {
@@ -137,7 +139,14 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
     @Override
     public void processTaskRun(TaskRunContext context) throws Exception {
         prepare(context);
+        try {
+            doMvRefresh(context);
+        } finally {
+            postProcess();
+        }
+    }
 
+    private void doMvRefresh(TaskRunContext context) throws Exception {
         InsertStmt insertStmt = null;
         ExecPlan execPlan = null;
         int retryNum = 0;
@@ -216,6 +225,10 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         if (mvContext.hasNextBatchPartition()) {
             generateNextTaskRun();
         }
+    }
+
+    private void postProcess() {
+        mvContext.ctx.getSessionVariable().setTransactionVisibleWaitTimeout(oldTransactionVisibleWaitTimeout);
     }
 
     public MVTaskRunExtraMessage getMVTaskRunExtraMessage() {
@@ -431,6 +444,11 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
             LOG.warn(errorMsg);
             throw new DmlException(errorMsg);
         }
+        // wait util transaction is visible for mv refresh task
+        // because mv will update base tables' visible version after insert, the mv's visible version
+        // should keep up with the base tables, or it will return outdated result.
+        oldTransactionVisibleWaitTimeout = context.ctx.getSessionVariable().getTransactionVisibleWaitTimeout();
+        context.ctx.getSessionVariable().setTransactionVisibleWaitTimeout(Long.MAX_VALUE / 1000);
         mvContext = new MvTaskRunContext(context);
     }
 
@@ -934,6 +952,10 @@ public class PartitionBasedMaterializedViewRefreshProcessor extends BaseTaskRunP
         ConnectContext ctx = mvContext.getCtx();
         StmtExecutor executor = new StmtExecutor(ctx, insertStmt);
         ctx.setExecutor(executor);
+        if (ctx.getParent() != null && ctx.getParent().getExecutor() != null) {
+            StmtExecutor parentStmtExecutor = ctx.getParent().getExecutor();
+            parentStmtExecutor.registerSubStmtExecutor(executor);
+        }
         ctx.setStmtId(new AtomicInteger().incrementAndGet());
         ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -85,7 +85,7 @@ public class TaskBuilder {
         task.setSource(Constants.TaskSource.MV);
         task.setDbName(dbName);
         Map<String, String> taskProperties = Maps.newHashMap();
-        taskProperties.put(PartitionBasedMaterializedViewRefreshProcessor.MV_ID,
+        taskProperties.put(PartitionBasedMvRefreshProcessor.MV_ID,
                 String.valueOf(materializedView.getId()));
         taskProperties.putAll(materializedView.getProperties());
 
@@ -102,7 +102,7 @@ public class TaskBuilder {
         Task task = new Task(getMvTaskName(materializedView.getId()));
         task.setSource(Constants.TaskSource.MV);
         task.setDbName(dbName);
-        previousTaskProperties.put(PartitionBasedMaterializedViewRefreshProcessor.MV_ID,
+        previousTaskProperties.put(PartitionBasedMvRefreshProcessor.MV_ID,
                 String.valueOf(materializedView.getId()));
         task.setProperties(previousTaskProperties);
         task.setDefinition(

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -57,7 +57,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -284,36 +283,58 @@ public class TaskManager {
         return taskRunManager.killTaskRun(task.getId());
     }
 
-    public Constants.TaskRunState executeTaskSync(String taskName) throws ExecutionException, InterruptedException {
-        return executeTaskSync(taskName, new ExecuteOption());
-    }
-
-    public Constants.TaskRunState executeTaskSync(String taskName, ExecuteOption option)
-            throws ExecutionException, InterruptedException {
-        Task task = nameToTaskMap.get(taskName);
-        if (task == null) {
-            throw new DmlException("execute task:" + taskName + " failed");
-        }
-        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        SubmitResult submitResult = taskRunManager.submitTaskRun(taskRun, option);
-        if (submitResult.getStatus() != SUBMITTED) {
-            throw new DmlException("execute task:" + taskName + " failed");
-        }
-        return taskRun.getFuture().get();
-    }
-
     public SubmitResult executeTask(String taskName) {
         return executeTask(taskName, new ExecuteOption());
     }
 
     public SubmitResult executeTask(String taskName, ExecuteOption option) {
-        Task task = nameToTaskMap.get(taskName);
+        Task task = getTask(taskName);
         if (task == null) {
             return new SubmitResult(null, SubmitResult.SubmitStatus.FAILED);
         }
+        if (option.getIsSync()) {
+            return executeTaskSync(task, option);
+        } else {
+            return executeTaskAsync(task, option);
+        }
+    }
+
+    // for test
+    public SubmitResult executeTaskSync(Task task) {
+        return executeTaskSync(task, new ExecuteOption());
+    }
+
+    public SubmitResult executeTaskSync(Task task, ExecuteOption option) {
+        TaskRun taskRun;
+        SubmitResult submitResult;
+        if (!tryTaskLock()) {
+            throw new DmlException("Failed to get task lock when execute Task sync[" + task.getName() + "]");
+        }
+        try {
+            taskRun = TaskRunBuilder.newBuilder(task).setConnectContext(ConnectContext.get()).build();
+            submitResult = taskRunManager.submitTaskRun(taskRun, option);
+            if (submitResult.getStatus() != SUBMITTED) {
+                throw new DmlException("execute task:" + task.getName() + " failed");
+            }
+        } finally {
+            taskUnlock();
+        }
+        try {
+            Constants.TaskRunState taskRunState = taskRun.getFuture().get();
+            if (taskRunState != Constants.TaskRunState.SUCCESS) {
+                throw new DmlException("execute task: %s failed. task source:%s, task run state:%s",
+                        task.getName(), task.getSource(), taskRunState);
+            }
+            return submitResult;
+        } catch (Exception e) {
+            throw new DmlException("execute task: %s failed.", e, task.getName());
+        }
+    }
+
+    public SubmitResult executeTaskAsync(Task task, ExecuteOption option) {
         return taskRunManager
                 .submitTaskRun(TaskRunBuilder.newBuilder(task).properties(option.getTaskRunProperties()).type(option).
-                                build(), option);
+                        build(), option);
     }
 
     public void dropTasks(List<Long> taskIdList, boolean isReplay) {
@@ -850,10 +871,24 @@ public class TaskManager {
     }
 
     public boolean containTask(String taskName) {
-        return nameToTaskMap.containsKey(taskName);
+        if (!tryTaskLock()) {
+            throw new DmlException("Failed to get task lock when check Task [" + taskName + "]");
+        }
+        try {
+            return nameToTaskMap.containsKey(taskName);
+        } finally {
+            taskUnlock();
+        }
     }
 
     public Task getTask(String taskName) {
-        return nameToTaskMap.get(taskName);
+        if (!tryTaskLock()) {
+            throw new DmlException("Failed to get task lock when get Task [" + taskName + "]");
+        }
+        try {
+            return nameToTaskMap.get(taskName);
+        } finally {
+            taskUnlock();
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -58,6 +58,8 @@ public class TaskRun implements Comparable<TaskRun> {
 
     private ConnectContext runCtx;
 
+    private ConnectContext parentRunCtx;
+
     private TaskRunProcessor processor;
 
     private TaskRunStatus status;
@@ -96,6 +98,10 @@ public class TaskRun implements Comparable<TaskRun> {
         this.task = task;
     }
 
+    public void setConnectContext(ConnectContext context) {
+        this.parentRunCtx = context;
+    }
+
     public TaskRunProcessor getProcessor() {
         return processor;
     }
@@ -119,7 +125,7 @@ public class TaskRun implements Comparable<TaskRun> {
 
         try {
             // NOTE: mvId is set in Task's properties when creating
-            long mvId = Long.parseLong(properties.get(PartitionBasedMaterializedViewRefreshProcessor.MV_ID));
+            long mvId = Long.parseLong(properties.get(PartitionBasedMvRefreshProcessor.MV_ID));
             Database database = GlobalStateMgr.getCurrentState().getDb(ctx.getDatabase());
             if (database == null) {
                 LOG.warn("database {} do not exist when refreshing materialized view:{}", ctx.getDatabase(), mvId);
@@ -147,6 +153,9 @@ public class TaskRun implements Comparable<TaskRun> {
         taskRunContext.setDefinition(status.getDefinition());
         taskRunContext.setPostRun(status.getPostRun());
         runCtx = new ConnectContext(null);
+        if (parentRunCtx != null) {
+            runCtx.setParentConnectContext(parentRunCtx);
+        }
         runCtx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
         runCtx.setDatabase(task.getDbName());
         runCtx.setQualifiedUser(status.getUser());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunBuilder.java
@@ -15,6 +15,8 @@
 
 package com.starrocks.scheduler;
 
+import com.starrocks.qe.ConnectContext;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,6 +24,7 @@ public class TaskRunBuilder {
     private final Task task;
     private Map<String, String> properties;
     private Constants.TaskType type;
+    private ConnectContext connectContext;
 
     public static TaskRunBuilder newBuilder(Task task) {
         return new TaskRunBuilder(task);
@@ -31,15 +34,21 @@ public class TaskRunBuilder {
         this.task = task;
     }
 
+    public TaskRunBuilder setConnectContext(ConnectContext connectContext) {
+        this.connectContext = connectContext;
+        return this;
+    }
+
     // TaskRun is the smallest unit of execution.
     public TaskRun build() {
         TaskRun taskRun = new TaskRun();
+        taskRun.setConnectContext(connectContext);
         taskRun.setTaskId(task.getId());
         taskRun.setProperties(mergeProperties());
         taskRun.setTask(task);
         taskRun.setType(getTaskType());
         if (task.getSource().equals(Constants.TaskSource.MV)) {
-            taskRun.setProcessor(new PartitionBasedMaterializedViewRefreshProcessor());
+            taskRun.setProcessor(new PartitionBasedMvRefreshProcessor());
         } else {
             taskRun.setProcessor(new SqlTaskRunProcessor());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3839,9 +3839,14 @@ public class LocalMetastore implements ConnectorMetadata {
         return materializedView;
     }
 
-    @Override
     public String refreshMaterializedView(String dbName, String mvName, boolean force, PartitionRangeDesc range,
                                           int priority, boolean mergeRedundant, boolean isManual)
+            throws DdlException, MetaNotFoundException {
+        return refreshMaterializedView(dbName, mvName, force, range, priority, mergeRedundant, isManual, false);
+    }
+
+    public String refreshMaterializedView(String dbName, String mvName, boolean force, PartitionRangeDesc range,
+                                          int priority, boolean mergeRedundant, boolean isManual, boolean isSync)
             throws DdlException, MetaNotFoundException {
         MaterializedView materializedView = getMaterializedViewToRefresh(dbName, mvName);
 
@@ -3854,12 +3859,12 @@ public class LocalMetastore implements ConnectorMetadata {
         if (isManual) {
             executeOption.setManual();
         }
+        executeOption.setSync(isSync);
         return executeRefreshMvTask(dbName, materializedView, executeOption);
     }
 
     @Override
-    public String refreshMaterializedView(RefreshMaterializedViewStatement refreshMaterializedViewStatement,
-                                          int priority)
+    public String refreshMaterializedView(RefreshMaterializedViewStatement refreshMaterializedViewStatement)
             throws DdlException, MetaNotFoundException {
         String dbName = refreshMaterializedViewStatement.getMvName().getDb();
         String mvName = refreshMaterializedViewStatement.getMvName().getTbl();
@@ -3867,7 +3872,8 @@ public class LocalMetastore implements ConnectorMetadata {
         PartitionRangeDesc range =
                 refreshMaterializedViewStatement.getPartitionRangeDesc();
 
-        return refreshMaterializedView(dbName, mvName, force, range, priority, false, true);
+        return refreshMaterializedView(dbName, mvName, force, range, Constants.TaskRunPriority.HIGH.value(),
+                false, true, refreshMaterializedViewStatement.isSync());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RefreshMaterializedViewStatement.java
@@ -20,9 +20,11 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.qe.ShowResultSetMetaData;
 
 public class RefreshMaterializedViewStatement extends DdlStmt {
+
     private final TableName mvName;
     private final PartitionRangeDesc partitionRangeDesc;
     private final boolean forceRefresh;
+    private final boolean isSync;
 
     public static final ShowResultSetMetaData META_DATA =
             ShowResultSetMetaData.builder()
@@ -31,10 +33,11 @@ public class RefreshMaterializedViewStatement extends DdlStmt {
 
     public RefreshMaterializedViewStatement(TableName mvName,
                                             PartitionRangeDesc partitionRangeDesc,
-                                            boolean forceRefresh) {
+                                            boolean forceRefresh, boolean isSync) {
         this.mvName = mvName;
         this.partitionRangeDesc = partitionRangeDesc;
         this.forceRefresh = forceRefresh;
+        this.isSync = isSync;
     }
 
     public TableName getMvName() {
@@ -52,5 +55,9 @@ public class RefreshMaterializedViewStatement extends DdlStmt {
 
     public boolean isForceRefresh() {
         return forceRefresh;
+    }
+
+    public boolean isSync() {
+        return isSync;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1587,7 +1587,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             partitionRangeDesc =
                     (PartitionRangeDesc) visit(context.partitionRangeDesc());
         }
-        return new RefreshMaterializedViewStatement(mvName, partitionRangeDesc, context.FORCE() != null);
+
+        return new RefreshMaterializedViewStatement(mvName, partitionRangeDesc, context.FORCE() != null,
+                context.SYNC() != null);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -553,7 +553,7 @@ alterMaterializedViewStatement
     ;
 
 refreshMaterializedViewStatement
-    : REFRESH MATERIALIZED VIEW mvName=qualifiedName (PARTITION partitionRangeDesc)? FORCE?
+    : REFRESH MATERIALIZED VIEW mvName=qualifiedName (PARTITION partitionRangeDesc)? FORCE? (WITH (SYNC | ASYNC) MODE)?
     ;
 
 cancelRefreshMaterializedViewStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewStatementTest.java
@@ -22,9 +22,6 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.scheduler.Task;
-import com.starrocks.scheduler.TaskBuilder;
-import com.starrocks.scheduler.TaskManager;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -96,15 +93,8 @@ public class RefreshMaterializedViewStatementTest {
         Table t2 = db.getTable("mv1");
         Assert.assertNotNull(t2);
         MaterializedView mv1 = (MaterializedView) t2;
+        cluster.runSql("test", "refresh materialized view mv1 with sync mode");
 
-        TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
-        final String mvTaskName = TaskBuilder.getMvTaskName(mv1.getId());
-        if (!taskManager.containTask(mvTaskName)) {
-            Task task = TaskBuilder.buildMvTask(mv1, "test");
-            TaskBuilder.updateTaskInfo(task, mv1);
-            taskManager.createTask(task, false);
-        }
-        taskManager.executeTaskSync(mvTaskName);
         MaterializedView.MvRefreshScheme refreshScheme = mv1.getRefreshScheme();
         Assert.assertNotNull(refreshScheme);
         System.out.println("visibleVersionMap:" + refreshScheme.getAsyncRefreshContext().getBaseTableVisibleVersionMap());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -23,9 +23,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.scheduler.Task;
-import com.starrocks.scheduler.TaskBuilder;
-import com.starrocks.scheduler.TaskManager;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.utframe.StarRocksAssert;
@@ -144,15 +141,7 @@ public class RefreshMaterializedViewTest {
     }
 
     private void refreshMaterializedView(String dbName, String mvName) throws Exception {
-        MaterializedView mv = getMv(dbName, mvName);
-        TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
-        final String mvTaskName = TaskBuilder.getMvTaskName(mv.getId());
-        if (!taskManager.containTask(mvTaskName)) {
-            Task task = TaskBuilder.buildMvTask(mv, "test");
-            TaskBuilder.updateTaskInfo(task, mv);
-            taskManager.createTask(task, false);
-        }
-        taskManager.executeTaskSync(mvTaskName);
+        cluster.runSql(dbName, String.format("refresh materialized view %s with sync mode", mvName));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -359,12 +359,13 @@ public class MaterializedViewTestBase extends PlanTestBase {
         MaterializedView mv = getMv(dbName, mvName);
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         final String mvTaskName = TaskBuilder.getMvTaskName(mv.getId());
-        if (!taskManager.containTask(mvTaskName)) {
-            Task task = TaskBuilder.buildMvTask(mv, dbName);
+        Task task = taskManager.getTask(mvTaskName);
+        if (task == null) {
+            task = TaskBuilder.buildMvTask(mv, dbName);
             TaskBuilder.updateTaskInfo(task, mv);
             taskManager.createTask(task, false);
         }
-        taskManager.executeTaskSync(mvTaskName);
+        taskManager.executeTaskSync(task);
     }
 
     protected static void createAndRefreshMV(String db, String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -68,7 +68,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static com.starrocks.scheduler.TaskRun.PARTITION_END;
 import static com.starrocks.scheduler.TaskRun.PARTITION_START;
 
-public class PartitionBasedMaterializedViewRefreshProcessorTest {
+public class PartitionBasedMvRefreshProcessorTest {
 
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
@@ -540,7 +540,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -616,7 +616,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -628,7 +628,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         mockedHiveMetadata.addPartition("partitioned_db", "lineitem_par", "l_shipdate=1998-01-06");
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
 
@@ -660,7 +660,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -673,7 +673,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("par_col=0/par_date=2020-01-03"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "par_date >= '2020-01-03', 9: par_date < '2020-01-04'", "partitions=2/6");
@@ -682,7 +682,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("par_col=0"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "partitions=6/6", "partitions=3/3");
@@ -708,7 +708,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -721,7 +721,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("l_shipdate=1998-01-04"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
 
@@ -731,7 +731,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         mockedHiveMetadata.updateTable("tpch", "orders");
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "partitions=6/6", "partitions=1/1");
@@ -755,7 +755,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -767,7 +767,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         mockedHiveMetadata.updateTable("tpch", "nation");
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "partitions=1/1");
@@ -798,7 +798,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -813,7 +813,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "PARTITION PREDICATES: 16: l_shipdate >= '1998-01-02', 16: l_shipdate < '1998-01-04'",
@@ -847,7 +847,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -860,7 +860,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "partitions=6/6");
@@ -892,7 +892,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -905,7 +905,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "partitions=6/6");
@@ -936,7 +936,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -949,7 +949,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "PARTITION PREDICATES: 16: l_shipdate >= '1998-01-02', 16: l_shipdate < '1998-01-04'",
@@ -985,7 +985,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -998,7 +998,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "PARTITION PREDICATES: 16: l_shipdate >= '1998-01-02', 16: l_shipdate < '1998-01-04'",
@@ -1034,7 +1034,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -1047,7 +1047,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
                 ImmutableList.of("par_col=0"));
 
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMaterializedViewRefreshProcessor) taskRun.getProcessor();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "par_col >= 0, 4: par_col < 1", "partitions=1/3");
@@ -1098,7 +1098,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         Assert.assertEquals(1, materializedView.getPartition("p19980104").getVisibleVersion());
         Assert.assertEquals(1, materializedView.getPartition("p19980105").getVisibleVersion());
 
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
@@ -1137,7 +1137,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(mvProperties).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -1176,7 +1176,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(mvProperties).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-        PartitionBasedMaterializedViewRefreshProcessor processor = (PartitionBasedMaterializedViewRefreshProcessor)
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -1279,7 +1279,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         String insertSql = "insert into tbl1 partition(p0) values('2021-12-01', 2, 10);";
         new StmtExecutor(connectContext, insertSql).execute();
 
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public void processTaskRun(TaskRunContext context) throws Exception {
                 throw new RuntimeException("new exception");
@@ -1299,7 +1299,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
     public void testBaseTablePartitionRename(TaskRun taskRun)
             throws Exception {
         // mv need refresh with base table partition p1, p1 renamed with p10 after collect and before insert overwrite
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             private Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
                 Map<Long, Pair<BaseTableInfo, Table>> olapTables = Maps.newHashMap();
@@ -1351,7 +1351,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
             throws Exception {
         // mv need refresh with base table partition p2, p2 replace with tp2 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
                 Map<Long, Pair<BaseTableInfo, Table>> olapTables = Maps.newHashMap();
@@ -1410,7 +1410,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
             throws Exception {
         // mv need refresh with base table partition p3, add partition p99 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
                 Map<Long, Pair<BaseTableInfo, Table>> olapTables = Maps.newHashMap();
@@ -1463,7 +1463,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
             throws Exception {
         // mv need refresh with base table partition p3, add partition p99 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public void refreshMaterializedView(MvTaskRunContext mvContext, ExecPlan execPlan,
                                                 InsertStmt insertStmt) throws Exception {
@@ -1501,7 +1501,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
             throws Exception {
         // mv need refresh with base table partition p4, drop partition p4 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             private Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
                 Map<Long, Pair<BaseTableInfo, Table>> olapTables = Maps.newHashMap();
@@ -1550,7 +1550,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
             throws Exception {
         // drop partition p4 after collect and before insert overwrite
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        new MockUp<PartitionBasedMaterializedViewRefreshProcessor>() {
+        new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
             public void refreshMaterializedView(MvTaskRunContext mvContext, ExecPlan execPlan,
                                                 InsertStmt insertStmt) throws Exception {
@@ -1602,7 +1602,7 @@ public class PartitionBasedMaterializedViewRefreshProcessorTest {
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
         materializedView.getTableProperty().setPartitionRefreshNumber(3);
-        PartitionBasedMaterializedViewRefreshProcessor processor = new PartitionBasedMaterializedViewRefreshProcessor();
+        PartitionBasedMvRefreshProcessor processor = new PartitionBasedMvRefreshProcessor();
 
         MvTaskRunContext mvContext = new MvTaskRunContext(new TaskRunContext());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTest.java
@@ -185,12 +185,13 @@ public class OptimizerTest {
         MaterializedView mv = getMv(dbName, mvName);
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         final String mvTaskName = TaskBuilder.getMvTaskName(mv.getId());
+        Task task = taskManager.getTask(mvTaskName);
         if (!taskManager.containTask(mvTaskName)) {
-            Task task = TaskBuilder.buildMvTask(mv, "test");
+            task = TaskBuilder.buildMvTask(mv, dbName);
             TaskBuilder.updateTaskInfo(task, mv);
             taskManager.createTask(task, false);
         }
-        taskManager.executeTaskSync(mvTaskName);
+        taskManager.executeTaskSync(task);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
@@ -32,9 +32,6 @@ import com.starrocks.connector.hive.MockedHiveMetadata;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSet;
-import com.starrocks.scheduler.Task;
-import com.starrocks.scheduler.TaskBuilder;
-import com.starrocks.scheduler.TaskManager;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.QueryRelation;
@@ -2500,21 +2497,13 @@ public class MvRewriteOptimizationTest {
         return mv;
     }
 
-    private void refreshMaterializedView(String dbName, String mvName) throws Exception {
-        MaterializedView mv = getMv(dbName, mvName);
-        TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
-        final String mvTaskName = TaskBuilder.getMvTaskName(mv.getId());
-        if (!taskManager.containTask(mvTaskName)) {
-            Task task = TaskBuilder.buildMvTask(mv, "test");
-            TaskBuilder.updateTaskInfo(task, mv);
-            taskManager.createTask(task, false);
-        }
-        taskManager.executeTaskSync(mvTaskName);
+    private void refreshMaterializedView(String dbName, String mvName) throws SQLException {
+        cluster.runSql(dbName, String.format("refresh materialized view %s with sync mode", mvName));
     }
 
     private void createAndRefreshMv(String dbName, String mvName, String sql) throws Exception {
         starRocksAssert.withMaterializedView(sql);
-        refreshMaterializedView(dbName, mvName);
+        cluster.runSql(dbName, String.format("refresh materialized view %s with sync mode", mvName));
     }
 
     private void dropMv(String dbName, String mvName) throws Exception {

--- a/test/sql/test_materialized_view/R/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_rewrite
@@ -26,9 +26,31 @@ insert into user_tags values('2023-04-13', 3, 'e', 6);
 create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
 -- result:
 -- !result
-select sleep(2);
+refresh materialized view user_tags_mv1 with sync mode;
+-- result:
+-- !result
+select count(*) from user_tags_mv1;
+-- result:
+3
+-- !result
+select user_id from user_tags_mv1 order by user_id;
 -- result:
 1
+2
+3
+-- !result
+refresh materialized view user_tags_mv1 force with sync mode;
+-- result:
+-- !result
+select count(*) from user_tags_mv1;
+-- result:
+3
+-- !result
+select user_id from user_tags_mv1 order by user_id;
+-- result:
+1
+2
+3
 -- !result
 set enable_materialized_view_rewrite = off;
 -- result:

--- a/test/sql/test_materialized_view/T/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_rewrite
@@ -10,7 +10,7 @@ insert into user_tags values('2023-04-13', 3, 'e', 6);
 
 -- TEST BITMAP: NO ROLLUP
 create materialized view user_tags_mv1  distributed by hash(user_id) as select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
-select sleep(2);
+refresh materialized view user_tags_mv1 with sync mode;
 set enable_materialized_view_rewrite = off;
 select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
 select user_id, bitmap_union_count(to_bitmap(tag_id)) from user_tags group by user_id order by user_id;
@@ -24,7 +24,7 @@ drop materialized view user_tags_mv1;
 
 -- TEST BITMAP: ROLLUP
 create materialized view user_tags_mv2  distributed by hash(user_id) as select user_id, time, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id, time;
-select sleep(2);
+refresh materialized view user_tags_mv2 with sync mode;
 set enable_materialized_view_rewrite = on;
 explain logical select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
 select user_id, count(distinct tag_id) from user_tags group by user_id order by user_id;
@@ -34,7 +34,7 @@ drop materialized view user_tags_mv2;
 
 -- TEST HLL: NO ROLLUP
 create materialized view user_tags_hll_mv1  distributed by hash(user_id) as select user_id, time, hll_union(hll_hash(tag_id)) a  from user_tags group by user_id, time;
-select sleep(2);
+refresh materialized view user_tags_hll_mv1 with sync mode;
 set enable_materialized_view_rewrite = off;
 select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
 select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
@@ -49,7 +49,7 @@ drop materialized view user_tags_hll_mv1;
 
 -- TEST HLL: ROLLUP
 create materialized view user_tags_hll_mv2  distributed by hash(user_id) as select user_id, time, hll_union(hll_hash(tag_id)) from user_tags group by user_id, time;
-select sleep(2);
+refresh materialized view user_tags_hll_mv2 with sync mode;
 set enable_materialized_view_rewrite = on;
 select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
 select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;
@@ -59,7 +59,7 @@ drop materialized view user_tags_hll_mv2;
 
 -- TEST PERCENTILE: NO ROLLUP
 create materialized view user_tags_percential_mv1 distributed by hash(user_id) as select user_id, percentile_union(percentile_hash(tag_id)) from user_tags group by user_id order by user_id;
-select sleep(2);
+refresh materialized view user_tags_percential_mv1 with sync mode;
 set enable_materialized_view_rewrite = off;
 select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
 select user_id, percentile_approx(tag_id, 0) x from user_tags group by user_id order by user_id;
@@ -73,6 +73,7 @@ drop materialized view user_tags_percential_mv1;
 
 -- TEST PERCENTILE: ROLLUP
 create materialized view user_tags_percential_mv2 distributed by hash(user_id) as select user_id, time, percentile_union(percentile_hash(tag_id)) from user_tags group by user_id, time;
+refresh materialized view user_tags_percential_mv2 with sync mode;
 set enable_materialized_view_rewrite = on;
 select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
 select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
@@ -82,7 +83,7 @@ drop materialized view user_tags_percential_mv2;
 
 -- TEST BITMAP : UNOION
 create materialized view user_tags_mv3  distributed by hash(user_id) as select user_id, tag_id from user_tags where user_id > 2;
-select sleep(2);
+refresh materialized view user_tags_mv3 with sync mode;
 set enable_materialized_view_rewrite = off;
 select user_id, approx_count_distinct(tag_id) x from user_tags group by user_id order by user_id;
 select user_id, ndv(tag_id) x from user_tags group by user_id order by user_id;


### PR DESCRIPTION
Fixes #24045
Support refresh materialized view synchronously, add the following sql: REFRESH MATERIALIZED VIEW mvName=qualifiedName (PARTITION partitionRangeDesc)? FORCE? (WITH (SYNC | ASYNC) MODE)?. In SYNC mode, refresh statement will submit a new refresh task and wait the task util finish.
In ASYNC mode, refresh statement will submit a new refresh task and return immediately. The refresh task will run in background. The ASYNC mode is the default mode

---------

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
