### PR TITLE
[Tool] Fix the bug of output short key index in meta_tool (#26140)

### DIFF
--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -609,7 +609,6 @@ private:
     SegmentFooterPB _footer;
     MemPool _mem_pool;
     const size_t _max_short_key_size = 36;
-    const size_t _max_varchar_key_size = 20;
     const size_t _max_short_key_col_cnt = 3;
 };
 
@@ -676,7 +675,6 @@ Status SegmentDump::_init() {
 
 void SegmentDump::_analyze_short_key_columns(size_t key_column_count, std::vector<ColItem>* cols) {
     size_t start_offset = 1;
-    size_t num_short_key_columns = 0;
     size_t short_key_size = 0;
 
     for (size_t i = 0; i < key_column_count; i++) {
@@ -686,7 +684,6 @@ void SegmentDump::_analyze_short_key_columns(size_t key_column_count, std::vecto
             if (short_key_size + col.length() > _max_short_key_size) {
                 break;
             }
-            num_short_key_columns++;
             short_key_size += col.length();
 
             ColItem item;
@@ -697,15 +694,11 @@ void SegmentDump::_analyze_short_key_columns(size_t key_column_count, std::vecto
 
             start_offset += item.type->size() + 1;
         } else {
-            num_short_key_columns++;
-
             ColItem item;
             item.type = get_type_info(logical_type);
             item.offset = start_offset;
-            item.size = std::min<size_t>(_max_short_key_size - short_key_size, _max_varchar_key_size);
+            item.size = 0;
             cols->emplace_back(item);
-
-            start_offset += item.type->size() + 1;
 
             break;
         }
@@ -714,12 +707,16 @@ void SegmentDump::_analyze_short_key_columns(size_t key_column_count, std::vecto
 
 Status SegmentDump::_output_short_key_string(const std::vector<ColItem>& cols, size_t idx, Slice& key,
                                              std::string* result) {
-    Slice convert_key = {key.data + cols[idx].offset, cols[idx].size};
+    size_t item_size = cols[idx].size;
+    if (item_size == 0) {
+        item_size = key.size - cols[idx].offset;
+    }
+    Slice convert_key = {key.data + cols[idx].offset, item_size};
 
     size_t num_short_key_columns = cols.size();
     const KeyCoder* coder = get_key_coder(cols[idx].type->type());
-    uint8_t* tmp_mem = _mem_pool.allocate(cols[idx].size);
-    coder->decode_ascending(&convert_key, cols[idx].size, tmp_mem, &_mem_pool);
+    uint8_t* tmp_mem = _mem_pool.allocate(item_size);
+    coder->decode_ascending(&convert_key, item_size, tmp_mem, &_mem_pool);
 
     auto logical_type = cols[idx].type->type();
 


### PR DESCRIPTION
Use the real short key size to decode varchar item.
