### PR TITLE
[Enhancement] check be version before update replica verison in fe

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -621,6 +621,7 @@ public class LeaderImpl {
 
         PublishVersionTask publishVersionTask = (PublishVersionTask) task;
         publishVersionTask.setErrorTablets(errorTabletIds);
+        publishVersionTask.collectTabletVersions(request);
         if (Config.enable_new_publish_mechanism) {
             if (request.isSetTablet_versions()) {
                 publishVersionTask.updateReplicaVersions(request.getTablet_versions());

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -969,7 +969,9 @@ public class DatabaseTransactionMgr {
                                     }
                                     // this means the replica is a healthy replica,
                                     // it is healthy in the past and does not have error in current load
-                                    if (replica.checkVersionCatchUp(partition.getVisibleVersion(), true)) {
+                                    if (replica.checkVersionCatchUp(partition.getVisibleVersion(), true) 
+                                            && transactionState.checkTabletVersionFinish(replica.getBackendId(), 
+                                            tablet.getId(), partitionCommitInfo.getVersion())) {
                                         // during rollup, the rollup replica's last failed version < 0,
                                         // it may be treated as a normal replica.
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -364,6 +364,14 @@ public class TransactionState implements Writable {
         this.publishVersionTasks.put(backendId, task);
     }
 
+    public boolean checkTabletVersionFinish(long backendId, long tabletId, long version) {
+        PublishVersionTask task = this.publishVersionTasks.get(backendId);
+        if (task != null) {
+            return task.checkTabletVersionFinish(tabletId, version);
+        }
+        return false;
+    }
+
     public void setHasSendTask(boolean hasSendTask) {
         this.hasSendTask = hasSendTask;
         this.publishVersionTime = System.currentTimeMillis();


### PR DESCRIPTION
In finishTransaction, before update replica's version in FE, check if be's real version is larger or equal to it.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
