### PR TITLE
[Enhancement] Change the default value of storage_flood_stage_left_capacity_bytes

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -564,7 +564,7 @@ CONF_mInt32(path_scan_interval_second, "86400");
 // The percent of max used capacity of a data dir
 CONF_mInt32(storage_flood_stage_usage_percent, "95"); // 95%
 // The min bytes that should be left of a data dir
-CONF_mInt64(storage_flood_stage_left_capacity_bytes, "1073741824"); // 1GB
+CONF_mInt64(storage_flood_stage_left_capacity_bytes, "107374182400"); // 100GB
 // Number of thread for flushing memtable per store.
 CONF_mInt32(flush_thread_num_per_store, "2");
 

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -337,6 +337,7 @@ int main(int argc, char** argv) {
     starrocks::fs::create_directories(root_path_2);
 
     starrocks::config::storage_root_path = root_path_1 + ";" + root_path_2;
+    starrocks::config::storage_flood_stage_left_capacity_bytes = 10485600;
 
     starrocks::CpuInfo::init();
     starrocks::DiskInfo::init();

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -51,6 +51,7 @@ int main(int argc, char** argv) {
     starrocks::config::storage_root_path = storage_root.value();
     starrocks::config::enable_event_based_compaction_framework = false;
     starrocks::config::l0_snapshot_size = 1048576;
+    starrocks::config::storage_flood_stage_left_capacity_bytes = 10485600;
 
     starrocks::init_glog("be_test", true);
     starrocks::CpuInfo::init();


### PR DESCRIPTION
in pr #22575, we haved changed the default value of
`storage_flood_stage_left_capacity_bytes` to 100GB to
accommodate nowadays hardware environment, but
backend's corresponding configuration is forgotten.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
