### PR TITLE
[BugFix] Fix schedule tablet in recycle bin failed bug (#25785)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -774,10 +774,11 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         // if this is a balance task, or this is a repair task with REPLICA_MISSING/REPLICA_RELOCATING or REPLICA_MISSING_IN_CLUSTER,
         // we create a new replica with state CLONE
         Database db = GlobalStateMgr.getCurrentState().getDbIncludeRecycleBin(dbId);
-        if (db == null || !db.writeLockAndCheckExist()) {
+        if (db == null) {
             throw new SchedException(Status.UNRECOVERABLE, "db " + dbId + " not exist");
         }
         try {
+            db.writeLock();
             if (tabletStatus == TabletStatus.REPLICA_MISSING
                     || tabletStatus == TabletStatus.REPLICA_RELOCATING
                     || tabletStatus == TabletStatus.COLOCATE_MISMATCH
@@ -825,10 +826,11 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
         final GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         Database db = globalStateMgr.getDbIncludeRecycleBin(dbId);
-        if (db == null || !db.writeLockAndCheckExist()) {
+        if (db == null) {
             throw new SchedException(Status.UNRECOVERABLE, "db " + dbId + " does not exist");
         }
         try {
+            db.writeLock();
             OlapTable olapTable = (OlapTable) globalStateMgr.getTableIncludeRecycleBin(
                     globalStateMgr.getDbIncludeRecycleBin(dbId),
                     tblId);

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -913,10 +913,11 @@ public class TabletScheduler extends LeaderDaemon {
         stat.counterReplicaRedundantErr.incrementAndGet();
 
         Database db = globalStateMgr.getDbIncludeRecycleBin(tabletCtx.getDbId());
-        if (db == null || !db.writeLockAndCheckExist()) {
+        if (db == null) {
             throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
         try {
+            db.writeLock();
             checkMetaExist(tabletCtx);
             if (deleteBackendDropped(tabletCtx, force)
                     || deleteBadReplica(tabletCtx, force)
@@ -1119,10 +1120,11 @@ public class TabletScheduler extends LeaderDaemon {
         Preconditions.checkNotNull(backendSet);
         stat.counterReplicaColocateRedundant.incrementAndGet();
         Database db = globalStateMgr.getDbIncludeRecycleBin(tabletCtx.getDbId());
-        if (db == null || !db.writeLockAndCheckExist()) {
+        if (db == null) {
             throw new SchedException(Status.UNRECOVERABLE, "db " + tabletCtx.getDbId() + " not exist");
         }
         try {
+            db.writeLock();
             checkMetaExist(tabletCtx);
             List<Replica> replicas = tabletCtx.getReplicas();
             for (Replica replica : replicas) {


### PR DESCRIPTION
Fixes
```
2023-06-21 19:42:49,307 INFO (tablet scheduler|30) [TabletScheduler.removeTabletCtx():1429] remove the tablet 2431373. because: db 2431321 not exist
2023-06-21 19:42:49,307 INFO (tablet scheduler|30) [TabletScheduler.removeTabletCtx():1429] remove the tablet 2431337. because: db 2431321 not exist
2023-06-21 19:42:49,307 INFO (tablet scheduler|30) [TabletScheduler.removeTabletCtx():1429] remove the tablet 2431363. because: db 2431321 not exist
2023-06-21 19:42:49,307 INFO (tablet scheduler|30) [TabletScheduler.removeTabletCtx():1429] remove the tablet 2431361. because: db 2431321 not exist
```

If the database is dropped, and moved to recycle bin the database.writeLockAndCheckExist will return false. So we should not check the existence when schedule tablet, because the tablet in recycle bin should be scheduled too.

backport #25785