### PR TITLE
[Enhancement] add  statistics to pipeline execution 

### DIFF
--- a/be/src/exec/pipeline/adaptive/lazy_instantiate_drivers_operator.cpp
+++ b/be/src/exec/pipeline/adaptive/lazy_instantiate_drivers_operator.cpp
@@ -120,7 +120,7 @@ void LazyInstantiateDriversOperator::close(RuntimeState* state) {
                     driver->prepare(state);
                 }
                 for (auto& driver : pipeline->drivers()) {
-                    driver->finalize(state, DriverState::FINISH);
+                    driver->finalize(state, DriverState::FINISH, 0, 0);
                 }
             }
         }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -53,6 +53,8 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     _overhead_timer = ADD_TIMER(_runtime_profile, "OverheadTime");
 
     _schedule_timer = ADD_TIMER(_runtime_profile, "ScheduleTime");
+    _global_schedule_counter = ADD_COUNTER(_runtime_profile, "GlobalScheduleCount", TUnit::UNIT);
+    _global_schedule_timer = ADD_TIMER(_runtime_profile, "GlobalScheduleTime");
     _schedule_counter = ADD_COUNTER(_runtime_profile, "ScheduleCount", TUnit::UNIT);
     _yield_by_time_limit_counter = ADD_COUNTER(_runtime_profile, "YieldByTimeLimit", TUnit::UNIT);
     _yield_by_preempt_counter = ADD_COUNTER(_runtime_profile, "YieldByPreempt", TUnit::UNIT);
@@ -433,7 +435,11 @@ void PipelineDriver::mark_precondition_ready(RuntimeState* runtime_state) {
     }
 }
 
-void PipelineDriver::start_timers() {
+void PipelineDriver::start_schedule(int64_t start_count, int64_t start_time) {
+    _global_schedule_counter->set(start_count);
+    _global_schedule_timer->set(start_time);
+
+    // start timers
     _total_timer_sw->start();
     _pending_timer_sw->start();
     _precondition_block_timer_sw->start();
@@ -487,7 +493,19 @@ void PipelineDriver::_adjust_memory_usage(RuntimeState* state, MemTracker* track
     }
 }
 
-void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state) {
+void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state, int64_t schedule_count,
+                              int64_t execution_time) {
+    if (schedule_count > 0) {
+        _global_schedule_counter->set(schedule_count - _global_schedule_counter->value());
+    } else {
+        _global_schedule_counter->set((int64_t)-1);
+    }
+    if (execution_time > 0) {
+        _global_schedule_timer->set(execution_time - _global_schedule_timer->value());
+    } else {
+        _global_schedule_timer->set((int64_t)-1);
+    }
+
     int64_t time_spent = 0;
     // The driver may be destructed after finalizing, so use a temporal driver to record
     // the information about the driver queue and workgroup.

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -31,6 +31,7 @@
 #include "runtime/runtime_state.h"
 #include "util/debug/query_trace.h"
 #include "util/defer_op.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks::pipeline {
 
@@ -335,6 +336,9 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                     new_first_unfinished = i + 1;
                     continue;
                 }
+            }
+            if (time_spent >= OVERLOADED_MAX_TIME_SPEND_NS) {
+                StarRocksMetrics::instance()->pipe_driver_overloaded.increment(1);
             }
             // yield when total chunks moved or time spent on-core for evaluation
             // exceed the designated thresholds.

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -451,6 +451,8 @@ protected:
     // Yield PipelineDriver when maximum time in nano-seconds has spent in current execution round,
     // if it runs in the worker thread owned by other workgroup, which has running drivers.
     static constexpr int64_t YIELD_PREEMPT_MAX_TIME_SPENT_NS = 5'000'000L;
+    // Execution time exceed this is considered overloaded
+    static constexpr int64_t OVERLOADED_MAX_TIME_SPEND_NS = 150'000'000L;
 
     // check whether fragment is cancelled. It is used before pull_chunk and push_chunk.
     bool _check_fragment_is_canceled(RuntimeState* runtime_state);

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -23,6 +23,7 @@
 #include "util/debug/query_trace.h"
 #include "util/defer_op.h"
 #include "util/stack_util.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks::pipeline {
 
@@ -33,36 +34,19 @@ GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_
                                               : std::make_unique<QuerySharedDriverQueue>()),
           _thread_pool(std::move(thread_pool)),
           _blocked_driver_poller(new PipelineDriverPoller(_driver_queue.get())),
