### PR TITLE
[BugFix] Return error if init column iterator failed

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -597,11 +597,11 @@ Status SegmentIterator::_get_row_ranges_by_key_ranges() {
         rowid_t upper_rowid = num_rows();
 
         if (!range.upper().empty()) {
-            _init_column_iterators<false>(range.upper().schema());
+            RETURN_IF_ERROR(_init_column_iterators<false>(range.upper().schema()));
             RETURN_IF_ERROR(_lookup_ordinal(range.upper(), !range.inclusive_upper(), num_rows(), &upper_rowid));
         }
         if (!range.lower().empty() && upper_rowid > 0) {
-            _init_column_iterators<false>(range.lower().schema());
+            RETURN_IF_ERROR(_init_column_iterators<false>(range.lower().schema()));
             RETURN_IF_ERROR(_lookup_ordinal(range.lower(), range.inclusive_lower(), upper_rowid, &lower_rowid));
         }
         if (lower_rowid <= upper_rowid) {
@@ -629,10 +629,10 @@ Status SegmentIterator::_get_row_ranges_by_short_key_ranges() {
 
         const auto& upper = short_key_range->upper;
         if (upper->tuple_key != nullptr) {
-            _init_column_iterators<false>(upper->tuple_key->schema());
+            RETURN_IF_ERROR(_init_column_iterators<false>(upper->tuple_key->schema()));
             RETURN_IF_ERROR(_lookup_ordinal(*(upper->tuple_key), !upper->inclusive, num_rows(), &upper_rowid));
         } else if (!upper->short_key.empty()) {
-            _init_column_iterators<false>(*(upper->short_key_schema));
+            RETURN_IF_ERROR(_init_column_iterators<false>(*(upper->short_key_schema)));
             RETURN_IF_ERROR(_lookup_ordinal(upper->short_key, *(upper->short_key_schema), !upper->inclusive, num_rows(),
                                             &upper_rowid));
         }
@@ -640,10 +640,10 @@ Status SegmentIterator::_get_row_ranges_by_short_key_ranges() {
         if (upper_rowid > 0) {
             const auto& lower = short_key_range->lower;
             if (lower->tuple_key != nullptr) {
-                _init_column_iterators<false>(lower->tuple_key->schema());
+                RETURN_IF_ERROR(_init_column_iterators<false>(lower->tuple_key->schema()));
                 RETURN_IF_ERROR(_lookup_ordinal(*(lower->tuple_key), lower->inclusive, upper_rowid, &lower_rowid));
             } else if (!lower->short_key.empty()) {
-                _init_column_iterators<false>(*(lower->short_key_schema));
+                RETURN_IF_ERROR(_init_column_iterators<false>(*(lower->short_key_schema)));
                 RETURN_IF_ERROR(_lookup_ordinal(lower->short_key, *(lower->short_key_schema), lower->inclusive,
                                                 upper_rowid, &lower_rowid));
             }


### PR DESCRIPTION
Fixes #issue

```
W0620 16:10:41.046085 708104 vertical_compaction_task.cpp:198] reader get next error. tablet=10514145, err=Not found: Failed to seek to ordinal 0
```

`_init_column_iterators` maybe failed because of mem usage exceed limit

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
