### PR TITLE
[Enhancement] Print stack trace if cannot acquire lock for a long time(#22593)

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -42,6 +42,7 @@
 #include "util/bthreads/shared_mutex.h"
 #include "util/compression/block_compression.h"
 #include "util/countdown_latch.h"
+#include "util/stack_trace_mutex.h"
 
 namespace starrocks {
 
@@ -83,7 +84,7 @@ private:
     using BThreadCountDownLatch = GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>;
 
     struct Sender {
-        bthread::Mutex lock;
+        StackTraceMutex<bthread::Mutex> lock;
         int64_t next_seq = 0;
         bool has_incremental_open = false;
     };
@@ -119,7 +120,7 @@ private:
     private:
         friend class LakeTabletsChannel;
 
-        mutable bthread::Mutex _mtx;
+        mutable StackTraceMutex<bthread::Mutex> _mtx;
         PTabletWriterAddBatchResult* _response;
 
         Chunk _chunk;
@@ -154,10 +155,10 @@ private:
 
     std::vector<Sender> _senders;
 
-    mutable bthread::Mutex _dirty_partitions_lock;
+    mutable StackTraceMutex<bthread::Mutex> _dirty_partitions_lock;
     std::unordered_set<int64_t> _dirty_partitions;
 
-    mutable bthread::Mutex _chunk_meta_lock;
+    mutable StackTraceMutex<bthread::Mutex> _chunk_meta_lock;
     serde::ProtobufChunkMeta _chunk_meta;
     std::atomic<bool> _has_chunk_meta;
 

--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -37,6 +37,8 @@ using std::string;
 
 namespace starrocks {
 
+extern std::vector<std::string> list_stack_trace_of_long_wait_mutex();
+
 #define REG_VAR(TYPE, NAME) cls.var<&TYPE::NAME>(#NAME)
 #define REG_METHOD(TYPE, NAME) cls.func<&TYPE::NAME>(#NAME)
 #define REG_STATIC_METHOD(TYPE, NAME) cls.funcStatic<&TYPE::NAME>(#NAME)
@@ -147,6 +149,7 @@ void bind_exec_env(ForeignModule& m) {
         cls.funcStaticExt<&grep_log_as_string>("grep_log_as_string");
         cls.funcStaticExt<&get_file_write_history>("get_file_write_history");
         cls.funcStaticExt<&unix_seconds>("unix_seconds");
+        cls.funcStaticExt<&list_stack_trace_of_long_wait_mutex>("list_stack_trace_of_long_wait_mutex");
         REG_METHOD(ExecEnv, process_mem_tracker);
         REG_METHOD(ExecEnv, query_pool_mem_tracker);
         REG_METHOD(ExecEnv, load_mem_tracker);

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -15,7 +15,6 @@
 #include "storage/lake/async_delta_writer.h"
 
 #include <bthread/execution_queue.h>
-#include <bthread/mutex.h>
 #include <fmt/format.h>
 
 #include <memory>
@@ -27,6 +26,7 @@
 #include "storage/lake/delta_writer.h"
 #include "storage/storage_engine.h"
 #include "testutil/sync_point.h"
+#include "util/stack_trace_mutex.h"
 
 namespace starrocks::lake {
 
@@ -105,7 +105,7 @@ private:
 
     DeltaWriter::Ptr _writer;
     bthread::ExecutionQueueId<Task> _queue_id;
-    bthread::Mutex _mtx;
+    StackTraceMutex<bthread::Mutex> _mtx;
     // _status、_opened and _closed are protected by _mtx
     Status _status;
     bool _opened;

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -97,6 +97,7 @@ set(UTIL_FILES
   tdigest.cpp
   debug/query_trace_impl.cpp
   random.cc
+  stack_trace_mutex.cpp
 )
 
 add_library(Util STATIC

--- a/be/src/util/stack_trace_mutex.cpp
+++ b/be/src/util/stack_trace_mutex.cpp
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace starrocks {
+
+namespace {
+
+class CircularBuffer {
+public:
+    void push(std::string s);
+
+    void list(std::vector<std::string>* res);
+
+private:
+    constexpr static const int kBufferSize = 12;
+
+    void pop();
+
+    mutable std::mutex _mtx;
+    std::array<std::string, kBufferSize> _buffer;
+    int _elements = 0;
+    int _read_pos = 0;
+    int _write_pos = 0;
+};
+
+inline void CircularBuffer::push(std::string s) {
+    std::lock_guard l(_mtx);
+    if (_elements == kBufferSize) {
+        pop();
+    }
+    _buffer[_write_pos % kBufferSize] = std::move(s);
+    _elements++;
+    _write_pos++;
+    if (_write_pos == kBufferSize) {
+        _write_pos = 0;
+    }
+}
+
+inline void CircularBuffer::pop() {
+    _elements--;
+    _read_pos++;
+    if (_read_pos == kBufferSize) {
+        _read_pos = 0;
+    }
+}
+
+inline void CircularBuffer::list(std::vector<std::string>* res) {
+    std::lock_guard l(_mtx);
+    res->reserve(_elements);
+    for (int i = 0; i < _elements; i++) {
+        res->emplace_back(_buffer[(_read_pos + i) % kBufferSize]);
+    }
+}
+
+CircularBuffer g_buffer;
+
+} // namespace
+
+void save_stack_trace_of_long_wait_mutex(const std::string& stack_trace) {
+    g_buffer.push(stack_trace);
+}
+
+std::vector<std::string> list_stack_trace_of_long_wait_mutex() {
+    std::vector<std::string> res;
+    g_buffer.list(&res);
+    return res;
+}
+
+} // namespace starrocks

--- a/be/src/util/stack_trace_mutex.h
+++ b/be/src/util/stack_trace_mutex.h
@@ -1,0 +1,148 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bthread/bthread.h>
+#include <bthread/mutex.h>
+#include <butil/time.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <ratio>
+#include <string>
+#include <vector>
+
+#include "common/compiler_util.h"
+#include "common/logging.h"
+#include "gutil//macros.h"
+#include "util/stack_util.h"
+#include "util/time.h"
+
+namespace starrocks {
+
+extern void save_stack_trace_of_long_wait_mutex(const std::string& stack_trace);
+extern std::vector<std::string> list_stack_trace_of_long_wait_mutex();
+
+// If the lock() method failed to acquire the mutex for a long time(5 minutes), print a
+// log message with call stack. Mainly used to detect dead lock in production environments.
+// Example output:
+// I0426 21:05:30.956799 22284 stack_trace_mutex.h:78] Long wait mutex:
+//    @          0x5d760ca  starrocks::lake::AsyncDeltaWriter::open()
+//    @          0x5d72a36  starrocks::LakeTabletsChannel::add_chunk()
+//    @          0x5cc0f1f  starrocks::LoadChannel::_add_chunk()
+//    @          0x5cc2165  starrocks::LoadChannel::add_chunk()
+//    @          0x5cba902  starrocks::LoadChannelMgr::add_chunk()
+//    @          0x5dd7345  starrocks::BackendInternalServiceImpl<>::tablet_writer_add_chunk()
+//    @          0x721cb8d  brpc::policy::ProcessRpcRequest()
+//    @          0x71930b7  brpc::ProcessInputMessage()
+//    @          0x7193f8b  brpc::InputMessenger::OnNewMessages()
+//    @          0x714446e  brpc::Socket::ProcessEvent()
+//    @          0x7106e8f  bthread::TaskGroup::task_runner()
+//    @          0x710b5c1  bthread_make_fcontext
+template <typename Mutex>
+class StackTraceMutex {
+public:
+    StackTraceMutex() : _mutex() {}
+
+    DISALLOW_COPY_AND_MOVE(StackTraceMutex);
+
+    void lock() {
+        while (!try_lock_for(std::chrono::minutes(5))) {
+            auto trace = get_stack_trace();
+            save_stack_trace_of_long_wait_mutex(trace);
+            LOG(INFO) << "Long wait mutex:\n" << trace;
+        }
+    }
+
+    bool try_lock() { return _mutex.try_lock(); }
+
+    template <class Rep, class Period>
+    bool try_lock_for(const std::chrono::duration<Rep, Period>& timeout_duration) {
+        return _mutex.try_lock_for(timeout_duration);
+    }
+
+    template <class Clock, class Duration>
+    bool try_lock_until(const std::chrono::time_point<Clock, Duration>& timeout_time) {
+        return _mutex.try_lock_until(timeout_time);
+    }
+
+    void unlock() { _mutex.unlock(); }
+
+    Mutex& native_mutex() { return _mutex; }
+
+private:
+    Mutex _mutex;
+};
+
+// Specialize for bthread_mutex_t
+
+template <>
+class StackTraceMutex<bthread::Mutex> {
+public:
+    StackTraceMutex() : _mutex() {}
+
+    void lock() {
+        while (!try_lock_for(std::chrono::minutes(5))) {
+            auto trace = get_stack_trace();
+            save_stack_trace_of_long_wait_mutex(trace);
+            LOG(INFO) << "Long wait mutex:\n" << trace;
+        }
+    }
+
+    bool try_lock() { return _mutex.try_lock(); }
+
+    template <class Rep, class Period>
+    bool try_lock_for(const std::chrono::duration<Rep, Period>& timeout_duration) {
+        auto rt = std::chrono::duration_cast<std::chrono::system_clock::duration>(timeout_duration);
+        if (std::ratio_greater<std::chrono::system_clock::period, Period>()) ++rt;
+        return try_lock_until(std::chrono::system_clock::now() + rt);
+    }
+
+    template <class Duration>
+    bool try_lock_until(const std::chrono::time_point<std::chrono::system_clock, Duration>& timeout_time) {
+        ::timespec due_time = TimespecFromTimePoint(timeout_time);
+        return bthread_mutex_timedlock(_mutex.native_handler(), &due_time) == 0;
+    }
+
+    template <class Duration>
+    bool try_lock_until(const std::chrono::time_point<std::chrono::steady_clock, Duration>& timeout_time) {
+        ::timespec due_time = TimespecFromTimePoint(timeout_time);
+        return bthread_mutex_timedlock(_mutex.native_handler(), &due_time) == 0;
+    }
+
+    template <class Clock, class Duration>
+    bool try_lock_until(const std::chrono::time_point<Clock, Duration>& atime) {
+        // The user-supplied clock may not tick at the same rate as
+        // steady_clock, so we must loop in order to guarantee that
+        // the timeout has expired before returning false.
+        auto now = Clock::now();
+        do {
+            auto rtime = atime - now;
+            if (try_lock_for(rtime)) return true;
+            now = Clock::now();
+        } while (atime > now);
+        return false;
+    }
+
+    void unlock() { _mutex.unlock(); }
+
+    bthread::Mutex& native_mutex() { return _mutex; }
+
+private:
+    bthread::Mutex _mutex;
+};
+
+} // namespace starrocks

--- a/be/src/util/time.h
+++ b/be/src/util/time.h
@@ -34,6 +34,9 @@
 
 #pragma once
 
+#include <sys/time.h> // timeval, gettimeofday
+
+#include <chrono>
 #include <cstdint>
 #include <ctime>
 #include <string>
@@ -145,5 +148,25 @@ std::string ToStringFromUnixMicros(int64_t us, TimePrecision p = TimePrecision::
 
 /// Converts input microseconds-since-epoch to date-time string in UTC time zone.
 std::string ToUtcStringFromUnixMicros(int64_t us, TimePrecision p = TimePrecision::Microsecond);
+
+template <typename Duration>
+inline ::timespec TimespecFromTimePoint(const std::chrono::time_point<std::chrono::system_clock, Duration>& atime) {
+    auto s = std::chrono::time_point_cast<std::chrono::seconds>(atime);
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(atime - s);
+
+    ::timespec spec = {.tv_sec = static_cast<std::time_t>(s.time_since_epoch().count()),
+                       .tv_nsec = static_cast<long>(ns.count())};
+    return spec;
+}
+
+template <typename Duration>
+inline ::timespec TimespecFromTimePoint(const std::chrono::time_point<std::chrono::steady_clock, Duration>& atime) {
+    auto s = std::chrono::time_point_cast<std::chrono::seconds>(atime);
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(atime - s);
+
+    ::timespec spec = {.tv_sec = static_cast<std::time_t>(s.time_since_epoch().count()),
+                       .tv_nsec = static_cast<long>(ns.count())};
+    return spec;
+}
 
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -368,6 +368,7 @@ set(EXEC_FILES
         ./util/cpu_usage_info_test.cpp
         ./util/timezone_utils_test.cpp
         ./util/concurrent_limiter_test.cpp
+        ./util/stack_trace_mutex_test.cpp
         ./gutil/cpu_test.cc
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp

--- a/be/test/util/stack_trace_mutex_test.cpp
+++ b/be/test/util/stack_trace_mutex_test.cpp
@@ -1,0 +1,88 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "util/stack_trace_mutex.h"
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+namespace starrocks {
+
+template <class T>
+class StackTraceMutexTest : public testing::Test {
+protected:
+    StackTraceMutexTest() : _mutex() {}
+
+    ~StackTraceMutexTest() override = default;
+
+    StackTraceMutex<T> _mutex;
+};
+
+typedef testing::Types<std::timed_mutex, bthread::Mutex> Implmentations;
+
+TYPED_TEST_SUITE(StackTraceMutexTest, Implmentations);
+
+TYPED_TEST(StackTraceMutexTest, test_lock_unlock) {
+    this->_mutex.lock();
+    this->_mutex.unlock();
+}
+
+TYPED_TEST(StackTraceMutexTest, test_multi_thread) {
+    int counter = 0;
+
+    std::thread t1([&]() {
+        for (int i = 0; i < 500; i++) {
+            this->_mutex.lock();
+            counter += 1;
+            this->_mutex.unlock();
+        }
+    });
+
+    std::thread t2([&]() {
+        for (int i = 0; i < 600; i++) {
+            this->_mutex.lock();
+            counter += 1;
+            this->_mutex.unlock();
+        }
+    });
+
+    for (int i = 0; i < 1000; i++) {
+        this->_mutex.lock();
+        counter += 1;
+        this->_mutex.unlock();
+    }
+
+    t1.join();
+    t2.join();
+    ASSERT_EQ(2100, counter);
+}
+
+TYPED_TEST(StackTraceMutexTest, test_timed_lock) {
+    bool locked = this->_mutex.try_lock_for(std::chrono::seconds(1));
+    ASSERT_TRUE(locked);
+    this->_mutex.unlock();
+}
+
+TYPED_TEST(StackTraceMutexTest, test_timed_lock_fail) {
+    this->_mutex.lock();
+    bool locked = this->_mutex.try_lock_for(std::chrono::milliseconds(100));
+    ASSERT_FALSE(locked);
+    this->_mutex.unlock();
+}
+
+} // namespace starrocks


### PR DESCRIPTION
Print stack trace if cannot acquire lock for a long time. Used to locate production environment deadlock issues.

Obtain stack trace through SQL:
```
> admin execute on 10006 '
for (s in ExecEnv.list_stack_trace_of_long_wait_mutex()) {
    System.print(s)
}
';
```

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
