### PR TITLE
[BugFix] fix sort key as scan range in lake pk table

### DIFF
--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -394,8 +394,18 @@ Status TabletReader::to_seek_tuple(const TabletSchema& tablet_schema, const Olap
     Schema schema;
     std::vector<Datum> values;
     values.reserve(input.size());
+    const auto& sort_key_idxes = tablet_schema.sort_key_idxes();
+    DCHECK(sort_key_idxes.empty() || sort_key_idxes.size() >= input.size());
+
+    if (sort_key_idxes.size() > 0) {
+        for (auto idx : sort_key_idxes) {
+            schema.append_sort_key_idx(idx);
+        }
+    }
+
     for (size_t i = 0; i < input.size(); i++) {
-        auto f = std::make_shared<Field>(ChunkHelper::convert_field(i, tablet_schema.column(i)));
+        int idx = sort_key_idxes.empty() ? i : sort_key_idxes[i];
+        auto f = std::make_shared<Field>(ChunkHelper::convert_field(idx, tablet_schema.column(idx)));
         schema.append(f);
         values.emplace_back();
         if (input.is_null(i)) {


### PR DESCRIPTION
Where create a seek tuple, should use sort key if it is define in primary key table. 

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
