### PR TITLE
[Doc] update show create table and optimize show partitions

### DIFF
--- a/docs/sql-reference/sql-statements/data-manipulation/SHOW CREATE TABLE.md
+++ b/docs/sql-reference/sql-statements/data-manipulation/SHOW CREATE TABLE.md
@@ -1,6 +1,19 @@
 # SHOW CREATE TABLE
 
-Returns the CREATE TABLE statement that was used to create a given table. In versions earlier than v3.0, the SHOW CREATE TABLE statement requires you to have the `SELECT_PRIV` privilege on the table. Since v3.0, the SHOW CREATE TABLE statement requires you to have the `SELECT` privilege on the table. Note that from v3.0 onwards you can use the SHOW CREATE TABLE statement to view the CREATE TABLE statements of the tables that are managed by an external catalog and are stored in Apache Hive™, Apache Iceberg, Apache Hudi, or Delta Lake.
+Returns the CREATE TABLE statement that was used to create a given table.
+
+> **NOTE**
+>
+> In versions earlier than v3.0, the SHOW CREATE TABLE statement requires you to have the `SELECT_PRIV` privilege on the table. Since v3.0, the SHOW CREATE TABLE statement requires you to have the `SELECT` privilege on the table.
+
+Since v3.0, you can use the SHOW CREATE TABLE statement to view the CREATE TABLE statements of the tables that are managed by an external catalog and are stored in Apache Hive™, Apache Iceberg, Apache Hudi, or Delta Lake.
+
+Since v2.5.7, StarRocks can automatically set the number of buckets (BUCKETS) when you create a table or add a partition. You no longer need to manually set the number of buckets. For detailed information, see [Determine the number of buckets](../../../table_design/Data_distribution.md#determine-the-number-of-buckets).
+
+- If you specified the number of buckets when creating a table, the output of SHOW CREATE TABLE will display the number of buckets.
+- If you did not specify the number of buckets when creating a table, the output of SHOW CREATE TABLE will not display the number of buckets. You can run [SHOW PARTITIONS](SHOW%20PARTITIONS.md) to view the number of buckets for each partition.
+
+In versions earlier than v2.5.7, you are required to set the number of buckets when creating a table. Therefore, SHOW CREATE TABLE displays the number of buckets by default.
 
 ## Syntax
 
@@ -32,7 +45,9 @@ The following table describes the parameters returned by this statement.
 
 ## Examples
 
-Create a table named `example_table`.
+### Bucket number is not specified
+
+Create a table named `example_table` with no bucket number specified in DISTRIBUTED BY.
 
 ```SQL
 CREATE TABLE example_table
@@ -48,15 +63,13 @@ COMMENT "my first starrocks table"
 DISTRIBUTED BY HASH(k1);
 ```
 
-Display the CREATE TABLE statement of `example_table`. Note that if you did not specify PROPERTIES when you create the table, the default properties are displayed in the output of SHOW CREATE TABLE.
+Run SHOW CREATE TABLE to display the CREATE TABLE statement of `example_table`. No bucket number is displayed in DISTRIBUTED BY. Note that if you did not specify PROPERTIES when you create the table, the default properties are displayed in the output of SHOW CREATE TABLE.
 
 ```Plain
-SHOW CREATE TABLE example_db.example_table;
-
-+---------------+--------------------------------------------------------+
-| Table         | Create Table                                           |
-+---------------+--------------------------------------------------------+
-| example_table | CREATE TABLE `example_table` (
+SHOW CREATE TABLE example_table\G
+*************************** 1. row ***************************
+       Table: example_table
+Create Table: CREATE TABLE `example_table` (
   `k1` tinyint(4) NULL COMMENT "",
   `k2` decimal64(10, 2) NULL DEFAULT "10.5" COMMENT "",
   `v1` char(10) REPLACE NULL COMMENT "",
@@ -64,13 +77,54 @@ SHOW CREATE TABLE example_db.example_table;
 ) ENGINE=OLAP 
 AGGREGATE KEY(`k1`, `k2`)
 COMMENT "my first starrocks table"
-DISTRIBUTED BY HASH(`k1`) 
+DISTRIBUTED BY HASH(`k1`)
 PROPERTIES (
 "replication_num" = "3",
 "in_memory" = "false",
 "enable_persistent_index" = "false",
 "replicated_storage" = "true",
 "compression" = "LZ4"
-);|
-+---------------+----------------------------------------------------------+
+);
+```
+
+### Bucket number is specified
+
+Create a table named `example_table1` with bucket number set to 10 in DISTRIBUTED BY.
+
+```SQL
+CREATE TABLE example_table1
+(
+    k1 TINYINT,
+    k2 DECIMAL(10, 2) DEFAULT "10.5",
+    v1 CHAR(10) REPLACE,
+    v2 INT SUM
+)
+ENGINE = olap
+AGGREGATE KEY(k1, k2)
+COMMENT "my first starrocks table"
+DISTRIBUTED BY HASH(k1) BUCKETS 10;
+```
+
+Run SHOW CREATE TABLE to display the CREATE TABLE statement of `example_table`. The bucket number (`BUCKETS 10`) is displayed in DISTRIBUTED BY. Note that if you did not specify PROPERTIES when you create the table, the default properties are displayed in the output of SHOW CREATE TABLE.
+
+```plain
+SHOW CREATE TABLE example_table1\G
+*************************** 1. row ***************************
+       Table: example_table1
+Create Table: CREATE TABLE `example_table1` (
+  `k1` tinyint(4) NULL COMMENT "",
+  `k2` decimal64(10, 2) NULL DEFAULT "10.5" COMMENT "",
+  `v1` char(10) REPLACE NULL COMMENT "",
+  `v2` int(11) SUM NULL COMMENT ""
+) ENGINE=OLAP 
+AGGREGATE KEY(`k1`, `k2`)
+COMMENT "my first starrocks table"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "3",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
 ```

--- a/docs/sql-reference/sql-statements/data-manipulation/SHOW PARTITIONS.md
+++ b/docs/sql-reference/sql-statements/data-manipulation/SHOW PARTITIONS.md
@@ -2,36 +2,43 @@
 
 ## Description
 
-This statement is used to display partition information
+Displays partition information, including common partitions and [temporary partitions](../../../table_design/Temporary_partition.md).
 
-Syntax:
+## Syntax
 
 ```sql
-SHOW PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT]
+SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT]
 ```
 
-Note:
-
-```plain text
-Support the filtering of PartitionId,PartitionName,State,Buckets,ReplicationNum,LastConsistencyCheckTime and other columns. This syntax only supports OLAP tables, ES tables and HIVE tables. Please use SHOW PROC '/dbs/db_id/table_id/partitions'SHOW PROC '/dbs/db_id/table_id/partitions'
-```
+> NOTE
+>
+> This syntax only supports StarRocks tables (`"ENGINE" = "OLAP"`). For Elasticsearch and Hive tables, use SHOW PROC '/dbs/db_id/table_id/partitions'.
 
 ## Examples
 
 1. Display all partition information of the specified table under the specified db
 
     ```sql
+    -- Common partition
     SHOW PARTITIONS FROM example_db.table_name;
+    -- Temporary partition
+    SHOW TEMPORARY PARTITIONS FROM example_db.table_name;
     ```
 
 2. Display the information of the specified partition of the specified table under the specified db
 
     ```sql
+    -- Common partition
     SHOW PARTITIONS FROM example_db.table_name WHERE PartitionName = "p1";
+    -- Temporary partition
+    SHOW TEMPORARY PARTITIONS FROM example_db.table_name WHERE PartitionName = "p1";
     ```
 
 3. Display the latest partition information of the specified table under the specified db
 
     ```sql
+    -- Common partition
     SHOW PARTITIONS FROM example_db.table_name ORDER BY PartitionId DESC LIMIT 1;
+    -- Temporary partition
+    SHOW TEMPORARY PARTITIONS FROM example_db.table_name ORDER BY PartitionId DESC LIMIT 1;
     ```

--- a/docs/sql-reference/sql-statements/data-manipulation/SHOW PARTITIONS.md
+++ b/docs/sql-reference/sql-statements/data-manipulation/SHOW PARTITIONS.md
@@ -13,6 +13,7 @@ SHOW [TEMPORARY] PARTITIONS FROM [db_name.]table_name [WHERE] [ORDER BY] [LIMIT]
 > NOTE
 >
 > This syntax only supports StarRocks tables (`"ENGINE" = "OLAP"`). For Elasticsearch and Hive tables, use SHOW PROC '/dbs/db_id/table_id/partitions'.
+> Since v3.0, this operation requires the SELECT privilege on the specified table. For v2.5 and earlier versions, this operation requires the SELECT__PRIV privilege on the specified table.
 
 ## Examples
 

--- a/docs/table_design/Data_distribution.md
+++ b/docs/table_design/Data_distribution.md
@@ -89,7 +89,7 @@ Data in partitions can be subdivided into tablets based on the hash values of th
 - high cardinality column such as ID
 - column that often used as a filter in queries
 
-But if the column that satisfies both requirements does not exist, you need to determine the buckting column according to the complexity of queries.
+But if the column that satisfies both requirements does not exist, you need to determine the bucketing column according to the complexity of queries.
 
 - If the query is complex, it is recommended that you select the high cardinality column as the bucketing column to ensure that the data is as balanced as possible in each bucket and improve the cluster resource utilization.
 - If the query is relatively simple, then it is recommended to select the column that is often used as in the query condition as the bucketing column to improve the query efficiency.
@@ -174,11 +174,11 @@ Buckets reflect how data files are organized in StarRocks.
     DISTRIBUTED BY HASH(site_id,city_code); -- do not need to set the number of buckets
     ```
 
-    To enable this feature, make sure that the FE dynamic parameter `enable_auto_tablet_distribution` is set to `TRUE`. After a table is created, you can execute [SHOW CREATE TABLE](../sql-reference/sql-statements/data-manipulation/SHOW%20CREATE%20TABLE.md) to view the bucket number automatically set by StarRocks.
+    To enable this feature, make sure that the FE dynamic parameter `enable_auto_tablet_distribution` is set to `TRUE`. After a table is created, you can execute [SHOW PARTITIONS](../sql-reference/sql-statements/data-manipulation/SHOW%20PARTITIONS.md) to view the bucket number automatically set by StarRocks for each partition.
 
   - Method 2: manually set the number of buckets
 
-    StarRocks 2.4 and later versions support using multiple threads to scan a tablet in parallel during a query, thereby reducing the dependency of scanning performance on the tablet count. We recommend that each tablet contain about 10 GB of raw data. If you intend to manually set the number of buckets, you can estimatethe the amount of data in each partition of a table and then decide the number of tablets. To enable parallel scanning on tablets, make sure the `enable_tablet_internal_parallel` parameter is set to `TRUE` globally for the entire system (`SET GLOBAL enable_tablet_internal_parallel = true;`).
+    StarRocks 2.4 and later versions support using multiple threads to scan a tablet in parallel during a query, thereby reducing the dependency of scanning performance on the tablet count. We recommend that each tablet contain about 10 GB of raw data. If you intend to manually set the number of buckets, you can estimate the the amount of data in each partition of a table and then decide the number of tablets. To enable parallel scanning on tablets, make sure the `enable_tablet_internal_parallel` parameter is set to `TRUE` globally for the entire system (`SET GLOBAL enable_tablet_internal_parallel = true;`).
 
     ```sql
     CREATE TABLE site_access (


### PR DESCRIPTION
from 2.5.7, show create table does not show bucket number if user does not set bucket number when creating a table. show partitions can be run to show this info.
Signed-off-by: evelynzhaojie <everlyn.[zhaojie@gmail.com](mailto:zhaojie@starrocks.com)>

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
