### PR TITLE
[BugFix] Fix prune map_values bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldRule.java
@@ -49,6 +49,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class PruneSubfieldRule implements TreeRewriteRule {
+    private static final List<String> SUPPORT_FUNCTIONS = ImmutableList.<String>builder()
+            .add(FunctionSet.MAP_KEYS, FunctionSet.MAP_SIZE)
+            .build();
 
     @Override
     public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
@@ -60,10 +63,6 @@ public class PruneSubfieldRule implements TreeRewriteRule {
      * collect all complex expressions, such as: MAP_KEYS, MAP_VALUES, map['key'], struct.a.b.c ...
      */
     private static class ComplexExpressionCollector extends ScalarOperatorVisitor<Void, Void> {
-        private static final List<String> SUPPORT_FUNCTIONS = ImmutableList.<String>builder()
-                .add(FunctionSet.MAP_KEYS, FunctionSet.MAP_SIZE, FunctionSet.MAP_VALUES)
-                .build();
-
         private final List<ScalarOperator> complexExpressions = Lists.newArrayList();
 
         @Override
@@ -306,9 +305,6 @@ public class PruneSubfieldRule implements TreeRewriteRule {
      * normalize expression to ColumnAccessPath
      */
     private static class SubfieldAccessPathNormalizer extends ScalarOperatorVisitor<Void, Void> {
-        private static final List<String> NORMALIZE_FUNCTIONS =
-                ImmutableList.of(FunctionSet.MAP_KEYS, FunctionSet.MAP_SIZE, FunctionSet.MAP_VALUES);
-
         private final Deque<AccessPath> allAccessPaths = Lists.newLinkedList();
 
         private AccessPath currentPath = null;
@@ -378,7 +374,7 @@ public class PruneSubfieldRule implements TreeRewriteRule {
 
         @Override
         public Void visitCall(CallOperator call, Void context) {
-            if (!NORMALIZE_FUNCTIONS.contains(call.getFnName())) {
+            if (!SUPPORT_FUNCTIONS.contains(call.getFnName())) {
                 return visit(call, context);
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -226,5 +226,9 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         String sql = "select map_keys(map1), map_values(map1) from pc0";
         String plan = getVerboseExplain(sql);
         assertNotContains(plan, "ColumnAccessPath");
+
+        sql = "select map_keys(map1), map_size(map1) from pc0";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "[/map1/KEY, /map1/OFFSET]");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -220,4 +220,11 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         plan = getVerboseExplain(sql);
         assertContains(plan, "[/st1/s2, /st1/s1]");
     }
+
+    @Test
+    public void testPruneMapValues() throws Exception {
+        String sql = "select map_keys(map1), map_values(map1) from pc0";
+        String plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath");
+    }
 }


### PR DESCRIPTION
Fixes #issue

When `map_keys` and `map_values` appear at the same time, the values is prune by mistake

```
MySQL test> select  map_values(col_map) from test_semi_struct_array_functions;
+---------------------------------+
| map_values(col_map)             |
+---------------------------------+
| [{"2023-01-01":{1.11:1.11100}}] |
+---------------------------------+
1 row in set
Time: 0.038s
MySQL test> select map_keys(col_map), map_values(col_map) from test_semi_struct_array_functions;
+-------------------+---------------------+
| map_keys(col_map) | map_values(col_map) |
+-------------------+---------------------+
| [1]               | [null]              |
+-------------------+---------------------+
1 row in set
Time: 0.037s
MySQL test>
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
