### PR TITLE
[BugFix] conditional expression process const columns error (backport #26484)

### DIFF
--- a/be/src/exprs/condition_expr.cpp
+++ b/be/src/exprs/condition_expr.cpp
@@ -116,8 +116,12 @@ private:
         return result.build(ColumnHelper::is_all_const(columns));
     }
 
-    ColumnPtr _evaluate_complex(const Columns& columns) {
-        auto num_rows = columns[0]->size();
+    ColumnPtr _evaluate_complex(const Columns& inputs) {
+        auto num_rows = inputs[0]->size();
+        Columns columns;
+        for (const auto& col : inputs) {
+            columns.push_back(ColumnHelper::unpack_and_duplicate_const_column(num_rows, col));
+        }
         auto res = ColumnHelper::cast_to_nullable_column(columns[0]->clone_empty());
         res->reserve(num_rows);
         NullColumnPtr null = nullptr;
@@ -186,8 +190,12 @@ private:
         return result.build(ColumnHelper::is_all_const(columns));
     }
 
-    ColumnPtr _evaluate_complex(const Columns& columns) {
-        auto num_rows = columns[0]->size();
+    ColumnPtr _evaluate_complex(const Columns& inputs) {
+        auto num_rows = inputs[0]->size();
+        Columns columns;
+        for (const auto& col : inputs) {
+            columns.push_back(ColumnHelper::unpack_and_duplicate_const_column(num_rows, col));
+        }
         auto res = ColumnHelper::cast_to_nullable_column(columns[0]->clone_empty());
         res->reserve(num_rows);
         auto right_data = columns[1];
@@ -198,7 +206,7 @@ private:
         }
         for (int row = 0; row < num_rows; ++row) {
             if ((right_nulls == nullptr || !right_nulls->get_data()[row]) &&
-                columns[0]->equals(row, *right_data, row)) {
+                columns[0]->equals(row, *right_data, row, false) == 1) {
                 res->append_nulls(1);
             } else {
                 res->append(*columns[0], row, 1);
@@ -334,9 +342,13 @@ private:
     }
 
     template <bool check_null>
-    ColumnPtr _evaluate_complex(const Columns& columns) {
+    ColumnPtr _evaluate_complex(const Columns& inputs) {
+        auto num_rows = inputs[0]->size();
+        Columns columns;
+        for (const auto& col : inputs) {
+            columns.push_back(ColumnHelper::unpack_and_duplicate_const_column(num_rows, col));
+        }
         ColumnViewer<TYPE_BOOLEAN> bhs_viewer(columns[0]);
-        auto num_rows = columns[0]->size();
         ColumnPtr res = ColumnHelper::cast_to_nullable_column(columns[1]->clone_empty());
         res->reserve(num_rows);
         if constexpr (check_null) {
@@ -408,9 +420,9 @@ public:
     }
 
 private:
-    StatusOr<ColumnPtr> _evaluate_general(const Columns columns) {
+    StatusOr<ColumnPtr> _evaluate_general(const Columns& columns) {
         std::vector<ColumnViewer<Type>> viewers;
-        for (auto value : columns) {
+        for (auto& value : columns) {
             viewers.push_back(ColumnViewer<Type>(value));
         }
         // choose not null
@@ -436,18 +448,22 @@ private:
         return builder.build(ColumnHelper::is_all_const(columns));
     }
 
-    StatusOr<ColumnPtr> _evaluate_complex(const Columns columns) { // without only-null columns
-        int size = columns[0]->size();
+    StatusOr<ColumnPtr> _evaluate_complex(const Columns& inputs) { // without only-null columns
+        int size = inputs[0]->size();
+        Columns columns;
+        for (const auto& col : inputs) {
+            columns.push_back(ColumnHelper::unpack_and_duplicate_const_column(size, col));
+        }
         int col_size = columns.size();
         auto res = ColumnHelper::cast_to_nullable_column(columns[0]->clone_empty());
         res->reserve(size);
         NullColumns nullColumns;
-        nullColumns.reserve(col_size);
+        nullColumns.resize(col_size);
         for (auto i = 0; i < col_size; ++i) {
             if (columns[i]->is_nullable()) {
-                nullColumns.emplace_back(down_cast<NullableColumn*>(columns[i].get())->null_column());
+                nullColumns[i] = down_cast<NullableColumn*>(columns[i].get())->null_column();
             } else {
-                nullColumns.emplace_back(nullptr);
+                nullColumns[i] = nullptr;
             }
         }
         for (int row = 0; row < size; ++row) {

--- a/be/test/exprs/compound_predicate_test.cpp
+++ b/be/test/exprs/compound_predicate_test.cpp
@@ -383,7 +383,7 @@ TEST_F(VectorizedCompoundPredicateTest, testOnlyNullAndZeroRow) {
 
     MockNullVectorizedExpr<TYPE_BOOLEAN> col1(expr_node, 0, 0);
     col1.only_null = true;
-    ASSERT_EQ(1, col1.evaluate(nullptr, nullptr)->size());
+    ASSERT_EQ(0, col1.evaluate(nullptr, nullptr)->size());
 
     MockNullVectorizedExpr<TYPE_BOOLEAN> col2(expr_node, 0, 0);
     ASSERT_EQ(0, col2.evaluate(nullptr, nullptr)->size());

--- a/be/test/exprs/condition_expr_test.cpp
+++ b/be/test/exprs/condition_expr_test.cpp
@@ -53,10 +53,14 @@ public:
         ttype_desc.types.back().scalar_type.__set_type(TPrimitiveType::VARCHAR);
         ttype_desc.types.back().scalar_type.__set_len(10);
         tttype_desc.push_back(ttype_desc);
+
+        tttype_desc1.push_back(ttype_desc);
+        tttype_desc1.push_back(gen_type_desc(TPrimitiveType::TINYINT));
     }
 
 private:
     std::vector<TTypeDesc> tttype_desc;
+    std::vector<TTypeDesc> tttype_desc1;
     TExprNode expr_node;
 };
 
@@ -144,6 +148,35 @@ TEST_F(VectorizedConditionExprTest, ifNull) {
 
         MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
         MockVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+            if (ptr->is_nullable()) {
+                ptr = down_cast<NullableColumn*>(ptr.get())->data_column();
+            }
+            ASSERT_TRUE(ptr->is_numeric());
+
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(ptr);
+            for (int j = 0; j < ptr->size(); ++j) {
+                if (j % 2 == 0) {
+                    ASSERT_EQ(10, v->get_data()[j]);
+                } else {
+                    ASSERT_EQ(20, v->get_data()[j]);
+                }
+            }
+        }
+    }
+}
+
+TEST_F(VectorizedConditionExprTest, ifNullRightConst) {
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_null_expr(expr_node));
+
+        MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockConstVectorizedExpr<TYPE_BIGINT> col2(expr_node, 20); // const
 
         expr->_children.push_back(&col1);
         expr->_children.push_back(&col2);
@@ -325,88 +358,111 @@ TEST_F(VectorizedConditionExprTest, ifExpr) {
         ASSERT_EQ(result, res_col2->get_data()[i]);
     }
 
-    // Test INT8 var const
-    auto expr3 = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
-    RandomValueExpr<TYPE_TINYINT> col7(expr_node, chunk_size, e);
-    MockConstVectorizedExpr<TYPE_TINYINT> col8(expr_node, 123);
-    auto copyed_data = select_col.get_data();
-    expr3->_children.push_back(&select_col);
-    expr3->_children.push_back(&col7);
-    expr3->_children.push_back(&col8);
+    for (auto desc : tttype_desc1) {
+        expr_node.type = desc;
+        // Test INT8 var const
+        auto expr3 = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
+        RandomValueExpr<TYPE_TINYINT> col7(expr_node, chunk_size, e);
+        MockConstVectorizedExpr<TYPE_TINYINT> col8(expr_node, 123);
+        auto copyed_data = select_col.get_data();
+        expr3->_children.push_back(&select_col);
+        expr3->_children.push_back(&col7);
+        expr3->_children.push_back(&col8);
 
-    ptr = expr3->evaluate(nullptr, nullptr);
-    auto* res_col3 = down_cast<Int8Column*>(ptr.get());
-    for (int i = 0; i < res_col3->size(); ++i) {
-        auto result = copyed_data[i] ? col7.get_data()[i] : 123;
-        ASSERT_EQ(result, res_col3->get_data()[i]);
-    }
-    // Test INT8 const var
-    auto expr4 = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
-    MockConstVectorizedExpr<TYPE_TINYINT> col9(expr_node, 123);
-    RandomValueExpr<TYPE_TINYINT> col10(expr_node, chunk_size, e);
-    copyed_data = select_col.get_data();
-    expr4->_children.push_back(&select_col);
-    expr4->_children.push_back(&col9);
-    expr4->_children.push_back(&col10);
+        ptr = expr3->evaluate(nullptr, nullptr);
+        auto* res_col3 = down_cast<Int8Column*>(ColumnHelper::get_data_column(ptr.get()));
+        for (int i = 0; i < res_col3->size(); ++i) {
+            auto result = copyed_data[i] ? col7.get_data()[i] : 123;
+            ASSERT_EQ(result, res_col3->get_data()[i]);
+        }
 
-    ptr = expr4->evaluate(nullptr, nullptr);
-    auto* res_col4 = down_cast<Int8Column*>(ptr.get());
-    for (int i = 0; i < res_col4->size(); ++i) {
-        auto result = copyed_data[i] ? 123 : col10.get_data()[i];
-        ASSERT_EQ(result, res_col4->get_data()[i]);
-    }
-    // Test INT8 const const
+        {
+            auto expr3 = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
+            MockNullVectorizedExpr<TYPE_TINYINT> col7(expr_node, chunk_size, 1, true);
+            MockConstVectorizedExpr<TYPE_TINYINT> col8(expr_node, 123);
+            auto copyed_data = select_col.get_data();
+            expr3->_children.push_back(&select_col);
+            expr3->_children.push_back(&col7);
+            expr3->_children.push_back(&col8);
 
-    // Test Nullable(INT8) var const
-    {
-        expr_node.type = gen_type_desc(TPrimitiveType::TINYINT);
-        auto if_expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
-        RandomValueExpr<TYPE_TINYINT> v_col(expr_node, chunk_size, e);
-        MakeNullableExpr<TYPE_TINYINT> col_x(expr_node, chunk_size, &v_col);
-        MockConstVectorizedExpr<TYPE_TINYINT> col_y(expr_node, 123);
-
-        if_expr->_children.push_back(&select_col);
-        if_expr->_children.push_back(&col_x);
-        if_expr->_children.push_back(&col_y);
-
-        ptr = if_expr->evaluate(nullptr, nullptr);
-
-        ColumnViewer<TYPE_TINYINT> viewer(ptr);
-        for (int i = 0; i < ptr->size(); ++i) {
-            auto result = select_col.get_data()[i] ? v_col.get_data()[i] : 123;
-            if (!viewer.is_null(i)) {
-                ASSERT_EQ(viewer.value(i), result);
-            } else {
-                ASSERT_TRUE(select_col.get_data()[i]);
+            ptr = expr3->evaluate(nullptr, nullptr);
+            auto* res_col3 = down_cast<Int8Column*>(ColumnHelper::get_data_column(ptr.get()));
+            for (int i = 0; i < res_col3->size(); ++i) {
+                if (copyed_data[i]) {
+                    ASSERT_TRUE(ptr->is_null(i));
+                } else {
+                    ASSERT_EQ(123, res_col3->get_data()[i]);
+                }
             }
         }
-    }
 
-    // Test Nullable(Selector) const const
-    {
-        expr_node.type = gen_type_desc(TPrimitiveType::TINYINT);
-        auto if_expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
-        MakeNullableExpr<TYPE_TINYINT> nullable_selector(expr_node, chunk_size, &select_col);
-        MockConstVectorizedExpr<TYPE_TINYINT> col_x(expr_node, 123);
-        MockConstVectorizedExpr<TYPE_TINYINT> col_y(expr_node, 4);
+        // Test INT8 const var
+        auto expr4 = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
+        MockConstVectorizedExpr<TYPE_TINYINT> col9(expr_node, 123);
+        RandomValueExpr<TYPE_TINYINT> col10(expr_node, chunk_size, e);
+        copyed_data = select_col.get_data();
+        expr4->_children.push_back(&select_col);
+        expr4->_children.push_back(&col9);
+        expr4->_children.push_back(&col10);
 
-        if_expr->_children.push_back(&nullable_selector);
-        if_expr->_children.push_back(&col_x);
-        if_expr->_children.push_back(&col_y);
+        ptr = expr4->evaluate(nullptr, nullptr);
+        auto* res_col4 = down_cast<Int8Column*>(ColumnHelper::get_data_column(ptr.get()));
+        for (int i = 0; i < res_col4->size(); ++i) {
+            auto result = copyed_data[i] ? 123 : col10.get_data()[i];
+            ASSERT_EQ(result, res_col4->get_data()[i]);
+        }
 
-        ptr = if_expr->evaluate(nullptr, nullptr);
+        // Test INT8 const const
 
-        ColumnViewer<TYPE_BOOLEAN> sel_viewer(nullable_selector.get_col_ptr());
-        auto* res_x = down_cast<Int8Column*>(ptr.get());
+        // Test Nullable(INT8) var const
+        {
+            auto if_expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
+            RandomValueExpr<TYPE_TINYINT> v_col(expr_node, chunk_size, e);
+            MakeNullableExpr<TYPE_TINYINT> col_x(expr_node, chunk_size, &v_col);
+            MockConstVectorizedExpr<TYPE_TINYINT> col_y(expr_node, 123);
 
-        for (int i = 0; i < ptr->size(); ++i) {
-            auto result = 0;
-            if (sel_viewer.is_null(i) || !sel_viewer.value(i)) {
-                result = 4;
-            } else {
-                result = 123;
+            if_expr->_children.push_back(&select_col);
+            if_expr->_children.push_back(&col_x);
+            if_expr->_children.push_back(&col_y);
+
+            ptr = if_expr->evaluate(nullptr, nullptr);
+
+            ColumnViewer<TYPE_TINYINT> viewer(ptr);
+            for (int i = 0; i < ptr->size(); ++i) {
+                auto result = select_col.get_data()[i] ? v_col.get_data()[i] : 123;
+                if (!viewer.is_null(i)) {
+                    ASSERT_EQ(viewer.value(i), result);
+                } else {
+                    ASSERT_TRUE(select_col.get_data()[i]);
+                }
             }
-            ASSERT_EQ(result, res_x->get_data()[i]);
+        }
+
+        // Test Nullable(Selector) const const
+        {
+            auto if_expr = std::unique_ptr<Expr>(VectorizedConditionExprFactory::create_if_expr(expr_node));
+            MakeNullableExpr<TYPE_TINYINT> nullable_selector(expr_node, chunk_size, &select_col);
+            MockConstVectorizedExpr<TYPE_TINYINT> col_x(expr_node, 123);
+            MockConstVectorizedExpr<TYPE_TINYINT> col_y(expr_node, 4);
+
+            if_expr->_children.push_back(&nullable_selector);
+            if_expr->_children.push_back(&col_x);
+            if_expr->_children.push_back(&col_y);
+
+            ptr = if_expr->evaluate(nullptr, nullptr);
+
+            ColumnViewer<TYPE_BOOLEAN> sel_viewer(nullable_selector.get_col_ptr());
+            auto* res_x = down_cast<Int8Column*>(ColumnHelper::get_data_column(ptr.get()));
+
+            for (int i = 0; i < ptr->size(); ++i) {
+                auto result = 0;
+                if (sel_viewer.is_null(i) || !sel_viewer.value(i)) {
+                    result = 4;
+                } else {
+                    result = 123;
+                }
+                ASSERT_EQ(result, res_x->get_data()[i]);
+            }
         }
     }
 }

--- a/be/test/exprs/if_expr_test.cpp
+++ b/be/test/exprs/if_expr_test.cpp
@@ -174,4 +174,37 @@ TEST_F(VectorizedIfExprTest, ifNull) {
     }
 }
 
+TEST_F(VectorizedIfExprTest, ifNullRightConst) {
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = VectorizedConditionExprFactory::create_if_expr(expr_node);
+        std::unique_ptr<Expr> expr_ptr(expr);
+
+        MockMultiVectorizedExpr<TYPE_BOOLEAN> bol(expr_node, 10, true, false);
+        MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10);
+        MockConstVectorizedExpr<TYPE_BIGINT> col2(expr_node, 20);
+
+        expr->_children.push_back(&bol);
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
+            ASSERT_TRUE(ptr->is_nullable());
+            ASSERT_FALSE(ptr->is_numeric());
+
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(
+                    ColumnHelper::as_raw_column<NullableColumn>(ptr)->data_column());
+            for (int j = 0; j < ptr->size(); ++j) {
+                if (j % 2 == 0) {
+                    ASSERT_FALSE(ptr->is_null(j));
+                    ASSERT_EQ(10, v->get_data()[j]);
+                } else {
+                    ASSERT_FALSE(ptr->is_null(j));
+                    ASSERT_EQ(20, v->get_data()[j]);
+                }
+            }
+        }
+    }
+}
+
 } // namespace starrocks

--- a/be/test/exprs/mock_vectorized_expr.h
+++ b/be/test/exprs/mock_vectorized_expr.h
@@ -150,7 +150,7 @@ public:
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
         start();
         if (only_null) {
-            return ColumnHelper::create_const_null_column(1);
+            return ColumnHelper::create_const_null_column(size);
         }
         ColumnPtr col = nullptr;
         if constexpr (lt_is_decimal<Type>) {

--- a/be/test/exprs/null_if_expr_test.cpp
+++ b/be/test/exprs/null_if_expr_test.cpp
@@ -66,9 +66,9 @@ TEST_F(VectorizedNullIfExprTest, nullIfArray) {
     auto array_expr0 = MockExpr(type_arr_int, array0);
 
     auto array1 = ColumnHelper::create_column(type_arr_int, false);
-    array1->append_datum(DatumArray{Datum((int32_t)11), Datum((int32_t)41)}); // [11,41]
-    array1->append_datum(DatumArray{Datum(), Datum()});                       // [NULL, NULL]
-    array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});             // [NULL, 1]
+    array1->append_datum(DatumArray{Datum((int32_t)1), Datum((int32_t)4)}); // [1,4]
+    array1->append_datum(DatumArray{Datum(), Datum()});                     // [NULL, NULL]
+    array1->append_datum(DatumArray{Datum(), Datum((int32_t)1)});           // [NULL, 1]
     auto array_expr1 = MockExpr(type_arr_int, array1);
 
     expr->_children.push_back(&array_expr0);
@@ -79,8 +79,8 @@ TEST_F(VectorizedNullIfExprTest, nullIfArray) {
         ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
         ASSERT_TRUE(ptr->is_nullable());
 
-        ASSERT_TRUE(!ptr->is_null(0));
-        ASSERT_TRUE(ptr->is_null(1));
+        ASSERT_TRUE(ptr->is_null(0));
+        ASSERT_TRUE(!ptr->is_null(1));
         ASSERT_TRUE(!ptr->is_null(2));
     }
 }
@@ -153,6 +153,59 @@ TEST_F(VectorizedNullIfExprTest, nullIfLeftAllNull) {
             ASSERT_TRUE(ptr->is_nullable());
             ASSERT_TRUE(ptr->only_null());
             ASSERT_FALSE(ptr->is_numeric());
+        }
+    }
+}
+
+TEST_F(VectorizedNullIfExprTest, nullIfLeftAllNullConstNULL) {
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = VectorizedConditionExprFactory::create_null_if_expr(expr_node);
+        std::unique_ptr<Expr> expr_ptr(expr);
+
+        MockNullVectorizedExpr<TYPE_BIGINT> col1(expr_node, 10, 10, true); // only null
+        MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+
+        col1.all_null = true;
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_nullable());
+            ASSERT_TRUE(ptr->only_null());
+            ASSERT_FALSE(ptr->is_numeric());
+        }
+    }
+}
+
+TEST_F(VectorizedNullIfExprTest, nullIfLeftConst) {
+    for (auto desc : tttype_desc) {
+        expr_node.type = desc;
+        auto expr = VectorizedConditionExprFactory::create_null_if_expr(expr_node);
+        std::unique_ptr<Expr> expr_ptr(expr);
+
+        MockConstVectorizedExpr<TYPE_BIGINT> col1(expr_node, 20); // only const
+        MockNullVectorizedExpr<TYPE_BIGINT> col2(expr_node, 10, 20);
+
+        expr->_children.push_back(&col1);
+        expr->_children.push_back(&col2);
+        {
+            Chunk chunk;
+            ColumnPtr ptr = expr->evaluate(nullptr, &chunk);
+            ASSERT_TRUE(ptr->is_nullable());
+            ASSERT_FALSE(ptr->is_numeric());
+
+            auto v = ColumnHelper::cast_to_raw<TYPE_BIGINT>(
+                    ColumnHelper::as_raw_column<NullableColumn>(ptr)->data_column());
+            for (int j = 0; j < ptr->size(); ++j) {
+                if (j % 2 == 1) {
+                    ASSERT_FALSE(ptr->is_null(j));
+                    ASSERT_EQ(20, v->get_data()[j]);
+                } else {
+                    ASSERT_TRUE(ptr->is_null(j));
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
fix conditional expression process const columns error, include if, ifnull, nullif, coalesce

---------

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
