### PR TITLE
[Enhancement] Wait starmgr address ready when get shard info from starmgr

### DIFF
--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -27,6 +27,7 @@
 #include "fslib/star_cache_configuration.h"
 #include "gflags/gflags.h"
 #include "gutil/strings/fastmem.h"
+#include "util/await.h"
 #include "util/debug_util.h"
 #include "util/lru_cache.h"
 #include "util/sha.h"
@@ -149,9 +150,18 @@ absl::StatusOr<std::shared_ptr<fslib::FileSystem>> StarOSWorker::get_shard_files
 
 absl::StatusOr<std::shared_ptr<fslib::FileSystem>> StarOSWorker::build_filesystem_on_demand(ShardId id,
                                                                                             const Configuration& conf) {
-    // get_shard_info call will probably trigger an add_shard() call to worker itself. Be sure there is no dead lock.
-    auto info_or = g_starlet->get_shard_info(id);
-    if (!info_or.ok()) {
+    static const int64_t kGetShardInfoTimeout = 5 * 1000 * 1000; // 5s (heartbeat interval)
+    static const int64_t kCheckInterval = 10 * 1000;             // 10ms
+    Awaitility wait;
+    absl::StatusOr<ShardInfo> info_or = absl::UnavailableError("starmgr address is still unknown");
+    auto cond = [&]() {
+        // get_shard_info call will probably trigger an add_shard() call to worker itself.
+        // Be sure there is no dead lock.
+        info_or = g_starlet->get_shard_info(id);
+        return !absl::IsUnavailable(info_or.status());
+    };
+    auto ret = wait.timeout(kGetShardInfoTimeout).interval(kCheckInterval).until(cond);
+    if (!ret || !info_or.ok()) {
         return info_or.status();
     }
     return build_filesystem_from_shard_info(info_or.value(), conf);


### PR DESCRIPTION
When BE restarts and receives new queries, starlet may not have received the heartbeat from starmgr, and does not know starmgr address, queries will be failed with error "server address is still unknown".

Starlet retries getting shard info until 5 seconds (heartbeat interval) to solve above problem.

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
