### PR TITLE
[BugFix] Fix NLJoin probe crash when probe chunk is null

### DIFF
--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
@@ -185,6 +185,11 @@ StatusOr<ChunkPtr> SpillableNLJoinProbeOperator::pull_chunk(RuntimeState* state)
 
         _prober.reset_probe();
     }
+    // if probe finished after reset probe side. it means probe side is empty
+    if (_prober.probe_finished()) {
+        _set_current_build_probe_finished(true);
+        return nullptr;
+    }
 
     ASSIGN_OR_RETURN(auto res, _prober.probe_chunk(state, _build_chunk));
     RETURN_IF_ERROR(eval_conjuncts(_prober.conjunct_ctxs(), res.get(), nullptr));

--- a/test/sql/test_spill/R/test_spill_nl_join
+++ b/test/sql/test_spill/R/test_spill_nl_join
@@ -23,11 +23,11 @@ create table t0 (
 insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  2048));
 -- result:
 -- !result
-select count(*) from t0 l, t0 r;
+select count(*) from t0 l join [broadcast] t0 r;
 -- result:
 4194304
 -- !result
-select l.*, r.* from t0 l, t0 r where l.c0 + r.c0 < 10 order by l.c0, l.c1, r.c0, r.c1;
+select l.*, r.* from t0 l join [broadcast] t0 r where l.c0 + r.c0 < 10 order by l.c0, l.c1, r.c0, r.c1;
 -- result:
 1	4095	1	4095
 1	4095	2	4094
@@ -66,7 +66,7 @@ select l.*, r.* from t0 l, t0 r where l.c0 + r.c0 < 10 order by l.c0, l.c1, r.c0
 7	4089	2	4094
 8	4088	1	4095
 -- !result
-select count(*) from t0 l, t0 r where r.c0 = 1;
+select count(*) from t0 l join [broadcast] t0 r where r.c0 = 1;
 -- result:
 2048
 -- !result
@@ -81,4 +81,60 @@ select count(*) from t0 l join [broadcast] t0 r where l.c0 < 0;
 select count(d.c0) from t0 d join [broadcast] (select l.c0 from t0 l join t0 r) t;
 -- result:
 8589934592
+-- !result
+create table empty_t like t0;
+-- result:
+-- !result
+select count(*) from t0 l join [broadcast] empty_t r;
+-- result:
+0
+-- !result
+select l.*, r.* from t0 l join [broadcast] empty_t r where l.c0 + r.c0 < 10 order by l.c0, l.c1, r.c0, r.c1;
+-- result:
+-- !result
+select count(*) from t0 l join [broadcast] empty_t r where r.c0 = 1;
+-- result:
+0
+-- !result
+select count(*) from t0 l join [broadcast] empty_t r where r.c0 < 0;
+-- result:
+0
+-- !result
+select count(*) from t0 l join [broadcast] empty_t r where l.c0 < 0;
+-- result:
+0
+-- !result
+select count(d.c0) from t0 d join [broadcast] (select l.c0 from t0 l join empty_t r) t;
+-- result:
+0
+-- !result
+select count(*) from empty_t l, t0 r;
+-- result:
+0
+-- !result
+select l.*, r.* from empty_t l, t0 r where l.c0 + r.c0 < 10 order by l.c0, l.c1, r.c0, r.c1;
+-- result:
+-- !result
+select count(*) from empty_t l, t0 r where r.c0 = 1;
+-- result:
+0
+-- !result
+select count(*) from empty_t l join [broadcast] t0 r where r.c0 < 0;
+-- result:
+0
+-- !result
+select count(*) from empty_t l join [broadcast] t0 r where l.c0 < 0;
+-- result:
+0
+-- !result
+select count(d.c0) from empty_t d join [broadcast] (select l.c0 from t0 l join t0 r) t;
+-- result:
+0
+-- !result
+select count(*) from (select 1) tbl, (select sleep(1) as c2) tbr;
+-- result:
+1
+-- !result
+select c2 from (select c3,c2 from (select sleep(1) as c2) tbr join [broadcast] (select 1 c3) tbl where c3 + c2 = 0) tb join [broadcast] t0;
+-- result:
 -- !result

--- a/test/sql/test_spill/T/test_spill_nl_join
+++ b/test/sql/test_spill/T/test_spill_nl_join
@@ -15,9 +15,28 @@ create table t0 (
 insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  2048));
 
 -- test spill for cross join
-select count(*) from t0 l, t0 r;
-select l.*, r.* from t0 l, t0 r where l.c0 + r.c0 < 10 order by l.c0, l.c1, r.c0, r.c1;
-select count(*) from t0 l, t0 r where r.c0 = 1;
+select count(*) from t0 l join [broadcast] t0 r;
+select l.*, r.* from t0 l join [broadcast] t0 r where l.c0 + r.c0 < 10 order by l.c0, l.c1, r.c0, r.c1;
+select count(*) from t0 l join [broadcast] t0 r where r.c0 = 1;
 select count(*) from t0 l join [broadcast] t0 r where r.c0 < 0;
 select count(*) from t0 l join [broadcast] t0 r where l.c0 < 0;
 select count(d.c0) from t0 d join [broadcast] (select l.c0 from t0 l join t0 r) t;
+
+-- test empty table
+---- build side emtpy
+create table empty_t like t0;
+select count(*) from t0 l join [broadcast] empty_t r;
+select l.*, r.* from t0 l join [broadcast] empty_t r where l.c0 + r.c0 < 10 order by l.c0, l.c1, r.c0, r.c1;
+select count(*) from t0 l join [broadcast] empty_t r where r.c0 = 1;
+select count(*) from t0 l join [broadcast] empty_t r where r.c0 < 0;
+select count(*) from t0 l join [broadcast] empty_t r where l.c0 < 0;
+select count(d.c0) from t0 d join [broadcast] (select l.c0 from t0 l join empty_t r) t;
+---- probe side empty
+select count(*) from empty_t l, t0 r;
+select l.*, r.* from empty_t l, t0 r where l.c0 + r.c0 < 10 order by l.c0, l.c1, r.c0, r.c1;
+select count(*) from empty_t l, t0 r where r.c0 = 1;
+select count(*) from empty_t l join [broadcast] t0 r where r.c0 < 0;
+select count(*) from empty_t l join [broadcast] t0 r where l.c0 < 0;
+select count(d.c0) from empty_t d join [broadcast] (select l.c0 from t0 l join t0 r) t;
+select count(*) from (select 1) tbl, (select sleep(1) as c2) tbr;
+select c2 from (select c3,c2 from (select sleep(1) as c2) tbr join [broadcast] (select 1 c3) tbl where c3 + c2 = 0) tb join [broadcast] t0;


### PR DESCRIPTION
Fixes #25903

if probe side has not push any data. but at this time build side is finished.
then has_output is true. prober->_probe_chunk is null. we should skip this case

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
