### PR TITLE
[Enhancement] Preventing the vacuum process from blocking the tablet creation

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -577,10 +577,7 @@ void LakeServiceImpl::vacuum(::google::protobuf::RpcController* controller,
                              ::starrocks::lake::VacuumResponse* response, ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
-
-    // The BE process already has enough threads. I don't want to create more threads, so I directly use
-    // the thread pool for creating local tablet's replica.
-    auto thread_pool = _env->agent_server()->get_thread_pool(TTaskType::CREATE);
+    auto thread_pool = _env->agent_server()->get_thread_pool(TTaskType::DROP);
     if (UNLIKELY(thread_pool == nullptr)) {
         cntl->SetFailed("vacuum thread pool is null");
         return;
@@ -604,9 +601,6 @@ void LakeServiceImpl::vacuum_full(::google::protobuf::RpcController* controller,
                                   ::starrocks::lake::VacuumFullResponse* response, ::google::protobuf::Closure* done) {
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
-
-    // The BE process already has enough threads. I don't want to create more threads, so I directly use
-    // the thread pool for dropping local tablet's replica.
     auto thread_pool = _env->agent_server()->get_thread_pool(TTaskType::DROP);
     if (UNLIKELY(thread_pool == nullptr)) {
         cntl->SetFailed("full vacuum thread pool is null");


### PR DESCRIPTION
Do not run vacuum in the thread pool used to create the tablet

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
