### PR TITLE
[BugFix] fix cache key access failure in staros worker

### DIFF
--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -78,7 +78,7 @@ private:
 
     static void cache_value_deleter(const CacheKey& /*key*/, void* value) { delete static_cast<CacheValue*>(value); }
 
-    static CacheKey get_cache_key(std::string_view scheme, const Configuration& conf);
+    static std::string get_cache_key(std::string_view scheme, const Configuration& conf);
 
     static absl::StatusOr<staros::starlet::fslib::Configuration> build_conf_from_shard_info(const ShardInfo& info);
 


### PR DESCRIPTION
found in asan mode, stack looks like this,
```
CacheKey::_decode_fixed32()
CacheKey::hash()
ShardedLRUCache::_hash_slice()
ShardedLRUCache::lookup()
StarOSWorker::new_shared_filesystem()
```

CacheKey does not own memory.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
