### PR TITLE
[BugFix] Fix wrong result local-dictionary exceed max(int16)

### DIFF
--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -35,6 +35,7 @@
 #include "simd/simd.h"
 #include "storage/column_expr_predicate.h"
 #include "storage/column_predicate.h"
+#include "storage/range.h"
 #include "storage/rowset/column_reader.h"
 #include "storage/rowset/scalar_column_iterator.h"
 
@@ -302,7 +303,23 @@ StatusOr<bool> ColumnPredicateRewriter::_rewrite_expr_predicate(ObjectPool* pool
     size_t value_size = raw_dict_column->size();
     std::vector<uint8_t> selection(value_size);
     const auto* pred = down_cast<const ColumnExprPredicate*>(raw_pred);
-    RETURN_IF_ERROR(pred->evaluate(raw_dict_column.get(), selection.data(), 0, value_size));
+    if (value_size <= pred->runtime_state()->chunk_size()) {
+        RETURN_IF_ERROR(pred->evaluate(raw_dict_column.get(), selection.data(), 0, value_size));
+    } else {
+        size_t chunk_size = pred->runtime_state()->chunk_size();
+        auto dict_column = raw_dict_column->clone_empty();
+        SparseRange range(0, value_size);
+        auto iter = range.new_iterator();
+        auto selection_cursor = selection.data();
+        while (iter.has_more()) {
+            auto next_range = iter.next(chunk_size);
+            size_t num_rows = next_range.span_size();
+            dict_column->append(*raw_dict_column, next_range.begin(), num_rows);
+            RETURN_IF_ERROR(pred->evaluate(dict_column.get(), selection_cursor, 0, num_rows));
+            dict_column->reset_column();
+            selection_cursor += num_rows;
+        }
+    }
 
     size_t code_size = raw_code_column->size();
     const auto& code_column = ColumnHelper::cast_to<TYPE_INT>(raw_code_column);

--- a/be/src/storage/column_predicate_rewriter.cpp
+++ b/be/src/storage/column_predicate_rewriter.cpp
@@ -316,6 +316,7 @@ StatusOr<bool> ColumnPredicateRewriter::_rewrite_expr_predicate(ObjectPool* pool
         while (iter.has_more()) {
             auto next_range = iter.next(chunk_size);
             size_t num_rows = next_range.span_size();
+            DCHECK_LE(next_range.begin() + num_rows, raw_dict_column->size());
             dict_column->append(*raw_dict_column, next_range.begin(), num_rows);
             RETURN_IF_ERROR(pred->evaluate(dict_column.get(), selection_cursor, 0, num_rows));
             dict_column->reset_column();

--- a/test/sql/test_push_down_predicate/R/test_expr_predicate_push_down
+++ b/test/sql/test_push_down_predicate/R/test_expr_predicate_push_down
@@ -1,0 +1,38 @@
+-- name: test_expr_predicate_pushdown
+create table t0 (
+    c0 string
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT concat("s_", generate_series) FROM TABLE(generate_series(0,  80000));
+-- result:
+-- !result
+insert into t0 SELECT * FROM t0;
+-- result:
+-- !result
+insert into t0 SELECT * FROM t0;
+-- result:
+-- !result
+insert into t0 SELECT * FROM t0;
+-- result:
+-- !result
+insert into t0 SELECT * FROM t0;
+-- result:
+-- !result
+insert into t0 SELECT * FROM t0;
+-- result:
+-- !result
+create table t1 like t0;
+-- result:
+-- !result
+insert into t1 select * from t0 order by c0;
+-- result:
+-- !result
+select count(*) from t1;
+-- result:
+2560032
+-- !result
+select count(*) from t1 where c0 like 's_%';
+-- result:
+2560032
+-- !result

--- a/test/sql/test_push_down_predicate/T/test_expr_predicate_push_down
+++ b/test/sql/test_push_down_predicate/T/test_expr_predicate_push_down
@@ -1,0 +1,16 @@
+-- name: test_expr_predicate_pushdown
+create table t0 (
+    c0 string
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT concat("s_", generate_series) FROM TABLE(generate_series(0,  80000));
+-- ratio 8/1
+insert into t0 SELECT * FROM t0;
+insert into t0 SELECT * FROM t0;
+insert into t0 SELECT * FROM t0;
+insert into t0 SELECT * FROM t0;
+insert into t0 SELECT * FROM t0;
+create table t1 like t0;
+insert into t1 select * from t0 order by c0;
+
+select count(*) from t1;
+select count(*) from t1 where c0 like 's_%';


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/26251

the interface for ColumnPredicate is int16_t
```
    virtual Status evaluate(const Column* column, uint8_t* selection, uint16_t from, uint16_t to) const = 0;
```
if elements size for local-dictionary gt than int16_t. we will got wrong result


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
