### PR TITLE
[UT] Add UT to verify schemascannode execute on correct BE

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -229,6 +229,8 @@ public class PseudoBackend {
 
     private Random random;
 
+    private AtomicLong numSchemaScan = new AtomicLong(0);
+
     private static ThreadLocal<PseudoBackend> currentBackend = new ThreadLocal<>();
 
     static class QueryProgress {
@@ -453,6 +455,10 @@ public class PseudoBackend {
 
     public float getPublishFailureRate() {
         return publishFailureRate;
+    }
+
+    public long getNumSchemaScan() {
+        return numSchemaScan.get();
     }
 
     private void reportTablets() {
@@ -1141,6 +1147,9 @@ public class PseudoBackend {
                         runOlapScan(planNode, scanRanges);
                         System.out.printf("per_driver_seq_scan_range not empty numTablets: %d\n", numTabletScan);
                     }
+                } else if (planNode.node_type == TPlanNodeType.SCHEMA_SCAN_NODE) {
+                    numSchemaScan.incrementAndGet();
+                    sb.append(" SchemaScanNode:" + planNode.schema_scan_node.table_name);
                 }
             }
             if (numTabletScan > 0) {
@@ -1205,10 +1214,13 @@ public class PseudoBackend {
                         runOlapScan(planNode, scanRanges);
                         System.out.printf("per_driver_seq_scan_range not empty numTablets: %d\n", numTabletScan);
                     }
+                } else if (planNode.node_type == TPlanNodeType.SCHEMA_SCAN_NODE) {
+                    numSchemaScan.incrementAndGet();
+                    sb.append(" SchemaScanNode:" + planNode.schema_scan_node.table_name);
                 }
             }
             if (allScans != numTabletScan) {
-                System.out.printf("not all scanrange used: all:%d used:%d\n", allScans, numTabletScan);
+                System.out.printf(" not all scanrange used: all:%d used:%d\n", allScans, numTabletScan);
             }
             if (numTabletScan > 0) {
                 scansByQueryId.computeIfAbsent(DebugUtil.printId(commonParams.params.query_id), k -> new AtomicInteger(0))


### PR DESCRIPTION
This PR is used to verify bug described in #26437, the reason for the issue is the plan fragment was not executed on the expected BE.
Unfortunately, the issue was not reproducible on main and branch 2.5. But still, the UT is helpful.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
