### PR TITLE
[BugFix] Fix orc timestamp and timestamp_instant issue

### DIFF
--- a/be/src/formats/orc/apache-orc/c++/include/orc/Vector.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/Vector.hh
@@ -347,6 +347,7 @@ protected:
    */
 struct TimestampVectorBatch : public ColumnVectorBatch {
     TimestampVectorBatch(uint64_t capacity, MemoryPool& pool);
+    TimestampVectorBatch(uint64_t capacity, MemoryPool& pool, bool is_timestamp_instant_type);
     ~TimestampVectorBatch() override;
     std::string toString() const override;
     void resize(uint64_t capacity) override;
@@ -361,6 +362,8 @@ struct TimestampVectorBatch : public ColumnVectorBatch {
 
     // the nanoseconds of each value
     DataBuffer<int64_t> nanoseconds;
+
+    bool is_timestamp_instant_type = false;
 
     void filter(uint8_t* f_data, uint32_t f_size, uint32_t true_size) override;
 };

--- a/be/src/formats/orc/apache-orc/c++/src/TypeImpl.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/TypeImpl.cc
@@ -328,8 +328,10 @@ std::unique_ptr<ColumnVectorBatch> TypeImpl::createRowBatch(uint64_t capacity, M
                        : std::unique_ptr<ColumnVectorBatch>(new StringVectorBatch(capacity, memoryPool));
 
     case TIMESTAMP:
+        return std::unique_ptr<ColumnVectorBatch>(new TimestampVectorBatch(capacity, memoryPool, false));
+
     case TIMESTAMP_INSTANT:
-        return std::unique_ptr<ColumnVectorBatch>(new TimestampVectorBatch(capacity, memoryPool));
+        return std::unique_ptr<ColumnVectorBatch>(new TimestampVectorBatch(capacity, memoryPool, true));
 
     case STRUCT: {
         auto* result = new StructVectorBatch(capacity, memoryPool);

--- a/be/src/formats/orc/apache-orc/c++/src/Vector.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Vector.cc
@@ -586,6 +586,14 @@ TimestampVectorBatch::TimestampVectorBatch(uint64_t _capacity, MemoryPool& pool)
     // PASS
 }
 
+TimestampVectorBatch::TimestampVectorBatch(uint64_t _capacity, MemoryPool& pool, bool is_timestamp_instant_type)
+        : ColumnVectorBatch(_capacity, pool),
+          data(pool, _capacity),
+          nanoseconds(pool, _capacity),
+          is_timestamp_instant_type(is_timestamp_instant_type) {
+    // PASS
+}
+
 TimestampVectorBatch::~TimestampVectorBatch() {
     // PASS
 }

--- a/be/src/formats/orc/fill_function.cpp
+++ b/be/src/formats/orc/fill_function.cpp
@@ -817,7 +817,7 @@ static void fill_timestamp_column(orc::ColumnVectorBatch* cvb, ColumnPtr& col, s
             ns = data->nanoseconds[from];
         }
         OrcTimestampHelper::orc_ts_to_native_ts(&(values[i]), reader->tzinfo(), reader->tzoffset_in_seconds(),
-                                                data->data[from], ns);
+                                                data->data[from], ns, data->is_timestamp_instant_type);
     }
 }
 static void fill_timestamp_column_with_null(orc::ColumnVectorBatch* cvb, ColumnPtr& col, size_t from, size_t size,
@@ -840,7 +840,7 @@ static void fill_timestamp_column_with_null(orc::ColumnVectorBatch* cvb, ColumnP
                 ns = data->nanoseconds[from];
             }
             OrcTimestampHelper::orc_ts_to_native_ts(&(values[i]), reader->tzinfo(), reader->tzoffset_in_seconds(),
-                                                    data->data[from], ns);
+                                                    data->data[from], ns, data->is_timestamp_instant_type);
         }
     }
 

--- a/be/src/formats/orc/fill_function.h
+++ b/be/src/formats/orc/fill_function.h
@@ -34,7 +34,7 @@
 namespace starrocks {
 
 using FillColumnFunction = void (*)(orc::ColumnVectorBatch* cvb, ColumnPtr& col, size_t from, size_t size,
-                                    const TypeDescriptor& type_desc, const OrcMappingPtr& mapping, void* ctx);
+                                    const TypeDescriptor& type_desc, const OrcMappingPtr& mapping, void* ctx, std::string col_name);
 
 extern const std::unordered_map<orc::TypeKind, LogicalType> g_orc_starrocks_logical_type_mapping;
 extern const std::set<LogicalType> g_starrocks_int_type;

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -23,7 +23,6 @@
 
 #include "cctz/civil_time.h"
 #include "cctz/time_zone.h"
