### PR TITLE
[Enhancement] Use one RandomAccessFile to read the index and data of a column

### DIFF
--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -81,18 +81,18 @@ Status BitmapIndexReader::_do_load(const IndexReadOptions& opts, const BitmapInd
     const IndexedColumnMetaPB& dict_meta = meta.dict_column();
     const IndexedColumnMetaPB& bitmap_meta = meta.bitmap_column();
     _has_null = meta.has_null();
-    _dict_column_reader = std::make_unique<IndexedColumnReader>(opts, dict_meta);
-    _bitmap_column_reader = std::make_unique<IndexedColumnReader>(opts, bitmap_meta);
-    RETURN_IF_ERROR(_dict_column_reader->load());
-    RETURN_IF_ERROR(_bitmap_column_reader->load());
+    _dict_column_reader = std::make_unique<IndexedColumnReader>(dict_meta);
+    _bitmap_column_reader = std::make_unique<IndexedColumnReader>(bitmap_meta);
+    RETURN_IF_ERROR(_dict_column_reader->load(opts));
+    RETURN_IF_ERROR(_bitmap_column_reader->load(opts));
     return Status::OK();
 }
 
-Status BitmapIndexReader::new_iterator(BitmapIndexIterator** iterator, const IndexReadOptions& opts) {
+Status BitmapIndexReader::new_iterator(const IndexReadOptions& opts, BitmapIndexIterator** iterator) {
     std::unique_ptr<IndexedColumnIterator> dict_iter;
     std::unique_ptr<IndexedColumnIterator> bitmap_iter;
-    RETURN_IF_ERROR(_dict_column_reader->new_iterator(&dict_iter, opts));
-    RETURN_IF_ERROR(_bitmap_column_reader->new_iterator(&bitmap_iter, opts));
+    RETURN_IF_ERROR(_dict_column_reader->new_iterator(opts, &dict_iter));
+    RETURN_IF_ERROR(_bitmap_column_reader->new_iterator(opts, &bitmap_iter));
     *iterator = new BitmapIndexIterator(this, std::move(dict_iter), std::move(bitmap_iter), _has_null, bitmap_nums());
     return Status::OK();
 }

--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -71,7 +71,7 @@ public:
 
     // create a new column iterator. Client should delete returned iterator
     // REQUIRES: the index data has been successfully `load()`ed into memory.
-    Status new_iterator(BitmapIndexIterator** iterator, const IndexReadOptions& opts);
+    Status new_iterator(const IndexReadOptions& opts, BitmapIndexIterator** iterator);
 
     // REQUIRES: the index data has been successfully `load()`ed into memory.
     int64_t bitmap_nums() { return _bitmap_column_reader->num_values(); }

--- a/be/src/storage/rowset/bloom_filter_index_reader.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_reader.cpp
@@ -72,8 +72,8 @@ Status BloomFilterIndexReader::_do_load(const IndexReadOptions& opts, const Bloo
     _algorithm = meta.algorithm();
     _hash_strategy = meta.hash_strategy();
     const IndexedColumnMetaPB& bf_index_meta = meta.bloom_filter();
-    _bloom_filter_reader = std::make_unique<IndexedColumnReader>(opts, bf_index_meta);
-    RETURN_IF_ERROR(_bloom_filter_reader->load());
+    _bloom_filter_reader = std::make_unique<IndexedColumnReader>(bf_index_meta);
+    RETURN_IF_ERROR(_bloom_filter_reader->load(opts));
     return Status::OK();
 }
 
@@ -84,10 +84,10 @@ void BloomFilterIndexReader::_reset() {
     _bloom_filter_reader.reset();
 }
 
-Status BloomFilterIndexReader::new_iterator(std::unique_ptr<BloomFilterIndexIterator>* iterator) {
+Status BloomFilterIndexReader::new_iterator(const IndexReadOptions& opts,
+                                            std::unique_ptr<BloomFilterIndexIterator>* iterator) {
     std::unique_ptr<IndexedColumnIterator> bf_iter;
-    IndexReadOptions options;
-    RETURN_IF_ERROR(_bloom_filter_reader->new_iterator(&bf_iter, options));
+    RETURN_IF_ERROR(_bloom_filter_reader->new_iterator(opts, &bf_iter));
     iterator->reset(new BloomFilterIndexIterator(this, std::move(bf_iter)));
     return Status::OK();
 }

--- a/be/src/storage/rowset/bloom_filter_index_reader.h
+++ b/be/src/storage/rowset/bloom_filter_index_reader.h
@@ -70,7 +70,7 @@ public:
 
     // create a new column iterator.
     // REQUIRES: the index data has been successfully `load()`ed into memory.
-    Status new_iterator(std::unique_ptr<BloomFilterIndexIterator>* iterator);
+    Status new_iterator(const IndexReadOptions& opts, std::unique_ptr<BloomFilterIndexIterator>* iterator);
 
     const TypeInfoPtr& type_info() const { return _typeinfo; }
 

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -54,6 +54,7 @@ struct ColumnIteratorOptions {
     // reader statistics
     OlapReaderStatistics* stats = nullptr;
     bool use_page_cache = false;
+    bool fill_data_cache = true;
 
     // check whether column pages are all dictionary encoding.
     bool check_dict_encoding = false;

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -263,9 +263,9 @@ Status ColumnReader::_init(ColumnMetaPB* meta) {
     }
 }
 
-Status ColumnReader::new_bitmap_index_iterator(const IndexReadOptions& options, BitmapIndexIterator** iterator) {
-    RETURN_IF_ERROR(_load_bitmap_index(options));
-    RETURN_IF_ERROR(_bitmap_index->new_iterator(iterator, options));
+Status ColumnReader::new_bitmap_index_iterator(const IndexReadOptions& opts, BitmapIndexIterator** iterator) {
+    RETURN_IF_ERROR(_load_bitmap_index(opts));
+    RETURN_IF_ERROR(_bitmap_index->new_iterator(opts, iterator));
     return Status::OK();
 }
 
@@ -310,11 +310,11 @@ Status ColumnReader::_parse_zone_map(const ZoneMapPB& zm, ZoneMapDetail* detail)
 
 // prerequisite: at least one predicate in |predicates| support bloom filter.
 Status ColumnReader::bloom_filter(const std::vector<const ColumnPredicate*>& predicates, SparseRange* row_ranges,
-                                  bool skip_fill_local_cache) {
-    RETURN_IF_ERROR(_load_bloom_filter_index(skip_fill_local_cache));
+                                  const IndexReadOptions& opts) {
+    RETURN_IF_ERROR(_load_bloom_filter_index(opts));
     SparseRange bf_row_ranges;
     std::unique_ptr<BloomFilterIndexIterator> bf_iter;
-    RETURN_IF_ERROR(_bloom_filter_index->new_iterator(&bf_iter));
+    RETURN_IF_ERROR(_bloom_filter_index->new_iterator(opts, &bf_iter));
     size_t range_size = row_ranges->size();
     // get covered page ids
     std::set<int32_t> page_ids;
@@ -342,19 +342,9 @@ Status ColumnReader::bloom_filter(const std::vector<const ColumnPredicate*>& pre
     return Status::OK();
 }
 
-Status ColumnReader::load_ordinal_index(bool skip_fill_local_cache) {
-    return _load_ordinal_index(skip_fill_local_cache);
-}
-
-Status ColumnReader::_load_ordinal_index(bool skip_fill_local_cache) {
+Status ColumnReader::load_ordinal_index(const IndexReadOptions& opts) {
     if (_ordinal_index == nullptr || _ordinal_index->loaded()) return Status::OK();
     SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
-    IndexReadOptions opts;
-    opts.fs = file_system();
-    opts.file_name = file_name();
-    opts.use_page_cache = config::enable_ordinal_index_memory_page_cache || !config::disable_storage_page_cache;
-    opts.kept_in_memory = config::enable_ordinal_index_memory_page_cache;
-    opts.skip_fill_local_cache = skip_fill_local_cache;
     auto meta = _ordinal_index_meta.get();
     ASSIGN_OR_RETURN(auto first_load, _ordinal_index->load(opts, *meta, num_rows()));
     if (UNLIKELY(first_load)) {
@@ -365,15 +355,9 @@ Status ColumnReader::_load_ordinal_index(bool skip_fill_local_cache) {
     return Status::OK();
 }
 
-Status ColumnReader::_load_zonemap_index(bool skip_fill_local_cache) {
+Status ColumnReader::_load_zonemap_index(const IndexReadOptions& opts) {
     if (_zonemap_index == nullptr || _zonemap_index->loaded()) return Status::OK();
     SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
-    IndexReadOptions opts;
-    opts.fs = file_system();
-    opts.file_name = file_name();
-    opts.use_page_cache = config::enable_zonemap_index_memory_page_cache || !config::disable_storage_page_cache;
-    opts.kept_in_memory = config::enable_zonemap_index_memory_page_cache;
-    opts.skip_fill_local_cache = skip_fill_local_cache;
     auto meta = _zonemap_index_meta.get();
     ASSIGN_OR_RETURN(auto first_load, _zonemap_index->load(opts, *meta));
     if (UNLIKELY(first_load)) {
@@ -384,11 +368,11 @@ Status ColumnReader::_load_zonemap_index(bool skip_fill_local_cache) {
     return Status::OK();
 }
 
-Status ColumnReader::_load_bitmap_index(const IndexReadOptions& options) {
+Status ColumnReader::_load_bitmap_index(const IndexReadOptions& opts) {
     if (_bitmap_index == nullptr || _bitmap_index->loaded()) return Status::OK();
     SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
     auto meta = _bitmap_index_meta.get();
-    ASSIGN_OR_RETURN(auto first_load, _bitmap_index->load(options, *meta));
+    ASSIGN_OR_RETURN(auto first_load, _bitmap_index->load(opts, *meta));
     if (UNLIKELY(first_load)) {
         MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->bitmap_index_mem_tracker(),
                                  _bitmap_index_meta->SpaceUsedLong());
@@ -397,15 +381,9 @@ Status ColumnReader::_load_bitmap_index(const IndexReadOptions& options) {
     return Status::OK();
 }
 
-Status ColumnReader::_load_bloom_filter_index(bool skip_fill_local_cache) {
+Status ColumnReader::_load_bloom_filter_index(const IndexReadOptions& opts) {
     if (_bloom_filter_index == nullptr || _bloom_filter_index->loaded()) return Status::OK();
     SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(false);
-    IndexReadOptions opts;
-    opts.fs = file_system();
-    opts.file_name = file_name();
-    opts.use_page_cache = !config::disable_storage_page_cache;
-    opts.kept_in_memory = keep_in_memory();
-    opts.skip_fill_local_cache = skip_fill_local_cache;
     auto meta = _bloom_filter_index_meta.get();
     ASSIGN_OR_RETURN(auto first_load, _bloom_filter_index->load(opts, *meta));
     if (UNLIKELY(first_load)) {
@@ -435,8 +413,8 @@ Status ColumnReader::seek_at_or_before(ordinal_t ordinal, OrdinalPageIndexIterat
 Status ColumnReader::zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
                                      const ColumnPredicate* del_predicate,
                                      std::unordered_set<uint32_t>* del_partial_filtered_pages, SparseRange* row_ranges,
-                                     bool skip_fill_local_cache) {
-    RETURN_IF_ERROR(_load_zonemap_index(skip_fill_local_cache));
+                                     const IndexReadOptions& opts) {
+    RETURN_IF_ERROR(_load_zonemap_index(opts));
     std::vector<uint32_t> page_indexes;
     RETURN_IF_ERROR(_zone_map_filter(predicates, del_predicate, del_partial_filtered_pages, &page_indexes));
     RETURN_IF_ERROR(_calculate_row_ranges(page_indexes, row_ranges));

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -106,7 +106,7 @@ public:
 
     // Caller should free returned iterator after unused.
     // TODO: StatusOr<std::unique_ptr<ColumnIterator>> new_bitmap_index_iterator()
-    Status new_bitmap_index_iterator(const IndexReadOptions& options, BitmapIndexIterator** iterator);
+    Status new_bitmap_index_iterator(const IndexReadOptions& opts, BitmapIndexIterator** iterator);
 
     // Seek to the first entry in the column.
     Status seek_to_first(OrdinalPageIndexIterator* iter);
@@ -139,7 +139,7 @@ public:
     Status zone_map_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p,
                            const ::starrocks::ColumnPredicate* del_predicate,
                            std::unordered_set<uint32_t>* del_partial_filtered_pages, SparseRange* row_ranges,
-                           bool skip_fill_local_cache);
+                           const IndexReadOptions& opts);
 
     // segment-level zone map filter.
     // Return false to filter out this segment.
@@ -148,16 +148,14 @@ public:
 
     // prerequisite: at least one predicate in |predicates| support bloom filter.
     Status bloom_filter(const std::vector<const ::starrocks::ColumnPredicate*>& p, SparseRange* ranges,
-                        bool skip_fill_local_cache);
+                        const IndexReadOptions& opts);
 
-    Status load_ordinal_index(bool skip_fill_local_cache);
+    Status load_ordinal_index(const IndexReadOptions& opts);
 
     uint32_t num_rows() const { return _segment->num_rows(); }
 
 private:
     const std::string& file_name() const { return _segment->file_name(); }
-
-    FileSystem* file_system() const { return _segment->file_system(); }
 
     bool keep_in_memory() const { return _segment->keep_in_memory(); }
 
@@ -171,10 +169,9 @@ private:
 
     Status _init(ColumnMetaPB* meta);
 
-    Status _load_zonemap_index(bool skip_fill_local_cache);
-    Status _load_ordinal_index(bool skip_fill_local_cache);
-    Status _load_bitmap_index(const IndexReadOptions& options);
-    Status _load_bloom_filter_index(bool skip_fill_local_cache);
+    Status _load_zonemap_index(const IndexReadOptions& opts);
+    Status _load_bitmap_index(const IndexReadOptions& opts);
+    Status _load_bloom_filter_index(const IndexReadOptions& opts);
 
     Status _parse_zone_map(const ZoneMapPB& zm, ZoneMapDetail* detail) const;
 

--- a/be/src/storage/rowset/indexed_column_reader.cpp
+++ b/be/src/storage/rowset/indexed_column_reader.cpp
@@ -44,7 +44,7 @@ namespace starrocks {
 
 using strings::Substitute;
 
-Status IndexedColumnReader::load() {
+Status IndexedColumnReader::load(const IndexReadOptions& opts) {
     _type_info = get_type_info((LogicalType)_meta.data_type());
     if (_type_info == nullptr) {
         return Status::NotSupported(strings::Substitute("unsupported type=$0", _meta.data_type()));
@@ -53,15 +53,13 @@ Status IndexedColumnReader::load() {
     RETURN_IF_ERROR(get_block_compression_codec(_meta.compression(), &_compress_codec));
     _validx_key_coder = get_key_coder(_type_info->type());
 
-    RandomAccessFileOptions file_opts{.skip_fill_local_cache = _skip_fill_local_cache};
-    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(file_opts, _file_name));
     // read and parse ordinal index page when exists
     if (_meta.has_ordinal_index_meta()) {
         if (_meta.ordinal_index_meta().is_root_data_page()) {
             _sole_data_page = PagePointer(_meta.ordinal_index_meta().root_page());
         } else {
-            RETURN_IF_ERROR(load_index_page(read_file.get(), _meta.ordinal_index_meta().root_page(),
-                                            &_ordinal_index_page_handle, &_ordinal_index_reader));
+            RETURN_IF_ERROR(load_index_page(opts, _meta.ordinal_index_meta().root_page(), &_ordinal_index_page_handle,
+                                            &_ordinal_index_reader));
             _has_index_page = true;
         }
     }
@@ -71,8 +69,8 @@ Status IndexedColumnReader::load() {
         if (_meta.value_index_meta().is_root_data_page()) {
             _sole_data_page = PagePointer(_meta.value_index_meta().root_page());
         } else {
-            RETURN_IF_ERROR(load_index_page(read_file.get(), _meta.value_index_meta().root_page(),
-                                            &_value_index_page_handle, &_value_index_reader));
+            RETURN_IF_ERROR(load_index_page(opts, _meta.value_index_meta().root_page(), &_value_index_page_handle,
+                                            &_value_index_reader));
             _has_index_page = true;
         }
     }
@@ -80,48 +78,37 @@ Status IndexedColumnReader::load() {
     return Status::OK();
 }
 
-Status IndexedColumnReader::load_index_page(RandomAccessFile* read_file, const PagePointerPB& pp, PageHandle* handle,
+Status IndexedColumnReader::load_index_page(const IndexReadOptions& opts, const PagePointerPB& pp, PageHandle* handle,
                                             IndexPageReader* reader) {
     Slice body;
     PageFooterPB footer;
-    RETURN_IF_ERROR(read_page(read_file, PagePointer(pp), handle, &body, &footer, nullptr));
+    RETURN_IF_ERROR(read_page(opts, PagePointer(pp), handle, &body, &footer));
     RETURN_IF_ERROR(reader->parse(body, footer.index_page_footer()));
     return Status::OK();
 }
 
-Status IndexedColumnReader::read_page(RandomAccessFile* read_file, const PagePointer& pp, PageHandle* handle,
-                                      Slice* body, PageFooterPB* footer, OlapReaderStatistics* stats) const {
-    PageReadOptions opts;
-    opts.read_file = read_file;
-    opts.page_pointer = pp;
-    opts.codec = _compress_codec;
-    OlapReaderStatistics tmp_stats;
-    opts.stats = &tmp_stats;
-    if (stats != nullptr) {
-        opts.stats = stats;
-    }
-    opts.use_page_cache = _use_page_cache;
-    opts.kept_in_memory = _kept_in_memory;
-    opts.encoding_type = _encoding_info->encoding();
-
-    return PageIO::read_and_decompress_page(opts, handle, body, footer);
+Status IndexedColumnReader::read_page(const IndexReadOptions& opts, const PagePointer& pp, PageHandle* handle,
+                                      Slice* body, PageFooterPB* footer) const {
+    PageReadOptions page_opts;
+    page_opts.read_file = opts.read_file;
+    page_opts.page_pointer = pp;
+    page_opts.codec = _compress_codec;
+    page_opts.stats = opts.stats;
+    page_opts.use_page_cache = opts.use_page_cache;
+    page_opts.kept_in_memory = opts.kept_in_memory;
+    page_opts.encoding_type = _encoding_info->encoding();
+    return PageIO::read_and_decompress_page(page_opts, handle, body, footer);
 }
 
-Status IndexedColumnReader::new_iterator(std::unique_ptr<IndexedColumnIterator>* iter, const IndexReadOptions& opts) {
-    RandomAccessFileOptions file_opts{.skip_fill_local_cache = _skip_fill_local_cache};
-    ASSIGN_OR_RETURN(auto file, _fs->new_random_access_file(file_opts, _file_name));
-
-    IndexedColumnIteratorOptions index_opts;
-    index_opts.read_file = std::move(file);
-    index_opts.stats = opts.stats;
-    iter->reset(new IndexedColumnIterator(this, std::move(index_opts)));
+Status IndexedColumnReader::new_iterator(const IndexReadOptions& opts, std::unique_ptr<IndexedColumnIterator>* iter) {
+    iter->reset(new IndexedColumnIterator(this, opts));
     return Status::OK();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-IndexedColumnIterator::IndexedColumnIterator(const IndexedColumnReader* reader, IndexedColumnIteratorOptions opts)
+IndexedColumnIterator::IndexedColumnIterator(const IndexedColumnReader* reader, const IndexReadOptions& opts)
         : _reader(reader),
-          _opts(std::move(opts)),
+          _opts(opts),
           _ordinal_iter(&reader->_ordinal_index_reader),
           _value_iter(&reader->_value_index_reader) {}
 
@@ -129,7 +116,7 @@ Status IndexedColumnIterator::_read_data_page(const PagePointer& pp) {
     PageHandle handle;
     Slice body;
     PageFooterPB footer;
-    RETURN_IF_ERROR(_reader->read_page(_opts.read_file.get(), pp, &handle, &body, &footer, _opts.stats));
+    RETURN_IF_ERROR(_reader->read_page(_opts, pp, &handle, &body, &footer));
     // parse data page
     // note that page_index is not used in IndexedColumnIterator, so we pass 0
     return parse_page(&_data_page, std::move(handle), body, footer.data_page_footer(), _reader->encoding_info(), pp, 0);

--- a/be/src/storage/rowset/indexed_column_reader.h
+++ b/be/src/storage/rowset/indexed_column_reader.h
@@ -57,11 +57,6 @@ class TypeInfo;
 class EncodingInfo;
 class IndexedColumnReader;
 
-struct IndexedColumnIteratorOptions {
-    std::unique_ptr<RandomAccessFile> read_file;
-    OlapReaderStatistics* stats = nullptr;
-};
-
 class IndexedColumnIterator {
     friend class IndexedColumnReader;
 
@@ -91,12 +86,12 @@ public:
     Status next_batch(size_t* n, Column* column);
 
 private:
-    IndexedColumnIterator(const IndexedColumnReader* reader, IndexedColumnIteratorOptions opts);
+    IndexedColumnIterator(const IndexedColumnReader* reader, const IndexReadOptions& opts);
 
     Status _read_data_page(const PagePointer& pp);
 
     const IndexedColumnReader* _reader = nullptr;
-    IndexedColumnIteratorOptions _opts;
+    IndexReadOptions _opts;
 
     // iterator for ordinal index page
     IndexPageIterator _ordinal_iter;
@@ -117,18 +112,11 @@ class IndexedColumnReader {
     friend class IndexedColumnIterator;
 
 public:
-    // Does *NOT* take the ownership of |fs|.
-    IndexedColumnReader(const IndexReadOptions& opts, IndexedColumnMetaPB meta)
-            : _fs(opts.fs),
-              _file_name(opts.file_name),
-              _meta(std::move(meta)),
-              _use_page_cache(opts.use_page_cache),
-              _kept_in_memory(opts.kept_in_memory),
-              _skip_fill_local_cache(opts.skip_fill_local_cache) {}
+    IndexedColumnReader(IndexedColumnMetaPB meta) : _meta(std::move(meta)) {}
 
-    Status load();
+    Status load(const IndexReadOptions& opts);
 
-    Status new_iterator(std::unique_ptr<IndexedColumnIterator>* iter, const IndexReadOptions& opts);
+    Status new_iterator(const IndexReadOptions& opts, std::unique_ptr<IndexedColumnIterator>* iter);
 
     int64_t num_values() const { return _num_values; }
     const EncodingInfo* encoding_info() const { return _encoding_info; }
@@ -143,20 +131,14 @@ public:
     }
 
 private:
-    Status load_index_page(RandomAccessFile* read_file, const PagePointerPB& pp, PageHandle* handle,
+    Status load_index_page(const IndexReadOptions& opts, const PagePointerPB& pp, PageHandle* handle,
                            IndexPageReader* reader);
 
     // read a page specified by `pp' from `file' into `handle'
-    Status read_page(RandomAccessFile* read_file, const PagePointer& pp, PageHandle* handle, Slice* body,
-                     PageFooterPB* footer, OlapReaderStatistics* stats) const;
+    Status read_page(const IndexReadOptions& opts, const PagePointer& pp, PageHandle* handle, Slice* body,
+                     PageFooterPB* footer) const;
 
-    FileSystem* _fs;
-    std::string _file_name;
     IndexedColumnMetaPB _meta;
-
-    bool _use_page_cache = true;
-    bool _kept_in_memory = false;
-    bool _skip_fill_local_cache = false;
 
     int64_t _num_values = 0;
     // whether this column contains any index page.

--- a/be/src/storage/rowset/options.h
+++ b/be/src/storage/rowset/options.h
@@ -41,6 +41,7 @@
 namespace starrocks {
 
 class FileSystem;
+class RandomAccessFile;
 
 static const uint32_t DEFAULT_PAGE_SIZE = 1024 * 1024; // default size: 1M
 
@@ -56,10 +57,10 @@ public:
     bool use_page_cache = false;
     bool kept_in_memory = false;
     // for lake tablet
-    bool skip_fill_local_cache = false;
-    std::string file_name = "";
+    bool skip_fill_data_cache = false;
+
+    RandomAccessFile* read_file = nullptr;
     OlapReaderStatistics* stats = nullptr;
-    FileSystem* fs = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/ordinal_page_index.cpp
+++ b/be/src/storage/rowset/ordinal_page_index.cpp
@@ -111,16 +111,12 @@ Status OrdinalIndexReader::_do_load(const IndexReadOptions& opts, const OrdinalI
         _pages[1] = meta.root_page().root_page().offset() + meta.root_page().root_page().size();
         return Status::OK();
     }
-    // need to read index page
-    RandomAccessFileOptions file_opts{.skip_fill_local_cache = opts.skip_fill_local_cache};
-    ASSIGN_OR_RETURN(auto read_file, opts.fs->new_random_access_file(file_opts, opts.file_name));
 
     PageReadOptions page_opts;
-    page_opts.read_file = read_file.get();
+    page_opts.read_file = opts.read_file;
     page_opts.page_pointer = PagePointer(meta.root_page().root_page());
     page_opts.codec = nullptr; // ordinal index page uses NO_COMPRESSION right now
-    OlapReaderStatistics tmp_stats;
-    page_opts.stats = &tmp_stats;
+    page_opts.stats = opts.stats;
     page_opts.use_page_cache = opts.use_page_cache;
     page_opts.kept_in_memory = opts.kept_in_memory;
 

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -48,7 +48,14 @@ ScalarColumnIterator::~ScalarColumnIterator() = default;
 
 Status ScalarColumnIterator::init(const ColumnIteratorOptions& opts) {
     _opts = opts;
-    RETURN_IF_ERROR(_reader->load_ordinal_index(_skip_fill_local_cache()));
+
+    IndexReadOptions index_opts;
+    index_opts.use_page_cache = config::enable_ordinal_index_memory_page_cache || !config::disable_storage_page_cache;
+    index_opts.kept_in_memory = config::enable_ordinal_index_memory_page_cache;
+    index_opts.skip_fill_data_cache = _skip_fill_data_cache();
+    index_opts.read_file = _opts.read_file;
+    index_opts.stats = _opts.stats;
+    RETURN_IF_ERROR(_reader->load_ordinal_index(index_opts));
     _opts.stats->total_columns_data_page_count += _reader->num_data_pages();
 
     if (_reader->encoding_info()->encoding() != DICT_ENCODING) {
@@ -301,8 +308,14 @@ Status ScalarColumnIterator::get_row_ranges_by_zone_map(const std::vector<const 
                                                         const ColumnPredicate* del_predicate, SparseRange* row_ranges) {
     DCHECK(row_ranges->empty());
     if (_reader->has_zone_map()) {
+        IndexReadOptions opts;
+        opts.use_page_cache = config::enable_zonemap_index_memory_page_cache || !config::disable_storage_page_cache;
+        opts.kept_in_memory = config::enable_zonemap_index_memory_page_cache;
+        opts.skip_fill_data_cache = _skip_fill_data_cache();
+        opts.read_file = _opts.read_file;
+        opts.stats = _opts.stats;
         RETURN_IF_ERROR(_reader->zone_map_filter(predicates, del_predicate, &_delete_partial_satisfied_pages,
-                                                 row_ranges, _skip_fill_local_cache()));
+                                                 row_ranges, opts));
     } else {
         row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
     }
@@ -317,7 +330,14 @@ Status ScalarColumnIterator::get_row_ranges_by_bloom_filter(const std::vector<co
         support = support | pred->support_bloom_filter();
     }
     RETURN_IF(!support, Status::OK());
-    RETURN_IF_ERROR(_reader->bloom_filter(predicates, row_ranges, _skip_fill_local_cache()));
+
+    IndexReadOptions opts;
+    opts.use_page_cache = !config::disable_storage_page_cache;
+    opts.kept_in_memory = !config::disable_storage_page_cache;
+    opts.skip_fill_data_cache = _skip_fill_data_cache();
+    opts.read_file = _opts.read_file;
+    opts.stats = _opts.stats;
+    RETURN_IF_ERROR(_reader->bloom_filter(predicates, row_ranges, opts));
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -125,7 +125,7 @@ private:
 
     bool _contains_deleted_row(uint32_t page_index) const;
 
-    bool _skip_fill_local_cache() const { return _opts.reader_type != READER_QUERY; }
+    bool _skip_fill_data_cache() const { return !_opts.fill_data_cache; }
 
     ColumnReader* _reader;
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -464,9 +464,11 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
     ColumnIteratorOptions iter_opts;
     iter_opts.stats = _opts.stats;
     iter_opts.use_page_cache = _opts.use_page_cache;
-    RandomAccessFileOptions opts{.skip_fill_local_cache = _skip_fill_data_cache()};
     iter_opts.check_dict_encoding = check_dict_enc;
     iter_opts.reader_type = _opts.reader_type;
+    iter_opts.fill_data_cache = _opts.fill_data_cache;
+
+    RandomAccessFileOptions opts{.skip_fill_local_cache = _skip_fill_data_cache()};
 
     ColumnAccessPath* access_path = nullptr;
     if (_opts.column_access_paths != nullptr && !_opts.column_access_paths->empty()) {
@@ -490,7 +492,7 @@ Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const C
     } else {
         // create delta column iterator
         _column_iterators[cid] = std::move(col_iter);
-        ASSIGN_OR_RETURN(auto dcg_file, _opts.fs->new_random_access_file(dcg_filename));
+        ASSIGN_OR_RETURN(auto dcg_file, _opts.fs->new_random_access_file(opts, dcg_filename));
         iter_opts.read_file = dcg_file.get();
         _column_files[cid] = std::move(dcg_file);
     }
@@ -1521,16 +1523,14 @@ Status SegmentIterator::_init_bitmap_index_iterators() {
                 col_index = cid;
             }
 
-            IndexReadOptions options;
-            options.fs = segment_ptr->file_system();
-            options.file_name = segment_ptr->file_name();
-            options.use_page_cache =
-                    config::enable_bitmap_index_memory_page_cache || !config::disable_storage_page_cache;
-            options.kept_in_memory = config::enable_bitmap_index_memory_page_cache;
-            options.skip_fill_local_cache = _skip_fill_data_cache();
-            options.stats = _opts.stats;
+            IndexReadOptions opts;
+            opts.use_page_cache = config::enable_bitmap_index_memory_page_cache || !config::disable_storage_page_cache;
+            opts.kept_in_memory = config::enable_bitmap_index_memory_page_cache;
+            opts.skip_fill_data_cache = _skip_fill_data_cache();
+            opts.read_file = _column_files[cid].get();
+            opts.stats = _opts.stats;
 
-            RETURN_IF_ERROR(segment_ptr->new_bitmap_index_iterator(col_index, options, &_bitmap_index_iterators[cid]));
+            RETURN_IF_ERROR(segment_ptr->new_bitmap_index_iterator(col_index, opts, &_bitmap_index_iterators[cid]));
             _has_bitmap_index |= (_bitmap_index_iterators[cid] != nullptr);
         }
     }

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -276,11 +276,10 @@ StatusOr<bool> ZoneMapIndexReader::load(const IndexReadOptions& opts, const Zone
 }
 
 Status ZoneMapIndexReader::_do_load(const IndexReadOptions& opts, const ZoneMapIndexPB& meta) {
-    IndexedColumnReader reader(opts, meta.page_zone_maps());
-    RETURN_IF_ERROR(reader.load());
+    IndexedColumnReader reader(meta.page_zone_maps());
+    RETURN_IF_ERROR(reader.load(opts));
     std::unique_ptr<IndexedColumnIterator> iter;
-    IndexReadOptions options;
-    RETURN_IF_ERROR(reader.new_iterator(&iter, options));
+    RETURN_IF_ERROR(reader.new_iterator(opts, &iter));
 
     _page_zone_maps.resize(reader.num_values());
 

--- a/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
@@ -57,10 +57,10 @@ protected:
         _fs = std::make_shared<MemoryFileSystem>();
         ASSERT_TRUE(_fs->create_dir(kTestDir).ok());
 
-        _opts.fs = _fs.get();
         _opts.use_page_cache = true;
         _opts.kept_in_memory = false;
-        _opts.skip_fill_local_cache = false;
+        _opts.skip_fill_data_cache = false;
+        _opts.stats = &_stats;
     }
     void TearDown() override { StoragePageCache::release_global_cache(); }
 
@@ -97,12 +97,14 @@ protected:
     void get_bloom_filter_reader_iter(const std::string& file_name, const ColumnIndexMetaPB& meta,
                                       std::unique_ptr<RandomAccessFile>* rfile, BloomFilterIndexReader** reader,
                                       std::unique_ptr<BloomFilterIndexIterator>* iter) {
-        _opts.file_name = kTestDir + "/" + file_name;
+        auto filename = kTestDir + "/" + file_name;
+        ASSIGN_OR_ABORT(*rfile, _fs->new_random_access_file(filename))
+        _opts.read_file = (*rfile).get();
 
         *reader = new BloomFilterIndexReader();
         ASSIGN_OR_ABORT(auto r, (*reader)->load(_opts, meta.bloom_filter_index()));
         ASSERT_TRUE(r);
-        ASSERT_OK((*reader)->new_iterator(iter));
+        ASSERT_OK((*reader)->new_iterator(_opts, iter));
     }
 
     template <LogicalType Type>
@@ -166,6 +168,7 @@ protected:
     std::unique_ptr<MemTracker> _mem_tracker = nullptr;
     std::shared_ptr<MemoryFileSystem> _fs = nullptr;
     IndexReadOptions _opts;
+    OlapReaderStatistics _stats;
 };
 
 TEST_F(BloomFilterIndexReaderWriterTest, test_int) {

--- a/be/test/storage/rowset/ordinal_page_index_test.cpp
+++ b/be/test/storage/rowset/ordinal_page_index_test.cpp
@@ -88,11 +88,13 @@ TEST_F(OrdinalPageIndexTest, normal) {
     }
 
     IndexReadOptions opts;
-    opts.fs = _fs.get();
-    opts.file_name = filename;
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(filename))
+    opts.read_file = rfile.get();
     opts.use_page_cache = true;
     opts.kept_in_memory = false;
-    opts.skip_fill_local_cache = false;
+    opts.skip_fill_data_cache = false;
+    OlapReaderStatistics stats;
+    opts.stats = &stats;
     OrdinalIndexReader index;
     ASSIGN_OR_ABORT(auto r, index.load(opts, index_meta.ordinal_index(), 16 * 1024 * 4096 + 1));
     ASSERT_TRUE(r);
@@ -149,11 +151,12 @@ TEST_F(OrdinalPageIndexTest, one_data_page) {
     }
 
     IndexReadOptions opts;
-    opts.fs = _fs.get();
-    opts.file_name = "";
+    opts.read_file = nullptr;
     opts.use_page_cache = true;
     opts.kept_in_memory = false;
-    opts.skip_fill_local_cache = false;
+    opts.skip_fill_data_cache = false;
+    OlapReaderStatistics stats;
+    opts.stats = &stats;
     OrdinalIndexReader index;
     ASSIGN_OR_ABORT(auto r, index.load(opts, index_meta.ordinal_index(), num_values));
     ASSERT_TRUE(r);

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -90,11 +90,13 @@ protected:
         }
 
         IndexReadOptions opts;
-        opts.fs = _fs.get();
-        opts.file_name = filename;
+        ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(filename))
+        opts.read_file = rfile.get();
         opts.use_page_cache = true;
         opts.kept_in_memory = false;
-        opts.skip_fill_local_cache = false;
+        opts.skip_fill_data_cache = false;
+        OlapReaderStatistics stats;
+        opts.stats = &stats;
         ZoneMapIndexReader column_zone_map;
         ASSIGN_OR_ABORT(auto r, column_zone_map.load(opts, index_meta.zone_map_index()));
         ASSERT_TRUE(r);
@@ -150,11 +152,13 @@ TEST_F(ColumnZoneMapTest, NormalTestIntPage) {
     }
 
     IndexReadOptions opts;
-    opts.fs = _fs.get();
-    opts.file_name = filename;
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(filename))
+    opts.read_file = rfile.get();
     opts.use_page_cache = true;
     opts.kept_in_memory = false;
-    opts.skip_fill_local_cache = false;
+    opts.skip_fill_data_cache = false;
+    OlapReaderStatistics stats;
+    opts.stats = &stats;
     ZoneMapIndexReader column_zone_map;
     ASSIGN_OR_ABORT(auto r, column_zone_map.load(opts, index_meta.zone_map_index()));
     ASSERT_TRUE(r);


### PR DESCRIPTION
currently, each index of each column will create a new file to read, which is not friendly to cloud native table.

Use one RandomAccessFile to read the index and data of a column, the benefits are as follows:
1. the indexes of each column of cloud native table may be combined read, and the remote io count will be reduced.
2. collect index read io statistics can be more easily.

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
