### PR TITLE
[BugFix] ReplicationNum has not been reset when doing restore (#26423)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -672,6 +672,9 @@ public class OlapTable extends Table {
             partition.setIdForRestore(entry.getKey());
         }
 
+        // reset replication number for olaptable
+        setReplicationNum((short) restoreReplicationNum);
+
         return Status.OK;
     }
 


### PR DESCRIPTION
Problem:
If we restore a table which has not been created currently. The ReplicationNum of the table will be reset and will be inconsistent with the ReplicationNum with partition info

Solution:
reset the ReplicationNum

Fixes #26423

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
