### PR TITLE
[BugFix] avoid allocate memory when dump trace info

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -86,7 +86,7 @@ static void dump_trace_info() {
         // dump query_id and fragment id
         auto query_id = CurrentThread::current().query_id();
         auto fragment_instance_id = CurrentThread::current().fragment_instance_id();
-        const std::string custom_coredump_msg = CurrentThread::current().get_custom_coredump_msg();
+        const std::string& custom_coredump_msg = CurrentThread::current().get_custom_coredump_msg();
         const uint32_t MAX_BUFFER_SIZE = 512;
         char buffer[MAX_BUFFER_SIZE] = {};
 
@@ -110,7 +110,7 @@ static void dump_trace_info() {
         wt = write(STDERR_FILENO, buffer, res);
         // dump memory usage
         // copy trackers
-        auto trackers = ExecEnv::GetInstance()->mem_trackers();
+        auto& trackers = ExecEnv::GetInstance()->mem_trackers();
         for (const auto& tracker : trackers) {
             if (tracker) {
                 size_t len = tracker->debug_string(buffer, sizeof(buffer));

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -212,9 +212,9 @@ public:
     void set_pipeline_driver_id(int32_t driver_id) { _driver_id = driver_id; }
     int32_t get_driver_id() const { return _driver_id; }
 
-    void set_custom_coredump_msg(const std::string custom_coredump_msg) { _custom_coredump_msg = custom_coredump_msg; }
+    void set_custom_coredump_msg(const std::string& custom_coredump_msg) { _custom_coredump_msg = custom_coredump_msg; }
 
-    const std::string get_custom_coredump_msg() const { return _custom_coredump_msg; }
+    const std::string& get_custom_coredump_msg() const { return _custom_coredump_msg; }
 
     // Return prev memory tracker.
     starrocks::MemTracker* set_mem_tracker(starrocks::MemTracker* mem_tracker) {


### PR DESCRIPTION
we shouldn't call any allocate memory function when dump trace info

```
start time: Tue Jun 27 23:05:11 CST 2023
<jemalloc>: src/arena.c:366: Failed assertion: "bitmap_get(slab_data->bitmap, &bin_info->bitmap_info, regind)"
UNKNOWN RELEASE (build 3f36b7a)
query_id:ebbbcb0d-1594-11ee-b0fd-52540062cc3e, fragment_instance:ebbbcb0d-1594-11ee-b0fd-52540062cc76
<jemalloc>: Should own 0 locks of rank >= 1: bin(4294967295)
start time: Wed Jun 28 17:23:10 CST 2023
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
