### PR TITLE
[BugFix] Fix External Olap table serialize bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -77,18 +77,27 @@ public class ExternalOlapTable extends OlapTable {
 
     public class ExternalTableInfo {
         // remote doris cluster fe addr
+        @SerializedName("ht")
         private String host;
+        @SerializedName("pt")
         private int port;
         // access credential
+        @SerializedName("us")
         private String user;
+        @SerializedName("pw")
         private String password;
 
         // source table info
+        @SerializedName("db")
         private String dbName;
+        @SerializedName("tb")
         private String tableName;
 
+        @SerializedName("dbi")
         private long dbId;
+        @SerializedName("tbi")
         private long tableId;
+        @SerializedName("tbt")
         private TableType tableType;
 
         public ExternalTableInfo() {


### PR DESCRIPTION
Fixes 
```
2023-06-27 19:45:41,512 ERROR (leaderCheckpointer|124) [Checkpoint.replayAndGenerateGlobalStateMgrImage():226] Exception when generate new image file
java.lang.NullPointerException: null
        at com.starrocks.catalog.Table$TableType.serialize(Table.java:124) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.ExternalOlapTable$ExternalTableInfo.toJsonObj(ExternalOlapTable.java:163) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.ExternalOlapTable.write(ExternalOlapTable.java:321) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.Database.write(Database.java:673) ~[starrocks-fe.jar:?]
        at com.starrocks.server.LocalMetastore.saveDb(LocalMetastore.java:374) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.saveImage(GlobalStateMgr.java:1801) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.saveImage(GlobalStateMgr.java:1770) ~[starrocks-fe.jar:?]
        at com.starrocks.leader.Checkpoint.replayAndGenerateGlobalStateMgrImage(Checkpoint.java:217) ~[starrocks-fe.jar:?]
        at com.starrocks.leader.Checkpoint.runAfterCatalogReady(Checkpoint.java:106) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.LeaderDaemon.runOneCycle(LeaderDaemon.java:73) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:115) ~[starrocks-fe.jar:?]
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
