### PR TITLE
[BugFix] Fix possible inconsistencies in the global dictionary

### DIFF
--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -203,6 +203,7 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
 
     // set global dict
     const auto& global_dict = _runtime_state->get_load_global_dict_map();
+    const auto& dict_version = _runtime_state->load_dict_versions();
     for (size_t i = 0; i < request.schema().slot_descs_size(); i++) {
         auto slot = request.mutable_schema()->mutable_slot_descs(i);
         auto it = global_dict.find(slot->id());
@@ -211,6 +212,10 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
             for (auto& item : dict) {
                 slot->add_global_dict_words(item.first.to_string());
             }
+        }
+        auto it_version = dict_version.find(slot->id());
+        if (it_version != dict_version.end()) {
+            slot->set_global_dict_version(it_version->second);
         }
     }
 
@@ -657,8 +662,6 @@ Status NodeChannel::_wait_request(ReusableClosure<PTabletWriterAddBatchResult>* 
     }
 
     std::vector<int64_t> tablet_ids;
-    std::unordered_set<std::string> invalid_dict_cache_column_set;
-    std::unordered_set<std::string> valid_dict_cache_column_set;
     for (auto& tablet : closure->result.tablet_vec()) {
         TTabletCommitInfo commit_info;
         commit_info.tabletId = tablet.tablet_id();
@@ -668,12 +671,18 @@ Status NodeChannel::_wait_request(ReusableClosure<PTabletWriterAddBatchResult>* 
             commit_info.backendId = _node_id;
         }
 
-        for (auto& col_name : tablet.invalid_dict_cache_columns()) {
-            invalid_dict_cache_column_set.insert(col_name);
+        for (const auto& col_name : tablet.invalid_dict_cache_columns()) {
+            _valid_dict_cache_info.invalid_dict_cache_column_set.insert(col_name);
         }
 
-        for (auto& col_name : tablet.valid_dict_cache_columns()) {
-            valid_dict_cache_column_set.insert(col_name);
+        for (size_t i = 0; i < tablet.valid_dict_cache_columns_size(); ++i) {
+            int64_t version = 0;
+            // Some BEs don't have this field during grayscale upgrades, and we need to detect this case
+            if (tablet.valid_dict_collected_version_size() == tablet.valid_dict_cache_columns_size()) {
+                version = tablet.valid_dict_collected_version(i);
+            }
+            const auto& col_name = tablet.valid_dict_cache_columns(i);
+            _valid_dict_cache_info.valid_dict_cache_column_set.emplace(std::make_pair(col_name, version));
         }
 
         _tablet_commit_infos.emplace_back(std::move(commit_info));
@@ -681,19 +690,6 @@ Status NodeChannel::_wait_request(ReusableClosure<PTabletWriterAddBatchResult>* 
         if (tablet_ids.size() < 128) {
             tablet_ids.emplace_back(commit_info.tabletId);
         }
-    }
-
-    // Only send valid and invalid dict cache columns info once
-    if (!_tablet_commit_infos.empty()) {
-        std::vector<std::string> invalid_dict_cache_columns;
-        invalid_dict_cache_columns.assign(invalid_dict_cache_column_set.begin(), invalid_dict_cache_column_set.end());
-        _tablet_commit_infos[0].__set_invalid_dict_cache_columns(invalid_dict_cache_columns);
-
-        std::vector<std::string> valid_dict_cache_columns;
-        std::set_difference(valid_dict_cache_column_set.begin(), valid_dict_cache_column_set.end(),
-                            invalid_dict_cache_column_set.begin(), invalid_dict_cache_column_set.end(),
-                            std::back_inserter(valid_dict_cache_columns));
-        _tablet_commit_infos[0].__set_valid_dict_cache_columns(valid_dict_cache_columns);
     }
 
     if (!tablet_ids.empty()) {
@@ -808,6 +804,25 @@ Status NodeChannel::close_wait(RuntimeState* state) {
 
     // 2. wait eos request finish
     RETURN_IF_ERROR(_wait_all_prev_request());
+
+    // assign tablet dict infos
+    if (!_tablet_commit_infos.empty()) {
+        std::vector<std::string> invalid_dict_cache_columns;
+        invalid_dict_cache_columns.assign(_valid_dict_cache_info.invalid_dict_cache_column_set.begin(),
+                                          _valid_dict_cache_info.invalid_dict_cache_column_set.end());
+        _tablet_commit_infos[0].__set_invalid_dict_cache_columns(invalid_dict_cache_columns);
+
+        std::vector<std::string> valid_dict_cache_columns;
+        std::vector<int64_t> valid_dict_collected_versions;
+        for (const auto& [name, version] : _valid_dict_cache_info.valid_dict_cache_column_set) {
+            if (_valid_dict_cache_info.invalid_dict_cache_column_set.count(name) == 0) {
+                valid_dict_cache_columns.emplace_back(name);
+                valid_dict_collected_versions.emplace_back(version);
+            }
+        }
+        _tablet_commit_infos[0].__set_valid_dict_cache_columns(valid_dict_cache_columns);
+        _tablet_commit_infos[0].__set_valid_dict_collected_versions(valid_dict_collected_versions);
+    }
 
     // 3. commit tablet infos
     state->append_tablet_commit_infos(_tablet_commit_infos);

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -208,6 +208,10 @@ private:
 
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
     std::vector<TTabletFailInfo> _tablet_fail_infos;
+    struct {
+        std::unordered_set<std::string> invalid_dict_cache_column_set;
+        std::unordered_map<std::string, int64_t> valid_dict_cache_column_set;
+    } _valid_dict_cache_info;
 
     AddBatchCounter _add_batch_counter;
     int64_t _serialize_batch_ns = 0;

--- a/be/src/runtime/global_dict/types_fwd_decl.h
+++ b/be/src/runtime/global_dict/types_fwd_decl.h
@@ -33,7 +33,14 @@ using GlobalDictMapEntity = std::pair<GlobalDictMap, RGlobalDictMap>;
 using GlobalDictMaps = phmap::flat_hash_map<uint32_t, GlobalDictMapEntity>;
 
 // column-name -> GlobalDictMap
-using GlobalDictByNameMaps = phmap::flat_hash_map<std::string, GlobalDictMap>;
+// template to avoid incomplete type problems
+template <class GlobalDictType>
+struct GlobalDictsWithVersion {
+    GlobalDictType dict;
+    long version;
+};
+
+using GlobalDictByNameMaps = phmap::flat_hash_map<std::string, GlobalDictsWithVersion<GlobalDictMap>>;
 
 using DictColumnsValidMap = phmap::flat_hash_map<std::string, bool, SliceHashWithSeed<PhmapSeed1>, SliceEqual>;
 

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -404,7 +404,10 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
                     Slice slice(data, dict_word.size());
                     global_dict.emplace(slice, i);
                 }
-                _global_dicts.insert(std::make_pair(slot.col_name(), std::move(global_dict)));
+                GlobalDictsWithVersion<GlobalDictMap> dict;
+                dict.dict = std::move(global_dict);
+                dict.version = slot.has_global_dict_version() ? slot.global_dict_version() : 0;
+                _global_dicts.emplace(std::make_pair(slot.col_name(), std::move(dict)));
             }
         }
     }

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -31,6 +31,7 @@
 #include "gutil/strings/join.h"
 #include "runtime/descriptors.h"
 #include "runtime/global_dict/types.h"
+#include "runtime/global_dict/types_fwd_decl.h"
 #include "runtime/load_channel.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
@@ -490,7 +491,10 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
                 Slice slice(data, dict_word.size());
                 global_dict.emplace(slice, i);
             }
