### PR TITLE
[Enhancement] Upgrade thirdparty lib hadoop to 3.3.6

### DIFF
--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -22,10 +22,10 @@
 #####################################################
 
 # HADOOP
-HADOOP_DOWNLOAD="https://cdn-thirdparty.starrocks.com/hadoop-3.3.0-aarch64.tar.gz"
-HADOOP_NAME="hadoop-3.3.0-aarch64.tar.gz"
-HADOOP_SOURCE="hadoop-3.3.0-aarch64"
-HADOOP_MD5SUM="c84cfa985175341d3df0b2b57521eec9"
+HADOOP_DOWNLOAD="https://archive.apache.org/dist/hadoop/common/hadoop-3.3.6/hadoop-3.3.6-aarch64.tar.gz"
+HADOOP_NAME="hadoop-3.3.6-aarch64.tar.gz"
+HADOOP_SOURCE="hadoop-3.3.6"
+HADOOP_MD5SUM="369f899194a920e0d1c3c3bc1718b3b5"
 
 # OPEN JDK FOR aarch64, provided by huawei kunpeng (https://www.hikunpeng.com/zh/developer/devkit/compiler)
 JDK_DOWNLOAD="https://mirror.iscas.ac.cn/kunpeng/archive/compiler/bisheng_jdk/bisheng-jdk-8u262-linux-aarch64.tar.gz"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -22,10 +22,10 @@
 #####################################################
 
 # HADOOP
-HADOOP_DOWNLOAD="https://cdn-thirdparty.starrocks.com/hadoop-3.3.0.tar.gz"
-HADOOP_NAME="hadoop-3.3.0.tar.gz"
-HADOOP_SOURCE="hadoop-3.3.0"
-HADOOP_MD5SUM="46c5004739df0c452610d5946eb8ce28"
+HADOOP_DOWNLOAD="https://archive.apache.org/dist/hadoop/common/hadoop-3.3.6/hadoop-3.3.6.tar.gz"
+HADOOP_NAME="hadoop-3.3.6.tar.gz"
+HADOOP_SOURCE="hadoop-3.3.6"
+HADOOP_MD5SUM="1cbe1214299cd3bd282d33d3934b5cbd"
 
 # OPEN JDK
 JDK_DOWNLOAD="https://cdn-thirdparty.starrocks.com/java-se-8u41-ri.tar.gz"


### PR DESCRIPTION
Fixes [#issue](https://github.com/advisories/GHSA-8wm5-8h9c-47pc)
To fix some security issue of lib hadoop, this PR upgrades hadoop from 3.3.0 to 3.3.6. 

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
