### PR TITLE
[BugFix] fix lake primary index load concurrent (backport #26280)

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -449,8 +449,7 @@ Status DeltaWriterImpl::_fill_auto_increment_id(const Chunk& chunk) {
     auto metadata = _tablet_manager->get_latest_cached_tablet_metadata(_tablet_id);
     std::unique_ptr<MetaFileBuilder> builder = std::make_unique<MetaFileBuilder>(tablet, metadata);
 
-    tablet.update_mgr()->get_rowids_from_pkindex(&tablet, *metadata.get(), upserts, metadata->version(), builder.get(),
-                                                 &rss_rowids);
+    RETURN_IF_ERROR(tablet.update_mgr()->get_rowids_from_pkindex(&tablet, metadata->version(), upserts, &rss_rowids));
 
     std::vector<uint8_t> filter;
     uint32_t gen_num = 0;

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -35,6 +35,11 @@ Status LakePrimaryIndex::lake_load(Tablet* tablet, const TabletMetadata& metadat
     return _status;
 }
 
+bool LakePrimaryIndex::is_load(int64_t base_version) {
+    std::lock_guard<std::mutex> lg(_lock);
+    return _loaded && _data_version >= base_version;
+}
+
 Status LakePrimaryIndex::_do_lake_load(Tablet* tablet, const TabletMetadata& metadata, int64_t base_version,
                                        const MetaFileBuilder* builder) {
     MonotonicStopWatch watch;

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -41,6 +41,8 @@ public:
     Status lake_load(Tablet* tablet, const TabletMetadata& metadata, int64_t base_version,
                      const MetaFileBuilder* builder);
 
+    bool is_load(int64_t base_version);
+
     int64_t data_version() const { return _data_version; }
     void update_data_version(int64_t version) { _data_version = version; }
 

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -52,8 +52,10 @@ Status RowsetUpdateState::load(const TxnLogPB_OpWrite& op_write, const TabletMet
         _tablet_id = metadata.id();
         _status = _do_load(op_write, metadata, tablet);
         if (!_status.ok()) {
-            LOG(WARNING) << "load RowsetUpdateState error: " << _status << " tablet:" << _tablet_id << " stack:\n"
-                         << get_stack_trace();
+            if (!_status.is_uninitialized()) {
+                LOG(WARNING) << "load RowsetUpdateState error: " << _status << " tablet:" << _tablet_id << " stack:\n"
+                             << get_stack_trace();
+            }
             if (_status.is_mem_limit_exceeded()) {
                 LOG(WARNING) << CurrentThread::mem_tracker()->debug_string();
             }
@@ -300,8 +302,7 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(const Tx
     }
     DCHECK_EQ(_upserts.size(), num_segments);
     // use upserts to get rowids in each segment
-    RETURN_IF_ERROR(tablet->update_mgr()->get_rowids_from_pkindex(tablet, metadata, _upserts, _base_version, _builder,
-                                                                  &rss_rowids));
+    RETURN_IF_ERROR(tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &rss_rowids));
 
     for (size_t i = 0; i < num_segments; i++) {
         std::vector<uint32_t> rowids;
@@ -410,8 +411,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(const TxnLogPB_OpWrite&
     }
     DCHECK_EQ(_upserts.size(), num_segments);
     // use upserts to get rowids in each segment
-    RETURN_IF_ERROR(tablet->update_mgr()->get_rowids_from_pkindex(tablet, metadata, _upserts, _base_version, _builder,
-                                                                  &rss_rowids));
+    RETURN_IF_ERROR(tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &rss_rowids));
 
     int64_t t_read_values = MonotonicMillis();
     size_t total_rows = 0;
@@ -543,8 +543,8 @@ Status RowsetUpdateState::_resolve_conflict(const TxnLogPB_OpWrite& op_write, co
     for (uint32_t segment_id = 0; segment_id < num_segments; segment_id++) {
         new_rss_rowids_vec[segment_id].resize(_upserts[segment_id]->size());
     }
-    RETURN_IF_ERROR(tablet->update_mgr()->get_rowids_from_pkindex(tablet, metadata, _upserts, _base_version, _builder,
-                                                                  &new_rss_rowids_vec));
+    RETURN_IF_ERROR(
+            tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &new_rss_rowids_vec));
 
     size_t total_conflicts = 0;
     std::unique_ptr<TabletSchema> tablet_schema = std::make_unique<TabletSchema>(metadata.schema());

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -58,23 +58,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     std::stringstream cost_str;
     MonotonicStopWatch watch;
     watch.start();
-    // 1. load rowset update data to cache, get upsert and delete list
-    const uint32_t rowset_id = metadata.next_rowset_id();
-    std::unique_ptr<TabletSchema> tablet_schema = std::make_unique<TabletSchema>(metadata.schema());
-    auto state_entry = _update_state_cache.get_or_create(strings::Substitute("$0_$1", tablet->id(), txn_id));
-    state_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
-    // only use state entry once, remove it when publish finish or fail
-    DeferOp remove_state_entry([&] { _update_state_cache.remove(state_entry); });
-    auto& state = state_entry->value();
-    RETURN_IF_ERROR(state.load(op_write, metadata, base_version, tablet, builder, true));
-    _update_state_cache.update_object_size(state_entry, state.memory_usage());
-    cost_str << " [UpdateStateCache load] " << watch.elapsed_time();
-    watch.reset();
-    // 2. rewrite segment file if it is partial update
-    RETURN_IF_ERROR(state.rewrite_segment(op_write, metadata, tablet));
-    cost_str << " [UpdateStateCache rewrite segment] " << watch.elapsed_time();
-    watch.reset();
-    // 3. update primary index
+    // 1. update primary index
     auto index_entry = _index_cache.get_or_create(tablet->id());
     index_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
     auto& index = index_entry->value();
@@ -88,6 +72,24 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     }
     // release index entry but keep it in cache
     DeferOp release_index_entry([&] { _index_cache.release(index_entry); });
+    cost_str << " [primary index load] " << watch.elapsed_time();
+    watch.reset();
+    // 2. load rowset update data to cache, get upsert and delete list
+    const uint32_t rowset_id = metadata.next_rowset_id();
+    std::unique_ptr<TabletSchema> tablet_schema = std::make_unique<TabletSchema>(metadata.schema());
+    auto state_entry = _update_state_cache.get_or_create(strings::Substitute("$0_$1", tablet->id(), txn_id));
+    state_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
+    // only use state entry once, remove it when publish finish or fail
+    DeferOp remove_state_entry([&] { _update_state_cache.remove(state_entry); });
+    auto& state = state_entry->value();
+    RETURN_IF_ERROR(state.load(op_write, metadata, base_version, tablet, builder, true));
+    _update_state_cache.update_object_size(state_entry, state.memory_usage());
+    cost_str << " [UpdateStateCache load] " << watch.elapsed_time();
+    watch.reset();
+    // 3. rewrite segment file if it is partial update
+    RETURN_IF_ERROR(state.rewrite_segment(op_write, metadata, tablet));
+    cost_str << " [UpdateStateCache rewrite segment] " << watch.elapsed_time();
+    watch.reset();
     PrimaryIndex::DeletesMap new_deletes;
     for (uint32_t i = 0; i < op_write.rowset().segments_size(); i++) {
         new_deletes[rowset_id + i] = {};
@@ -257,32 +259,28 @@ Status UpdateManager::_do_update_with_condition(Tablet* tablet, const TabletMeta
     return Status::OK();
 }
 
-Status UpdateManager::_handle_index_op(Tablet* tablet, const TabletMetadata& metadata, const int64_t base_version,
-                                       const MetaFileBuilder* builder, std::function<void(LakePrimaryIndex&)> op) {
-    auto index_entry = _index_cache.get_or_create(tablet->id());
-    index_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
-    auto& index = index_entry->value();
-    auto st = index.lake_load(tablet, metadata, base_version, builder);
-    _index_cache.update_object_size(index_entry, index.memory_usage());
-    if (!st.ok()) {
-        _index_cache.remove(index_entry);
-        std::string msg =
-                strings::Substitute("get_rss_rowids_by_pk error: load primary index failed: $0", st.to_string());
-        LOG(ERROR) << msg;
-        return Status::InternalError(msg);
+Status UpdateManager::_handle_index_op(Tablet* tablet, int64_t base_version,
+                                       const std::function<void(LakePrimaryIndex&)>& op) {
+    auto index_entry = _index_cache.get(tablet->id());
+    if (index_entry == nullptr) {
+        return Status::Uninitialized(fmt::format("Primary index not load yet, tablet_id: {}", tablet->id()));
     }
+    index_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
     // release index entry but keep it in cache
     DeferOp release_index_entry([&] { _index_cache.release(index_entry); });
+    auto& index = index_entry->value();
+    if (!index.is_load(base_version)) {
+        return Status::Uninitialized(fmt::format("Primary index not load yet, tablet_id: {}", tablet->id()));
+    }
     op(index);
 
     return Status::OK();
 }
 
-Status UpdateManager::get_rowids_from_pkindex(Tablet* tablet, const TabletMetadata& metadata,
-                                              const std::vector<ColumnUniquePtr>& upserts, const int64_t base_version,
-                                              const MetaFileBuilder* builder,
+Status UpdateManager::get_rowids_from_pkindex(Tablet* tablet, int64_t base_version,
+                                              const std::vector<ColumnUniquePtr>& upserts,
                                               std::vector<std::vector<uint64_t>*>* rss_rowids) {
-    return _handle_index_op(tablet, metadata, base_version, builder, [&](LakePrimaryIndex& index) {
+    return _handle_index_op(tablet, base_version, [&](LakePrimaryIndex& index) {
         // get rss_rowids for each segment of rowset
         uint32_t num_segments = upserts.size();
         for (size_t i = 0; i < num_segments; i++) {
@@ -292,11 +290,10 @@ Status UpdateManager::get_rowids_from_pkindex(Tablet* tablet, const TabletMetada
     });
 }
 
-Status UpdateManager::get_rowids_from_pkindex(Tablet* tablet, const TabletMetadata& metadata,
-                                              const std::vector<ColumnUniquePtr>& upserts, const int64_t base_version,
-                                              const MetaFileBuilder* builder,
+Status UpdateManager::get_rowids_from_pkindex(Tablet* tablet, int64_t base_version,
+                                              const std::vector<ColumnUniquePtr>& upserts,
                                               std::vector<std::vector<uint64_t>>* rss_rowids) {
-    return _handle_index_op(tablet, metadata, base_version, builder, [&](LakePrimaryIndex& index) {
+    return _handle_index_op(tablet, base_version, [&](LakePrimaryIndex& index) {
         // get rss_rowids for each segment of rowset
         uint32_t num_segments = upserts.size();
         for (size_t i = 0; i < num_segments; i++) {
@@ -641,8 +638,13 @@ void UpdateManager::preload_update_state(const TxnLog& txnlog, Tablet* tablet) {
         auto st = state.load(txnlog.op_write(), *metadata_ptr, metadata_ptr->version(), tablet, nullptr, false);
         if (!st.ok()) {
             _update_state_cache.remove(state_entry);
-            LOG(ERROR) << strings::Substitute("lake primary table preload_update_state id:$0 error:$1", tablet->id(),
-                                              st.to_string());
+            if (!st.is_uninitialized()) {
+                LOG(ERROR) << strings::Substitute("lake primary table preload_update_state id:$0 error:$1",
+                                                  tablet->id(), st.to_string());
+            } else {
+                LOG(INFO) << strings::Substitute("lake primary table preload_update_state id:$0 failed:$1",
+                                                 tablet->id(), st.to_string());
+            }
             // not return error even it fail, because we can load update state in publish again.
         } else {
             // just release it, will use it again in publish

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -63,12 +63,10 @@ public:
                                       Tablet* tablet, MetaFileBuilder* builder, int64_t base_version);
 
     // get rowids from primary index by each upserts
-    Status get_rowids_from_pkindex(Tablet* tablet, const TabletMetadata& metadata,
-                                   const std::vector<ColumnUniquePtr>& upserts, int64_t base_version,
-                                   const MetaFileBuilder* builder, std::vector<std::vector<uint64_t>*>* rss_rowids);
-    Status get_rowids_from_pkindex(Tablet* tablet, const TabletMetadata& metadata,
-                                   const std::vector<ColumnUniquePtr>& upserts, const int64_t base_version,
-                                   const MetaFileBuilder* builder, std::vector<std::vector<uint64_t>>* rss_rowids);
+    Status get_rowids_from_pkindex(Tablet* tablet, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
+                                   std::vector<std::vector<uint64_t>*>* rss_rowids);
+    Status get_rowids_from_pkindex(Tablet* tablet, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
+                                   std::vector<std::vector<uint64_t>>* rss_rowids);
 
     // get column data by rssid and rowids
     Status get_column_values(Tablet* tablet, const TabletMetadata& metadata, const TxnLogPB_OpWrite& op_write,
@@ -133,8 +131,7 @@ private:
 
     int32_t _get_condition_column(const TxnLogPB_OpWrite& op_write, const TabletSchema& tablet_schema);
 
-    Status _handle_index_op(Tablet* tablet, const TabletMetadata& metadata, const int64_t base_version,
-                            const MetaFileBuilder* builder, std::function<void(LakePrimaryIndex&)> op);
+    Status _handle_index_op(Tablet* tablet, int64_t base_version, const std::function<void(LakePrimaryIndex&)>& op);
 
     static const size_t kPrintMemoryStatsInterval = 300; // 5min
 private:


### PR DESCRIPTION
When partial update happen, preload update state may have chance to update primary index and conflict with publish thread. Only allow update primary index in publish thread. Preload will give up if primary index not build yet.

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