-            _global_dicts.insert(std::make_pair(slot.col_name(), std::move(global_dict)));
+            GlobalDictsWithVersion<GlobalDictMap> dict;
+            dict.dict = std::move(global_dict);
+            dict.version = slot.has_global_dict_version() ? slot.global_dict_version() : 0;
+            _global_dicts.emplace(std::make_pair(slot.col_name(), std::move(dict)));
         }
     }
 
@@ -779,14 +783,18 @@ void LocalTabletsChannel::WriteCallback::run(const Status& st, const CommittedRo
     }
     if (committed_info != nullptr) {
         // committed tablets from primary replica
+        // TODO: dup code with SegmentFlushToken::submit
         PTabletInfo tablet_info;
         tablet_info.set_tablet_id(committed_info->tablet->tablet_id());
         tablet_info.set_schema_hash(committed_info->tablet->schema_hash());
         const auto& rowset_global_dict_columns_valid_info =
                 committed_info->rowset_writer->global_dict_columns_valid_info();
+        const auto* rowset_global_dicts = committed_info->rowset_writer->rowset_global_dicts();
         for (const auto& item : rowset_global_dict_columns_valid_info) {
-            if (item.second) {
+            if (item.second && rowset_global_dicts != nullptr &&
+                rowset_global_dicts->find(item.first) != rowset_global_dicts->end()) {
                 tablet_info.add_valid_dict_cache_columns(item.first);
+                tablet_info.add_valid_dict_collected_version(rowset_global_dicts->at(item.first).version);
             } else {
                 tablet_info.add_invalid_dict_cache_columns(item.first);
             }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -431,14 +431,15 @@ GlobalDictMaps* RuntimeState::mutable_query_global_dict_map() {
 }
 
 Status RuntimeState::init_query_global_dict(const GlobalDictLists& global_dict_list) {
-    return _build_global_dict(global_dict_list, &_query_global_dicts);
+    return _build_global_dict(global_dict_list, &_query_global_dicts, nullptr);
 }
 
 Status RuntimeState::init_load_global_dict(const GlobalDictLists& global_dict_list) {
-    return _build_global_dict(global_dict_list, &_load_global_dicts);
+    return _build_global_dict(global_dict_list, &_load_global_dicts, &_load_dict_versions);
 }
 
-Status RuntimeState::_build_global_dict(const GlobalDictLists& global_dict_list, GlobalDictMaps* result) {
+Status RuntimeState::_build_global_dict(const GlobalDictLists& global_dict_list, GlobalDictMaps* result,
+                                        phmap::flat_hash_map<uint32_t, int64_t>* column_id_to_version) {
     for (const auto& global_dict : global_dict_list) {
         DCHECK_EQ(global_dict.ids.size(), global_dict.strings.size());
         GlobalDictMap dict_map;
@@ -454,6 +455,9 @@ Status RuntimeState::_build_global_dict(const GlobalDictLists& global_dict_list,
             rdict_map.emplace(global_dict.ids[i], slice);
         }
         result->emplace(uint32_t(global_dict.columnId), std::make_pair(std::move(dict_map), std::move(rdict_map)));
+        if (column_id_to_version != nullptr) {
+            column_id_to_version->emplace(uint32_t(global_dict.columnId), global_dict.version);
+        }
     }
     return Status::OK();
 }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -54,6 +54,7 @@
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
 #include "util/logging.h"
+#include "util/phmap/phmap.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks {
@@ -376,6 +377,8 @@ public:
 
     const GlobalDictMaps& get_load_global_dict_map() const;
 
+    const phmap::flat_hash_map<uint32_t, int64_t>& load_dict_versions() { return _load_dict_versions; }
+
     using GlobalDictLists = std::vector<TGlobalDict>;
     Status init_query_global_dict(const GlobalDictLists& global_dict_list);
     Status init_load_global_dict(const GlobalDictLists& global_dict_list);
@@ -404,7 +407,8 @@ private:
 
     Status create_error_log_file();
 
-    Status _build_global_dict(const GlobalDictLists& global_dict_list, GlobalDictMaps* result);
+    Status _build_global_dict(const GlobalDictLists& global_dict_list, GlobalDictMaps* result,
+                              phmap::flat_hash_map<uint32_t, int64_t>* version);
 
     // put runtime state before _obj_pool, so that it will be deconstructed after
     // _obj_pool. Because some object in _obj_pool will use profile when deconstructing.
@@ -520,6 +524,7 @@ private:
 
     GlobalDictMaps _query_global_dicts;
     GlobalDictMaps _load_global_dicts;
+    phmap::flat_hash_map<uint32_t, int64_t> _load_dict_versions;
 
     pipeline::QueryContext* _query_ctx = nullptr;
     pipeline::FragmentContext* _fragment_ctx = nullptr;

--- a/be/src/storage/rowset/column_writer.h
+++ b/be/src/storage/rowset/column_writer.h
@@ -124,7 +124,8 @@ public:
     // only invalid in the case of global_dict is not nullptr
     // column is not encoding by dict or append new words that
     // not in global_dict, it will return false
-    virtual bool is_global_dict_valid() { return true; }
+    // return false if type is not string column
+    virtual bool is_global_dict_valid() { return false; }
 
     TypeInfo* type_info() const { return _type_info.get(); }
     int length() const { return _length; }

--- a/be/src/storage/rowset/rowset_writer.h
+++ b/be/src/storage/rowset/rowset_writer.h
@@ -156,9 +156,9 @@ public:
 
     virtual RowsetId rowset_id() { return _context.rowset_id; }
 
-    virtual const DictColumnsValidMap& global_dict_columns_valid_info() const {
-        return _global_dict_columns_valid_info;
-    }
+    const DictColumnsValidMap& global_dict_columns_valid_info() const { return _global_dict_columns_valid_info; }
+
+    const GlobalDictByNameMaps* rowset_global_dicts() const { return _writer_options.global_dicts; }
 
 private:
     Status _flush_segment(const SegmentPB& segment_pb, butil::IOBuf& data);

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -47,6 +47,7 @@
 #include "storage/rowset/page_io.h"
 #include "storage/seek_tuple.h"
 #include "storage/short_key_index.h"
+#include "types/logical_type.h"
 #include "util/crc32c.h"
 #include "util/faststring.h"
 #include "util/json.h"
@@ -173,7 +174,7 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         if (column.type() == LogicalType::TYPE_VARCHAR && _opts.global_dicts != nullptr) {
             auto iter = _opts.global_dicts->find(column.name().data());
             if (iter != _opts.global_dicts->end()) {
-                opts.global_dict = &iter->second;
+                opts.global_dict = &iter->second.dict;
                 _global_dict_columns_valid_info[iter->first] = true;
             }
         }
@@ -260,10 +261,10 @@ Status SegmentWriter::finalize_columns(uint64_t* index_size) {
         RETURN_IF_ERROR(column_writer->write_bloom_filter_index());
         *index_size += _wfile->size() - index_offset;
 
-        // global dict
-        if (!column_writer->is_global_dict_valid()) {
-            std::string col_name(_tablet_schema->columns()[column_index].name().data(),
-                                 _tablet_schema->columns()[column_index].name().size());
+        // check global dict valid
+        const auto& column = _tablet_schema->column(column_index);
+        if (!column_writer->is_global_dict_valid() && is_string_type(column.type())) {
+            std::string col_name(column.name());
             _global_dict_columns_valid_info[col_name] = false;
         }
 

--- a/be/src/storage/segment_flush_executor.cpp
+++ b/be/src/storage/segment_flush_executor.cpp
@@ -59,9 +59,12 @@ Status SegmentFlushToken::submit(brpc::Controller* cntl, const PTabletWriterAddS
                     tablet_info->set_node_id(writer->node_id());
                     const auto& rowset_global_dict_columns_valid_info =
                             writer->committed_rowset_writer()->global_dict_columns_valid_info();
+                    const auto* rowset_global_dicts = writer->committed_rowset_writer()->rowset_global_dicts();
                     for (const auto& item : rowset_global_dict_columns_valid_info) {
-                        if (item.second) {
+                        if (item.second && rowset_global_dicts != nullptr &&
+                            rowset_global_dicts->find(item.first) != rowset_global_dicts->end()) {
                             tablet_info->add_valid_dict_cache_columns(item.first);
+                            tablet_info->add_valid_dict_collected_version(rowset_global_dicts->at(item.first).version);
                         } else {
                             tablet_info->add_invalid_dict_cache_columns(item.first);
                         }

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -85,15 +85,10 @@ public:
         return Status::OK();
     }
 
-    const DictColumnsValidMap& global_dict_columns_valid_info() const override {
-        return _global_dict_columns_valid_info;
-    }
-
     std::unique_ptr<Column> all_pks;
     vector<uint32_t> all_rssids;
 
     vector<std::unique_ptr<Column>> non_key_columns;
-    DictColumnsValidMap _global_dict_columns_valid_info;
 };
 
 class RowsetMergerTest : public testing::Test {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -411,6 +411,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
                 strings.add(kv.getKey());
                 integers.add(kv.getValue());
             }
+            globalDict.setVersion(dictPair.second.getCollectedVersionTime());
             globalDict.setStrings(strings);
             globalDict.setIds(integers);
             result.add(globalDict);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
@@ -241,7 +241,7 @@ public class CacheDictManager implements IDictManager {
     }
 
     @Override
-    public void updateGlobalDict(long tableId, String columnName, long versionTime) {
+    public void updateGlobalDict(long tableId, String columnName, long collectVersion, long versionTime) {
         // skip dictionary operator in checkpoint thread
         if (GlobalStateMgr.isCheckpointThread()) {
             return;
@@ -260,6 +260,12 @@ public class CacheDictManager implements IDictManager {
                 if (columnOptional.isPresent()) {
                     ColumnDict columnDict = columnOptional.get();
                     long lastVersion = columnDict.getVersionTime();
+                    long dictCollectVersion = columnDict.getCollectedVersionTime();
+                    if (collectVersion != dictCollectVersion) {
+                        LOG.info("remove dict by unmatched version {}:{}", collectVersion, dictCollectVersion);
+                        removeGlobalDict(tableId, columnName);
+                        return;
+                    }
                     columnDict.updateVersionTime(versionTime);
                     LOG.info("update dict for table {} column {} from version {} to {}", tableId, columnName,
                             lastVersion, versionTime);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IDictManager.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 public interface IDictManager {
     boolean hasGlobalDict(long tableId, String columnName, long versionTime);
 
-    void updateGlobalDict(long tableId, String columnName, long versionTime);
+    void updateGlobalDict(long tableId, String columnName, long collectedVersion, long versionTime);
 
     boolean hasGlobalDict(long tableId, String columnName);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/MockDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/MockDictManager.java
@@ -42,7 +42,7 @@ public class MockDictManager implements IDictManager {
     }
 
     @Override
-    public void updateGlobalDict(long tableId, String columnName, long versionTime) {
+    public void updateGlobalDict(long tableId, String columnName,  long collectedVersion, long versionTime) {
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -47,6 +47,8 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
 
     public void applyVisibleLog(TransactionState txnState, TableCommitInfo commitInfo, Database db) {
         List<String> validDictCacheColumns = Lists.newArrayList();
+        List<Long> dictCollectedVersions = Lists.newArrayList();
+
         long maxPartitionVersionTime = -1;
         long tableId = table.getId();
         CompactionMgr compactionManager = GlobalStateMgr.getCurrentState().getCompactionMgr();
@@ -74,10 +76,17 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
             if (!partitionCommitInfo.getValidDictCacheColumns().isEmpty()) {
                 validDictCacheColumns = partitionCommitInfo.getValidDictCacheColumns();
             }
+            if (!partitionCommitInfo.getDictCollectedVersions().isEmpty()) {
+                dictCollectedVersions = partitionCommitInfo.getDictCollectedVersions();
+            }
             maxPartitionVersionTime = Math.max(maxPartitionVersionTime, versionTime);
         }
-        for (String column : validDictCacheColumns) {
-            IDictManager.getInstance().updateGlobalDict(tableId, column, maxPartitionVersionTime);
+
+        Preconditions.checkState(dictCollectedVersions.size() == validDictCacheColumns.size());
+        for (int i = 0; i < validDictCacheColumns.size(); i++) {
+            String columnName = validDictCacheColumns.get(i);
+            long collectedVersion = dictCollectedVersions.get(i);
+            IDictManager.getInstance().updateGlobalDict(tableId, columnName, collectedVersion, maxPartitionVersionTime);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.transaction;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.LocalTablet;
@@ -72,6 +73,8 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
             return;
         }
         List<String> validDictCacheColumns = Lists.newArrayList();
+        List<Long> dictCollectedVersions = Lists.newArrayList();
+
         long maxPartitionVersionTime = -1;
 
         table.lastVersionUpdateStartTime.set(System.currentTimeMillis());
@@ -148,12 +151,18 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
             if (!partitionCommitInfo.getValidDictCacheColumns().isEmpty()) {
                 validDictCacheColumns = partitionCommitInfo.getValidDictCacheColumns();
             }
+            if (!partitionCommitInfo.getDictCollectedVersions().isEmpty()) {
+                dictCollectedVersions = partitionCommitInfo.getDictCollectedVersions();
+            }
             maxPartitionVersionTime = Math.max(maxPartitionVersionTime, versionTime);
         }
 
         table.lastVersionUpdateEndTime.set(System.currentTimeMillis());
-        for (String column : validDictCacheColumns) {
-            IDictManager.getInstance().updateGlobalDict(tableId, column, maxPartitionVersionTime);
+        Preconditions.checkState(dictCollectedVersions.size() == validDictCacheColumns.size());
+        for (int i = 0; i < validDictCacheColumns.size(); i++) {
+            String columnName = validDictCacheColumns.get(i);
+            long collectedVersion = dictCollectedVersions.get(i);
+            IDictManager.getInstance().updateGlobalDict(tableId, columnName, collectedVersion, maxPartitionVersionTime);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.transaction;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
@@ -53,7 +53,7 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
     private Set<Long> errorReplicaIds;
     private Set<Long> dirtyPartitionSet;
     private Set<String> invalidDictCacheColumns;
-    private Set<String> validDictCacheColumns;
+    private Map<String, Long> validDictCacheColumns;
 
     public OlapTableTxnStateListener(DatabaseTransactionMgr dbTxnMgr, OlapTable table) {
         this.dbTxnMgr = dbTxnMgr;
@@ -62,7 +62,7 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
 
     @Override
     public void preCommit(TransactionState txnState, List<TabletCommitInfo> tabletCommitInfos,
-            List<TabletFailInfo> failedTablets) throws TransactionException {
+                          List<TabletFailInfo> failedTablets) throws TransactionException {
         Preconditions.checkState(txnState.getTransactionStatus() != TransactionStatus.COMMITTED);
         if (table.getState() == OlapTable.OlapTableState.RESTORE) {
             throw new TransactionCommitFailedException("Cannot write RESTORE state table \"" + table.getName() + "\"");
@@ -71,7 +71,7 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
         errorReplicaIds = Sets.newHashSet();
         dirtyPartitionSet = Sets.newHashSet();
         invalidDictCacheColumns = Sets.newHashSet();
-        validDictCacheColumns = Sets.newHashSet();
+        validDictCacheColumns = Maps.newHashMap();
 
         TabletInvertedIndex tabletInvertedIndex = dbTxnMgr.getGlobalStateMgr().getTabletInvertedIndex();
         Map<Long, Set<Long>> tabletToBackends = new HashMap<>();
@@ -82,7 +82,8 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
         // if index is dropped, it does not matter.
         // if table or partition is dropped during load, just ignore that tablet,
         // because we should allow dropping rollup or partition during load
-        List<Long> tabletIds = tabletCommitInfos.stream().map(TabletCommitInfo::getTabletId).collect(Collectors.toList());
+        List<Long> tabletIds =
+                tabletCommitInfos.stream().map(TabletCommitInfo::getTabletId).collect(Collectors.toList());
         List<TabletMeta> tabletMetaList = tabletInvertedIndex.getTabletMetaList(tabletIds);
         for (int i = 0; i < tabletMetaList.size(); i++) {
             TabletMeta tabletMeta = tabletMetaList.get(i);
@@ -112,11 +113,21 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
             // Only need to add valid column set once
             if (validDictCacheColumns.isEmpty() &&
                     !tabletCommitInfos.get(i).getValidDictCacheColumns().isEmpty()) {
-                validDictCacheColumns.addAll(tabletCommitInfos.get(i).getValidDictCacheColumns());
+                TabletCommitInfo tabletCommitInfo = tabletCommitInfos.get(i);
+                List<Long> validDictCollectedVersions = tabletCommitInfo.getValidDictCollectedVersions();
+                List<String> validDictCacheColumns = tabletCommitInfo.getValidDictCacheColumns();
+                for (int j = 0; j < validDictCacheColumns.size(); j++) {
+                    long version = 0;
+                    // validDictCollectedVersions != validDictCacheColumns means be has not upgrade
+                    if (validDictCollectedVersions.size() == validDictCacheColumns.size()) {
+                        version = validDictCollectedVersions.get(j);
+                    }
+                    this.validDictCacheColumns.put(validDictCacheColumns.get(j), version);
+                }
             }
 
             if (i == tabletMetaList.size() - 1) {
-                validDictCacheColumns.removeAll(invalidDictCacheColumns);
+                validDictCacheColumns.entrySet().removeIf(entry -> invalidDictCacheColumns.contains(entry.getKey()));
             }
         }
 
@@ -129,7 +140,8 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
                     backend.setLastWriteFail(true);
                 }
             } else {
-                Replica replica = tabletInvertedIndex.getReplica(failedTablet.getTabletId(), failedTablet.getBackendId());
+                Replica replica =
+                        tabletInvertedIndex.getReplica(failedTablet.getTabletId(), failedTablet.getBackendId());
                 if (replica != null) {
                     replica.setLastWriteFail(true);
                 }
@@ -229,11 +241,20 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
                 version = partition.getNextVersion();
             }
             if (isFirstPartition) {
+
+                List<String> validDictCacheColumnNames = Lists.newArrayList();
+                List<Long> validDictCacheColumnVersions = Lists.newArrayList();
+
+                validDictCacheColumns.forEach((name, dictVersion) -> {
+                    validDictCacheColumnNames.add(name);
+                    validDictCacheColumnVersions.add(dictVersion);
+                });
                 partitionCommitInfo = new PartitionCommitInfo(partitionId,
                         version,
                         System.currentTimeMillis(),
                         Lists.newArrayList(invalidDictCacheColumns),
-                        Lists.newArrayList(validDictCacheColumns));
+                        validDictCacheColumnNames,
+                        validDictCacheColumnVersions);
             } else {
                 partitionCommitInfo = new PartitionCommitInfo(partitionId,
                         version,
@@ -294,7 +315,8 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
         AgentBatchTask batchTask = null;
         synchronized (CLEAR_TRANSACTION_TASKS) {
             for (Long beId : allBeIds) {
-                ClearTransactionTask task = new ClearTransactionTask(beId, txnState.getTransactionId(), Lists.newArrayList());
+                ClearTransactionTask task =
+                        new ClearTransactionTask(beId, txnState.getTransactionId(), Lists.newArrayList());
                 CLEAR_TRANSACTION_TASKS.add(task);
             }
             // try to group send tasks, not sending every time a txn is aborted. to avoid too many task rpc.

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PartitionCommitInfo.java
@@ -72,6 +72,8 @@ public class PartitionCommitInfo implements Writable {
     private List<String> invalidDictCacheColumns = Lists.newArrayList();
     @SerializedName(value = "validColumns")
     private List<String> validDictCacheColumns = Lists.newArrayList();
+    @SerializedName(value = "DictCollectedVersion")
+    private List<Long> dictCollectedVersions = Lists.newArrayList();
 
     // compaction score quantiles of lake table
     @SerializedName(value = "compactionScore")
@@ -90,13 +92,15 @@ public class PartitionCommitInfo implements Writable {
 
     public PartitionCommitInfo(long partitionId, long version, long visibleTime,
                                List<String> invalidDictCacheColumns,
-                               List<String> validDictCacheColumns) {
+                               List<String> validDictCacheColumns,
+                               List<Long> dictCollectedVersions) {
         super();
         this.partitionId = partitionId;
         this.version = version;
         this.versionTime = visibleTime;
         this.invalidDictCacheColumns = invalidDictCacheColumns;
         this.validDictCacheColumns = validDictCacheColumns;
+        this.dictCollectedVersions = dictCollectedVersions;
     }
 
     @Override
@@ -136,6 +140,10 @@ public class PartitionCommitInfo implements Writable {
 
     public List<String> getValidDictCacheColumns() {
         return validDictCacheColumns;
+    }
+
+    public List<Long> getDictCollectedVersions() {
+        return dictCollectedVersions;
     }
 
     public void setCompactionScore(Quantiles compactionScore) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TabletCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TabletCommitInfo.java
@@ -52,6 +52,7 @@ public class TabletCommitInfo implements Writable {
     // For low cardinality string column with global dict
     private List<String> invalidDictCacheColumns = Lists.newArrayList();
     private List<String> validDictCacheColumns = Lists.newArrayList();
+    private List<Long> validDictCollectedVersions = Lists.newArrayList();
 
     public TabletCommitInfo(long tabletId, long backendId) {
         super();
@@ -60,11 +61,12 @@ public class TabletCommitInfo implements Writable {
     }
 
     public TabletCommitInfo(long tabletId, long backendId, List<String> invalidDictCacheColumns,
-                            List<String> validDictCacheColumns) {
+                            List<String> validDictCacheColumns, List<Long> validDictCollectedVersions) {
         this.tabletId = tabletId;
         this.backendId = backendId;
         this.invalidDictCacheColumns = invalidDictCacheColumns;
         this.validDictCacheColumns = validDictCacheColumns;
+        this.validDictCollectedVersions = validDictCollectedVersions;
     }
 
     public long getTabletId() {
@@ -83,6 +85,10 @@ public class TabletCommitInfo implements Writable {
         return validDictCacheColumns;
     }
 
+    public List<Long> getValidDictCollectedVersions() {
+        return validDictCollectedVersions;
+    }
+
     public static List<TabletCommitInfo> fromThrift(List<TTabletCommitInfo> tTabletCommitInfos) {
         List<TabletCommitInfo> commitInfos = Lists.newArrayList();
         for (TTabletCommitInfo tTabletCommitInfo : tTabletCommitInfos) {
@@ -90,7 +96,9 @@ public class TabletCommitInfo implements Writable {
                 commitInfos.add(new TabletCommitInfo(tTabletCommitInfo.getTabletId(),
                         tTabletCommitInfo.getBackendId(),
                         tTabletCommitInfo.getInvalid_dict_cache_columns(),
-                        tTabletCommitInfo.getValid_dict_cache_columns()));
+                        tTabletCommitInfo.getValid_dict_cache_columns(),
+                        tTabletCommitInfo.getValid_dict_collected_versions()
+                ));
             } else {
                 commitInfos.add(new TabletCommitInfo(tTabletCommitInfo.getTabletId(),
                         tTabletCommitInfo.getBackendId()));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -316,7 +316,7 @@ public class LowCardinalityTest extends PlanTestBase {
         Assert.assertTrue(plan.contains("  2:Decode\n" +
                 "  |  <dict id 10> : <string id 3>"));
         String thrift = getThriftPlan(sql);
-        Assert.assertTrue(thrift.contains("TGlobalDict(columnId:10, strings:[6D 6F 63 6B], ids:[1])"));
+        Assert.assertTrue(thrift.contains("TGlobalDict(columnId:10, strings:[6D 6F 63 6B], ids:[1]"));
     }
 
     @Test
@@ -454,8 +454,7 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  <slot 14> : DictExpr(12: S_ADDRESS,[upper(<place-holder>)])"));
         Assert.assertFalse(plan.contains("common expressions"));
         plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("global_dicts:[TGlobalDict(columnId:12, strings:[6D 6F 63 6B], ids:[1])]"));
-        Assert.assertTrue(plan.contains("global_dicts:[TGlobalDict(columnId:12, strings:[6D 6F 63 6B], ids:[1])]"));
+        Assert.assertTrue(plan.contains("global_dicts:[TGlobalDict(columnId:12, strings:[6D 6F 63 6B], ids:[1]"));
 
         sql = "select count(*) from supplier group by S_ADDRESS";
         plan = getFragmentPlan(sql);
@@ -466,16 +465,16 @@ public class LowCardinalityTest extends PlanTestBase {
 
         sql = "select count(*) from supplier group by S_ADDRESS";
         plan = getThriftPlan(sql);
-        Assert.assertTrue(plan.contains("global_dicts:[TGlobalDict(columnId:10, strings:[6D 6F 63 6B], ids:[1])"));
+        Assert.assertTrue(plan.contains("global_dicts:[TGlobalDict(columnId:10, strings:[6D 6F 63 6B], ids:[1]"));
         Assert.assertTrue(plan.contains("partition:TDataPartition(type:RANDOM, partition_exprs:[]), " +
-                "query_global_dicts:[TGlobalDict(columnId:10, strings:[6D 6F 63 6B], ids:[1])"));
+                "query_global_dicts:[TGlobalDict(columnId:10, strings:[6D 6F 63 6B], ids:[1]"));
 
         sql = "select count(distinct S_NATIONKEY) from supplier group by S_ADDRESS";
         plan = getThriftPlan(sql);
         System.out.println(plan);
         Assert.assertTrue(plan, plan.contains(
                 "partition:TDataPartition(type:RANDOM, partition_exprs:[]), " +
-                        "query_global_dicts:[TGlobalDict(columnId:10, strings:[6D 6F 63 6B], ids:[1])]"));
+                        "query_global_dicts:[TGlobalDict(columnId:10, strings:[6D 6F 63 6B], ids:[1]"));
 
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
     }
@@ -1035,10 +1034,10 @@ public class LowCardinalityTest extends PlanTestBase {
         plan = getThriftPlan(sql);
         Assert.assertEquals(plan.split("\n").length, 3);
         assertContains(plan.split("\n")[0], "query_global_dicts:" +
-                "[TGlobalDict(columnId:19, strings:[6D 6F 63 6B], ids:[1]), " +
-                "TGlobalDict(columnId:20, strings:[6D 6F 63 6B], ids:[1]), " +
-                "TGlobalDict(columnId:21, strings:[6D 6F 63 6B], ids:[1]), " +
-                "TGlobalDict(columnId:22, strings:[6D 6F 63 6B], ids:[1])])");
+                "[TGlobalDict(columnId:19, strings:[6D 6F 63 6B], ids:[1], version:1), " +
+                "TGlobalDict(columnId:20, strings:[6D 6F 63 6B], ids:[1], version:1), " +
+                "TGlobalDict(columnId:21, strings:[6D 6F 63 6B], ids:[1], version:1), " +
+                "TGlobalDict(columnId:22, strings:[6D 6F 63 6B], ids:[1], version:1)])");
         // the fragment on the top don't have to send global dicts
         sql = "select upper(ST_S_ADDRESS),\n" +
                 "    upper(ST_S_COMMENT)\n" +
@@ -1494,7 +1493,7 @@ public class LowCardinalityTest extends PlanTestBase {
                 "select x1.a, x1.b from v1 x1 join v1 x2 on x1.a=x2.a";
         String plan = getThriftPlan(sql);
         Assert.assertTrue(
-                plan.contains("query_global_dicts:[TGlobalDict(columnId:28, strings:[6D 6F 63 6B], ids:[1])"));
+                plan.contains("query_global_dicts:[TGlobalDict(columnId:28, strings:[6D 6F 63 6B], ids:[1]"));
         connectContext.getSessionVariable().setCboCteReuse(false);
         connectContext.getSessionVariable().setEnablePipelineEngine(false);
     }

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -51,6 +51,7 @@ message PSlotDescriptor {
     required int32 slot_idx = 9;
     required bool is_materialized = 10;
     repeated string global_dict_words = 11; 
+    optional int64 global_dict_version = 12;
 };
 
 message PTupleDescriptor {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -148,6 +148,7 @@ message PTabletInfo {
     repeated string invalid_dict_cache_columns = 3;
     repeated string valid_dict_cache_columns = 4;
     optional int64 node_id = 5;
+    repeated int64 valid_dict_collected_version = 6;
 }
 
 // Open a tablet writer.

--- a/gensrc/thrift/Data.thrift
+++ b/gensrc/thrift/Data.thrift
@@ -96,6 +96,7 @@ struct TGlobalDict {
     1: optional i32 columnId
     2: optional list<binary> strings
     3: optional list<i32> ids
+    4: optional i64 version
 }
 
 // Statistic data for new planner 

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -435,6 +435,7 @@ struct TTabletCommitInfo {
     2: required i64 backendId
     3: optional list<string> invalid_dict_cache_columns
     4: optional list<string> valid_dict_cache_columns
+    5: optional list<i64> valid_dict_collected_versions
 }
 
 struct TTabletFailInfo {

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -882,12 +882,13 @@ class StarrocksSQLApiLib(object):
                 tools.assert_true(False, "acquire dictionary error")
             if str(res["result"]).find("Decode") > 0:
                 return ""
-            time.sleep(1) 
+            time.sleep(1)
 
     def assert_has_global_dict(self, column_name, table_name):
         """
         assert table_name:column_name has global dict
         """
+        time.sleep(1)
         sql = "explain costs select distinct %s from %s" % (column_name, table_name)
         res = self.execute_sql(sql, True)
         tools.assert_true(str(res["result"]).find("Decode") > 0, "assert dictionary error")
@@ -896,6 +897,7 @@ class StarrocksSQLApiLib(object):
         """
         assert table_name:column_name has global dict
         """
+        time.sleep(1)
         sql = "explain costs select distinct %s from %s" % (column_name, table_name)
         res = self.execute_sql(sql, True)
         tools.assert_true(str(res["result"]).find("Decode") <= 0, "assert dictionary error")

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -847,7 +847,6 @@ class StarrocksSQLApiLib(object):
             time.sleep(0.5)
         tools.assert_equal("FINISHED", status, "wait alter table finish error")
 
-
     def wait_alter_table_finish(self, alter_type="COLUMN"):
         """
         wait alter table job finish and return status
@@ -866,6 +865,55 @@ class StarrocksSQLApiLib(object):
                 break
             time.sleep(0.5)
         tools.assert_equal("FINISHED", status, "wait alter table finish error")
+
+
+    def wait_global_dict_ready(self, column_name, table_name):
+        """
+        wait global dict ready
+        """
+        status = ""
+        count = 0
+        while True:
+            if count > 60:
+                tools.assert_true(False, "acquire dictionary timeout for 60s")
+            sql = "explain costs select distinct %s from %s" % (column_name, table_name)
+            res = self.execute_sql(sql, True)
+            if not res["status"]:
+                tools.assert_true(False, "acquire dictionary error")
+            if str(res["result"]).find("Decode") > 0:
+                return ""
+            time.sleep(1) 
+
+    def assert_has_global_dict(self, column_name, table_name):
+        """
+        assert table_name:column_name has global dict
+        """
+        sql = "explain costs select distinct %s from %s" % (column_name, table_name)
+        res = self.execute_sql(sql, True)
+        tools.assert_true(str(res["result"]).find("Decode") > 0, "assert dictionary error")
+    
+    def assert_no_global_dict(self, column_name, table_name):
+        """
+        assert table_name:column_name has global dict
+        """
+        sql = "explain costs select distinct %s from %s" % (column_name, table_name)
+        res = self.execute_sql(sql, True)
+        tools.assert_true(str(res["result"]).find("Decode") <= 0, "assert dictionary error")
+
+    def wait_submit_task_ready(self, task_name):
+        """
+        wait submit task ready
+        """
+        status = ""
+        while True:
+            sql = "select STATE from information_schema.task_runs where TASK_NAME = '%s'" % task_name
+            res = self.execute_sql(sql, True)
+            if not res["status"]:
+                tools.assert_true(False, "acquire task state error")
+            state = res["result"][0][0]
+            if status != "RUNNING":
+                return ""
+            time.sleep(1)
 
     def check_es_table_metadata_ready(self, table_name):
         check_sql = "SELECT * FROM %s limit 1" % table_name

--- a/test/sql/test_global_dict/R/continuous_insert
+++ b/test/sql/test_global_dict/R/continuous_insert
@@ -1,0 +1,40 @@
+-- name: test_continuous_insert
+CREATE TABLE `allstring` (
+  `v1` varchar(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into allstring select * from (select 'C4' union select 'A10' union select 1 )tb;
+-- result:
+-- !result
+analyze full table allstring;
+-- result:
+-- !result
+function: wait_global_dict_ready('v1', 'allstring')
+-- result:
+
+-- !result
+insert into allstring select * from (select 'C4' union select 'A10' union select 1 )tb;
+-- result:
+-- !result
+function: assert_has_global_dict('v1', 'allstring')
+-- result:
+None
+-- !result
+insert into allstring select * from (select 'C8' union select 'A10' union select 1 ) tb;
+-- result:
+-- !result
+function: assert_no_global_dict('v1', 'allstring')
+-- result:
+None
+-- !result

--- a/test/sql/test_global_dict/R/truncate_with_insert
+++ b/test/sql/test_global_dict/R/truncate_with_insert
@@ -1,0 +1,49 @@
+-- name: test_truncate_with_insert
+CREATE TABLE `allstring` (
+  `v1` varchar(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into allstring select * from (select 'C4' union select 'A10' union select 1 )tb;
+-- result:
+-- !result
+analyze full table allstring;
+-- result:
+-- !result
+function: wait_global_dict_ready('v1', 'allstring')
+-- result:
+
+-- !result
+truncate table allstring;
+-- result:
+-- !result
+submit task etl_${uuid0} as insert into allstring select * from (select 'C8' union select 'A10' union select sleep(10) ) tb;
+-- result:
+-- !result
+insert into allstring select * from (select 'C8' union select 'A10' union select 1 ) tb;
+-- result:
+-- !result
+function: wait_global_dict_ready('v1', 'allstring')
+-- result:
+
+-- !result
+function: wait_submit_task_ready('etl_${uuid0}')
+-- result:
+
+-- !result
+select distinct v1 from allstring order by v1;
+-- result:
+1
+A10
+C8
+-- !result

--- a/test/sql/test_global_dict/T/continuous_insert
+++ b/test/sql/test_global_dict/T/continuous_insert
@@ -1,0 +1,26 @@
+-- name: test_continuous_insert
+
+CREATE TABLE `allstring` (
+  `v1` varchar(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+-- prepare init data and analyze
+insert into allstring select * from (select 'C4' union select 'A10' union select 1 )tb;
+analyze full table allstring;
+function: wait_global_dict_ready('v1', 'allstring')
+-- insert the same value
+insert into allstring select * from (select 'C4' union select 'A10' union select 1 )tb;
+function: assert_has_global_dict('v1', 'allstring')
+-- insert new value
+insert into allstring select * from (select 'C8' union select 'A10' union select 1 ) tb;
+function: assert_no_global_dict('v1', 'allstring')

--- a/test/sql/test_global_dict/T/truncate_with_insert
+++ b/test/sql/test_global_dict/T/truncate_with_insert
@@ -1,0 +1,32 @@
+-- name: test_truncate_with_insert
+
+CREATE TABLE `allstring` (
+  `v1` varchar(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+-- prepare init data and analyze
+insert into allstring select * from (select 'C4' union select 'A10' union select 1 )tb;
+analyze full table allstring;
+
+function: wait_global_dict_ready('v1', 'allstring')
+-- truncate
+truncate table allstring;
+-- session 1
+submit task etl_${uuid0} as insert into allstring select * from (select 'C8' union select 'A10' union select sleep(10) ) tb;
+-- session 2
+insert into allstring select * from (select 'C8' union select 'A10' union select 1 ) tb;
+function: wait_global_dict_ready('v1', 'allstring')
+-- session 1
+function: wait_submit_task_ready('etl_${uuid0}')
+-- session 2
+select distinct v1 from allstring order by v1;


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/26472

two problems:
1. we always set dictionary info to tablet_commit_info 0. when rpc disorder, maybe the eos package was affected earlier.
```

    // Only send valid and invalid dict cache columns info once
    if (!_tablet_commit_infos.empty()) {
        std::vector<std::string> invalid_dict_cache_columns;
        invalid_dict_cache_columns.assign(invalid_dict_cache_column_set.begin(), invalid_dict_cache_column_set.end());
        _tablet_commit_infos[0].__set_invalid_dict_cache_columns(invalid_dict_cache_columns);

        std::vector<std::string> valid_dict_cache_columns;
        std::set_difference(valid_dict_cache_column_set.begin(), valid_dict_cache_column_set.end(),
                            invalid_dict_cache_column_set.begin(), invalid_dict_cache_column_set.end(),
                            std::back_inserter(valid_dict_cache_columns));
        _tablet_commit_infos[0].__set_valid_dict_cache_columns(valid_dict_cache_columns);
    }
```
2. when we update dictionary version we should check the collected version.
```
for a operator sequence.
update event may not match last collected dictionary as #26472. we support provide a version field
```


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
