### PR TITLE
[Enhancement] Change Sort Key Order and  default delimiter for AirByte tables

### DIFF
--- a/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/DefaultStreamLoader.java
+++ b/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/DefaultStreamLoader.java
@@ -105,9 +105,9 @@ public class DefaultStreamLoader implements StreamLoader {
         LOG.info("Stream loading, label : {}, database : {}, table : {}, request : {}",
                 label, database, loadTable, httpPut);
 
+        String responseBody = null;
         try (CloseableHttpClient client = clientBuilder.build()) {
             long startNanoTime = System.nanoTime();
-            String responseBody;
             try (CloseableHttpResponse response = client.execute(httpPut)) {
                 responseBody = EntityUtils.toString(response.getEntity());
             }
@@ -147,11 +147,11 @@ public class DefaultStreamLoader implements StreamLoader {
         } catch (StreamLoadFailException e) {
             throw e;
         }  catch (Exception e) {
+            LOG.error("error response from stream load: \n" + responseBody);
             String errorMsg = String.format("Stream load failed because of unknown exception, db: %s, table: %s, " +
                     "label: %s", database, loadTable, label);
             throw new StreamLoadFailException(errorMsg, e);
         }
-
     }
 
     protected String getAvailableHost() {

--- a/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/DefaultStreamLoader.java
+++ b/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/DefaultStreamLoader.java
@@ -147,7 +147,7 @@ public class DefaultStreamLoader implements StreamLoader {
         } catch (StreamLoadFailException e) {
             throw e;
         }  catch (Exception e) {
-            LOG.error("error response from stream load: \n" + responseBody);
+            LOG.error(responseBody);
             String errorMsg = String.format("Stream load failed because of unknown exception, db: %s, table: %s, " +
                     "label: %s", database, loadTable, label);
             throw new StreamLoadFailException(errorMsg, e);

--- a/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/SqlUtil.java
+++ b/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/SqlUtil.java
@@ -77,11 +77,11 @@ public class SqlUtil {
 
     public static void createTableIfNotExist(Connection conn, String tableName) throws SQLException {
         String sql = "CREATE TABLE IF NOT EXISTS " + tableName + " ( \n"
-                + "`" + JavaBaseConstants.COLUMN_NAME_AB_ID + "` varchar(40),\n"
                 + "`" + JavaBaseConstants.COLUMN_NAME_EMITTED_AT + "` BIGINT,\n"
+                + "`" + JavaBaseConstants.COLUMN_NAME_AB_ID + "` varchar(40),\n"
                 + "`" + JavaBaseConstants.COLUMN_NAME_DATA + "` String)\n"
-                + "DUPLICATE KEY(`" + JavaBaseConstants.COLUMN_NAME_AB_ID + "`,`"
-                + JavaBaseConstants.COLUMN_NAME_EMITTED_AT + "`) \n"
+                + "DUPLICATE KEY(`" + JavaBaseConstants.COLUMN_NAME_EMITTED_AT + "`,`"
+                + JavaBaseConstants.COLUMN_NAME_AB_ID + "`) \n"
                 + "DISTRIBUTED BY HASH(`" + JavaBaseConstants.COLUMN_NAME_AB_ID + "`) BUCKETS 16 \n"
                 + "PROPERTIES ( \n"
                 + "\"replication_num\" = \"1\" \n"

--- a/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/StarRocksConstants.java
+++ b/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/StarRocksConstants.java
@@ -65,13 +65,15 @@ public interface StarRocksConstants {
 
     //csv
     interface CsvFormat {
-        String LINE_DELIMITER = "\n";
-        byte[] LINE_DELIMITER_BYTE = LINE_DELIMITER.getBytes(StandardCharsets.UTF_8);
+        String LINE_DELIMITER = "\\x02";
+        byte[] LINE_DELIMITER_BYTE = StarRocksDelimiterParser.parse(LINE_DELIMITER).getBytes(StandardCharsets.UTF_8);
 
-        String COLUMN_DELIMITER = "\t";
-        byte[] COLUMN_DELIMITER_BYTE = COLUMN_DELIMITER.getBytes(StandardCharsets.UTF_8);
+        String COLUMN_DELIMITER = "\\x01";
+        byte[] COLUMN_DELIMITER_BYTE = StarRocksDelimiterParser.parse(COLUMN_DELIMITER).getBytes(StandardCharsets.UTF_8);
 
-        String LINE_PATTERN = "%s" + COLUMN_DELIMITER + "%d" + COLUMN_DELIMITER + "%s" + LINE_DELIMITER;
+        String LINE_PATTERN = "%s" + StarRocksDelimiterParser.parse(COLUMN_DELIMITER)
+            + "%d" + StarRocksDelimiterParser.parse(COLUMN_DELIMITER)
+            + "%s" + StarRocksDelimiterParser.parse(LINE_DELIMITER);
     }
 
 }

--- a/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/StarRocksConstants.java
+++ b/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/StarRocksConstants.java
@@ -71,8 +71,8 @@ public interface StarRocksConstants {
         String COLUMN_DELIMITER = "\\x01";
         byte[] COLUMN_DELIMITER_BYTE = StarRocksDelimiterParser.parse(COLUMN_DELIMITER).getBytes(StandardCharsets.UTF_8);
 
-        String LINE_PATTERN = "%s" + StarRocksDelimiterParser.parse(COLUMN_DELIMITER)
-            + "%d" + StarRocksDelimiterParser.parse(COLUMN_DELIMITER)
+        String LINE_PATTERN = "%d" + StarRocksDelimiterParser.parse(COLUMN_DELIMITER)
+            + "%s" + StarRocksDelimiterParser.parse(COLUMN_DELIMITER)
             + "%s" + StarRocksDelimiterParser.parse(LINE_DELIMITER);
     }
 

--- a/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/StarRocksDelimiterParser.java
+++ b/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/StarRocksDelimiterParser.java
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.airbyte.integrations.destination.starrocks;
+
+import java.io.StringWriter;
+
+public class StarRocksDelimiterParser {
+
+    private static final String HEX_STRING = "0123456789ABCDEF";
+
+    public static String parse(String sp) throws RuntimeException {
+        if (sp == null || sp.length() == 0) {
+            throw new IllegalArgumentException("Delimiter is null or empty.");
+        }
+        if (!sp.toUpperCase().startsWith("\\X")) {
+            return sp;
+        }
+        String hexStr = sp.substring(2);
+        // check hex str
+        if (hexStr.isEmpty()) {
+            throw new RuntimeException("Failed to parse delimiter: `Hex str is empty`");
+        }
+        if (hexStr.length() % 2 != 0) {
+            throw new RuntimeException("Failed to parse delimiter: `Hex str length error`");
+        }
+        for (char hexChar : hexStr.toUpperCase().toCharArray()) {
+            if (HEX_STRING.indexOf(hexChar) == -1) {
+                throw new RuntimeException("Failed to parse delimiter: `Hex str format error`");
+            }
+        }
+        // transform to separator
+        StringWriter writer = new StringWriter();
+        for (byte b : hexStrToBytes(hexStr)) {
+            writer.append((char) b);
+        }
+        return writer.toString();
+    }
+
+    private static byte[] hexStrToBytes(String hexStr) {
+        String upperHexStr = hexStr.toUpperCase();
+        int length = upperHexStr.length() / 2;
+        char[] hexChars = upperHexStr.toCharArray();
+        byte[] bytes = new byte[length];
+        for (int i = 0; i < length; i++) {
+            int pos = i * 2;
+            bytes[i] = (byte) (charToByte(hexChars[pos]) << 4 | charToByte(hexChars[pos + 1]));
+        }
+        return bytes;
+    }
+
+    private static byte charToByte(char c) {
+        return (byte) HEX_STRING.indexOf(c);
+    }
+
+}

--- a/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/io/StreamLoadStream.java
+++ b/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/io/StreamLoadStream.java
@@ -135,8 +135,8 @@ public class StreamLoadStream extends InputStream {
         if (recordIter.hasNext()) {
             AirbyteRecordMessage record = recordIter.next();
             return String.format(CsvFormat.LINE_PATTERN,
-                    UUID.randomUUID(),
                     record.getEmittedAt(),
+                    UUID.randomUUID(),
                     Jsons.serialize(record.getData())).getBytes(StandardCharsets.UTF_8);
         } else {
             endStream = true;

--- a/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/stream/StreamLoadUtils.java
+++ b/contrib/destination-starrocks/src/main/java/io/airbyte/integrations/destination/starrocks/stream/StreamLoadUtils.java
@@ -21,6 +21,7 @@ import org.apache.http.impl.client.DefaultRedirectStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
+import io.airbyte.integrations.destination.starrocks.StarRocksConstants;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -78,6 +79,8 @@ public class StreamLoadUtils {
         headers.put("timeout", "600");
         headers.put(HttpHeaders.AUTHORIZATION, StreamLoadUtils.getBasicAuthHeader(user, pwd));
         headers.put(HttpHeaders.EXPECT, "100-continue");
+        headers.put("column_separator", StarRocksConstants.CsvFormat.COLUMN_DELIMITER);
+        headers.put("row_delimiter", StarRocksConstants.CsvFormat.LINE_DELIMITER);
         return headers.entrySet().stream()
                 .map(entry -> new BasicHeader(entry.getKey(), entry.getValue()))
                 .toArray(Header[]::new);


### PR DESCRIPTION
## Description
1. Change Sort Key Order to improve performance for querying newly added rows by AirByte #25026 
2. Change default row/column delimiter

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
