### PR TITLE
[Enhancement] Add LastReportVersion to Replica to help detect data lose on backend

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -76,6 +76,10 @@ public class Replica implements Writable {
     // the version could be queried
     @SerializedName(value = "version")
     private volatile long version;
+    // The last version reported from BE, this version should be increased monotonically.
+    // Use this version to detect data lose on BE.
+    // This version is only accessed by ReportHandler, so lock is unnecessary when updating.
+    private volatile long lastReportVersion = 0;
     private int schemaHash = -1;
     @SerializedName(value = "dataSize")
     private volatile long dataSize = 0;
@@ -468,6 +472,8 @@ public class Replica implements Writable {
         strBuffer.append(version);
         strBuffer.append(", versionHash=");
         strBuffer.append(0);
+        strBuffer.append(", lastReportVersion=");
+        strBuffer.append(lastReportVersion);
         strBuffer.append(", dataSize=");
         strBuffer.append(dataSize);
         strBuffer.append(", rowCount=");
@@ -570,5 +576,13 @@ public class Replica implements Writable {
 
     public long getWatermarkTxnId() {
         return watermarkTxnId;
+    }
+
+    public void setLastReportVersion(long lastReportVersion) {
+        this.lastReportVersion = lastReportVersion;
+    }
+
+    public long getLastReportVersion() {
+        return this.lastReportVersion;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -193,7 +193,10 @@ public class TabletInvertedIndex {
                                             backendTabletInfo.isSetVersion_miss() ? backendTabletInfo.isVersion_miss() :
                                                     "unset");
                                     tabletRecoveryMap.put(tabletMeta.getDbId(), tabletId);
+                                } else {
+                                    replica.setLastReportVersion(backendTabletInfo.getVersion());
                                 }
+
 
                                 // check if tablet needs migration
                                 long partitionId = tabletMeta.getPartitionId();
@@ -381,26 +384,18 @@ public class TabletInvertedIndex {
             return false;
         }
 
-        if (backendTabletInfo.getVersion() == replicaInFe.getVersion() - 1) {
-            /*
-             * This is very tricky:
-             * 1. Assume that we want to create a replica with version (X, Y), the init version of replica in FE
-             *      is (X, Y), and BE will create a replica with version (X+1, 0).
-             * 2. BE will report version (X+1, 0), and FE will sync with this version, change to (X+1, 0), too.
-             * 3. When restore, BE will restore the replica with version (X, Y) (which is the visible version of partition)
-             * 4. BE report the version (X-Y), and than we fall into here
-             *
-             * Actually, the version (X+1, 0) is a 'virtual' version, so here we ignore this kind of report
-             */
-            return false;
-        }
-
         if (backendTabletInfo.isSetVersion_miss() && backendTabletInfo.isVersion_miss()) {
             // even if backend version is less than fe's version, but if version_miss is false,
             // which means this may be a stale report.
             // so we only return true if version_miss is true.
             return true;
         }
+
+        // lastReportVersion should be increased monotonically.
+        if (backendTabletInfo.getVersion() < replicaInFe.getLastReportVersion()) {
+            return true;
+        }
+
         return false;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -992,7 +992,8 @@ public class ReportHandler extends Daemon {
 
                     for (TTabletInfo tTabletInfo : backendTablets.get(tabletId).getTablet_infos()) {
                         if (tTabletInfo.getSchema_hash() == schemaHash) {
-                            if (tTabletInfo.isSetUsed() && !tTabletInfo.isUsed()) {
+                            if ((tTabletInfo.isSetUsed() && !tTabletInfo.isUsed())
+                                    || (tTabletInfo.getVersion() < replica.getLastReportVersion())) {
                                 if (replica.setBad(true)) {
                                     LOG.warn("set bad for replica {} of tablet {} on backend {}",
                                             replica.getId(), tabletId, backendId);
@@ -1023,6 +1024,8 @@ public class ReportHandler extends Daemon {
                                 // no need to write edit log, if FE crashed, this will be recovered again
                                 break;
                             }
+
+
                         }
                     }
                 }


### PR DESCRIPTION
Add lastReportVersion to Replica, and this version is updated only when BE reports tablet, if the version on BE is less than lastReportVersion, that means data is lost on BE, because this version can only be increased monotonically.

Why not just check based on Replica.version?
There may be data load when processing the tablet report, in this case, the version reported from BE is less than Replica.version too.

cherry-pick #26518