### PR TITLE
[Enhancement] infer bucket number for materialized view

### DIFF
--- a/be/src/util/stack_trace_mutex.cpp
+++ b/be/src/util/stack_trace_mutex.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <array>
 #include <iostream>
 #include <mutex>
 #include <string>

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2761,25 +2761,7 @@ public class LocalMetastore implements ConnectorMetadata {
         if (properties == null) {
             properties = Maps.newHashMap();
         }
-        // set replication_num
-        short replicationNum = RunMode.defaultReplicationNum();
-        try {
-            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
-                replicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, replicationNum);
-                materializedView.setReplicationNum(replicationNum);
-            }
-            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_MV_REWRITE_STALENESS_SECOND)) {
-                Integer maxMVRewriteStaleness = PropertyAnalyzer.analyzeMVRewriteStaleness(properties);
-                materializedView.setMaxMVRewriteStaleness(maxMVRewriteStaleness);
-            }
-        } catch (AnalysisException e) {
-            throw new DdlException(e.getMessage(), e);
-        }
-        // replicated storage
-        materializedView.setEnableReplicatedStorage(
-                PropertyAnalyzer.analyzeBooleanProp(
-                        properties, PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE,
-                        Config.enable_replicated_storage_as_default_engine));
+
         boolean isNonPartitioned = partitionInfo.getType() == PartitionType.UNPARTITIONED;
         DataProperty dataProperty = analyzeMVDataProperties(db, materializedView, properties, isNonPartitioned);
 
@@ -2789,7 +2771,7 @@ public class LocalMetastore implements ConnectorMetadata {
             long partitionId = GlobalStateMgr.getCurrentState().getNextId();
             Preconditions.checkNotNull(dataProperty);
             partitionInfo.setDataProperty(partitionId, dataProperty);
-            partitionInfo.setReplicationNum(partitionId, replicationNum);
+            partitionInfo.setReplicationNum(partitionId, materializedView.getDefaultReplicationNum());
             partitionInfo.setIsInMemory(partitionId, false);
             partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
             StorageInfo storageInfo = materializedView.getTableProperty().getStorageInfo();
@@ -2815,8 +2797,45 @@ public class LocalMetastore implements ConnectorMetadata {
                                                  MaterializedView materializedView,
                                                  Map<String, String> properties,
                                                  boolean isNonPartitioned) throws DdlException {
-        DataProperty dataProperty;
+        DataProperty dataProperty = null;
         try {
+            // replicated storage
+            materializedView.setEnableReplicatedStorage(
+                    PropertyAnalyzer.analyzeBooleanProp(
+                            properties, PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE,
+                            Config.enable_replicated_storage_as_default_engine));
+
+            // replication_num
+            short replicationNum = RunMode.defaultReplicationNum();
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
+                replicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, replicationNum);
+                materializedView.setReplicationNum(replicationNum);
+            }
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_MV_REWRITE_STALENESS_SECOND)) {
+                Integer maxMVRewriteStaleness = PropertyAnalyzer.analyzeMVRewriteStaleness(properties);
+                materializedView.setMaxMVRewriteStaleness(maxMVRewriteStaleness);
+            }
+
+            // bucket number
+            // infer bucket number of materialized view based on base-table,
+            // currently is max{bucket_num of base_table}
+            // TODO: infer the bucket number according to MV pattern and cardinality
+            DistributionInfo distributionInfo = materializedView.getDefaultDistributionInfo();
+            if (distributionInfo.getBucketNum() == 0) {
+                int inferredBucketNum = 0;
+                for (BaseTableInfo base : materializedView.getBaseTableInfos()) {
+                    if (base.getTable().isNativeTableOrMaterializedView()) {
+                        OlapTable olapTable = (OlapTable) base.getTable();
+                        DistributionInfo dist = olapTable.getDefaultDistributionInfo();
+                        inferredBucketNum = Math.max(inferredBucketNum, dist.getBucketNum());
+                    }
+                }
+                if (inferredBucketNum == 0) {
+                    inferredBucketNum = CatalogUtils.calBucketNumAccordingToBackends();
+                }
+                distributionInfo.setBucketNum(inferredBucketNum);
+            }
+
             // set storage medium
             boolean hasMedium = properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM);
             dataProperty = PropertyAnalyzer.analyzeDataProperty(properties,
@@ -2937,7 +2956,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 materializedView.getTableProperty().getProperties().putAll(properties);
             }
         } catch (AnalysisException e) {
-            throw new DdlException(e.getMessage(), e);
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_PARAMETER, e.getMessage());
         }
         return dataProperty;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -37,6 +37,7 @@ import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.persist.TaskSchedule;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.PartitionKeyDesc;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
