### PR TITLE
[BugFix] fix lake primary index load concurrent

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -449,8 +449,7 @@ Status DeltaWriterImpl::_fill_auto_increment_id(const Chunk& chunk) {
     auto metadata = _tablet_manager->get_latest_cached_tablet_metadata(_tablet_id);
     std::unique_ptr<MetaFileBuilder> builder = std::make_unique<MetaFileBuilder>(tablet, metadata);
 
-    tablet.update_mgr()->get_rowids_from_pkindex(&tablet, *metadata.get(), upserts, metadata->version(), builder.get(),
-                                                 &rss_rowids);
+    RETURN_IF_ERROR(tablet.update_mgr()->get_rowids_from_pkindex(&tablet, metadata->version(), upserts, &rss_rowids));
 
     std::vector<uint8_t> filter;
     uint32_t gen_num = 0;

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -34,6 +34,11 @@ Status LakePrimaryIndex::lake_load(Tablet* tablet, const TabletMetadata& metadat
     return _status;
 }
 
+bool LakePrimaryIndex::is_load(int64_t base_version) {
+    std::lock_guard<std::mutex> lg(_lock);
+    return _loaded && _data_version >= base_version;
+}
+
 Status LakePrimaryIndex::_do_lake_load(Tablet* tablet, const TabletMetadata& metadata, int64_t base_version,
                                        const MetaFileBuilder* builder) {
     MonotonicStopWatch watch;

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -41,6 +41,8 @@ public:
     Status lake_load(Tablet* tablet, const TabletMetadata& metadata, int64_t base_version,
                      const MetaFileBuilder* builder);
 
+    bool is_load(int64_t base_version);
+
     int64_t data_version() const { return _data_version; }
     void update_data_version(int64_t version) { _data_version = version; }
 

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -63,12 +63,10 @@ public:
                                       Tablet* tablet, MetaFileBuilder* builder, int64_t base_version);
 
     // get rowids from primary index by each upserts
-    Status get_rowids_from_pkindex(Tablet* tablet, const TabletMetadata& metadata,
-                                   const std::vector<ColumnUniquePtr>& upserts, int64_t base_version,
-                                   const MetaFileBuilder* builder, std::vector<std::vector<uint64_t>*>* rss_rowids);
-    Status get_rowids_from_pkindex(Tablet* tablet, const TabletMetadata& metadata,
-                                   const std::vector<ColumnUniquePtr>& upserts, const int64_t base_version,
-                                   const MetaFileBuilder* builder, std::vector<std::vector<uint64_t>>* rss_rowids);
+    Status get_rowids_from_pkindex(Tablet* tablet, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
+                                   std::vector<std::vector<uint64_t>*>* rss_rowids);
+    Status get_rowids_from_pkindex(Tablet* tablet, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
+                                   std::vector<std::vector<uint64_t>>* rss_rowids);
 
     // get column data by rssid and rowids
     Status get_column_values(Tablet* tablet, const TabletMetadata& metadata, const TxnLogPB_OpWrite& op_write,
@@ -133,8 +131,7 @@ private:
 
     int32_t _get_condition_column(const TxnLogPB_OpWrite& op_write, const TabletSchema& tablet_schema);
 
-    Status _handle_index_op(Tablet* tablet, const TabletMetadata& metadata, const int64_t base_version,
-                            const MetaFileBuilder* builder, const std::function<void(LakePrimaryIndex&)>& op);
+    Status _handle_index_op(Tablet* tablet, int64_t base_version, const std::function<void(LakePrimaryIndex&)>& op);
 
     static const size_t kPrintMemoryStatsInterval = 300; // 5min
 private:


### PR DESCRIPTION
When partial update happen, preload update state may have chance to update primary index and conflict with publish thread. Only allow update primary index in publish thread. Preload will give up if primary index not build yet.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
