### PR TITLE
[BugFix] improve lake primary table compaction strategy

### DIFF
--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -87,19 +87,28 @@ public:
     double calc_del_bytes() const { return (double)stat.bytes * (double)stat.num_dels / (double)stat.num_rows; }
     // The goal of lake primary table compaction:
     // 1. clean up deleted bytes.
-    // 2. merge small rowsets to bigger rowset.
+    // 2. merge rowsets with bigger compaction score
+    // 3. merge small rowsets to bigger rowset.
     // so we pick rowset to compact by this logic:
     // First, pick out rowset with more deleted bytes.
-    // Second, pick out rowset with less bytes.
+    // Second, pick out rowset with bigger compaction score
+    // Finally, pick out rowset with less bytes.
     bool operator<(const RowsetCandidate& other) const {
         if (calc_del_bytes() < other.calc_del_bytes()) {
             return true;
         } else if (calc_del_bytes() > other.calc_del_bytes()) {
             return false;
+        } else if (rowset_compaction_score() < other.rowset_compaction_score()) {
+            return true;
+        } else if (rowset_compaction_score() > other.rowset_compaction_score()) {
+            return false;
         } else {
             // may happen when deleted rows is zero
             return stat.bytes > other.stat.bytes;
         }
+    }
+    double rowset_compaction_score() const {
+        return rowset_meta_ptr->overlapped() ? rowset_meta_ptr->segments_size() : 1;
     }
     RowsetMetadataPtr rowset_meta_ptr;
     RowsetStat stat;
@@ -111,6 +120,7 @@ public:
     ~PrimaryCompactionPolicy() override = default;
 
     StatusOr<std::vector<RowsetPtr>> pick_rowsets(int64_t version) override;
+    StatusOr<std::vector<RowsetPtr>> pick_rowsets(const TabletMetadataPtr& tablet_metadata);
 
 private:
     static const size_t kCompactionResultBytesThreashold = 1000000000;
@@ -119,7 +129,10 @@ private:
 
 StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets(int64_t version) {
     ASSIGN_OR_RETURN(auto tablet_metadata, _tablet->get_metadata(version));
+    return pick_rowsets(tablet_metadata);
+}
 
+StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets(const TabletMetadataPtr& tablet_metadata) {
     std::vector<RowsetPtr> input_rowsets;
     UpdateManager* mgr = _tablet->update_mgr();
     std::priority_queue<RowsetCandidate> rowset_queue;
@@ -127,7 +140,7 @@ StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets(int64_t v
         RowsetStat stat;
         stat.num_rows = rowset_pb.num_rows();
         stat.bytes = rowset_pb.data_size();
-        stat.num_dels = mgr->get_rowset_num_deletes(_tablet->id(), version, rowset_pb);
+        stat.num_dels = mgr->get_rowset_num_deletes(_tablet->id(), tablet_metadata->version(), rowset_pb);
         rowset_queue.emplace(std::make_shared<const RowsetMetadata>(rowset_pb), stat);
     }
     size_t cur_compaction_result_bytes = 0;
@@ -154,18 +167,34 @@ StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets(int64_t v
         rowset_queue.pop();
     }
     VLOG(2) << strings::Substitute("lake PrimaryCompactionPolicy pick_rowsets tabletid:$0 version:$1 inputs:$2",
-                                   _tablet->id(), version, input_infos.str());
+                                   _tablet->id(), tablet_metadata->version(), input_infos.str());
 
     return input_rowsets;
 }
 
-double primary_compaction_score(const TabletMetadataPB& metadata) {
+StatusOr<uint32_t> primary_compaction_score_by_policy(const TabletMetadataPB& metadata) {
+    ASSIGN_OR_RETURN(auto tablet, ExecEnv::GetInstance()->lake_tablet_manager()->get_tablet(metadata.id()));
+    auto policy = std::make_shared<PrimaryCompactionPolicy>(std::make_shared<Tablet>(tablet));
+    ASSIGN_OR_RETURN(auto pick_rowsets, policy->pick_rowsets(std::make_shared<TabletMetadataPB>(metadata)));
+
     uint32_t segment_num_score = 0;
-    for (uint32_t i = 0; i < metadata.rowsets_size(); i++) {
-        const auto& rowset = metadata.rowsets(i);
-        segment_num_score += rowset.overlapped() ? rowset.segments_size() : 1;
+    for (const auto& pick_rowset : pick_rowsets) {
+        segment_num_score += pick_rowset->is_overlapped() ? pick_rowset->num_segments() : 1;
     }
     return segment_num_score;
+}
+
+double primary_compaction_score(const TabletMetadataPB& metadata) {
+    // calc compaction score by picked rowsets
+    auto score_st = primary_compaction_score_by_policy(metadata);
+    if (!score_st.ok()) {
+        // should not happen, return score zero if error
+        LOG(ERROR) << "primary_compaction_score by policy fail, tablet_id: " << metadata.id()
+                   << ", st: " << score_st.status();
+        return 0;
+    } else {
+        return *score_st;
+    }
 }
 
 StatusOr<std::vector<RowsetPtr>> BaseAndCumulativeCompactionPolicy::pick_cumulative_rowsets() {


### PR DESCRIPTION
Do some changes to lake primary table compaction policy:
1. Consider rowset's compaction score when picking rowsets.
2. When calc compaction score of tablet, only the picked rowsets will be involved.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