@@ -610,7 +611,7 @@ public class MaterializedViewTest {
         Assert.assertTrue(Strings.isNullOrEmpty(connectContext.getState().getErrorMessage()));
     }
 
-    @Test(expected = DdlException.class)
+    @Test(expected = SemanticException.class)
     public void testNonPartitionMvSupportedProperties() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
         ConnectContext connectContext = UtFrameUtils.createDefaultCtx();

--- a/test/sql/test_materialized_view/R/test_create
+++ b/test/sql/test_materialized_view/R/test_create
@@ -1,0 +1,219 @@
+-- name: test_create_materialized_view
+create database test_create_mv;
+-- result:
+-- !result
+use test_create_mv;
+-- result:
+-- !result
+CREATE TABLE `t_hash` (
+  `k1` int(11) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+)
+DUPLICATE KEY(`k1`) 
+DISTRIBUTED BY hash(k1) BUCKETS 64
+PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE `t_random` (
+  `k1` int(11) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+)
+DUPLICATE KEY(`k1`) 
+DISTRIBUTED BY RANDOM BUCKETS 64
+PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `k1` int(11) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`k1`) (
+    PARTITION p2 VALUES [("202301"), ("202302")),
+    PARTITION p3 VALUES [("202302"), ("202303")),
+    PARTITION p4 VALUES [("202303"), ("202304")),
+    PARTITION p5 VALUES [("202304"), ("202305")),
+    PARTITION p6 VALUES [("202305"), ("202306"))
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE `t2` (
+  `k1` int(11) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`k1`) (
+    PARTITION p2 VALUES [("202301"), ("202302")),
+    PARTITION p3 VALUES [("202302"), ("202303")),
+    PARTITION p4 VALUES [("202303"), ("202304")),
+    PARTITION p5 VALUES [("202304"), ("202305")),
+    PARTITION p6 VALUES [("202305"), ("202306"))
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW `mv1`
+REFRESH ASYNC 
+AS
+select t0.k1, t1.v1
+from t_hash t0 join t_random t1 on t0.k1 = t1.k1;
+-- result:
+-- !result
+SHOW CREATE MATERIALIZED VIEW mv1;
+-- result:
+mv1	CREATE MATERIALIZED VIEW `mv1` (k1, v1)
+DISTRIBUTED BY RANDOM BUCKETS 64
+REFRESH ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"replicated_storage" = "true",
+"storage_medium" = "HDD"
+)
+AS SELECT `t0`.`k1`, `t1`.`v1`
+FROM `test_create_mv`.`t_hash` AS `t0` INNER JOIN `test_create_mv`.`t_random` AS `t1` ON `t0`.`k1` = `t1`.`k1`;
+-- !result
+CREATE MATERIALIZED VIEW `mv2`
+REFRESH ASYNC 
+AS
+select k1, count(v1)  from t_random group by k1;
+-- result:
+-- !result
+SHOW CREATE MATERIALIZED VIEW mv2;
+-- result:
+mv2	CREATE MATERIALIZED VIEW `mv2` (k1, count(v1))
+DISTRIBUTED BY RANDOM BUCKETS 64
+REFRESH ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"replicated_storage" = "true",
+"storage_medium" = "HDD"
+)
+AS SELECT `t_random`.`k1`, count(`t_random`.`v1`) AS `count(v1)`
+FROM `test_create_mv`.`t_random`
+GROUP BY `t_random`.`k1`;
+-- !result
+CREATE MATERIALIZED VIEW `mv3`
+REFRESH ASYNC 
+AS
+select t0.k1, t1.v1
+from t_hash t0 join t1 on t0.k1 = t1.k1;
+-- result:
+-- !result
+SHOW CREATE MATERIALIZED VIEW mv3;
+-- result:
+mv3	CREATE MATERIALIZED VIEW `mv3` (k1, v1)
+DISTRIBUTED BY RANDOM BUCKETS 64
+REFRESH ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"replicated_storage" = "true",
+"storage_medium" = "HDD"
+)
+AS SELECT `t0`.`k1`, `t1`.`v1`
+FROM `test_create_mv`.`t_hash` AS `t0` INNER JOIN `test_create_mv`.`t1` ON `t0`.`k1` = `t1`.`k1`;
+-- !result
+CREATE MATERIALIZED VIEW `mv4`
+REFRESH ASYNC 
+AS
+select t0.k1, t1.v1
+from t_random t0 join t1 on t0.k1 = t1.k1;
+-- result:
+-- !result
+SHOW CREATE MATERIALIZED VIEW mv4;
+-- result:
+mv4	CREATE MATERIALIZED VIEW `mv4` (k1, v1)
+DISTRIBUTED BY RANDOM BUCKETS 64
+REFRESH ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"replicated_storage" = "true",
+"storage_medium" = "HDD"
+)
+AS SELECT `t0`.`k1`, `t1`.`v1`
+FROM `test_create_mv`.`t_random` AS `t0` INNER JOIN `test_create_mv`.`t1` ON `t0`.`k1` = `t1`.`k1`;
+-- !result
+CREATE MATERIALIZED VIEW `mv_part1`
+REFRESH ASYNC 
+AS
+select t1.k1, t2.v1
+from t1 join t2 on t1.k1 = t2.k1;
+-- result:
+-- !result
+SHOW CREATE MATERIALIZED VIEW mv_part1;
+-- result:
+mv_part1	CREATE MATERIALIZED VIEW `mv_part1` (k1, v1)
+DISTRIBUTED BY RANDOM BUCKETS 2
+REFRESH ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"replicated_storage" = "true",
+"storage_medium" = "HDD"
+)
+AS SELECT `t1`.`k1`, `t2`.`v1`
+FROM `test_create_mv`.`t1` INNER JOIN `test_create_mv`.`t2` ON `t1`.`k1` = `t2`.`k1`;
+-- !result
+CREATE MATERIALIZED VIEW `mv5`
+PARTITION BY (`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+REFRESH ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS select k1, v1, v2 from t1
+union all
+select k1, v1, v2 from t2;
+-- result:
+-- !result
+SHOW CREATE MATERIALIZED VIEW mv5;
+-- result:
+mv5	CREATE MATERIALIZED VIEW `mv5` (k1, v1, v2)
+PARTITION BY (`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2 
+REFRESH ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"replicated_storage" = "true",
+"storage_medium" = "HDD"
+)
+AS SELECT `t1`.`k1`, `t1`.`v1`, `t1`.`v2`
+FROM `test_create_mv`.`t1` UNION ALL SELECT `t2`.`k1`, `t2`.`v1`, `t2`.`v2`
+FROM `test_create_mv`.`t2`;
+-- !result
+CREATE MATERIALIZED VIEW `mv6`
+PARTITION BY (`k1`)
+DISTRIBUTED BY RANDOM
+REFRESH ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS select k1, v1, v2 from t1
+union all
+select k1, v1, v2 from t2;
+-- result:
+-- !result
+SHOW CREATE MATERIALIZED VIEW mv6;
+-- result:
+mv6	CREATE MATERIALIZED VIEW `mv6` (k1, v1, v2)
+PARTITION BY (`k1`)
+DISTRIBUTED BY RANDOM BUCKETS 2
+REFRESH ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"replicated_storage" = "true",
+"storage_medium" = "HDD"
+)
+AS SELECT `t1`.`k1`, `t1`.`v1`, `t1`.`v2`
+FROM `test_create_mv`.`t1` UNION ALL SELECT `t2`.`k1`, `t2`.`v1`, `t2`.`v2`
+FROM `test_create_mv`.`t2`;
+-- !result

