### PR TITLE
[BugFix][Cherry-pick][Branch-3.0] Failed delete job do not return until timeout (#23320)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/MarkedCountDownLatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MarkedCountDownLatch.java
@@ -64,6 +64,13 @@ public class MarkedCountDownLatch<K, V> extends CountDownLatch {
         return false;
     }
 
+    public synchronized boolean markedCountDown(K key, V value, Status status) {
+        if (st.ok()) {
+            st = status;
+        }
+        return markedCountDown(key, value);
+    }
+
     public synchronized List<Entry<K, V>> getLeftMarks() {
         return Lists.newArrayList(marks.entries());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -218,12 +218,26 @@ public class LeaderImpl {
                 String errMsg = "task type: " + taskType + ", status_code: " + taskStatus.getStatus_code().toString() +
                         ", backendId: " + backend + ", signature: " + signature;
                 task.setErrorMsg(errMsg);
+                LOG.warn(errMsg);
                 // We start to let FE perceive the task's error msg
                 if (taskType != TTaskType.MAKE_SNAPSHOT && taskType != TTaskType.UPLOAD
                         && taskType != TTaskType.DOWNLOAD && taskType != TTaskType.MOVE
                         && taskType != TTaskType.CLONE && taskType != TTaskType.PUBLISH_VERSION
                         && taskType != TTaskType.CREATE && taskType != TTaskType.UPDATE_TABLET_META_INFO
                         && taskType != TTaskType.DROP_AUTO_INCREMENT_MAP) {
+                    if (taskType == TTaskType.REALTIME_PUSH) {
+                        PushTask pushTask = (PushTask) task;
+                        if (pushTask.getPushType() == TPushType.DELETE) {
+                            LOG.info("remove push replica. tabletId: {}, backendId: {}", task.getSignature(),
+                                     pushTask.getBackendId());
+
+                            String failMsg = "Backend: " + task.getBackendId() + "Tablet: " + pushTask.getTabletId() +
+                                             " error msg: " + taskStatus.getError_msgs().toString();
+                            pushTask.countDownLatch(pushTask.getBackendId(), pushTask.getTabletId(), failMsg);
+                            AgentTaskQueue.removeTask(pushTask.getBackendId(), TTaskType.REALTIME_PUSH, 
+                                                      task.getSignature());
+                        }
+                    }
                     return result;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
@@ -54,6 +54,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.MarkedCountDownLatch;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.Status;
 import com.starrocks.common.UserException;
 import com.starrocks.qe.QueryStateException;
 import com.starrocks.server.GlobalStateMgr;
@@ -183,6 +184,7 @@ public class OlapDeleteJob extends DeleteJob {
         } finally {
             db.readUnlock();
         }
+        LOG.info("countDownLatch count: {}", countDownLatch.getCount());
 
         long timeoutMs = getTimeoutMs();
         LOG.info("waiting delete Job finish, signature: {}, timeout: {}", getTransactionId(), timeoutMs);
@@ -208,59 +210,65 @@ public class OlapDeleteJob extends DeleteJob {
         } catch (InterruptedException e) {
             LOG.warn("InterruptedException: ", e);
         }
-
-        if (!ok) {
-            String errMsg = "";
-            List<Map.Entry<Long, Long>> unfinishedMarks = countDownLatch.getLeftMarks();
-            // only show at most 5 results
-            List<Map.Entry<Long, Long>> subList = unfinishedMarks.subList(0, Math.min(unfinishedMarks.size(), 5));
-            if (!subList.isEmpty()) {
-                errMsg = "unfinished replicas: " + Joiner.on(", ").join(subList);
-            }
-            LOG.warn(errMsg);
-
-            try {
-                checkAndUpdateQuorum();
-            } catch (MetaNotFoundException e) {
-                cancel(DeleteMgr.CancelType.METADATA_MISSING, e.getMessage());
-                throw new DdlException(e.getMessage(), e);
-            }
-            DeleteState state = getState();
-            switch (state) {
-                case DELETING:
-                    LOG.warn("delete job timeout: transactionId {}, timeout {}, {}", getTransactionId(), timeoutMs,
-                            errMsg);
-                    cancel(DeleteMgr.CancelType.TIMEOUT, "delete job timeout");
-                    throw new DdlException("failed to execute delete. transaction id " + getTransactionId() +
-                            ", timeout(ms) " + timeoutMs + ", " + errMsg);
-                case QUORUM_FINISHED:
-                case FINISHED:
-                    try {
-                        long nowQuorumTimeMs = System.currentTimeMillis();
-                        long endQuorumTimeoutMs = nowQuorumTimeMs + timeoutMs / 2;
-                        // if job's state is quorum_finished then wait for a period of time and commit it.
-                        while (getState() == DeleteState.QUORUM_FINISHED && endQuorumTimeoutMs > nowQuorumTimeMs) {
-                            checkAndUpdateQuorum();
-                            Thread.sleep(1000);
-                            nowQuorumTimeMs = System.currentTimeMillis();
-                            LOG.debug("wait for quorum finished delete job: {}, txn_id: {}", getId(),
-                                    getTransactionId());
-                        }
-                    } catch (MetaNotFoundException e) {
-                        cancel(DeleteMgr.CancelType.METADATA_MISSING, e.getMessage());
-                        throw new DdlException(e.getMessage(), e);
-                    } catch (InterruptedException e) {
-                        cancel(DeleteMgr.CancelType.UNKNOWN, e.getMessage());
-                        throw new DdlException(e.getMessage(), e);
-                    }
-                    commit(db, timeoutMs);
-                    break;
-                default:
-                    throw new IllegalStateException("wrong delete job state: " + state.name());
-            }
-        } else {
-            commit(db, timeoutMs);
+        LOG.info("delete job finish, countDownLatch count: {}", countDownLatch.getCount());
+ 
+        String errMsg = "";
+        List<Map.Entry<Long, Long>> unfinishedMarks = countDownLatch.getLeftMarks();
+        Status st = countDownLatch.getStatus();
+        // only show at most 5 results
+        List<Map.Entry<Long, Long>> subList = unfinishedMarks.subList(0, Math.min(unfinishedMarks.size(), 5));
+        if (!subList.isEmpty()) {
+            errMsg = "unfinished replicas: " + Joiner.on(", ").join(subList);
+        } else if (!st.ok()) {
+            errMsg = st.toString();
         }
+        LOG.warn(errMsg);
+
+        try {
+            checkAndUpdateQuorum();
+        } catch (MetaNotFoundException e) {
+            cancel(DeleteHandler.CancelType.METADATA_MISSING, e.getMessage());
+            throw new DdlException(e.getMessage(), e);
+        }
+        DeleteState state = getState();
+        switch (state) {
+            case DELETING:
+                LOG.warn("delete job failed: transactionId {}, timeout {}, {}", getTransactionId(), timeoutMs,
+                        errMsg);
+                if (countDownLatch.getCount() > 0) {
+                    cancel(DeleteHandler.CancelType.TIMEOUT, "delete job timeout");
+                } else {
+                    cancel(DeleteHandler.CancelType.UNKNOWN, "delete job failed");
+                }
+                throw new DdlException("failed to execute delete. transaction id " + getTransactionId() +
+                        ", timeout(ms) " + timeoutMs + ", " + errMsg);
+            case QUORUM_FINISHED:
+            case FINISHED:
+                try {
+                    long nowQuorumTimeMs = System.currentTimeMillis();
+                    long endQuorumTimeoutMs = nowQuorumTimeMs + timeoutMs / 2;
+                    // if job's state is quorum_finished then wait for a period of time and commit it.
+                    while (getState() == DeleteState.QUORUM_FINISHED && endQuorumTimeoutMs > nowQuorumTimeMs
+                          && countDownLatch.getCount() > 0) {
+                        checkAndUpdateQuorum();
+                        Thread.sleep(1000);
+                        nowQuorumTimeMs = System.currentTimeMillis();
+                        LOG.debug("wait for quorum finished delete job: {}, txn_id: {}", getId(),
+                                getTransactionId());
+                    }
+                } catch (MetaNotFoundException e) {
+                    cancel(DeleteHandler.CancelType.METADATA_MISSING, e.getMessage());
+                    throw new DdlException(e.getMessage(), e);
+                } catch (InterruptedException e) {
+                    cancel(DeleteHandler.CancelType.UNKNOWN, e.getMessage());
+                    throw new DdlException(e.getMessage(), e);
+                }
+                commit(db, timeoutMs);
+                break;
+            default:
+                throw new IllegalStateException("wrong delete job state: " + state.name());
+        }
+
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
@@ -43,6 +43,7 @@ import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.Predicate;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.common.MarkedCountDownLatch;
+import com.starrocks.common.Status;
 import com.starrocks.thrift.TBrokerScanRange;
 import com.starrocks.thrift.TCondition;
 import com.starrocks.thrift.TDescriptorTable;
@@ -50,6 +51,7 @@ import com.starrocks.thrift.TPriority;
 import com.starrocks.thrift.TPushReq;
 import com.starrocks.thrift.TPushType;
 import com.starrocks.thrift.TResourceInfo;
+import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TTaskType;
 import org.apache.logging.log4j.LogManager;
@@ -213,6 +215,15 @@ public class PushTask extends AgentTask {
     public void countDownLatch(long backendId, long tabletId) {
         if (this.latch != null) {
             if (latch.markedCountDown(backendId, tabletId)) {
+                LOG.info("pushTask current latch count: {}. backend: {}, tablet:{}",
+                        latch.getCount(), backendId, tabletId);
+            }
+        }
+    }
+
+    public void countDownLatch(long backendId, long tabletId, String errMsg) {
+        if (this.latch != null) {
+            if (latch.markedCountDown(backendId, tabletId, new Status(TStatusCode.INTERNAL_ERROR, errMsg))) {
                 LOG.info("pushTask current latch count: {}. backend: {}, tablet:{}",
                         latch.getCount(), backendId, tabletId);
             }


### PR DESCRIPTION
If a delete job execute failed in BE and it return failed to FE, FE will ignore the fail status and retry until timeout. It will confuse users and ignore the real fail reason.

