### PR TITLE
[BugFix] Restore NPE when restart fe cause by new JSON META for FE (#26446)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BlobStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BlobStorage.java
@@ -108,7 +108,9 @@ public class BlobStorage implements Writable {
     private String brokerName;
     @SerializedName("pt")
     private Map<String, String> properties = Maps.newHashMap();
+    @SerializedName("hasBroker")
     private boolean hasBroker;
+    @SerializedName("brokerDesc")
     private BrokerDesc brokerDesc; // for non broker operation only
 
     private BlobStorage() {


### PR DESCRIPTION
Problem:
Restore will hit NPE problem when fe restart. This problem is caused by new fe meta data framework which use JSON format to store meta data. Some member in blobstorge have not been assigned SerializedName causing this members can not be recorded in edit log.

Solution:
Add the SerializedName.

Fixes #26446

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
