### PR TITLE
[Refactor][Cherry-Pick][Branch-2.5] Wait for apply finish when exec primary key publish version (#17101)

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -35,6 +35,7 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "gutil/strings/substitute.h"
+#include "gutil/sysinfo.h"
 #include "runtime/exec_env.h"
 #include "storage/snapshot_manager.h"
 #include "util/phmap/phmap.h"
@@ -217,7 +218,7 @@ void AgentServer::Impl::init_or_die() {
 #define CREATE_AND_START_POOL(pool_name, CLASS_NAME, worker_num)
 #endif // BE_TEST
 
-    CREATE_AND_START_POOL(_publish_version_workers, PublishVersionTaskWorkerPool, 1)
+    CREATE_AND_START_POOL(_publish_version_workers, PublishVersionTaskWorkerPool, base::NumCPUs())
     // Both PUSH and REALTIME_PUSH type use _push_workers
     CREATE_AND_START_POOL(_push_workers, PushTaskWorkerPool,
                           config::push_worker_count_high_priority + config::push_worker_count_normal_priority)

--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -37,7 +37,8 @@ struct TabletPublishVersionTask {
 };
 
 void run_publish_version_task(ThreadPoolToken* token, const PublishVersionAgentTaskRequest& publish_version_task,
-                              TFinishTaskRequest& finish_task, std::unordered_set<DataDir*>& affected_dirs) {
+                              TFinishTaskRequest& finish_task, std::unordered_set<DataDir*>& affected_dirs,
+                              uint32_t wait_time) {
     int64_t start_ts = MonotonicMillis();
     auto& publish_version_req = publish_version_task.task_req;
     int64_t transaction_id = publish_version_req.transaction_id;
@@ -100,7 +101,7 @@ void run_publish_version_task(ThreadPoolToken* token, const PublishVersionAgentT
                     affected_dirs.insert(tablet->data_dir());
                 }
                 task.st = StorageEngine::instance()->txn_manager()->publish_txn(task.partition_id, tablet, task.txn_id,
-                                                                                task.version, task.rowset);
+                                                                                task.version, task.rowset, wait_time);
                 if (!task.st.ok()) {
                     LOG(WARNING) << "Publish txn failed tablet:" << tablet->tablet_id() << " version:" << task.version
                                  << " partition:" << task.partition_id << " txn_id: " << task.txn_id

--- a/be/src/agent/publish_version.h
+++ b/be/src/agent/publish_version.h
@@ -14,6 +14,7 @@ class ThreadPoolToken;
 class DataDir;
 
 void run_publish_version_task(ThreadPoolToken* token, const PublishVersionAgentTaskRequest& publish_version_task,
-                              TFinishTaskRequest& finish_task, std::unordered_set<DataDir*>& affected_dirs);
+                              TFinishTaskRequest& finish_task, std::unordered_set<DataDir*>& affected_dirs,
+                              uint32_t wait_time);
 
 } // namespace starrocks

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -499,8 +499,7 @@ void* PublishVersionTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_backend(BackendOptions::get_localBackend());
         finish_task_request.__set_report_version(g_report_version.load(std::memory_order_relaxed));
         int64_t start_ts = MonotonicMillis();
-        run_publish_version_task(token.get(), publish_version_task, finish_task_request, affected_dirs,
-                                 wait_time);
+        run_publish_version_task(token.get(), publish_version_task, finish_task_request, affected_dirs, wait_time);
         batch_publish_latency += MonotonicMillis() - start_ts;
         priority_tasks.pop();
 

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -470,14 +470,19 @@ void* PublishVersionTaskWorkerPool::_worker_thread_callback(void* arg_this) {
     int64_t batch_publish_latency = 0;
 
     while (true) {
+        uint32_t wait_time = config::wait_apply_time;
         {
             std::unique_lock l(worker_pool_this->_worker_thread_lock);
+            worker_pool_this->_sleeping_count++;
             worker_pool_this->_worker_thread_condition_variable->wait(l, [&]() {
                 return !priority_tasks.empty() || !worker_pool_this->_tasks.empty() || worker_pool_this->_stopped;
             });
+            worker_pool_this->_sleeping_count--;
             if (worker_pool_this->_stopped) {
                 break;
             }
+            // All thread are running, set wait_timeout = 0 to avoid publish block
+            wait_time = wait_time * worker_pool_this->_sleeping_count / worker_pool_this->_worker_count;
 
             while (!worker_pool_this->_tasks.empty()) {
                 // collect some publish version tasks as a group.
@@ -494,7 +499,8 @@ void* PublishVersionTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         finish_task_request.__set_backend(BackendOptions::get_localBackend());
         finish_task_request.__set_report_version(g_report_version.load(std::memory_order_relaxed));
         int64_t start_ts = MonotonicMillis();
-        run_publish_version_task(token.get(), publish_version_task, finish_task_request, affected_dirs);
+        run_publish_version_task(token.get(), publish_version_task, finish_task_request, affected_dirs,
+                                 wait_time);
         batch_publish_latency += MonotonicMillis() - start_ts;
         priority_tasks.pop();
 

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -98,6 +98,7 @@ protected:
     std::deque<AgentTaskRequestPtr> _tasks;
 
     uint32_t _worker_count = 0;
+    uint32_t _sleeping_count = 0;
     CALLBACK_FUNCTION _callback_function = nullptr;
 
     std::atomic<bool> _stopped{false};

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -929,9 +929,9 @@ CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache={
 
 CONF_mInt64(txn_info_history_size, "20000");
 CONF_mInt64(file_write_history_size, "10000");
-CONF_mInt64(wait_apply_time, "6000") 
+CONF_mInt64(wait_apply_time, "6000")
 
-CONF_mInt32(update_cache_evict_internal_sec, "11");
+        CONF_mInt32(update_cache_evict_internal_sec, "11");
 CONF_mBool(enable_auto_evict_update_cache, "true");
 
 CONF_Bool(enable_preload_column_mode_update_cache, "true");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -929,6 +929,7 @@ CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache={
 
 CONF_mInt64(txn_info_history_size, "20000");
 CONF_mInt64(file_write_history_size, "10000");
+CONF_mInt64(wait_apply_time, "6000") 
 
 CONF_mInt32(update_cache_evict_internal_sec, "11");
 CONF_mBool(enable_auto_evict_update_cache, "true");

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1125,9 +1125,9 @@ void Tablet::generate_tablet_meta_copy_unlocked(const TabletMetaSharedPtr& new_t
     new_tablet_meta->init_from_pb(&tablet_meta_pb);
 }
 
-Status Tablet::rowset_commit(int64_t version, const RowsetSharedPtr& rowset) {
+Status Tablet::rowset_commit(int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time) {
     CHECK(_updates) << "updates should exists";
-    return _updates->rowset_commit(version, rowset);
+    return _updates->rowset_commit(version, rowset, wait_time);
 }
 
 void Tablet::on_shutdown() {

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -228,7 +228,7 @@ public:
 
     // updatable tablet specific operations
     TabletUpdates* updates() { return _updates.get(); }
-    Status rowset_commit(int64_t version, const RowsetSharedPtr& rowset);
+    Status rowset_commit(int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time = 0);
 
     // if there is _compaction_task running
     // do not do compaction

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -488,7 +488,7 @@ Status TabletUpdates::_get_apply_version_and_rowsets(int64_t* version, std::vect
     return Status::OK();
 }
 
-Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rowset) {
+Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time) {
     auto span = Tracer::Instance().start_trace("rowset_commit");
     auto scope_span = trace::Scope(span);
     if (_error) {
@@ -497,7 +497,7 @@ Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rows
     }
     Status st;
     {
-        std::lock_guard wl(_lock);
+        std::unique_lock<std::mutex> ul(_lock);
         if (_edit_version_infos.empty()) {
             string msg = Substitute("tablet deleted when rowset_commit tablet:$0", _tablet.tablet_id());
             LOG(WARNING) << msg;
@@ -546,11 +546,16 @@ Status TabletUpdates::rowset_commit(int64_t version, const RowsetSharedPtr& rows
                       << " #pending:" << _pending_commits.size();
             _try_commit_pendings_unlocked();
             _check_for_apply();
+            if (wait_time > 0) {
+                st = _wait_for_version(EditVersion(version, 0), wait_time, ul);
+            }
         }
     }
-    if (!st.ok()) {
+    if (!st.ok() && !st.is_time_out()) {
         LOG(WARNING) << "rowset commit failed tablet:" << _tablet.tablet_id() << " version:" << version
                      << " txn_id: " << rowset->txn_id() << " pending:" << _pending_commits.size() << " msg:" << st;
+    } else if (st.is_time_out()) {
+        st = Status::OK();
     }
     return st;
 }
@@ -3323,7 +3328,7 @@ Status TabletUpdates::load_snapshot(const SnapshotMeta& snapshot_meta, bool rest
             if (rowset->start_version() != rowset->end_version()) {
                 return Status::InternalError("mismatched start and end version");
             }
-            RETURN_IF_ERROR(rowset_commit(rowset->end_version(), rowset));
+            RETURN_IF_ERROR(rowset_commit(rowset->end_version(), rowset, 0));
         }
         LOG(INFO) << "load incremental snapshot done " << _debug_string(true);
         return Status::OK();

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -111,7 +111,7 @@ public:
 
     Status get_rowsets_total_stats(const std::vector<uint32_t>& rowsets, size_t* total_rows, size_t* total_dels);
 
-    Status rowset_commit(int64_t version, const RowsetSharedPtr& rowset);
+    Status rowset_commit(int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time);
 
     Status save_meta();
 

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -290,10 +290,10 @@ Status TxnManager::commit_txn(KVStore* meta, TPartitionId partition_id, TTransac
 }
 
 Status TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
-                               int64_t version, const RowsetSharedPtr& rowset) {
+                               int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time) {
     if (tablet->updates() != nullptr) {
         StarRocksMetrics::instance()->update_rowset_commit_request_total.increment(1);
-        auto st = tablet->rowset_commit(version, rowset);
+        auto st = tablet->rowset_commit(version, rowset, wait_time);
         if (!st.ok()) {
             StarRocksMetrics::instance()->update_rowset_commit_request_failed.increment(1);
             return st;

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -84,7 +84,7 @@ public:
                       const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr, bool is_recovery);
 
     Status publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet, TTransactionId transaction_id,
-                       int64_t version, const RowsetSharedPtr& rowset);
+                       int64_t version, const RowsetSharedPtr& rowset, uint32_t wait_time = 0);
 
     // persist_tablet_related_txns persists the tablets' meta and make it crash-safe.
     Status persist_tablet_related_txns(const std::vector<TabletSharedPtr>& tablets);

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -1197,7 +1197,7 @@ void build_persistent_index_from_tablet(size_t N) {
     RowsetSharedPtr rowset = create_rowset(tablet, keys);
     auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
     auto version = 2;
-    auto st = tablet->rowset_commit(version, rowset);
+    auto st = tablet->rowset_commit(version, rowset, 0);
     ASSERT_TRUE(st.ok()) << st.to_string();
     // Ensure that there is at most one thread doing the version apply job.
     ASSERT_LE(pool->num_threads(), 1);

--- a/be/test/storage/publish_version_task_test.cpp
+++ b/be/test/storage/publish_version_task_test.cpp
@@ -274,7 +274,7 @@ TEST_F(PublishVersionTaskTest, test_publish_version) {
     publish_version_req.partition_version_infos.push_back(pvinfo);
     PublishVersionAgentTaskRequest publish_version_task(tareq, publish_version_req, time(nullptr));
     // run publish version
-    run_publish_version_task(token.get(), publish_version_task, finish_task_request, affected_dirs);
+    run_publish_version_task(token.get(), publish_version_task, finish_task_request, affected_dirs, 0);
     // check finish_task_request
     ASSERT_EQ(1, finish_task_request.tablet_versions.size());
     ASSERT_EQ(3, finish_task_request.tablet_versions[0].version);
@@ -342,7 +342,7 @@ TEST_F(PublishVersionTaskTest, test_publish_version2) {
         publish_version_req.partition_version_infos.push_back(pvinfo);
         PublishVersionAgentTaskRequest publish_version_task(tareq, publish_version_req, time(nullptr));
         // run publish version
-        run_publish_version_task(token.get(), publish_version_task, finish_task_request, affected_dirs);
+        run_publish_version_task(token.get(), publish_version_task, finish_task_request, affected_dirs, 0);
         // check finish_task_request
         ASSERT_EQ(1, finish_task_request.tablet_versions.size());
         ASSERT_EQ(3, finish_task_request.tablet_versions[0].version);
@@ -366,7 +366,7 @@ TEST_F(PublishVersionTaskTest, test_publish_version2) {
         publish_version_req.partition_version_infos.push_back(pvinfo);
         PublishVersionAgentTaskRequest publish_version_task(tareq, publish_version_req, time(nullptr));
         // run publish version
-        run_publish_version_task(token.get(), publish_version_task, finish_task_request, affected_dirs);
+        run_publish_version_task(token.get(), publish_version_task, finish_task_request, affected_dirs, 0);
         // check finish_task_request
         ASSERT_EQ(1, finish_task_request.tablet_versions.size());
         ASSERT_EQ(3, finish_task_request.tablet_versions[0].version);

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -360,7 +360,7 @@ void RowsetTest::test_final_merge(bool has_merge_condition = false) {
 
     ASSERT_EQ(1, tablet->updates()->version_history_count());
     auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
-    auto st = tablet->rowset_commit(2, rowset);
+    auto st = tablet->rowset_commit(2, rowset, 0);
     ASSERT_TRUE(st.ok()) << st.to_string();
     ASSERT_LE(pool->num_threads(), 1);
     ASSERT_EQ(2, tablet->updates()->max_version());
@@ -520,7 +520,7 @@ TEST_F(RowsetTest, FinalMergeVerticalTest) {
 
     ASSERT_EQ(1, tablet->updates()->version_history_count());
     auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
-    auto st = tablet->rowset_commit(2, rowset);
+    auto st = tablet->rowset_commit(2, rowset, 0);
     ASSERT_TRUE(st.ok()) << st.to_string();
     ASSERT_LE(pool->num_threads(), 1);
     ASSERT_EQ(2, tablet->updates()->max_version());
@@ -674,7 +674,7 @@ TEST_F(RowsetTest, FinalMergeVerticalPartialTest) {
     ASSERT_EQ(3, rowset->rowset_meta()->num_segments());
     ASSERT_EQ(rows_per_segment * 3, rowset->rowset_meta()->num_rows());
 
-    ASSERT_TRUE(tablet->rowset_commit(2, rowset).ok());
+    ASSERT_TRUE(tablet->rowset_commit(2, rowset, 0).ok());
     EXPECT_EQ(rows_per_segment * 2, read_tablet_and_compare(tablet, partial_schema, 2, rows_per_segment * 2));
     ASSERT_OK(starrocks::StorageEngine::instance()->update_manager()->on_rowset_finished(tablet.get(), rowset.get()));
 }

--- a/be/test/storage/rowset_update_state_test.cpp
+++ b/be/test/storage/rowset_update_state_test.cpp
@@ -214,7 +214,7 @@ TEST_F(RowsetUpdateStateTest, prepare_partial_update_states) {
     auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
     for (int i = 0; i < rowsets.size(); i++) {
         auto version = i + 2;
-        auto st = _tablet->rowset_commit(version, rowsets[i]);
+        auto st = _tablet->rowset_commit(version, rowsets[i], 0);
         ASSERT_TRUE(st.ok()) << st.to_string();
         // Ensure that there is at most one thread doing the version apply job.
         ASSERT_LE(pool->num_threads(), 1);
@@ -250,7 +250,7 @@ TEST_F(RowsetUpdateStateTest, check_conflict) {
     RowsetSharedPtr rowset = create_rowset(_tablet, keys);
     auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
     auto version = 2;
-    auto st = _tablet->rowset_commit(version, rowset);
+    auto st = _tablet->rowset_commit(version, rowset, 0);
     ASSERT_TRUE(st.ok()) << st.to_string();
     ASSERT_LE(pool->num_threads(), 1);
     ASSERT_EQ(version, _tablet->updates()->max_version());
@@ -297,7 +297,7 @@ TEST_F(RowsetUpdateStateTest, check_conflict) {
     CHECK_OK(writer->flush_chunk(*chunk));
     RowsetSharedPtr new_rowset = *writer->build();
     version = 3;
-    st = _tablet->rowset_commit(version, new_rowset);
+    st = _tablet->rowset_commit(version, new_rowset, 0);
     ASSERT_TRUE(st.ok()) << st.to_string();
     ASSERT_LE(pool->num_threads(), 1);
     ASSERT_EQ(version, _tablet->updates()->max_version());

--- a/be/test/storage/table_reader_test.cpp
+++ b/be/test/storage/table_reader_test.cpp
@@ -1,0 +1,329 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/table_reader.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+
+#include "column/datum_tuple.h"
+#include "column/vectorized_fwd.h"
+#include "gutil/strings/substitute.h"
+#include "runtime/descriptor_helper.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/schema_change.h"
+#include "storage/snapshot_manager.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
+#include "storage/tablet_manager.h"
+#include "storage/union_iterator.h"
+#include "storage/update_manager.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+using DatumTupleVector = std::vector<DatumTuple>;
+
+class TableReaderTest : public testing::Test {
+public:
+    static void create_row(vector<DatumTuple>& data, int64_t c0, int32_t c1, int32_t c2, int16_t c3, int32_t c4) {
+        DatumTuple tuple;
+        tuple.append(Datum(c0));
+        tuple.append(Datum(c1));
+        tuple.append(Datum(c2));
+        tuple.append(Datum(c3));
+        tuple.append(Datum(c4));
+        data.push_back(tuple);
+    }
+
+    static void create_rowset(const TabletSharedPtr& tablet, int version, const vector<DatumTuple>& data, int start_pos,
+                              int end_pos) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = &tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, data.size());
+        auto& cols = chunk->columns();
+        for (int pos = start_pos; pos < end_pos; pos++) {
+            const DatumTuple& row = data[pos];
+            DatumTuple tmp_row;
+            for (size_t i = 0; i < row.size(); i++) {
+                cols[i]->append_datum(row.get(i));
+            }
+        }
+        CHECK_OK(writer->flush_chunk(*chunk));
+        auto row_set = *writer->build();
+        ASSERT_TRUE(tablet->rowset_commit(version, row_set, 0).ok());
+        ASSERT_EQ(version, tablet->updates()->max_version());
+    }
+
+    static TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn pk1;
+        pk1.column_name = "pk1_bigint";
+        pk1.__set_is_key(true);
+        pk1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(pk1);
+        TColumn pk2;
+        pk2.column_name = "pk2_int";
+        pk2.__set_is_key(true);
+        pk2.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(pk2);
+        TColumn pk3;
+        pk3.column_name = "pk3_int";
+        pk3.__set_is_key(true);
+        pk3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(pk3);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    void build_multi_get_request(DatumTuple& tuple, Chunk* key_chunk, std::vector<bool>& found, Chunk* value_chunk) {
+        key_chunk->get_column_by_index(0)->append_datum(tuple.get(0));
+        key_chunk->get_column_by_index(1)->append_datum(tuple.get(1));
+        key_chunk->get_column_by_index(2)->append_datum(tuple.get(2));
+        found.push_back(true);
+        value_chunk->get_column_by_index(0)->append_datum(tuple.get(3));
+        value_chunk->get_column_by_index(1)->append_datum(tuple.get(4));
+    }
+
+    void build_eq_predicates(Schema& scan_key_schema, DatumTuple& tuple,
+                             std::vector<const ColumnPredicate*>& predicates) {
+        predicates.clear();
+        for (size_t i = 0; i < scan_key_schema.num_fields(); i++) {
+            const FieldPtr& field = scan_key_schema.field(i);
+            ColumnPredicate* predicate = new_column_eq_predicate(field->type(), field->id(),
+                                                                 datum_to_string(field->type().get(), tuple.get(i)));
+            _object_pool.add(predicate);
+            predicates.push_back(predicate);
+        }
+    }
+
+    void build_scan_request(DatumTupleVector& tuples, Schema& scan_key_schema, std::vector<int> tuple_index,
+                            std::vector<int> value_column_index, std::vector<const ColumnPredicate*>& predicates,
+                            Chunk* result) {
+        build_eq_predicates(scan_key_schema, tuples[tuple_index[0]], predicates);
+        result->reset();
+        for (int i : tuple_index) {
+            DatumTuple tuple = tuples[i];
+            for (int j = 0; j < value_column_index.size(); j++) {
+                Datum datum = tuple.get(value_column_index[j]);
+                result->get_column_by_index(j)->append_datum(datum);
+            }
+        }
+    }
+
+    void SetUp() override {
+        srand(GetCurrentTimeMicros());
+        db_id = 1;
+        table_name = "table_reader_test";
+        table_id = 2;
+        version = 10;
+        for (int i = 0; i < 3; i++) {
+            TabletSharedPtr tablet = create_tablet(rand(), rand());
+            _tablets.push_back(tablet);
+        }
+        _key_schema = ChunkHelper::convert_schema(_tablets[0]->tablet_schema(), {0, 1, 2});
+        _value_schema = ChunkHelper::convert_schema(_tablets[0]->tablet_schema(), {3, 4});
+    }
+
+    void TearDown() override {
+        for (TabletSharedPtr& tablet : _tablets) {
+            StorageEngine::instance()->tablet_manager()->drop_tablet(tablet->tablet_id());
+            tablet.reset();
+        }
+    }
+
+protected:
+    int64_t db_id;
+    std::string table_name;
+    int64_t table_id;
+    int64_t version;
+    std::vector<TabletSharedPtr> _tablets;
+    ObjectPool _object_pool;
+    Schema _key_schema;
+    Schema _value_schema;
+};
+
+void collect_chunk_iterator_result(StatusOr<ChunkIteratorPtr>& status_or, Chunk& result) {
+    if (!status_or.status().ok()) {
+        ASSERT_TRUE(status_or.status().is_end_of_file());
+    }
+    ChunkIteratorPtr iterator = status_or.value();
+    std::shared_ptr<Chunk> chunk = ChunkHelper::new_chunk(iterator->schema(), 2);
+    Status status = iterator->get_next(chunk.get());
+    result.reset();
+    while (status.ok()) {
+        result.append(*chunk);
+        chunk->reset();
+        status = iterator->get_next(chunk.get());
+    }
+    ASSERT_TRUE(status.is_end_of_file());
+    iterator->close();
+}
+
+void verify_chunk_eq(Schema& schema, Chunk* expect_chunk, Chunk* actual_chunk) {
+    ASSERT_EQ(expect_chunk->num_rows(), actual_chunk->num_rows());
+    for (int i = 0; i < expect_chunk->num_rows(); i++) {
+        DatumTuple expect_tuple = expect_chunk->get(i);
+        DatumTuple actual_tuple = actual_chunk->get(i);
+        for (size_t j = 0; j < schema.num_fields(); j++) {
+            int cmp = schema.field(j)->type()->cmp(expect_tuple.get(j), actual_tuple.get(j));
+            ASSERT_EQ(0, cmp);
+        }
+    }
+}
+
+TEST_F(TableReaderTest, test_basic_read) {
+    // 1. generate data, and write to tablet
+    DatumTupleVector rows;
+    create_row(rows, (int64_t)1, (int32_t)1, (int32_t)1, (int16_t)1, (int32_t)1);
+    create_row(rows, (int64_t)1, (int32_t)1, (int32_t)2, (int16_t)2, (int32_t)1);
+    create_row(rows, (int64_t)1, (int32_t)1, (int32_t)3, (int16_t)1, (int32_t)1);
+    create_rowset(_tablets[0], 2, rows, 0, 3);
+    create_row(rows, (int64_t)2, (int32_t)1, (int32_t)1, (int16_t)1, (int32_t)1);
+    create_row(rows, (int64_t)2, (int32_t)1, (int32_t)2, (int16_t)2, (int32_t)1);
+    create_row(rows, (int64_t)2, (int32_t)1, (int32_t)3, (int16_t)3, (int32_t)1);
+    create_rowset(_tablets[0], 3, rows, 3, 6);
+    create_row(rows, (int64_t)3, (int32_t)3, (int32_t)4, (int16_t)1, (int32_t)1);
+    create_row(rows, (int64_t)4, (int32_t)2, (int32_t)3, (int16_t)2, (int32_t)1);
+    create_row(rows, (int64_t)5, (int32_t)1, (int32_t)5, (int16_t)3, (int32_t)1);
+    create_rowset(_tablets[0], 4, rows, 6, 9);
+    while (true) {
+        std::vector<RowsetSharedPtr> dummy_rowsets;
+        EditVersion full_version;
+        ASSERT_TRUE(_tablets[0]->updates()->get_applied_rowsets(4, &dummy_rowsets, &full_version).ok());
+        if (full_version.major() == 4) {
+            break;
+        }
+        std::cerr << "waiting for version 4\n";
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+
+    // 2. build TableReaderParams, and create TableReader
+    LocalTableReaderParams params;
+    // 2.1 data version to read
+    params.version = 4;
+    params.tablet_id = _tablets[0]->tablet_id();
+
+    // 2.3 create TableReader
+    std::shared_ptr<TableReader> table_reader = std::make_shared<TableReader>();
+    EXPECT_TRUE(table_reader->init(params).ok());
+
+    // 3. verify multi_get
+    ChunkPtr key_chunk = ChunkHelper::new_chunk(_key_schema, 10);
+    std::vector<bool> expected_found;
+    ChunkPtr expected_value_chunk = ChunkHelper::new_chunk(_value_schema, 10);
+
+    // key (1, 1, 2), value (2, 1)
+    build_multi_get_request(rows[1], key_chunk.get(), expected_found, expected_value_chunk.get());
+
+    // key (1, 1, 4) not found
+    key_chunk->get_column_by_index(0)->append_datum(Datum((int64_t)1));
+    key_chunk->get_column_by_index(1)->append_datum(Datum((int32_t)1));
+    key_chunk->get_column_by_index(2)->append_datum(Datum((int32_t)4));
+    expected_found.push_back(false);
+
+    // key (2, 1, 3), value (3, 1)
+    build_multi_get_request(rows[5], key_chunk.get(), expected_found, expected_value_chunk.get());
+
+    // key (3, 3, 4), value (1, 1)
+    build_multi_get_request(rows[6], key_chunk.get(), expected_found, expected_value_chunk.get());
+
+    // key (5, 8, 9) not found
+    key_chunk->get_column_by_index(0)->append_datum(Datum((int64_t)5));
+    key_chunk->get_column_by_index(1)->append_datum(Datum((int32_t)8));
+    key_chunk->get_column_by_index(2)->append_datum(Datum((int32_t)9));
+    expected_found.push_back(false);
+
+    std::vector<bool> found;
+    ChunkPtr value_chunk = ChunkHelper::new_chunk(_value_schema, 10);
+    Status status = table_reader->multi_get(*key_chunk, {"v1", "v2"}, found, *value_chunk);
+    ASSERT_OK(status);
+    ASSERT_EQ(expected_found.size(), found.size());
+    for (int i = 0; i < expected_found.size(); i++) {
+        ASSERT_EQ(expected_found[i], found[i]);
+    }
+    verify_chunk_eq(_value_schema, expected_value_chunk.get(), value_chunk.get());
+
+    // 4. verify scan
+    Schema scan_key_schema = ChunkHelper::convert_schema(_tablets[0]->tablet_schema(), {0, 1});
+    Schema scan_value_schema = ChunkHelper::convert_schema(_tablets[0]->tablet_schema(), {2, 3, 4});
+
+    ChunkPtr expect_scan_result = ChunkHelper::new_chunk(scan_value_schema, 0);
+    ChunkPtr scan_result = ChunkHelper::new_chunk(scan_value_schema, 0);
+    std::vector<const ColumnPredicate*> predicates;
+
+    // scan prefix key (1, 1)
+    build_scan_request(rows, scan_key_schema, {0, 1, 2}, {2, 3, 4}, predicates, expect_scan_result.get());
+    StatusOr<ChunkIteratorPtr> status_or = table_reader->scan({"pk3_int", "v1", "v2"}, predicates);
+    collect_chunk_iterator_result(status_or, *scan_result);
+    verify_chunk_eq(scan_value_schema, expect_scan_result.get(), scan_result.get());
+
+    // scan prefix key (2, 1)
+    build_scan_request(rows, scan_key_schema, {3, 4, 5}, {2, 3, 4}, predicates, expect_scan_result.get());
+    status_or = table_reader->scan({"pk3_int", "v1", "v2"}, predicates);
+    collect_chunk_iterator_result(status_or, *scan_result);
+    verify_chunk_eq(scan_value_schema, expect_scan_result.get(), scan_result.get());
+
+    // scan prefix key (6, 7), no data
+    expect_scan_result->reset();
+    DatumTuple prefix_key;
+    prefix_key.append(Datum((int64_t)6));
+    prefix_key.append(Datum((int32_t)7));
+    build_eq_predicates(scan_key_schema, prefix_key, predicates);
+    status_or = table_reader->scan({"pk3_int", "v1", "v2"}, predicates);
+    collect_chunk_iterator_result(status_or, *scan_result);
+    verify_chunk_eq(scan_value_schema, expect_scan_result.get(), scan_result.get());
+}
+
+} // namespace starrocks


### PR DESCRIPTION
PrimaryKey table only submit apply task to thread pool and return success directly when we do publish version right now. If we query immediately after publish success, we may need to wait for version apply finish which cause unstable query time. So we try to wait for apply finished when we exec publish version.

It is important to note that this solution is a temporary one and does not completely solve the problem of unstable query time, i will reconsider the primary key publish version mechanism and solve the problem in the future pr.