### PR TITLE
[BugFix] primary key table with sort key compaction maybe failed

### DIFF
--- a/be/src/storage/compaction_utils.cpp
+++ b/be/src/storage/compaction_utils.cpp
@@ -97,8 +97,10 @@ void CompactionUtils::split_column_into_groups(size_t num_columns, const std::ve
     for (ColumnId i = 0; i < num_columns; ++i) {
         all_columns.push_back(i);
     }
+    std::vector<ColumnId> tmp_sort_key_idxes(sort_key_idxes.begin(), sort_key_idxes.end());
+    std::sort(tmp_sort_key_idxes.begin(), tmp_sort_key_idxes.end());
     std::vector<ColumnId> non_sort_columns;
-    std::set_difference(all_columns.begin(), all_columns.end(), sort_key_idxes.begin(), sort_key_idxes.end(),
+    std::set_difference(all_columns.begin(), all_columns.end(), tmp_sort_key_idxes.begin(), tmp_sort_key_idxes.end(),
                         std::back_inserter(non_sort_columns));
     for (auto i = 0; i < non_sort_columns.size(); ++i) {
         if (i % max_columns_per_group == 0) {


### PR DESCRIPTION
When we create a primary key table that separates the sort key column and the primary key column, the vertical compaction is performed as follows:
1. Split all columns into multiple column groups and all sort key columns are in the same column group
2. Compact sort key column group first
3. Compact non-sort key column groups one by one

In step one, we need to split sort key columns and non sort key columns and the code are shown:
```
void CompactionUtils::split_column_into_groups(size_t num_columns, const std::vector<ColumnId>& sort_key_idxes,
                                               int64_t max_columns_per_group,
                                               std::vector<std::vector<uint32_t>>* column_groups) {
    column_groups->emplace_back(sort_key_idxes);
    std::vector<ColumnId> all_columns;
    for (ColumnId i = 0; i < num_columns; ++i) {
        all_columns.push_back(i);
    }
    std::vector<ColumnId> non_sort_columns;
    std::set_difference(all_columns.begin(), all_columns.end(), sort_key_idxes.begin(), sort_key_idxes.end(),
                        std::back_inserter(non_sort_columns));
    for (auto i = 0; i < non_sort_columns.size(); ++i) {
        if (i % max_columns_per_group == 0) {
            column_groups->emplace_back();
        }
        column_groups->back().emplace_back(non_sort_columns[i]);
    }
}
```
We use `std::set_difference` to get different sets between `all_columns` and `sort_key_column_idxes`. However, the `sort_key_column_idxes` may not be sorted by column id because we allow arbitrary columns as sort key columns, but the `std::set_difference` operation required the two sets to be sorted, so the function `split_column_into_groups` may get error result which cause compaction failed.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
