### PR TITLE
[BugFix] fill AUTO_INCREMENT fail in Cloud Native mode(#26584)

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -248,7 +248,7 @@ inline Status DeltaWriterImpl::flush_async() {
     if (_mem_table != nullptr) {
         RETURN_IF_ERROR(_mem_table->finalize());
         if (_miss_auto_increment_column && _mem_table->get_result_chunk() != nullptr) {
-            _fill_auto_increment_id(*_mem_table->get_result_chunk());
+            RETURN_IF_ERROR(_fill_auto_increment_id(*_mem_table->get_result_chunk()));
         }
         st = _flush_token->submit(std::move(_mem_table));
         _mem_table.reset(nullptr);
@@ -447,21 +447,30 @@ Status DeltaWriterImpl::_fill_auto_increment_id(const Chunk& chunk) {
 
     // 2. probe index
     auto metadata = _tablet_manager->get_latest_cached_tablet_metadata(_tablet_id);
-    std::unique_ptr<MetaFileBuilder> builder = std::make_unique<MetaFileBuilder>(tablet, metadata);
-
-    RETURN_IF_ERROR(tablet.update_mgr()->get_rowids_from_pkindex(&tablet, metadata->version(), upserts, &rss_rowids));
+    Status st;
+    if (metadata != nullptr) {
+        st = tablet.update_mgr()->get_rowids_from_pkindex(&tablet, metadata->version(), upserts, &rss_rowids);
+    }
 
     std::vector<uint8_t> filter;
     uint32_t gen_num = 0;
-    for (uint32_t i = 0; i < rss_rowid_map.size(); i++) {
-        uint64_t v = rss_rowid_map[i];
-        uint32_t rssid = v >> 32;
-        if (rssid == (uint32_t)-1) {
-            filter.emplace_back(1);
-            ++gen_num;
-        } else {
-            filter.emplace_back(0);
+    // There are two cases we should allocate full id for this chunk for simplicity:
+    // 1. We can not get the tablet meta from cache.
+    // 2. fail in seeking index
+    if (metadata != nullptr && st.ok()) {
+        for (uint32_t i = 0; i < rss_rowid_map.size(); i++) {
+            uint64_t v = rss_rowid_map[i];
+            uint32_t rssid = v >> 32;
+            if (rssid == (uint32_t)-1) {
+                filter.emplace_back(1);
+                ++gen_num;
+            } else {
+                filter.emplace_back(0);
+            }
         }
+    } else {
+        gen_num = rss_rowid_map.size();
+        filter.resize(gen_num, 1);
     }
 
     // 3. fill the non-existing rows


### PR DESCRIPTION
Problem:
There are two reasons that will cause a failure when filling AUTO_INCREMENT id in partial update mode for table in Cloud Native mode:
1. We can not get the tablet meta from cache and get nullptr crash
2. Currently, seek pk index will fail if the index has not been cached. Filling AUTO_INCREMENT id will fail if there the index has not been cached. But it will keep failing if there is no other load commit and cache the index into memory.

Fixes #26584

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
