### PR TITLE
[BugFix] fix memory usage issue of spillable hash join

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -70,8 +70,20 @@ bool SpillableHashJoinBuildOperator::need_input() const {
 Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
     auto defer_set_finishing = DeferOp([this]() { _join_builder->spill_channel()->set_finishing(); });
 
-    if (!_join_builder->spiller()->spilled()) {
+    if (spill_strategy() == spill::SpillStrategy::NO_SPILL) {
         return HashJoinBuildOperator::set_finishing(state);
+    }
+
+    // if this operator is changed to spill mode just before set_finishing,
+    // we should create spill task
+    if (!_join_builder->spiller()->spilled()) {
+        DCHECK(_is_first_time_spill);
+        _is_first_time_spill = false;
+        auto& ht = _join_builder->hash_join_builder()->hash_table();
+        RETURN_IF_ERROR(init_spiller_partitions(ht));
+
+        _hash_table_slice_iterator = _convert_hash_map_to_chunk();
+        RETURN_IF_ERROR(_join_builder->append_spill_task(state, _hash_table_slice_iterator));
     }
 
     if (state->is_cancelled()) {
@@ -141,6 +153,15 @@ Status SpillableHashJoinBuildOperator::append_hash_columns(const ChunkPtr& chunk
     return Status::OK();
 }
 
+Status SpillableHashJoinBuildOperator::init_spiller_partitions(JoinHashTable& ht) {
+    if (ht.get_row_count() > 0) {
+        // We estimate the size of the hash table to be twice the size of the already input hash table
+        auto num_partitions = ht.mem_usage() * 2 / _join_builder->spiller()->options().spill_mem_table_bytes_size;
+        RETURN_IF_ERROR(_join_builder->spiller()->set_partition(state, num_partitions));
+    }
+    return Status::OK();
+}
+
 bool SpillableHashJoinBuildOperator::is_finished() const {
     return _is_finished || _join_builder->is_finished();
 }
@@ -159,10 +180,8 @@ Status SpillableHashJoinBuildOperator::push_chunk(RuntimeState* state, const Chu
 
     auto& ht = _join_builder->hash_join_builder()->hash_table();
     // Estimate the appropriate number of partitions
-    if (_is_first_time_spill && ht.get_row_count() > 0) {
-        // We estimate the size of the hash table to be twice the size of the already input hash table
-        auto num_partitions = ht.mem_usage() * 2 / _join_builder->spiller()->options().spill_mem_table_bytes_size;
-        RETURN_IF_ERROR(_join_builder->spiller()->set_partition(state, num_partitions));
+    if (_is_first_time_spill) {
+        RETURN_IF_ERROR(init_spiller_partitions(ht));
     }
 
     ASSIGN_OR_RETURN(auto spill_chunk, ht.convert_to_spill_schema(chunk));

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -70,7 +70,9 @@ bool SpillableHashJoinBuildOperator::need_input() const {
 Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
     auto defer_set_finishing = DeferOp([this]() { _join_builder->spill_channel()->set_finishing(); });
 
-    if (spill_strategy() == spill::SpillStrategy::NO_SPILL) {
+    if (spill_strategy() == spill::SpillStrategy::NO_SPILL ||
+        (!_join_builder->spiller()->spilled() &&
+         _join_builder->hash_join_builder()->hash_table().get_row_count() == 0)) {
         return HashJoinBuildOperator::set_finishing(state);
     }
 

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -76,6 +76,7 @@ Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
         return HashJoinBuildOperator::set_finishing(state);
     }
 
+    DCHECK(spill_strategy() == spill::SpillStrategy::SPILL_ALL);
     // if this operator is changed to spill mode just before set_finishing,
     // we should create spill task
     if (!_join_builder->spiller()->spilled()) {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
@@ -61,6 +61,8 @@ private:
 
     Status append_hash_columns(const ChunkPtr& chunk);
 
+    Status init_spiller_partitions(JoinHashTable& ht);
+
     ChunkSharedSlice _hash_table_build_chunk_slice;
     std::function<StatusOr<ChunkPtr>()> _hash_table_slice_iterator;
     bool _is_first_time_spill = true;

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.h
@@ -61,7 +61,7 @@ private:
 
     Status append_hash_columns(const ChunkPtr& chunk);
 
-    Status init_spiller_partitions(JoinHashTable& ht);
+    Status init_spiller_partitions(RuntimeState* state, JoinHashTable& ht);
 
     ChunkSharedSlice _hash_table_build_chunk_slice;
     std::function<StatusOr<ChunkPtr>()> _hash_table_slice_iterator;

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -461,7 +461,6 @@ void SpillableHashJoinProbeOperator::_acquire_next_partitions() {
             }
         }
     }
-
     _component_pool.clear();
     size_t process_partition_nums = _processing_partitions.size();
     _probers.resize(process_partition_nums);

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -260,6 +260,79 @@ void PartitionedSpillerWriter::_remove_partition(const SpilledPartition* partiti
     }
 }
 
+Status PartitionedSpillerWriter::_choose_partitions_to_flush(bool is_final_flush,
+                                                             std::vector<SpilledPartition*>& partitions_need_split,
+                                                             std::vector<SpilledPartition*>& partitions_need_flush) {
+    if (options().splittable) {
+        for (const auto& [pid, partition] : _id_to_partitions) {
+            const auto& mem_table = partition->spill_writer->mem_table();
+            // partition not in memory
+            if (!partition->in_mem && partition->level < max_partition_level &&
+                mem_table->mem_usage() + partition->bytes > options().spill_mem_table_bytes_size) {
+                RETURN_IF_ERROR(mem_table->done());
+                partition->in_mem = false;
+                partition->mem_size = 0;
+                partition->bytes += mem_table->mem_usage();
+                partition->is_spliting = true;
+                partitions_need_split.emplace_back(partition);
+            }
+        }
+    }
+
+    std::vector<SpilledPartition*> partitions_can_flush;
+    for (const auto& [pid, partition] : _id_to_partitions) {
+        const auto& mem_table = partition->spill_writer->mem_table();
+        if (partition->is_spliting) {
+            continue;
+        }
+        if (mem_table->is_full()) {
+            partition->in_mem = false;
+            partition->mem_size = 0;
+            partitions_need_flush.emplace_back(partition);
+        } else {
+            partitions_can_flush.emplace_back(partition);
+        }
+    }
+
+    if (!is_final_flush && !partitions_need_flush.empty()) {
+        return Status::OK();
+    }
+
+    if (is_final_flush) {
+        // order by bytes desc
+        std::sort(partitions_can_flush.begin(), partitions_can_flush.end(),
+                  [](SpilledPartition* left, SpilledPartition* right) { return left->bytes > right->bytes; });
+        size_t in_mem_bytes = 0;
+        for (auto partition : partitions_can_flush) {
+            if (in_mem_bytes + partition->bytes > options().spill_mem_table_bytes_size) {
+                partition->in_mem = false;
+                partition->mem_size = 0;
+                partitions_need_flush.emplace_back(partition);
+                continue;
+            }
+            in_mem_bytes += partition->bytes;
+        }
+    } else {
+        // order by mem usage desc
+        std::sort(partitions_can_flush.begin(), partitions_can_flush.end(),
+                  [](SpilledPartition* left, SpilledPartition* right) {
+                      return left->spill_writer->mem_table()->mem_usage() >
+                             right->spill_writer->mem_table()->mem_usage();
+                  });
+        size_t accumulate_spill_bytes = 0;
+        for (auto partition : partitions_can_flush) {
+            accumulate_spill_bytes += partition->spill_writer->mem_table()->mem_usage();
+            partition->in_mem = false;
+            partition->mem_size = 0;
+            partitions_need_flush.emplace_back(partition);
+            if (accumulate_spill_bytes > _mem_tracker->consumption() / 2) {
+                break;
+            }
+        }
+    }
+    return Status::OK();
+}
+
 // make shuffle public
 void PartitionedSpillerWriter::shuffle(std::vector<uint32_t>& dst, const SpillHashColumn* hash_column) {
     const auto& hashs = hash_column->get_data();

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -86,7 +86,7 @@ template <class TaskExecutor, class MemGuard>
 Status Spiller::flush(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
     RETURN_IF_ERROR(task_status());
     if (_opts.init_partition_nums > 0) {
-        return _writer->as<PartitionedSpillerWriter*>()->flush(state, executor, guard);
+        return _writer->as<PartitionedSpillerWriter*>()->flush(state, true, executor, guard);
     } else {
         return _writer->as<RawSpillerWriter*>()->flush(state, executor, guard);
     }
@@ -251,7 +251,7 @@ Status PartitionedSpillerWriter::spill(RuntimeState* state, const ChunkPtr& chun
 template <class TaskExecutor, class MemGuard>
 Status PartitionedSpillerWriter::flush_if_full(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
     if (_mem_tracker->consumption() > options().spill_mem_table_bytes_size) {
-        return flush(state, executor, guard);
+        return flush(state, false, executor, guard);
     }
     return Status::OK();
 }
@@ -421,63 +421,10 @@ Status PartitionedSpillerWriter::_split_partition(SerdeContext& spill_ctx, Spill
 }
 
 template <class TaskExecutor, class MemGuard>
-Status PartitionedSpillerWriter::flush(RuntimeState* state, TaskExecutor&& executor, MemGuard&& guard) {
-    // check need split partition
-    std::vector<SpilledPartition*> splitting_partitions;
-    if (options().splittable) {
-        for (const auto& [pid, partition] : _id_to_partitions) {
-            const auto& mem_table = partition->spill_writer->mem_table();
-            // partition not in memory
-            if (!partition->in_mem && partition->level < max_partition_level &&
-                mem_table->mem_usage() + partition->bytes > options().spill_mem_table_bytes_size) {
-                RETURN_IF_ERROR(mem_table->done());
-                partition->in_mem = false;
-                partition->mem_size = 0;
-                partition->bytes += mem_table->mem_usage();
-                partition->is_spliting = true;
-                splitting_partitions.emplace_back(partition);
-            }
-        }
-    }
-
-    //
-    std::vector<SpilledPartition*> spilling_partitions;
-    for (const auto& [pid, partition] : _id_to_partitions) {
-        const auto& mem_table = partition->spill_writer->mem_table();
-        if (!partition->is_spliting && (mem_table->is_full() || mem_table->mem_usage() > options().min_spilled_size)) {
-            RETURN_IF_ERROR(mem_table->done());
-            partition->in_mem = false;
-            partition->mem_size = 0;
-            spilling_partitions.emplace_back(partition);
-        }
-    }
-
-    // all of the partition is the small partition
-    if (spilling_partitions.empty()) {
-        // select partition
-        std::vector<SpilledPartition*> all_spillable_partitions;
-        for (const auto& [pid, partition] : _id_to_partitions) {
-            if (!partition->is_spliting) {
-                all_spillable_partitions.emplace_back(partition);
-            }
-        }
-
-        // order by mem_usage desc
-        std::sort(all_spillable_partitions.begin(), all_spillable_partitions.end(),
-                  [](SpilledPartition* left, SpilledPartition* right) {
-                      return left->spill_writer->mem_table()->mem_usage() >
-                             left->spill_writer->mem_table()->mem_usage();
-                  });
-        // select partitions to spill util half of mem_table
-        size_t accumulate_spill_bytes = 0;
-        for (auto partition : all_spillable_partitions) {
-            accumulate_spill_bytes += partition->spill_writer->mem_table()->mem_usage();
-            spilling_partitions.emplace_back(partition);
-            if (accumulate_spill_bytes > _mem_tracker->consumption() / 2) {
-                break;
-            }
-        }
-    }
+Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush, TaskExecutor&& executor,
+                                       MemGuard&& guard) {
+    std::vector<SpilledPartition*> splitting_partitions, spilling_partitions;
+    RETURN_IF_ERROR(_choose_partitions_to_flush(is_final_flush, splitting_partitions, spilling_partitions));
 
     if (spilling_partitions.empty() && splitting_partitions.empty()) {
         return Status::OK();


### PR DESCRIPTION

fix two memory usage issues of spillable hash join operator: 

1. if hash join build operator change to spill mode just before set_finishing phase, current implementation didn't handle it correctly and still execute as non-spill mode, here I fix it
2. in hash join probe side, it will load all in-memory partitions first, but in build side, it doesn't consider the total partition bytes during flush, this may lead to uncontrollable memory usage when the probe loads the partition. here I added a strategy to ensure that the partition resident in memory is not too large after the final flush.


after applying this change, tpc-ds Q29 can run successfully under 1T scale with 20G query_mem_limit in one 16c BE instance.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
