### PR TITLE
[BugFix] Check sort key columns type when reorder primary key table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -600,6 +600,11 @@ public class SchemaChangeHandler extends AlterHandler {
             }
             int sortKeyIdx = targetIndexSchema.indexOf(oneCol.get());
             sortKeyIdxes.add(sortKeyIdx);
+            Type t = oneCol.get().getType();
+            if (!(t.isBoolean() || t.isIntegerType() || t.isLargeint() || t.isVarchar() || t.isDate() ||
+                    t.isDatetime())) {
+                throw new DdlException("Sort key column[" + colName + "] type not supported: " + t.toSql());
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -603,7 +603,7 @@ public class SchemaChangeHandler extends AlterHandler {
             Type t = oneCol.get().getType();
             if (!(t.isBoolean() || t.isIntegerType() || t.isLargeint() || t.isVarchar() || t.isDate() ||
                     t.isDatetime())) {
-                throw new DdlException("Sort key column[" + colName + "] type not supported: " + t.toSql());
+                throw new DdlException("Sort key column[" + colName + "] type not supported: " + t);
             }
         }
     }

--- a/test/sql/test_ddl/R/test_alter_pk_reorder
+++ b/test/sql/test_ddl/R/test_alter_pk_reorder
@@ -54,10 +54,6 @@ select * from tab1;
 700	700	700	700	700
 -- !result
 
-
-
-
-
 -- name: test_alter_pk_reorder_column_type
 CREATE TABLE `test_alter_pk_reorder_column_type` (
   `k1` date NOT NULL COMMENT "",

--- a/test/sql/test_ddl/R/test_alter_pk_reorder
+++ b/test/sql/test_ddl/R/test_alter_pk_reorder
@@ -53,3 +53,36 @@ select * from tab1;
 600	600	600	600	600
 700	700	700	700	700
 -- !result
+
+
+
+-- name: test_alter_pk_reorder_column_type
+CREATE TABLE `test_pk_alter_double` (
+  `k1` date NOT NULL COMMENT "",
+  `v1` datetime NOT NULL COMMENT "",
+  `v2` varchar(20) NOT NULL COMMENT "",
+  `v3` varchar(20) NOT NULL COMMENT "",
+  `v4` double NOT NULL COMMENT "",
+  `v5` float NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`k1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+ORDER BY(`v2`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3, v4);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table test_db_e29d521016fd11eeb17200163e237e98.test_alter_pk_reorder_column_type is not found.')
+-- !result
+ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3, v5);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table test_db_e29d521016fd11eeb17200163e237e98.test_alter_pk_reorder_column_type is not found.')
+-- !result
+ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table test_db_e29d521016fd11eeb17200163e237e98.test_alter_pk_reorder_column_type is not found.')
+-- !result

--- a/test/sql/test_ddl/R/test_alter_pk_reorder
+++ b/test/sql/test_ddl/R/test_alter_pk_reorder
@@ -56,8 +56,10 @@ select * from tab1;
 
 
 
+
+
 -- name: test_alter_pk_reorder_column_type
-CREATE TABLE `test_pk_alter_double` (
+CREATE TABLE `test_alter_pk_reorder_column_type` (
   `k1` date NOT NULL COMMENT "",
   `v1` datetime NOT NULL COMMENT "",
   `v2` varchar(20) NOT NULL COMMENT "",
@@ -76,13 +78,12 @@ PROPERTIES (
 -- !result
 ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3, v4);
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table test_db_e29d521016fd11eeb17200163e237e98.test_alter_pk_reorder_column_type is not found.')
+E: (1064, 'Unexpected exception: Sort key column[v4] type not supported: double')
 -- !result
 ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3, v5);
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table test_db_e29d521016fd11eeb17200163e237e98.test_alter_pk_reorder_column_type is not found.')
+E: (1064, 'Unexpected exception: Sort key column[v5] type not supported: float')
 -- !result
 ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3);
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table test_db_e29d521016fd11eeb17200163e237e98.test_alter_pk_reorder_column_type is not found.')
 -- !result

--- a/test/sql/test_ddl/R/test_alter_pk_reorder
+++ b/test/sql/test_ddl/R/test_alter_pk_reorder
@@ -74,11 +74,11 @@ PROPERTIES (
 -- !result
 ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3, v4);
 -- result:
-E: (1064, 'Unexpected exception: Sort key column[v4] type not supported: double')
+E: (1064, 'Unexpected exception: Sort key column[v4] type not supported: DOUBLE')
 -- !result
 ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3, v5);
 -- result:
-E: (1064, 'Unexpected exception: Sort key column[v5] type not supported: float')
+E: (1064, 'Unexpected exception: Sort key column[v5] type not supported: FLOAT')
 -- !result
 ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3);
 -- result:

--- a/test/sql/test_ddl/T/test_alter_pk_reorder
+++ b/test/sql/test_ddl/T/test_alter_pk_reorder
@@ -27,7 +27,7 @@ select * from tab1;
 
 
 -- name: test_alter_pk_reorder_column_type
-CREATE TABLE `test_pk_alter_double` (
+CREATE TABLE `test_alter_pk_reorder_column_type` (
   `k1` date NOT NULL COMMENT "",
   `v1` datetime NOT NULL COMMENT "",
   `v2` varchar(20) NOT NULL COMMENT "",

--- a/test/sql/test_ddl/T/test_alter_pk_reorder
+++ b/test/sql/test_ddl/T/test_alter_pk_reorder
@@ -24,3 +24,25 @@ alter table tab1 order by (k2,k1);
 function: wait_alter_table_finish()
 insert into tab1 values (700,700,700,700,700);
 select * from tab1;
+
+
+-- name: test_alter_pk_reorder_column_type
+CREATE TABLE `test_pk_alter_double` (
+  `k1` date NOT NULL COMMENT "",
+  `v1` datetime NOT NULL COMMENT "",
+  `v2` varchar(20) NOT NULL COMMENT "",
+  `v3` varchar(20) NOT NULL COMMENT "",
+  `v4` double NOT NULL COMMENT "",
+  `v5` float NOT NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`k1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+ORDER BY(`v2`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3, v4);
+ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3, v5);
+ALTER TABLE test_alter_pk_reorder_column_type ORDER BY(v3);


### PR DESCRIPTION
Currently, the types of sort key columns are not fully supported, some types are not support(e.g. float/double), we will check the sort key columns type and reject create table request when we create a new table. However, no type checking is done when performing reorder operation. So a column of an unsupported type maybe defined as a sort key column after the reorder operation is executed and this will cause some unexpected error. (e.g. compaction task always failed)

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
