### PR TITLE
[BugFix] fix version not found when concurrent clone and publish version

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -376,22 +376,6 @@ public class Replica implements Writable {
                 this.lastSuccessVersion, this.minReadableVersion, dataSize, rowCount);
     }
 
-    public void updateVersionInfoForRecovery(
-            long newVersion,
-            long lastFailedVersion,
-            long lastSuccessVersion) {
-
-        LOG.warn("update replica {} on backend {}'s version for recovery. current_version: {}, new_version: {}."
-                 + " last failed version: {}:{}, last success version: {}:{}",
-                this.id, this.backendId, this.version, newVersion,
-                this.lastFailedVersion, lastFailedVersion,
-                this.lastSuccessVersion, lastSuccessVersion);
-
-        this.version = newVersion;
-        this.lastFailedVersion = lastFailedVersion;
-        this.lastSuccessVersion = lastSuccessVersion;
-    }
-
     /* last failed version:  LFV
      * last success version: LSV
      * version:              V

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -395,6 +395,20 @@ public class TabletInvertedIndex {
             return false;
         }
 
+        if (backendTabletInfo.getVersion() == replicaInFe.getVersion() - 1) {
+            /*
+             * This is very tricky:
+             * 1. Assume that we want to create a replica with version (X, Y), the init version of replica in FE
+             *      is (X, Y), and BE will create a replica with version (X+1, 0).
+             * 2. BE will report version (X+1, 0), and FE will sync with this version, change to (X+1, 0), too.
+             * 3. When restore, BE will restore the replica with version (X, Y) (which is the visible version of partition)
+             * 4. BE report the version (X-Y), and then we fall into here
+             *
+             * Actually, the version (X+1, 0) is a 'virtual' version, so here we ignore this kind of report
+             */
+            return false;
+        }
+
         if (backendTabletInfo.isSetVersion_miss() && backendTabletInfo.isVersion_miss()) {
             // even if backend version is less than fe's version, but if version_miss is false,
             // which means this may be a stale report.

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1102,27 +1102,6 @@ public class ReportHandler extends Daemon {
                                 }
                                 break;
                             }
-
-                            if (replica.getVersion() > tTabletInfo.getVersion()) {
-                                LOG.warn("recover for replica {} of tablet {} on backend {}",
-                                        replica.getId(), tabletId, backendId);
-                                if (replica.getVersion() == tTabletInfo.getVersion() + 1) {
-                                    // this missing version is the last version of this replica
-                                    replica.updateVersionInfoForRecovery(
-                                            tTabletInfo.getVersion(), /* set version to BE report version */
-                                            replica.getVersion(), /* set LFV to current FE version */
-                                            tTabletInfo.getVersion()); /* set LSV to BE report version */
-                                } else {
-                                    // this missing version is a hole
-                                    replica.updateVersionInfoForRecovery(
-                                            tTabletInfo.getVersion(), /* set version to BE report version */
-                                            tTabletInfo.getVersion() + 1, /* LFV */
-                                            /* remain LSV unchanged, which should be equal to replica.version */
-                                            replica.getLastSuccessVersion());
-                                }
-                                // no need to write edit log, if FE crashed, this will be recovered again
-                                break;
-                            }
                         }
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -818,6 +818,10 @@ public class DatabaseTransactionMgr {
                             // which means publish version task finished in replica
                             for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
                                 if (!errReplicas.contains(replica.getId())) {
+                                    // if replica not in can load state, skip it.
+                                    if (!replica.getState().canLoad()) {
+                                        continue;
+                                    }
                                     // success healthy replica condition:
                                     // 1. version is equal to partition's visible version
                                     // 2. publish version task in this replica has finished
@@ -959,6 +963,10 @@ public class DatabaseTransactionMgr {
                             for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
                                 if (!errorReplicaIds.contains(replica.getId())
                                         && replica.getLastFailedVersion() < 0) {
+                                    // if replica not in can load state, skip it.
+                                    if (!replica.getState().canLoad()) {
+                                        continue;
+                                    }
                                     // this means the replica is a healthy replica,
                                     // it is healthy in the past and does not have error in current load
                                     if (replica.checkVersionCatchUp(partition.getVisibleVersion(), true)) {


### PR DESCRIPTION
When clone execute and concurrent with data loading. E.g.
1. Clone replica_a, version = 132
2. Continue data loading, and publish version to replica_a , from version = 139 to version = 174.
3. Clone and data loading finish, and replica_a's version in FE is [V: 174, LFV: -1, LSV: 174]. but in replica_a, version [133-138] is missing.
4. Query on replica_a will be failed. Error msg: "capture_consistent_versions error: version not found"

We can't inc replica's version in FE, when this replica isn't `canLoad`
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