-          _exec_state_reporter(new ExecStateReporter()) {}
+          _exec_state_reporter(new ExecStateReporter()) {
+    REGISTER_GAUGE_STARROCKS_METRIC(pipe_driver_schedule_count, [this]() { return _schedule_count.load(); });
+    REGISTER_GAUGE_STARROCKS_METRIC(pipe_driver_execution_time, [this]() { return _driver_execution_ns.load(); });
+    REGISTER_GAUGE_STARROCKS_METRIC(pipe_driver_queue_len, [this]() { return _driver_queue->size(); });
+    REGISTER_GAUGE_STARROCKS_METRIC(pipe_poller_block_queue_len,
+                                    [this]() { return _blocked_driver_poller->blocked_driver_queue_len(); });
+}
 
 GlobalDriverExecutor::~GlobalDriverExecutor() {
-    {
-        // unregist hook
-        auto metrics = StarRocksMetrics::instance()->metrics();
-        metrics->deregister_hook("driver_queue_len");
-        metrics->deregister_hook("poller_block_queue_len");
-        _driver_queue_len.reset();
-        _driver_poller_block_queue_len.reset();
-    }
     _driver_queue->close();
 }
 
 void GlobalDriverExecutor::initialize(int num_threads) {
-    {
-        // regist pipeline metrics
-        auto metrics = StarRocksMetrics::instance()->metrics();
-        auto regist_metric = [this, metrics](const std::string& metric_name, std::unique_ptr<UIntGauge>& metric,
-                                             const std::function<unsigned long()>& provider) {
-            std::string full_name = _name + "_" + metric_name;
-            metric = std::make_unique<UIntGauge>(MetricUnit::NOUNIT);
-            metrics->register_metric(full_name, metric.get());
-            metrics->register_hook(full_name, [&metric, provider]() { metric->set_value(provider()); });
-        };
-        regist_metric("driver_queue_len", _driver_queue_len, [this]() { return _driver_queue->size(); });
-        regist_metric("poller_block_queue_len", _driver_poller_block_queue_len,
-                      [this]() { return _blocked_driver_poller->blocked_driver_queue_len(); });
-    }
-
     _blocked_driver_poller->start();
     _num_threads_setter.set_actual_num(num_threads);
     for (auto i = 0; i < num_threads; ++i) {
@@ -82,7 +66,7 @@ void GlobalDriverExecutor::change_num_threads(int32_t num_threads) {
 
 void GlobalDriverExecutor::_finalize_driver(DriverRawPtr driver, RuntimeState* runtime_state, DriverState state) {
     DCHECK(driver);
-    driver->finalize(runtime_state, state);
+    driver->finalize(runtime_state, state, _schedule_count, _driver_execution_ns);
 }
 
 void GlobalDriverExecutor::_worker_thread() {
@@ -118,6 +102,7 @@ void GlobalDriverExecutor::_worker_thread() {
         auto* fragment_ctx = driver->fragment_ctx();
 
         driver->increment_schedule_times();
+        _schedule_count++;
 
         SCOPED_SET_TRACE_INFO(driver->driver_id(), query_ctx->query_id(), fragment_ctx->fragment_instance_id());
 
@@ -148,6 +133,7 @@ void GlobalDriverExecutor::_worker_thread() {
                 continue;
             }
             StatusOr<DriverState> maybe_state;
+            int64_t start_time = driver->get_active_time();
 #ifdef NDEBUG
             TRY_CATCH_ALL(maybe_state, driver->process(runtime_state, worker_id));
 #else
@@ -158,6 +144,8 @@ void GlobalDriverExecutor::_worker_thread() {
             }
             Status status = maybe_state.status();
             this->_driver_queue->update_statistics(driver);
+            int64_t end_time = driver->get_active_time();
+            _driver_execution_ns += end_time - start_time;
 
             // Check big query
             if (!driver->is_query_never_expired() && status.ok() && driver->workgroup()) {
@@ -246,7 +234,7 @@ StatusOr<DriverRawPtr> GlobalDriverExecutor::_get_next_driver(std::queue<DriverR
 }
 
 void GlobalDriverExecutor::submit(DriverRawPtr driver) {
-    driver->start_timers();
+    driver->start_schedule(_schedule_count, _driver_execution_ns);
 
     if (driver->is_precondition_block()) {
         driver->set_driver_state(DriverState::PRECONDITION_BLOCK);

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -103,6 +103,8 @@ private:
     std::unique_ptr<ExecStateReporter> _exec_state_reporter;
 
     std::atomic<int> _next_id = 0;
+    std::atomic_int64_t _schedule_count = 0;
+    std::atomic_int64_t _driver_execution_ns = 0;
 
     // metrics
     std::unique_ptr<UIntGauge> _driver_queue_len;

--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -15,11 +15,14 @@
 #include "exec/workgroup/scan_executor.h"
 
 #include "exec/workgroup/scan_task_queue.h"
+#include "util/starrocks_metrics.h"
 
 namespace starrocks::workgroup {
 
 ScanExecutor::ScanExecutor(std::unique_ptr<ThreadPool> thread_pool, std::unique_ptr<ScanTaskQueue> task_queue)
-        : _task_queue(std::move(task_queue)), _thread_pool(std::move(thread_pool)) {}
+        : _task_queue(std::move(task_queue)), _thread_pool(std::move(thread_pool)) {
+    REGISTER_GAUGE_STARROCKS_METRIC(pipe_scan_executor_queuing, [this]() { return _task_queue->size(); });
+}
 
 ScanExecutor::~ScanExecutor() {
     _task_queue->close();

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -72,14 +72,19 @@ public:
     // query execution
     METRIC_DEFINE_INT_GAUGE(pipe_scan_executor_queuing, MetricUnit::NOUNIT);
     METRIC_DEFINE_INT_GAUGE(pipe_driver_overloaded, MetricUnit::NOUNIT);
+    METRIC_DEFINE_INT_GAUGE(pipe_driver_schedule_count, MetricUnit::NOUNIT);
+    METRIC_DEFINE_INT_GAUGE(pipe_driver_execution_time, MetricUnit::NANOSECONDS);
+    METRIC_DEFINE_INT_GAUGE(pipe_driver_queue_len, MetricUnit::NOUNIT);
+    METRIC_DEFINE_INT_GAUGE(pipe_poller_block_queue_len, MetricUnit::NOUNIT);
+    METRIC_DEFINE_INT_GAUGE(query_scan_bytes_per_second, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_COUNTER(query_scan_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_COUNTER(query_scan_rows, MetricUnit::ROWS);
 
     // counters
     METRIC_DEFINE_INT_COUNTER(fragment_requests_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(fragment_request_duration_us, MetricUnit::MICROSECONDS);
     METRIC_DEFINE_INT_COUNTER(http_requests_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(http_request_send_bytes, MetricUnit::BYTES);
-    METRIC_DEFINE_INT_COUNTER(query_scan_bytes, MetricUnit::BYTES);
-    METRIC_DEFINE_INT_COUNTER(query_scan_rows, MetricUnit::ROWS);
     METRIC_DEFINE_INT_COUNTER(push_requests_success_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(push_requests_fail_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(push_request_duration_us, MetricUnit::MICROSECONDS);
@@ -204,7 +209,6 @@ public:
     // The following metrics will be calculated
     // by metric calculator
     METRIC_DEFINE_INT_GAUGE(push_request_write_bytes_per_second, MetricUnit::BYTES);
-    METRIC_DEFINE_INT_GAUGE(query_scan_bytes_per_second, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(max_disk_io_util_percent, MetricUnit::PERCENT);
     METRIC_DEFINE_INT_GAUGE(max_network_send_bytes_rate, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(max_network_receive_bytes_rate, MetricUnit::BYTES);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -69,6 +69,9 @@ private:
 
 class StarRocksMetrics {
 public:
+    // query execution
+    METRIC_DEFINE_INT_GAUGE(pipe_scan_executor_queuing, MetricUnit::NOUNIT);
+
     // counters
     METRIC_DEFINE_INT_COUNTER(fragment_requests_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(fragment_request_duration_us, MetricUnit::MICROSECONDS);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -71,6 +71,7 @@ class StarRocksMetrics {
 public:
     // query execution
     METRIC_DEFINE_INT_GAUGE(pipe_scan_executor_queuing, MetricUnit::NOUNIT);
+    METRIC_DEFINE_INT_GAUGE(pipe_driver_overloaded, MetricUnit::NOUNIT);
 
     // counters
     METRIC_DEFINE_INT_COUNTER(fragment_requests_total, MetricUnit::REQUESTS);


### PR DESCRIPTION
Fixes #issue

Add several counter to diagnose concurrent query performance.


Profile metric:
- `GlobalScheduleCount`: the global counter during the pipeline lifecycle
- `GlobalScheduleTime`: the global execution timer during the pipeline lifecycle

System metric:
- `pipe_driver_execution_time`: accumulated value of driver execution
- `pipe_driver_schedule_count`: accumulated value of driver schedule count
- `pipe_scan_executor_queuing`: current value of ScanExecutor queue length


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
