### PR TITLE
[BugFix] Fix aggregate set_finishing called multi-times

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_sink_operator.cpp
@@ -32,6 +32,8 @@ void AggregateDistinctBlockingSinkOperator::close(RuntimeState* state) {
 }
 
 Status AggregateDistinctBlockingSinkOperator::set_finishing(RuntimeState* state) {
+    if (_is_finished) return Status::OK();
+
     _is_finished = true;
 
     COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_set_variant().size());


### PR DESCRIPTION
stack in release
```
#6  starrocks::vectorized::AggHashSetVariant::visit<starrocks::Aggregator::convert_hash_set_to_chunk(int32_t, starrocks::vectorized::ChunkPtr*)::<lambda(auto:47&)> > (vistor=..., 
    this=0x7f7d2c24cd70) at /home/code/starrocks/be/src/exec/vectorized/aggregate/agg_hash_variant.h:559
#7  starrocks::Aggregator::convert_hash_set_to_chunk (this=0x7f7d2c24cc10, chunk_size=<optimized out>, chunk_size@entry=4096, chunk=<optimized out>, chunk@entry=0x7f7ce67f5d30)
    at /home/code/starrocks/be/src/exec/vectorized/aggregator.cpp:1076
#8  0x00000000025c01c4 in starrocks::pipeline::AggregateDistinctBlockingSourceOperator::pull_chunk (this=0x7f7a9229fc10, state=<optimized out>)
    at /home/code/starrocks/be/src/exec/pipeline/aggregate/aggregate_distinct_blocking_source_operator.cpp:31
#9  0x00000000022a9f20 in starrocks::pipeline::PipelineDriver::process (this=this@entry=0x7f7a8e726790, runtime_state=runtime_state@entry=0x7f7d2c228e00, worker_id=worker_id@entry=39)
    at /home/code/starrocks/be/src/exec/pipeline/pipeline_driver.cpp:237
#10 0x000000000451dbb3 in starrocks::pipeline::GlobalDriverExecutor::_worker_thread (this=0x7f7f0331db40) at /home/code/starrocks/be/src/exec/pipeline/pipeline_driver_executor.cpp:133
--Type <RET> for more, q to quit, c to continue without paging--
#11 0x0000000003f0fc72 in std::function<void ()>::operator()() const (this=0x7f7f02598758) at /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
#12 starrocks::FunctionRunnable::run (this=0x7f7f02598750) at /home/code/starrocks/be/src/util/threadpool.cpp:44
#13 starrocks::ThreadPool::dispatch_thread (this=0x7f7f02e786c0) at /home/code/starrocks/be/src/util/threadpool.cpp:539
#14 0x0000000003f0a76a in std::function<void ()>::operator()() const (this=0x7f7f02599418) at /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
#15 starrocks::Thread::supervise_thread (arg=0x7f7f02599400) at /home/code/starrocks/be/src/util/thread.cpp:351
```
reproduce case:
```
[root@query-dev-centos share]# cat tmp2.cc 
#include <cstdio>
#include <memory>
#include <thread>
#include <unistd.h>
#include <any>
#include <cassert>

char buffer[1024];

struct Iterator {
    const char* a;
    const char* b;
};

std::any any_test;

void foo(void) {
  for (;;) {
        if (!any_test.has_value()) continue;
        auto iter = std::any_cast<Iterator>(any_test);
        assert(iter.a == buffer);
        assert(iter.b == buffer);
  }
}

int main() {
   Iterator iter{.a=buffer,.b=buffer};
   any_test = iter;

  std::thread t1(foo), t2(foo);
  for (;;) {
    usleep(10000);
    Iterator iter;
    iter.a = buffer;
    iter.b = buffer;
    any_test = iter;
  }
  return 0;
}


[root@query-dev-centos share]#  g++ tmp2.cc -std=c++17 -lpthread -fsanitize=address  -static-libasan -static-libstdc++
a[root@query-dev-centos share]# a./a.ou
bash: a./a.ou: No such file or directory
[root@query-dev-centos share]# ./a.out 
=================================================================
==67186==ERROR: AddressSanitizer: heap-use-after-free on address 0x602000000010 at pc 0x0000004cd586 bp 0x7f2c91cfdd40 sp 0x7f2c91cfdd38
READ of size 16 at 0x602000000010 thread T2
    #0 0x4cd585 in Iterator std::any_cast<Iterator>(std::any&) (/root/share/a.out+0x4cd585)
    #1 0x4cc9f2 in foo() (/root/share/a.out+0x4cc9f2)
    #2 0x4ce674 in void std::__invoke_impl<void, void (*)()>(std::__invoke_other, void (*&&)()) (/root/share/a.out+0x4ce674)
    #3 0x4ce5fe in std::__invoke_result<void (*)()>::type std::__invoke<void (*)()>(void (*&&)()) (/root/share/a.out+0x4ce5fe)
    #4 0x4ce5ab in void std::thread::_Invoker<std::tuple<void (*)()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) (/root/share/a.out+0x4ce5ab)
    #5 0x4ce57f in std::thread::_Invoker<std::tuple<void (*)()> >::operator()() (/root/share/a.out+0x4ce57f)
    #6 0x4ce563 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)()> > >::_M_run() (/root/share/a.out+0x4ce563)
    #7 0x4d004f in execute_native_thread_routine ../../../.././libstdc++-v3/src/c++11/thread.cc:80
    #8 0x7f2c96486ea4 in start_thread (/lib64/libpthread.so.0+0x7ea4)
    #9 0x7f2c9588bb0c in clone (/lib64/libc.so.6+0xfeb0c)

0x602000000010 is located 0 bytes inside of 16-byte region [0x602000000010,0x602000000020)
freed by thread T0 here:
    #0 0x48ff97 in operator delete(void*, unsigned long) ../../.././libsanitizer/asan/asan_new_delete.cpp:172
    #1 0x4cdd31 in std::any::_Manager_external<Iterator>::_S_manage(std::any::_Op, std::any const*, std::any::_Arg*) (/root/share/a.out+0x4cdd31)
    #2 0x4cd3a4 in std::any::reset() (/root/share/a.out+0x4cd3a4)
    #3 0x4cd2a0 in std::any::operator=(std::any&&) (/root/share/a.out+0x4cd2a0)
    #4 0x4cd646 in std::enable_if<std::is_copy_constructible<std::enable_if<!(is_same_v<std::decay<Iterator&>::type, std::any>), std::decay<Iterator&>::type>::type>::value, std::any&>::type std::any::operator=<Iterator&>(Iterator&) (/root/share/a.out+0x4cd646)
    #5 0x4ccbf0 in main (/root/share/a.out+0x4ccbf0)
    #6 0x7f2c957af554 in __libc_start_main (/lib64/libc.so.6+0x22554)

previously allocated by thread T0 here:
    #0 0x48f177 in operator new(unsigned long) ../../.././libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x4cde43 in void std::any::_Manager_external<Iterator>::_S_create<Iterator&>(std::any::_Storage&, Iterator&) (/root/share/a.out+0x4cde43)
    #2 0x4cd88d in std::any::any<Iterator&, Iterator, std::any::_Manager_external<Iterator>, true>(Iterator&) (/root/share/a.out+0x4cd88d)
    #3 0x4cd633 in std::enable_if<std::is_copy_constructible<std::enable_if<!(is_same_v<std::decay<Iterator&>::type, std::any>), std::decay<Iterator&>::type>::type>::value, std::any&>::type std::any::operator=<Iterator&>(Iterator&) (/root/share/a.out+0x4cd633)
    #4 0x4ccb4a in main (/root/share/a.out+0x4ccb4a)
    #5 0x7f2c957af554 in __libc_start_main (/lib64/libc.so.6+0x22554)

Thread T2 created by T0 here:
    #0 0x438e72 in __interceptor_pthread_create ../../.././libsanitizer/asan/asan_interceptors.cpp:214
    #1 0x4d02c4 in __gthread_create /workspace/gcc/x86_64-pc-linux-gnu/libstdc++-v3/include/x86_64-pc-linux-gnu/bits/gthr-default.h:663
    #2 0x4d02c4 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) ../../../.././libstdc++-v3/src/c++11/thread.cc:135
    #3 0x4ccb6c in main (/root/share/a.out+0x4ccb6c)
    #4 0x7f2c957af554 in __libc_start_main (/lib64/libc.so.6+0x22554)

SUMMARY: AddressSanitizer: heap-use-after-free (/root/share/a.out+0x4cd585) in Iterator std::any_cast<Iterator>(std::any&)
Shadow bytes around the buggy address:
  0x0c047fff7fb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c047fff7fc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c047fff7fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c047fff7fe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c047fff7ff0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c047fff8000: fa fa[fd]fd fa fa 00 00 fa fa 00 00 fa fa fd fd
  0x0c047fff8010: fa fa fd fd fa fa fd fd fa fa 00 00 fa fa fa fa
  0x0c047fff8020: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8030: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8040: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8050: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==67186==ABORTING
```


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
