### PR TITLE
[Feature] Suppport jodatime_format function

### DIFF
--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -1346,7 +1346,7 @@ StatusOr<ColumnPtr> TimeFunctions::from_unix_to_datetime_with_format_32(Function
 
 // from_days
 DEFINE_UNARY_FN_WITH_IMPL(from_daysImpl, v) {
-    //return 00-00-00 if the argument is negative or too large, according to MySQL
+    // return 00-00-00 if the argument is negative or too large, according to MySQL
     DateValue dv{date::BC_EPOCH_JULIAN + v};
     if (!dv.is_valid()) {
         return DateValue{date::ZERO_EPOCH_JULIAN};
@@ -1906,7 +1906,198 @@ StatusOr<ColumnPtr> TimeFunctions::date_format(FunctionContext* context, const C
 
             common_format_process(&viewer_date, &viewer_format, &builder, i);
         }
+        return builder.build(ColumnHelper::is_all_const(columns));
+    }
+}
 
+Status TimeFunctions::jodatime_format_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
+        return Status::OK();
+    }
+
+    if (!context->is_constant_column(1)) {
+        return Status::OK();
+    }
+
+    ColumnPtr column = context->get_constant_column(1);
+    auto* fc = new FormatCtx();
+    context->set_function_state(scope, fc);
+
+    if (column->only_null()) {
+        fc->is_valid = false;
+        return Status::OK();
+    }
+
+    Slice slice = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
+    fc->fmt = slice.to_string();
+
+    fc->len = DateTimeValue::compute_format_len(slice.data, slice.size);
+    if (fc->len >= 128) {
+        fc->is_valid = false;
+        return Status::OK();
+    }
+
+    if (fc->fmt == "yyyyMMdd") {
+        fc->fmt_type = TimeFunctions::yyyyMMdd;
+    } else if (fc->fmt == "yyyy-MM-dd") {
+        fc->fmt_type = TimeFunctions::yyyy_MM_dd;
+    } else if (fc->fmt == "yyyy-MM-dd HH:mm:ss") {
+        fc->fmt_type = TimeFunctions::yyyy_MM_dd_HH_mm_ss;
+    } else if (fc->fmt == "yyyy-MM") {
+        fc->fmt_type = TimeFunctions::yyyy_MM;
+    } else if (fc->fmt == "yyyyMM") {
+        fc->fmt_type = TimeFunctions::yyyyMM;
+    } else if (fc->fmt == "yyyy") {
+        fc->fmt_type = TimeFunctions::yyyy;
+    } else {
+        fc->fmt_type = TimeFunctions::None;
+    }
+
+    fc->is_valid = true;
+    return Status::OK();
+}
+
+Status TimeFunctions::jodatime_format_close(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
+    if (scope != FunctionContext::FRAGMENT_LOCAL) {
+        return Status::OK();
+    }
+
+    auto* fc = reinterpret_cast<FormatCtx*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+    if (fc != nullptr) {
+        delete fc;
+    }
+
+    return Status::OK();
+}
+
+bool joda_standard_format_one_row(const TimestampValue& timestamp_value, char* buf, const std::string& fmt) {
+    int year, month, day, hour, minute, second, microsecond;
+    timestamp_value.to_timestamp(&year, &month, &day, &hour, &minute, &second, &microsecond);
+    DateTimeValue dt(TIME_DATETIME, year, month, day, hour, minute, second, microsecond);
+    bool b = dt.to_joda_format_string(fmt.c_str(), fmt.size(), buf);
+    return b;
+}
+
+template <LogicalType Type>
+StatusOr<ColumnPtr> joda_standard_format(const std::string& fmt, int len, const starrocks::Columns& columns) {
+    if (fmt.size() <= 0) {
+        return ColumnHelper::create_const_null_column(columns[0]->size());
+    }
+
+    auto ts_viewer = ColumnViewer<Type>(columns[0]);
+
+    size_t size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
+
+    char buf[len];
+    for (size_t i = 0; i < size; ++i) {
+        if (ts_viewer.is_null(i)) {
+            result.append_null();
+        } else {
+            auto ts = (TimestampValue)ts_viewer.value(i);
+            bool b = joda_standard_format_one_row(ts, buf, fmt);
+            result.append(Slice(std::string(buf)), !b);
+        }
+    }
+    return result.build(ColumnHelper::is_all_const(columns));
+}
+
+template <LogicalType Type>
+StatusOr<ColumnPtr> joda_format(const TimeFunctions::FormatCtx* ctx, const Columns& cols) {
+    if (ctx->fmt_type == TimeFunctions::yyyyMMdd) {
+        return date_format_func<yyyyMMddImpl, Type>(cols, 8);
+    } else if (ctx->fmt_type == TimeFunctions::yyyy_MM_dd) {
+        return date_format_func<yyyy_MM_dd_Impl, Type>(cols, 10);
+    } else if (ctx->fmt_type == TimeFunctions::yyyy_MM_dd_HH_mm_ss) {
+        return date_format_func<yyyyMMddHHmmssImpl, Type>(cols, 28);
+    } else if (ctx->fmt_type == TimeFunctions::yyyy_MM) {
+        return date_format_func<yyyy_MMImpl, Type>(cols, 7);
+    } else if (ctx->fmt_type == TimeFunctions::yyyyMM) {
+        return date_format_func<yyyyMMImpl, Type>(cols, 6);
+    } else if (ctx->fmt_type == TimeFunctions::yyyy) {
+        return date_format_func<yyyyImpl, Type>(cols, 4);
+    } else {
+        return joda_standard_format<Type>(ctx->fmt, 128, cols);
+    }
+}
+
+template <LogicalType Type>
+void common_joda_format_process(ColumnViewer<Type>* viewer_date, ColumnViewer<TYPE_VARCHAR>* viewer_format,
+                                ColumnBuilder<TYPE_VARCHAR>* builder, int i) {
+    if (viewer_format->is_null(i) || viewer_format->value(i).empty()) {
+        builder->append_null();
+        return;
+    }
+
+    auto format = viewer_format->value(i).to_string();
+    if (format == "yyyyMMdd") {
+        builder->append(format_for_yyyyMMdd(viewer_date->value(i)));
+    } else if (format == "yyyy-MM-dd") {
+        builder->append(format_for_yyyy_MM_dd_Impl(viewer_date->value(i)));
+    } else if (format == "yyyy-MM-dd HH:mm:ss") {
+        builder->append(format_for_yyyyMMddHHmmssImpl(viewer_date->value(i)));
+    } else if (format == "yyyy-MM") {
+        builder->append(format_for_yyyy_MMImpl(viewer_date->value(i)));
+    } else if (format == "yyyyMM") {
+        builder->append(format_for_yyyyMMImpl(viewer_date->value(i)));
+    } else if (format == "yyyy") {
+        builder->append(format_for_yyyyImpl(viewer_date->value(i)));
+    } else {
+        char buf[128];
+        auto ts = (TimestampValue)viewer_date->value(i);
+        bool b = joda_standard_format_one_row(ts, buf, viewer_format->value(i).to_string());
+        builder->append(Slice(std::string(buf)), !b);
+    }
+}
+
+// format datetime using joda format
+StatusOr<ColumnPtr> TimeFunctions::jodadatetime_format(FunctionContext* context, const Columns& columns) {
+    RETURN_IF_COLUMNS_ONLY_NULL(columns);
+    auto* fc = reinterpret_cast<FormatCtx*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+
+    if (fc != nullptr && fc->is_valid) {
+        return joda_format<TYPE_DATETIME>(fc, columns);
+    } else {
+        auto [all_const, num_rows] = ColumnHelper::num_packed_rows(columns);
+        ColumnViewer<TYPE_DATETIME> viewer_date(columns[0]);
+        ColumnViewer<TYPE_VARCHAR> viewer_format(columns[1]);
+
+        ColumnBuilder<TYPE_VARCHAR> builder(num_rows);
+        for (int i = 0; i < num_rows; ++i) {
+            if (viewer_date.is_null(i)) {
+                builder.append_null();
+                continue;
+            }
+
+            common_joda_format_process(&viewer_date, &viewer_format, &builder, i);
+        }
+
+        return builder.build(all_const);
+    }
+}
+
+// format date using joda format
+StatusOr<ColumnPtr> TimeFunctions::jodadate_format(FunctionContext* context, const Columns& columns) {
+    RETURN_IF_COLUMNS_ONLY_NULL(columns);
+    auto* fc = reinterpret_cast<FormatCtx*>(context->get_function_state(FunctionContext::FRAGMENT_LOCAL));
+
+    if (fc != nullptr && fc->is_valid) {
+        return joda_format<TYPE_DATE>(fc, columns);
+    } else {
+        int num_rows = columns[0]->size();
+        ColumnViewer<TYPE_DATE> viewer_date(columns[0]);
+        ColumnViewer<TYPE_VARCHAR> viewer_format(columns[1]);
+
+        ColumnBuilder<TYPE_VARCHAR> builder(columns[0]->size());
+
+        for (int i = 0; i < num_rows; ++i) {
+            if (viewer_date.is_null(i)) {
+                builder.append_null();
+                continue;
+            }
+
+            common_joda_format_process(&viewer_date, &viewer_format, &builder, i);
+        }
         return builder.build(ColumnHelper::is_all_const(columns));
     }
 }

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -519,6 +519,10 @@ public:
 
     static Status format_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
 
