### PR TITLE
[BugFix] Change lower to upper in _get_row_ranges_by_key_ranges (#16252)

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -454,7 +454,7 @@ Status SegmentIterator::_get_row_ranges_by_keys() {
         rowid_t upper_rowid = num_rows();
 
         if (!range.upper().empty()) {
-            _init_column_iterators<false>(range.lower().schema());
+            _init_column_iterators<false>(range.upper().schema());
             RETURN_IF_ERROR(_lookup_ordinal(range.upper(), !range.inclusive_upper(), num_rows(), &upper_rowid));
         }
         if (!range.lower().empty() && upper_rowid > 0) {


### PR DESCRIPTION
Should use the correct variable in _get_row_ranges_by_key_ranges. This is only a potential bug, may not cause actual problem.

