### PR TITLE
[BugFix] Bind storage volume to db when it has been created successfully

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
@@ -180,7 +180,7 @@ public abstract class StorageVolumeMgr implements GsonPostProcessable {
 
     public boolean bindDbToStorageVolume(String svId, long dbId) {
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
-            if (!storageVolumeToTables.containsKey(svId) && getStorageVolume(svId) == null) {
+            if (!storageVolumeToDbs.containsKey(svId) && getStorageVolume(svId) == null) {
                 return false;
             }
             Set<Long> dbs = storageVolumeToDbs.getOrDefault(svId, new HashSet<>());

--- a/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/StorageVolumeMgr.java
@@ -178,12 +178,16 @@ public abstract class StorageVolumeMgr implements GsonPostProcessable {
         return enabled;
     }
 
-    public void bindDbToStorageVolume(String svId, long dbId) {
+    public boolean bindDbToStorageVolume(String svId, long dbId) {
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
+            if (!storageVolumeToTables.containsKey(svId) && getStorageVolume(svId) == null) {
+                return false;
+            }
             Set<Long> dbs = storageVolumeToDbs.getOrDefault(svId, new HashSet<>());
             dbs.add(dbId);
             storageVolumeToDbs.put(svId, dbs);
             dbToStorageVolume.put(dbId, svId);
+            return true;
         }
     }
 
@@ -201,12 +205,16 @@ public abstract class StorageVolumeMgr implements GsonPostProcessable {
         }
     }
 
-    public void bindTableToStorageVolume(String svId, long tableId) {
+    public boolean bindTableToStorageVolume(String svId, long tableId) {
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {
+            if (!storageVolumeToTables.containsKey(svId) && getStorageVolume(svId) == null) {
+                return false;
+            }
             Set<Long> tables = storageVolumeToTables.getOrDefault(svId, new HashSet<>());
             tables.add(tableId);
             storageVolumeToTables.put(svId, tables);
             tableToStorageVolume.put(tableId, svId);
+            return true;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -200,9 +200,11 @@ public class SharedDataStorageVolumeMgrTest {
             Assert.assertTrue(e.getMessage().contains("Default volume can not be disabled"));
         }
 
+        Assert.assertFalse(svm.bindDbToStorageVolume("0", 1L));
+        Assert.assertFalse(svm.bindTableToStorageVolume("0", 1L));
         // bind/unbind db and table to storage volume
-        svm.bindDbToStorageVolume(sv.getId(), 1L);
-        svm.bindTableToStorageVolume(sv.getId(), 1L);
+        Assert.assertTrue(svm.bindDbToStorageVolume(sv.getId(), 1L));
+        Assert.assertTrue(svm.bindTableToStorageVolume(sv.getId(), 1L));
 
         // remove
         try {


### PR DESCRIPTION
Fixes #issue
```
MySQL [(none)]> create database test properties("storage_volume"="storage_volume4");
ERROR 1064 (HY000): Unexpected exception: Unknown storage volume "storage_volume4"
MySQL [(none)]> create database test properties("storage_volume"="storage_volume4");
ERROR 1064 (HY000): Unexpected exception: Can't create database 'test'; database exists
MySQL [(none)]>show databases;
+--------------------+
| Database           |
+--------------------+
| _statistics_       |
| information_schema |
| starrocks          |
| test              |
+--------------------+
5 rows in set (0.01 sec)
```
database will be created if the storage volume not exists.
database should be created after checking the existence of storage volume and the edit log is written successfully.
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
