### PR TITLE
[Enhancement][CherryPick] optimize mv union rewrite for 3.1 (#25679)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Table;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.Rule;
@@ -47,6 +48,7 @@ public class MvRewriteContext {
 
     private final List<ScalarOperator> onPredicates;
     private final Rule rule;
+    private List<ColumnRefOperator> enforcedColumns;
 
     private List<JoinDeriveContext> joinDeriveContexts;
 
@@ -124,5 +126,13 @@ public class MvRewriteContext {
 
     public List<JoinDeriveContext> getJoinDeriveContexts() {
         return joinDeriveContexts;
+    }
+
+    public List<ColumnRefOperator> getEnforcedColumns() {
+        return enforcedColumns;
+    }
+
+    public void setEnforcedColumns(List<ColumnRefOperator> enforcedColumns) {
+        this.enforcedColumns = enforcedColumns;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -97,9 +97,8 @@ public final class ColumnRefOperator extends ScalarOperator {
     }
 
     @Override
-    public List<ColumnRefOperator> getColumnRefs(List<ColumnRefOperator> list) {
-        list.add(this);
-        return list;
+    public void getColumnRefs(List<ColumnRefOperator> columns) {
+        columns.add(this);
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -158,11 +158,16 @@ public abstract class ScalarOperator implements Cloneable {
      */
     public abstract ColumnRefSet getUsedColumns();
 
-    public List<ColumnRefOperator> getColumnRefs(List<ColumnRefOperator> list) {
+    public List<ColumnRefOperator> getColumnRefs() {
+        List<ColumnRefOperator> columns = Lists.newArrayList();
+        getColumnRefs(columns);
+        return columns;
+    }
+
+    public void getColumnRefs(List<ColumnRefOperator> columns) {
         for (ScalarOperator child : getChildren()) {
-            list.addAll(child.getColumnRefs(list));
+            child.getColumnRefs(columns);
         }
-        return list;
     }
 
     public String debugString() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FilterSelectivityEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FilterSelectivityEvaluator.java
@@ -128,7 +128,7 @@ public class FilterSelectivityEvaluator {
         public ColumnFilter visitBinaryPredicate(BinaryPredicateOperator predicate, Void context) {
             ScalarOperator left = predicate.getChild(0);
             ScalarOperator right = predicate.getChild(1);
-            List<ColumnRefOperator> usedCols = left.getColumnRefs(Lists.newArrayList());
+            List<ColumnRefOperator> usedCols = left.getColumnRefs();
 
             if (!isOnlyRefOneCol(usedCols)) {
                 return new ColumnFilter(NON_SELECTIVITY, predicate);
@@ -155,7 +155,7 @@ public class FilterSelectivityEvaluator {
                 return new ColumnFilter(NON_SELECTIVITY, predicate);
             } else {
                 Set<ScalarOperator> inSet = predicate.getChildren().stream().skip(1).collect(Collectors.toSet());
-                List<ColumnRefOperator> usedCols = predicate.getChild(0).getColumnRefs(Lists.newArrayList());
+                List<ColumnRefOperator> usedCols = predicate.getChild(0).getColumnRefs();
                 if (isOnlyRefOneCol(usedCols) && inSet.stream().allMatch(ScalarOperator::isConstantRef)) {
                     ColumnRefOperator column = usedCols.get(0);
                     ColumnStatistic columnStatistic = statistics.getColumnStatistic(column);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnEnforcer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/ColumnEnforcer.java
@@ -1,0 +1,112 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import autovalue.shaded.com.google.common.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+import java.util.List;
+import java.util.Map;
+
+// Add columnsToEnforce into LogicalScanOperator's colRefToColumnMetaMap.
+// enforce() will return a new OptExpression based on old OptExpression insteading of
+// modifying it locally.
+public class ColumnEnforcer {
+    private OptExpression optExpression;
+    private List<ColumnRefOperator> columnsToEnforce;
+    private EnforceContext enforceContext;
+
+    public ColumnEnforcer(
+            OptExpression optExpression, List<ColumnRefOperator> columnsToEnforce) {
+        this.optExpression = optExpression;
+        this.columnsToEnforce = columnsToEnforce;
+        this.enforceContext = new EnforceContext();
+    }
+
+    public OptExpression enforce() {
+        ColumnEnforcerVisitor visitor = new ColumnEnforcerVisitor();
+        OptExpression rootOptExpression = optExpression.getOp().accept(visitor, optExpression, enforceContext);
+        return rootOptExpression;
+    }
+
+    public List<ColumnRefOperator> getEnforcedColumns() {
+        return enforceContext.enforcedColumns;
+    }
+
+    private class EnforceContext {
+        public List<ColumnRefOperator> enforcedColumns;
+
+        public EnforceContext() {
+            this.enforcedColumns = Lists.newArrayList();
+        }
+    }
+
+    private class ColumnEnforcerVisitor extends OptExpressionVisitor<OptExpression, EnforceContext> {
+        @Override
+        public OptExpression visitLogicalTableScan(OptExpression optExpression, EnforceContext context) {
+            LogicalScanOperator scanOperator = optExpression.getOp().cast();
+            LogicalScanOperator.Builder builder = OperatorBuilderFactory.build(scanOperator);
+            builder.withOperator(scanOperator);
+            Map<ColumnRefOperator, Column> columnRefOperatorColumnMap = Maps.newHashMap(scanOperator.getColRefToColumnMetaMap());
+            for (ColumnRefOperator columnRef : columnsToEnforce) {
+                for (Map.Entry<Column, ColumnRefOperator> entry : scanOperator.getColumnMetaToColRefMap().entrySet()) {
+                    if (entry.getValue().equals(columnRef)) {
+                        columnRefOperatorColumnMap.put(columnRef, entry.getKey());
+                        context.enforcedColumns.add(columnRef);
+                    }
+                }
+            }
+            builder.setColRefToColumnMetaMap(columnRefOperatorColumnMap);
+            OptExpression newScan = new OptExpression(builder.build());
+            newScan.deriveLogicalPropertyItself();
+            return newScan;
+        }
+
+        @Override
+        public OptExpression visit(OptExpression optExpression, EnforceContext context) {
+            List<OptExpression> inputs = Lists.newArrayList();
+            EnforceContext localContext = new EnforceContext();
+            for (OptExpression child : optExpression.getInputs()) {
+                inputs.add(child.getOp().accept(this, child, localContext));
+            }
+
+            LogicalOperator.Builder builder = OperatorBuilderFactory.build(optExpression.getOp());
+            builder.withOperator(optExpression.getOp());
+
+            if (optExpression.getOp().getProjection() != null) {
+                Map<ColumnRefOperator, ScalarOperator> columnRefMap =
+                        Maps.newHashMap(optExpression.getOp().getProjection().getColumnRefMap());
+                for (ColumnRefOperator columnRef : localContext.enforcedColumns) {
+                    columnRefMap.put(columnRef, columnRef);
+                }
+                builder.setProjection(new Projection(columnRefMap));
+            }
+            OptExpression newOptExpression = OptExpression.create(builder.build(), inputs);
+            context.enforcedColumns.addAll(localContext.enforcedColumns);
+            newOptExpression.deriveLogicalPropertyItself();
+            return newOptExpression;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteOptimizationTest.java
@@ -1850,8 +1850,7 @@ public class MvRewriteOptimizationTest {
         String query6 =
                 "SELECT `emps`.`deptno`, `emps`.`name`, sum(salary) as salary FROM `emps` group by deptno, name;";
         String plan6 = getFragmentPlan(query6);
-        PlanTestBase.assertNotContains(plan6, "mv_agg_1");
-        PlanTestBase.assertContains(plan6, "emps");
+        PlanTestBase.assertContains(plan6, "mv_agg_1", "emps", "UNION");
         dropMv("test", "mv_agg_1");
     }
 

--- a/test/sql/test_materialized_view/R/test_mv_union_rewrite
+++ b/test/sql/test_materialized_view/R/test_mv_union_rewrite
@@ -1,0 +1,44 @@
+-- name: test_union_rewrite_without_output_column
+CREATE TABLE `event1` (
+    `event_id` int(11) NOT NULL,
+    `event_type` varchar(26) NOT NULL,
+    `event_time` datetime NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`event_id`)
+PARTITION BY RANGE(`event_time`)
+(PARTITION p1 VALUES [("19900101"), ("20200101")),
+PARTITION p2 VALUES [("20200101"), ("20210101")),
+PARTITION p3 VALUES [("20210101"), ("20220101")),
+PARTITION p4 VALUES [("20220101"), ("20230101")),
+PARTITION p5 VALUES [("20230101"), ("20240101")),
+PARTITION p6 VALUES [("20240101"), ("20250101")),
+PARTITION p7 VALUES [("20250101"), ("20260101")))
+DISTRIBUTED BY HASH(`event_id`) BUCKETS 12
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into event1 values(129, "click", "2023-01-06 12:12:23"), (128, "click", "2023-01-06 18:12:23"), (127, "click2", "2023-01-05 12:12:23");
+
+CREATE MATERIALIZED VIEW `olap_mv1`
+COMMENT "MATERIALIZED_VIEW"
+PARTITION BY (`event_time`)
+DISTRIBUTED BY HASH(`event_id`) BUCKETS 1
+REFRESH MANUAL
+PROPERTIES (
+"replication_num" = "1"
+)
+AS SELECT `event_id`, `event_type`, `event_time`
+FROM `event1`
+WHERE `event_type` = 'click';
+
+refresh materialized view olap_mv1 with sync mode;
+
+explain logical select count(event_id) from event1;
+-- result:
+[REGEX]olap_mv1
+[REGEX]UNION
+
+select count(event_id) from event1;
+-- result:
+3

--- a/test/sql/test_materialized_view/T/test_mv_union_rewrite
+++ b/test/sql/test_materialized_view/T/test_mv_union_rewrite
@@ -1,0 +1,39 @@
+-- name: test_union_rewrite_without_output_column
+CREATE TABLE `event1` (
+    `event_id` int(11) NOT NULL,
+    `event_type` varchar(26) NOT NULL,
+    `event_time` datetime NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`event_id`)
+PARTITION BY RANGE(`event_time`)
+(PARTITION p1 VALUES [("19900101"), ("20200101")),
+PARTITION p2 VALUES [("20200101"), ("20210101")),
+PARTITION p3 VALUES [("20210101"), ("20220101")),
+PARTITION p4 VALUES [("20220101"), ("20230101")),
+PARTITION p5 VALUES [("20230101"), ("20240101")),
+PARTITION p6 VALUES [("20240101"), ("20250101")),
+PARTITION p7 VALUES [("20250101"), ("20260101")))
+DISTRIBUTED BY HASH(`event_id`) BUCKETS 12
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into event1 values(129, "click", "2023-01-06 12:12:23"), (128, "click", "2023-01-06 18:12:23"), (127, "click2", "2023-01-05 12:12:23");
+
+CREATE MATERIALIZED VIEW `olap_mv1`
+COMMENT "MATERIALIZED_VIEW"
+PARTITION BY (`event_time`)
+DISTRIBUTED BY HASH(`event_id`) BUCKETS 1
+REFRESH MANUAL
+PROPERTIES (
+"replication_num" = "1"
+)
+AS SELECT `event_id`, `event_type`, `event_time`
+FROM `event1`
+WHERE `event_type` = 'click';
+
+refresh materialized view olap_mv1 with sync mode;
+
+explain logical select count(event_id) from event1;
+
+select count(event_id) from event1;


### PR DESCRIPTION
Enhance union rewrite, to support compensated predicates reference columns not in query's outputs.

Fixes #23028

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
