### PR TITLE
[BugFix] Return error if init column iterator failed (#26291)

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -454,11 +454,11 @@ Status SegmentIterator::_get_row_ranges_by_keys() {
         rowid_t upper_rowid = num_rows();
 
         if (!range.upper().empty()) {
-            _init_column_iterators<false>(range.upper().schema());
+            RETURN_IF_ERROR(_init_column_iterators<false>(range.upper().schema()));
             RETURN_IF_ERROR(_lookup_ordinal(range.upper(), !range.inclusive_upper(), num_rows(), &upper_rowid));
         }
         if (!range.lower().empty() && upper_rowid > 0) {
-            _init_column_iterators<false>(range.lower().schema());
+            RETURN_IF_ERROR(_init_column_iterators<false>(range.lower().schema()));
             RETURN_IF_ERROR(_lookup_ordinal(range.lower(), range.inclusive_lower(), upper_rowid, &lower_rowid));
         }
         if (lower_rowid <= upper_rowid) {


### PR DESCRIPTION
Fixes #issue

```
W0620 16:10:41.046085 708104 vertical_compaction_task.cpp:198] reader get next error. tablet=10514145, err=Not found: Failed to seek to ordinal 0
```

`_init_column_iterators` maybe failed because of mem usage exceed limit

