### PR TITLE
[BugFix] make parser error message more clear

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/SqlParser.java
@@ -42,6 +42,7 @@ import org.apache.commons.text.similarity.JaroWinklerDistance;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -241,22 +242,23 @@ public class SqlParser {
                         }
                     }
                 }
-                String upperToken = StringUtils.upperCase(token);
-                Collections.sort(words, Comparator.comparingDouble(s -> jaroWinklerDistance.apply(s, upperToken)));
-                int limit = Math.min(5, words.size());
-                result.addAll(words.subList(0, limit));
-                result.addAll(symbols);
+
                 // if there exists an expect word in nonReserved words, there should be a legal identifier.
-                if (result.contains("'ACCESS'")) {
-                    result.clear();
+                if (words.contains("'ACCESS'")) {
                     result.add("a legal identifier");
+                } else {
+                    String upperToken = StringUtils.upperCase(token);
+                    Collections.sort(words, Comparator.comparingDouble(s -> jaroWinklerDistance.apply(s, upperToken)));
+                    int limit = Math.min(5, words.size());
+                    result.addAll(words.subList(0, limit));
+                    result.addAll(symbols);
                 }
 
                 result.forEach(joiner::add);
                 return joiner.toString();
             }
 
-            private void addToken(Vocabulary vocabulary, int a, List<String> symbols, List<String> words) {
+            private void addToken(Vocabulary vocabulary, int a, Collection<String> symbols, Collection<String> words) {
                 if (a == Token.EOF) {
                     symbols.add(EOF);
                 } else if (a == Token.EPSILON) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -393,6 +393,8 @@ class ParserTest {
                 "PROPERTIES (\n" +
                 " \"replication_num\" = \"1\"\n" +
                 ");", "the most similar input is {<EOF>, ';'}"));
+        arguments.add(Arguments.of("create MATERIALIZED VIEW  as select * from (t1 join t2);",
+                "the most similar input is {a legal identifier}."));
         return arguments.stream();
     }
 


### PR DESCRIPTION
Fixes #issue
before
```
# expect a view name after VIEW token
mysql> create MATERIALIZED VIEW  as select * from (t1 join t2);
ERROR 1064 (HY000): Getting syntax error at line 1, column 26. Detail message: Unexpected input 'as', the most similar input is {'BASE', 'CAST', 'HASH', 'LAST', 'TASK', '...'}.
mysql>
```
after
```
mysql> create MATERIALIZED VIEW  as select * from (t1 join t2);
ERROR 1064 (HY000): Getting syntax error at line 1, column 26. Detail message: Unexpected input 'as', the most similar input is {a legal identifier}.
mysql>
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
