### PR TITLE
[Enhancement][Cherry-pick][Branch-2.5] support mixed upsert delete for primary key table

### DIFF
--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -279,6 +279,7 @@ Status RowsetWriter::flush_segment(const SegmentPB& segment_pb, butil::IOBuf& da
         }
         RETURN_IF_ERROR(wfile->close());
 
+        _delfile_idxes.emplace_back(_num_segment + _num_delfile);
         _num_delfile++;
         _num_rows_del += segment_pb.delete_num_rows();
 

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -140,6 +140,10 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
     _rowset_meta_pb->set_rowset_seg_id(0);
     // updatable tablet require extra processing
     if (_context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
+        DCHECK(_delfile_idxes.size() == _num_delfile);
+        if (!_delfile_idxes.empty()) {
+            _rowset_meta_pb->mutable_delfile_idxes()->Add(_delfile_idxes.begin(), _delfile_idxes.end());
+        }
         _rowset_meta_pb->set_num_delete_files(_num_delfile);
         if (_num_segment <= 1) {
             _rowset_meta_pb->set_segments_overlap_pb(NONOVERLAPPING);
@@ -382,11 +386,26 @@ Status HorizontalRowsetWriter::add_chunk(const vectorized::Chunk& chunk) {
     return Status::OK();
 }
 
-std::string HorizontalRowsetWriter::_dump_mixed_segment_delfile_not_supported() {
-    std::string msg = strings::Substitute(
-            "multi-segment rowset do not support mixing upsert and delete tablet:$0 txn:$1 #seg:$2 #delfile:$3 "
-            "#upsert:$4 #del:$5",
-            _context.tablet_id, _context.txn_id, _num_segment, _num_delfile, _num_rows_written, _num_rows_del);
+std::string HorizontalRowsetWriter::_flush_state_to_string() {
+    switch (_flush_chunk_state) {
+    case FlushChunkState::UNKNOWN:
+        return "UNKNOWN";
+    case FlushChunkState::UPSERT:
+        return "UPSERT";
+    case FlushChunkState::DELETE:
+        return "DELETE";
+    case FlushChunkState::MIXED:
+        return "MIXED";
+    default:
+        return "ERROR FLUSH STATE";
+    }
+}
+
+std::string HorizontalRowsetWriter::_error_msg() {
+    std::string msg =
+            strings::Substitute("UNKNOWN flush chunk state:$0, tablet:$1 txn:$2 #seg:$3 #delfile:$4 #upsert:$5 #del:$6",
+                                _flush_state_to_string(), _context.tablet_id, _context.txn_id, _num_segment,
+                                _num_delfile, _num_rows_written, _num_rows_del);
     LOG(WARNING) << msg;
     return msg;
 }
@@ -400,8 +419,13 @@ Status HorizontalRowsetWriter::flush_chunk(const vectorized::Chunk& chunk, Segme
         break;
     case FlushChunkState::UPSERT:
         break;
+    case FlushChunkState::DELETE:
+        _flush_chunk_state = FlushChunkState::MIXED;
+        break;
+    case FlushChunkState::MIXED:
+        break;
     default:
-        return Status::Cancelled(_dump_mixed_segment_delfile_not_supported());
+        return Status::Cancelled(_error_msg());
     }
     return _flush_chunk(chunk, seg_info);
 }
@@ -445,6 +469,7 @@ Status HorizontalRowsetWriter::flush_chunk_with_deletes(const vectorized::Chunk&
             seg_info->set_delete_data_size(content.size());
             seg_info->set_delete_path(wfile->filename());
         }
+        _delfile_idxes.emplace_back(_num_segment + _num_delfile);
         _num_delfile++;
         _num_rows_del += deletes.size();
         return Status::OK();
@@ -464,8 +489,12 @@ Status HorizontalRowsetWriter::flush_chunk_with_deletes(const vectorized::Chunk&
             break;
         case FlushChunkState::DELETE:
             break;
+        case FlushChunkState::UPSERT:
+            _flush_chunk_state = FlushChunkState::MIXED;
+        case FlushChunkState::MIXED:
+            break;
         default:
-            return Status::Cancelled(_dump_mixed_segment_delfile_not_supported());
+            return Status::Cancelled(_error_msg());
         }
         RETURN_IF_ERROR(flush_del_file(deletes, seg_info));
         return Status::OK();
@@ -476,10 +505,11 @@ Status HorizontalRowsetWriter::flush_chunk_with_deletes(const vectorized::Chunk&
             _flush_chunk_state = FlushChunkState::MIXED;
             break;
         default:
-            return Status::Cancelled(_dump_mixed_segment_delfile_not_supported());
+            break;
         }
+        RETURN_IF_ERROR(_flush_chunk(upserts, seg_info));
         RETURN_IF_ERROR(flush_del_file(deletes, seg_info));
-        return _flush_chunk(upserts, seg_info);
+        return Status::OK();
     } else {
         return Status::OK();
     }

--- a/be/src/storage/rowset/rowset_writer.h
+++ b/be/src/storage/rowset/rowset_writer.h
@@ -160,6 +160,7 @@ protected:
 
     int _num_segment{0};
     int _num_delfile{0};
+    vector<uint32> _delfile_idxes;
     vector<std::string> _tmp_segment_files;
     // mutex lock for vectorized add chunk and flush
     std::mutex _lock;
@@ -212,7 +213,9 @@ private:
 
     Status _flush_chunk(const vectorized::Chunk& chunk, SegmentPB* seg_info = nullptr);
 
-    std::string _dump_mixed_segment_delfile_not_supported();
+    std::string _flush_state_to_string();
+
+    std::string _error_msg();
 
     std::unique_ptr<SegmentWriter> _segment_writer;
     std::unique_ptr<VerticalRowsetWriter> _vertical_rowset_writer;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -899,50 +899,92 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
     EditVersion latest_applied_version;
     st = get_latest_applied_version(&latest_applied_version);
 
-    for (uint32_t i = 0; i < rowset->num_segments(); i++) {
-        state.load_upserts(rowset.get(), i);
-        auto& upserts = state.upserts();
-        if (upserts[i] != nullptr) {
-            // apply partial rowset segment
-            st = state.apply(&_tablet, rowset.get(), rowset_id, i, latest_applied_version, index);
-            if (!st.ok()) {
-                manager->update_state_cache().remove(state_entry);
-                std::string msg =
-                        strings::Substitute("_apply_rowset_commit error: apply rowset update state failed: $0 $1",
-                                            st.to_string(), debug_string());
-                LOG(ERROR) << msg;
-                _set_error(msg);
-                return;
+    if (rowset->rowset_meta()->get_meta_pb().delfile_idxes_size() == 0) {
+        for (uint32_t i = 0; i < rowset->num_segments(); i++) {
+            state.load_upserts(rowset.get(), i);
+            auto& upserts = state.upserts();
+            if (upserts[i] != nullptr) {
+                // apply partial rowset segment
+                st = state.apply(&_tablet, rowset.get(), rowset_id, i, latest_applied_version, index);
+                if (!st.ok()) {
+                    manager->update_state_cache().remove(state_entry);
+                    std::string msg =
+                            strings::Substitute("_apply_rowset_commit error: apply rowset update state failed: $0 $1",
+                                                st.to_string(), debug_string());
+                    LOG(ERROR) << msg;
+                    _set_error(msg);
+                    return;
+                }
+                st = _do_update(rowset_id, i, conditional_column, upserts, index, tablet_id, &new_deletes);
+                if (!st.ok()) {
+                    manager->update_state_cache().remove(state_entry);
+                    std::string msg =
+                            strings::Substitute("_apply_rowset_commit error: apply rowset update state failed: $0 $1",
+                                                st.to_string(), debug_string());
+                    LOG(ERROR) << msg;
+                    _set_error(msg);
+                    return;
+                }
+                manager->index_cache().update_object_size(index_entry, index.memory_usage());
             }
-            st = _do_update(rowset_id, i, conditional_column, upserts, index, tablet_id, &new_deletes);
-            if (!st.ok()) {
-                manager->update_state_cache().remove(state_entry);
-                std::string msg =
-                        strings::Substitute("_apply_rowset_commit error: apply rowset update state failed: $0 $1",
-                                            st.to_string(), debug_string());
-                LOG(ERROR) << msg;
-                _set_error(msg);
-                return;
-            }
-            manager->index_cache().update_object_size(index_entry, index.memory_usage());
+            state.release_upserts(i);
         }
-        state.release_upserts(i);
-    }
+        // two states
+        // 1. upgrade from old version. delfile_idxes in rowset meta is empty, we still need to load delete files
+        // 2. pure upsert. no delete files, the following logic will be skip
+        for (uint32_t i = 0; i < rowset->num_delete_files(); i++) {
+            state.load_deletes(rowset.get(), i);
+            auto& deletes = state.deletes();
+            delete_op += deletes[i]->size();
+            index.erase(*deletes[i], &new_deletes);
+            state.release_deletes(i);
+        }
+    } else {
+        uint32_t delfile_num = rowset->rowset_meta()->get_meta_pb().delfile_idxes_size();
+        uint32_t upsert_num = rowset->num_segments();
+        DCHECK(rowset->num_delete_files() == delfile_num);
 
-    for (uint32_t i = 0; i < rowset->num_delete_files(); i++) {
-        state.load_deletes(rowset.get(), i);
-        auto& deletes = state.deletes();
-        delete_op += deletes[i]->size();
-        st = index.erase(*deletes[i], &new_deletes);
-        if (!st.ok()) {
-            manager->update_state_cache().remove(state_entry);
-            std::string msg = strings::Substitute("_apply_rowset_commit error: apply rowset update state failed: $0 $1",
-                                                  st.to_string(), debug_string());
-            LOG(ERROR) << msg;
-            _set_error(msg);
-            return;
+        uint32_t loaded_delfile = 0;
+        uint32_t loaded_upsert = 0;
+        uint32_t i = 0;
+        while (i < delfile_num + upsert_num) {
+            uint32_t del_idx = delfile_num + upsert_num;
+            if (loaded_delfile < delfile_num) {
+                del_idx = rowset->rowset_meta()->get_meta_pb().delfile_idxes(loaded_delfile);
+            }
+            while (i < del_idx) {
+                state.load_upserts(rowset.get(), loaded_upsert);
+                auto& upserts = state.upserts();
+                if (upserts[loaded_upsert] != nullptr) {
+                    // apply partial rowset segment
+                    st = state.apply(&_tablet, rowset.get(), rowset_id, loaded_upsert, latest_applied_version, index);
+                    if (!st.ok()) {
+                        manager->update_state_cache().remove(state_entry);
+                        std::string msg = strings::Substitute(
+                                "_apply_rowset_commit error: apply rowset update state failed: $0 $1", st.to_string(),
+                                debug_string());
+                        LOG(ERROR) << msg;
+                        _set_error(msg);
+                        return;
+                    }
+                    _do_update(rowset_id, loaded_upsert, conditional_column, upserts, index, tablet_id, &new_deletes);
+                    manager->index_cache().update_object_size(index_entry, index.memory_usage());
+                }
+                i++;
+                loaded_upsert++;
+                state.release_upserts(i);
+            }
+            if (loaded_delfile < delfile_num) {
+                DCHECK(i == del_idx);
+                state.load_deletes(rowset.get(), loaded_delfile);
+                auto& deletes = state.deletes();
+                delete_op += deletes[loaded_delfile]->size();
+                index.erase(*deletes[loaded_delfile], &new_deletes);
+                state.release_deletes(loaded_delfile);
+                i++;
+                loaded_delfile++;
+            }
         }
-        state.release_deletes(i);
     }
 
     PersistentIndexMetaPB index_meta;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3184,17 +3184,17 @@ TEST_F(TabletUpdatesTest, multiple_delete_and_upsert) {
         auto chunk = ChunkHelper::new_chunk(schema, keys.size());
         auto& cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
-            cols[2]->append_datum(Datum((int32_t)(key % 100 + 2)));
+            cols[0]->append_datum(vectorized::Datum(key));
+            cols[1]->append_datum(vectorized::Datum((int16_t)(key % 100 + 1)));
+            cols[2]->append_datum(vectorized::Datum((int32_t)(key % 100 + 2)));
         }
         CHECK_OK(writer->flush_chunk(*chunk));
     }
     // 2. delete [0, 1, 2 ... 50)
     {
-        Int64Column deletes;
+        vectorized::Int64Column deletes;
         for (int64_t i = 0; i < 50; i++) {
-            deletes.append_datum(Datum(i));
+            deletes.append_datum(vectorized::Datum(i));
         }
         auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
         auto chunk = ChunkHelper::new_chunk(schema, 0);
@@ -3210,9 +3210,9 @@ TEST_F(TabletUpdatesTest, multiple_delete_and_upsert) {
         auto chunk = ChunkHelper::new_chunk(schema, keys.size());
         auto& cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(key % 100 + 2)));
-            cols[2]->append_datum(Datum((int32_t)(key % 100 + 3)));
+            cols[0]->append_datum(vectorized::Datum(key));
+            cols[1]->append_datum(vectorized::Datum((int16_t)(key % 100 + 2)));
+            cols[2]->append_datum(vectorized::Datum((int32_t)(key % 100 + 3)));
         }
         CHECK_OK(writer->flush_chunk(*chunk));
     }
@@ -3223,26 +3223,26 @@ TEST_F(TabletUpdatesTest, multiple_delete_and_upsert) {
         for (int i = 100; i < 200; i++) {
             keys.emplace_back(i);
         }
-        Int64Column deletes;
+        vectorized::Int64Column deletes;
         for (int64_t i = 50; i < 100; i++) {
-            deletes.append_datum(Datum(i));
+            deletes.append_datum(vectorized::Datum(i));
         }
 
         auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
         auto chunk = ChunkHelper::new_chunk(schema, keys.size());
         auto& cols = chunk->columns();
         for (int64_t key : keys) {
-            cols[0]->append_datum(Datum(key));
-            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
-            cols[2]->append_datum(Datum((int32_t)(key % 100 + 2)));
+            cols[0]->append_datum(vectorized::Datum(key));
+            cols[1]->append_datum(vectorized::Datum((int16_t)(key % 100 + 1)));
+            cols[2]->append_datum(vectorized::Datum((int32_t)(key % 100 + 2)));
         }
         CHECK_OK(writer->flush_chunk_with_deletes(*chunk, deletes));
     }
     // 5. delete [150, 151, 152 ... 200)
     {
-        Int64Column deletes;
+        vectorized::Int64Column deletes;
         for (int64_t i = 150; i < 200; i++) {
-            deletes.append_datum(Datum(i));
+            deletes.append_datum(vectorized::Datum(i));
         }
         auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
         auto chunk = ChunkHelper::new_chunk(schema, 0);
@@ -3251,8 +3251,8 @@ TEST_F(TabletUpdatesTest, multiple_delete_and_upsert) {
     RowsetSharedPtr rowset = *writer->build();
     ASSERT_TRUE(_tablet->rowset_commit(2, rowset).ok());
 
-    Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
-    TabletReader reader(_tablet, Version(0, 2), schema);
+    auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+    vectorized::TabletReader reader(_tablet, Version(0, 2), schema);
     auto iter = create_tablet_iterator(reader, schema);
     ASSERT_TRUE(iter != nullptr);
     std::vector<int64_t> keys;
@@ -3266,15 +3266,15 @@ TEST_F(TabletUpdatesTest, multiple_delete_and_upsert) {
     auto full_chunk = ChunkHelper::new_chunk(iter->schema(), keys.size());
     auto& cols = full_chunk->columns();
     for (int i = 0; i < 50; i++) {
-        cols[0]->append_datum(Datum(keys[i]));
-        cols[1]->append_datum(Datum((int16_t)(keys[i] % 100 + 2)));
-        cols[2]->append_datum(Datum((int32_t)(keys[i] % 100 + 3)));
+        cols[0]->append_datum(vectorized::Datum(keys[i]));
+        cols[1]->append_datum(vectorized::Datum((int16_t)(keys[i] % 100 + 2)));
+        cols[2]->append_datum(vectorized::Datum((int32_t)(keys[i] % 100 + 3)));
     }
 
     for (int i = 50; i < 100; i++) {
-        cols[0]->append_datum(Datum(keys[i]));
-        cols[1]->append_datum(Datum((int16_t)(keys[i] % 100 + 1)));
-        cols[2]->append_datum(Datum((int32_t)(keys[i] % 100 + 2)));
+        cols[0]->append_datum(vectorized::Datum(keys[i]));
+        cols[1]->append_datum(vectorized::Datum((int16_t)(keys[i] % 100 + 1)));
+        cols[2]->append_datum(vectorized::Datum((int32_t)(keys[i] % 100 + 2)));
     }
 
     size_t count = 0;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3156,4 +3156,143 @@ TEST_F(TabletUpdatesTest, load_snapshot_primary) {
     test_load_snapshot_primary(7, {3, 5, 7});
 }
 
+TEST_F(TabletUpdatesTest, multiple_delete_and_upsert) {
+    _tablet = create_tablet(rand(), rand());
+
+    RowsetWriterContext writer_context;
+    RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+    writer_context.rowset_id = rowset_id;
+    writer_context.tablet_id = _tablet->tablet_id();
+    writer_context.tablet_schema_hash = _tablet->schema_hash();
+    writer_context.partition_id = 0;
+    writer_context.rowset_path_prefix = _tablet->schema_hash_path();
+    writer_context.rowset_state = COMMITTED;
+    writer_context.tablet_schema = &_tablet->tablet_schema();
+    writer_context.version.first = 0;
+    writer_context.version.second = 0;
+    writer_context.segments_overlap = NONOVERLAPPING;
+    std::unique_ptr<RowsetWriter> writer;
+    EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+
+    // 1. upsert [0, 1, 2 ... 100)
+    {
+        std::vector<int64_t> keys;
+        for (int i = 0; i < 100; i++) {
+            keys.emplace_back(i);
+        }
+        auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        auto& cols = chunk->columns();
+        for (int64_t key : keys) {
+            cols[0]->append_datum(Datum(key));
+            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[2]->append_datum(Datum((int32_t)(key % 100 + 2)));
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
+    }
+    // 2. delete [0, 1, 2 ... 50)
+    {
+        Int64Column deletes;
+        for (int64_t i = 0; i < 50; i++) {
+            deletes.append_datum(Datum(i));
+        }
+        auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, 0);
+        CHECK_OK(writer->flush_chunk_with_deletes(*chunk, deletes));
+    }
+    // 3. upsert [0, 1, 2 ... 50)
+    {
+        std::vector<int64_t> keys;
+        for (int i = 0; i < 50; i++) {
+            keys.emplace_back(i);
+        }
+        auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        auto& cols = chunk->columns();
+        for (int64_t key : keys) {
+            cols[0]->append_datum(Datum(key));
+            cols[1]->append_datum(Datum((int16_t)(key % 100 + 2)));
+            cols[2]->append_datum(Datum((int32_t)(key % 100 + 3)));
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
+    }
+
+    // 4. upsert [100, 102, 103 ... 200) and delete [50, 51, 52 ... 100)
+    {
+        std::vector<int64_t> keys;
+        for (int i = 100; i < 200; i++) {
+            keys.emplace_back(i);
+        }
+        Int64Column deletes;
+        for (int64_t i = 50; i < 100; i++) {
+            deletes.append_datum(Datum(i));
+        }
+
+        auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        auto& cols = chunk->columns();
+        for (int64_t key : keys) {
+            cols[0]->append_datum(Datum(key));
+            cols[1]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            cols[2]->append_datum(Datum((int32_t)(key % 100 + 2)));
+        }
+        CHECK_OK(writer->flush_chunk_with_deletes(*chunk, deletes));
+    }
+    // 5. delete [150, 151, 152 ... 200)
+    {
+        Int64Column deletes;
+        for (int64_t i = 150; i < 200; i++) {
+            deletes.append_datum(Datum(i));
+        }
+        auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, 0);
+        CHECK_OK(writer->flush_chunk_with_deletes(*chunk, deletes));
+    }
+    RowsetSharedPtr rowset = *writer->build();
+    ASSERT_TRUE(_tablet->rowset_commit(2, rowset).ok());
+
+    Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+    TabletReader reader(_tablet, Version(0, 2), schema);
+    auto iter = create_tablet_iterator(reader, schema);
+    ASSERT_TRUE(iter != nullptr);
+    std::vector<int64_t> keys;
+    for (int i = 0; i < 50; i++) {
+        keys.emplace_back(i);
+    }
+    for (int i = 100; i < 150; i++) {
+        keys.emplace_back(i);
+    }
+    auto chunk = ChunkHelper::new_chunk(iter->schema(), 100);
+    auto full_chunk = ChunkHelper::new_chunk(iter->schema(), keys.size());
+    auto& cols = full_chunk->columns();
+    for (int i = 0; i < 50; i++) {
+        cols[0]->append_datum(Datum(keys[i]));
+        cols[1]->append_datum(Datum((int16_t)(keys[i] % 100 + 2)));
+        cols[2]->append_datum(Datum((int32_t)(keys[i] % 100 + 3)));
+    }
+
+    for (int i = 50; i < 100; i++) {
+        cols[0]->append_datum(Datum(keys[i]));
+        cols[1]->append_datum(Datum((int16_t)(keys[i] % 100 + 1)));
+        cols[2]->append_datum(Datum((int32_t)(keys[i] % 100 + 2)));
+    }
+
+    size_t count = 0;
+    while (true) {
+        auto st = iter->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        } else if (st.ok()) {
+            for (auto i = 0; i < chunk->num_rows(); i++) {
+                EXPECT_EQ(full_chunk->get(count + i).compare(iter->schema(), chunk->get(i)), 0);
+            }
+            count += chunk->num_rows();
+            chunk->reset();
+        } else {
+            ASSERT_TRUE(false);
+        }
+    }
+    ASSERT_TRUE(count == keys.size());
+}
+
 } // namespace starrocks

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -134,6 +134,8 @@ message RowsetMetaPB {
     optional int64 total_row_size = 54;
     // some txn semantic information bind to this rowset
     optional RowsetTxnMetaPB txn_meta = 55;
+    // delete file index
+    repeated uint32 delfile_idxes = 56;
 }
 
 enum DataFileType {


### PR DESCRIPTION
PrimaryKey table support delete operation in data import right now. However, if we mixed upsert and delete in one data import, we only support a small batch data(smaller than one segment file size). If the imported data size need to flush more than one segment, we will refuse the import request.

This pr will support mixed upsert and delete data import for PrimaryKey table and don't need to limit the segment num.