--- a/test/sql/test_materialized_view/R/test_show_materialized_view
+++ b/test/sql/test_materialized_view/R/test_show_materialized_view
@@ -14,7 +14,7 @@ create materialized view user_tags_mv1  distributed by hash(user_id) as select u
 show create materialized view user_tags_mv1;
 -- result:
 user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (user_id, bitmap_union(to_bitmap(tag_id)))
-DISTRIBUTED BY HASH(`user_id`)
+DISTRIBUTED BY HASH(`user_id`) BUCKETS 3 
 REFRESH MANUAL
 PROPERTIES (
 "replication_num" = "1",
@@ -28,7 +28,7 @@ GROUP BY `user_tags`.`user_id`;
 show create table user_tags_mv1;
 -- result:
 user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (user_id, bitmap_union(to_bitmap(tag_id)))
-DISTRIBUTED BY HASH(`user_id`)
+DISTRIBUTED BY HASH(`user_id`) BUCKETS 3 
 REFRESH MANUAL
 PROPERTIES (
 "replication_num" = "1",
@@ -48,7 +48,7 @@ alter materialized view user_tags_mv1 set ("mv_rewrite_staleness_second" = "3600
 show create materialized view user_tags_mv1;
 -- result:
 user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (user_id, bitmap_union(to_bitmap(tag_id)))
-DISTRIBUTED BY HASH(`user_id`)
+DISTRIBUTED BY HASH(`user_id`) BUCKETS 3 
 REFRESH MANUAL
 PROPERTIES (
 "replication_num" = "1",
@@ -64,7 +64,7 @@ GROUP BY `user_tags`.`user_id`;
 show create table user_tags_mv1;
 -- result:
 user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (user_id, bitmap_union(to_bitmap(tag_id)))
-DISTRIBUTED BY HASH(`user_id`)
+DISTRIBUTED BY HASH(`user_id`) BUCKETS 3 
 REFRESH MANUAL
 PROPERTIES (
 "replication_num" = "1",

--- a/test/sql/test_materialized_view/T/test_create
+++ b/test/sql/test_materialized_view/T/test_create
@@ -1,0 +1,124 @@
+-- name: test_create_materialized_view
+
+create database test_create_mv;
+use test_create_mv;
+
+CREATE TABLE `t_hash` (
+  `k1` int(11) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+)
+DUPLICATE KEY(`k1`) 
+DISTRIBUTED BY hash(k1) BUCKETS 64
+PROPERTIES ( "replication_num" = "1");
+
+CREATE TABLE `t_random` (
+  `k1` int(11) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+)
+DUPLICATE KEY(`k1`) 
+DISTRIBUTED BY RANDOM BUCKETS 64
+PROPERTIES ( "replication_num" = "1");
+
+CREATE TABLE `t1` (
+  `k1` int(11) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`k1`) (
+    PARTITION p2 VALUES [("202301"), ("202302")),
+    PARTITION p3 VALUES [("202302"), ("202303")),
+    PARTITION p4 VALUES [("202303"), ("202304")),
+    PARTITION p5 VALUES [("202304"), ("202305")),
+    PARTITION p6 VALUES [("202305"), ("202306"))
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+PROPERTIES ( "replication_num" = "1");
+
+CREATE TABLE `t2` (
+  `k1` int(11) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`k1`) (
+    PARTITION p2 VALUES [("202301"), ("202302")),
+    PARTITION p3 VALUES [("202302"), ("202303")),
+    PARTITION p4 VALUES [("202303"), ("202304")),
+    PARTITION p5 VALUES [("202304"), ("202305")),
+    PARTITION p6 VALUES [("202305"), ("202306"))
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+PROPERTIES ( "replication_num" = "1");
+
+-- simplified syntax case 1
+CREATE MATERIALIZED VIEW `mv1`
+REFRESH ASYNC 
+AS
+select t0.k1, t1.v1
+from t_hash t0 join t_random t1 on t0.k1 = t1.k1;
+SHOW CREATE MATERIALIZED VIEW mv1;
+
+-- simplified syntax case 2
+CREATE MATERIALIZED VIEW `mv2`
+REFRESH ASYNC 
+AS
+select k1, count(v1)  from t_random group by k1;
+SHOW CREATE MATERIALIZED VIEW mv2;
+
+-- simplified syntax for partition table
+CREATE MATERIALIZED VIEW `mv3`
+REFRESH ASYNC 
+AS
+select t0.k1, t1.v1
+from t_hash t0 join t1 on t0.k1 = t1.k1;
+SHOW CREATE MATERIALIZED VIEW mv3;
+
+-- simplified syntax for partition table
+CREATE MATERIALIZED VIEW `mv4`
+REFRESH ASYNC 
+AS
+select t0.k1, t1.v1
+from t_random t0 join t1 on t0.k1 = t1.k1;
+SHOW CREATE MATERIALIZED VIEW mv4;
+
+-- simplified syntax for partition table
+CREATE MATERIALIZED VIEW `mv_part1`
+REFRESH ASYNC 
+AS
+select t1.k1, t2.v1
+from t1 join t2 on t1.k1 = t2.k1;
+SHOW CREATE MATERIALIZED VIEW mv_part1;
+
+
+-- complex syntax case 1
+CREATE MATERIALIZED VIEW `mv5`
+PARTITION BY (`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 2
+REFRESH ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS select k1, v1, v2 from t1
+union all
+select k1, v1, v2 from t2;
+SHOW CREATE MATERIALIZED VIEW mv5;
+
+-- complex syntax case 2
+CREATE MATERIALIZED VIEW `mv6`
+PARTITION BY (`k1`)
+DISTRIBUTED BY RANDOM
+REFRESH ASYNC
+PROPERTIES (
+"replication_num" = "1",
+"storage_medium" = "HDD"
+)
+AS select k1, v1, v2 from t1
+union all
+select k1, v1, v2 from t2;
+SHOW CREATE MATERIALIZED VIEW mv6;


### PR DESCRIPTION
Fixes #issue

With simplified syntax we don't bother to specify the data distribution property. 
Now it could infer the bucket number base on bucket number of base table.

```sql
CREATE MATERIALIZED VIEW mv
REFRESH ASYNC
AS 
<query> 
```



## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
