### PR TITLE
[Enhancement] randomize mv refresh start

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -162,6 +162,10 @@ public class PropertyAnalyzer {
 
     // Materialized View properties
     public static final String PROPERTIES_MV_REWRITE_STALENESS_SECOND = "mv_rewrite_staleness_second";
+    // Randomized start interval
+    // 0(default value): automatically chosed between [0, min(300, INTERVAL/2))
+    // -1: disable randomize, use current time as start
+    // positive value: use [0, mv_randomize_start) as random interval
     public static final String PROPERTY_MV_RANDOMIZE_START = "mv_randomize_start";
 
     public static final String PROPERTIES_DEFAULT_PREFIX = "default.";

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -160,7 +160,9 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_DATACACHE_ENABLE = "datacache.enable";
     public static final String PROPERTIES_DATACACHE_PARTITION_DURATION = "datacache.partition_duration";
 
+    // Materialized View properties
     public static final String PROPERTIES_MV_REWRITE_STALENESS_SECOND = "mv_rewrite_staleness_second";
+    public static final String PROPERTY_MV_RANDOMIZE_START = "mv_randomize_start";
 
     public static final String PROPERTIES_DEFAULT_PREFIX = "default.";
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2712,7 +2712,7 @@ public class LocalMetastore implements ConnectorMetadata {
             }
             if (asyncRefreshSchemeDesc.isDefineStartTime() || !randomizeStart) {
                 asyncRefreshContext.setStartTime(Utils.getLongFromDateTime(asyncRefreshSchemeDesc.getStartTime()));
-            } else {
+            } else if (asyncRefreshSchemeDesc.getIntervalLiteral() != null) {
                 // randomize the start time if not specified manually, to avoid refresh conflicts
                 IntervalLiteral interval = asyncRefreshSchemeDesc.getIntervalLiteral();
                 long period = ((IntLiteral) interval.getValue()).getLongValue();

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -240,6 +240,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -2706,6 +2707,8 @@ public class LocalMetastore implements ConnectorMetadata {
                 randomizeStart =
                         VariableMgr.parseBooleanVariable(
                                 properties.get((PropertyAnalyzer.PROPERTY_MV_RANDOMIZE_START)));
+                // remove this transient variable
+                properties.remove(PropertyAnalyzer.PROPERTY_MV_RANDOMIZE_START);
             }
             if (asyncRefreshSchemeDesc.isDefineStartTime() || !randomizeStart) {
                 asyncRefreshContext.setStartTime(Utils.getLongFromDateTime(asyncRefreshSchemeDesc.getStartTime()));
@@ -2716,8 +2719,9 @@ public class LocalMetastore implements ConnectorMetadata {
                 TimeUnit timeUnit =
                         TimeUtils.convertUnitIdentifierToTimeUnit(interval.getUnitIdentifier().getDescription());
                 long intervalSeconds = TimeUtils.convertTimeUnitValueToSecond(period, timeUnit);
-                long currentTimeSecond = System.currentTimeMillis() / 1000;
-                long randomizedStart = currentTimeSecond + ThreadLocalRandom.current().nextLong(intervalSeconds);
+                long currentTimeSecond = Utils.getLongFromDateTime(LocalDateTime.now());
+                long random = ThreadLocalRandom.current().nextLong(Math.min(300, intervalSeconds / 2));
+                long randomizedStart = currentTimeSecond + random;
 
                 asyncRefreshContext.setStartTime(randomizedStart);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -42,7 +42,6 @@ import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.CreateMaterializedViewStmt;
@@ -50,6 +49,7 @@ import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.RefreshSchemeDesc;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.StarRocksAssert;
@@ -3026,6 +3026,53 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
+    public void testRandomizeStart() throws Exception {
+        String sql = "create materialized view mv_test_randomize \n" +
+                "distributed by hash(k1) buckets 10\n" +
+                "refresh async every(interval 1 minute) " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ")\n" +
+                "as " +
+                "select tb1.k1, k2, " +
+                "array<int>[1,2,3] as type_array, " +
+                "map<int, int>{1:2} as type_map, " +
+                "parse_json('{\"a\": 1}') as type_json, " +
+                "row('c') as type_struct, " +
+                "array<json>[parse_json('{}')] as type_array_json " +
+                "from tbl1 tb1;";
+        long currentSecond = Utils.getLongFromDateTime(LocalDateTime.now());
+        starRocksAssert.withMaterializedView(sql);
+        MaterializedView mv = getMv(testDb.getFullName(), "mv_test_randomize");
+        long startTime = mv.getRefreshScheme().getAsyncRefreshContext().getStartTime();
+        Assert.assertTrue("difference is " + (startTime - currentSecond),
+                currentSecond <= startTime && startTime < currentSecond + 60);
+        starRocksAssert.dropMaterializedView("mv_test_randomize");
+
+        // manual disable it
+        sql = "create materialized view mv_test_randomize \n" +
+                "distributed by hash(k1) buckets 10\n" +
+                "refresh async every(interval 1 minute) " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1', " +
+                "'mv_randomize_start' = 'false'" +
+                ")\n" +
+                "as " +
+                "select tb1.k1, k2, " +
+                "array<int>[1,2,3] as type_array, " +
+                "map<int, int>{1:2} as type_map, " +
+                "parse_json('{\"a\": 1}') as type_json, " +
+                "row('c') as type_struct, " +
+                "array<json>[parse_json('{}')] as type_array_json " +
+                "from tbl1 tb1;";
+        currentSecond = Utils.getLongFromDateTime(LocalDateTime.now());
+        starRocksAssert.withMaterializedView(sql);
+        mv = getMv(testDb.getFullName(), "mv_test_randomize");
+        startTime = mv.getRefreshScheme().getAsyncRefreshContext().getStartTime();
+        Assert.assertEquals(startTime, currentSecond);
+    }
+
+    @Test
     public void testCreateMvWithTypes() throws Exception {
         String sql = "create materialized view mv_test_types \n" +
                 "distributed by hash(k1) buckets 10\n" +
@@ -3042,5 +3089,6 @@ public class CreateMaterializedViewTest {
                 "from tbl1 tb1;";
         starRocksAssert.withMaterializedView(sql);
     }
+
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1471,7 +1471,7 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testCreateMvFromMv2() {
+    public void testCreateMvFromMv2() throws Exception {
         String sql1 = "create materialized view base_mv2 " +
                 "partition by k1 " +
                 "distributed by hash(k2) buckets 10 " +
@@ -1480,12 +1480,11 @@ public class CreateMaterializedViewTest {
                 "\"replication_num\" = \"1\"\n" +
                 ") " +
                 "as select k1, k2 from tbl1;";
-        try {
+        {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql1, connectContext);
             currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
         }
+
         String sql2 = "create materialized view mv_from_base_mv2 " +
                 "partition by k1 " +
                 "distributed by hash(k2) buckets 10 " +


### PR DESCRIPTION
Fixes #issue

Randomize the MV refresh start time to avoid refresh too many MV at the same time.
1. When creating a mv: `create materialized view refresh async every (1 minute) as xxxx `
2. We will randomize the start time by `currentSecond() + random(INTERVAL)` as the real schedule start. The maximum random value is `300s`, to avoid skew too much.

User could change the behavior through MV property `mv_randomize_start`:
- `0` (default): use `[0, min(300, INTERVAL/2))` as random interval
- `-1`: use current time as start
- `positive value`: use `[0, mv_randomize_start)` as random interval


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
