### PR TITLE
[Enhancement] display table names when show colocate group info

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ColocationGroupProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ColocationGroupProcDir.java
@@ -47,7 +47,7 @@ import java.util.List;
  */
 public class ColocationGroupProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add("GroupId").add("GroupName").add("TableIds")
+            .add("GroupId").add("GroupName").add("TableIds").add("TableNames")
             .add("BucketsNum").add("ReplicationNum").add("DistCols").add("IsStable").build();
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -159,7 +159,8 @@ public class ColocateTableIndexTest {
         map = groupByName(infos);
         Assert.assertEquals(2, infos.size());
         Assert.assertEquals(String.format("%d*, %d*", table1To1.getId(), table1To2.getId()), map.get("group1").get(2));
-        Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()), map.get("group1").get(3));
+        Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()),
+                map.get("group1").get(3));
 
         Assert.assertEquals(String.format("%d", table2To1.getId()), map.get("group2").get(2));
         Assert.assertEquals(String.format("table2_1", table2To1.getId()), map.get("group2").get(3));
@@ -203,9 +204,11 @@ public class ColocateTableIndexTest {
         Assert.assertEquals(String.format("%d*, %d*", table1To1.getId(), table1To2.getId()), map.get("group1").get(2));
         Assert.assertEquals("[deleted], [deleted]", map.get("group1").get(3));
         Assert.assertEquals(String.format("%d*", table2To1.getId()), map.get("group2").get(2));
-        Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()), map.get("group1").get(3));
+        Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()),
+                map.get("group1").get(3));
         Assert.assertEquals(String.format("%d*", table2To3.getId()), map.get("group3").get(2));
-        Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()), map.get("group1").get(3));
+        Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()),
+                map.get("group1").get(3));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColocateTableIndexTest.java
@@ -159,7 +159,12 @@ public class ColocateTableIndexTest {
         map = groupByName(infos);
         Assert.assertEquals(2, infos.size());
         Assert.assertEquals(String.format("%d*, %d*", table1To1.getId(), table1To2.getId()), map.get("group1").get(2));
+        Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()), map.get("group1").get(3));
+
         Assert.assertEquals(String.format("%d", table2To1.getId()), map.get("group2").get(2));
+        Assert.assertEquals(String.format("table2_1", table2To1.getId()), map.get("group2").get(3));
+
+
         LOG.info("after drop db1.table1_2: {}", infos);
 
         // drop db2
@@ -196,8 +201,11 @@ public class ColocateTableIndexTest {
         LOG.info("after create & drop db2: {}", infos);
         Assert.assertEquals(3, infos.size());
         Assert.assertEquals(String.format("%d*, %d*", table1To1.getId(), table1To2.getId()), map.get("group1").get(2));
+        Assert.assertEquals("[deleted], [deleted]", map.get("group1").get(3));
         Assert.assertEquals(String.format("%d*", table2To1.getId()), map.get("group2").get(2));
+        Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()), map.get("group1").get(3));
         Assert.assertEquals(String.format("%d*", table2To3.getId()), map.get("group3").get(2));
+        Assert.assertEquals(String.format("[deleted], [deleted]", table1To1.getId(), table1To2.getId()), map.get("group1").get(3));
     }
 
     @Test


### PR DESCRIPTION
Add colocate table names col like:
```
mysql> show proc '/colocation_group';
+-------------+-----------------+----------------------------+------------------+------------+----------------+----------------------+----------+
| GroupId     | GroupName       | TableIds                   | TableNames       | BucketsNum | ReplicationNum | DistCols             | IsStable |
+-------------+-----------------+----------------------------+------------------+------------+----------------+----------------------+----------+
| 91023.91027 | 91023_group1    | 91025, 91039, 91052, 91065 | t1, t2, t3, t4   | 5          | 1              | int(11), varchar(20) | true     |
| 40011.53215 | 40011_cg_group1 | 53213, 63611, 74008        | EKPO, RSEG, EKKO | 5197       | 1              | int(11)              | true     |
| 40011.44022 | 40011_g2        | 44020                      | test_fifa_month  | 160        | 1              | varchar(65533)       | true     |
+-------------+-----------------+----------------------------+------------------+------------+----------------+----------------------+----------+
3 rows in set (0.00 sec)
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
