### PR TITLE
[BugFix] Fix replay colocate table NPE BUG

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1990,6 +1990,7 @@ public class LocalMetastore implements ConnectorMetadata {
                                 "table already exists");
                     } else {
                         LOG.info("Create table[{}] which already exists", table.getName());
+                        return;
                     }
                 }
 


### PR DESCRIPTION
Fixes
```
2023-07-03 20:28:04,482 WARN (replayer|94) [GlobalStateMgr.replayJournalInner():2257] catch exception when replaying 3331981,
com.starrocks.journal.JournalInconsistentException: failed to load journal type 94
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:1085) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.replayJournalInner(GlobalStateMgr.java:2246) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$5.runOneCycle(GlobalStateMgr.java:2104) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:115) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$5.run(GlobalStateMgr.java:2169) ~[starrocks-fe.jar:?]
Caused by: java.lang.NullPointerException
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:903) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.catalog.ColocateTableIndex.replayAddTableToGroup(ColocateTableIndex.java:594) ~[starrocks-fe.jar:?]
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:628) ~[starrocks-fe.jar:?]
```
If the table already exists, we should break the following procedure.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
