### PR TITLE
[Tool] Upgrade ftm from 7.0.3 to 8.1.1.

### DIFF
--- a/be/src/fs/fs_broker.cpp
+++ b/be/src/fs/fs_broker.cpp
@@ -336,7 +336,7 @@ StatusOr<std::unique_ptr<WritableFile>> BrokerFileSystem::new_writable_file(cons
                                                                             const std::string& path) {
     if (opts.mode == FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE) {
         if (auto st = _path_exists(path); st.ok()) {
-            return Status::NotSupported("Cannot truncate a file by broker, path={}"_format(path));
+            return Status::NotSupported(fmt::format("Cannot truncate a file by broker, path={}", path));
         }
     } else if (opts.mode == MUST_CREATE) {
         if (auto st = _path_exists(path); st.ok()) {
@@ -346,7 +346,8 @@ StatusOr<std::unique_ptr<WritableFile>> BrokerFileSystem::new_writable_file(cons
         return Status::NotSupported("Open with MUST_EXIST not supported by broker");
     } else if (opts.mode == CREATE_OR_OPEN) {
         if (auto st = _path_exists(path); st.ok()) {
-            return Status::NotSupported("Cannot open an already exists file through broker, path={}"_format(path));
+            return Status::NotSupported(
+                    fmt::format("Cannot open an already exists file through broker, path={}", path));
         }
     } else {
         auto msg = strings::Substitute("Unsupported open mode $0", opts.mode);

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -187,7 +187,7 @@ Status HDFSWritableFile::append(const Slice& data) {
     }
     if (r != data.size) {
         auto error_msg =
-                "Fail to append {}, expect written size: {}, actual written size {} "_format(_path, data.size, r);
+                fmt::format("Fail to append {}, expect written size: {}, actual written size {} ", _path, data.size, r);
         LOG(WARNING) << error_msg;
         return Status::IOError(error_msg);
     }
@@ -340,7 +340,7 @@ Status HdfsFileSystem::iterate_dir(const std::string& dir, const std::function<b
     int numEntries;
     fileinfo = hdfsListDirectory(hdfs_client->hdfs_fs, dir.data(), &numEntries);
     if (fileinfo == nullptr) {
-        return Status::InvalidArgument("hdfs list directory error {}"_format(dir));
+        return Status::InvalidArgument(fmt::format("hdfs list directory error {}", dir));
     }
     for (int i = 0; i < numEntries && fileinfo; ++i) {
         // obj_key.data() + uri.key().size(), obj_key.size() - uri.key().size()
@@ -375,7 +375,7 @@ Status HdfsFileSystem::iterate_dir2(const std::string& dir, const std::function<
     int numEntries;
     fileinfo = hdfsListDirectory(hdfs_client->hdfs_fs, dir.data(), &numEntries);
     if (fileinfo == nullptr) {
-        return Status::InvalidArgument("hdfs list directory error {}"_format(dir));
+        return Status::InvalidArgument(fmt::format("hdfs list directory error {}", dir));
     }
     for (int i = 0; i < numEntries && fileinfo; ++i) {
         // obj_key.data() + uri.key().size(), obj_key.size() - uri.key().size()
@@ -391,7 +391,7 @@ Status HdfsFileSystem::iterate_dir2(const std::string& dir, const std::function<
             std::string mName(fileinfo[i].mName);
             std::size_t found = mName.rfind('/');
             if (found == std::string::npos) {
-                return Status::InvalidArgument("parse path fail {}"_format(dir));
+                return Status::InvalidArgument(fmt::format("parse path fail {}", dir));
             }
 
             dir_size = found + 1;
@@ -530,7 +530,7 @@ Status HdfsFileSystem::rename_file(const std::string& src, const std::string& ta
     RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, hdfs_client, _options));
     int ret = hdfsRename(hdfs_client->hdfs_fs, src.data(), target.data());
     if (ret != 0) {
-        return Status::InvalidArgument("rename file from {} to {} error"_format(src, target));
+        return Status::InvalidArgument(fmt::format("rename file from {} to {} error", src, target));
     }
     return Status::OK();
 }

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -162,11 +162,12 @@ Status EngineCloneTask::_do_clone_primary_tablet(Tablet* tablet) {
         if (st.ok()) {
             st = _finish_clone_primary(tablet, download_path);
         } else if (st.is_not_found()) {
-            LOG(INFO) << "No missing version found from src replica. tablet: {}, src BE:{}:{}, type: {}, "
-                         "missing_version_ranges: {}, committed_version: {}"_format(
-                                 tablet->tablet_id(), _clone_req.src_backends[0].host,
-                                 _clone_req.src_backends[0].be_port, KeysType_Name(tablet->keys_type()),
-                                 version_range_list_to_string(missing_version_ranges), _clone_req.committed_version);
+            LOG(INFO) << fmt::format(
+                    "No missing version found from src replica. tablet: {}, src BE:{}:{}, type: {}, "
+                    "missing_version_ranges: {}, committed_version: {}",
+                    tablet->tablet_id(), _clone_req.src_backends[0].host, _clone_req.src_backends[0].be_port,
+                    KeysType_Name(tablet->keys_type()), version_range_list_to_string(missing_version_ranges),
+                    _clone_req.committed_version);
             return Status::OK();
         }
     }

--- a/docker/dockerfiles/dev-env/dev-env.Dockerfile
+++ b/docker/dockerfiles/dev-env/dev-env.Dockerfile
@@ -22,7 +22,7 @@ ARG predownload_thirdparty=false
 ARG thirdparty_url=https://cdn-thirdparty.starrocks.com/starrocks-thirdparty-main-20230317.tar
 ARG commit_id
 # check thirdparty/starlet-artifacts-version.sh, to get the right tag
-ARG starlet_tag=v3.1-rc5
+ARG starlet_tag=v3.1-rc6
 # build for which linux distro: centos7|ubuntu
 ARG distro=ubuntu
 

--- a/thirdparty/starlet-artifacts-version.sh
+++ b/thirdparty/starlet-artifacts-version.sh
@@ -9,4 +9,4 @@
 #   https://hub.docker.com/r/starrocks/starlet-artifacts-centos7/tags
 #
 # Update the following tag when STARLET releases a new version.
-export STARLET_ARTIFACTS_TAG=v3.1-rc5
+export STARLET_ARTIFACTS_TAG=v3.1-rc6

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -277,10 +277,10 @@ CCTZ_SOURCE="cctz-2.3"
 CCTZ_MD5SUM="209348e50b24dbbdec6d961059c2fc92"
 
 # FMT
-FMT_DOWNLOAD="https://github.com/fmtlib/fmt/releases/download/7.0.3/fmt-7.0.3.zip"
-FMT_NAME="fmt-7.0.3.zip"
-FMT_SOURCE="fmt-7.0.3"
-FMT_MD5SUM="60c8803eb36a6ff81a4afde33c0f621a"
+FMT_DOWNLOAD="https://github.com/fmtlib/fmt/releases/download/8.1.1/fmt-8.1.1.zip"
+FMT_NAME="fmt-8.1.1.zip"
+FMT_SOURCE="fmt-8.1.1"
+FMT_MD5SUM="16dcd48ecc166f10162450bb28aabc87"
 
 # RYU
 RYU_DOWNLOAD="https://github.com/ulfjack/ryu/archive/aa31ca9361d21b1a00ee054aac49c87d07e74abc.zip"


### PR DESCRIPTION
Upgrade fmt from 7.0.3 to 8.1.1.
In my fork, I need to use a library that requires fmt-8.1.1.

I have fixed a potential compatibility issue in https://github.com/StarRocks/starrocks/pull/25806.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [X] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
