### PR TITLE
[Cherry-pick][Branch-3.1][BugFix] Fix partition prune error when predicate with partition column has cast function (#25839)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
@@ -22,6 +22,7 @@ import com.starrocks.analysis.BinaryType;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
@@ -159,6 +160,175 @@ public class ListPartitionPrunerTest {
         conjuncts.add(new BinaryPredicateOperator(BinaryType.LT, intColumn,
                 ConstantOperator.createInt(2)));
         Assert.assertEquals(Lists.newArrayList(3L, 4L, 6L, 7L), pruner.prune());
+    }
+
+    @Test
+    public void testExternalTableBinaryPredicate() throws AnalysisException {
+        // string_col=2021-01-01   1
+        // string_col=2021-01-02   2
+        // string_col=2021-01-03   3
+        // string_col=2021-01-04   4
+
+        ColumnRefOperator stringColumn = new ColumnRefOperator(1, Type.STRING, "string_col", true);
+
+        // column -> partition values
+        Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap = Maps.newHashMap();
+        TreeMap<LiteralExpr, Set<Long>> stringPartitionValuesMap = Maps.newTreeMap();
+        columnToPartitionValuesMap.put(stringColumn, stringPartitionValuesMap);
+        stringPartitionValuesMap.put(new StringLiteral("2021-01-01"), Sets.newHashSet(1L));
+        stringPartitionValuesMap.put(new StringLiteral("2021-01-02"), Sets.newHashSet(2L));
+        stringPartitionValuesMap.put(new StringLiteral("2021-01-03"), Sets.newHashSet(3L));
+        stringPartitionValuesMap.put(new StringLiteral("2021-01-04"), Sets.newHashSet(4L));
+
+        Map<ColumnRefOperator, Set<Long>> columnToNullPartitions = Maps.newHashMap();
+        columnToNullPartitions.put(stringColumn, Sets.newHashSet(9L));
+
+        List<ScalarOperator> conjuncts = Lists.newArrayList();
+        ListPartitionPruner pruner = new ListPartitionPruner(columnToPartitionValuesMap, columnToNullPartitions, conjuncts, null);
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.EQ, stringColumn, ConstantOperator.createVarchar("2021-01-02")));
+        Assert.assertEquals(Lists.newArrayList(2L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.GE, stringColumn, ConstantOperator.createVarchar("2021-01-02")));
+        Assert.assertEquals(Lists.newArrayList(2L, 3L, 4L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.LT, new CastOperator(Type.DATE, stringColumn),
+                ConstantOperator.createDate(LocalDateTime.of(2021, 1, 3, 0, 0, 0))));
+        Assert.assertEquals(Lists.newArrayList(1L, 2L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.GE, new CastOperator(Type.DATE, stringColumn),
+                ConstantOperator.createDate(LocalDateTime.of(2021, 1, 4, 0, 0, 0))));
+        Assert.assertEquals(Lists.newArrayList(4L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.EQ, new CastOperator(Type.DATE, stringColumn),
+                ConstantOperator.createDate(LocalDateTime.of(2021, 1, 1, 0, 0, 0))));
+        Assert.assertEquals(Lists.newArrayList(1L), pruner.prune());
+    }
+
+    @Test
+    public void testExternalTableBinaryPredicate2() throws AnalysisException {
+        // string_col=01   1
+        // string_col=02   2
+        // string_col=03   3
+        // string_col=1   4
+        // string_col=10   5
+        // string_col=11   6
+        // string_col=12   7
+        // string_col=21   8
+
+        ColumnRefOperator stringColumn = new ColumnRefOperator(1, Type.STRING, "string_col", true);
+
+        // column -> partition values
+        Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap = Maps.newHashMap();
+        TreeMap<LiteralExpr, Set<Long>> stringPartitionValuesMap = Maps.newTreeMap();
+        columnToPartitionValuesMap.put(stringColumn, stringPartitionValuesMap);
+        stringPartitionValuesMap.put(new StringLiteral("01"), Sets.newHashSet(1L));
+        stringPartitionValuesMap.put(new StringLiteral("02"), Sets.newHashSet(2L));
+        stringPartitionValuesMap.put(new StringLiteral("03"), Sets.newHashSet(3L));
+        stringPartitionValuesMap.put(new StringLiteral("1"), Sets.newHashSet(4L));
+        stringPartitionValuesMap.put(new StringLiteral("10"), Sets.newHashSet(5L));
+        stringPartitionValuesMap.put(new StringLiteral("11"), Sets.newHashSet(6L));
+        stringPartitionValuesMap.put(new StringLiteral("12"), Sets.newHashSet(7L));
+        stringPartitionValuesMap.put(new StringLiteral("21"), Sets.newHashSet(8L));
+
+        Map<ColumnRefOperator, Set<Long>> columnToNullPartitions = Maps.newHashMap();
+        columnToNullPartitions.put(stringColumn, Sets.newHashSet(9L));
+
+        List<ScalarOperator> conjuncts = Lists.newArrayList();
+        ListPartitionPruner pruner = new ListPartitionPruner(columnToPartitionValuesMap, columnToNullPartitions, conjuncts, null);
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.EQ, stringColumn, ConstantOperator.createVarchar("01")));
+        Assert.assertEquals(Lists.newArrayList(1L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.EQ, stringColumn, ConstantOperator.createVarchar("1")));
+        Assert.assertEquals(Lists.newArrayList(4L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.GE, stringColumn, ConstantOperator.createVarchar("03")));
+        Assert.assertEquals(Lists.newArrayList(3L, 4L, 5L, 6L, 7L, 8L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.LT, stringColumn, ConstantOperator.createVarchar("03")));
+        Assert.assertEquals(Lists.newArrayList(1L, 2L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.EQ, new CastOperator(Type.INT, stringColumn),
+                ConstantOperator.createInt(1)));
+        Assert.assertEquals(Lists.newArrayList(1L, 4L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.GT, new CastOperator(Type.INT, stringColumn),
+                ConstantOperator.createInt(3)));
+        Assert.assertEquals(Lists.newArrayList(5L, 6L, 7L, 8L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.LT, new CastOperator(Type.INT, stringColumn),
+                ConstantOperator.createInt(3)));
+        Assert.assertEquals(Lists.newArrayList(1L, 2L, 4L), pruner.prune());
+    }
+
+    @Test
+    public void testExternalTableBinaryPredicate3() throws AnalysisException {
+        // int_col=1   1
+        // int_col=2   2
+        // int_col=3   3
+        // int_col=10   4
+        // int_col=11   5
+        // int_col=12   6
+        // int_col=20   7
+        // int_col=21   8
+
+        ColumnRefOperator intColumn = new ColumnRefOperator(1, Type.INT, "int_col", true);
+
+        // column -> partition values
+        Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap = Maps.newHashMap();
+        TreeMap<LiteralExpr, Set<Long>> intPartitionValuesMap = Maps.newTreeMap();
+        columnToPartitionValuesMap.put(intColumn, intPartitionValuesMap);
+        intPartitionValuesMap.put(new IntLiteral(1), Sets.newHashSet(1L));
+        intPartitionValuesMap.put(new IntLiteral(2), Sets.newHashSet(2L));
+        intPartitionValuesMap.put(new IntLiteral(3), Sets.newHashSet(3L));
+        intPartitionValuesMap.put(new IntLiteral(10), Sets.newHashSet(4L));
+        intPartitionValuesMap.put(new IntLiteral(11), Sets.newHashSet(5L));
+        intPartitionValuesMap.put(new IntLiteral(12), Sets.newHashSet(6L));
+        intPartitionValuesMap.put(new IntLiteral(20), Sets.newHashSet(7L));
+        intPartitionValuesMap.put(new IntLiteral(21), Sets.newHashSet(8L));
+
+        Map<ColumnRefOperator, Set<Long>> columnToNullPartitions = Maps.newHashMap();
+        columnToNullPartitions.put(intColumn, Sets.newHashSet(9L));
+
+        List<ScalarOperator> conjuncts = Lists.newArrayList();
+        ListPartitionPruner pruner = new ListPartitionPruner(columnToPartitionValuesMap, columnToNullPartitions, conjuncts, null);
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.EQ, intColumn, ConstantOperator.createInt(1)));
+        Assert.assertEquals(Lists.newArrayList(1L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.GE, intColumn, ConstantOperator.createInt(3)));
+        Assert.assertEquals(Lists.newArrayList(3L, 4L, 5L, 6L, 7L, 8L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.LT, intColumn, ConstantOperator.createInt(3)));
+        Assert.assertEquals(Lists.newArrayList(1L, 2L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.EQ, new CastOperator(Type.STRING, intColumn),
+                ConstantOperator.createVarchar("1")));
+        Assert.assertEquals(Lists.newArrayList(1L), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.GT, new CastOperator(Type.STRING, intColumn),
+                ConstantOperator.createVarchar("3")));
+        Assert.assertEquals(Lists.newArrayList(), pruner.prune());
+
+        conjuncts.clear();
+        conjuncts.add(new BinaryPredicateOperator(BinaryType.LT, new CastOperator(Type.STRING, intColumn),
+                ConstantOperator.createVarchar("2")));
+        Assert.assertEquals(Lists.newArrayList(1L, 4L, 5L, 6L), pruner.prune());
     }
 
     @Test


### PR DESCRIPTION
Fixes #25838

partitionValueMap' type is TreeMap<LiteralExpr, Set<Long>>, it should cast the key LiteralExpr to cast operator's type, not use partition column origin type

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
