### PR TITLE
[Refactor] extract WorkerProvider from Coordinator

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -242,6 +242,14 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.2</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-api</artifactId>

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.catalog;
 
 import com.google.common.collect.ImmutableSet;
@@ -21,6 +20,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TQueryType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.net.util.SubnetUtils;
 
@@ -217,6 +217,12 @@ public class ResourceGroupClassifier implements Writable {
         SCHEMA_CHANGE,
         CLONE,
         MV,
-        SYSTEM_OTHER
+        SYSTEM_OTHER;
+
+        public static QueryType fromTQueryType(TQueryType type) {
+            return type == TQueryType.LOAD
+                    ? ResourceGroupClassifier.QueryType.INSERT
+                    : ResourceGroupClassifier.QueryType.SELECT;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Status.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Status.java
@@ -105,7 +105,7 @@ public class Status {
         this.errorMsg = status.getErrorMsg();
     }
 
-    public void setStatus(String msg) {
+    public void setInternalErrorStatus(String msg) {
         this.errorCode = TStatusCode.INTERNAL_ERROR;
         this.errorMsg = msg;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MultiCastPlanFragment.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.planner;
 
 import com.google.common.base.Preconditions;
@@ -103,4 +102,9 @@ public class MultiCastPlanFragment extends PlanFragment {
         Preconditions.checkState(false);
     }
 
+    @Override
+    public void reset() {
+        MultiCastDataSink multiSink = (MultiCastDataSink) getSink();
+        multiSink.getDestinations().forEach(List::clear);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -56,6 +56,8 @@ import org.apache.commons.collections.CollectionUtils;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -671,5 +673,26 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         }
 
         return olapScanNodes;
+    }
+
+    public boolean isUnionFragment() {
+        Deque<PlanNode> dq = new LinkedList<>();
+        dq.offer(planRoot);
+
+        while (!dq.isEmpty()) {
+            PlanNode nd = dq.poll();
+
+            if (nd instanceof UnionNode) {
+                return true;
+            }
+            if (!(nd instanceof ExchangeNode)) {
+                dq.addAll(nd.getChildren());
+            }
+        }
+        return false;
+    }
+
+    public void reset() {
+        // Do nothing.
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.qe;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.InternalCatalog;
@@ -458,7 +459,7 @@ public class ConnectContext {
     }
 
     public void setErrorCodeOnce(String errorCode) {
-        if (this.errorCode == null || this.errorCode.isEmpty()) {
+        if (Strings.isNullOrEmpty(this.errorCode)) {
             this.errorCode = errorCode;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -238,7 +238,6 @@ public class Coordinator {
         this.fragments = null;
     }
 
-
     // Used for new planner
     public Coordinator(ConnectContext context, List<PlanFragment> fragments, List<ScanNode> scanNodes,
                        TDescriptorTable descTable) {
@@ -430,7 +429,7 @@ public class Coordinator {
     }
 
     public List<String> getRejectedRecordPaths() {
-        return rejectedRecordPaths.stream().collect(Collectors.toList());
+        return new ArrayList<>(rejectedRecordPaths);
     }
 
     public long getStartTime() {
@@ -445,8 +444,8 @@ public class Coordinator {
         this.queryOptions.setLoad_mem_limit(loadMemLimit);
     }
 
-    public void setTimeout(int timeout) {
-        this.queryOptions.setQuery_timeout(timeout);
+    public void setTimeout(int timeoutSecond) {
+        this.queryOptions.setQuery_timeout(timeoutSecond);
     }
 
     public void addReplicateScanId(Integer scanId) {
@@ -485,7 +484,7 @@ public class Coordinator {
     }
 
     public boolean isUsingBackend(Long backendID) {
-        return coordinatorPreprocessor.getUsedBackendIDs().contains(backendID);
+        return coordinatorPreprocessor.getWorkerProvider().isUsingWorker(backendID);
     }
 
     private void lock() {
@@ -582,9 +581,10 @@ public class Coordinator {
                 coordinatorPreprocessor.getFragmentExecParamsMap().get(topId);
         if (topParams.fragment.getSink() instanceof ResultSink) {
             TNetworkAddress execBeAddr = topParams.instanceExecParams.get(0).host;
+
             receiver = new ResultReceiver(
                     topParams.instanceExecParams.get(0).instanceId,
-                    coordinatorPreprocessor.getAddressToBackendID().get(execBeAddr),
+                    coordinatorPreprocessor.getWorkerProvider().getUsingWorkerByAddr(execBeAddr).getId(),
                     SystemInfoService.toBrpcHost(execBeAddr),
                     queryOptions.query_timeout * 1000);
 
@@ -610,12 +610,12 @@ public class Coordinator {
             this.queryOptions.setEnable_profile(true);
             deltaUrls = Lists.newArrayList();
             loadCounters = Maps.newHashMap();
-            List<Long> relatedBackendIds = Lists.newArrayList(coordinatorPreprocessor.getAddressToBackendID().values());
+            List<Long> relatedBackendIds = coordinatorPreprocessor.getWorkerProvider().getUsingWorkerIDs();
             GlobalStateMgr.getCurrentState().getLoadMgr()
                     .initJobProgress(jobId, queryId, coordinatorPreprocessor.getInstanceIds(),
                             relatedBackendIds);
             LOG.info("dispatch load job: {} to {}", DebugUtil.printId(queryId),
-                    coordinatorPreprocessor.getAddressToBackendID().keySet());
+                    coordinatorPreprocessor.getWorkerProvider().getUsingWorkerAddrs());
         }
     }
 
@@ -759,7 +759,8 @@ public class Coordinator {
                         // TODO: pool of pre-formatted BackendExecStates?
                         TNetworkAddress host = instanceId2Host.get(tParam.params.fragment_instance_id);
                         BackendExecState execState = new BackendExecState(fragment.getFragmentId(), host,
-                                profileFragmentId, tParam, coordinatorPreprocessor.getAddressToBackendID());
+                                profileFragmentId, tParam,
+                                coordinatorPreprocessor.getWorkerProvider().getUsingWorkerByAddr(host));
                         backendExecStates.put(tParam.backend_num, execState);
                         if (needCheckBackendState) {
                             needCheckBackendExecStates.add(execState);
@@ -800,7 +801,7 @@ public class Coordinator {
                             if (errMsg == null) {
                                 errMsg = "exec rpc error. backend id: " + pair.first.backend.getId();
                             }
-                            queryStatus.setStatus(errMsg + " backend:" + pair.first.address.hostname);
+                            queryStatus.setInternalErrorStatus(errMsg + " backend:" + pair.first.address.hostname);
                             LOG.warn("exec plan fragment failed, errmsg={}, code: {}, fragmentId={}, backend={}:{}",
                                     errMsg, code, fragment.getFragmentId(),
                                     pair.first.address.hostname, pair.first.address.port);
@@ -972,7 +973,6 @@ public class Coordinator {
                     Map<TNetworkAddress, List<CoordinatorPreprocessor.FInstanceExecParam>> requestsPerHost =
                             params.instanceExecParams.stream()
                                     .collect(Collectors.groupingBy(CoordinatorPreprocessor.FInstanceExecParam::getHost,
-                                            HashMap::new,
                                             Collectors.mapping(Function.identity(), Collectors.toList())));
                     // if pipeline is enable and current fragment contain olap table sink, in fe we will 
                     // calculate the number of all tablet sinks in advance and assign them to each fragment instance
@@ -1058,7 +1058,7 @@ public class Coordinator {
                             // TODO: pool of pre-formatted BackendExecStates?
                             BackendExecState execState = new BackendExecState(fragment.getFragmentId(), host,
                                     profileFragmentId, tCommonParams, tUniquePrams,
-                                    coordinatorPreprocessor.getAddressToBackendID());
+                                    coordinatorPreprocessor.getWorkerProvider().getUsingWorkerByAddr(host));
                             execStates.add(execState);
                             backendExecStates.put(tUniquePrams.backend_num, execState);
                             if (needCheckBackendState) {
@@ -1119,7 +1119,7 @@ public class Coordinator {
                             if (errMsg == null) {
                                 errMsg = "exec rpc error. backend id: " + pair.first.backend.getId();
                             }
-                            queryStatus.setStatus(errMsg + " backend:" + pair.first.address.hostname);
+                            queryStatus.setInternalErrorStatus(errMsg + " backend:" + pair.first.address.hostname);
                             LOG.warn("exec plan fragment failed, errmsg={}, code: {}, fragmentId={}, backend={}:{}",
                                     errMsg, code, pair.first.fragmentId,
                                     pair.first.address.hostname, pair.first.address.port);
@@ -1324,10 +1324,10 @@ public class Coordinator {
                 numLoadBytesTotal += Long.parseLong(value);
             }
 
-            this.loadCounters.put(LoadEtlTask.DPP_NORMAL_ALL, "" + numRowsNormal);
-            this.loadCounters.put(LoadEtlTask.DPP_ABNORMAL_ALL, "" + numRowsAbnormal);
-            this.loadCounters.put(LoadJob.UNSELECTED_ROWS, "" + numRowsUnselected);
-            this.loadCounters.put(LoadJob.LOADED_BYTES, "" + numLoadBytesTotal);
+            this.loadCounters.put(LoadEtlTask.DPP_NORMAL_ALL, String.valueOf(numRowsNormal));
+            this.loadCounters.put(LoadEtlTask.DPP_ABNORMAL_ALL, String.valueOf(numRowsAbnormal));
+            this.loadCounters.put(LoadJob.UNSELECTED_ROWS, String.valueOf(numRowsUnselected));
+            this.loadCounters.put(LoadJob.LOADED_BYTES, String.valueOf(numLoadBytesTotal));
         } finally {
             lock.unlock();
         }
@@ -1449,7 +1449,7 @@ public class Coordinator {
     // Cancel execution of query. This includes the execution of the local plan
     // fragment,
     // if any, as well as all plan fragments on remote nodes.
-    public void cancel(PPlanFragmentCancelReason cancelReason, String cancelledMessage) {
+    public void cancel(PPlanFragmentCancelReason reason, String message) {
         lock();
         try {
             if (!queryStatus.ok()) {
@@ -1457,18 +1457,19 @@ public class Coordinator {
                 return;
             } else {
                 queryStatus.setStatus(Status.CANCELLED);
-                queryStatus.setErrorMsg(cancelledMessage);
+                queryStatus.setErrorMsg(message);
             }
             LOG.warn("cancel execution of query, this is outside invoke");
-            cancelInternal(cancelReason);
+            cancelInternal(reason);
         } finally {
             try {
                 // when enable_profile is true, it disable count down profileDoneSignal for collect all backend's profile
                 // but if backend has crashed, we need count down profileDoneSignal since it will not report by itself
                 if (connectContext.getSessionVariable().isEnableProfile() && profileDoneSignal != null
-                        && cancelledMessage.equals(FeConstants.BACKEND_NODE_NOT_FOUND_ERROR)) {
+                        && message.equals(FeConstants.BACKEND_NODE_NOT_FOUND_ERROR)) {
                     profileDoneSignal.countDownToZero(new Status());
-                    LOG.info("count down profileDoneSignal since backend has crashed, query id: {}", DebugUtil.printId(queryId));
+                    LOG.info("count down profileDoneSignal since backend has crashed, query id: {}",
+                            DebugUtil.printId(queryId));
                 }
             } finally {
                 unlock();
@@ -1874,7 +1875,7 @@ public class Coordinator {
         }
     }
 
-    /*
+    /**
      * Check the state of backends in needCheckBackendExecStates.
      * return true if all of them are OK. Otherwise, return false.
      */
@@ -1894,22 +1895,18 @@ public class Coordinator {
     }
 
     public boolean isEnableLoadProfile() {
-        if (connectContext != null && connectContext.getSessionVariable().isEnableLoadProfile()) {
-            return true;
-        }
-        return false;
+        return connectContext != null && connectContext.getSessionVariable().isEnableLoadProfile();
     }
 
     // consistent with EXPLAIN's fragment index
     public List<QueryStatisticsItem.FragmentInstanceInfo> getFragmentInstanceInfos() {
-        final List<QueryStatisticsItem.FragmentInstanceInfo> result =
-                Lists.newArrayList();
-        for (int index = 0; index < fragments.size(); index++) {
+        final List<QueryStatisticsItem.FragmentInstanceInfo> result = Lists.newArrayList();
+        for (PlanFragment fragment : fragments) {
             for (BackendExecState backendExecState : backendExecStates.values()) {
-                if (fragments.get(index).getFragmentId() != backendExecState.fragmentId) {
+                if (fragment.getFragmentId() != backendExecState.fragmentId) {
                     continue;
                 }
-                final QueryStatisticsItem.FragmentInstanceInfo info = backendExecState.buildFragmentInstanceInfo();
+                final FragmentInstanceInfo info = backendExecState.buildFragmentInstanceInfo();
                 result.add(info);
             }
         }
@@ -1945,26 +1942,26 @@ public class Coordinator {
         int profileFragmentId;
         RuntimeProfile profile;
         TNetworkAddress address;
-        ComputeNode backend;
+        final ComputeNode backend;
         long lastMissingHeartbeatTime = -1;
-
 
         // fake backendExecState, only user for stream load profile
         public BackendExecState(TUniqueId fragmentInstanceId, TNetworkAddress address) {
             String name = "Instance " + DebugUtil.printId(fragmentInstanceId);
             this.profile = new RuntimeProfile(name);
             this.profile.addInfoString("Address", String.format("%s:%s", address.hostname, address.port));
+            this.backend = null;
         }
 
         public BackendExecState(PlanFragmentId fragmentId, TNetworkAddress host, int profileFragmentId,
                                 TExecPlanFragmentParams rpcParams,
-                                Map<TNetworkAddress, Long> addressToBackendID) {
-            this(fragmentId, host, profileFragmentId, rpcParams, rpcParams, addressToBackendID);
+                                ComputeNode backend) {
+            this(fragmentId, host, profileFragmentId, rpcParams, rpcParams, backend);
         }
 
         public BackendExecState(PlanFragmentId fragmentId, TNetworkAddress host, int profileFragmentId,
                                 TExecPlanFragmentParams commonRpcParams, TExecPlanFragmentParams uniqueRpcParams,
-                                Map<TNetworkAddress, Long> addressToBackendID) {
+                                ComputeNode backend) {
             this.profileFragmentId = profileFragmentId;
             this.fragmentId = fragmentId;
             this.commonRpcParams = commonRpcParams;
@@ -1972,10 +1969,7 @@ public class Coordinator {
             this.initiated = false;
             this.done = false;
             this.address = host;
-
-            // if useComputeNode and it's olapScan now, backend is null ,need get from olapScanNodeIdToComputeNode
-            this.backend = GlobalStateMgr.getCurrentSystemInfo().getBackendOrComputeNode(addressToBackendID.get(address));
-
+            this.backend = backend;
             String name =
                     "Instance " + DebugUtil.printId(uniqueRpcParams.params.fragment_instance_id) + " (host=" + address +
                             ")";
@@ -2034,7 +2028,8 @@ public class Coordinator {
                 } catch (RpcException e) {
                     LOG.warn("cancel plan fragment get a exception, address={}:{}", brpcAddress.getHostname(),
                             brpcAddress.getPort());
-                    SimpleScheduler.addToBlacklist(coordinatorPreprocessor.getAddressToBackendID().get(brpcAddress));
+                    SimpleScheduler.addToBlacklist(
+                            coordinatorPreprocessor.getWorkerProvider().getUsingWorkerByAddr(brpcAddress).getId());
                 }
 
                 this.hasCanceled = true;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -51,6 +51,7 @@ import com.starrocks.planner.ResultSink;
 import com.starrocks.planner.RuntimeFilterDescription;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.planner.SchemaScanNode;
+import com.starrocks.qe.scheduler.DefaultWorkerProvider;
 import com.starrocks.qe.scheduler.WorkerProvider;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
@@ -142,6 +143,7 @@ public class CoordinatorPreprocessor {
     private final Map<Integer, TNetworkAddress> channelIdToBEHTTP = Maps.newHashMap();
     private final Map<Integer, TNetworkAddress> channelIdToBEPort = Maps.newHashMap();
 
+    private final WorkerProvider.Factory workerProviderFactory = new DefaultWorkerProvider.Factory();
     private WorkerProvider workerProvider;
 
     // Resource group
@@ -160,7 +162,7 @@ public class CoordinatorPreprocessor {
         this.usePipeline = canUsePipeline(this.connectContext, this.fragments);
 
         SessionVariable sessionVariable = connectContext.getSessionVariable();
-        this.workerProvider = WorkerProvider.captureAvailableWorkers(GlobalStateMgr.getCurrentSystemInfo(),
+        this.workerProvider = workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentSystemInfo(),
                 sessionVariable.isPreferComputeNode(), sessionVariable.getUseComputeNodes());
     }
 
@@ -177,7 +179,7 @@ public class CoordinatorPreprocessor {
         this.fragments = fragments;
 
         SessionVariable sessionVariable = connectContext.getSessionVariable();
-        this.workerProvider = WorkerProvider.captureAvailableWorkers(GlobalStateMgr.getCurrentSystemInfo(),
+        this.workerProvider = workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentSystemInfo(),
                 sessionVariable.isPreferComputeNode(), sessionVariable.getUseComputeNodes());
 
         Map<PlanFragmentId, PlanFragment> fragmentMap =
@@ -326,7 +328,7 @@ public class CoordinatorPreprocessor {
      */
     private void resetExec() {
         SessionVariable sessionVariable = connectContext.getSessionVariable();
-        workerProvider = WorkerProvider.captureAvailableWorkers(GlobalStateMgr.getCurrentSystemInfo(),
+        workerProvider = workerProviderFactory.captureAvailableWorkers(GlobalStateMgr.getCurrentSystemInfo(),
                 sessionVariable.isPreferComputeNode(), sessionVariable.getUseComputeNodes());
 
         fragments.forEach(PlanFragment::reset);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -287,7 +287,7 @@ public class CoordinatorPreprocessor {
     }
 
     public TNetworkAddress getBrpcAddress(TNetworkAddress beAddress) {
-        return workerProvider.getUsingWorkerByAddr(beAddress).getBrpcAddress();
+        return workerProvider.getUsedWorkerByBeAddr(beAddress).getBrpcAddress();
     }
 
     public WorkerProvider getWorkerProvider() {
@@ -612,7 +612,7 @@ public class CoordinatorPreprocessor {
                             if (this.queryOptions.getLoad_job_type() == TLoadJobType.STREAM_LOAD) {
                                 for (TScanRangeParams scanRange : scanRangeParams) {
                                     int channelId = scanRange.scan_range.broker_scan_range.channel_id;
-                                    TNetworkAddress beHttpAddress = workerProvider.getUsingHttpAddrByAddr(key);
+                                    TNetworkAddress beHttpAddress = workerProvider.getUsedHttpAddrByBeAddr(key);
                                     channelIdToBEHTTP.put(channelId, beHttpAddress);
                                     channelIdToBEPort.put(channelId, key);
                                 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -1743,7 +1743,7 @@ public class CoordinatorPreprocessor {
                 Long minAssignedBytes = Long.MAX_VALUE;
                 TScanRangeLocation minLocation = null;
                 for (final TScanRangeLocation location : scanRangeLocations.getLocations()) {
-                    if (!workerProvider.containsBackend(location.getBackend_id())) {
+                    if (!workerProvider.isBackendAvailable(location.getBackend_id())) {
                         continue;
                     }
 
@@ -1925,7 +1925,7 @@ public class CoordinatorPreprocessor {
             int maxBucketNum = Integer.MAX_VALUE;
             long buckendId = Long.MAX_VALUE;
             for (TScanRangeLocation location : seqLocation.locations) {
-                if (!workerProvider.containsBackend(location.getBackend_id())) {
+                if (!workerProvider.isBackendAvailable(location.getBackend_id())) {
                     continue;
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/FragmentScanRangeAssignment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/FragmentScanRangeAssignment.java
@@ -17,7 +17,6 @@ package com.starrocks.qe;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TScanRangeParams;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -34,18 +33,18 @@ import java.util.Map;
  * records scan range assignment for a single fragment
  */
 class FragmentScanRangeAssignment extends
-        HashMap<TNetworkAddress, Map<Integer, List<TScanRangeParams>>> {
+        HashMap<Long, Map<Integer, List<TScanRangeParams>>> {
     public String toDebugString() {
         StringBuilder sb = new StringBuilder();
         sb.append("---------- FragmentScanRangeAssignment ----------\n");
-        for (TNetworkAddress addr : keySet()) {
-            Map<Integer, List<TScanRangeParams>> placement = get(addr);
+        for (Long workerId : keySet()) {
+            Map<Integer, List<TScanRangeParams>> placement = get(workerId);
             for (Integer scanNodeId : placement.keySet()) {
                 ArrayList<TScanRangeParams> scanRangeParams = new ArrayList<>(placement.get(scanNodeId));
                 Collections.sort(scanRangeParams);
                 TMemoryBuffer transport = new TMemoryBuffer(1024 * 1024);
                 TBinaryProtocol protocol = new TBinaryProtocol(transport);
-                String output = null;
+                String output;
                 try {
                     for (TScanRangeParams param : scanRangeParams) {
                         param.write(protocol);
@@ -56,9 +55,7 @@ class FragmentScanRangeAssignment extends
                 } catch (TException e) {
                     output = e.toString();
                 }
-                sb.append(
-                        String.format("Backend:%s, ScanNode:%s, Hash:%s\n", addr.toString(), scanNodeId.toString(),
-                                output));
+                sb.append(String.format("Backend:%s, ScanNode:%s, Hash:%s\n", workerId, scanNodeId.toString(), output));
 
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -16,7 +16,6 @@ package com.starrocks.qe;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
@@ -24,8 +23,6 @@ import com.google.common.hash.Funnel;
 import com.google.common.hash.Hashing;
 import com.google.common.hash.PrimitiveSink;
 import com.starrocks.catalog.PartitionKey;
-import com.starrocks.common.FeConstants;
-import com.starrocks.common.UserException;
 import com.starrocks.common.util.ConsistentHashRing;
 import com.starrocks.common.util.HashRing;
 import com.starrocks.common.util.RendezvousHashRing;
@@ -36,6 +33,7 @@ import com.starrocks.planner.HudiScanNode;
 import com.starrocks.planner.IcebergScanNode;
 import com.starrocks.planner.PaimonScanNode;
 import com.starrocks.planner.ScanNode;
+import com.starrocks.qe.scheduler.WorkerProvider;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.THdfsScanRange;
@@ -76,12 +74,9 @@ public class HDFSBackendSelector implements BackendSelector {
     private final ScanNode scanNode;
     private final List<TScanRangeLocations> locations;
     private final FragmentScanRangeAssignment assignment;
-    private final Set<Long> usedBackendIDs;
-    private final Map<TNetworkAddress, Long> addressToBackendId;
-    private final ImmutableCollection<ComputeNode> computeNodes;
-    private boolean forceScheduleLocal;
-    private boolean chooseComputeNode;
-    private boolean shuffleScanRange;
+    private final WorkerProvider workerProvider;
+    private final boolean forceScheduleLocal;
+    private final boolean shuffleScanRange;
     private final int kCandidateNumber = 3;
     private final int kMaxImbalanceRatio = 3;
     private final int kMaxNodeSizeUseRendezvousHashRing = 64;
@@ -140,20 +135,17 @@ public class HDFSBackendSelector implements BackendSelector {
         }
     }
 
-    private HdfsScanRangeHasher hdfsScanRangeHasher;
+    private final HdfsScanRangeHasher hdfsScanRangeHasher;
 
     public HDFSBackendSelector(ScanNode scanNode, List<TScanRangeLocations> locations,
-                               FragmentScanRangeAssignment assignment, Map<TNetworkAddress, Long> addressToBackendId,
-                               Set<Long> usedBackendIDs, ImmutableCollection<ComputeNode> computeNodes,
-                               boolean chooseComputeNode, boolean forceScheduleLocal, boolean shuffleScanRange) {
+                               FragmentScanRangeAssignment assignment, WorkerProvider workerProvider,
+                               boolean forceScheduleLocal,
+                               boolean shuffleScanRange) {
         this.scanNode = scanNode;
         this.locations = locations;
         this.assignment = assignment;
-        this.computeNodes = computeNodes;
-        this.chooseComputeNode = chooseComputeNode;
+        this.workerProvider = workerProvider;
         this.forceScheduleLocal = forceScheduleLocal;
-        this.addressToBackendId = addressToBackendId;
-        this.usedBackendIDs = usedBackendIDs;
         this.hdfsScanRangeHasher = new HdfsScanRangeHasher();
         this.shuffleScanRange = shuffleScanRange;
     }
@@ -231,16 +223,9 @@ public class HDFSBackendSelector implements BackendSelector {
         long avgScanRangeBytes = computeAverageScanRangeBytes();
         long maxImbalanceBytes = avgScanRangeBytes * kMaxImbalanceRatio;
 
-        // exclude non-alive or in-blacklist compute nodes.
-        for (ComputeNode computeNode : computeNodes) {
-            if (!computeNode.isAlive() || SimpleScheduler.isInBlacklist(computeNode.getId())) {
-                continue;
-            }
+        for (ComputeNode computeNode : workerProvider.getWorkersPreferringComputeNode()) {
             assignedScansPerComputeNode.put(computeNode, 0L);
             hostToBackends.put(computeNode.getHost(), computeNode);
-        }
-        if (hostToBackends.isEmpty()) {
-            throw new UserException(FeConstants.getNodeNotFoundError(chooseComputeNode));
         }
 
         // schedule scan ranges to co-located backends.
@@ -290,9 +275,8 @@ public class HDFSBackendSelector implements BackendSelector {
     }
 
     private void recordScanRangeAssignment(ComputeNode node, TScanRangeLocations scanRangeLocations) {
-        TNetworkAddress address = new TNetworkAddress(node.getHost(), node.getBePort());
-        usedBackendIDs.add(node.getId());
-        addressToBackendId.put(address, node.getId());
+        TNetworkAddress address = node.getAddress();
+        workerProvider.recordUsedWorker(node.getId(), address);
 
         // update statistic
         long addedScans = scanRangeLocations.scan_range.hdfs_scan_range.length;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -223,7 +223,7 @@ public class HDFSBackendSelector implements BackendSelector {
         long avgScanRangeBytes = computeAverageScanRangeBytes();
         long maxImbalanceBytes = avgScanRangeBytes * kMaxImbalanceRatio;
 
-        for (ComputeNode computeNode : workerProvider.getWorkersPreferringComputeNode()) {
+        for (ComputeNode computeNode : workerProvider.getWorkers()) {
             assignedScansPerComputeNode.put(computeNode, 0L);
             hostToBackends.put(computeNode.getHost(), computeNode);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
@@ -148,7 +148,7 @@ public class ResultReceiver {
             }
         } catch (TimeoutException e) {
             LOG.warn("fetch result timeout, finstId={}", DebugUtil.printId(finstId), e);
-            status.setStatus(String.format("Query exceeded time limit of %d seconds",
+            status.setInternalErrorStatus(String.format("Query exceeded time limit of %d seconds",
                     ConnectContext.get().getSessionVariable().getQueryTimeoutS()));
             if (MetricRepo.isInit) {
                 MetricRepo.COUNTER_QUERY_TIMEOUT.increase(1L);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -299,7 +299,8 @@ public class StmtExecutor {
         profile = buildTopLevelProfile();
         if (coord != null) {
             if (coord.getQueryProfile() != null) {
-                coord.getQueryProfile().getCounterTotalTime().setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
+                coord.getQueryProfile().getCounterTotalTime()
+                        .setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
                 coord.endProfile();
                 profile.addChild(coord.buildMergedQueryProfile(getQueryStatisticsForAuditLog()));
             }
@@ -525,7 +526,8 @@ public class StmtExecutor {
                         // When enable_collect_query_detail_info is set to true, the plan will be recorded in the query detail,
                         // and hence there is no need to log it here.
                         if (i == 0 && context.getQueryDetail() == null && Config.log_plan_cancelled_by_crash_be) {
-                            LOG.warn("Query cancelled by crash of backends or RpcException, [QueryId={}] [SQL={}] [Plan={}]",
+                            LOG.warn(
+                                    "Query cancelled by crash of backends or RpcException, [QueryId={}] [SQL={}] [Plan={}]",
                                     DebugUtil.printId(context.getExecutionId()),
                                     originStmt == null ? "" : originStmt.originStmt,
                                     execPlan.getExplainString(TExplainLevel.COSTS),
@@ -1547,7 +1549,7 @@ public class StmtExecutor {
                 }
             }
 
-            TLoadJobType type = null;
+            TLoadJobType type;
             if (containOlapScanNode) {
                 coord.setLoadJobType(TLoadJobType.INSERT_QUERY);
                 type = TLoadJobType.INSERT_QUERY;
@@ -1638,7 +1640,8 @@ public class StmtExecutor {
                                 externalTable.getSourceTableDbId(), transactionId,
                                 externalTable.getSourceTableHost(),
                                 externalTable.getSourceTablePort(),
-                                TransactionCommitFailedException.FILTER_DATA_IN_STRICT_MODE + ", tracking sql = " + trackingSql
+                                TransactionCommitFailedException.FILTER_DATA_IN_STRICT_MODE + ", tracking sql = " +
+                                        trackingSql
                         );
                     } else if (targetTable instanceof SystemTable || targetTable instanceof IcebergTable) {
                         // schema table does not need txn
@@ -1646,7 +1649,8 @@ public class StmtExecutor {
                         GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(
                                 database.getId(),
                                 transactionId,
-                                TransactionCommitFailedException.FILTER_DATA_IN_STRICT_MODE + ", tracking sql = " + trackingSql,
+                                TransactionCommitFailedException.FILTER_DATA_IN_STRICT_MODE + ", tracking sql = " +
+                                        trackingSql,
                                 TabletFailInfo.fromThrift(coord.getFailInfos())
                         );
                     }
@@ -1856,7 +1860,7 @@ public class StmtExecutor {
             } while (!batch.isEos());
         } catch (Exception e) {
             LOG.warn(e);
-            coord.getExecStatus().setStatus(e.getMessage());
+            coord.getExecStatus().setInternalErrorStatus(e.getMessage());
         } finally {
             QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -1,0 +1,353 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Reference;
+import com.starrocks.qe.SimpleScheduler;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TNetworkAddress;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntSupplier;
+import java.util.stream.Collectors;
+
+public class DefaultWorkerProvider implements WorkerProvider {
+    private static final Logger LOG = LogManager.getLogger(DefaultWorkerProvider.class);
+    private static final AtomicInteger NEXT_COMPUTE_NODE_INDEX = new AtomicInteger(0);
+    private static final AtomicInteger NEXT_BACKEND_INDEX = new AtomicInteger(0);
+
+    /**
+     * All the backend nodes, including those that are not alive or in blacklist.
+     */
+    private final ImmutableMap<Long, ComputeNode> id2Backend;
+    /**
+     * All the compute nodes, including those that are not alive or in blacklist.
+     */
+    private final ImmutableMap<Long, ComputeNode> id2ComputeNode;
+    /**
+     * The available backend nodes, which are alive and not in the blacklist.
+     */
+    private final ImmutableMap<Long, ComputeNode> availableID2Backend;
+    /**
+     * The available compute nodes, which are alive and not in the blacklist.
+     */
+    private final ImmutableMap<Long, ComputeNode> availableID2ComputeNode;
+
+    /**
+     * These three members record the workers used by the related job.
+     * They are updated when calling {@code chooseXXX} methods.
+     */
+    private final Set<Long> usedWorkerIDs;
+    private final Map<TNetworkAddress, ComputeNode> beAddr2UsedWorker;
+    /**
+     * Used only by channel stream load, recording the mapping from BE port to BE's HTTP port.
+     */
+    private final Map<TNetworkAddress, TNetworkAddress> beAddr2HttpAddr;
+
+    /**
+     * Indicates whether there are available compute nodes.
+     */
+    private final boolean hasComputeNode;
+    /**
+     * Indicates whether compute nodes should be used for non-HDFS operators.
+     * The HDFS operator always prefers to use compute nodes even if {@code usedComputeNode} is false.
+     */
+    private final boolean usedComputeNode;
+
+    public static class Factory implements WorkerProvider.Factory {
+        @Override
+        public DefaultWorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
+                                                             boolean preferComputeNode,
+                                                             int numUsedComputeNodes) {
+
+            ImmutableMap<Long, ComputeNode> idToComputeNode =
+                    buildComputeNodeInfo(systemInfoService, numUsedComputeNodes);
+            ImmutableMap<Long, ComputeNode> idToBackend;
+            if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+                idToBackend = idToComputeNode;
+            } else {
+                idToBackend = ImmutableMap.copyOf(systemInfoService.getIdToBackend());
+            }
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("idToBackend size={}", idToBackend.size());
+                for (Map.Entry<Long, ComputeNode> entry : idToBackend.entrySet()) {
+                    Long backendID = entry.getKey();
+                    ComputeNode backend = entry.getValue();
+                    LOG.debug("backend: {}-{}-{}", backendID, backend.getHost(), backend.getBePort());
+                }
+
+                LOG.debug("idToComputeNode: {}", idToComputeNode);
+            }
+
+            // Backends and compute nodes are identical in the SHARED_DATA mode.
+            preferComputeNode = preferComputeNode || RunMode.getCurrentRunMode() == RunMode.SHARED_DATA;
+
+            return new DefaultWorkerProvider(idToBackend, idToComputeNode,
+                    filterAvailableWorkers(idToBackend), filterAvailableWorkers(idToComputeNode),
+                    preferComputeNode);
+        }
+    }
+
+    @VisibleForTesting
+    public DefaultWorkerProvider(ImmutableMap<Long, ComputeNode> id2Backend,
+                                 ImmutableMap<Long, ComputeNode> id2ComputeNode,
+                                 ImmutableMap<Long, ComputeNode> availableID2Backend,
+                                 ImmutableMap<Long, ComputeNode> availableID2ComputeNode,
+                                 boolean preferComputeNode) {
+        this.id2Backend = id2Backend;
+        this.id2ComputeNode = id2ComputeNode;
+
+        this.availableID2Backend = availableID2Backend;
+        this.availableID2ComputeNode = availableID2ComputeNode;
+
+        this.usedWorkerIDs = Sets.newConcurrentHashSet();
+        this.beAddr2UsedWorker = Maps.newHashMap();
+        this.beAddr2HttpAddr = Maps.newHashMap();
+
+        this.hasComputeNode = MapUtils.isNotEmpty(availableID2ComputeNode);
+        this.usedComputeNode = hasComputeNode && preferComputeNode;
+    }
+
+    @Override
+    public TNetworkAddress chooseBackend(Long backendID) throws SchedulerException {
+        ComputeNode backend = getBackend(backendID);
+
+        if (backend == null) {
+            reportBackendNotFoundException();
+        }
+        Preconditions.checkNotNull(backend);
+
+        TNetworkAddress addr = backend.getAddress();
+        recordUsedWorker(backend.getId(), addr);
+        return addr;
+    }
+
+    @Override
+    public TNetworkAddress chooseNextWorker(Reference<Long> workerIdRef) throws SchedulerException {
+        ComputeNode worker;
+        if (usedComputeNode) {
+            worker = getNextWorker(availableID2ComputeNode, DefaultWorkerProvider::getNextComputeNodeIndex);
+        } else {
+            worker = getNextWorker(availableID2Backend, DefaultWorkerProvider::getNextBackendIndex);
+        }
+
+        if (worker == null) {
+            reportWorkerNotFoundException();
+        }
+        Preconditions.checkNotNull(worker);
+
+        TNetworkAddress addr = worker.getAddress();
+        recordUsedWorker(worker.getId(), addr);
+        workerIdRef.setRef(worker.getId());
+        return addr;
+    }
+
+    @Override
+    public List<TNetworkAddress> chooseAllComputedNodes() {
+        if (!usedComputeNode) {
+            return Collections.emptyList();
+        }
+
+        List<TNetworkAddress> addrs = new ArrayList<>(availableID2ComputeNode.size());
+        for (ComputeNode computeNode : availableID2ComputeNode.values()) {
+            TNetworkAddress addr = computeNode.getAddress();
+            recordUsedWorker(computeNode.getId(), addr);
+            addrs.add(addr);
+        }
+
+        return addrs;
+    }
+
+    @Override
+    public Collection<ComputeNode> getWorkers() {
+        if (hasComputeNode) {
+            return availableID2ComputeNode.values();
+        } else {
+            return ImmutableList.copyOf(availableID2Backend.values());
+        }
+    }
+
+    @Override
+    public boolean isBackendAvailable(Long backendID) {
+        return getBackend(backendID) != null;
+    }
+
+    @Override
+    public void reportBackendNotFoundException() throws SchedulerException {
+        reportWorkerNotFoundException(false);
+    }
+
+    @Override
+    public void reportWorkerNotFoundException() throws SchedulerException {
+        reportWorkerNotFoundException(usedComputeNode);
+    }
+
+    @Override
+    public void recordUsedWorker(Long workerID, TNetworkAddress beAddr) {
+        if (usedWorkerIDs.add(workerID)) {
+            ComputeNode worker = getWorker(workerID);
+            beAddr2UsedWorker.put(beAddr, worker);
+            beAddr2HttpAddr.put(beAddr, worker.getHttpAddress());
+        }
+    }
+
+    @Override
+    public boolean isUsingWorker(Long workerID) {
+        return usedWorkerIDs.contains(workerID);
+    }
+
+    @Override
+    public ComputeNode getUsedWorkerByBeAddr(TNetworkAddress addr) {
+        ComputeNode worker = beAddr2UsedWorker.get(addr);
+        return Preconditions.checkNotNull(worker, "Expect backend address [{}] to being used", addr);
+    }
+
+    @Override
+    public TNetworkAddress getUsedHttpAddrByBeAddr(TNetworkAddress addr) {
+        TNetworkAddress httpAddr = beAddr2HttpAddr.get(addr);
+        return Preconditions.checkNotNull(httpAddr, "Expect backend address [{}] to being used", addr);
+    }
+
+    @Override
+    public List<Long> getUsedWorkerIDs() {
+        return new ArrayList<>(usedWorkerIDs);
+    }
+
+    @Override
+    public Collection<TNetworkAddress> getUsedWorkerBeAddrs() {
+        return beAddr2UsedWorker.keySet();
+    }
+
+    @Override
+    public String toString() {
+        return toString(usedComputeNode);
+    }
+
+    @VisibleForTesting
+    ComputeNode getBackend(Long backendID) {
+        return availableID2Backend.get(backendID);
+    }
+
+    @VisibleForTesting
+    ComputeNode getWorker(Long workerID) {
+        ComputeNode worker = availableID2Backend.get(workerID);
+        if (worker != null) {
+            return worker;
+        }
+        return availableID2ComputeNode.get(workerID);
+    }
+
+    private String toString(boolean chooseComputeNode) {
+        return chooseComputeNode ? computeNodesToString() : backendsToString();
+    }
+
+    private void reportWorkerNotFoundException(boolean chooseComputeNode) throws SchedulerException {
+        throw new SchedulerException(
+                FeConstants.getNodeNotFoundError(chooseComputeNode) + toString(chooseComputeNode));
+    }
+
+    private String computeNodesToString() {
+        StringBuilder out = new StringBuilder("compute node: ");
+        id2ComputeNode.forEach((backendID, backend) -> out.append(
+                String.format("[%s alive: %b inBlacklist: %b] ", backend.getHost(),
+                        backend.isAlive(), SimpleScheduler.isInBlacklist(backendID))));
+        return out.toString();
+    }
+
+    private String backendsToString() {
+        StringBuilder out = new StringBuilder("backend: ");
+        id2Backend.forEach((backendID, backend) -> out.append(
+                String.format("[%s alive: %b inBlacklist: %b] ", backend.getHost(),
+                        backend.isAlive(), SimpleScheduler.isInBlacklist(backendID))));
+        return out.toString();
+    }
+
+    @VisibleForTesting
+    static int getNextComputeNodeIndex() {
+        return NEXT_COMPUTE_NODE_INDEX.getAndIncrement();
+    }
+
+    @VisibleForTesting
+    static int getNextBackendIndex() {
+        return NEXT_BACKEND_INDEX.getAndIncrement();
+    }
+
+    private static ImmutableMap<Long, ComputeNode> buildComputeNodeInfo(SystemInfoService systemInfoService,
+                                                                        int numUsedComputeNodes) {
+        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+            return GlobalStateMgr.getCurrentWarehouseMgr().getComputeNodesFromWarehouse();
+        }
+
+        ImmutableMap<Long, ComputeNode> idToComputeNode
+                = ImmutableMap.copyOf(systemInfoService.getIdComputeNode());
+        if (numUsedComputeNodes <= 0 || numUsedComputeNodes >= idToComputeNode.size()) {
+            return idToComputeNode;
+        } else {
+            Map<Long, ComputeNode> computeNodes = new HashMap<>(numUsedComputeNodes);
+            for (int i = 0; i < idToComputeNode.size() && computeNodes.size() < numUsedComputeNodes; i++) {
+                ComputeNode computeNode =
+                        getNextWorker(idToComputeNode, DefaultWorkerProvider::getNextComputeNodeIndex);
+                Preconditions.checkNotNull(computeNode);
+                if (!isWorkerAvailable(computeNode)) {
+                    continue;
+                }
+                computeNodes.put(computeNode.getId(), computeNode);
+            }
+            return ImmutableMap.copyOf(computeNodes);
+        }
+    }
+
+    private static <C extends ComputeNode> C getNextWorker(ImmutableMap<Long, C> workers,
+                                                           IntSupplier getNextWorkerNodeIndex) {
+        if (workers.isEmpty()) {
+            return null;
+        }
+        int index = getNextWorkerNodeIndex.getAsInt() % workers.size();
+        return workers.values().asList().get(index);
+    }
+
+    private static boolean isWorkerAvailable(ComputeNode worker) {
+        return worker.isAlive() && !SimpleScheduler.isInBlacklist(worker.getId());
+    }
+
+    private static <C extends ComputeNode> ImmutableMap<Long, C> filterAvailableWorkers(ImmutableMap<Long, C> workers) {
+        return ImmutableMap.copyOf(
+                workers.entrySet().stream()
+                        .filter(entry -> isWorkerAvailable(entry.getValue()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+        );
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -275,7 +275,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
     }
 
     private void reportWorkerNotFoundException(boolean chooseComputeNode) throws SchedulerException {
-        throw new SchedulerException(
+        throw new NonRecoverableException(
                 FeConstants.getNodeNotFoundError(chooseComputeNode) + toString(chooseComputeNode));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/NonRecoverableException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/NonRecoverableException.java
@@ -1,0 +1,21 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+public class NonRecoverableException extends SchedulerException {
+    public NonRecoverableException(String msg) {
+        super(msg);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/RecoverableException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/RecoverableException.java
@@ -1,0 +1,21 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+public class RecoverableException extends SchedulerException {
+    public RecoverableException(String msg) {
+        super(msg);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/SchedulerException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/SchedulerException.java
@@ -1,0 +1,23 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.common.UserException;
+
+public class SchedulerException extends UserException {
+    public SchedulerException(String msg) {
+        super(msg);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
@@ -14,133 +14,26 @@
 
 package com.starrocks.qe.scheduler;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.Reference;
-import com.starrocks.common.UserException;
-import com.starrocks.qe.SimpleScheduler;
-import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.server.RunMode;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TNetworkAddress;
-import org.apache.commons.collections4.MapUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.IntSupplier;
-import java.util.stream.Collectors;
 
-public class WorkerProvider {
-    private static final Logger LOG = LogManager.getLogger(WorkerProvider.class);
-    private static final AtomicInteger NEXT_COMPUTE_NODE_INDEX = new AtomicInteger(0);
-    private static final AtomicInteger NEXT_BACKEND_INDEX = new AtomicInteger(0);
-
-    /**
-     * All the backend nodes, including those that are not alive or in blacklist.
-     */
-    private final ImmutableMap<Long, ComputeNode> id2Backend;
-    /**
-     * All the compute nodes, including those that are not alive or in blacklist.
-     */
-    private final ImmutableMap<Long, ComputeNode> id2ComputeNode;
-    /**
-     * The available backend nodes, which are alive and not in the blacklist.
-     */
-    private final ImmutableMap<Long, ComputeNode> availableID2Backend;
-    /**
-     * The available compute nodes, which are alive and not in the blacklist.
-     */
-    private final ImmutableMap<Long, ComputeNode> availableID2ComputeNode;
-
-    /**
-     * These three members record the workers used by the related job.
-     * They are updated when calling {@code chooseXXX} methods.
-     */
-    private final Set<Long> usedWorkerIDs;
-    private final Map<TNetworkAddress, ComputeNode> beAddr2UsedWorker;
-    /**
-     * Used only by channel stream load, recording the mapping from BE port to BE's HTTP port.
-     */
-    private final Map<TNetworkAddress, TNetworkAddress> beAddr2HttpAddr;
-
-    /**
-     * Indicates whether there are available compute nodes.
-     */
-    private final boolean hasComputeNode;
-    /**
-     * Indicates whether compute nodes should be used for non-HDFS operators.
-     * The HDFS operator always prefers to use compute nodes even if {@code usedComputeNode} is false.
-     */
-    private final boolean usedComputeNode;
-
-    @VisibleForTesting
-    public WorkerProvider(ImmutableMap<Long, ComputeNode> id2Backend, ImmutableMap<Long, ComputeNode> id2ComputeNode,
-                          ImmutableMap<Long, ComputeNode> availableID2Backend,
-                          ImmutableMap<Long, ComputeNode> availableID2ComputeNode,
-                          boolean preferComputeNode) {
-        this.id2Backend = id2Backend;
-        this.id2ComputeNode = id2ComputeNode;
-
-        this.availableID2Backend = availableID2Backend;
-        this.availableID2ComputeNode = availableID2ComputeNode;
-
-        this.usedWorkerIDs = Sets.newConcurrentHashSet();
-        this.beAddr2UsedWorker = Maps.newHashMap();
-        this.beAddr2HttpAddr = Maps.newHashMap();
-
-        this.hasComputeNode = MapUtils.isNotEmpty(availableID2ComputeNode);
-        this.usedComputeNode = hasComputeNode && preferComputeNode;
-    }
-
-    /**
-     * Capture the available workers from {@code systemInfoService}, which are alive and not in the blacklist.
-     *
-     * @param systemInfoService   The service which provides all the backend nodes and compute nodes.
-     * @param preferComputeNode   Whether to prefer using compute nodes over backend nodes.
-     * @param numUsedComputeNodes The maximum number of used compute nodes.
-     */
-    public static WorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
-                                                         boolean preferComputeNode,
-                                                         int numUsedComputeNodes) {
-        ImmutableMap<Long, ComputeNode> idToComputeNode = buildComputeNodeInfo(systemInfoService, numUsedComputeNodes);
-        ImmutableMap<Long, ComputeNode> idToBackend;
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
-            idToBackend = idToComputeNode;
-        } else {
-            idToBackend = ImmutableMap.copyOf(systemInfoService.getIdToBackend());
-        }
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("idToBackend size={}", idToBackend.size());
-            for (Map.Entry<Long, ComputeNode> entry : idToBackend.entrySet()) {
-                Long backendID = entry.getKey();
-                ComputeNode backend = entry.getValue();
-                LOG.debug("backend: {}-{}-{}", backendID, backend.getHost(), backend.getBePort());
-            }
-
-            LOG.debug("idToComputeNode: {}", idToComputeNode);
-        }
-
-        // Backends and compute nodes are identical in the SHARED_DATA mode.
-        preferComputeNode = preferComputeNode || RunMode.getCurrentRunMode() == RunMode.SHARED_DATA;
-
-        return new WorkerProvider(idToBackend, idToComputeNode,
-                filterAvailableWorkers(idToBackend), filterAvailableWorkers(idToComputeNode),
-                preferComputeNode);
+public interface WorkerProvider {
+    interface Factory {
+        /**
+         * Capture the available workers from {@code systemInfoService}, which are alive and not in the blacklist.
+         *
+         * @param systemInfoService   The service which provides all the backend nodes and compute nodes.
+         * @param preferComputeNode   Whether to prefer using compute nodes over backend nodes.
+         * @param numUsedComputeNodes The maximum number of used compute nodes.
+         */
+        WorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
+                                               boolean preferComputeNode,
+                                               int numUsedComputeNodes);
     }
 
     /**
@@ -148,205 +41,43 @@ public class WorkerProvider {
      *
      * @param backendID The ID of the backend node to choose.
      * @return The address with the {@code ComputeNode#bePort} of the backend node.
-     * @throws UserException if there is no available backend with {@code backendID}.
+     * @throws SchedulerException if there is no available backend with {@code backendID}.
      */
-    public TNetworkAddress chooseBackend(Long backendID) throws UserException {
-        ComputeNode backend = getBackend(backendID);
-        if (backend == null) {
-            reportWorkerNotFoundException(false);
-        }
-        TNetworkAddress addr = backend.getAddress();
-        recordUsedWorker(backend.getId(), addr);
-        return addr;
-    }
+    TNetworkAddress chooseBackend(Long backendID) throws SchedulerException;
 
     /**
      * Choose the next worker node.
      *
      * @param workerIdRef storing ID of the worker node to choose.
      * @return The address with the {@code ComputeNode#bePort} of the worker node.
-     * @throws UserException if there is no available backend with {@code backendID}.
+     * @throws SchedulerException if there is no available backend with {@code backendID}.
      */
-    public TNetworkAddress chooseNextWorker(Reference<Long> workerIdRef) throws UserException {
-        ComputeNode worker;
-        if (usedComputeNode) {
-            worker = getNextWorker(availableID2ComputeNode, WorkerProvider::getNextComputeNodeIndex);
-        } else {
-            worker = getNextWorker(availableID2Backend, WorkerProvider::getNextBackendIndex);
-        }
-
-        if (worker == null) {
-            reportWorkerNotFoundException(usedComputeNode);
-        }
-
-        TNetworkAddress addr = worker.getAddress();
-        recordUsedWorker(worker.getId(), addr);
-        workerIdRef.setRef(worker.getId());
-        return addr;
-    }
+    TNetworkAddress chooseNextWorker(Reference<Long> workerIdRef) throws SchedulerException;
 
     /**
      * Choose all the available compute nodes.
      *
      * @return The address with the {@code ComputeNode#bePort} of the compute nodes to choose.
      */
-    public List<TNetworkAddress> chooseAllComputedNodes() {
-        if (!usedComputeNode) {
-            return Collections.emptyList();
-        }
+    List<TNetworkAddress> chooseAllComputedNodes();
 
-        List<TNetworkAddress> addrs = new ArrayList<>(availableID2ComputeNode.size());
-        for (ComputeNode computeNode : availableID2ComputeNode.values()) {
-            TNetworkAddress addr = computeNode.getAddress();
-            recordUsedWorker(computeNode.getId(), addr);
-            addrs.add(addr);
-        }
+    Collection<ComputeNode> getWorkers();
 
-        return addrs;
-    }
+    boolean isBackendAvailable(Long backendID);
 
-    public Collection<ComputeNode> getWorkers() {
-        if (hasComputeNode) {
-            return availableID2ComputeNode.values();
-        } else {
-            return ImmutableList.copyOf(availableID2Backend.values());
-        }
-    }
+    void reportBackendNotFoundException() throws SchedulerException;
 
-    public boolean isBackendAvailable(Long backendID) {
-        return getBackend(backendID) != null;
-    }
+    void reportWorkerNotFoundException() throws SchedulerException;
 
-    public boolean isUsingWorker(Long workerID) {
-        return usedWorkerIDs.contains(workerID);
-    }
+    void recordUsedWorker(Long workerID, TNetworkAddress beAddr);
 
-    public ComputeNode getUsedWorkerByBeAddr(TNetworkAddress addr) {
-        ComputeNode worker = beAddr2UsedWorker.get(addr);
-        return Preconditions.checkNotNull(worker, "Expect backend address [{}] to being used", addr);
-    }
+    boolean isUsingWorker(Long workerID);
 
-    public TNetworkAddress getUsedHttpAddrByBeAddr(TNetworkAddress addr) {
-        TNetworkAddress httpAddr = beAddr2HttpAddr.get(addr);
-        return Preconditions.checkNotNull(httpAddr, "Expect backend address [{}] to being used", addr);
-    }
+    ComputeNode getUsedWorkerByBeAddr(TNetworkAddress addr);
 
-    public List<Long> getUsedWorkerIDs() {
-        return new ArrayList<>(usedWorkerIDs);
-    }
+    TNetworkAddress getUsedHttpAddrByBeAddr(TNetworkAddress addr);
 
-    public Collection<TNetworkAddress> getUsedWorkerBeAddrs() {
-        return beAddr2UsedWorker.keySet();
-    }
+    List<Long> getUsedWorkerIDs();
 
-    public void reportBackendNotFoundException() throws SchedulerException {
-        reportWorkerNotFoundException(false);
-    }
-
-    private void reportWorkerNotFoundException(boolean chooseComputeNode) throws SchedulerException {
-        throw new SchedulerException(
-                FeConstants.getNodeNotFoundError(chooseComputeNode) + toString(chooseComputeNode));
-    }
-
-    public void recordUsedWorker(Long workerID, TNetworkAddress beAddr) {
-        if (usedWorkerIDs.add(workerID)) {
-            ComputeNode worker = getWorker(workerID);
-            beAddr2UsedWorker.put(beAddr, worker);
-            beAddr2HttpAddr.put(beAddr, worker.getHttpAddress());
-        }
-    }
-
-    @Override
-    public String toString() {
-        return toString(usedComputeNode);
-    }
-
-    public String toString(boolean chooseComputeNode) {
-        return chooseComputeNode ? computeNodesToString() : backendsToString();
-    }
-
-    @VisibleForTesting
-    ComputeNode getBackend(Long backendID) {
-        return availableID2Backend.get(backendID);
-    }
-
-    @VisibleForTesting
-    ComputeNode getWorker(Long workerID) {
-        ComputeNode worker = availableID2Backend.get(workerID);
-        if (worker != null) {
-            return worker;
-        }
-        return availableID2ComputeNode.get(workerID);
-    }
-
-    private String computeNodesToString() {
-        StringBuilder out = new StringBuilder("compute node: ");
-        id2ComputeNode.forEach((backendID, backend) -> out.append(
-                String.format("[%s alive: %b inBlacklist: %b] ", backend.getHost(),
-                        backend.isAlive(), SimpleScheduler.isInBlacklist(backendID))));
-        return out.toString();
-    }
-
-    private String backendsToString() {
-        StringBuilder out = new StringBuilder("backend: ");
-        id2Backend.forEach((backendID, backend) -> out.append(
-                String.format("[%s alive: %b inBlacklist: %b] ", backend.getHost(),
-                        backend.isAlive(), SimpleScheduler.isInBlacklist(backendID))));
-        return out.toString();
-    }
-
-    @VisibleForTesting
-    static int getNextComputeNodeIndex() {
-        return NEXT_COMPUTE_NODE_INDEX.getAndIncrement();
-    }
-
-    @VisibleForTesting
-    static int getNextBackendIndex() {
-        return NEXT_BACKEND_INDEX.getAndIncrement();
-    }
-
-    private static ImmutableMap<Long, ComputeNode> buildComputeNodeInfo(SystemInfoService systemInfoService,
-                                                                        int numUsedComputeNodes) {
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
-            return GlobalStateMgr.getCurrentWarehouseMgr().getComputeNodesFromWarehouse();
-        }
-
-        ImmutableMap<Long, ComputeNode> idToComputeNode
-                = ImmutableMap.copyOf(systemInfoService.getIdComputeNode());
-        if (numUsedComputeNodes <= 0 || numUsedComputeNodes >= idToComputeNode.size()) {
-            return idToComputeNode;
-        } else {
-            Map<Long, ComputeNode> computeNodes = new HashMap<>(numUsedComputeNodes);
-            for (int i = 0; i < idToComputeNode.size() && computeNodes.size() < numUsedComputeNodes; i++) {
-                ComputeNode computeNode = getNextWorker(idToComputeNode, WorkerProvider::getNextComputeNodeIndex);
-                Preconditions.checkNotNull(computeNode);
-                if (!isWorkerAvailable(computeNode)) {
-                    continue;
-                }
-                computeNodes.put(computeNode.getId(), computeNode);
-            }
-            return ImmutableMap.copyOf(computeNodes);
-        }
-    }
-
-    private static <C extends ComputeNode> C getNextWorker(ImmutableMap<Long, C> workers,
-                                                           IntSupplier getNextWorkerNodeIndex) {
-        if (workers.isEmpty()) {
-            return null;
-        }
-        int index = getNextWorkerNodeIndex.getAsInt() % workers.size();
-        return workers.values().asList().get(index);
-    }
-
-    private static boolean isWorkerAvailable(ComputeNode worker) {
-        return worker.isAlive() && !SimpleScheduler.isInBlacklist(worker.getId());
-    }
-
-    private static <C extends ComputeNode> ImmutableMap<Long, C> filterAvailableWorkers(ImmutableMap<Long, C> workers) {
-        return ImmutableMap.copyOf(
-                workers.entrySet().stream()
-                        .filter(entry -> isWorkerAvailable(entry.getValue()))
-                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
-        );
-    }
+    Collection<TNetworkAddress> getUsedWorkerBeAddrs();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
@@ -60,11 +60,11 @@ public class WorkerProvider {
     /**
      * The available backend nodes, which are alive and not in the blacklist.
      */
-    private ImmutableMap<Long, ComputeNode> availableID2Backend;
+    private final ImmutableMap<Long, ComputeNode> availableID2Backend;
     /**
      * The available compute nodes, which are alive and not in the blacklist.
      */
-    private ImmutableMap<Long, ComputeNode> availableID2ComputeNode;
+    private final ImmutableMap<Long, ComputeNode> availableID2ComputeNode;
 
     /**
      * These three members record the workers used by the related job.
@@ -72,18 +72,20 @@ public class WorkerProvider {
      */
     private final Set<Long> usedWorkerIDs;
     private final Map<TNetworkAddress, ComputeNode> beAddr2UsedWorker;
-    // Used only by channel stream load, records the mapping from BE port to BE's webserver port.
+    /**
+     * Used only by channel stream load, recording the mapping from BE port to BE's HTTP port.
+     */
     private final Map<TNetworkAddress, TNetworkAddress> beAddr2HttpAddr;
 
     /**
      * Indicates whether there are available compute nodes.
      */
-    private boolean hasComputeNode;
+    private final boolean hasComputeNode;
     /**
      * Indicates whether compute nodes should be used for non-HDFS operators.
      * The HDFS operator always prefers to use compute nodes even if {@code usedComputeNode} is false.
      */
-    private boolean usedComputeNode;
+    private final boolean usedComputeNode;
 
     @VisibleForTesting
     public WorkerProvider(ImmutableMap<Long, ComputeNode> id2Backend, ImmutableMap<Long, ComputeNode> id2ComputeNode,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/WorkerProvider.java
@@ -1,0 +1,348 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Reference;
+import com.starrocks.common.UserException;
+import com.starrocks.qe.SimpleScheduler;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TNetworkAddress;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntSupplier;
+import java.util.stream.Collectors;
+
+public class WorkerProvider {
+    private static final Logger LOG = LogManager.getLogger(WorkerProvider.class);
+    private static final AtomicInteger NEXT_COMPUTE_NODE_INDEX = new AtomicInteger(0);
+    private static final AtomicInteger NEXT_BACKEND_INDEX = new AtomicInteger(0);
+
+    /**
+     * All the backend nodes, including those that are not alive or in blacklist.
+     */
+    private final ImmutableMap<Long, ComputeNode> id2Backend;
+    /**
+     * All the compute nodes, including those that are not alive or in blacklist.
+     */
+    private final ImmutableMap<Long, ComputeNode> id2ComputeNode;
+    /**
+     * The available backend nodes, which are alive and not in the blacklist.
+     */
+    private ImmutableMap<Long, ComputeNode> availableID2Backend;
+    /**
+     * The available compute nodes, which are alive and not in the blacklist.
+     */
+    private ImmutableMap<Long, ComputeNode> availableID2ComputeNode;
+
+    /**
+     * These three members record the workers used by the related job.
+     * They are updated when calling {@code chooseXXX} methods.
+     */
+    private final Set<Long> usingWorkerIDs;
+    private final Map<TNetworkAddress, ComputeNode> addr2UsingWorker;
+    // Used only by channel stream load, records the mapping from BE port to BE's webserver port.
+    private final Map<TNetworkAddress, TNetworkAddress> addr2HttpAddr;
+
+    /**
+     * Indicates whether there are available compute nodes.
+     */
+    private boolean hasComputeNode;
+    /**
+     * Indicates whether compute nodes should be used for non-HDFS operators.
+     * The HDFS operator always prefers to use compute nodes even if {@code usedComputeNode} is false.
+     */
+    private boolean usedComputeNode;
+
+    @VisibleForTesting
+    public WorkerProvider(ImmutableMap<Long, ComputeNode> id2Backend, ImmutableMap<Long, ComputeNode> id2ComputeNode,
+                          ImmutableMap<Long, ComputeNode> availableID2Backend,
+                          ImmutableMap<Long, ComputeNode> availableID2ComputeNode,
+                          boolean preferComputeNode) {
+        this.id2Backend = id2Backend;
+        this.id2ComputeNode = id2ComputeNode;
+
+        this.availableID2Backend = availableID2Backend;
+        this.availableID2ComputeNode = availableID2ComputeNode;
+
+        this.usingWorkerIDs = Sets.newConcurrentHashSet();
+        this.addr2UsingWorker = Maps.newHashMap();
+        this.addr2HttpAddr = Maps.newHashMap();
+
+        this.hasComputeNode = MapUtils.isNotEmpty(availableID2ComputeNode);
+        this.usedComputeNode = hasComputeNode && preferComputeNode;
+    }
+
+    /**
+     * Capture the available workers from {@code systemInfoService}, which are alive and not in the blacklist.
+     *
+     * @param systemInfoService   The service which provides all the backend nodes and compute nodes.
+     * @param preferComputeNode   Whether to prefer using compute nodes over backend nodes.
+     * @param numUsedComputeNodes The maximum number of used compute nodes.
+     */
+    public static WorkerProvider captureAvailableWorkers(SystemInfoService systemInfoService,
+                                                         boolean preferComputeNode,
+                                                         int numUsedComputeNodes) {
+        ImmutableMap<Long, ComputeNode> idToComputeNode = buildComputeNodeInfo(systemInfoService, numUsedComputeNodes);
+        ImmutableMap<Long, ComputeNode> idToBackend;
+        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+            idToBackend = idToComputeNode;
+        } else {
+            idToBackend = ImmutableMap.copyOf(systemInfoService.getIdToBackend());
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("idToBackend size={}", idToBackend.size());
+            for (Map.Entry<Long, ComputeNode> entry : idToBackend.entrySet()) {
+                Long backendID = entry.getKey();
+                ComputeNode backend = entry.getValue();
+                LOG.debug("backend: {}-{}-{}", backendID, backend.getHost(), backend.getBePort());
+            }
+
+            LOG.debug("idToComputeNode: {}", idToComputeNode);
+        }
+
+        return new WorkerProvider(idToBackend, idToComputeNode,
+                filterAvailableWorkers(idToBackend), filterAvailableWorkers(idToComputeNode),
+                preferComputeNode || RunMode.getCurrentRunMode() == RunMode.SHARED_DATA);
+    }
+
+    /**
+     * Choose the specific backend node.
+     *
+     * @param backendID The ID of the backend node to choose.
+     * @return The address with the {@code ComputeNode#bePort} of the backend node.
+     * @throws UserException if there is no available backend with {@code backendID}.
+     */
+    public TNetworkAddress chooseBackend(Long backendID) throws UserException {
+        ComputeNode backend = getBackend(backendID);
+        backend = checkNotNull(backend, false);
+        TNetworkAddress addr = backend.getAddress();
+        recordUsedWorker(backend.getId(), addr);
+        return addr;
+    }
+
+    /**
+     * Choose the next worker node.
+     *
+     * @param workerIdRef storing ID of the worker node to choose.
+     * @return The address with the {@code ComputeNode#bePort} of the worker node.
+     * @throws UserException if there is no available backend with {@code backendID}.
+     */
+    public TNetworkAddress chooseNextWorker(Reference<Long> workerIdRef) throws UserException {
+        ComputeNode worker;
+        if (usedComputeNode) {
+            worker = getNextWorker(availableID2ComputeNode, WorkerProvider::getNextComputeNodeIndex);
+        } else {
+            worker = getNextWorker(availableID2Backend, WorkerProvider::getNextBackendIndex);
+        }
+
+        worker = checkNotNull(worker, usedComputeNode);
+
+        TNetworkAddress addr = worker.getAddress();
+        recordUsedWorker(worker.getId(), addr);
+        workerIdRef.setRef(worker.getId());
+        return addr;
+    }
+
+    /**
+     * Choose all the available compute nodes.
+     *
+     * @return The address with the {@code ComputeNode#bePort} of the compute nodes to choose.
+     */
+    public List<TNetworkAddress> chooseAllComputedNodes() {
+        if (!usedComputeNode) {
+            return Collections.emptyList();
+        }
+
+        List<TNetworkAddress> addrs = new ArrayList<>(availableID2ComputeNode.size());
+        for (ComputeNode computeNode : availableID2ComputeNode.values()) {
+            TNetworkAddress addr = computeNode.getAddress();
+            recordUsedWorker(computeNode.getId(), addr);
+            addrs.add(addr);
+        }
+
+        return addrs;
+    }
+
+    public boolean containsBackend(Long backendID) {
+        return getBackend(backendID) != null;
+    }
+
+    public ComputeNode getBackend(Long backendID) {
+        return availableID2Backend.get(backendID);
+    }
+
+    public ComputeNode getWorker(Long workerID) {
+        ComputeNode worker = availableID2Backend.get(workerID);
+        if (worker != null) {
+            return worker;
+        }
+        return availableID2ComputeNode.get(workerID);
+    }
+
+    public Collection<ComputeNode> getWorkersPreferringComputeNode() {
+        if (hasComputeNode) {
+            return availableID2ComputeNode.values();
+        } else {
+            return ImmutableList.copyOf(availableID2Backend.values());
+        }
+    }
+
+    public boolean isUsingWorker(Long workerID) {
+        return usingWorkerIDs.contains(workerID);
+    }
+
+    public ComputeNode getUsingWorkerByAddr(TNetworkAddress addr) {
+        ComputeNode worker = addr2UsingWorker.get(addr);
+        return Preconditions.checkNotNull(worker, "Expect backend address [{}] to being used", addr);
+    }
+
+    public TNetworkAddress getUsingHttpAddrByAddr(TNetworkAddress addr) {
+        TNetworkAddress httpAddr = addr2HttpAddr.get(addr);
+        return Preconditions.checkNotNull(httpAddr, "Expect backend address [{}] to being used", addr);
+    }
+
+    public List<Long> getUsingWorkerIDs() {
+        return new ArrayList<>(usingWorkerIDs);
+    }
+
+    public Collection<TNetworkAddress> getUsingWorkerAddrs() {
+        return addr2UsingWorker.keySet();
+    }
+
+    public void reportBackendNotFoundException() throws SchedulerException {
+        reportWorkerNotFoundException(false);
+    }
+
+    private void reportWorkerNotFoundException(boolean chooseComputeNode) throws SchedulerException {
+        throw new SchedulerException(
+                FeConstants.getNodeNotFoundError(chooseComputeNode) + toString(chooseComputeNode));
+    }
+
+    @Override
+    public String toString() {
+        return toString(usedComputeNode);
+    }
+
+    public String toString(boolean chooseComputeNode) {
+        return chooseComputeNode ? computeNodesToString() : backendsToString();
+    }
+
+    public String computeNodesToString() {
+        StringBuilder out = new StringBuilder("compute node: ");
+        id2ComputeNode.forEach((backendID, backend) -> out.append(
+                String.format("[%s alive: %b inBlacklist: %b] ", backend.getHost(),
+                        backend.isAlive(), SimpleScheduler.isInBlacklist(backendID))));
+        return out.toString();
+    }
+
+    public String backendsToString() {
+        StringBuilder out = new StringBuilder("backend: ");
+        id2Backend.forEach((backendID, backend) -> out.append(
+                String.format("[%s alive: %b inBlacklist: %b] ", backend.getHost(),
+                        backend.isAlive(), SimpleScheduler.isInBlacklist(backendID))));
+        return out.toString();
+    }
+
+    public void recordUsedWorker(Long workerID, TNetworkAddress addr) {
+        if (usingWorkerIDs.add(workerID)) {
+            ComputeNode worker = getWorker(workerID);
+            addr2UsingWorker.put(addr, worker);
+            addr2HttpAddr.put(addr, worker.getHttpAddress());
+        }
+    }
+
+    @VisibleForTesting
+    static int getNextComputeNodeIndex() {
+        return NEXT_COMPUTE_NODE_INDEX.getAndIncrement();
+    }
+
+    @VisibleForTesting
+    static int getNextBackendIndex() {
+        return NEXT_BACKEND_INDEX.getAndIncrement();
+    }
+
+    private <T> T checkNotNull(T obj, boolean chooseComputeNode) throws UserException {
+        if (obj == null) {
+            reportWorkerNotFoundException(chooseComputeNode);
+        }
+        return obj;
+    }
+
+    private static ImmutableMap<Long, ComputeNode> buildComputeNodeInfo(SystemInfoService systemInfoService,
+                                                                        int numUsedComputeNodes) {
+        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+            return GlobalStateMgr.getCurrentWarehouseMgr().getComputeNodesFromWarehouse();
+        }
+
+        ImmutableMap<Long, ComputeNode> idToComputeNode
+                = ImmutableMap.copyOf(systemInfoService.getIdComputeNode());
+        if (numUsedComputeNodes <= 0 || numUsedComputeNodes >= idToComputeNode.size()) {
+            return idToComputeNode;
+        } else {
+            Map<Long, ComputeNode> computeNodes = new HashMap<>(numUsedComputeNodes);
+            for (int i = 0; i < idToComputeNode.size() && computeNodes.size() < numUsedComputeNodes; i++) {
+                ComputeNode computeNode = getNextWorker(idToComputeNode, WorkerProvider::getNextComputeNodeIndex);
+                Preconditions.checkNotNull(computeNode);
+                if (!isWorkerAvailable(computeNode)) {
+                    continue;
+                }
+                computeNodes.put(computeNode.getId(), computeNode);
+            }
+            return ImmutableMap.copyOf(computeNodes);
+        }
+    }
+
+    private static <C extends ComputeNode> C getNextWorker(ImmutableMap<Long, C> workers,
+                                                           IntSupplier getNextWorkerNodeIndex) {
+        if (workers.isEmpty()) {
+            return null;
+        }
+        int index = getNextWorkerNodeIndex.getAsInt() % workers.size();
+        return workers.values().asList().get(index);
+    }
+
+    private static boolean isWorkerAvailable(ComputeNode worker) {
+        return worker.isAlive() && !SimpleScheduler.isInBlacklist(worker.getId());
+    }
+
+    private static <C extends ComputeNode> ImmutableMap<Long, C> filterAvailableWorkers(ImmutableMap<Long, C> workers) {
+        return ImmutableMap.copyOf(
+                workers.entrySet().stream()
+                        .filter(entry -> isWorkerAvailable(entry.getValue()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+        );
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceJob.java
@@ -303,7 +303,7 @@ public class MVMaintenanceJob implements Writable, GsonPreProcessable, GsonPostP
             for (int i = 0; i < execParams.instanceExecParams.size(); i++) {
                 CoordinatorPreprocessor.FInstanceExecParam instanceParam = execParams.instanceExecParams.get(i);
                 // Get brpc address instead of the default address
-                TNetworkAddress beRpcAddr = queryCoordinator.getBrpcAddress(instanceParam.getHost());
+                TNetworkAddress beRpcAddr = queryCoordinator.getBrpcAddress(instanceParam.getWorkerId());
                 Long taskId = addr2TaskId.get(beRpcAddr);
                 MVMaintenanceTask task;
                 if (taskId == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -366,51 +366,6 @@ public class PlanFragmentBuilder {
         return execPlan;
     }
 
-    private static void maybeClearOlapScanNodePartitions(PlanFragment fragment) {
-        List<OlapScanNode> olapScanNodes = fragment.collectOlapScanNodes();
-        long numNodesWithBucketColumns =
-                olapScanNodes.stream().filter(node -> !node.getBucketColumns().isEmpty()).count();
-        // Either all OlapScanNode use bucketColumns for local shuffle, or none of them do.
-        // Therefore, clear bucketColumns if only some of them contain bucketColumns.
-        boolean needClear = numNodesWithBucketColumns > 0 && numNodesWithBucketColumns < olapScanNodes.size();
-        if (needClear) {
-            clearOlapScanNodePartitions(fragment.getPlanRoot());
-        }
-    }
-
-    /**
-     * Clear partitionExprs of OlapScanNode (the bucket keys to pass to BE).
-     * <p>
-     * When partitionExprs of OlapScanNode are passed to BE, the post operators will use them as
-     * local shuffle partition exprs.
-     * Otherwise, the operators will use the original partition exprs (group by keys or join on keys).
-     * <p>
-     * The bucket keys can satisfy the required hash property of blocking aggregation except two scenarios:
-     * - OlapScanNode only has one tablet after pruned.
-     * - It is executed on the single BE.
-     * As for these two scenarios, which will generate ScanNode(k1)->LocalShuffle(c1)->BlockingAgg(c1),
-     * partitionExprs of OlapScanNode must be cleared to make BE use group by keys not bucket keys as
-     * local shuffle partition exprs.
-     *
-     * @param root The root node of the fragment which need to check whether to clear bucket keys of OlapScanNode.
-     */
-    private static void clearOlapScanNodePartitions(PlanNode root) {
-        if (root instanceof OlapScanNode) {
-            OlapScanNode scanNode = (OlapScanNode) root;
-            scanNode.setBucketExprs(Lists.newArrayList());
-            scanNode.setBucketColumns(Lists.newArrayList());
-            return;
-        }
-
-        if (root instanceof ExchangeNode) {
-            return;
-        }
-
-        for (PlanNode child : root.getChildren()) {
-            clearOlapScanNodePartitions(child);
-        }
-    }
-
     private static class PhysicalPlanTranslator extends OptExpressionVisitor<PlanFragment, ExecPlan> {
         private final ColumnRefFactory columnRefFactory;
         private final IdGenerator<RuntimeFilterId> runtimeFilterIdIdGenerator = RuntimeFilterId.createGenerator();

--- a/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
@@ -45,7 +45,6 @@ import com.starrocks.catalog.DiskInfo.DiskState;
 import com.starrocks.common.io.Text;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TDisk;
-import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TStorageMedium;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -108,10 +107,6 @@ public class Backend extends ComputeNode {
 
     public boolean hasPathHash() {
         return disksRef.values().stream().allMatch(DiskInfo::hasPathHash);
-    }
-
-    public TNetworkAddress getAddress() {
-        return new TNetworkAddress(getHost(), getBePort());
     }
 
     public long getTotalCapacityB() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -186,8 +186,20 @@ public class ComputeNode implements IComputable, Writable {
         return brpcPort;
     }
 
+    public TNetworkAddress getAddress() {
+        return new TNetworkAddress(host, bePort);
+    }
+
     public TNetworkAddress getBrpcAddress() {
         return new TNetworkAddress(host, brpcPort);
+    }
+
+    public TNetworkAddress getBeRpcAddress() {
+        return new TNetworkAddress(host, beRpcPort);
+    }
+
+    public TNetworkAddress getHttpAddress() {
+        return new TNetworkAddress(host, httpPort);
     }
 
     public String getHeartbeatErrMsg() {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -38,7 +38,6 @@ import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.system.Backend;
 import com.starrocks.thrift.TBinlogOffset;
 import com.starrocks.thrift.TDescriptorTable;
-import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TPartitionType;
 import com.starrocks.thrift.TScanRangeParams;
 import com.starrocks.thrift.TUniqueId;
@@ -127,11 +126,11 @@ public class CoordinatorTest extends PlanTestBase {
     }
 
     private void testComputeColocatedJoinInstanceParamHelper(int scanId,
-                                                             Map<Integer, TNetworkAddress> bucketSeqToAddress,
+                                                             Map<Integer, Long> bucketSeqToWorkerId,
                                                              int parallelExecInstanceNum,
                                                              int pipelineDop, boolean enablePipeline,
                                                              int expectedInstances,
-                                                             List<TNetworkAddress> expectedParamAddresses,
+                                                             List<Long> expectedParamAddresses,
                                                              List<Integer> expectedPipelineDops,
                                                              List<Map<Integer, Integer>> expectedBucketSeqToDriverSeqs,
                                                              List<Integer> expectedNumScanRangesList,
@@ -140,18 +139,18 @@ public class CoordinatorTest extends PlanTestBase {
                 coordinatorPreprocessor.new FragmentExecParams(genFragment());
         CoordinatorPreprocessor.BucketSeqToScanRange bucketSeqToScanRange =
                 new CoordinatorPreprocessor.BucketSeqToScanRange();
-        for (Integer bucketSeq : bucketSeqToAddress.keySet()) {
+        for (Integer bucketSeq : bucketSeqToWorkerId.keySet()) {
             bucketSeqToScanRange.put(bucketSeq, createScanId2scanRanges(scanId, 1));
         }
 
-        coordinatorPreprocessor.computeColocatedJoinInstanceParam(bucketSeqToAddress, bucketSeqToScanRange,
+        coordinatorPreprocessor.computeColocatedJoinInstanceParam(bucketSeqToWorkerId, bucketSeqToScanRange,
                 parallelExecInstanceNum, pipelineDop, enablePipeline, params);
-        params.instanceExecParams.sort(Comparator.comparing(param -> param.host));
+        params.instanceExecParams.sort(Comparator.comparing(CoordinatorPreprocessor.FInstanceExecParam::getWorkerId));
 
         Assert.assertEquals(expectedInstances, params.instanceExecParams.size());
         for (int i = 0; i < expectedInstances; ++i) {
             CoordinatorPreprocessor.FInstanceExecParam param = params.instanceExecParams.get(i);
-            Assert.assertEquals(expectedParamAddresses.get(i), param.host);
+            Assert.assertEquals(expectedParamAddresses.get(i), param.getWorkerId());
             Assert.assertEquals(expectedPipelineDops.get(i).intValue(), param.getPipelineDop());
 
             Map<Integer, Integer> bucketSeqToDriverSeq = param.getBucketSeqToDriverSeq();
@@ -190,10 +189,10 @@ public class CoordinatorTest extends PlanTestBase {
         // - addr1: 11, 12, 13, 14, 15.
         // - addr2: 21, 22, 23.
         // - addr3: 31, 32
-        TNetworkAddress addr1 = new TNetworkAddress("host1", 8000);
-        TNetworkAddress addr2 = new TNetworkAddress("host2", 8000);
-        TNetworkAddress addr3 = new TNetworkAddress("host3", 8000);
-        Map<Integer, TNetworkAddress> bucketSeqToAddress = ImmutableMap.<Integer, TNetworkAddress>builder()
+        Long addr1 = 1L;
+        Long addr2 = 2L;
+        Long addr3 = 3L;
+        Map<Integer, Long> bucketSeqToWorkerId = ImmutableMap.<Integer, Long>builder()
                 .put(11, addr1).put(12, addr1).put(13, addr1).put(14, addr1).put(15, addr1)
                 .put(21, addr2).put(22, addr2).put(23, addr2)
                 .put(32, addr3).put(31, addr3)
@@ -215,7 +214,7 @@ public class CoordinatorTest extends PlanTestBase {
         //          - DriverSequence#0: 32.
         //          - DriverSequence#1: 31.
         int expectedInstances = 3;
-        List<TNetworkAddress> expectedParamAddresses = ImmutableList.of(addr1, addr2, addr3);
+        List<Long> expectedParamAddresses = ImmutableList.of(addr1, addr2, addr3);
         List<Map<Integer, Integer>> expectedBucketSeqToDriverSeqs = ImmutableList.of(
                 ImmutableMap.of(11, 0, 12, 1, 13, 2, 14, 0, 15, 1),
                 ImmutableMap.of(21, 0, 22, 1, 23, 2),
@@ -228,7 +227,7 @@ public class CoordinatorTest extends PlanTestBase {
                 ImmutableMap.of(0, 1, 1, 1, 2, 1),
                 ImmutableMap.of(0, 1, 1, 1)
         );
-        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 1, 3, true,
+        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToWorkerId, 1, 3, true,
                 expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
                 expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);
 
@@ -277,7 +276,7 @@ public class CoordinatorTest extends PlanTestBase {
                 ImmutableMap.of(0, 1),
                 ImmutableMap.of(0, 1)
         );
-        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 3, 2, true,
+        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToWorkerId, 3, 2, true,
                 expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
                 expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);
 
@@ -323,7 +322,7 @@ public class CoordinatorTest extends PlanTestBase {
                 ImmutableMap.of(0, 1),
                 ImmutableMap.of(0, 1)
         );
-        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 3, 1, true,
+        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToWorkerId, 3, 1, true,
                 expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
                 expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);
 
@@ -352,7 +351,7 @@ public class CoordinatorTest extends PlanTestBase {
                 ImmutableMap.of(31, -1)
         );
         expectedDriverSeq2NumScanRangesList = null;
-        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 3, 1, false,
+        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToWorkerId, 3, 1, false,
                 expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
                 expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);
 
@@ -386,7 +385,7 @@ public class CoordinatorTest extends PlanTestBase {
                 ImmutableMap.of(0, 1, 1, 0, 2, 0),
                 ImmutableMap.of(0, 1, 1, 0)
         );
-        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 1, 3, true,
+        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToWorkerId, 1, 3, true,
                 expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
                 expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);
 
@@ -396,7 +395,7 @@ public class CoordinatorTest extends PlanTestBase {
         // - addr2: 21, 22, 23.
         // - addr3: 31
         scanId = 1;
-        bucketSeqToAddress = ImmutableMap.<Integer, TNetworkAddress>builder()
+        bucketSeqToWorkerId = ImmutableMap.<Integer, Long>builder()
                 .put(11, addr1).put(12, addr1).put(13, addr1).put(14, addr1).put(15, addr1)
                 .put(21, addr2).put(22, addr2).put(23, addr2)
                 .put(31, addr3)
@@ -417,7 +416,7 @@ public class CoordinatorTest extends PlanTestBase {
         expectedPipelineDops = ImmutableList.of(-1, -1, -1);
         expectedNumScanRangesList = ImmutableList.of(5, 3, 1);
         expectedDriverSeq2NumScanRangesList = null;
-        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToAddress, 1, 3, true,
+        testComputeColocatedJoinInstanceParamHelper(scanId, bucketSeqToWorkerId, 1, 3, true,
                 expectedInstances, expectedParamAddresses, expectedPipelineDops, expectedBucketSeqToDriverSeqs,
                 expectedNumScanRangesList, expectedDriverSeq2NumScanRangesList);
 
@@ -460,9 +459,9 @@ public class CoordinatorTest extends PlanTestBase {
                 prepare.getFragmentScanRangeAssignment(fragmentId);
         Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackends().get(0);
         Assert.assertFalse(scanRangeMap.isEmpty());
-        TNetworkAddress expectedAddress = backend.getAddress();
-        Assert.assertTrue(scanRangeMap.containsKey(expectedAddress));
-        Map<Integer, List<TScanRangeParams>> rangesPerNode = scanRangeMap.get(expectedAddress);
+        Long expectedWorkerId = backend.getId();
+        Assert.assertTrue(scanRangeMap.containsKey(expectedWorkerId));
+        Map<Integer, List<TScanRangeParams>> rangesPerNode = scanRangeMap.get(expectedWorkerId);
         Assert.assertTrue(rangesPerNode.containsKey(planNodeId.asInt()));
         List<TScanRangeParams> ranges = rangesPerNode.get(planNodeId.asInt());
         List<Long> tabletIds =

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.qe;
 
 import com.google.common.collect.ImmutableList;
@@ -88,11 +87,11 @@ public class CoordinatorTest extends PlanTestBase {
         PlanFragment fragment = genFragment();
         CoordinatorPreprocessor.FragmentExecParams params = coordinatorPreprocessor.new FragmentExecParams(fragment);
         CoordinatorPreprocessor.FInstanceExecParam instance0 =
-                new CoordinatorPreprocessor.FInstanceExecParam(null, null, 0, params);
+                new CoordinatorPreprocessor.FInstanceExecParam(null, null, params);
         CoordinatorPreprocessor.FInstanceExecParam instance1 =
-                new CoordinatorPreprocessor.FInstanceExecParam(null, null, 1, params);
+                new CoordinatorPreprocessor.FInstanceExecParam(null, null, params);
         CoordinatorPreprocessor.FInstanceExecParam instance2 =
-                new CoordinatorPreprocessor.FInstanceExecParam(null, null, 2, params);
+                new CoordinatorPreprocessor.FInstanceExecParam(null, null, params);
         instance0.bucketSeqToDriverSeq = ImmutableMap.of(2, -1, 0, -1);
         instance1.bucketSeqToDriverSeq = ImmutableMap.of(1, -1, 4, -1);
         instance2.bucketSeqToDriverSeq = ImmutableMap.of(3, -1, 5, -1);
@@ -137,7 +136,8 @@ public class CoordinatorTest extends PlanTestBase {
                                                              List<Map<Integer, Integer>> expectedBucketSeqToDriverSeqs,
                                                              List<Integer> expectedNumScanRangesList,
                                                              List<Map<Integer, Integer>> expectedDriverSeq2NumScanRangesList) {
-        CoordinatorPreprocessor.FragmentExecParams params = coordinatorPreprocessor.new FragmentExecParams(genFragment());
+        CoordinatorPreprocessor.FragmentExecParams params =
+                coordinatorPreprocessor.new FragmentExecParams(genFragment());
         CoordinatorPreprocessor.BucketSeqToScanRange bucketSeqToScanRange =
                 new CoordinatorPreprocessor.BucketSeqToScanRange();
         for (Integer bucketSeq : bucketSeqToAddress.keySet()) {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
@@ -79,11 +79,9 @@ public class HDFSBackendSelectorTest {
         return ImmutableMap.copyOf(ans);
     }
 
-    private Map<TNetworkAddress, Long> computeHostReadBytes(
-            FragmentScanRangeAssignment assignment,
-            int scanNodeId) {
-        Map<TNetworkAddress, Long> stats = new HashMap<>();
-        for (Map.Entry<TNetworkAddress, Map<Integer, List<TScanRangeParams>>> entry : assignment.entrySet()) {
+    private Map<Long, Long> computeWorkerIdToReadBytes(FragmentScanRangeAssignment assignment, int scanNodeId) {
+        Map<Long, Long> stats = new HashMap<>();
+        for (Map.Entry<Long, Map<Integer, List<TScanRangeParams>>> entry : assignment.entrySet()) {
             List<TScanRangeParams> scanRangeParams = entry.getValue().get(scanNodeId);
             for (TScanRangeParams params : scanRangeParams) {
                 THdfsScanRange scanRange = params.scan_range.hdfs_scan_range;
@@ -124,8 +122,8 @@ public class HDFSBackendSelectorTest {
 
         int avg = (scanRangeNumber * scanRangeSize) / hostNumber;
         int variance = 5 * scanRangeSize;
-        Map<TNetworkAddress, Long> stats = computeHostReadBytes(assignment, scanNodeId);
-        for (Map.Entry<TNetworkAddress, Long> entry : stats.entrySet()) {
+        Map<Long, Long> stats = computeWorkerIdToReadBytes(assignment, scanNodeId);
+        for (Map.Entry<Long, Long> entry : stats.entrySet()) {
             System.out.printf("%s -> %d bytes\n", entry.getKey(), entry.getValue());
             Assert.assertTrue(Math.abs(entry.getValue() - avg) < variance);
         }
@@ -174,9 +172,9 @@ public class HDFSBackendSelectorTest {
                 new HDFSBackendSelector(hdfsScanNode, locations, assignment, workerProvider, true, false);
         selector.computeScanRangeAssignment();
 
-        Map<TNetworkAddress, Long> stats = computeHostReadBytes(assignment, scanNodeId);
+        Map<Long, Long> stats = computeWorkerIdToReadBytes(assignment, scanNodeId);
         Assert.assertEquals(stats.size(), localHostNumber);
-        for (Map.Entry<TNetworkAddress, Long> entry : stats.entrySet()) {
+        for (Map.Entry<Long, Long> entry : stats.entrySet()) {
             System.out.printf("%s -> %d bytes\n", entry.getKey(), entry.getValue());
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
@@ -17,7 +17,7 @@ package com.starrocks.qe;
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.planner.HdfsScanNode;
-import com.starrocks.qe.scheduler.WorkerProvider;
+import com.starrocks.qe.scheduler.DefaultWorkerProvider;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.THdfsScanRange;
 import com.starrocks.thrift.TNetworkAddress;
@@ -110,7 +110,7 @@ public class HDFSBackendSelectorTest {
         List<TScanRangeLocations> locations = createScanRanges(scanRangeNumber, scanRangeSize);
         FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
         ImmutableMap<Long, ComputeNode> computeNodes = createComputeNodes(hostNumber);
-        WorkerProvider workerProvider = new WorkerProvider(
+        DefaultWorkerProvider workerProvider = new DefaultWorkerProvider(
                 ImmutableMap.of(),
                 computeNodes,
                 ImmutableMap.of(),
@@ -162,7 +162,7 @@ public class HDFSBackendSelectorTest {
 
         FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
         ImmutableMap<Long, ComputeNode> computeNodes = createComputeNodes(hostNumber);
-        WorkerProvider workerProvider = new WorkerProvider(
+        DefaultWorkerProvider workerProvider = new DefaultWorkerProvider(
                 ImmutableMap.of(),
                 computeNodes,
                 ImmutableMap.of(),

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/WorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/WorkerProviderTest.java
@@ -344,9 +344,9 @@ public class WorkerProviderTest {
 
     public static void testUsingWorkerHelper(WorkerProvider workerProvider, ComputeNode worker) {
         Assert.assertTrue(workerProvider.isUsingWorker(worker.getId()));
-        Assert.assertEquals(worker.getHttpAddress(), workerProvider.getUsingHttpAddrByAddr(worker.getAddress()));
-        Assert.assertEquals(worker, workerProvider.getUsingWorkerByAddr(worker.getAddress()));
-        assertThat(workerProvider.getUsingWorkerIDs()).contains(worker.getId());
-        assertThat(workerProvider.getUsingWorkerAddrs()).contains(worker.getAddress());
+        Assert.assertEquals(worker.getHttpAddress(), workerProvider.getUsedHttpAddrByBeAddr(worker.getAddress()));
+        Assert.assertEquals(worker, workerProvider.getUsedWorkerByBeAddr(worker.getAddress()));
+        assertThat(workerProvider.getUsedWorkerIDs()).contains(worker.getId());
+        assertThat(workerProvider.getUsedWorkerBeAddrs()).contains(worker.getAddress());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/WorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/WorkerProviderTest.java
@@ -297,7 +297,7 @@ public class WorkerProviderTest {
                                                                      Map<Long, C> availableId2Worker) {
         for (long id = -1; id < 16; id++) {
             ComputeNode backend = workerProvider.getBackend(id);
-            boolean isContained = workerProvider.containsBackend(id);
+            boolean isContained = workerProvider.isBackendAvailable(id);
             if (!availableId2Worker.containsKey(id)) {
                 Assert.assertNull(backend);
                 Assert.assertFalse(isContained);
@@ -322,16 +322,16 @@ public class WorkerProviderTest {
 
         workerProvider =
                 new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode, true);
-        assertThat(workerProvider.getWorkersPreferringComputeNode())
+        assertThat(workerProvider.getWorkers())
                 .containsOnlyOnceElementsOf(availableId2ComputeNode.values());
 
         workerProvider = new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, ImmutableMap.of(), true);
-        assertThat(workerProvider.getWorkersPreferringComputeNode())
+        assertThat(workerProvider.getWorkers())
                 .containsOnlyOnceElementsOf(availableId2Backend.values());
 
         workerProvider =
                 new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode, false);
-        assertThat(workerProvider.getWorkersPreferringComputeNode())
+        assertThat(workerProvider.getWorkers())
                 .containsOnlyOnceElementsOf(availableId2ComputeNode.values());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/WorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/WorkerProviderTest.java
@@ -1,0 +1,352 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.starrocks.common.Config;
+import com.starrocks.common.Reference;
+import com.starrocks.common.UserException;
+import com.starrocks.qe.SimpleScheduler;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TNetworkAddress;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WorkerProviderTest {
+    private final ImmutableMap<Long, ComputeNode> id2Backend = genWorkers(0, 10, Backend::new);
+    private final ImmutableMap<Long, ComputeNode> id2ComputeNode = genWorkers(10, 15, ComputeNode::new);
+    private final ImmutableMap<Long, ComputeNode> availableId2Backend = ImmutableMap.of(
+            0L, id2Backend.get(0L),
+            2L, id2Backend.get(2L),
+            3L, id2Backend.get(3L),
+            5L, id2Backend.get(5L),
+            7L, id2Backend.get(7L));
+    private final ImmutableMap<Long, ComputeNode> availableId2ComputeNode = ImmutableMap.of(
+            10L, id2ComputeNode.get(10L),
+            12L, id2ComputeNode.get(12L),
+            14L, id2ComputeNode.get(14L));
+    private final Map<Long, ComputeNode> availableId2Worker = Stream.of(availableId2Backend, availableId2ComputeNode)
+            .map(Map::entrySet)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    private static <C extends ComputeNode> ImmutableMap<Long, C> genWorkers(long startId, long endId,
+                                                                            Supplier<C> factory) {
+        Map<Long, C> res = new TreeMap<>();
+        for (long i = startId; i < endId; i++) {
+            C worker = factory.get();
+            worker.setId(i);
+            worker.setAlive(true);
+            worker.setHost("host#" + i);
+            worker.setBePort(80);
+            res.put(i, worker);
+        }
+        return ImmutableMap.copyOf(res);
+    }
+
+    @Test
+    public void testCaptureAvailableWorkers() {
+
+        long deadBEId = 1L;
+        long deadCNId = 11L;
+        long inBlacklistBEId = 3L;
+        long inBlacklistCNId = 13L;
+        Set<Long> nonAvailableWorkerId = ImmutableSet.of(deadBEId, deadCNId, inBlacklistBEId, inBlacklistCNId);
+        id2Backend.get(deadBEId).setAlive(false);
+        id2ComputeNode.get(deadCNId).setAlive(false);
+        new MockUp<SimpleScheduler>() {
+            @Mock
+            public boolean isInBlacklist(long backendId) {
+                return backendId == inBlacklistBEId || backendId == inBlacklistCNId;
+            }
+        };
+
+        Reference<Integer> nextComputeNodeIndex = new Reference<>(0);
+        new MockUp<WorkerProvider>() {
+            @Mock
+            int getNextComputeNodeIndex() {
+                int next = nextComputeNodeIndex.getRef();
+                nextComputeNodeIndex.setRef(next + 1);
+                return next;
+            }
+        };
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public ImmutableMap<Long, ComputeNode> getIdToBackend() {
+                return id2Backend;
+            }
+
+            @Mock
+            public ImmutableMap<Long, ComputeNode> getIdComputeNode() {
+                return id2ComputeNode;
+            }
+        };
+
+        WorkerProvider workerProvider;
+        List<Integer> numUsedComputeNodesList = ImmutableList.of(100, 0, -1, 1, 2, 3, 4, 5, 6);
+        for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
+            // Reset nextComputeNodeIndex.
+            nextComputeNodeIndex.setRef(0);
+
+            workerProvider =
+                    WorkerProvider.captureAvailableWorkers(GlobalStateMgr.getCurrentSystemInfo(), true,
+                            numUsedComputeNodes);
+
+            int numAvailableComputeNodes = 0;
+            for (long id = 0; id < 15; id++) {
+                ComputeNode worker = workerProvider.getWorker(id);
+                if (nonAvailableWorkerId.contains(id)
+                        // Exceed the limitation of numUsedComputeNodes.
+                        || (numUsedComputeNodes > 0 && numAvailableComputeNodes >= numUsedComputeNodes)) {
+                    Assert.assertNull(worker);
+                } else {
+                    Assert.assertNotNull("numUsedComputeNodes=" + numUsedComputeNodes + ",id=" + id, worker);
+                    Assert.assertEquals(id, worker.getId());
+
+                    if (id2ComputeNode.containsKey(id)) {
+                        numAvailableComputeNodes++;
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testCaptureAvailableWorkersForSharedData() {
+        String prevRunMode = Config.run_mode;
+        try {
+            Config.run_mode = "shared_data";
+            RunMode.detectRunMode();
+
+            long deadBEId = 1L;
+            long deadCNId = 11L;
+            long inBlacklistBEId = 3L;
+            long inBlacklistCNId = 13L;
+            Set<Long> nonAvailableWorkerId = ImmutableSet.of(deadBEId, deadCNId, inBlacklistBEId, inBlacklistCNId);
+            id2Backend.get(deadBEId).setAlive(false);
+            id2ComputeNode.get(deadCNId).setAlive(false);
+            new MockUp<SimpleScheduler>() {
+                @Mock
+                public boolean isInBlacklist(long backendId) {
+                    return backendId == inBlacklistBEId || backendId == inBlacklistCNId;
+                }
+            };
+
+            Reference<Integer> nextComputeNodeIndex = new Reference<>(0);
+            new MockUp<WorkerProvider>() {
+                @Mock
+                int getNextComputeNodeIndex() {
+                    int next = nextComputeNodeIndex.getRef();
+                    nextComputeNodeIndex.setRef(next + 1);
+                    return next;
+                }
+            };
+
+            new MockUp<WarehouseManager>() {
+                @Mock
+                public ImmutableMap<Long, ComputeNode> getComputeNodesFromWarehouse() {
+                    return id2ComputeNode;
+                }
+            };
+
+            WorkerProvider workerProvider;
+            List<Integer> numUsedComputeNodesList = ImmutableList.of(100, 0, -1, 1, 2, 3, 4, 5, 6);
+            for (Integer numUsedComputeNodes : numUsedComputeNodesList) {
+                // Reset nextComputeNodeIndex.
+                nextComputeNodeIndex.setRef(0);
+
+                workerProvider =
+                        WorkerProvider.captureAvailableWorkers(GlobalStateMgr.getCurrentSystemInfo(), false,
+                                numUsedComputeNodes);
+
+                for (long id = 0; id < 15; id++) {
+                    ComputeNode worker = workerProvider.getWorker(id);
+                    ComputeNode backend = workerProvider.getBackend(id);
+                    // SHARED_DATA MODE considers backends and compute nodes the same.
+                    Assert.assertEquals(backend, worker);
+                    if (nonAvailableWorkerId.contains(id) || !id2ComputeNode.containsKey(id)) {
+                        Assert.assertNull(worker);
+                    } else {
+                        Assert.assertNotNull("id=" + id, worker);
+                        Assert.assertEquals(id, worker.getId());
+                    }
+                }
+            }
+        } finally {
+            Config.run_mode = prevRunMode;
+            RunMode.detectRunMode();
+        }
+    }
+
+    @Test
+    public void testChooseBackend() throws UserException {
+        WorkerProvider workerProvider =
+                new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode, true);
+        for (long id = 0; id < 15; id++) {
+            if (availableId2Backend.containsKey(id)) {
+                ComputeNode backend = availableId2Backend.get(id);
+
+                TNetworkAddress addr = workerProvider.chooseBackend(id);
+                Assert.assertEquals(backend.getAddress(), addr);
+                testUsingWorkerHelper(workerProvider, backend);
+            } else {
+                long finalId = id;
+                Assert.assertThrows(UserException.class, () -> workerProvider.chooseBackend(finalId));
+            }
+        }
+    }
+
+    private static <C extends ComputeNode> void testChooseNextWorkerHelper(WorkerProvider workerProvider,
+                                                                           Map<Long, C> id2Worker)
+            throws UserException {
+
+        Reference<Long> workerIdRef = new Reference<>();
+        Set<Long> selectedWorkers = new HashSet<>(id2Worker.size());
+        for (int i = 0; i < id2Worker.size(); i++) {
+            TNetworkAddress addr = workerProvider.chooseNextWorker(workerIdRef);
+            long id = workerIdRef.getRef();
+            ComputeNode worker = id2Worker.get(id);
+
+            Assert.assertEquals(worker.getAddress(), addr);
+
+            Assert.assertFalse(selectedWorkers.contains(id));
+            selectedWorkers.add(id);
+
+            testUsingWorkerHelper(workerProvider, worker);
+        }
+    }
+
+    @Test
+    public void testChooseNextWorker() throws UserException {
+        WorkerProvider workerProvider;
+        Reference<Long> workerIdRef = new Reference<>();
+
+        workerProvider =
+                new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode, true);
+        testChooseNextWorkerHelper(workerProvider, availableId2ComputeNode);
+
+        workerProvider = new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, ImmutableMap.of(), true);
+        testChooseNextWorkerHelper(workerProvider, availableId2Backend);
+
+        workerProvider =
+                new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode, false);
+        testChooseNextWorkerHelper(workerProvider, availableId2Backend);
+
+        workerProvider = new WorkerProvider(id2Backend, id2ComputeNode, ImmutableMap.of(), ImmutableMap.of(), false);
+        WorkerProvider finalWorkerProvider = workerProvider;
+        Assert.assertThrows(UserException.class, () -> finalWorkerProvider.chooseNextWorker(workerIdRef));
+    }
+
+    @Test
+    public void testChooseAllComputedNodes() {
+        WorkerProvider workerProvider;
+        List<TNetworkAddress> computeNodeAddrs;
+
+        workerProvider =
+                new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode, false);
+        computeNodeAddrs = workerProvider.chooseAllComputedNodes();
+        Assert.assertTrue(computeNodeAddrs.isEmpty());
+
+        workerProvider =
+                new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode, true);
+        computeNodeAddrs = workerProvider.chooseAllComputedNodes();
+        Assert.assertEquals(availableId2ComputeNode.size(), computeNodeAddrs.size());
+        Set<TNetworkAddress> computeNodeAddrSet = new HashSet<>(computeNodeAddrs);
+        for (ComputeNode computeNode : availableId2ComputeNode.values()) {
+            Assert.assertTrue(computeNodeAddrSet.contains(computeNode.getAddress()));
+
+            testUsingWorkerHelper(workerProvider, computeNode);
+        }
+    }
+
+    private static <C extends ComputeNode> void testGetBackendHelper(WorkerProvider workerProvider,
+                                                                     Map<Long, C> availableId2Worker) {
+        for (long id = -1; id < 16; id++) {
+            ComputeNode backend = workerProvider.getBackend(id);
+            boolean isContained = workerProvider.containsBackend(id);
+            if (!availableId2Worker.containsKey(id)) {
+                Assert.assertNull(backend);
+                Assert.assertFalse(isContained);
+            } else {
+                Assert.assertNotNull("id=" + id, backend);
+                Assert.assertEquals(availableId2Worker.get(id), backend);
+                Assert.assertTrue(isContained);
+            }
+        }
+    }
+
+    @Test
+    public void testGetBackend() {
+        WorkerProvider workerProvider =
+                new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode, true);
+        testGetBackendHelper(workerProvider, availableId2Backend);
+    }
+
+    @Test
+    public void testGetWorkersPreferringComputeNode() {
+        WorkerProvider workerProvider;
+
+        workerProvider =
+                new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode, true);
+        assertThat(workerProvider.getWorkersPreferringComputeNode())
+                .containsOnlyOnceElementsOf(availableId2ComputeNode.values());
+
+        workerProvider = new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, ImmutableMap.of(), true);
+        assertThat(workerProvider.getWorkersPreferringComputeNode())
+                .containsOnlyOnceElementsOf(availableId2Backend.values());
+
+        workerProvider =
+                new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode, false);
+        assertThat(workerProvider.getWorkersPreferringComputeNode())
+                .containsOnlyOnceElementsOf(availableId2ComputeNode.values());
+    }
+
+    @Test
+    public void testReportBackendNotFoundException() {
+        WorkerProvider workerProvider =
+                new WorkerProvider(id2Backend, id2ComputeNode, availableId2Backend, availableId2ComputeNode, true);
+        Assert.assertThrows(SchedulerException.class, workerProvider::reportBackendNotFoundException);
+    }
+
+    public static void testUsingWorkerHelper(WorkerProvider workerProvider, ComputeNode worker) {
+        Assert.assertTrue(workerProvider.isUsingWorker(worker.getId()));
+        Assert.assertEquals(worker.getHttpAddress(), workerProvider.getUsingHttpAddrByAddr(worker.getAddress()));
+        Assert.assertEquals(worker, workerProvider.getUsingWorkerByAddr(worker.getAddress()));
+        assertThat(workerProvider.getUsingWorkerIDs()).contains(worker.getId());
+        assertThat(workerProvider.getUsingWorkerAddrs()).contains(worker.getAddress());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.plan;
 
 import com.google.common.collect.Maps;


### PR DESCRIPTION
1. Extract all the logic about choosing backends and compute nodes from `Coordinator` to `WorkerProvider`.
2. Do not check backend whether available or not at scheduling in `Coordinator`, only check it by `WorkerProvider` at the beginning of `exec`.
3. Use worker id instead of address to indicate a specific worker (compute node or backend node) at scheduling. In this way, we needn't maintain the address to worker mapping and just use `WorkerProvider#getWorkerById()`, because address of worker is mutable but id of worker is immutable.


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
