### PR TITLE
[Enhancement][CherryPick] optimize mv union rewrite for 3.0 (#25679)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Table;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.mv.JoinDeriveContext;
@@ -45,6 +46,8 @@ public class MvRewriteContext {
     private ScalarOperator mvPruneConjunct;
 
     private final List<ScalarOperator> onPredicates;
+    private List<ColumnRefOperator> enforcedColumns;
+
     private List<JoinDeriveContext> joinDeriveContexts;
 
     public MvRewriteContext(
@@ -116,5 +119,13 @@ public class MvRewriteContext {
 
     public List<JoinDeriveContext> getJoinDeriveContexts() {
         return joinDeriveContexts;
+    }
+
+    public List<ColumnRefOperator> getEnforcedColumns() {
+        return enforcedColumns;
+    }
+
+    public void setEnforcedColumns(List<ColumnRefOperator> enforcedColumns) {
+        this.enforcedColumns = enforcedColumns;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -96,6 +96,10 @@ public final class ColumnRefOperator extends ScalarOperator {
         return new ColumnRefSet(id);
     }
 
+    @Override
+    public void getColumnRefs(List<ColumnRefOperator> columns) {
+        columns.add(this);
+    }
 
     @Override
     public String toString() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -158,6 +158,18 @@ public abstract class ScalarOperator implements Cloneable {
      */
     public abstract ColumnRefSet getUsedColumns();
 
+    public List<ColumnRefOperator> getColumnRefs() {
+        List<ColumnRefOperator> columns = Lists.newArrayList();
+        getColumnRefs(columns);
+        return columns;
+    }
+
+    public void getColumnRefs(List<ColumnRefOperator> columns) {
+        for (ScalarOperator child : getChildren()) {
+            child.getColumnRefs(columns);
+        }
+    }
+
     public String debugString() {
         return toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnEnforcer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnEnforcer.java
@@ -1,0 +1,115 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import autovalue.shaded.com.google.common.common.collect.Lists;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+import java.util.List;
+import java.util.Map;
+
+// Add columnsToEnforce into LogicalScanOperator's colRefToColumnMetaMap.
+// enforce() will return a new OptExpression based on old OptExpression insteading of
+// modifying it locally.
+public class ColumnEnforcer {
+    private OptExpression optExpression;
+    private List<ColumnRefOperator> columnsToEnforce;
+    private EnforceContext enforceContext;
+
+    public ColumnEnforcer(
+            OptExpression optExpression, List<ColumnRefOperator> columnsToEnforce) {
+        this.optExpression = optExpression;
+        this.columnsToEnforce = columnsToEnforce;
+        this.enforceContext = new EnforceContext();
+    }
+
+    public OptExpression enforce() {
+        ColumnEnforcerVisitor visitor = new ColumnEnforcerVisitor();
+        OptExpression rootOptExpression = optExpression.getOp().accept(visitor, optExpression, enforceContext);
+        return rootOptExpression;
+    }
+
+    public List<ColumnRefOperator> getEnforcedColumns() {
+        return enforceContext.enforcedColumns;
+    }
+
+    private class EnforceContext {
+        public List<ColumnRefOperator> enforcedColumns;
+
+        public EnforceContext() {
+            this.enforcedColumns = Lists.newArrayList();
+        }
+    }
+
+    private class ColumnEnforcerVisitor extends OptExpressionVisitor<OptExpression, EnforceContext> {
+        @Override
+        public OptExpression visitLogicalTableScan(OptExpression optExpression, EnforceContext context) {
+            LogicalScanOperator scanOperator = optExpression.getOp().cast();
+            Operator.Builder builder = OperatorBuilderFactory.build(scanOperator);
+            builder.withOperator(scanOperator);
+            Map<ColumnRefOperator, Column> columnRefOperatorColumnMap = Maps.newHashMap(scanOperator.getColRefToColumnMetaMap());
+            for (ColumnRefOperator columnRef : columnsToEnforce) {
+                for (Map.Entry<Column, ColumnRefOperator> entry : scanOperator.getColumnMetaToColRefMap().entrySet()) {
+                    if (entry.getValue().equals(columnRef)) {
+                        columnRefOperatorColumnMap.put(columnRef, entry.getKey());
+                        context.enforcedColumns.add(columnRef);
+                    }
+                }
+            }
+            LogicalScanOperator.Builder scanBuilder = (LogicalScanOperator.Builder) builder;
+            scanBuilder.setColRefToColumnMetaMap(ImmutableMap.copyOf(columnRefOperatorColumnMap));
+            OptExpression newScan = new OptExpression(scanBuilder.build());
+            newScan.deriveLogicalPropertyItself();
+            return newScan;
+        }
+
+        @Override
+        public OptExpression visit(OptExpression optExpression, EnforceContext context) {
+            List<OptExpression> inputs = Lists.newArrayList();
+            EnforceContext localContext = new EnforceContext();
+            for (OptExpression child : optExpression.getInputs()) {
+                inputs.add(child.getOp().accept(this, child, localContext));
+            }
+
+            LogicalOperator.Builder builder = OperatorBuilderFactory.build(optExpression.getOp());
+            builder.withOperator(optExpression.getOp());
+
+            if (optExpression.getOp().getProjection() != null) {
+                Map<ColumnRefOperator, ScalarOperator> columnRefMap =
+                        Maps.newHashMap(optExpression.getOp().getProjection().getColumnRefMap());
+                for (ColumnRefOperator columnRef : localContext.enforcedColumns) {
+                    columnRefMap.put(columnRef, columnRef);
+                }
+                builder.setProjection(new Projection(columnRefMap));
+            }
+            OptExpression newOptExpression = OptExpression.create(builder.build(), inputs);
+            context.enforcedColumns.addAll(localContext.enforcedColumns);
+            newOptExpression.deriveLogicalPropertyItself();
+            return newOptExpression;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1273,7 +1273,7 @@ public class MaterializedViewRewriter {
         EquationRewriter queryExprToMvExprRewriter =
                 buildEquationRewriter(mvColumnRefToScalarOp, rewriteContext, isMVBased, true, useEc);
         List<ScalarOperator> candidates = rewriteScalarOpToTarget(rewrittenConjuncts, queryExprToMvExprRewriter,
-                rewriteContext.getOutputMapping(), new ColumnRefSet(rewriteContext.getQueryColumnSet()));
+                rewriteContext.getOutputMapping(), new ColumnRefSet(rewriteContext.getQueryColumnSet()), false, null);
         if (candidates == null || candidates.isEmpty()) {
             return null;
         }
@@ -1323,27 +1323,38 @@ public class MaterializedViewRewriter {
         ScalarOperator mvOtherPreds = MvUtils.canonizePredicate(Utils.compoundAnd(
                 mvCompensationToQuery.getRangePredicates(),
                 mvCompensationToQuery.getResidualPredicates()));
+        List<ScalarOperator> rewrittenFailedPredicates = Lists.newArrayList();
+        OptExpression queryExpression = rewriteContext.getQueryExpression();
         if (!ConstantOperator.TRUE.equals(mvEqualPreds)) {
             mvEqualPreds = columnRewriter.rewriteViewToQueryWithQueryEc(mvEqualPreds);
-            mvEqualPreds =
-                    rewriteScalarOperatorToTarget(mvEqualPreds, queryExprMap, rewriteContext, mvToQueryRefSet, true);
+            mvEqualPreds = rewriteScalarOperatorToTarget(
+                    mvEqualPreds, queryExprMap, rewriteContext, mvToQueryRefSet, true, true, rewrittenFailedPredicates);
         }
         if (!ConstantOperator.TRUE.equals(mvOtherPreds)) {
             mvOtherPreds = columnRewriter.rewriteViewToQueryWithViewEc(mvOtherPreds);
-            mvOtherPreds =
-                    rewriteScalarOperatorToTarget(mvOtherPreds, queryExprMap, rewriteContext, mvToQueryRefSet, false);
+            mvOtherPreds = rewriteScalarOperatorToTarget(
+                    mvOtherPreds, queryExprMap, rewriteContext, mvToQueryRefSet, false, true, rewrittenFailedPredicates);
         }
-        if (mvEqualPreds == null || mvOtherPreds == null) {
+        ScalarOperator mvCompensationPredicates = Utils.compoundAnd(mvEqualPreds, mvOtherPreds);
+        if (!rewrittenFailedPredicates.isEmpty()) {
+            Pair<ScalarOperator, OptExpression> rewrittenPair = tryRewritePredicates(rewriteContext, mvToQueryRefSet,
+                    rewriteContext.getQueryExpression(), rewriteContext.getQueryRefFactory(), rewrittenFailedPredicates);
+            if (rewrittenPair == null) {
+                return null;
+            }
+            mvCompensationPredicates = Utils.compoundAnd(mvCompensationPredicates, rewrittenPair.first);
+            queryExpression = rewrittenPair.second;
+        }
+
+        if (mvCompensationPredicates == null) {
             return null;
         }
-        final ScalarOperator mvCompensationPredicates = Utils.compoundAnd(mvEqualPreds, mvOtherPreds);
 
         // for mv: select a, b from t where a < 10;
         // query: select a, b from t where a < 20;
         // queryBasedRewrite will return the tree of "select a, b from t where a >= 10 and a < 20"
         // which is realized by adding the compensation predicate to original query expression
-        final OptExpression queryInput = queryBasedRewrite(rewriteContext,
-                mvCompensationPredicates, mvRewriteContext.getQueryExpression());
+        final OptExpression queryInput = queryBasedRewrite(rewriteContext, mvCompensationPredicates, queryExpression);
         if (queryInput == null) {
             return null;
         }
@@ -1361,18 +1372,62 @@ public class MaterializedViewRewriter {
         return createUnion(queryInput, viewInput, rewriteContext);
     }
 
+    // retry to rewrite the rewritten failed predicates by enforcing the columns not exists in query
+    private Pair<ScalarOperator, OptExpression> tryRewritePredicates(
+            RewriteContext rewriteContext,
+            ColumnRefSet mvToQueryRefSet,
+            OptExpression query,
+            ColumnRefFactory queryRefFactory,
+            List<ScalarOperator> predicatesToEnforce) {
+        List<ColumnRefOperator> columns = Lists.newArrayList();
+        for (ScalarOperator predicate : predicatesToEnforce) {
+            predicate.getColumnRefs(columns);
+        }
+        // check every columns to enforce should be in the Scan Operator
+        for (ColumnRefOperator column : columns) {
+            if (queryRefFactory.getRelationId(column.getId()) == -1) {
+                return null;
+            }
+        }
+        ColumnEnforcer columnEnforcer = new ColumnEnforcer(query, columns);
+        OptExpression newQuery = columnEnforcer.enforce();
+        mvRewriteContext.setEnforcedColumns(columnEnforcer.getEnforcedColumns());
+
+        final List<LogicalScanOperator> queryScanOps = MvUtils.getScanOperator(newQuery);
+        final List<ColumnRefOperator> queryScanOutputColRefs = queryScanOps.stream()
+                .map(scan -> scan.getOutputColumns())
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+
+        mvToQueryRefSet.except(queryScanOutputColRefs);
+
+        OptExpression expr = newQuery.getOp() instanceof LogicalAggregationOperator ? newQuery.inputAt(0) : newQuery;
+        final Map<ColumnRefOperator, ScalarOperator> queryExprMap =
+                MvUtils.getColumnRefMap(expr, rewriteContext.getQueryRefFactory());
+
+        ScalarOperator newPredicate = rewriteScalarOperatorToTarget(Utils.compoundAnd(predicatesToEnforce), queryExprMap,
+                rewriteContext, mvToQueryRefSet, false, false, null);
+        if (newPredicate == null) {
+            return null;
+        }
+        return new Pair<>(newPredicate, newQuery);
+    }
+
+
     private ScalarOperator rewriteScalarOperatorToTarget(
             ScalarOperator predicate,
             Map<ColumnRefOperator, ScalarOperator> exprMap,
             RewriteContext rewriteContext,
             ColumnRefSet originalRefSet,
-            boolean isEqual) {
+            boolean isEqual,
+            boolean isUnion,
+            List<ScalarOperator> rewrittenFailedPredciates) {
         final EquationRewriter equationRewriter = isEqual ?
                 buildEquationRewriter(exprMap, rewriteContext, false, false) :
                 buildEquationRewriter(exprMap, rewriteContext, true, false);
         final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
         final List<ScalarOperator> rewrittens =
-                rewriteScalarOpToTarget(conjuncts, equationRewriter, null, originalRefSet);
+                rewriteScalarOpToTarget(conjuncts, equationRewriter, null, originalRefSet, isUnion, rewrittenFailedPredciates);
         if (rewrittens == null || rewrittens.isEmpty()) {
             return null;
         }
@@ -1405,10 +1460,48 @@ public class MaterializedViewRewriter {
 
             OptExpression newQueryExpr = pushdownPredicatesForJoin(queryExpression, queryCompensationPredicate);
             deriveLogicalProperty(newQueryExpr);
+            if (mvRewriteContext.getEnforcedColumns() != null && !mvRewriteContext.getEnforcedColumns().isEmpty()) {
+                newQueryExpr = pruneEnforcedColumns(newQueryExpr);
+                deriveLogicalProperty(newQueryExpr);
+            }
             return newQueryExpr;
 
         }
         return null;
+    }
+
+    private OptExpression pruneEnforcedColumns(OptExpression queryExpr) {
+        List<OptExpression> newInputs = Lists.newArrayList();
+        for (OptExpression input : queryExpr.getInputs()) {
+            OptExpression newInput = pruneEnforcedColumns(input);
+            newInputs.add(newInput);
+        }
+        Operator newOp = doPruneEnforcedColumns(queryExpr);
+        return OptExpression.create(newOp, newInputs);
+    }
+
+    private Operator doPruneEnforcedColumns(OptExpression queryExpr) {
+        Map<ColumnRefOperator, ScalarOperator> newColumnRefMap = Maps.newHashMap();
+        if (queryExpr.getOp().getProjection() != null) {
+            Map<ColumnRefOperator, ScalarOperator> columnRefMap = queryExpr.getOp().getProjection().getColumnRefMap();
+            for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : columnRefMap.entrySet()) {
+                if (mvRewriteContext.getEnforcedColumns().contains(entry.getKey())) {
+                    continue;
+                }
+                newColumnRefMap.put(entry.getKey(), entry.getValue());
+            }
+        } else {
+            List<ColumnRefOperator> outputColumns =
+                    queryExpr.getOutputColumns().getColumnRefOperators(materializationContext.getQueryRefFactory());
+            outputColumns = outputColumns.stream()
+                    .filter(column -> !mvRewriteContext.getEnforcedColumns().contains(column)).collect(Collectors.toList());
+            outputColumns.stream().forEach(column -> newColumnRefMap.put(column, column));
+        }
+        Projection newProjection = new Projection(newColumnRefMap);
+        Operator.Builder builder = OperatorBuilderFactory.build(queryExpr.getOp());
+        builder.withOperator(queryExpr.getOp());
+        builder.setProjection(newProjection);
+        return builder.build();
     }
 
     // pushdown predicates on join nodes
@@ -1798,18 +1891,28 @@ public class MaterializedViewRewriter {
         return mvOptExpr;
     }
 
-    protected List<ScalarOperator> rewriteScalarOpToTarget(List<ScalarOperator> exprsToRewrites,
-                                                           EquationRewriter queryExprToMvExprRewriter,
-                                                           Map<ColumnRefOperator, ColumnRefOperator> outputMapping,
-                                                           ColumnRefSet originalColumnSet) {
+    protected List<ScalarOperator> rewriteScalarOpToTarget(
+            List<ScalarOperator> exprsToRewrites,
+            EquationRewriter queryExprToMvExprRewriter,
+            Map<ColumnRefOperator, ColumnRefOperator> outputMapping,
+            ColumnRefSet originalColumnSet, boolean isUnion,
+            List<ScalarOperator> rewrittenFailedPredciates) {
         List<ScalarOperator> rewrittenExprs = Lists.newArrayList();
         for (ScalarOperator expr : exprsToRewrites) {
             ScalarOperator rewritten = replaceExprWithTarget(expr, queryExprToMvExprRewriter, outputMapping);
             if (expr.isVariable() && expr == rewritten) {
                 // it means it can not be rewritten  by target
+                if (isUnion) {
+                    rewrittenFailedPredciates.add(expr);
+                    continue;
+                }
                 return Lists.newArrayList();
             }
             if (originalColumnSet != null && !isAllExprReplaced(rewritten, originalColumnSet)) {
+                if (isUnion) {
+                    rewrittenFailedPredciates.add(expr);
+                    continue;
+                }
                 // it means there is some column that can not be rewritten by outputs of mv
                 return Lists.newArrayList();
             }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -15,6 +15,9 @@
 package com.starrocks.planner;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -371,6 +374,19 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "properties('replication_num' = '1');";
         starRocksAssert
                 .withTable(userTagTable);
+
+        String eventTable = "CREATE TABLE `event1` (\n" +
+                "  `event_id` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `event_type` varchar(26) NOT NULL COMMENT \"\",\n" +
+                "  `event_time` datetime NOT NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`event_id`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`event_id`) BUCKETS 12\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");";
+        starRocksAssert.withTable(eventTable);
     }
 
     @Test
@@ -2701,6 +2717,31 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "WHERE `customer`.`c_city` = 'ETHIOPIA 9'";
             String query = "select * from customer, lineorder";
             testRewriteOK(mv, query);
+        }
+
+        {
+            // test compensation predicates are not in output of query
+            String mv = "SELECT `event_id`, `event_type`, `event_time`\n" +
+                    "FROM `event1`\n" +
+                    "WHERE `event_type` = 'click'; ";
+            String query = "select count(event_id) from event1";
+            MVRewriteChecker checker = testRewriteOK(mv, query);
+            checker.contains("UNION");
+        }
+
+        {
+            String mv = "SELECT count(lo_linenumber)\n" +
+                    "FROM lineorder inner join customer on lo_custkey = c_custkey\n" +
+                    "WHERE `c_name` != 'name'; ";
+
+            String query = "SELECT count(lo_linenumber)\n" +
+                    "FROM lineorder inner join customer on lo_custkey = c_custkey";
+            Table table1 = getTable(MATERIALIZED_DB_NAME, "lineorder");
+            PlanTestBase.setTableStatistics((OlapTable) table1, 1000000);
+            Table table2 = getTable(MATERIALIZED_DB_NAME, "customer");
+            PlanTestBase.setTableStatistics((OlapTable) table2, 1000000);
+            MVRewriteChecker checker = testRewriteOK(mv, query);
+            checker.contains("UNION");
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
@@ -1858,8 +1858,7 @@ public class MvRewriteOptimizationTest {
         String query6 =
                 "SELECT `emps`.`deptno`, `emps`.`name`, sum(salary) as salary FROM `emps` group by deptno, name;";
         String plan6 = getFragmentPlan(query6);
-        PlanTestBase.assertNotContains(plan6, "mv_agg_1");
-        PlanTestBase.assertContains(plan6, "emps");
+        PlanTestBase.assertContains(plan6, "mv_agg_1", "emps", "UNION");
         dropMv("test", "mv_agg_1");
     }
 

--- a/test/sql/test_materialized_view/R/test_mv_union_rewrite
+++ b/test/sql/test_materialized_view/R/test_mv_union_rewrite
@@ -1,0 +1,44 @@
+-- name: test_union_rewrite_without_output_column
+CREATE TABLE `event1` (
+    `event_id` int(11) NOT NULL,
+    `event_type` varchar(26) NOT NULL,
+    `event_time` datetime NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`event_id`)
+PARTITION BY RANGE(`event_time`)
+(PARTITION p1 VALUES [("19900101"), ("20200101")),
+PARTITION p2 VALUES [("20200101"), ("20210101")),
+PARTITION p3 VALUES [("20210101"), ("20220101")),
+PARTITION p4 VALUES [("20220101"), ("20230101")),
+PARTITION p5 VALUES [("20230101"), ("20240101")),
+PARTITION p6 VALUES [("20240101"), ("20250101")),
+PARTITION p7 VALUES [("20250101"), ("20260101")))
+DISTRIBUTED BY HASH(`event_id`) BUCKETS 12
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into event1 values(129, "click", "2023-01-06 12:12:23"), (128, "click", "2023-01-06 18:12:23"), (127, "click2", "2023-01-05 12:12:23");
+
+CREATE MATERIALIZED VIEW `olap_mv1`
+COMMENT "MATERIALIZED_VIEW"
+PARTITION BY (`event_time`)
+DISTRIBUTED BY HASH(`event_id`) BUCKETS 1
+REFRESH MANUAL
+PROPERTIES (
+"replication_num" = "1"
+)
+AS SELECT `event_id`, `event_type`, `event_time`
+FROM `event1`
+WHERE `event_type` = 'click';
+
+refresh materialized view olap_mv1 with sync mode;
+
+explain logical select count(event_id) from event1;
+-- result:
+[REGEX]olap_mv1
+[REGEX]UNION
+
+select count(event_id) from event1;
+-- result:
+3

--- a/test/sql/test_materialized_view/T/test_mv_union_rewrite
+++ b/test/sql/test_materialized_view/T/test_mv_union_rewrite
@@ -1,0 +1,39 @@
+-- name: test_union_rewrite_without_output_column
+CREATE TABLE `event1` (
+    `event_id` int(11) NOT NULL,
+    `event_type` varchar(26) NOT NULL,
+    `event_time` datetime NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`event_id`)
+PARTITION BY RANGE(`event_time`)
+(PARTITION p1 VALUES [("19900101"), ("20200101")),
+PARTITION p2 VALUES [("20200101"), ("20210101")),
+PARTITION p3 VALUES [("20210101"), ("20220101")),
+PARTITION p4 VALUES [("20220101"), ("20230101")),
+PARTITION p5 VALUES [("20230101"), ("20240101")),
+PARTITION p6 VALUES [("20240101"), ("20250101")),
+PARTITION p7 VALUES [("20250101"), ("20260101")))
+DISTRIBUTED BY HASH(`event_id`) BUCKETS 12
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into event1 values(129, "click", "2023-01-06 12:12:23"), (128, "click", "2023-01-06 18:12:23"), (127, "click2", "2023-01-05 12:12:23");
+
+CREATE MATERIALIZED VIEW `olap_mv1`
+COMMENT "MATERIALIZED_VIEW"
+PARTITION BY (`event_time`)
+DISTRIBUTED BY HASH(`event_id`) BUCKETS 1
+REFRESH MANUAL
+PROPERTIES (
+"replication_num" = "1"
+)
+AS SELECT `event_id`, `event_type`, `event_time`
+FROM `event1`
+WHERE `event_type` = 'click';
+
+refresh materialized view olap_mv1 with sync mode;
+
+explain logical select count(event_id) from event1;
+
+select count(event_id) from event1;


### PR DESCRIPTION
Enhance union rewrite, to support compensated predicates reference columns not in query's outputs.

Fixes #23028

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
