### PR TITLE
[Enhancement] Delete data files after truncating a table

### DIFF
--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -128,6 +128,17 @@ inline std::pair<int64_t, int64_t> parse_txn_log_filename(std::string_view file_
     return {tablet_id, txn_id};
 }
 
+// Return value: <tablet id, version number>
+inline std::pair<int64_t, int64_t> parse_txn_vlog_filename(std::string_view file_name) {
+    constexpr static int kBase = 16;
+    StringParser::ParseResult res;
+    auto tablet_id = StringParser::string_to_int<int64_t>(file_name.data(), 16, kBase, &res);
+    CHECK_EQ(StringParser::PARSE_SUCCESS, res) << file_name;
+    auto version = StringParser::string_to_int<int64_t>(file_name.data() + 17, 16, kBase, &res);
+    CHECK_EQ(StringParser::PARSE_SUCCESS, res) << file_name;
+    return {tablet_id, version};
+}
+
 // Return value: <tablet id, version, expire time>
 inline std::tuple<int64_t, int64_t, int64_t> parse_tablet_metadata_lock_filename(std::string_view file_name) {
     constexpr static int kBase = 16;

--- a/be/src/storage/lake/vacuum.h
+++ b/be/src/storage/lake/vacuum.h
@@ -24,4 +24,10 @@ void vacuum(TabletManager* tablet_mgr, const VacuumRequest& request, VacuumRespo
 
 void vacuum_full(TabletManager* tablet_mgr, const VacuumFullRequest& request, VacuumFullResponse* response);
 
+// REQUIRES:
+//  - tablet_mgr != NULL
+//  - request.tablet_ids_size() > 0
+//  - response != NULL
+void delete_tablets(TabletManager* tablet_mgr, const DeleteTabletRequest& request, DeleteTabletResponse* response);
+
 } // namespace starrocks::lake

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -370,9 +370,7 @@ TEST_F(LakeServiceTest, test_delete_tablet) {
     _lake_service.delete_tablet(&cntl, &request, &response, nullptr);
     ASSERT_FALSE(cntl.Failed());
     ASSERT_EQ(0, response.failed_tablets_size());
-    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_id));
-    ASSERT_TRUE(tablet.get_schema().status().is_not_found()) << tablet.get_schema().status();
-    ASSERT_TRUE(tablet.get_metadata(1).status().is_not_found()) << tablet.get_metadata(1).status();
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
 }
 
 // NOLINTNEXTLINE
@@ -385,6 +383,7 @@ TEST_F(LakeServiceTest, test_delete_tablet_dir_not_exit) {
     _lake_service.delete_tablet(&cntl, &request, &response, nullptr);
     ASSERT_FALSE(cntl.Failed());
     ASSERT_EQ(0, response.failed_tablets_size());
+    EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
     // restore test directory
     ASSERT_OK(fs::create_directories(kRootLocation));
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/ShardDeleter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/ShardDeleter.java
@@ -119,7 +119,9 @@ public class ShardDeleter extends FrontendDaemon {
 
             // 2. delete shard
             try {
-                starOSAgent.deleteShards(shards);
+                if (!shards.isEmpty()) {
+                    starOSAgent.deleteShards(shards);
+                }
             } catch (DdlException e) {
                 LOG.warn("failed to delete shard from starMgr");
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -57,7 +57,7 @@ public interface LakeService {
     @ProtobufRPC(serviceName = "LakeService", methodName = "compact", onceTalkTimeout = /*6 hours=*/21600000)
     Future<CompactResponse> compact(CompactRequest request);
 
-    @ProtobufRPC(serviceName = "LakeService", methodName = "delete_tablet", onceTalkTimeout = 5000)
+    @ProtobufRPC(serviceName = "LakeService", methodName = "delete_tablet", onceTalkTimeout = /*10 minutes=*/60000)
     Future<DeleteTabletResponse> deleteTablet(DeleteTabletRequest request);
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "delete_data", onceTalkTimeout = 300000)

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -52,6 +52,7 @@ message DeleteTabletRequest {
 
 message DeleteTabletResponse {
     repeated int64 failed_tablets = 1;
+    optional StatusPB status = 2;
 }
 
 message CompactRequest {


### PR DESCRIPTION
After truncate a table, FE will send deleteTablet request, in the previous implementation, deleteTablet processing will only delete the tablet metadata file, this patch not only delete the tablet metadata file but also delete all the data files referenced by the tablets to be deleted.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
