### PR TITLE
[Enhancement] Calculate compaction score from max size-tiered level rowsets for cloud native table

### DIFF
--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -39,6 +39,17 @@ private:
     TabletMetadataPtr _tablet_metadata;
 };
 
+struct SizeTieredLevel {
+    SizeTieredLevel(std::vector<int> r, int64_t s, int64_t l, int64_t t, double sc)
+            : rowsets(std::move(r)), segment_num(s), level_size(l), total_size(t), score(sc) {}
+
+    std::vector<int> rowsets;
+    int64_t segment_num;
+    int64_t level_size;
+    int64_t total_size;
+    double score;
+};
+
 class SizeTieredCompactionPolicy : public CompactionPolicy {
 public:
     explicit SizeTieredCompactionPolicy(TabletPtr tablet)
@@ -49,20 +60,11 @@ public:
 
     StatusOr<std::vector<RowsetPtr>> pick_rowsets(int64_t version) override;
 
+    static StatusOr<std::unique_ptr<SizeTieredLevel>> pick_max_level(const TabletMetadataPB& metadata);
+
 private:
     static double cal_compaction_score(int64_t segment_num, int64_t level_size, int64_t total_size,
                                        int64_t max_level_size, KeysType keys_type, bool reached_max_version);
-
-    struct SizeTieredLevel {
-        SizeTieredLevel(std::vector<int> r, int64_t s, int64_t l, int64_t t, double sc)
-                : rowsets(std::move(r)), segment_num(s), level_size(l), total_size(t), score(sc) {}
-
-        std::vector<int> rowsets;
-        int64_t segment_num;
-        int64_t level_size;
-        int64_t total_size;
-        double score;
-    };
 
     struct LevelReverseOrderComparator {
         bool operator()(const SizeTieredLevel* left, const SizeTieredLevel* right) const {
@@ -157,28 +159,6 @@ StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets(int64_t v
     return input_rowsets;
 }
 
-double cumulative_compaction_score(const TabletMetadataPB& metadata) {
-    if (metadata.rowsets_size() == 0) {
-        return 0;
-    }
-
-    uint32_t segment_num_score = 0;
-    for (uint32_t i = metadata.cumulative_point(), size = metadata.rowsets_size(); i < size; ++i) {
-        const auto& rowset = metadata.rowsets(i);
-        segment_num_score += rowset.overlapped() ? rowset.segments_size() : 1;
-    }
-    VLOG(2) << "Tablet: " << metadata.id() << ", cumulative compaction score: " << segment_num_score;
-    return segment_num_score;
-}
-
-double base_compaction_score(const TabletMetadataPB& metadata) {
-    uint32_t cumulative_point = metadata.cumulative_point();
-    if (cumulative_point == 0 || metadata.rowsets_size() == 0) {
-        return 0;
-    }
-    return cumulative_point - 1;
-}
-
 double primary_compaction_score(const TabletMetadataPB& metadata) {
     uint32_t segment_num_score = 0;
     for (uint32_t i = 0; i < metadata.rowsets_size(); i++) {
@@ -267,6 +247,24 @@ void BaseAndCumulativeCompactionPolicy::debug_rowsets(CompactionType type,
                        << ", delete rowsets: [" << JoinInts(delete_rowset_ids, ",") + "]";
 }
 
+double cumulative_compaction_score(const TabletMetadataPB& metadata) {
+    if (metadata.rowsets_size() == 0) {
+        return 0;
+    }
+
+    uint32_t segment_num_score = 0;
+    for (uint32_t i = metadata.cumulative_point(), size = metadata.rowsets_size(); i < size; ++i) {
+        const auto& rowset = metadata.rowsets(i);
+        segment_num_score += rowset.overlapped() ? rowset.segments_size() : 1;
+    }
+    VLOG(2) << "Tablet: " << metadata.id() << ", cumulative compaction score: " << segment_num_score;
+    return segment_num_score;
+}
+
+double base_compaction_score(const TabletMetadataPB& metadata) {
+    return metadata.cumulative_point();
+}
+
 StatusOr<std::vector<RowsetPtr>> BaseAndCumulativeCompactionPolicy::pick_rowsets(int64_t version) {
     ASSIGN_OR_RETURN(_tablet_metadata, _tablet->get_metadata(version));
 
@@ -315,13 +313,14 @@ double SizeTieredCompactionPolicy::cal_compaction_score(int64_t segment_num, int
     return score;
 }
 
-StatusOr<std::vector<RowsetPtr>> SizeTieredCompactionPolicy::pick_rowsets(int64_t version) {
-    ASSIGN_OR_RETURN(auto tablet_metadata, _tablet->get_metadata(version));
-    const auto& rowsets = tablet_metadata->rowsets();
+StatusOr<std::unique_ptr<SizeTieredLevel>> SizeTieredCompactionPolicy::pick_max_level(
+        const TabletMetadataPB& metadata) {
+    int64_t max_level_size =
+            config::size_tiered_min_level_size * pow(config::size_tiered_level_multiple, config::size_tiered_level_num);
+    const auto& rowsets = metadata.rowsets();
 
-    std::vector<RowsetPtr> input_rowsets;
     if (rowsets.empty() || (rowsets.size() == 1 && !rowsets[0].overlapped())) {
-        return input_rowsets;
+        return nullptr;
     }
 
     // too many delete version will incur read overhead
@@ -335,6 +334,8 @@ StatusOr<std::vector<RowsetPtr>> SizeTieredCompactionPolicy::pick_rowsets(int64_
 
     // check reach max version
     bool reached_max_version = (rowsets.size() > config::tablet_max_versions / 10 * 9);
+    VLOG(3) << "Pick compaction max level. force base compaction: " << force_base_compaction
+            << ", reached max version: " << reached_max_version;
 
     std::vector<std::unique_ptr<SizeTieredLevel>> order_levels;
     std::set<SizeTieredLevel*, LevelReverseOrderComparator> priority_levels;
@@ -342,7 +343,7 @@ StatusOr<std::vector<RowsetPtr>> SizeTieredCompactionPolicy::pick_rowsets(int64_
     std::vector<int> transient_rowsets;
     size_t segment_num = 0;
     int64_t level_multiple = config::size_tiered_level_multiple;
-    auto keys_type = tablet_metadata->schema().keys_type();
+    auto keys_type = metadata.schema().keys_type();
     auto min_compaction_segment_num =
             std::max<int64_t>(2, std::min(config::min_cumulative_compaction_num_singleton_deltas, level_multiple));
     int64_t level_size = -1;
@@ -351,7 +352,7 @@ StatusOr<std::vector<RowsetPtr>> SizeTieredCompactionPolicy::pick_rowsets(int64_
         const auto& rowset = rowsets[i];
         int64_t rowset_size = rowset.data_size() > 0 ? rowset.data_size() : 1;
         if (level_size == -1) {
-            level_size = rowset_size < _max_level_size ? rowset_size : _max_level_size;
+            level_size = rowset_size < max_level_size ? rowset_size : max_level_size;
             total_size = 0;
         }
 
@@ -386,7 +387,7 @@ StatusOr<std::vector<RowsetPtr>> SizeTieredCompactionPolicy::pick_rowsets(int64_
                 if (!transient_rowsets.empty() && transient_rowsets[0] != 0) {
                     auto level = std::make_unique<SizeTieredLevel>(
                             transient_rowsets, segment_num, level_size, total_size,
-                            cal_compaction_score(segment_num, level_size, total_size, _max_level_size, keys_type,
+                            cal_compaction_score(segment_num, level_size, total_size, max_level_size, keys_type,
                                                  reached_max_version));
                     priority_levels.emplace(level.get());
                     order_levels.emplace_back(std::move(level));
@@ -405,14 +406,14 @@ StatusOr<std::vector<RowsetPtr>> SizeTieredCompactionPolicy::pick_rowsets(int64_
             if (!transient_rowsets.empty()) {
                 auto level = std::make_unique<SizeTieredLevel>(
                         transient_rowsets, segment_num, level_size, total_size,
-                        cal_compaction_score(segment_num, level_size, total_size, _max_level_size, keys_type,
+                        cal_compaction_score(segment_num, level_size, total_size, max_level_size, keys_type,
                                              reached_max_version));
                 priority_levels.emplace(level.get());
                 order_levels.emplace_back(std::move(level));
             }
             segment_num = 0;
             transient_rowsets.clear();
-            level_size = rowset_size < _max_level_size ? rowset_size : _max_level_size;
+            level_size = rowset_size < max_level_size ? rowset_size : max_level_size;
             total_size = 0;
         }
 
@@ -422,34 +423,53 @@ StatusOr<std::vector<RowsetPtr>> SizeTieredCompactionPolicy::pick_rowsets(int64_
     }
 
     if (!transient_rowsets.empty()) {
-        auto level = std::make_unique<SizeTieredLevel>(
-                transient_rowsets, segment_num, level_size, total_size,
-                cal_compaction_score(segment_num, level_size, total_size, _max_level_size, keys_type,
-                                     reached_max_version));
+        auto level =
+                std::make_unique<SizeTieredLevel>(transient_rowsets, segment_num, level_size, total_size,
+                                                  cal_compaction_score(segment_num, level_size, total_size,
+                                                                       max_level_size, keys_type, reached_max_version));
         priority_levels.emplace(level.get());
         order_levels.emplace_back(std::move(level));
     }
 
-    SizeTieredLevel* selected_level = nullptr;
-    std::vector<uint32_t> level_rowset_ids;
-    if (!priority_levels.empty()) {
-        // We need a minimum number of segments that trigger compaction to
-        // avoid triggering compaction too frequently compared to the old version
-        // But in the old version of compaction, the user may set a large min_cumulative_compaction_num_singleton_deltas
-        // to avoid TOO_MANY_VERSION errors, it is unnecessary in size tiered compaction
-        selected_level = *priority_levels.begin();
-        if (selected_level->segment_num >= min_compaction_segment_num) {
-            int64_t max_segments = config::max_cumulative_compaction_num_singleton_deltas;
-            for (auto i : selected_level->rowsets) {
-                const auto& rowset = rowsets[i];
-                auto metadata_ptr = std::make_shared<RowsetMetadata>(rowset);
-                input_rowsets.emplace_back(std::make_shared<Rowset>(_tablet.get(), std::move(metadata_ptr), i));
-                level_rowset_ids.emplace_back(rowset.id());
+    if (priority_levels.empty()) {
+        return nullptr;
+    }
 
-                max_segments -= rowset.overlapped() ? rowset.segments_size() : 1;
-                if (max_segments <= 0) {
-                    break;
-                }
+    auto* selected_level = *priority_levels.begin();
+    return std::make_unique<SizeTieredLevel>(selected_level->rowsets, selected_level->segment_num,
+                                             selected_level->level_size, selected_level->total_size,
+                                             selected_level->score);
+}
+
+StatusOr<std::vector<RowsetPtr>> SizeTieredCompactionPolicy::pick_rowsets(int64_t version) {
+    ASSIGN_OR_RETURN(auto tablet_metadata, _tablet->get_metadata(version));
+    ASSIGN_OR_RETURN(auto selected_level, pick_max_level(*tablet_metadata));
+    std::vector<RowsetPtr> input_rowsets;
+    if (selected_level == nullptr) {
+        return input_rowsets;
+    }
+
+    int64_t level_multiple = config::size_tiered_level_multiple;
+    auto min_compaction_segment_num =
+            std::max<int64_t>(2, std::min(config::min_cumulative_compaction_num_singleton_deltas, level_multiple));
+    std::vector<uint32_t> input_rowset_ids;
+    const auto& rowsets = tablet_metadata->rowsets();
+
+    // We need a minimum number of segments that trigger compaction to
+    // avoid triggering compaction too frequently compared to the old version
+    // But in the old version of compaction, the user may set a large min_cumulative_compaction_num_singleton_deltas
+    // to avoid TOO_MANY_VERSION errors, it is unnecessary in size tiered compaction
+    if (selected_level->segment_num >= min_compaction_segment_num) {
+        int64_t max_segments = config::max_cumulative_compaction_num_singleton_deltas;
+        for (auto i : selected_level->rowsets) {
+            const auto& rowset = rowsets[i];
+            auto metadata_ptr = std::make_shared<RowsetMetadata>(rowset);
+            input_rowsets.emplace_back(std::make_shared<Rowset>(_tablet.get(), std::move(metadata_ptr), i));
+            input_rowset_ids.emplace_back(rowset.id());
+
+            max_segments -= rowset.overlapped() ? rowset.segments_size() : 1;
+            if (max_segments <= 0) {
+                break;
             }
         }
     }
@@ -458,13 +478,24 @@ StatusOr<std::vector<RowsetPtr>> SizeTieredCompactionPolicy::pick_rowsets(int64_
     const auto& level_rowsets = selected_level->rowsets;
     auto type = !level_rowsets.empty() && level_rowsets[0] == 0 ? BASE_COMPACTION : CUMULATIVE_COMPACTION;
     VLOG(3) << "Pick compaction input rowsets. tablet: " << _tablet->id() << ", type: " << to_string(type)
-            << ", input rowsets: [" << JoinInts(level_rowset_ids, ",") << "]"
-            << ", input rowsets size: " << level_rowset_ids.size() << ", level rowsets size: " << level_rowsets.size()
+            << ", input rowsets: [" << JoinInts(input_rowset_ids, ",") << "]"
+            << ", input rowsets size: " << input_rowset_ids.size() << ", level rowsets size: " << level_rowsets.size()
             << ", level segment num: " << selected_level->segment_num << ", level size: " << selected_level->level_size
-            << ", level total size: " << selected_level->total_size << ", level score: " << selected_level->score
-            << ", force base compaction: " << force_base_compaction << ", reached max version: " << reached_max_version;
+            << ", level total size: " << selected_level->total_size << ", level score: " << selected_level->score;
 
     return input_rowsets;
+}
+
+double size_tiered_compaction_score(const TabletMetadataPB& metadata) {
+    auto selected_level_or = SizeTieredCompactionPolicy::pick_max_level(metadata);
+    if (!selected_level_or.ok()) {
+        return 0;
+    }
+    auto selected_level = std::move(selected_level_or).value();
+    if (selected_level == nullptr) {
+        return 0;
+    }
+    return selected_level->segment_num;
 }
 
 StatusOr<CompactionAlgorithm> CompactionPolicy::choose_compaction_algorithm(const std::vector<RowsetPtr>& rowsets) {
@@ -500,9 +531,11 @@ StatusOr<CompactionPolicyPtr> CompactionPolicy::create_compaction_policy(TabletP
 double compaction_score(const TabletMetadataPB& metadata) {
     if (is_primary_key(metadata)) {
         return primary_compaction_score(metadata);
-    } else {
-        return std::max(base_compaction_score(metadata), cumulative_compaction_score(metadata));
     }
+    if (config::enable_size_tiered_compaction_strategy) {
+        return size_tiered_compaction_score(metadata);
+    }
+    return std::max(base_compaction_score(metadata), cumulative_compaction_score(metadata));
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_policy_test.cpp
+++ b/be/test/storage/lake/compaction_policy_test.cpp
@@ -133,6 +133,8 @@ TEST_F(LakeCompactionPolicyTest, test_cumulative_by_segment_num) {
     }
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
+    ASSERT_EQ(7, compaction_score(*_tablet_metadata));
+
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create_compaction_policy(tablet_ptr));
@@ -164,6 +166,8 @@ TEST_F(LakeCompactionPolicyTest, test_base_by_segment_num) {
     }
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
+    ASSERT_EQ(6, compaction_score(*_tablet_metadata));
+
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create_compaction_policy(tablet_ptr));
@@ -190,6 +194,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_min_compaction) {
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
+    ASSERT_EQ(2, compaction_score(*_tablet_metadata));
+
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create_compaction_policy(tablet_ptr));
@@ -212,6 +218,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_max_compaction) {
 
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    ASSERT_EQ(6, compaction_score(*_tablet_metadata));
 
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
@@ -241,6 +249,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_max_compaction_by_max_singleto
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
+    ASSERT_EQ(6, compaction_score(*_tablet_metadata));
+
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create_compaction_policy(tablet_ptr));
@@ -267,6 +277,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_one_delete_middle) {
 
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    ASSERT_EQ(4, compaction_score(*_tablet_metadata));
 
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
@@ -296,6 +308,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_two_delete_middle) {
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
+    ASSERT_EQ(5, compaction_score(*_tablet_metadata));
+
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create_compaction_policy(tablet_ptr));
@@ -323,6 +337,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_two_delete_first) {
 
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    ASSERT_EQ(5, compaction_score(*_tablet_metadata));
 
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
@@ -356,6 +372,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_delete_limit_force_base_compac
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
+    ASSERT_EQ(7, compaction_score(*_tablet_metadata));
+
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create_compaction_policy(tablet_ptr));
@@ -382,6 +400,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_descending_order_level_size) {
 
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    ASSERT_EQ(2, compaction_score(*_tablet_metadata));
 
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
@@ -413,6 +433,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_multi_descending_order_level_s
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
+    ASSERT_EQ(7, compaction_score(*_tablet_metadata));
+
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create_compaction_policy(tablet_ptr));
@@ -434,6 +456,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_multi_descending_order_level_s
     _tablet_metadata->set_version(3);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
+    ASSERT_EQ(6, compaction_score(*_tablet_metadata));
+
     // compact 2 ~ 4, 9
     ASSIGN_OR_ABORT(input_rowsets, compaction_policy->pick_rowsets(3));
     // compaction input rowsets: [2, 3, 4, 9]
@@ -454,6 +478,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_multi_descending_order_level_s
 
     _tablet_metadata->set_version(4);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    ASSERT_EQ(3, compaction_score(*_tablet_metadata));
 
     // compact 1, 10
     ASSIGN_OR_ABORT(input_rowsets, compaction_policy->pick_rowsets(4));
@@ -478,6 +504,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_order_level_size) {
 
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    ASSERT_EQ(5, compaction_score(*_tablet_metadata));
 
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
@@ -505,6 +533,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_backtrace_base_compaction_dele
 
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    ASSERT_EQ(3, compaction_score(*_tablet_metadata));
 
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
@@ -539,6 +569,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_backtrace_base_compaction_dele
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
+    ASSERT_EQ(3, compaction_score(*_tablet_metadata));
+
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create_compaction_policy(tablet_ptr));
@@ -561,6 +593,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_backtrace_base_compaction_dele
 
     _tablet_metadata->set_version(3);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    ASSERT_EQ(5, compaction_score(*_tablet_metadata));
 
     // compact 1, 2, 8, 6, 7
     ASSIGN_OR_ABORT(input_rowsets, compaction_policy->pick_rowsets(3));
@@ -592,6 +626,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_backtrace_base_compaction_mult
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
+    ASSERT_EQ(5, compaction_score(*_tablet_metadata));
+
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);
     ASSIGN_OR_ABORT(auto compaction_policy, CompactionPolicy::create_compaction_policy(tablet_ptr));
@@ -621,6 +657,8 @@ TEST_F(LakeCompactionPolicyTest, test_size_tiered_backtrace_base_compaction_cont
 
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    ASSERT_EQ(5, compaction_score(*_tablet_metadata));
 
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
     auto tablet_ptr = std::make_shared<Tablet>(tablet);


### PR DESCRIPTION
Previously, compaction score was calculated from all rowsets of tablet and this may cause FE useless compaction scheduling.

In addition, fix base compaction score bug.

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
