### PR TITLE
[Feature]Support lake_persistent_index

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -124,6 +124,11 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
         heartbeat_result.backend_info.__set_brpc_port(config::brpc_port);
 #ifdef USE_STAROS
         heartbeat_result.backend_info.__set_starlet_port(config::starlet_port);
+        if (StorageEngine::instance()->get_store_num() != 0) {
+            heartbeat_result.backend_info.__set_is_set_storage_path(true);
+        } else {
+            heartbeat_result.backend_info.__set_is_set_storage_path(false);
+        }
 #endif
         heartbeat_result.backend_info.__set_version(get_short_version());
         heartbeat_result.backend_info.__set_num_hardware_cores(num_hardware_cores);

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -197,4 +197,4 @@ add_library(Storage STATIC
     binlog_reader.cpp
     lake/update_compaction_state.cpp
     lake/txn_log_applier.cpp
-)
+    lake/lake_persistent_index.cpp)

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -197,4 +197,4 @@ add_library(Storage STATIC
     binlog_reader.cpp
     lake/update_compaction_state.cpp
     lake/txn_log_applier.cpp
-    lake/lake_persistent_index.cpp)
+        lake/lake_local_persistent_index.cpp)

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -197,4 +197,4 @@ add_library(Storage STATIC
     binlog_reader.cpp
     lake/update_compaction_state.cpp
     lake/txn_log_applier.cpp
-        lake/lake_local_persistent_index.cpp)
+    lake/lake_local_persistent_index.cpp)

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -114,7 +114,7 @@ Status DataDir::_init_data_dir() {
 }
 
 Status DataDir::init_persistent_index_dir() {
-    std::string persistent_index_path = _path + PERSISTENT_INDEX_PREFIX;
+    std::string persistent_index_path = get_persistent_index_path();
     auto st = _fs->create_dir_recursive(persistent_index_path);
     LOG_IF(ERROR, !st.ok()) << "failed to create persistent directory " << persistent_index_path;
     return st;
@@ -224,7 +224,7 @@ std::string DataDir::get_absolute_tablet_path(int64_t shard_id, int64_t tablet_i
     return strings::Substitute("$0/$1/$2", get_absolute_shard_path(shard_id), tablet_id, schema_hash);
 }
 
-Status DataDir::create_dir_if_path_not_exists(std::string path) {
+Status DataDir::create_dir_if_path_not_exists(const std::string& path) {
     auto st = _fs->create_dir_recursive(path);
     LOG_IF(ERROR, !st.ok()) << "failed to create directory " << path;
     return st;

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -113,6 +113,13 @@ Status DataDir::_init_data_dir() {
     return st;
 }
 
+Status DataDir::init_persistent_index_dir() {
+    std::string persistent_index_path = _path + PERSISTENT_INDEX_PREFIX;
+    auto st = _fs->create_dir_recursive(persistent_index_path);
+    LOG_IF(ERROR, !st.ok()) << "failed to create persistent directory " << persistent_index_path;
+    return st;
+}
+
 Status DataDir::_init_tmp_dir() {
     std::string tmp_path = _path + TMP_PREFIX;
     auto st = _fs->create_dir_recursive(tmp_path);
@@ -215,6 +222,12 @@ std::string DataDir::get_absolute_shard_path(int64_t shard_id) {
 
 std::string DataDir::get_absolute_tablet_path(int64_t shard_id, int64_t tablet_id, int32_t schema_hash) {
     return strings::Substitute("$0/$1/$2", get_absolute_shard_path(shard_id), tablet_id, schema_hash);
+}
+
+Status DataDir::create_dir_if_path_not_exists(std::string path) {
+    auto st = _fs->create_dir_recursive(path);
+    LOG_IF(ERROR, !st.ok()) << "failed to create directory " << path;
+    return st;
 }
 
 void DataDir::find_tablet_in_trash(int64_t tablet_id, std::vector<std::string>* paths) {

--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -114,6 +114,7 @@ public:
     std::string get_absolute_shard_path(int64_t shard_id);
     std::string get_absolute_tablet_path(int64_t shard_id, int64_t tablet_id, int32_t schema_hash);
 
+    Status create_dir_if_path_not_exists(std::string path);
     void find_tablet_in_trash(int64_t tablet_id, std::vector<std::string>* paths);
 
     static std::string get_root_path_from_schema_hash_path_in_trash(const std::string& schema_hash_dir_in_trash);
@@ -138,6 +139,9 @@ public:
     bool capacity_limit_reached(int64_t incoming_data_size);
 
     Status update_capacity();
+
+    std::string get_persistent_index_path() { return _path + "/" + PERSISTENT_INDEX_PREFIX; }
+    Status init_persistent_index_dir();
 
 private:
     Status _init_data_dir();

--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -114,7 +114,7 @@ public:
     std::string get_absolute_shard_path(int64_t shard_id);
     std::string get_absolute_tablet_path(int64_t shard_id, int64_t tablet_id, int32_t schema_hash);
 
-    Status create_dir_if_path_not_exists(std::string path);
+    Status create_dir_if_path_not_exists(const std::string& path);
     void find_tablet_in_trash(int64_t tablet_id, std::vector<std::string>* paths);
 
     static std::string get_root_path_from_schema_hash_path_in_trash(const std::string& schema_hash_dir_in_trash);

--- a/be/src/storage/lake/lake_local_persistent_index.h
+++ b/be/src/storage/lake/lake_local_persistent_index.h
@@ -21,24 +21,15 @@
 #include "storage/persistent_index.h"
 #include "storage/storage_engine.h"
 
-namespace starrocks {
-
-namespace lake {
+namespace starrocks::lake {
 
 class MetaFileBuilder;
 
-class LakePersistentIndex : public PersistentIndex {
+class LakeLocalPersistentIndex : public PersistentIndex {
 public:
-    LakePersistentIndex(std::string path) : PersistentIndex(path) { _path = path; }
+    explicit LakeLocalPersistentIndex(std::string path) : PersistentIndex(path) { _path = path; }
 
-    ~LakePersistentIndex() {}
-
-    DataDir* getTabletDataDir(int64_t tablet_id) {
-        StorageEngine* storage_engine = StorageEngine::instance();
-        DCHECK(storage_engine != nullptr);
-        std::vector<DataDir*> dirs = storage_engine->get_stores();
-        _meta_dir = dirs[tablet_id % dirs.size()];
-    }
+    ~LakeLocalPersistentIndex() override {}
 
     Status load_from_lake_tablet(starrocks::lake::Tablet* tablet, const TabletMetadata& metadata, int64_t base_version,
                                  const MetaFileBuilder* builder);
@@ -48,5 +39,4 @@ private:
     std::string _path;
 };
 
-} // namespace lake
-} // namespace starrocks
+} // namespace starrocks::lake

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -1,0 +1,281 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/lake_persistent_index.h"
+
+#include "gen_cpp/persistent_index.pb.h"
+#include "storage/chunk_helper.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/tablet_meta_manager.h"
+
+namespace starrocks {
+namespace lake {
+
+Status LakePersistentIndex::load_from_lake_tablet(starrocks::lake::Tablet* tablet, const TabletMetadata& metadata,
+                                                  int64_t base_version, const MetaFileBuilder* builder) {
+    MonotonicStopWatch timer;
+    timer.start();
+    //        if (tablet->keys_type() != PRIMARY_KEYS) {
+    //            LOG(WARNING) << "tablet: " << tablet->id() << " is not primary key tablet";
+    //            return Status::NotSupported("Only PrimaryKey table is supported to use persistent index");
+    //        }
+
+    PersistentIndexMetaPB index_meta;
+
+    Status status = TabletMetaManager::get_persistent_index_meta(
+            StorageEngine::instance()->get_persistent_index_store(), tablet->id(), &index_meta);
+    if (!status.ok() && !status.is_not_found()) {
+        return Status::InternalError("get tablet persistent index meta failed");
+    }
+
+    // There are three conditions
+    // First is we do not find PersistentIndexMetaPB in TabletMeta, it maybe the first time to
+    // enable persistent index
+    // Second is we find PersistentIndexMetaPB in TabletMeta, but it's version is behind applied_version
+    // in TabletMeta. It could be happened as below:
+    //    1. Enable persistent index and apply rowset, applied_version is 1-0
+    //    2. Restart be and disable persistent index, applied_version is update to 2-0
+    //    3. Restart be and enable persistent index
+    // In this case, we don't have all rowset data in persistent index files, so we also need to rebuild it
+    // The last is we find PersistentIndexMetaPB and it's version is equal to latest applied version. In this case,
+    // we can load from index file directly
+
+    if (status.ok()) {
+        // all applied rowsets has save in existing persistent index meta
+        // so we can load persistent index according to PersistentIndexMetaPB
+        EditVersion version = index_meta.version();
+
+        // Compaction of Lake tablet also generate a new version
+        // here just use version.major so that PersistentIndexMetaPB need't to be modified,
+        // the minor is meaningless
+        if (version.major() == base_version) {
+            // If format version is not equal to PERSISTENT_INDEX_VERSION_2, this maybe upgrade from
+            // PERSISTENT_INDEX_VERSION_2.
+            // We need to rebuild persistent index because the meta structure is changed
+            if (index_meta.format_version() != PERSISTENT_INDEX_VERSION_2) {
+                LOG(WARNING) << "different format version, we need to rebuild persistent index";
+                status = Status::InternalError("different format version");
+            } else {
+                status = load(index_meta);
+            }
+            if (status.ok()) {
+                LOG(INFO) << "load persistent index tablet:" << tablet->id() << " version:" << version.to_string()
+                          << " size: " << _size << " l0_size: " << (_l0 ? _l0->size() : 0)
+                          << " l0_capacity:" << (_l0 ? _l0->capacity() : 0)
+                          << " #shard: " << (_has_l1 ? _l1_vec[0]->_shards.size() : 0)
+                          << " l1_size:" << (_has_l1 ? _l1_vec[0]->_size : 0) << " memory: " << memory_usage()
+                          << " status: " << status.to_string() << " time:" << timer.elapsed_time() / 1000000 << "ms";
+                return status;
+            } else {
+                LOG(WARNING) << "load persistent index failed, tablet: " << tablet->id() << ", status: " << status;
+                if (index_meta.has_l0_meta()) {
+                    EditVersion l0_version = index_meta.l0_meta().snapshot().version();
+                    std::string l0_file_name =
+                            strings::Substitute("index.l0.$0.$1", l0_version.major(), l0_version.minor());
+                    Status st = FileSystem::Default()->delete_file(l0_file_name);
+                    LOG(WARNING) << "delete error l0 index file: " << l0_file_name << ", status: " << st;
+                }
+                if (index_meta.has_l1_version()) {
+                    EditVersion l1_version = index_meta.l1_version();
+                    std::string l1_file_name =
+                            strings::Substitute("index.l1.$0.$1", l1_version.major(), l1_version.minor());
+                    Status st = FileSystem::Default()->delete_file(l1_file_name);
+                    LOG(WARNING) << "delete error l1 index file: " << l1_file_name << ", status: " << st;
+                }
+            }
+        }
+    }
+
+    // 1. create and set key column schema
+    std::unique_ptr<TabletSchema> tablet_schema = std::make_unique<TabletSchema>(metadata.schema());
+    vector<ColumnId> pk_columns(tablet_schema->num_key_columns());
+    for (auto i = 0; i < tablet_schema->num_key_columns(); i++) {
+        pk_columns[i] = (ColumnId)i;
+    }
+    auto pkey_schema = ChunkHelper::convert_schema(*tablet_schema, pk_columns);
+
+    size_t fix_size = PrimaryKeyEncoder::get_encoded_fixed_size(pkey_schema);
+
+    // Init PersistentIndex
+    _key_size = fix_size;
+    _size = 0;
+    _version = EditVersion(base_version, 0);
+    auto st = ShardByLengthMutableIndex::create(_key_size, _path);
+    if (!st.ok()) {
+        LOG(WARNING) << "Build persistent index failed because initialization failed: " << st.status().to_string();
+        return st.status();
+    }
+    _l0 = std::move(st).value();
+    ASSIGN_OR_RETURN(_fs, FileSystem::CreateSharedFromString(_path));
+    // set _dump_snapshot to true
+    // In this case, only do flush or dump snapshot, set _dump_snapshot to avoid append wal
+    _dump_snapshot = true;
+
+    // clear l1
+    _l1_vec.clear();
+    _usage_and_size_by_key_length.clear();
+    _l1_merged_num.clear();
+    _has_l1 = false;
+    for (const auto& [key_size, shard_info] : _l0->_shard_info_by_key_size) {
+        auto [l0_shard_offset, l0_shard_size] = shard_info;
+        const auto l0_kv_pairs_size = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
+                                                      std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
+                                                      0LL, [](size_t s, const auto& e) { return s + e->size(); });
+        const auto l0_kv_pairs_usage = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
+                                                       std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
+                                                       0LL, [](size_t s, const auto& e) { return s + e->usage(); });
+        if (auto [_, inserted] =
+                    _usage_and_size_by_key_length.insert({key_size, {l0_kv_pairs_usage, l0_kv_pairs_size}});
+            !inserted) {
+            std::string msg = strings::Substitute(
+                    "load persistent index from tablet failed, insert usage and size by key size failed, key_size: "
+                    "$0",
+                    key_size);
+            LOG(WARNING) << msg;
+            return Status::InternalError(msg);
+        }
+    }
+
+    // Init PersistentIndexMetaPB
+    //   1. reset |version| |key_size|
+    //   2. delete WALs because maybe PersistentIndexMetaPB has expired wals
+    //   3. reset SnapshotMeta
+    //   4. write all data into new tmp _l0 index file (tmp file will be delete in _build_commit())
+    index_meta.clear_l0_meta();
+    index_meta.clear_l1_version();
+    index_meta.set_key_size(_key_size);
+    index_meta.set_format_version(PERSISTENT_INDEX_VERSION_2);
+    _version.to_pb(index_meta.mutable_version());
+    MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
+    l0_meta->clear_wals();
+    IndexSnapshotMetaPB* snapshot = l0_meta->mutable_snapshot();
+    _version.to_pb(snapshot->mutable_version());
+    PagePointerPB* data = snapshot->mutable_data();
+    data->set_offset(0);
+    data->set_size(0);
+
+    int64_t apply_version = 0;
+    std::vector<uint32_t> rowset_ids;
+
+    OlapReaderStatistics stats;
+    std::unique_ptr<Column> pk_column;
+    if (pk_columns.size() > 1) {
+        // more than one key column
+        if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
+            CHECK(false) << "create column for primary key encoder failed";
+        }
+    }
+    vector<uint32_t> rowids;
+    rowids.reserve(4096);
+    auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
+    auto chunk = chunk_shared_ptr.get();
+    // 2. scan all rowsets and segments to build primary index
+    auto rowsets = tablet->get_rowsets(metadata);
+    if (!rowsets.ok()) {
+        return rowsets.status();
+    }
+    // NOTICE: primary index will be builded by segment files in metadata, and delvecs.
+    // The delvecs we need are stored in delvec file by base_version and current MetaFileBuilder's cache.
+    for (auto& rowset : *rowsets) {
+        auto res = rowset->get_each_segment_iterator_with_delvec(pkey_schema, base_version, builder, &stats);
+        if (!res.ok()) {
+            return res.status();
+        }
+        auto& itrs = res.value();
+        CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
+        for (size_t i = 0; i < itrs.size(); i++) {
+            auto itr = itrs[i].get();
+            if (itr == nullptr) {
+                continue;
+            }
+            while (true) {
+                chunk->reset();
+                rowids.clear();
+                auto st = itr->get_next(chunk, &rowids);
+                if (st.is_end_of_file()) {
+                    break;
+                } else if (!st.ok()) {
+                    return st;
+                } else {
+                    Column* pkc = nullptr;
+                    if (pk_column) {
+                        pk_column->reset_column();
+                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get());
+                        pkc = pk_column.get();
+                    } else {
+                        pkc = chunk->columns()[0].get();
+                    }
+                    uint32_t rssid = rowset->id() + i;
+                    uint64_t base = ((uint64_t)rssid) << 32;
+                    std::vector<IndexValue> values;
+                    values.reserve(pkc->size());
+                    DCHECK(pkc->size() <= rowids.size());
+                    for (uint32_t i = 0; i < pkc->size(); i++) {
+                        values.emplace_back(base + rowids[i]);
+                    }
+                    Status st;
+                    if (pkc->is_binary()) {
+                        st = insert(pkc->size(), reinterpret_cast<const Slice*>(pkc->raw_data()), values.data(), false);
+                    } else {
+                        std::vector<Slice> keys;
+                        keys.reserve(pkc->size());
+                        const auto* fkeys = pkc->continuous_data();
+                        for (size_t i = 0; i < pkc->size(); ++i) {
+                            keys.emplace_back(fkeys, _key_size);
+                            fkeys += _key_size;
+                        }
+                        st = insert(pkc->size(), reinterpret_cast<const Slice*>(keys.data()), values.data(), false);
+                    }
+                    if (!st.ok()) {
+                        LOG(ERROR) << "load index failed\n";
+                        return st;
+                    }
+                }
+            }
+            itr->close();
+        }
+    }
+
+    //RETURN_IF_ERROR(_build_commit(tablet, index_meta));
+    //-------------- build commit
+    // commit: flush _l0 and build _l1
+    // write PersistentIndexMetaPB in RocksDB
+    status = commit(&index_meta);
+    if (!status.ok()) {
+        LOG(WARNING) << "build persistent index failed because commit failed: " << status.to_string();
+        return status;
+    }
+    // write pesistent index meta
+    // data_dir -> rocksdb
+    status = TabletMetaManager::write_persistent_index_meta(StorageEngine::instance()->get_persistent_index_store(),
+                                                            tablet->id(), index_meta);
+    if (!status.ok()) {
+        LOG(WARNING) << "build persistent index failed because write persistent index meta failed: "
+                     << status.to_string();
+        return status;
+    }
+
+    RETURN_IF_ERROR(_delete_expired_index_file(_version, _l1_version));
+    _dump_snapshot = false;
+    _flushed = false;
+
+    //---------------------------
+
+    LOG(INFO) << "build persistent index finish tablet: " << tablet->id() << " version:" << apply_version;
+    return Status::OK();
+}
+
+} // namespace lake
+
+} // namespace starrocks

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_metadata.h"
+#include "storage/persistent_index.h"
+#include "storage/storage_engine.h"
+
+namespace starrocks {
+
+namespace lake {
+
+class MetaFileBuilder;
+
+class LakePersistentIndex : public PersistentIndex {
+public:
+    LakePersistentIndex(std::string path) : PersistentIndex(path) { _path = path; }
+
+    ~LakePersistentIndex() {}
+
+    DataDir* getTabletDataDir(int64_t tablet_id) {
+        StorageEngine* storage_engine = StorageEngine::instance();
+        DCHECK(storage_engine != nullptr);
+        std::vector<DataDir*> dirs = storage_engine->get_stores();
+        _meta_dir = dirs[tablet_id % dirs.size()];
+    }
+
+    Status load_from_lake_tablet(starrocks::lake::Tablet* tablet, const TabletMetadata& metadata, int64_t base_version,
+                                 const MetaFileBuilder* builder);
+
+private:
+    DataDir* _meta_dir = nullptr;
+    std::string _path;
+};
+
+} // namespace lake
+} // namespace starrocks

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -17,7 +17,7 @@
 #include <bvar/bvar.h>
 
 #include "storage/chunk_helper.h"
-#include "storage/lake/lake_persistent_index.h"
+#include "storage/lake/lake_local_persistent_index.h"
 #include "storage/lake/tablet.h"
 #include "storage/primary_key_encoder.h"
 #include "util/trace.h"
@@ -65,13 +65,36 @@ Status LakePrimaryIndex::_do_lake_load(Tablet* tablet, const TabletMetadata& met
     if (tablet->get_enable_persistent_index(base_version) && (fix_size <= 128)) {
         DCHECK(_persistent_index == nullptr);
 
-        std::string path = strings::Substitute(
-                "$0/$1/", StorageEngine::instance()->get_persistent_index_store()->get_persistent_index_path(),
-                tablet->id());
-        StorageEngine::instance()->get_persistent_index_store()->create_dir_if_path_not_exists(path);
-        _persistent_index = std::make_unique<LakePersistentIndex>(path);
-        return ((LakePersistentIndex*)_persistent_index.get())
-                ->load_from_lake_tablet(tablet, metadata, base_version, builder);
+        // Even if `enable_persistent_index` is enabled,
+        // it may not take effect because `storage_root_path` is not set
+        if (StorageEngine::instance()->is_lake_persistent_index_dir_inited()) {
+            auto persistent_index_type = tablet->get_persistent_index_type(base_version);
+            if (persistent_index_type.ok()) {
+                switch (persistent_index_type.value()) {
+                case PersistentIndexTypePB::LOCAL: {
+                    std::string path = strings::Substitute(
+                            "$0/$1/",
+                            StorageEngine::instance()->get_persistent_index_store()->get_persistent_index_path(),
+                            tablet->id());
+
+                    RETURN_IF_ERROR(
+                            StorageEngine::instance()->get_persistent_index_store()->create_dir_if_path_not_exists(
+                                    path));
+                    _persistent_index = std::make_unique<LakeLocalPersistentIndex>(path);
+                    return ((LakeLocalPersistentIndex*)_persistent_index.get())
+                            ->load_from_lake_tablet(tablet, metadata, base_version, builder);
+                }
+                default:
+                    LOG(WARNING) << "only support LOCAL lake_persistend_index_type for now";
+                    return Status::InternalError("only support LOCAL lake_persistend_index_type for now");
+                }
+            }
+
+        } else {
+            LOG(WARNING) << "lake tablet persistent_index will not take effect, for storage_root_path is not set";
+            return Status::InternalError(
+                    "lake tablet persistent_index will not take effect, for storage_root_path is not set");
+        }
     }
 
     OlapReaderStatistics stats;

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -72,15 +72,9 @@ public:
 
     [[nodiscard]] Status delete_metadata(int64_t version);
 
-    bool get_enable_persistent_index(int64_t version) {
-        auto tablet_metadata = _mgr->get_tablet_metadata(_id, version);
-        if (!tablet_metadata.ok()) {
-            LOG(WARNING) << "Fail to get tablet metadata. tablet_id: " << _id << ", version: " << version
-                         << ", error: " << tablet_metadata.status();
-            return false;
-        }
-        return (*tablet_metadata)->enable_persistent_index();
-    }
+    bool get_enable_persistent_index(int64_t version);
+
+    StatusOr<PersistentIndexTypePB> get_persistent_index_type(int64_t version);
 
     [[nodiscard]] Status put_txn_log(const TxnLog& log);
 

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -72,6 +72,16 @@ public:
 
     [[nodiscard]] Status delete_metadata(int64_t version);
 
+    bool get_enable_persistent_index(int64_t version) {
+        auto tablet_metadata = _mgr->get_tablet_metadata(_id, version);
+        if (!tablet_metadata.ok()) {
+            LOG(WARNING) << "Fail to get tablet metadata. tablet_id: " << _id << ", version: " << version
+                         << ", error: " << tablet_metadata.status();
+            return false;
+        }
+        return (*tablet_metadata)->enable_persistent_index();
+    }
+
     [[nodiscard]] Status put_txn_log(const TxnLog& log);
 
     [[nodiscard]] Status put_txn_log(TxnLogPtr log);

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -309,6 +309,10 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
     tablet_metadata_pb->set_next_rowset_id(1);
     tablet_metadata_pb->set_cumulative_point(0);
 
+    if (req.__isset.enable_persistent_index) {
+        tablet_metadata_pb->set_enable_persistent_index(true);
+    }
+
     if (req.__isset.base_tablet_id && req.base_tablet_id > 0) {
         struct Finder {
             std::string_view name;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -311,6 +311,7 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
 
     if (req.__isset.enable_persistent_index) {
         tablet_metadata_pb->set_enable_persistent_index(true);
+        tablet_metadata_pb->set_persistent_index_type(PersistentIndexType::LOCAL);
     }
 
     if (req.__isset.base_tablet_id && req.base_tablet_id > 0) {

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -310,8 +310,17 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
     tablet_metadata_pb->set_cumulative_point(0);
 
     if (req.__isset.enable_persistent_index) {
-        tablet_metadata_pb->set_enable_persistent_index(true);
-        tablet_metadata_pb->set_persistent_index_type(PersistentIndexType::LOCAL);
+        tablet_metadata_pb->set_enable_persistent_index(req.enable_persistent_index);
+        if (req.__isset.persistent_index_type) {
+            switch (req.persistent_index_type) {
+            case TPersistentIndexType::LOCAL:
+                tablet_metadata_pb->set_persistent_index_type(PersistentIndexTypePB::LOCAL);
+                break;
+            default:
+                return Status::InternalError(
+                        strings::Substitute("Unknown persistent index type, tabletId:$0", req.tablet_id));
+            }
+        }
     }
 
     if (req.__isset.base_tablet_id && req.base_tablet_id > 0) {

--- a/be/src/storage/olap_define.h
+++ b/be/src/storage/olap_define.h
@@ -73,6 +73,7 @@ static const std::string ERROR_LOG_PREFIX = "/error_log";             // NOLINT
 static const std::string REJECTED_RECORD_PREFIX = "/rejected_record"; // NOLINT
 static const std::string CLONE_PREFIX = "/clone";                     // NOLINT
 static const std::string TMP_PREFIX = "/tmp";                         // NOLINT
+static const std::string PERSISTENT_INDEX_PREFIX = "/persistent";     // NOLINT
 
 static const int32_t OLAP_DATA_VERSION_APPLIED = STARROCKS_V1;
 

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -34,7 +34,7 @@ class Schema;
 class Column;
 
 namespace lake {
-class LakePersistentIndex;
+class LakeLocalPersistentIndex;
 }
 
 // Add version for persistent index file to support future upgrade compatibility
@@ -336,7 +336,7 @@ public:
 
 private:
     friend class PersistentIndex;
-    friend class starrocks::lake::LakePersistentIndex;
+    friend class starrocks::lake::LakeLocalPersistentIndex;
 
     template <int N>
     void _init_loop_helper();
@@ -422,7 +422,7 @@ public:
 
 private:
     friend class PersistentIndex;
-    friend class starrocks::lake::LakePersistentIndex;
+    friend class starrocks::lake::LakeLocalPersistentIndex;
     friend class ImmutableIndexWriter;
 
     Status _get_fixlen_kvs_for_shard(std::vector<std::vector<KVRef>>& kvs_by_shard, size_t shard_idx,
@@ -525,7 +525,7 @@ class PersistentIndex {
 public:
     // |path|: directory that contains index files
     PersistentIndex(std::string path);
-    ~PersistentIndex();
+    virtual ~PersistentIndex();
 
     bool loaded() const { return (bool)_l0; }
 
@@ -632,8 +632,8 @@ public:
 
     bool is_error() { return _error; }
 
-    void set_dump_snapshot(bool dump_snapshot) { _dump_snapshot = dump_snapshot; }
-    void set_flushed(bool flushed) { _flushed = flushed; }
+    //    void set_dump_snapshot(bool dump_snapshot) { _dump_snapshot = dump_snapshot; }
+    //    void set_flushed(bool flushed) { _flushed = flushed; }
 
 private:
     size_t _dump_bound();
@@ -677,14 +677,14 @@ private:
 
     Status _update_usage_and_size_by_key_length(std::vector<std::pair<int64_t, int64_t>>& add_usage_and_size);
 
-    // prevent concurrent operations
-    // Currently there are only concurrent read/write conflicts for _l1_vec between apply_thread and commit_thread
-    mutable std::shared_mutex _lock;
-
 protected:
     Status _delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version);
 
 protected:
+    // prevent concurrent operations
+    // Currently there are only concurrent read/write conflicts for _l1_vec between apply_thread and commit_thread
+    mutable std::shared_mutex _lock;
+
     // index storage directory
     std::string _path;
     size_t _key_size = 0;

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -166,6 +166,7 @@ protected:
     std::atomic<bool> _loaded{false};
     Status _status;
     int64_t _tablet_id = 0;
+    std::unique_ptr<PersistentIndex> _persistent_index;
 
 private:
     size_t _key_size = 0;
@@ -173,7 +174,6 @@ private:
     Schema _pk_schema;
     LogicalType _enc_pk_type = TYPE_UNKNOWN;
     std::unique_ptr<HashIndex> _pkey_to_rssid_rowid;
-    std::unique_ptr<PersistentIndex> _persistent_index;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const PrimaryIndex& o) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -276,8 +276,7 @@ Status StorageEngine::_init_store_map() {
         if (!_lake_persistent_index_dir_inited) {
             auto status = store.second->init_persistent_index_dir();
             if (!status.ok()) {
-                return Status::InternalError(
-                        strings::Substitute("init persistIndex dir          failed, error=$0", error_msg));
+                return Status::InternalError(strings::Substitute("init persistIndex dir failed, error=$0", error_msg));
             }
             _lake_persistent_index_dir_inited = true;
             _persistent_index_data_dir = store.second;

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -273,8 +273,12 @@ Status StorageEngine::_init_store_map() {
     for (auto& store : tmp_stores) {
         _store_map.emplace(store.second->path(), store.second);
         store.first = false;
-        if (_lake_persistent_index_dir_inited == false) {
-            store.second->init_persistent_index_dir();
+        if (!_lake_persistent_index_dir_inited) {
+            auto status = store.second->init_persistent_index_dir();
+            if (!status.ok()) {
+                return Status::InternalError(
+                        strings::Substitute("init persistIndex dir          failed, error=$0", error_msg));
+            }
             _lake_persistent_index_dir_inited = true;
             _persistent_index_data_dir = store.second;
         }
@@ -525,6 +529,15 @@ DataDir* StorageEngine::get_store(int64_t path_hash) {
         }
     }
     return nullptr;
+}
+
+bool StorageEngine::is_lake_persistent_index_dir_inited() {
+    return _lake_persistent_index_dir_inited;
+}
+
+// maybe nullptr if storage_root_path is not set
+DataDir* StorageEngine::get_persistent_index_store() {
+    return _persistent_index_data_dir;
 }
 
 static bool too_many_disks_are_failed(uint32_t unused_num, uint32_t total_num) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -273,7 +273,13 @@ Status StorageEngine::_init_store_map() {
     for (auto& store : tmp_stores) {
         _store_map.emplace(store.second->path(), store.second);
         store.first = false;
+        if (_lake_persistent_index_dir_inited == false) {
+            store.second->init_persistent_index_dir();
+            _lake_persistent_index_dir_inited = true;
+            _persistent_index_data_dir = store.second;
+        }
     }
+
     release_guard.cancel();
     return Status::OK();
 }

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -155,10 +155,8 @@ public:
     DataDir* get_store(const std::string& path);
     DataDir* get_store(int64_t path_hash);
 
-    DataDir* get_persistent_index_store() {
-        DCHECK(_persistent_index_data_dir != nullptr);
-        return _persistent_index_data_dir;
-    }
+    bool is_lake_persistent_index_dir_inited();
+    DataDir* get_persistent_index_store();
 
     uint32_t available_storage_medium_type_count() { return _available_storage_medium_type_count; }
 

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -155,6 +155,11 @@ public:
     DataDir* get_store(const std::string& path);
     DataDir* get_store(int64_t path_hash);
 
+    DataDir* get_persistent_index_store() {
+        DCHECK(_persistent_index_data_dir != nullptr);
+        return _persistent_index_data_dir;
+    }
+
     uint32_t available_storage_medium_type_count() { return _available_storage_medium_type_count; }
 
     virtual Status set_cluster_id(int32_t cluster_id);
@@ -358,7 +363,10 @@ private:
     EngineOptions _options;
     std::mutex _store_lock;
     std::map<std::string, DataDir*> _store_map;
+    DataDir* _persistent_index_data_dir = nullptr;
     uint32_t _available_storage_medium_type_count;
+
+    std::atomic<bool> _lake_persistent_index_dir_inited{false};
 
     bool _is_all_cluster_id_exist;
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -95,6 +95,7 @@ import com.starrocks.task.DropAutoIncrementMapTask;
 import com.starrocks.task.DropReplicaTask;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TOlapTable;
+import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTableDescriptor;
@@ -2074,6 +2075,20 @@ public class OlapTable extends Table {
         return false;
     }
 
+    public String getPersistentIndexTypeString() {
+        if (tableProperty != null) {
+            return tableProperty.getPersistentIndexTypeString();
+        }
+        return "";
+    }
+
+    public TPersistentIndexType getPersistentIndexType() {
+        if (tableProperty != null) {
+            return tableProperty.getPersistentIndexType();
+        }
+        return null;
+    }
+
     // Determine which situation supports importing and automatically creating
     // partitions
     public Boolean supportedAutomaticPartition() {
@@ -2102,6 +2117,25 @@ public class OlapTable extends Table {
                 .modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,
                         Boolean.valueOf(enablePersistentIndex).toString());
         tableProperty.buildEnablePersistentIndex();
+    }
+
+    public void setPersistentIndexType(TPersistentIndexType persistentIndexType) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+
+        // only support LOCAL for now
+        if (persistentIndexType == TPersistentIndexType.LOCAL) {
+            tableProperty
+                    .modifyTableProperties(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE,
+                            TableProperty.persistentIndexTypeToString(persistentIndexType));
+        } else {
+            // do nothing
+            LOG.warn("Unknown TPersistentIndexType, only supports LOCAL at now");
+            return;
+        }
+
+        tableProperty.buildPersistentIndexType();
     }
 
     public Boolean enableReplicatedStorage() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -56,6 +56,7 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.thrift.TCompressionType;
+import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TWriteQuorumType;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.logging.log4j.LogManager;
@@ -143,6 +144,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
     private boolean isInMemory = false;
 
     private boolean enablePersistentIndex = false;
+
+    // Only meaningful when enablePersistentIndex = true.
+    // and it's null in SHARED NOTHGING
+    TPersistentIndexType persistendIndexType;
 
     /*
      * the default storage volume of this table.
@@ -443,6 +448,27 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildPersistentIndexType() {
+        String type = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, "LOCAL");
+        if (type.equals("LOCAL")) {
+            persistendIndexType = TPersistentIndexType.LOCAL;
+        }
+        return this;
+    }
+
+    public static String persistentIndexTypeToString(TPersistentIndexType type) {
+        switch (type) {
+            case LOCAL:
+                return "LOCAL";
+            default:
+                // shouldn't happen
+                // for it has been checked outside
+                LOG.warn("unknown PersistentIndexType");
+                return "UNKNOWN";
+        }
+    }
+
+
     public TableProperty buildConstraint() {
         try {
             uniqueConstraints = UniqueConstraint.parse(
@@ -548,6 +574,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return enablePersistentIndex;
     }
 
+    public String getPersistentIndexTypeString() {
+        return persistentIndexTypeToString(persistendIndexType);
+    }
+
+    public TPersistentIndexType getPersistentIndexType() {
+        return persistendIndexType;
+    }
+
     public TWriteQuorumType writeQuorum() {
         return writeQuorum;
     }
@@ -642,6 +676,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildInMemory();
         buildStorageVolume();
         buildEnablePersistentIndex();
+        buildPersistentIndexType();
         buildCompressionType();
         buildWriteQuorum();
         buildPartitionTTL();

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
@@ -46,7 +46,7 @@ public class ComputeNodeProcDir implements ProcDirInterface {
                 .add("BePort").add("HttpPort").add("BrpcPort").add("LastStartTime").add("LastHeartbeat").add("Alive")
                 .add("SystemDecommissioned").add("ClusterDecommissioned").add("ErrMsg")
                 .add("Version")
-                .add("CpuCores").add("NumRunningQueries").add("MemUsedPct").add("CpuUsedPct");
+                .add("CpuCores").add("NumRunningQueries").add("MemUsedPct").add("CpuUsedPct").add("HasStoragePath");
         if (RunMode.allowCreateLakeTable()) {
             builder.add("StarletPort").add("WorkerId");
         }
@@ -137,6 +137,8 @@ public class ComputeNodeProcDir implements ProcDirInterface {
                 long workerId = GlobalStateMgr.getCurrentStarOSAgent().getWorkerIdByBackendId(computeNodeId);
                 computeNodeInfo.add(String.valueOf(workerId));
             }
+
+            computeNodeInfo.add(String.valueOf(computeNode.isSetStoragePath()));
 
             comparableComputeNodeInfos.add(computeNodeInfo);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -118,6 +118,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_ENABLE_PERSISTENT_INDEX = "enable_persistent_index";
 
+    public static final String PROPERTIES_PERSISTENT_INDEX_TYPE = "persistent_index_type";
+
     public static final String PROPERTIES_BINLOG_VERSION = "binlog_version";
 
     public static final String PROPERTIES_BINLOG_ENABLE = "binlog_enable";

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2645,7 +2645,14 @@ public class GlobalStateMgr {
                 sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR)
                         .append(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)
                         .append("\" = \"");
-                sb.append(storageProperties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)).append("\"");
+                sb.append(olapTable.enablePersistentIndex()).append("\"");
+
+                if (olapTable.enablePersistentIndex() && !Strings.isNullOrEmpty(olapTable.getPersistentIndexTypeString())) {
+                    sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR)
+                            .append(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)
+                            .append("\" = \"");
+                    sb.append(olapTable.getPersistentIndexTypeString()).append("\"");
+                }
             } else {
                 // in memory
                 sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_INMEMORY)

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2641,6 +2641,11 @@ public class GlobalStateMgr {
                         .append(PropertyAnalyzer.PROPERTIES_ENABLE_ASYNC_WRITE_BACK)
                         .append("\" = \"");
                 sb.append(storageProperties.get(PropertyAnalyzer.PROPERTIES_ENABLE_ASYNC_WRITE_BACK)).append("\"");
+
+                sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR)
+                        .append(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)
+                        .append("\" = \"");
+                sb.append(storageProperties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)).append("\"");
             } else {
                 // in memory
                 sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_INMEMORY)

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1797,6 +1797,7 @@ public class LocalMetastore implements ConnectorMetadata {
                         table.getIndexes(),
                         table.getPartitionInfo().getIsInMemory(partition.getId()),
                         table.enablePersistentIndex(),
+                        table.getPersistentIndexType(),
                         TTabletType.TABLET_TYPE_LAKE,
                         table.getCompressionType(), indexMeta.getSortKeyIdxes());
                 tasks.add(task);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -262,12 +262,9 @@ public class OlapTableFactory implements AbstractTableFactory {
                     PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_INMEMORY, false);
             table.setIsInMemory(isInMemory);
 
-            boolean enablePersistentIndex =
-                    PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,
-                            false);
-            if (enablePersistentIndex && table.isCloudNativeTable()) {
-                throw new DdlException("Cannot create cloud native table with persistent index yet");
-            }
+        boolean enablePersistentIndex =
+                PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,
+                        false);
 
             table.setEnablePersistentIndex(enablePersistentIndex);
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -56,6 +56,7 @@ import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.thrift.TCompressionType;
+import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletType;
 import org.apache.commons.lang3.StringUtils;
@@ -262,10 +263,23 @@ public class OlapTableFactory implements AbstractTableFactory {
                     PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_INMEMORY, false);
             table.setIsInMemory(isInMemory);
 
-        boolean enablePersistentIndex =
-                PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,
-                        false);
+            boolean enablePersistentIndex =
+                    PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,
+                            false);
+            if (enablePersistentIndex && table.isCloudNativeTable()) {
+                // Judge there are whether compute nodes without storagePath or not.
+                // Cannot create cloud native table with persistent_index = true when ComputeNode without storagePath
+                Set<Long> cnUnSetStoragePath = GlobalStateMgr.getCurrentSystemInfo().getAvailableComputeNodeIds().
+                        stream().filter(id -> !GlobalStateMgr.getCurrentSystemInfo().getComputeNode(id).
+                                isSetStoragePath()).collect(Collectors.toSet());
+                if (cnUnSetStoragePath.size() != 0) {
+                    throw new DdlException("Cannot create cloud native table with persistent_index = true " +
+                            "when ComputeNode without storage_path, nodeId:" + cnUnSetStoragePath);
+                } else {
+                    table.setPersistentIndexType(TPersistentIndexType.LOCAL);
+                }
 
+            }
             table.setEnablePersistentIndex(enablePersistentIndex);
 
             if (properties != null && (properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_ENABLE) ||

--- a/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
@@ -286,6 +286,11 @@ public class Backend extends ComputeNode {
         return backendStatus;
     }
 
+    @Override
+    public boolean isSetStoragePath() {
+        return true;
+    }
+
     public static Backend read(DataInput in) throws IOException {
         Backend backend = new Backend();
         backend.readFields(in);

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
@@ -62,10 +62,17 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     @SerializedName(value = "cpuCores")
     private int cpuCores;
     @SerializedName(value = "rebootTime")
-    private long rebootTime = -1L;   
+    private long rebootTime = -1L;
+    private boolean isSetStoragePath = false;
 
     public BackendHbResponse() {
         super(HeartbeatResponse.Type.BACKEND);
+    }
+
+    public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort,
+                             int starletPort, long hbTime, String version, int cpuCores, boolean isSetStoragePath) {
+        this(beId, bePort, httpPort, brpcPort, starletPort, hbTime, version, cpuCores);
+        this.isSetStoragePath = isSetStoragePath;
     }
 
     public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort,
@@ -123,6 +130,10 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
 
     public int getCpuCores() {
         return cpuCores;
+    }
+
+    public boolean isSetStoragePath() {
+        return isSetStoragePath;
     }
 
     public static BackendHbResponse read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -92,6 +92,11 @@ public class ComputeNode implements IComputable, Writable {
     @SerializedName("lastWriteFail")
     private volatile boolean lastWriteFail = false;
 
+    // Indicate there is whether storage_path or not with CN node
+    // It must be true for Backend
+    @SerializedName("isSetStoragePath")
+    private volatile boolean isSetStoragePath = false;
+
     private volatile int numRunningQueries = 0;
     private volatile long memLimitBytes = 0;
     private volatile long memUsedBytes = 0;
@@ -148,6 +153,10 @@ public class ComputeNode implements IComputable, Writable {
     // for test only
     public void setStarletPort(int starletPort) {
         this.starletPort = starletPort;
+    }
+
+    public boolean isSetStoragePath() {
+        return isSetStoragePath;
     }
 
     public long getId() {
@@ -465,6 +474,11 @@ public class ComputeNode implements IComputable, Writable {
             if (RunMode.allowCreateLakeTable() && this.starletPort != hbResponse.getStarletPort()) {
                 isChanged = true;
                 this.starletPort = hbResponse.getStarletPort();
+            }
+
+            if (RunMode.allowCreateLakeTable() && this.isSetStoragePath != hbResponse.isSetStoragePath()) {
+                isChanged = true;
+                this.isSetStoragePath = hbResponse.isSetStoragePath();
             }
 
             this.lastUpdateMs = hbResponse.getHbTime();

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -293,11 +293,15 @@ public class HeartbeatMgr extends FrontendDaemon {
                     int httpPort = tBackendInfo.getHttp_port();
                     int brpcPort = -1;
                     int starletPort = 0;
+                    boolean isSetStoragePath = false;
                     if (tBackendInfo.isSetBrpc_port()) {
                         brpcPort = tBackendInfo.getBrpc_port();
                     }
                     if (tBackendInfo.isSetStarlet_port()) {
                         starletPort = tBackendInfo.getStarlet_port();
+                    }
+                    if (tBackendInfo.isSetIs_set_storage_path()) {
+                        isSetStoragePath = tBackendInfo.isIs_set_storage_path();
                     }
                     String version = "";
                     if (tBackendInfo.isSetVersion()) {
@@ -313,7 +317,7 @@ public class HeartbeatMgr extends FrontendDaemon {
                     // backend.updateOnce(bePort, httpPort, beRpcPort, brpcPort);
                     BackendHbResponse backendHbResponse = new BackendHbResponse(
                             computeNodeId, bePort, httpPort, brpcPort, starletPort,
-                            System.currentTimeMillis(), version, cpuCores);
+                            System.currentTimeMillis(), version, cpuCores, isSetStoragePath);
                     if (tBackendInfo.isSetReboot_time()) {
                         backendHbResponse.setRebootTime(tBackendInfo.getReboot_time());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -46,6 +46,7 @@ import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TCreateTabletReq;
 import com.starrocks.thrift.TOlapTableIndex;
+import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
@@ -86,6 +87,8 @@ public class CreateReplicaTask extends AgentTask {
     private boolean isInMemory;
 
     private boolean enablePersistentIndex;
+
+    private TPersistentIndexType persistentIndexType;
 
     private BinlogConfig binlogConfig;
 
@@ -168,6 +171,22 @@ public class CreateReplicaTask extends AgentTask {
         this.tabletType = tabletType;
 
         this.compressionType = compressionType;
+    }
+
+    public CreateReplicaTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
+                             short shortKeyColumnCount, int schemaHash, long version,
+                             KeysType keysType, TStorageType storageType,
+                             TStorageMedium storageMedium, List<Column> columns,
+                             Set<String> bfColumns, double bfFpp, MarkedCountDownLatch<Long, Long> latch,
+                             List<Index> indexes,
+                             boolean isInMemory,
+                             boolean enablePersistentIndex,
+                             TPersistentIndexType persistentIndexType,
+                             TTabletType tabletType, TCompressionType compressionType, List<Integer> sortKeyIdxes) {
+        this(backendId, dbId, tableId, partitionId, indexId, tabletId, shortKeyColumnCount, schemaHash, version,
+                keysType, storageType, storageMedium, columns, bfColumns, bfFpp, latch, indexes, isInMemory,
+                enablePersistentIndex, tabletType, compressionType, sortKeyIdxes);
+        this.persistentIndexType = persistentIndexType;
     }
 
     public void setIsRecoverTask(boolean isRecoverTask) {
@@ -257,6 +276,10 @@ public class CreateReplicaTask extends AgentTask {
 
         createTabletReq.setStorage_medium(storageMedium);
         createTabletReq.setEnable_persistent_index(enablePersistentIndex);
+
+        if (persistentIndexType != null) {
+            createTabletReq.setPersistent_index_type(persistentIndexType);
+        }
 
         if (binlogConfig != null) {
             TBinlogConfig tBinlogConfig = binlogConfig.toTBinlogConfig();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -33,12 +33,15 @@ import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.SharedDataStorageVolumeMgr;
 import com.starrocks.server.SharedNothingStorageVolumeMgr;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.storagevolume.StorageVolume;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -285,6 +288,50 @@ public class CreateLakeTableTest {
         ExceptionChecker.expectThrows(AnalysisException.class, () -> createTable(
                 "create table lake_test.auto_partition (key1 date, key2 varchar(10), key3 int)\n" +
                         "partition by day(key1) distributed by hash(key2) buckets 3;"));
+    }
+
+    @Test
+    public void testCreateLakeTableEnablePersistentIndex(@Mocked StarOSAgent agent) throws Exception {
+        new Expectations() {
+            {
+                agent.allocateFilePath(anyString, anyLong);
+                result = getPathInfo();
+                agent.createShardGroup(anyLong, anyLong, anyLong);
+                result = GlobalStateMgr.getCurrentState().getNextId();
+                agent.createShards(anyInt, (FilePathInfo) any, (FileCacheInfo) any, anyLong, (Map<String, String>) any);
+                returns(Lists.newArrayList(20001L, 20002L, 20003L),
+                        Lists.newArrayList(20004L, 20005L), Lists.newArrayList(20006L, 20007L),
+                        Lists.newArrayList(20008L), Lists.newArrayList(20009L));
+                agent.getPrimaryComputeNodeIdByShard(anyLong, anyLong);
+                result = GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true).get(0);
+            }
+        };
+
+        Deencapsulation.setField(GlobalStateMgr.getCurrentState(), "starOSAgent", agent);
+
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "create table lake_test.table_with_persistent_index\n" +
+                        "(c0 int, c1 string, c2 int, c3 bigint)\n" +
+                        "PRIMARY KEY(c0)\n" +
+                        "distributed by hash(c0) buckets 2\n" +
+                        "properties('enable_persistent_index' = 'true');"));
+        {
+            LakeTable lakeTable = getLakeTable("lake_test", "table_with_persistent_index");
+            // check table persistentIndex
+            boolean enablePersistentIndex = lakeTable.enablePersistentIndex();
+            Assert.assertTrue(enablePersistentIndex);
+            // check table persistentIndexType
+            String indexType = lakeTable.getPersistentIndexTypeString();
+            Assert.assertEquals(indexType, "LOCAL");
+
+            String sql = "show create table lake_test.table_with_persistent_index";
+            ShowCreateTableStmt showCreateTableStmt =
+                    (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            ShowExecutor executor = new ShowExecutor(connectContext, showCreateTableStmt);
+            ShowResultSet resultSet = executor.execute();
+
+            Assert.assertTrue(resultSet.getResultRows().size() != 0);
+        }
     }
 
     @Test

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -74,6 +74,7 @@ message TabletMetadataPB {
     // not empty.
     optional int64 prev_garbage_version = 9;
     repeated FileMetaPB orphan_files = 10;
+    optional bool enable_persistent_index = 11;
 }
 
 message TxnLogPB {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -59,7 +59,7 @@ message RowsetMetadataPB {
 
 // At present, the lake persistent index reuses the logic of the persistent index,
 // and writes the index to the local disk, which may be upgraded and written to the remote end in the future,
-// the type is is to make it upgradable for compatibility；
+// the type is is to make it upgradable for compatibility.
 enum PersistentIndexTypePB {
     LOCAL = 0;
 }

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -56,6 +56,14 @@ message RowsetMetadataPB {
     optional DeletePredicatePB delete_predicate = 6;
 }
 
+
+// At present, the lake persistent index reuses the logic of the persistent index,
+// and writes the index to the local disk, which may be upgraded and written to the remote end in the future,
+// the type is is to make it upgradable for compatibility；
+enum PersistentIndexTypePB {
+    LOCAL = 0;
+}
+
 message TabletMetadataPB {
     optional int64 id = 1;
     optional int64 version = 2;
@@ -75,6 +83,7 @@ message TabletMetadataPB {
     optional int64 prev_garbage_version = 9;
     repeated FileMetaPB orphan_files = 10;
     optional bool enable_persistent_index = 11;
+    optional PersistentIndexTypePB persistent_index_type = 12;
 }
 
 message TxnLogPB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -80,6 +80,12 @@ struct TBinlogConfig {
     4: optional i64 binlog_max_size;
 }
 
+// If you want to add types,
+// don't forget to also add type to PersistentIndexTypePB
+enum TPersistentIndexType {
+    LOCAL = 0
+}
+
 struct TCreateTabletReq {
     1: required Types.TTabletId tablet_id
     2: required TTabletSchema tablet_schema
@@ -102,6 +108,7 @@ struct TCreateTabletReq {
     15: optional bool enable_persistent_index
     16: optional Types.TCompressionType compression_type = Types.TCompressionType.LZ4_FRAME
     17: optional TBinlogConfig binlog_config;
+    18: optional TPersistentIndexType persistent_index_type;
 }
 
 struct TDropTabletReq {

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -42,6 +42,7 @@ struct TBackendInfo {
     6: optional i32 num_hardware_cores
     7: optional Types.TPort starlet_port
     8: optional i64 reboot_time
+    9: optional bool is_set_storage_path
 }
 
 struct THeartbeatResult {


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

In the scenario of separation of storage-compute , the primary index can only exist in memory. This PR enables the persistent index, which stores the index file locally and stores the metadata in the rocksdb initialized from the first `data_dir`.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
