### PR TITLE
[BugFix] upgrade jemalloc from 5.2.1 to 5.3.0

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -424,7 +424,7 @@ fi
 
 # patch jemalloc_hook
 cd $TP_SOURCE_DIR/$JEMALLOC_SOURCE
-if [ ! -f $PATCHED_MARK ] && [ $JEMALLOC_SOURCE = "jemalloc-5.2.1" ]; then
+if [ ! -f $PATCHED_MARK ] && [ $JEMALLOC_SOURCE = "jemalloc-5.3.0" ]; then
     patch -p0 < $TP_PATCH_DIR/jemalloc_hook.patch
     touch $PATCHED_MARK
 fi

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -265,10 +265,10 @@ CROARINGBITMAP_SOURCE=CRoaring-1.1.3
 CROARINGBITMAP_MD5SUM="605924d21c14c760e66466799215868f"
 
 # jemalloc
-JEMALLOC_DOWNLOAD="https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2"
-JEMALLOC_NAME="jemalloc-5.2.1.tar.bz2"
-JEMALLOC_SOURCE="jemalloc-5.2.1"
-JEMALLOC_MD5SUM="3d41fbf006e6ebffd489bdb304d009ae"
+JEMALLOC_DOWNLOAD="https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2"
+JEMALLOC_NAME="jemalloc-5.3.0.tar.bz2"
+JEMALLOC_SOURCE="jemalloc-5.3.0"
+JEMALLOC_MD5SUM="09a8328574dab22a7df848eae6dbbf53"
 
 # CCTZ
 CCTZ_DOWNLOAD="https://github.com/google/cctz/archive/v2.3.tar.gz"


### PR DESCRIPTION
Fixes #issue

```
Thread 912 (Thread 0x7f50197ff700 (LWP 3944)):
#0  0x00007f501ad7854d in __lll_lock_wait () from /lib64/libpthread.so.0
#1  0x00007f501ad73e9b in _L_lock_883 () from /lib64/libpthread.so.0
#2  0x00007f501ad73d68 in pthread_mutex_lock () from /lib64/libpthread.so.0
#3  0x0000000006059a27 in pthread_mutex_lock_impl (mutex=<optimized out>) at src/bthread/mutex.cpp:564
#4  pthread_mutex_lock (__mutex=0x7f5019a032a8) at src/bthread/mutex.cpp:818
#5  pthread_mutex_lock (__mutex=0x7f5019a032a8) at src/bthread/mutex.cpp:817
#6  0x000000000697819f in malloc_mutex_lock_final (mutex=0x7f5019a03268) at include/jemalloc/internal/mutex.h:155
#7  je_malloc_mutex_lock_slow (mutex=mutex@entry=0x7f5019a03268) at src/mutex.c:85
#8  0x000000000696f8c8 in malloc_mutex_lock (mutex=0x7f5019a03268, tsdn=0x7f50197f9040) at include/jemalloc/internal/mutex.h:221
#9  je_extents_evict (tsdn=tsdn@entry=0x7f50197f9040, arena=arena@entry=0x7f5019a00980, r_extent_hooks=r_extent_hooks@entry=0x7f50197f84d8, extents=extents@entry=0x7f5019a03268, npages_min=npages_min@entry=18533) at src/extent.c:572
#10 0x0000000006936004 in arena_stash_decayed (decay_extents=<synthetic pointer>, npages_decay_max=492, npages_limit=<optimized out>, extents=0x7f5019a03268, r_extent_hooks=0x7f50197f84d8, arena=0x7f5019a00980, tsdn=0x7f50197f9040) at src/arena.c:833
#11 arena_decay_to_limit (tsdn=tsdn@entry=0x7f50197f9040, arena=arena@entry=0x7f5019a00980, decay=decay@entry=0x7f5019a06ca0, extents=extents@entry=0x7f5019a03268, all=all@entry=false, npages_limit=<optimized out>, npages_decay_max=<optimized out>, is_background_thread=<optimized out>) at src/arena.c:934
#12 0x00000000069363fb in arena_decay_try_purge (is_background_thread=<optimized out>, npages_limit=<optimized out>, current_npages=<optimized out>, extents=<optimized out>, decay=<optimized out>, arena=<optimized out>, tsdn=<optimized out>) at src/arena.c:722
#13 arena_decay_try_purge (is_background_thread=<optimized out>, npages_limit=<optimized out>, current_npages=<optimized out>, extents=<optimized out>, decay=<optimized out>, arena=<optimized out>, tsdn=<optimized out>) at src/arena.c:611
#14 arena_maybe_decay (is_background_thread=<optimized out>, extents=<optimized out>, decay=<optimized out>, arena=<optimized out>, tsdn=<optimized out>) at src/arena.c:762
#15 arena_maybe_decay (tsdn=<optimized out>, arena=0x7f5019a00980, decay=0x7f5019a06ca0, extents=0x7f5019a03268, is_background_thread=<optimized out>) at src/arena.c:714
#16 0x00000000069389ab in arena_decay_impl (all=false, is_background_thread=true, extents=0x7f5019a03268, decay=0x7f5019a06ca0, arena=0x7f5019a00980, tsdn=0x7f50197f9040) at src/arena.c:964
#17 arena_decay_dirty (all=false, is_background_thread=true, arena=0x7f5019a00980, tsdn=0x7f50197f9040) at src/arena.c:985
#18 je_arena_decay (tsdn=0x7f50197f9040, arena=0x7f5019a00980, is_background_thread=true, all=<optimized out>) at src/arena.c:998
#19 0x00000000069403e9 in background_work_sleep_once (ind=0, info=<optimized out>, tsdn=<optimized out>) at src/background_thread.c:295
#20 background_thread0_work (tsd=<optimized out>) at src/background_thread.c:452
#21 background_work (ind=<optimized out>, tsd=<optimized out>) at src/background_thread.c:490
#22 background_thread_entry () at src/background_thread.c:522
#23 0x00007f501ad71ea5 in start_thread () from /lib64/libpthread.so.0
#24 0x00007f501a38cb0d in clone () from /lib64/libc.so.6
```

upgrade jemalloc from 5.2.1 to 5.3.0 to fix the deadlock:

https://github.com/jemalloc/jemalloc/issues/2019

Redis also encountered this problem

https://github.com/redis/redis/pull/12115

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
