### PR TITLE
[Refactor] Refactor some publish version logs

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -86,14 +86,15 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
                 auto score = compaction_score(*metadata);
                 std::lock_guard l(response_mtx);
                 response->mutable_compaction_scores()->insert({tablet_id, score});
+                VLOG(5) << "Publish version success. tablet_id=" << tablet_id << " txn_id=" << txns[0]
+                        << " version=" << new_version;
             } else {
                 LOG(WARNING) << "Fail to publish version: " << res.status() << ". tablet_id=" << tablet_id
-                             << " txn_id=" << txns[0];
+                             << " txn_id=" << txns[0] << " version=" << new_version;
                 std::lock_guard l(response_mtx);
                 response->add_failed_tablets(tablet_id);
             }
             latch.count_down();
-            VLOG(5) << "Published version. tablet_id=" << tablet_id << " txn_id=" << txns[0];
         };
 
         auto st = thread_pool->submit_func(task, ThreadPool::HIGH_PRIORITY);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -142,8 +142,7 @@ public class Utils {
             try {
                 PublishVersionResponse response = responseList.get(i).get();
                 if (response != null && response.failedTablets != null && !response.failedTablets.isEmpty()) {
-                    throw new RpcException(backendList.get(i).getHost(),
-                            "Fail to publish version for tablets {}" + response.failedTablets);
+                    throw new RpcException("Fail to publish version for tablets " + response.failedTablets);
                 }
                 if (compactionScores != null && response != null && response.compactionScores != null) {
                     compactionScores.putAll(response.compactionScores);

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/RpcException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/RpcException.java
@@ -24,6 +24,10 @@ public class RpcException extends IOException {
         super(message + ", host: " + host);
     }
 
+    public RpcException(String message) {
+        super(message);
+    }
+
     public RpcException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -437,7 +437,6 @@ public class PublishVersionDaemon extends FrontendDaemon {
         } catch (Throwable e) {
             LOG.error("Fail to publish partition {} of txn {}: {}", partitionCommitInfo.getPartitionId(),
                     txnId, e.getMessage());
-            LOG.debug(e);
             return false;
         }
     }


### PR DESCRIPTION
1. remove duplicated host in log and duplicated debug log when publish version failed in FE
`2023-07-04 18:49:36,325 ERROR (pool-41-thread-11[237) [PublishVersionDaemon.publishPartition():438] Fail to publish partition 45403 of txn 70128: Fail to publish version for tablets {}[477041], host: 10.0.0.1, host: 10.0.0.1`

2. refactor publish version success log in BE

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
