### PR TITLE
[Enhancement] Support runtime profile(2)

### DIFF
--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -130,7 +130,6 @@ void FragmentContext::report_exec_state_if_necessary() {
         return;
     }
     if (_last_report_exec_state_ns.compare_exchange_strong(last_report_exec_state_ns, now)) {
-        LOG(ERROR) << "report runtime profile, query_id=" << print_id(_query_id);
         state->exec_env()->wg_driver_executor()->report_exec_state(query_ctx, this, Status::OK(), false, true);
     }
 }

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -502,7 +502,7 @@ Status ScanOperator::_pickup_morsel(RuntimeState* state, int chunk_source_index)
 void ScanOperator::_merge_chunk_source_profiles(RuntimeState* state) {
     auto query_ctx = _query_ctx.lock();
     // _query_ctx uses lazy initialization, maybe it is not initialized
-    // under certian circumstance
+    // under certain circumstance
     if (query_ctx == nullptr) {
         query_ctx = state->exec_env()->query_context_mgr()->get(state->query_id());
         DCHECK(query_ctx != nullptr);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1744,6 +1744,7 @@ public class Coordinator {
             mergedInstanceProfile.getChildList().forEach(pair -> {
                 RuntimeProfile pipelineProfile = pair.first;
                 foldUnnecessaryLimitOperators(pipelineProfile);
+                setOperatorStatus(pipelineProfile);
                 newFragmentProfile.addChild(pipelineProfile);
             });
 
@@ -1777,7 +1778,8 @@ public class Coordinator {
                 RuntimeProfile pipelineProfile = pipelineProfilePair.first;
                 for (Pair<RuntimeProfile, Boolean> operatorProfilePair : pipelineProfile.getChildList()) {
                     RuntimeProfile operatorProfile = operatorProfilePair.first;
-                    if (!foundResultSink & operatorProfile.getName().contains("RESULT_SINK")) {
+                    if (!foundResultSink && (operatorProfile.getName().contains("RESULT_SINK") ||
+                            operatorProfile.getName().contains("OLAP_TABLE_SINK"))) {
                         long executionWallTime = pipelineProfile.getCounter("DriverTotalTime").getValue();
                         Counter executionTotalTime =
                                 newQueryProfile.addCounter("QueryExecutionWallTime", TUnit.TIME_NS, null);
@@ -1855,6 +1857,21 @@ public class Coordinator {
         }
 
         foldNames.forEach(pipelineProfile::removeChild);
+    }
+
+    private void setOperatorStatus(RuntimeProfile pipelineProfile) {
+        for (Pair<RuntimeProfile, Boolean> child : pipelineProfile.getChildList()) {
+            RuntimeProfile operatorProfile = child.first;
+            RuntimeProfile commonMetrics = operatorProfile.getChild("CommonMetrics");
+            Preconditions.checkNotNull(commonMetrics);
+
+            Counter closeTime = commonMetrics.getCounter("CloseTime");
+            Counter minCloseTime = commonMetrics.getCounter("__MIN_OF_CloseTime");
+            if (closeTime != null && closeTime.getValue() == 0 ||
+                    minCloseTime != null && minCloseTime.getValue() == 0) {
+                commonMetrics.addInfoString("Status", "Running");
+            }
+        }
     }
 
     /*

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -275,6 +275,9 @@ public class StmtExecutor {
             sb.append(SessionVariable.ENABLE_RUNTIME_ADAPTIVE_DOP).append("=")
                     .append(variables.isEnableRuntimeAdaptiveDop())
                     .append(",");
+            sb.append(SessionVariable.RUNTIME_PROFILE_REPORT_INTERVAL).append("=")
+                    .append(variables.getRuntimeProfileReportInterval())
+                    .append(",");
             if (context.getResourceGroup() != null) {
                 sb.append(SessionVariable.RESOURCE_GROUP).append("=").append(context.getResourceGroup().getName())
                         .append(",");


### PR DESCRIPTION
Continuation work of #25131

Main work of this pr
1. Add an info string `Status: Running` to indicate this operator is still running, it can help facilitate better visual representation.
2. Add session variable `runtime_profile_report_interval` in profile to facilitate the adjustment of the refresh interval for the front-end page
3. Add Compatible process for `insert into` statement

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
