### PR TITLE
[BugFix][cherry-pick][branch-2.5] Fix partition prune error when predicate with partition column has cast function (#25839)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.planner.PartitionPruner;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
@@ -176,9 +177,42 @@ public class ListPartitionPruner implements PartitionPruner {
         return false;
     }
 
+    // generate new partition value map using cast operator' type.
+    // eg. string partition value cast to int
+    // string_col = '01'  1
+    // string_col = '1'   2
+    // string_col = '001' 3
+    // will generate new partition value map
+    // int_col = 1  [1, 2, 3]
+    private TreeMap<LiteralExpr, Set<Long>> getCastPartitionValueMap(CastOperator castOperator,
+                                                                     TreeMap<LiteralExpr, Set<Long>> partitionValueMap) {
+        TreeMap<LiteralExpr, Set<Long>> newPartitionValueMap = new TreeMap<>();
+
+        for (Map.Entry<LiteralExpr, Set<Long>> entry : partitionValueMap.entrySet()) {
+            LiteralExpr literalExpr = null;
+            LiteralExpr key = entry.getKey();
+            try {
+                literalExpr = LiteralExpr.create(key.getStringValue(), castOperator.getType());
+            } catch (Exception e) {
+                // ignore
+            }
+            if (literalExpr == null) {
+                try {
+                    literalExpr = (LiteralExpr) key.uncheckedCastTo(castOperator.getType());
+                } catch (Exception e) {
+                    LOG.error(e);
+                    throw new StarRocksConnectorException("can not cast partition value" + key.getStringValue() +
+                            "to target type " + castOperator.getType().prettyPrint());
+                }
+            }
+            Set<Long> partitions = newPartitionValueMap.computeIfAbsent(literalExpr, k -> Sets.newHashSet());
+            partitions.addAll(entry.getValue());
+        }
+        return newPartitionValueMap;
+    }
+
     private Set<Long> evalBinaryPredicate(BinaryPredicateOperator binaryPredicate) {
         Preconditions.checkNotNull(binaryPredicate);
-        ScalarOperator left = binaryPredicate.getChild(0);
         ScalarOperator right = binaryPredicate.getChild(1);
 
         if (!(right.isConstantRef())) {
@@ -194,6 +228,13 @@ public class ListPartitionPruner implements PartitionPruner {
         Set<Long> matches = Sets.newHashSet();
         TreeMap<LiteralExpr, Set<Long>> partitionValueMap = columnToPartitionValuesMap.get(leftChild);
         Set<Long> nullPartitions = columnToNullPartitions.get(leftChild);
+
+        if (binaryPredicate.getChild(0) instanceof CastOperator && partitionValueMap != null) {
+            // partitionValueMap need cast to target type
+            partitionValueMap = getCastPartitionValueMap((CastOperator) binaryPredicate.getChild(0),
+                    partitionValueMap);
+        }
+
         if (partitionValueMap == null || nullPartitions == null || partitionValueMap.isEmpty()) {
             return null;
         }


### PR DESCRIPTION
Fixes #25838

partitionValueMap' type is TreeMap<LiteralExpr, Set<Long>>, it should cast the key LiteralExpr to cast operator's type, not use partition column origin type

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
