### PR TITLE
[Enhancement] Turn on default block cache configuration in be.conf.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -912,7 +912,7 @@ CONF_Int64(max_length_for_to_base64, "200000");
 // Used by bitmap functions
 CONF_Int64(max_length_for_bitmap_function, "1000000");
 
-CONF_Bool(block_cache_enable, "false");
+CONF_Bool(block_cache_enable, "true");
 CONF_Int64(block_cache_disk_size, "0");
 CONF_String(block_cache_disk_path, "${STARROCKS_HOME}/block_cache/");
 CONF_String(block_cache_meta_path, "${STARROCKS_HOME}/block_cache/");

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -318,6 +318,7 @@ int main(int argc, char** argv) {
 #if !defined(WITH_CACHELIB) && !defined(WITH_STARCACHE)
     if (starrocks::config::block_cache_enable) {
         starrocks::config::block_cache_enable = false;
+        LOG(ERROR) << "block cache is disabled because no cache engine is supported, please check your build options.";
     }
 #endif
 

--- a/be/test/exec/hdfs_scan_node_test.cpp
+++ b/be/test/exec/hdfs_scan_node_test.cpp
@@ -34,6 +34,7 @@ public:
     void SetUp() override {
         config::enable_system_metrics = false;
         config::enable_metric_calculator = false;
+        config::block_cache_enable = false;
 
         _exec_env = ExecEnv::GetInstance();
 


### PR DESCRIPTION
As we also have a system variable `enable_scan_block_cache` to control whether use block cache, so we turn on the default `enable_block_cache` in be.conf, to avoid restarting BE process if users want to use block cache. 

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
