### PR TITLE
[BugFix][Cherry-Pick][Branch-2.5] Fix BE crashed when table's type is different from ORC's type

### DIFF
--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -550,7 +550,7 @@ Status OrcChunkReader::_fill_chunk(ChunkPtr* chunk, const std::vector<SlotDescri
             }
         }
         ColumnPtr& col = (*chunk)->get_column_by_slot_id(slot_desc->id());
-        _fill_functions[src_index](cvb, col, 0, _batch->numElements, slot_desc->type(),
+        _fill_functions[src_index](cvb, col, 0, _batch->numElements, _src_types[src_index],
                                    _root_selected_mapping->get_column_id_or_child_mapping(src_index).orc_mapping, this);
     }
 


### PR DESCRIPTION
Cherry-pick from #25921

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
