### PR TITLE
[BugFix] AUTO_INCREMENT column can be inserted by null using SELECT (#24795)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -26,6 +26,7 @@ import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Type;
@@ -205,10 +206,31 @@ public class InsertPlanner {
                     Preconditions.checkState(!CollectionUtils.isEmpty(targetPartitionIds));
                     enableAutomaticPartition = olapTable.supportedAutomaticPartition();
                 }
+                boolean nullExprInAutoIncrement = false;
+                // In INSERT INTO SELECT, if AUTO_INCREMENT column
+                // is specified, the column values must not be NULL
+                if (!(queryRelation instanceof ValuesRelation) &&
+                        !(insertStmt.getTargetTable() instanceof MaterializedView)) {
+                    boolean specifyAutoIncrementColumn = false;
+                    if (insertStmt.getTargetColumnNames() != null) {
+                        for (String colName : insertStmt.getTargetColumnNames()) {
+                            for (Column col : olapTable.getBaseSchema()) {
+                                if (col.isAutoIncrement() && col.getName().equals(colName)) {
+                                    specifyAutoIncrementColumn = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if (insertStmt.getTargetColumnNames() == null || specifyAutoIncrementColumn) {
+                        nullExprInAutoIncrement = true;
+                    }
+
+                }
                 dataSink = new OlapTableSink(olapTable, olapTuple, insertStmt.getTargetPartitionIds(),
                         canUsePipeline, olapTable.writeQuorum(),
                         forceReplicatedStorage ? true : olapTable.enableReplicatedStorage(),
-                        false, enableAutomaticPartition);
+                        nullExprInAutoIncrement, enableAutomaticPartition);
             } else if (insertStmt.getTargetTable() instanceof MysqlTable) {
                 dataSink = new MysqlTableSink((MysqlTable) insertStmt.getTargetTable());
             } else {
@@ -259,8 +281,9 @@ public class InsertPlanner {
             if (insertStatement.getTargetColumnNames() == null) {
                 for (List<Expr> row : values.getRows()) {
                     if (isAutoIncrement && row.get(columnIdx).getType() == Type.NULL) {
-                        throw new SemanticException("AUTO_INCREMENT column: " + targetColumn.getName() +
-                                                    " must not be NULL");
+                        throw new SemanticException(" `NULL` value is not supported for an AUTO_INCREMENT column: " +
+                                                     targetColumn.getName() + " You can use `default` for an" +
+                                                     " AUTO INCREMENT column");
                     }
                     if (row.get(columnIdx) instanceof DefaultValueExpr) {
                         if (isAutoIncrement) {
@@ -277,8 +300,9 @@ public class InsertPlanner {
                 if (idx != -1) {
                     for (List<Expr> row : values.getRows()) {
                         if (isAutoIncrement && row.get(idx).getType() == Type.NULL) {
-                            throw new SemanticException("AUTO_INCREMENT column: " + targetColumn.getName() +
-                                                        " must not be NULL");
+                            throw new SemanticException(" `NULL` value is not supported for an AUTO_INCREMENT column: " +
+                                                        targetColumn.getName() + " You can use `default` for an" +
+                                                        " AUTO INCREMENT column");
                         }
                         if (row.get(idx) instanceof DefaultValueExpr) {
                             if (isAutoIncrement) {

--- a/test/sql/test_auto_increment/R/test_auto_increment
+++ b/test/sql/test_auto_increment/R/test_auto_increment
@@ -94,11 +94,11 @@ SELECT * FROM t;
 -- !result
 INSERT INTO t (id, name, job1, job2) VALUES (1,NULL,NULL,2);
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: AUTO_INCREMENT column: name must not be NULL.')
+E: (1064, 'Getting analyzing error. Detail message:  `NULL` value is not supported for an AUTO_INCREMENT column: name You can use `default` for an AUTO INCREMENT column.')
 -- !result
 INSERT INTO t VALUES (1,NULL,NULL,2);
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: AUTO_INCREMENT column: name must not be NULL.')
+E: (1064, 'Getting analyzing error. Detail message:  `NULL` value is not supported for an AUTO_INCREMENT column: name You can use `default` for an AUTO INCREMENT column.')
 -- !result
 UPDATE t SET name = NULL where id = 1;
 -- result:
@@ -109,6 +109,70 @@ SELECT * FROM t;
 1	1	None	2
 -- !result
 DROP TABLE t;
+-- result:
+-- !result
+CREATE TABLE t1 ( id BIGINT NOT NULL, idx BIGINT AUTO_INCREMENT )
+Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+CREATE TABLE t2 ( id BIGINT NOT NULL, idx BIGINT NULL )
+Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+INSERT INTO t2 VALUES (1, NULL), (2, NULL);
+-- result:
+-- !result
+INSERT INTO t1 SELECT * FROM t2;
+-- result:
+-- !result
+INSERT INTO t1 (id, idx) SELECT * FROM t2;
+-- result:
+-- !result
+INSERT INTO t1 (id, idx) SELECT id, idx FROM t2;
+-- result:
+-- !result
+INSERT INTO t1 SELECT 1, NULL;
+-- result:
+-- !result
+SELECT * FROM t1;
+-- result:
+-- !result
+INSERT INTO t2 VALUES (10, 1), (20, 2);
+-- result:
+-- !result
+DROP TABLE t1;
+-- result:
+-- !result
+CREATE TABLE t1 ( id BIGINT NOT NULL, idx BIGINT AUTO_INCREMENT )
+Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+-- result:
+-- !result
+INSERT INTO t1 (id, idx) SELECT * FROM t2;
+-- result:
+-- !result
+INSERT INTO t1 (id, idx) SELECT id, idx FROM t2;
+-- result:
+-- !result
+INSERT INTO t1 (id) SELECT id FROM t2;
+-- result:
+-- !result
+SELECT * FROM t1;
+-- result:
+1	5
+2	6
+10	7
+20	8
+-- !result
+DROP TABLE t1;
+-- result:
+-- !result
+DROP TABLE t2;
+-- result:
+-- !result
+SET enable_insert_strict = true;
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("empty_load_as_error" = "true");
 -- result:
 -- !result
 DROP DATABASE test_table_with_null;

--- a/test/sql/test_auto_increment/T/test_auto_increment
+++ b/test/sql/test_auto_increment/T/test_auto_increment
@@ -184,4 +184,33 @@ UPDATE t SET name = NULL where id = 1;
 SELECT * FROM t;
 
 DROP TABLE t;
+
+CREATE TABLE t1 ( id BIGINT NOT NULL, idx BIGINT AUTO_INCREMENT )
+Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+
+CREATE TABLE t2 ( id BIGINT NOT NULL, idx BIGINT NULL )
+Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+
+INSERT INTO t2 VALUES (1, NULL), (2, NULL);
+
+INSERT INTO t1 SELECT * FROM t2;
+INSERT INTO t1 (id, idx) SELECT * FROM t2;
+INSERT INTO t1 (id, idx) SELECT id, idx FROM t2;
+INSERT INTO t1 SELECT 1, NULL;
+SELECT * FROM t1;
+INSERT INTO t2 VALUES (10, 1), (20, 2);
+DROP TABLE t1;
+CREATE TABLE t1 ( id BIGINT NOT NULL, idx BIGINT AUTO_INCREMENT )
+Primary KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1", "replicated_storage"="true");
+INSERT INTO t1 (id, idx) SELECT * FROM t2;
+INSERT INTO t1 (id, idx) SELECT id, idx FROM t2;
+INSERT INTO t1 (id) SELECT id FROM t2;
+SELECT * FROM t1;
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+SET enable_insert_strict = true;
+ADMIN SET FRONTEND CONFIG ("empty_load_as_error" = "true");
+
 DROP DATABASE test_table_with_null;


### PR DESCRIPTION
Problem:
AUTO_INCREMENT column can not be specified by NULL through simple INSERT stmt. But It can be inserted by INSERT INTO t SELECT 1, NULL or INSERT INTO a t1 SELECT b from t2, where a is AUTO_INCREMENT column and b may contain NULL value.

Solution:
Set nullExprInAutoIncrement == TRUE WHEN the INSERT INTO SELECT case happen. It can make sure that OlapTableSink::send_chunk will check the nullable column for AUTO_INCREMENT Column if nullExprInAutoIncrement == TRUE.

Fixes #24795

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
