### PR TITLE
[BugFix] Disable creating generated columns in lake and agg table (#26084)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
@@ -28,6 +28,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Index;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
@@ -301,6 +302,14 @@ public class AlterTableStatementAnalyzer {
                     throw new SemanticException("Materialized Column only support olap table");
                 }
 
+                if (table.isCloudNativeTable()) {
+                    throw new SemanticException("Lake table does not support generated column");
+                }
+
+                if (((OlapTable) table).getKeysType() == KeysType.AGG_KEYS) {
+                    throw new SemanticException("Generated Column does not support AGG table");
+                }
+
                 clause.setRollupName(Strings.emptyToNull(clause.getRollupName()));
 
                 Expr expr = columnDef.materializedColumnExpr();
@@ -411,6 +420,14 @@ public class AlterTableStatementAnalyzer {
                     if (!table.isOlapTable()) {
                         throw new SemanticException("Materialized Column only support olap table");
                     }
+
+                    if (table.isCloudNativeTable()) {
+                        throw new SemanticException("Lake table does not support generated column");
+                    }
+
+                    if (((OlapTable) table).getKeysType() == KeysType.AGG_KEYS) {
+                        throw new SemanticException("Generated Column does not support AGG table");
+                    }
     
                     Expr expr = colDef.materializedColumnExpr();
                     TableName tableName = new TableName(context.getDatabase(), table.getName());
@@ -520,6 +537,14 @@ public class AlterTableStatementAnalyzer {
             if (columnDef.isMaterializedColumn()) {
                 if (!(table instanceof OlapTable)) {
                     throw new SemanticException("Materialized Column only support olap table");
+                }
+
+                if (table.isCloudNativeTable()) {
+                    throw new SemanticException("Lake table does not support generated column");
+                }
+
+                if (((OlapTable) table).getKeysType() == KeysType.AGG_KEYS) {
+                    throw new SemanticException("Generated Column does not support AGG table");
                 }
     
                 clause.setRollupName(Strings.emptyToNull(clause.getRollupName()));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -40,6 +40,7 @@ import com.starrocks.connector.elasticsearch.EsUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DistributionDesc;
@@ -410,6 +411,10 @@ public class CreateTableAnalyzer {
             throw new SemanticException("Generated Column only support olap table");
         }
 
+        if (hasMaterializedColum && keysDesc.getKeysType() == KeysType.AGG_KEYS) {
+            throw new SemanticException("Generated Column does not support AGG table");
+        }
+
         Map<String, Column> columnsMap = Maps.newHashMap();
         for (Column column : columns) {
             columnsMap.put(column.getName(), column);
@@ -421,6 +426,10 @@ public class CreateTableAnalyzer {
         if (hasMaterializedColum) {
             if (!statement.isOlapEngine()) {
                 throw new SemanticException("Materialized Column only support olap table");
+            }
+
+            if (RunMode.allowCreateLakeTable()) {
+                throw new SemanticException("Table with Generated column can not be lake table");
             }
 
             boolean found = false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateTableTest.java
@@ -393,4 +393,11 @@ public class AnalyzeCreateTableTest {
                     "\"table\" = \"hive_hdfs_orc_nocompress\"," +
                     "\"database\" = \"hive_extbl_test\");");
     }
+
+    @Test
+    public void testGeneratedColumnOnAGGTable() throws Exception {
+        analyzeFail("CREATE TABLE t ( id BIGINT NOT NULL,  name BIGINT NOT NULL, v1 BIGINT SUM as id)" +
+                    "AGGREGATE KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 " +
+                    "PROPERTIES(\"replication_num\" = \"1\", \"replicated_storage\"=\"true\");");
+    }
 }


### PR DESCRIPTION
Problem:
1. Currently, generated column does not support lake table, but there is no restriction for creating it in lake table which is a bug.
2. agg table can be created generated column actually, but it is difficult to understand the semantic and it is no clearly scenes to use it. So we should disable it too.

Fixes #26084

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
