### PR TITLE
[Enhancement] support http concurrent limit for stream load (backport #25809)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -959,4 +959,7 @@ CONF_mBool(enable_pk_value_column_zonemap, "true");
 
 // Max size of key columns size of primary key table, default value is 128 bytes
 CONF_mInt32(primary_key_limit_size, "128");
+
+CONF_mBool(enable_http_stream_load_limit, "false");
+
 } // namespace starrocks::config

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -124,7 +124,8 @@ static bool is_format_support_streaming(TFileFormatType::type format) {
     }
 }
 
-StreamLoadAction::StreamLoadAction(ExecEnv* exec_env) : _exec_env(exec_env) {
+StreamLoadAction::StreamLoadAction(ExecEnv* exec_env, ConcurrentLimiter* limiter)
+        : _exec_env(exec_env), _http_concurrent_limiter(limiter) {
     StarRocksMetrics::instance()->metrics()->register_metric("streaming_load_requests_total",
                                                              &streaming_load_requests_total);
     StarRocksMetrics::instance()->metrics()->register_metric("streaming_load_bytes", &streaming_load_bytes);
@@ -220,7 +221,19 @@ int StreamLoadAction::on_header(HttpRequest* req) {
         ctx->label = generate_uuid_string();
     }
 
-    LOG(INFO) << "new income streaming load request." << ctx->brief() << ", db=" << ctx->db << ", tbl=" << ctx->table;
+    if (config::enable_http_stream_load_limit && !ctx->check_and_set_http_limiter(_http_concurrent_limiter)) {
+        LOG(WARNING) << "income streaming load request hit limit." << ctx->brief() << ", db=" << ctx->db
+                     << ", tbl=" << ctx->table;
+        ctx->status =
+                Status::ResourceBusy(fmt::format("Stream Load exceed http cuncurrent limit {}, please try again later",
+                                                 config::be_http_num_workers - 1));
+        auto str = ctx->to_json();
+        HttpChannel::send_reply(req, str);
+        return -1;
+    } else {
+        LOG(INFO) << "new income streaming load request." << ctx->brief() << ", db=" << ctx->db
+                  << ", tbl=" << ctx->table;
+    }
 
     VLOG(1) << "streaming load request: " << req->debug_string();
 

--- a/be/src/http/action/stream_load.h
+++ b/be/src/http/action/stream_load.h
@@ -47,10 +47,11 @@ namespace starrocks {
 class ExecEnv;
 class Status;
 class StreamLoadContext;
+class ConcurrentLimiter;
 
 class StreamLoadAction : public HttpHandler {
 public:
-    explicit StreamLoadAction(ExecEnv* exec_env);
+    explicit StreamLoadAction(ExecEnv* exec_env, ConcurrentLimiter* limiter);
     ~StreamLoadAction() override;
 
     void handle(HttpRequest* req) override;
@@ -71,6 +72,7 @@ private:
 
 private:
     ExecEnv* _exec_env;
+    ConcurrentLimiter* _http_concurrent_limiter = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -228,4 +228,9 @@ std::string StreamLoadContext::brief(bool detail) const {
     return ss.str();
 }
 
+bool StreamLoadContext::check_and_set_http_limiter(ConcurrentLimiter* limiter) {
+    _http_limiter_guard.reset(new ConcurrentLimiterGuard());
+    return _http_limiter_guard->set_limiter(limiter);
+}
+
 } // namespace starrocks

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -49,6 +49,7 @@
 #include "runtime/stream_load/load_stream_mgr.h"
 #include "runtime/stream_load/stream_load_executor.h"
 #include "service/backend_options.h"
+#include "util/concurrent_limiter.h"
 #include "util/string_util.h"
 #include "util/time.h"
 #include "util/uid_util.h"
@@ -169,6 +170,8 @@ public:
     // If unref() returns true, this object should be delete
     bool unref() { return _refs.fetch_sub(1) == 1; }
 
+    bool check_and_set_http_limiter(ConcurrentLimiter* limiter);
+
 public:
     // 1) Before the stream load receiving thread exits, Fragment may have been destructed.
     // At this time, mem_tracker may have been destructed,
@@ -266,6 +269,8 @@ public:
     ByteBufferPtr buffer = nullptr;
 
     TStreamLoadPutRequest request;
+
+    std::unique_ptr<ConcurrentLimiterGuard> _http_limiter_guard;
 
 public:
     bool is_channel_stream_load_context() { return channel_id != -1; }

--- a/be/src/service/service_be/http_service.h
+++ b/be/src/service/service_be/http_service.h
@@ -37,6 +37,7 @@
 #include <memory>
 
 #include "common/status.h"
+#include "util/concurrent_limiter.h"
 
 namespace starrocks {
 
@@ -60,6 +61,8 @@ private:
     std::unique_ptr<WebPageHandler> _web_page_handler;
 
     std::vector<HttpHandler*> _http_handlers;
+
+    std::unique_ptr<ConcurrentLimiter> _http_concurrent_limiter;
 };
 
 } // namespace starrocks

--- a/be/src/util/concurrent_limiter.h
+++ b/be/src/util/concurrent_limiter.h
@@ -1,0 +1,68 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+
+namespace starrocks {
+
+class ConcurrentLimiter {
+public:
+    explicit ConcurrentLimiter(int64_t limit_count) : _limit_count(limit_count) {}
+
+    ~ConcurrentLimiter() = default;
+
+    bool inc() {
+        int64_t old_cnt = 0;
+        do {
+            old_cnt = _counter.load();
+            if (reach_limit(old_cnt)) {
+                return false;
+            }
+        } while (!_counter.compare_exchange_strong(old_cnt, old_cnt + 1));
+        return true;
+    }
+    void dec() { _counter.fetch_add(-1); }
+    bool reach_limit(int64_t cnt) const { return cnt >= _limit_count; }
+
+private:
+    int64_t _limit_count = 0;
+    std::atomic<int64_t> _counter{0};
+};
+
+class ConcurrentLimiterGuard {
+public:
+    explicit ConcurrentLimiterGuard() {}
+
+    bool set_limiter(ConcurrentLimiter* limiter) {
+        if (limiter->inc()) {
+            _limiter = limiter;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    ~ConcurrentLimiterGuard() {
+        if (_limiter != nullptr) {
+            _limiter->dec();
+        }
+    }
+
+private:
+    ConcurrentLimiter* _limiter = nullptr;
+};
+
+} // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -349,6 +349,7 @@ set(EXEC_FILES
         ./util/system_metrics_test.cpp
         ./util/ratelimit_test.cpp
         ./util/cpu_usage_info_test.cpp
+        ./util/concurrent_limiter_test.cpp
         ./gutil/cpu_test.cc
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp

--- a/be/test/util/concurrent_limiter_test.cpp
+++ b/be/test/util/concurrent_limiter_test.cpp
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "util/concurrent_limiter.h"
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+namespace starrocks {
+
+class ConcurrentLimiterTest : public testing::Test {
+public:
+    ConcurrentLimiterTest() = default;
+    ~ConcurrentLimiterTest() override = default;
+};
+
+TEST_F(ConcurrentLimiterTest, test_concurrent_limiter) {
+    ConcurrentLimiter limiter0(0);
+    ASSERT_FALSE(limiter0.inc());
+    for (int i = 1; i <= 100; i++) {
+        ConcurrentLimiter limiter(i);
+        // repeate inc and dec
+        for (int j = 0; j < 100; j++) {
+            ASSERT_TRUE(limiter.inc());
+            limiter.dec();
+        }
+        // inc until fail
+        for (int j = 0; j < i; j++) {
+            ASSERT_TRUE(limiter.inc());
+        }
+        ASSERT_FALSE(limiter.inc());
+        ASSERT_FALSE(limiter.inc());
+        for (int j = 0; j < i; j++) {
+            limiter.dec();
+        }
+    }
+}
+
+TEST_F(ConcurrentLimiterTest, test_concurrent_limiter_guard) {
+    ConcurrentLimiter limiter(1);
+    for (int j = 0; j < 10; j++) {
+        ConcurrentLimiterGuard guard;
+        ASSERT_TRUE(guard.set_limiter(&limiter));
+    }
+}
+
+} // namespace starrocks


### PR DESCRIPTION
Support http concurrent limit for stream load, and limit size will be `be_http_num_workers - 1`, to make sure there will be at least one http worker can handle other request. When `enable_http_stream_load_limit` == true, this strategy will be enable.

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