+    static Status jodatime_format_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+
+    static Status jodatime_format_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+
     /**
      * Format TimestampValue.
      * @param context
@@ -536,6 +540,22 @@ public:
     DEFINE_VECTORIZED_FN(date_format);
     //    DEFINE_VECTORIZED_FN(month_name);
     //    DEFINE_VECTORIZED_FN(day_name);
+
+    /**
+     * Format TimestampValue using JodaTime’s date time format
+     * @param context
+     * @param columns [TimestampColumn, BinaryColumn of TYPE_VARCHAR] The first column holds the timestamp, the second column holds the format.
+     * @return  BinaryColumn of TYPE_VARCHAR.
+     */
+    DEFINE_VECTORIZED_FN(jodadatetime_format);
+
+    /**
+     * Format DateValue using JodaTime’s date time format
+     * @param context
+     * @param columns [DateColumn, BinaryColumn of TYPE_VARCHAR] The first column holds the date, the second column holds the format.
+     * @return  BinaryColumn of TYPE_VARCHAR.
+     */
+    DEFINE_VECTORIZED_FN(jodadate_format);
 
     /**
      * @param: [timestampstr, formatstr]

--- a/be/src/runtime/datetime_value.cpp
+++ b/be/src/runtime/datetime_value.cpp
@@ -663,6 +663,258 @@ int DateTimeValue::compute_format_len(const char* format, int len) {
     return size;
 }
 
+bool DateTimeValue::to_joda_format_string(const char* format, int len, char* to) const {
+    // max buffer size is 128
+    // we need write a terminal zero
+    constexpr int buffer_size = 127;
+    const char* buffer_start = to;
+    char buf[64];
+    char* pos = nullptr;
+    const char* ptr = format;
+    const char* end = format + len;
+    char ch = '\0';
+
+    while (ptr < end) {
+        int write_size = to - buffer_start;
+        if (write_size == buffer_size) return false;
+        // '\'' is the escape for text，the text in '\'' do not need to convert
+        ch = *ptr;
+        if (ch == '\'') {
+            ++ptr;
+            while (ptr < end && *ptr != '\'') {
+                *to++ = *ptr++;
+            }
+            if (ptr < end && *ptr == '\'') {
+                // skip the '\''
+                ++ptr;
+                continue;
+            }
+        }
+
+        // compute the size of same char, this will determine if additional prefixes are required,
+        // eg. format 'yyyyyy' need to display '002023'
+        const char* next_ch_ptr = ptr;
+        uint32_t same_ch_size = 0;
+        uint32_t buf_size = 0;
+        uint32_t actual_size = 0;
+        ch = *ptr;
+        for (; ch == *next_ch_ptr && next_ch_ptr < end; ++next_ch_ptr) {
+            ++same_ch_size;
+        }
+
+        switch (ch) {
+        case 'G':
+            // era
+            if (write_size + 2 >= buffer_size) return false;
+            if (_year <= 0) {
+                to = append_string("BC", to);
+            } else {
+                to = append_string("AD", to);
+            }
+            break;
+        case 'C':
+            // century of era
+            pos = int_to_str(_year / 100, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 'Y':
+            // year of era
+            if (_year <= 0) {
+                pos = int_to_str(1 - _year, buf);
+            } else {
+                pos = int_to_str(_year, buf);
+            }
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 'x': {
+            // weekyear
+            if (_type == TIME_TIME) {
+                return false;
+            }
+            uint32_t year = 0;
+            calc_week(*this, mysql_week_mode(3), &year);
+            pos = int_to_str(year, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        }
+        case 'w':
+            // week of weekyear
+            if (_type == TIME_TIME) {
+                return false;
+            }
+            pos = int_to_str(week(mysql_week_mode(3)), buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 'e': {
+            // day of week
+            if (_type == TIME_TIME || (_month == 0 && _year == 0)) {
+                return false;
+            }
+            uint8_t weekday = calc_weekday(daynr(), true);
+            if (weekday == 0) weekday = 7;
+            pos = int_to_str(weekday, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        }
+        case 'E':
+            // weekday name (Sunday..Saturday)
+            if (same_ch_size > 3) {
+                if (write_size + 8 >= buffer_size) return false;
+                to = append_string(s_day_name[weekday()], to);
+            } else {
+                if (write_size + 3 >= buffer_size) return false;
+                if (_type == TIME_TIME || (_year == 0 && _month == 0)) {
+                    return false;
+                }
+                to = append_string(s_ab_day_name[weekday()], to);
+            }
+            break;
+        case 'y':
+            // year
+            pos = int_to_str(_year, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 'D':
+            // day of year (001..366)
+            pos = int_to_str(daynr() - calc_daynr(_year, 1, 1) + 1, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 'M':
+            if (same_ch_size > 3) {
+                // month name (January..December)
+                if (write_size + 9 >= buffer_size) return false;
+                if (_month == 0) {
+                    return false;
+                }
+                to = append_string(s_month_name[_month], to);
+                break;
+            } else if (same_ch_size == 3) {
+                // Abbreviated month name
+                if (write_size + 3 >= buffer_size) return false;
+                if (_month == 0) {
+                    return false;
+                }
+                to = append_string(s_ab_month_name[_month], to);
+                break;
+            } else {
+                // month, numeric (00..12)
+                pos = int_to_str(_month, buf);
+                buf_size = pos - buf;
+                actual_size = std::max(buf_size, same_ch_size);
+                if (write_size + actual_size >= buffer_size) return false;
+                to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+                break;
+            }
+        case 'd':
+            // day of month (00...31)
+            pos = int_to_str(_day, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 'a':
+            // AM or PM
+            if (write_size + 2 >= buffer_size) return false;
+            if ((_hour % 24) >= 12) {
+                to = append_string("PM", to);
+            } else {
+                to = append_string("AM", to);
+            }
+            break;
+        case 'K':
+            // hour (0..11)
+            pos = int_to_str((_hour % 24 + 12) % 12, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 'h':
+            // hour (1..12)
+            pos = int_to_str((_hour % 24 + 11) % 12 + 1, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 'H':
+            // hour (0..23)
+            pos = int_to_str(_hour, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 'k':
+            // hour (1..24)
+            pos = int_to_str((_hour + 23) % 24 + 1, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 'm':
+            // minutes, numeric (00..59)
+            pos = int_to_str(_minute, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + 2 >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 's':
+            // seconds (00..59)
+            pos = int_to_str(_second, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 'S':
+            // fraction of second
+            pos = int_to_str(_microsecond / 100000, buf);
+            buf_size = pos - buf;
+            actual_size = std::max(buf_size, same_ch_size);
+            if (write_size + actual_size >= buffer_size) return false;
+            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            break;
+        case 'z':
+        case 'Z':
+            // sr do not support datetime with timezone type， just ignore
+            break;
+        default:
+            if (write_size + 1 >= buffer_size) return false;
+            *to++ = ch;
+            break;
+        }
+
+        ptr = next_ch_ptr;
+    }
+    *to++ = '\0';
+    return true;
+}
+
 bool DateTimeValue::to_format_string(const char* format, int len, char* to) const {
     // max buffer size is 128
     // we need write a terminal zero
@@ -1146,7 +1398,7 @@ bool DateTimeValue::from_date_format_str(const char* format, int format_len, con
             int64_t int_value = 0;
             ptr++;
             switch (*ptr++) {
-                // Year
+            // Year
             case 'y':
                 // Year, numeric (two digits)
                 tmp = val + min(2, val_end - val);
@@ -1171,7 +1423,7 @@ bool DateTimeValue::from_date_format_str(const char* format, int format_len, con
                 val = tmp;
                 date_part_used = true;
                 break;
-                // Month
+            // Month
             case 'm':
             case 'c':
                 tmp = val + min(2, val_end - val);
@@ -1196,7 +1448,7 @@ bool DateTimeValue::from_date_format_str(const char* format, int format_len, con
                 }
                 _month = int_value;
                 break;
-                // Day
+            // Day
             case 'd':
             case 'e':
                 tmp = val + min(2, val_end - val);
@@ -1216,12 +1468,12 @@ bool DateTimeValue::from_date_format_str(const char* format, int format_len, con
                 val = tmp + min(2, val_end - tmp);
                 date_part_used = true;
                 break;
-                // Hour
+            // Hour
             case 'h':
             case 'I':
             case 'l':
                 usa_time = true;
-                // Fall through
+            // Fall through
             case 'k':
             case 'H':
                 tmp = val + min(2, val_end - val);
@@ -1232,7 +1484,7 @@ bool DateTimeValue::from_date_format_str(const char* format, int format_len, con
                 val = tmp;
                 time_part_used = true;
                 break;
-                // Minute
+            // Minute
             case 'i':
                 tmp = val + min(2, val_end - val);
                 if (!str_to_int64(val, &tmp, &int_value)) {
@@ -1242,7 +1494,7 @@ bool DateTimeValue::from_date_format_str(const char* format, int format_len, con
                 val = tmp;
                 time_part_used = true;
                 break;
-                // Second
+            // Second
             case 's':
             case 'S':
                 tmp = val + min(2, val_end - val);
@@ -1253,7 +1505,7 @@ bool DateTimeValue::from_date_format_str(const char* format, int format_len, con
                 val = tmp;
                 time_part_used = true;
                 break;
-                // Micro second
+            // Micro second
             case 'f':
                 tmp = val + min(6, val_end - val);
                 if (!str_to_int64(val, &tmp, &int_value)) {
@@ -1264,7 +1516,7 @@ bool DateTimeValue::from_date_format_str(const char* format, int format_len, con
                 val = tmp;
                 frac_part_used = true;
                 break;
-                // AM/PM
+            // AM/PM
             case 'p':
                 if ((val_end - val) < 2 || toupper(*(val + 1)) != 'M' || !usa_time) {
                     return false;
@@ -1276,7 +1528,7 @@ bool DateTimeValue::from_date_format_str(const char* format, int format_len, con
                 time_part_used = true;
                 val += 2;
                 break;
-                // Weekday
+            // Weekday
             case 'W':
                 int_value = check_word(s_day_name, val, val_end, &val);
                 if (int_value < 0) {
@@ -1337,7 +1589,7 @@ bool DateTimeValue::from_date_format_str(const char* format, int format_len, con
                 val = tmp;
                 date_part_used = true;
                 break;
-                // strict week number, must be used with %V or %v
+            // strict week number, must be used with %V or %v
             case 'x':
             case 'X':
                 strict_week_number_year_type = (*(ptr - 1) == 'X');

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -224,6 +224,9 @@ public:
     // Convert this datetime value to string by the format string
     bool to_format_string(const char* format, int len, char* to) const;
 
+    // Convert this datetime value to string by the joda format string
+    bool to_joda_format_string(const char* format, int len, char* to) const;
+
     // compute the length of data format pattern
     static int compute_format_len(const char* format, int len);
 

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -1834,7 +1834,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
         ASSERT_EQ(true, result->is_null(0));
     }
-    
+
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("", 0), 1);
 

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -1552,6 +1552,351 @@ TEST_F(TimeFunctionsTest, date_format) {
     }
 }
 
+TEST_F(TimeFunctionsTest, jodatime_format) {
+    FunctionContext* ctx = FunctionContext::create_test_context();
+    auto ptr = std::unique_ptr<FunctionContext>(ctx);
+
+    auto date_col = DateColumn::create();
+    date_col->append(DateValue::create(2013, 5, 1));
+    auto dt_col = TimestampColumn::create();
+    dt_col->append(TimestampValue::create(2020, 6, 25, 15, 58, 21));
+    // jodadate_format
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("dd,MM,yy"), 1);
+
+        Columns columns;
+        columns.emplace_back(date_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadate_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("01,05,2013"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyyMMdd"), 1);
+
+        Columns columns;
+        columns.emplace_back(date_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadate_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("20130501"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd"), 1);
+
+        Columns columns;
+        columns.emplace_back(date_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadate_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("2013-05-01"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd HH:mm:ss"), 1);
+
+        Columns columns;
+        columns.emplace_back(date_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadate_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("2013-05-01 00:00:00"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-ddTHH:mm:ss"), 1);
+
+        Columns columns;
+        columns.emplace_back(date_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadate_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("2013-05-01T00:00:00"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("bcfbcf"), 1);
+
+        Columns columns;
+        columns.emplace_back(date_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadate_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("bcfbcf"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("", 0), 1);
+
+        Columns columns;
+        columns.emplace_back(date_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadate_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->only_null());
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("G C Y x w e E y D M d"), 1);
+
+        Columns columns;
+        columns.emplace_back(date_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadate_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("AD 20 2013 2013 18 3 Wed 2013 121 5 1"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy MMM dd EEEE ee"), 1);
+
+        Columns columns;
+        columns.emplace_back(date_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadate_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("2013 May 01 Wednesday 03"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy MMM 'abcd'"), 1);
+
+        Columns columns;
+        columns.emplace_back(date_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadate_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("2013 May abcd"), v->get_data()[0]);
+    }
+
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("'abcd' yyyyMM"), 1);
+
+        Columns columns;
+        columns.emplace_back(date_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadate_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("abcd 201305"), v->get_data()[0]);
+    }
+
+    // datetime_format
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("dd,MM,yy"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadatetime_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("25,06,2020"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyyMMdd"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadatetime_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("20200625"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadatetime_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("2020-06-25"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-dd HH:mm:ss"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadatetime_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("2020-06-25 15:58:21"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyy-MM-ddTHH:mm:ss"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadatetime_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("2020-06-25T15:58:21"), v->get_data()[0]);
+    }
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("bcfbcf"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadatetime_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("bcfbcf"), v->get_data()[0]);
+    }
+    {
+        // stack-buffer-overflow test
+        std::string test_string;
+        for (int i = 0; i < 10000; ++i) {
+            test_string.append("x");
+        }
+        auto fmt_col =
+                ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice(test_string.c_str(), test_string.size()), 1);
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadatetime_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_EQ(true, result->is_null(0));
+    }
+    
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("", 0), 1);
+
+        Columns columns;
+        columns.emplace_back(date_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadatetime_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->only_null());
+    }
+
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("a K h H k m s S"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadatetime_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("PM 3 3 15 15 58 21 0"), v->get_data()[0]);
+    }
+
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("a K 'abcd'"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadatetime_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("PM 3 abcd"), v->get_data()[0]);
+    }
+
+    {
+        auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("'abcd' yyyyMM"), 1);
+
+        Columns columns;
+        columns.emplace_back(dt_col);
+        columns.emplace_back(fmt_col);
+        ctx->set_constant_columns(columns);
+        TimeFunctions::format_prepare(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ColumnPtr result = TimeFunctions::jodadatetime_format(ctx, columns).value();
+        TimeFunctions::format_close(ctx, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL);
+        ASSERT_TRUE(result->is_binary());
+        ASSERT_EQ(1, result->size());
+        auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
+        ASSERT_EQ(Slice("abcd 202006"), v->get_data()[0]);
+    }
+}
+
 TEST_F(TimeFunctionsTest, daynameTest) {
     auto tc = TimestampColumn::create();
     tc->append(TimestampValue::create(2020, 1, 1, 21, 22, 1));

--- a/docs/sql-reference/sql-functions/date-time-functions/jodatime_format.md
+++ b/docs/sql-reference/sql-functions/date-time-functions/jodatime_format.md
@@ -1,0 +1,85 @@
+# jodatime_format
+
+## Description
+
+Converts a date into a string according to the format that is compatible with JodaTime’s DateTimeFormat pattern format. Currently it supports strings with a maximum of 128 bytes. If the length of the returned value exceeds 128, NULL is returned.
+
+## Syntax
+
+```Haskell
+VARCHAR JODATIME_FORMAT(DATETIME date, VARCHAR format)
+```
+
+## Parameters
+
+- The `date` parameter must be a valid date or date expression.
+
+- `format` specifies the output format of the date or time.
+
+The available formats could refer to [joda-time format](https://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html)
+
+## Examples
+
+```Plain Text
+mysql> select jodatime_format('2020-06-25 15:58:51', 'yyyy-MM-dd');
++------------------------------------------------------+
+| jodatime_format('2020-06-25 15:58:51', 'yyyy-MM-dd') |
++------------------------------------------------------+
+| 2020-06-25                                           |
++------------------------------------------------------+
+
+mysql> select jodatime_format('2020-06-25 15:58:51', 'yyyy-MM-dd HH:mm:ss');
++---------------------------------------------------------------+
+| jodatime_format('2020-06-25 15:58:51', 'yyyy-MM-dd HH:mm:ss') |
++---------------------------------------------------------------+
+| 2020-06-25 15:58:51                                           |
++---------------------------------------------------------------+
+
+mysql> select jodatime_format('2020-06-25 15:58:51', 'MM dd ee EE');
++-------------------------------------------------------+
+| jodatime_format('2020-06-25 15:58:51', 'MM dd ee EE') |
++-------------------------------------------------------+
+| 06 25 04 Thu                                          |
++-------------------------------------------------------+
+1 row in set (0.02 sec)
+
+mysql> select jodatime_format('2020-06-25 15:58:51', 'MMM dd ee EEE');
++---------------------------------------------------------+
+| jodatime_format('2020-06-25 15:58:51', 'MMM dd ee EEE') |
++---------------------------------------------------------+
+| Jun 25 04 Thu                                           |
++---------------------------------------------------------+
+1 row in set (0.01 sec)
+
+mysql> select jodatime_format('2020-06-25 15:58:51', 'MMMM dd ee EEEE');
++-----------------------------------------------------------+
+| jodatime_format('2020-06-25 15:58:51', 'MMMM dd ee EEEE') |
++-----------------------------------------------------------+
+| June 25 04 Thursday                                       |
++-----------------------------------------------------------+
+
+mysql> select jodatime_format('2023-06-25 12:00:00', 'KK:mm:ss a');
++------------------------------------------------------+
+| jodatime_format('2023-06-25 12:00:00', 'KK:mm:ss a') |
++------------------------------------------------------+
+| 00:00:00 PM                                          |
++------------------------------------------------------+
+
+mysql> select jodatime_format('2023-06-25 12:00:00', 'hh:mm:ss a');
++------------------------------------------------------+
+| jodatime_format('2023-06-25 12:00:00', 'hh:mm:ss a') |
++------------------------------------------------------+
+| 12:00:00 PM                                          |
++------------------------------------------------------+
+
+mysql> select jodatime_format('2023-06-25 00:00:00', 'yyyyMMdd ''starrocks''');
++------------------------------------------------------------------+
+| jodatime_format('2023-06-25 00:00:00', 'yyyyMMdd \'starrocks\'') |
++------------------------------------------------------------------+
+| 20230625 starrocks                                               |
++------------------------------------------------------------------+
+```
+
+## keyword
+
+JODATIME_FORMAT,JODA,FORMAT

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -411,6 +411,8 @@ vectorized_functions = [
     # cast string to date, the function will call by FE getStrToDateFunction, and is invisible to user
     [50243, 'str2date', 'DATE', ['VARCHAR', 'VARCHAR'], 'TimeFunctions::str2date', 'TimeFunctions::str_to_date_prepare', 'TimeFunctions::str_to_date_close'],
     [50250, 'time_to_sec', 'BIGINT', ['TIME'], 'TimeFunctions::time_to_sec'],
+    [50260, 'jodatime_format', 'VARCHAR', ['DATETIME', 'VARCHAR'], 'TimeFunctions::jodadatetime_format', 'TimeFunctions::jodatime_format_prepare', 'TimeFunctions::jodatime_format_close'],
+    [50261, 'jodatime_format', 'VARCHAR', ['DATE', 'VARCHAR'], 'TimeFunctions::jodadate_format', 'TimeFunctions::jodatime_format_prepare', 'TimeFunctions::jodatime_format_close'],
 
     # unix timestamp extended version to int64
     # be sure to put before int32 version, so fe will find signature in order.


### PR DESCRIPTION
Fixes 
#23422


## Description

Converts a date into a string according to the format that is compatible with JodaTime’s DateTimeFormat pattern format. Currently it supports strings with a maximum of 128 bytes. If the length of the returned value exceeds 128, NULL is returned.

## Syntax

```Haskell
VARCHAR JODATIME_FORMAT(DATETIME date, VARCHAR format)
```

## Parameters

- The `date` parameter must be a valid date or date expression.

- `format` specifies the output format of the date or time.

The available formats could refer to [joda-time format](https://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html)

## Examples

```Plain Text
mysql> select jodatime_format('2020-06-25 15:58:51', 'yyyy-MM-dd');
+------------------------------------------------------+
| jodatime_format('2020-06-25 15:58:51', 'yyyy-MM-dd') |
+------------------------------------------------------+
| 2020-06-25                                           |
+------------------------------------------------------+
mysql> select jodatime_format('2020-06-25 15:58:51', 'yyyy-MM-dd HH:mm:ss');
+---------------------------------------------------------------+
| jodatime_format('2020-06-25 15:58:51', 'yyyy-MM-dd HH:mm:ss') |
+---------------------------------------------------------------+
| 2020-06-25 15:58:51                                           |
+---------------------------------------------------------------+

```

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
