### PR TITLE
[BugFix] Use capacity_limit_reached to check overflow

### DIFF
--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -477,16 +477,10 @@ Status Analytor::add_chunk(const ChunkPtr& chunk) {
     const size_t chunk_size = chunk->num_rows();
 
     {
-        auto check_if_overflow = [](Column* maybe_nullable_column) {
-            auto* column = ColumnHelper::get_data_column(maybe_nullable_column);
-            if (!column->is_binary()) {
-                return Status::OK();
-            }
-
-            auto* binary_column = down_cast<BinaryColumn*>(column);
-            if (binary_column->get_bytes().size() > std::numeric_limits<uint32_t>::max()) {
-                return Status::InternalError(
-                        strings::Substitute("Binary column size overflow: $0", binary_column->get_bytes().size()));
+        auto check_if_overflow = [](Column* column) {
+            std::string msg;
+            if (column->capacity_limit_reached(&msg)) {
+                return Status::InternalError(msg);
             }
             return Status::OK();
         };


### PR DESCRIPTION
This is introduced by https://github.com/StarRocks/starrocks/pull/25355


For const null column, `is_nullable()` returns true, but it's actually an `ConstColumn<NullableColumn>` not a `NullableColumn`, so unpacking from `ColumnHelper::get_data_column` may fail at assertion.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
