### PR TITLE
[Enhancement] Optimize the partition prune for hive table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -78,7 +78,7 @@ public class PartitionUtil {
     public static PartitionKey createPartitionKey(List<String> values, List<Column> columns,
                                                   Table.TableType tableType) throws AnalysisException {
         Preconditions.checkState(values.size() == columns.size(),
-                String.format("columns size is %d, but values size is %d", columns.size(), values.size()));
+                "columns size is %s, but values size is %s", columns.size(), values.size());
 
         PartitionKey partitionKey = null;
         switch (tableType) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rewrite;
 
 import com.google.common.base.Preconditions;
@@ -36,6 +35,7 @@ import com.starrocks.planner.PartitionColumnFilter;
 import com.starrocks.planner.PartitionPruner;
 import com.starrocks.planner.RangePartitionPruner;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.PlannerProfile;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -58,7 +58,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
 
 import static com.starrocks.connector.PartitionUtil.createPartitionKey;
@@ -67,7 +68,16 @@ import static com.starrocks.connector.PartitionUtil.toPartitionValues;
 public class OptExternalPartitionPruner {
     private static final Logger LOG = LogManager.getLogger(OptExternalPartitionPruner.class);
 
-    public static LogicalScanOperator prunePartitions(OptimizerContext context, LogicalScanOperator logicalScanOperator) {
+    public static LogicalScanOperator prunePartitions(OptimizerContext context,
+                                                      LogicalScanOperator logicalScanOperator) {
+        try (PlannerProfile.ScopedTimer ignore = PlannerProfile.getScopedTimer(
+                "RuleBaseOptimize.RewriteTreeTask.ExternalTablePartitionPrune")) {
+            return prunePartitionsImpl(context, logicalScanOperator);
+        }
+    }
+
+    public static LogicalScanOperator prunePartitionsImpl(OptimizerContext context,
+                                                          LogicalScanOperator logicalScanOperator) {
         if (logicalScanOperator instanceof LogicalEsScanOperator) {
             LogicalEsScanOperator operator = (LogicalEsScanOperator) logicalScanOperator;
             EsTablePartitions esTablePartitions = operator.getEsTablePartitions();
@@ -101,10 +111,11 @@ public class OptExternalPartitionPruner {
         } else {
             // partitionColumnName -> (LiteralExpr -> partition ids)
             // no null partitions in this map, used by ListPartitionPruner
-            Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap = Maps.newHashMap();
+            Map<ColumnRefOperator, ConcurrentNavigableMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap =
+                    Maps.newConcurrentMap();
             // Store partitions with null partition values separately, used by ListPartitionPruner
             // partitionColumnName -> null partitionIds
-            Map<ColumnRefOperator, Set<Long>> columnToNullPartitions = Maps.newHashMap();
+            Map<ColumnRefOperator, Set<Long>> columnToNullPartitions = Maps.newConcurrentMap();
 
             try {
                 initPartitionInfo(logicalScanOperator, context, columnToPartitionValuesMap, columnToNullPartitions);
@@ -182,10 +193,9 @@ public class OptExternalPartitionPruner {
         return partitionValues;
     }
 
-
     private static void initPartitionInfo(LogicalScanOperator operator, OptimizerContext context,
-                                          Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap,
-                                          Map<ColumnRefOperator, Set<Long>> columnToNullPartitions)
+            Map<ColumnRefOperator, ConcurrentNavigableMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap,
+            Map<ColumnRefOperator, Set<Long>> columnToNullPartitions)
             throws AnalysisException {
         Table table = operator.getTable();
         // RemoteScanPartitionPruneRule may be run multiple times, such like after MaterializedViewRewriter rewrite，
@@ -197,8 +207,8 @@ public class OptExternalPartitionPruner {
             List<ColumnRefOperator> partitionColumnRefOperators = new ArrayList<>();
             for (Column column : partitionColumns) {
                 ColumnRefOperator partitionColumnRefOperator = operator.getColumnReference(column);
-                columnToPartitionValuesMap.put(partitionColumnRefOperator, new TreeMap<>());
-                columnToNullPartitions.put(partitionColumnRefOperator, Sets.newHashSet());
+                columnToPartitionValuesMap.put(partitionColumnRefOperator, new ConcurrentSkipListMap<>());
+                columnToNullPartitions.put(partitionColumnRefOperator, Sets.newConcurrentHashSet());
                 partitionColumnRefOperators.add(partitionColumnRefOperator);
             }
 
@@ -231,7 +241,7 @@ public class OptExternalPartitionPruner {
                 partitionKeys.put(new PartitionKey(), 0L);
             }
 
-            for (Map.Entry<PartitionKey, Long> entry : partitionKeys.entrySet()) {
+            partitionKeys.entrySet().stream().parallel().forEach(entry -> {
                 PartitionKey key = entry.getKey();
                 long partitionId = entry.getValue();
                 List<LiteralExpr> literals = key.getKeys();
@@ -244,9 +254,14 @@ public class OptExternalPartitionPruner {
                     }
 
                     Set<Long> partitions = columnToPartitionValuesMap.get(columnRefOperator)
-                            .computeIfAbsent(literal, k -> Sets.newHashSet());
+                            .computeIfAbsent(literal, k -> Sets.newConcurrentHashSet());
                     partitions.add(partitionId);
                 }
+            });
+
+            for (Map.Entry<PartitionKey, Long> entry : partitionKeys.entrySet()) {
+                PartitionKey key = entry.getKey();
+                long partitionId = entry.getValue();
                 operator.getScanOperatorPredicates().getIdToPartitionKey().put(partitionId, key);
             }
         }
@@ -255,7 +270,7 @@ public class OptExternalPartitionPruner {
     }
 
     private static void classifyConjuncts(LogicalScanOperator operator,
-                                          Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap)
+            Map<ColumnRefOperator, ConcurrentNavigableMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap)
             throws AnalysisException {
         for (ScalarOperator scalarOperator : Utils.extractConjuncts(operator.getPredicate())) {
             List<ColumnRefOperator> columnRefOperatorList = Utils.extractColumnRef(scalarOperator);
@@ -268,8 +283,9 @@ public class OptExternalPartitionPruner {
     }
 
     private static void computePartitionInfo(LogicalScanOperator operator,
-                                             Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap,
-                                             Map<ColumnRefOperator, Set<Long>> columnToNullPartitions) throws AnalysisException {
+            Map<ColumnRefOperator, ConcurrentNavigableMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap,
+            Map<ColumnRefOperator, Set<Long>> columnToNullPartitions)
+            throws AnalysisException {
         Table table = operator.getTable();
         if (table instanceof HiveMetaStoreTable) {
             ScanOperatorPredicates scanOperatorPredicates = operator.getScanOperatorPredicates();
@@ -295,7 +311,8 @@ public class OptExternalPartitionPruner {
      * @throws AnalysisException
      */
     private static Collection<Long> partitionPrune(PartitionInfo partitionInfo,
-                                                   Map<String, PartitionColumnFilter> columnFilters) throws AnalysisException {
+                                                   Map<String, PartitionColumnFilter> columnFilters)
+            throws AnalysisException {
         if (partitionInfo == null) {
             return null;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
@@ -53,10 +53,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 public class ListPartitionPrunerTest {
-    private Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap;
+    private Map<ColumnRefOperator, ConcurrentNavigableMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap;
     private Map<ColumnRefOperator, Set<Long>> columnToNullPartitions;
     private List<ScalarOperator> conjuncts;
     private ColumnRefOperator dateColumn;
@@ -80,13 +81,13 @@ public class ListPartitionPrunerTest {
         intColumn = new ColumnRefOperator(2, Type.INT, "int_col", true);
 
         // column -> partition values
-        columnToPartitionValuesMap = Maps.newHashMap();
-        TreeMap<LiteralExpr, Set<Long>> datePartitionValuesMap = Maps.newTreeMap();
+        columnToPartitionValuesMap = Maps.newConcurrentMap();
+        ConcurrentNavigableMap<LiteralExpr, Set<Long>> datePartitionValuesMap = new ConcurrentSkipListMap<>();
         columnToPartitionValuesMap.put(dateColumn, datePartitionValuesMap);
         datePartitionValuesMap.put(new DateLiteral(2021, 1, 1), Sets.newHashSet(0L, 1L, 2L));
         datePartitionValuesMap.put(new DateLiteral(2021, 1, 2), Sets.newHashSet(3L, 4L, 5L));
         datePartitionValuesMap.put(new DateLiteral(2021, 1, 3), Sets.newHashSet(6L, 7L, 8L));
-        TreeMap<LiteralExpr, Set<Long>> intPartitionValuesMap = Maps.newTreeMap();
+        ConcurrentNavigableMap<LiteralExpr, Set<Long>> intPartitionValuesMap = new ConcurrentSkipListMap<>();
         columnToPartitionValuesMap.put(intColumn, intPartitionValuesMap);
         intPartitionValuesMap.put(new IntLiteral(0, Type.INT), Sets.newHashSet(0L, 3L, 6L));
         intPartitionValuesMap.put(new IntLiteral(1, Type.INT), Sets.newHashSet(1L, 4L, 7L));
@@ -180,8 +181,8 @@ public class ListPartitionPrunerTest {
         ColumnRefOperator stringColumn = new ColumnRefOperator(1, Type.STRING, "string_col", true);
 
         // column -> partition values
-        Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap = Maps.newHashMap();
-        TreeMap<LiteralExpr, Set<Long>> stringPartitionValuesMap = Maps.newTreeMap();
+        Map<ColumnRefOperator, ConcurrentNavigableMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap = Maps.newHashMap();
+        ConcurrentNavigableMap<LiteralExpr, Set<Long>> stringPartitionValuesMap = new ConcurrentSkipListMap<>();
         columnToPartitionValuesMap.put(stringColumn, stringPartitionValuesMap);
         stringPartitionValuesMap.put(new StringLiteral("2021-01-01"), Sets.newHashSet(1L));
         stringPartitionValuesMap.put(new StringLiteral("2021-01-02"), Sets.newHashSet(2L));
@@ -231,8 +232,9 @@ public class ListPartitionPrunerTest {
         ColumnRefOperator stringColumn = new ColumnRefOperator(1, Type.STRING, "string_col", true);
 
         // column -> partition values
-        Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap = Maps.newHashMap();
-        TreeMap<LiteralExpr, Set<Long>> stringPartitionValuesMap = Maps.newTreeMap();
+        Map<ColumnRefOperator, ConcurrentNavigableMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap =
+                Maps.newConcurrentMap();
+        ConcurrentNavigableMap<LiteralExpr, Set<Long>> stringPartitionValuesMap = new ConcurrentSkipListMap<>();
         columnToPartitionValuesMap.put(stringColumn, stringPartitionValuesMap);
         stringPartitionValuesMap.put(new StringLiteral("01"), Sets.newHashSet(1L));
         stringPartitionValuesMap.put(new StringLiteral("02"), Sets.newHashSet(2L));
@@ -294,8 +296,8 @@ public class ListPartitionPrunerTest {
         ColumnRefOperator intColumn = new ColumnRefOperator(1, Type.INT, "int_col", true);
 
         // column -> partition values
-        Map<ColumnRefOperator, TreeMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap = Maps.newHashMap();
-        TreeMap<LiteralExpr, Set<Long>> intPartitionValuesMap = Maps.newTreeMap();
+        Map<ColumnRefOperator, ConcurrentNavigableMap<LiteralExpr, Set<Long>>> columnToPartitionValuesMap = Maps.newHashMap();
+        ConcurrentNavigableMap<LiteralExpr, Set<Long>> intPartitionValuesMap = new ConcurrentSkipListMap<>();
         columnToPartitionValuesMap.put(intColumn, intPartitionValuesMap);
         intPartitionValuesMap.put(new IntLiteral(1), Sets.newHashSet(1L));
         intPartitionValuesMap.put(new IntLiteral(2), Sets.newHashSet(2L));
@@ -352,11 +354,11 @@ public class ListPartitionPrunerTest {
 
         // column -> partition values
         columnToPartitionValuesMap = Maps.newHashMap();
-        TreeMap<LiteralExpr, Set<Long>> intPartitionValuesMap1 = Maps.newTreeMap();
+        ConcurrentNavigableMap<LiteralExpr, Set<Long>> intPartitionValuesMap1 = new ConcurrentSkipListMap<>();
         columnToPartitionValuesMap.put(intCol1, intPartitionValuesMap1);
         intPartitionValuesMap1.put(new IntLiteral(0, Type.INT), Sets.newHashSet(0L, 1L));
         intPartitionValuesMap1.put(new IntLiteral(1, Type.INT), Sets.newHashSet(2L));
-        TreeMap<LiteralExpr, Set<Long>> intPartitionValuesMap2 = Maps.newTreeMap();
+        ConcurrentNavigableMap<LiteralExpr, Set<Long>> intPartitionValuesMap2 = new ConcurrentSkipListMap<>();
         columnToPartitionValuesMap.put(intCol2, intPartitionValuesMap2);
         intPartitionValuesMap2.put(new IntLiteral(10, Type.INT), Sets.newHashSet(0L, 2L));
         intPartitionValuesMap2.put(new IntLiteral(11, Type.INT), Sets.newHashSet(1L));
@@ -386,11 +388,11 @@ public class ListPartitionPrunerTest {
 
         // column -> partition values
         columnToPartitionValuesMap = Maps.newHashMap();
-        TreeMap<LiteralExpr, Set<Long>> intPartitionValuesMap1 = Maps.newTreeMap();
+        ConcurrentNavigableMap<LiteralExpr, Set<Long>> intPartitionValuesMap1 = new ConcurrentSkipListMap<>();
         columnToPartitionValuesMap.put(intCol1, intPartitionValuesMap1);
         intPartitionValuesMap1.put(new IntLiteral(0, Type.INT), Sets.newHashSet(0L, 1L));
         intPartitionValuesMap1.put(new IntLiteral(1, Type.INT), Sets.newHashSet(2L));
-        TreeMap<LiteralExpr, Set<Long>> intPartitionValuesMap2 = Maps.newTreeMap();
+        ConcurrentNavigableMap<LiteralExpr, Set<Long>> intPartitionValuesMap2 = new ConcurrentSkipListMap<>();
         columnToPartitionValuesMap.put(intCol2, intPartitionValuesMap2);
         intPartitionValuesMap2.put(new IntLiteral(10, Type.INT), Sets.newHashSet(0L, 2L));
         intPartitionValuesMap2.put(new IntLiteral(11, Type.INT), Sets.newHashSet(1L));
@@ -636,7 +638,7 @@ public class ListPartitionPrunerTest {
     public void testBinaryPredicateWithEmptyPartition() throws AnalysisException {
         ColumnRefOperator operator = new ColumnRefOperator(5, Type.VARCHAR, "ds", true);
         columnToPartitionValuesMap = Maps.newHashMap();
-        columnToPartitionValuesMap.put(operator, new TreeMap<>());
+        columnToPartitionValuesMap.put(operator, new ConcurrentSkipListMap<>());
         columnToNullPartitions = new HashMap<>();
         columnToNullPartitions.put(operator, new HashSet<>());
         conjuncts = Lists.newArrayList();
@@ -650,7 +652,7 @@ public class ListPartitionPrunerTest {
     public void testInPredicateWithEmptyPartition() throws AnalysisException {
         ColumnRefOperator operator = new ColumnRefOperator(5, Type.VARCHAR, "ds", true);
         columnToPartitionValuesMap = Maps.newHashMap();
-        columnToPartitionValuesMap.put(operator, new TreeMap<>());
+        columnToPartitionValuesMap.put(operator, new ConcurrentSkipListMap<>());
         columnToNullPartitions = new HashMap<>();
         columnToNullPartitions.put(operator, new HashSet<>());
         conjuncts = Lists.newArrayList();


### PR DESCRIPTION
Fixes #issue
When there are a lot of partitions in the hive/hudi table. there could cost lots of times, eg.
<img width="1020" alt="image" src="https://github.com/StarRocks/starrocks/assets/9495145/f4fcda7c-61ab-439c-bc22-64bd2ee97d59">

it will costs 3845ms to partition prune, after optimize, 
![img_v2_bea8a789-74ba-4479-9ae6-d3eaa3a2e2dg](https://github.com/StarRocks/starrocks/assets/9495145/45c9998c-9d23-45c3-8385-2caa2d6837b7)

Main change:
use parallel stream to compute the columnToPartitionValuesMap

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