-#include "column/array_column.h"
 #include "column/map_column.h"
 #include "column/struct_column.h"
 #include "column/vectorized_fwd.h"
@@ -55,7 +54,6 @@ OrcChunkReader::OrcChunkReader(int chunk_size, std::vector<SlotDescriptor*> src_
     if (_read_chunk_size == 0) {
         _read_chunk_size = 4096;
     }
-    _row_reader_options.useWriterTimezone();
 
     // some caller of `OrcChunkReader` may pass nullptr
     // This happens when there are extra fields in broker load specification

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -425,6 +425,7 @@ Status OrcChunkReader::_init_src_types(const std::unique_ptr<OrcMapping>& mappin
                 _reader->getType().getSubtypeByColumnId(mapping->get_column_id_or_child_mapping(i).orc_column_id);
         RETURN_IF_ERROR(_create_type_descriptor_by_orc(
                 slot_desc->type(), orc_type, mapping->get_column_id_or_child_mapping(i).orc_mapping, &_src_types[i]));
+        _orc_types.insert({slot_desc->col_name(), orc_type->getKind()});
         _try_implicit_cast(&_src_types[i], slot_desc->type());
     }
     return Status::OK();
@@ -561,7 +562,7 @@ Status OrcChunkReader::_fill_chunk(ChunkPtr* chunk, const std::vector<SlotDescri
         }
         ColumnPtr& col = (*chunk)->get_column_by_slot_id(slot_desc->id());
         _fill_functions[src_index](cvb, col, 0, _batch->numElements, slot_desc->type(),
-                                   _root_selected_mapping->get_column_id_or_child_mapping(src_index).orc_mapping, this);
+                                   _root_selected_mapping->get_column_id_or_child_mapping(src_index).orc_mapping, this, slot_desc->col_name());
     }
 
     if (_broker_load_mode) {

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -137,6 +137,8 @@ public:
 
     bool is_implicit_castable(TypeDescriptor& starrocks_type, const TypeDescriptor& orc_type);
 
+    bool is_timestamp_instant_type(const std::string& col_name) { return _orc_types[col_name] == orc::TIMESTAMP_INSTANT; }
+
 private:
     ChunkPtr _create_chunk(const std::vector<SlotDescriptor*>& slots, const std::vector<int>* indices);
     Status _fill_chunk(ChunkPtr* chunk, const std::vector<SlotDescriptor*>& slots, const std::vector<int>* indices);
@@ -166,6 +168,7 @@ private:
     bool _use_orc_column_names = false;
     std::unique_ptr<OrcMapping> _root_selected_mapping;
     std::vector<TypeDescriptor> _src_types;
+    std::unordered_map<std::string, orc::TypeKind> _orc_types;
     // slot id to position in orc.
     std::unordered_map<SlotId, int> _slot_id_to_position;
     std::vector<Expr*> _cast_exprs;

--- a/be/src/formats/orc/utils.h
+++ b/be/src/formats/orc/utils.h
@@ -85,9 +85,10 @@ public:
         tv->from_timestamp(tp.year(), tp.month(), tp.day(), tp.hour(), tp.minute(), tp.second(), 0);
     }
     static void orc_ts_to_native_ts(TimestampValue* tv, const cctz::time_zone& tz, int64_t tzoffset, int64_t seconds,
-                                    int64_t nanoseconds) {
+                                    int64_t nanoseconds, bool is_instant = false) {
         if (seconds >= 0) {
-            orc_ts_to_native_ts_after_unix_epoch(tv, seconds + tzoffset, nanoseconds);
+            seconds = is_instant ? seconds + tzoffset : seconds;
+            orc_ts_to_native_ts_after_unix_epoch(tv, seconds, nanoseconds);
         } else {
             orc_ts_to_native_ts_before_unix_epoch(tv, tz, seconds, nanoseconds);
         }


### PR DESCRIPTION
Fixes #issue
If a user uses Hive 3.0 to write a timestamp column value and then queries the data using the time zone in StarRocks, the query result is incorrect.
Hive or trino or spark：
 2023-02-03 03:45:56.000 

SR:
+---------------------+
| k1                  |
+---------------------+
| 2023-02-03 11:45:56 |
+---------------------+

We need to follow Apache orc's timestamp and timestamp_instant format. https://orc.apache.org/docs/types.html
the major changes of this pr:

- timestamp: read value from orc file according orc write time zone using apache-orc lib.
- timestamp_instant: We use the session time zone offset in combination with the original value to produce the desired result. This is necessary because StarRocks lacks support for the TIMESTAMP_WITH_TIMEZONE data type.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
