### PR TITLE
[BugFix] Fix use-after-free when set_call_back

### DIFF
--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -522,7 +522,7 @@ Status Aggregator::spill_aggregate_data(RuntimeState* state, std::function<Statu
         if (chunk_with_st.ok()) {
             if (!chunk_with_st.value()->is_empty()) {
                 RETURN_IF_ERROR(spiller->spill(state, chunk_with_st.value(), *io_executor,
-                                               RESOURCE_TLS_MEMTRACER_GUARD(state)));
+                                               TRACKER_WITH_SPILLER_GUARD(state, spiller)));
             }
         } else if (chunk_with_st.status().is_end_of_file()) {
             // chunk_provider return eos means provider has output all data from hash_map/hash_set.

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -107,10 +107,11 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::_pull_spilled_chunk
         return accumulated;
     }
 
+    auto& spiller = _aggregator->spiller();
+
     if (!_aggregator->is_spilled_eos()) {
         auto executor = _aggregator->spill_channel()->io_executor();
-        ASSIGN_OR_RETURN(auto chunk,
-                         _aggregator->spiller()->restore(state, *executor, RESOURCE_TLS_MEMTRACER_GUARD(state)));
+        ASSIGN_OR_RETURN(auto chunk, spiller->restore(state, *executor, TRACKER_WITH_SPILLER_GUARD(state, spiller)));
         if (chunk->is_empty()) {
             return chunk;
         }

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -79,18 +79,20 @@ Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
     }
 
     auto flush_function = [this](RuntimeState* state, auto io_executor) {
-        return _join_builder->spiller()->flush(state, *io_executor, RESOURCE_TLS_MEMTRACER_GUARD(state));
+        auto& spiller = _join_builder->spiller();
+        return spiller->flush(state, *io_executor, TRACKER_WITH_SPILLER_GUARD(state, spiller));
     };
 
     auto io_executor = _join_builder->spill_channel()->io_executor();
     auto set_call_back_function = [this](RuntimeState* state, auto io_executor) {
-        return _join_builder->spiller()->set_flush_all_call_back(
+        auto& spiller = _join_builder->spiller();
+        return spiller->set_flush_all_call_back(
                 [this]() {
                     _is_finished = true;
                     _join_builder->enter_probe_phase();
                     return Status::OK();
                 },
-                state, *io_executor, RESOURCE_TLS_MEMTRACER_GUARD(state));
+                state, *io_executor, TRACKER_WITH_SPILLER_GUARD(state, spiller));
     };
 
     publish_runtime_filters(state);

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -103,10 +103,9 @@ bool SpillableHashJoinProbeOperator::has_output() const {
             if (_current_reader[i]->has_output_data()) {
                 return true;
             } else if (!_current_reader[i]->has_restore_task()) {
-                auto query_ctx = runtime_state()->query_ctx()->weak_from_this();
-                auto wreader = std::weak_ptr(_current_reader[i]);
-                auto guard = spill::ResourceMemTrackerGuard(tls_mem_tracker, std::move(query_ctx), std::move(wreader));
-                _current_reader[i]->trigger_restore(runtime_state(), *_executor, guard);
+                _current_reader[i]->trigger_restore(
+                        runtime_state(), *_executor,
+                        RESOURCE_TLS_MEMTRACER_GUARD(runtime_state(), std::weak_ptr(_current_reader[i])));
             }
         }
     }
@@ -231,7 +230,7 @@ Status SpillableHashJoinProbeOperator::_push_probe_chunk(RuntimeState* state, co
         probe_partition->num_rows += size;
     };
     RETURN_IF_ERROR(_probe_spiller->partitioned_spill(state, chunk, hash_column.get(), partition_processer, executor,
-                                                      RESOURCE_TLS_MEMTRACER_GUARD(state)));
+                                                      TRACKER_WITH_SPILLER_GUARD(state, _probe_spiller)));
 
     return Status::OK();
 }
@@ -256,7 +255,7 @@ Status SpillableHashJoinProbeOperator::_load_partition_build_side(RuntimeState* 
             int64_t old_mem_usage = hash_table_mem_usage;
             RETURN_IF_ERROR(builder->append_chunk(state, std::move(chunk_st.value())));
             hash_table_mem_usage = builder->hash_table_mem_usage();
-            metrics.build_partition_peak_memory_usage->add(hash_table_mem_usage - old_mem_usage);
+            COUNTER_ADD(metrics.build_partition_peak_memory_usage, hash_table_mem_usage - old_mem_usage);
         } else if (chunk_st.status().is_end_of_file()) {
             RETURN_IF_ERROR(builder->build(state));
             finish = true;
@@ -328,8 +327,10 @@ Status SpillableHashJoinProbeOperator::_restore_probe_partition(RuntimeState* st
     for (size_t i = 0; i < _probers.size(); ++i) {
         // probe partition has been processed
         if (_probe_read_eofs[i]) continue;
-        RETURN_IF_ERROR(_current_reader[i]->trigger_restore(
-                state, *_executor, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_current_reader[i]))));
+        if (!_current_reader[i]->has_restore_task()) {
+            RETURN_IF_ERROR(_current_reader[i]->trigger_restore(
+                    state, *_executor, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_current_reader[i]))));
+        }
         if (_current_reader[i]->has_output_data()) {
             auto chunk_st = _current_reader[i]->restore(
                     state, *_executor, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_current_reader[i])));

--- a/be/src/exec/pipeline/nljoin/nljoin_context.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_context.cpp
@@ -48,7 +48,7 @@ Status NJJoinBuildInputChannel::add_chunk_to_spill_buffer(RuntimeState* state, C
     _num_rows += build_chunk->num_rows();
     _accumulator.push(std::move(build_chunk));
     if (auto chunk = _accumulator.pull()) {
-        RETURN_IF_ERROR(_spiller->spill(state, chunk, executor, RESOURCE_TLS_MEMTRACER_GUARD(state)));
+        RETURN_IF_ERROR(_spiller->spill(state, chunk, executor, TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
     }
 
     return Status::OK();

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_build_operator.cpp
@@ -61,7 +61,7 @@ Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
         return Status::OK();
     }
 
-    RETURN_IF_ERROR(spiller->flush(state, executor, RESOURCE_TLS_MEMTRACER_GUARD(state)));
+    RETURN_IF_ERROR(spiller->flush(state, executor, TRACKER_WITH_SPILLER_GUARD(state, spiller)));
     spiller->set_flush_all_call_back(
             [&, state]() {
                 RETURN_IF_ERROR(_cross_join_context->finish_one_right_sinker(_driver_sequence, state));
@@ -69,7 +69,7 @@ Status SpillableNLJoinBuildOperator::set_finishing(RuntimeState* state) {
                 _spill_channel->set_finishing();
                 return Status::OK();
             },
-            state, executor, RESOURCE_TLS_MEMTRACER_GUARD(state));
+            state, executor, TRACKER_WITH_SPILLER_GUARD(state, spiller));
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
@@ -149,7 +149,7 @@ bool SpillableNLJoinProbeOperator::is_finished() const {
 }
 
 bool SpillableNLJoinProbeOperator::has_output() const {
-    return _chunk_stream && _chunk_stream->has_output();
+    return !_is_current_build_probe_finished() && _chunk_stream && _chunk_stream->has_output();
 }
 
 bool SpillableNLJoinProbeOperator::need_input() const {
@@ -199,6 +199,9 @@ StatusOr<ChunkPtr> SpillableNLJoinProbeOperator::pull_chunk(RuntimeState* state)
 
 Status SpillableNLJoinProbeOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
     TRACE_SPILL_LOG << "push_chunk:" << _driver_sequence;
+    if (chunk == nullptr || chunk->is_empty()) {
+        return Status::OK();
+    }
     _set_current_build_probe_finished(false);
     RETURN_IF_ERROR(_prober.push_probe_chunk(chunk));
     RETURN_IF_ERROR(_chunk_stream->reset(state, _spiller.get()));

--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -79,7 +79,7 @@ Status SpillablePartitionSortSinkOperator::set_finishing(RuntimeState* state) {
                     _is_finished = true;
                     return Status::OK();
                 },
-                state, *io_executor, RESOURCE_TLS_MEMTRACER_GUARD(state));
+                state, *io_executor, TRACKER_WITH_SPILLER_GUARD(state, _chunks_sorter->spiller()));
     };
 
     Status ret_status;

--- a/be/src/exec/pipeline/spill_process_operator.cpp
+++ b/be/src/exec/pipeline/spill_process_operator.cpp
@@ -47,8 +47,9 @@ StatusOr<ChunkPtr> SpillProcessOperator::pull_chunk(RuntimeState* state) {
     if (chunk_st.status().ok() && !state->is_cancelled()) {
         auto chunk = chunk_st.value();
         if (chunk != nullptr && !chunk->is_empty()) {
-            RETURN_IF_ERROR(_channel->spiller()->spill(state, std::move(chunk_st.value()), *_channel->io_executor(),
-                                                       RESOURCE_TLS_MEMTRACER_GUARD(state)));
+            auto& spiller = _channel->spiller();
+            RETURN_IF_ERROR(spiller->spill(state, std::move(chunk_st.value()), *_channel->io_executor(),
+                                           TRACKER_WITH_SPILLER_GUARD(state, spiller)));
         }
     } else if (chunk_st.status().is_end_of_file()) {
         _channel->current_task().reset();

--- a/be/src/exec/spill/executor.h
+++ b/be/src/exec/spill/executor.h
@@ -90,7 +90,7 @@ struct IOTaskExecutor {
     workgroup::ScanExecutor* pool;
     workgroup::WorkGroupPtr wg;
 
-    IOTaskExecutor(workgroup::ScanExecutor* pool_, workgroup::WorkGroupPtr wg_) : pool(pool_), wg(wg_) {}
+    IOTaskExecutor(workgroup::ScanExecutor* pool_, workgroup::WorkGroupPtr wg_) : pool(pool_), wg(std::move(wg_)) {}
 
     template <class Func>
     Status submit(Func&& func) {
@@ -113,5 +113,7 @@ struct SyncTaskExecutor {
 
 #define RESOURCE_TLS_MEMTRACER_GUARD(state, ...) \
     spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this(), ##__VA_ARGS__)
+
+#define TRACKER_WITH_SPILLER_GUARD(state, spiller) RESOURCE_TLS_MEMTRACER_GUARD(state, spiller->weak_from_this())
 
 } // namespace starrocks::spill

--- a/be/src/exec/spill/input_stream.cpp
+++ b/be/src/exec/spill/input_stream.cpp
@@ -378,6 +378,10 @@ StatusOr<InputStreamPtr> BlockGroup::as_unordered_stream(const SerdePtr& serde, 
 
 StatusOr<InputStreamPtr> BlockGroup::as_ordered_stream(RuntimeState* state, const SerdePtr& serde, Spiller* spiller,
                                                        const SortExecExprs* sort_exprs, const SortDescs* sort_descs) {
+    if (_blocks.empty()) {
+        return as_unordered_stream(serde, spiller);
+    }
+
     auto stream = std::make_shared<OrderedInputStream>(_blocks, state);
     RETURN_IF_ERROR(stream->init(serde, sort_exprs, sort_descs, spiller));
     return stream;

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -94,7 +94,7 @@ public:
 };
 
 // major spill interfaces
-class Spiller {
+class Spiller : public std::enable_shared_from_this<Spiller> {
 public:
     Spiller(SpilledOptions opts, const std::shared_ptr<SpillerFactory>& factory)
             : _opts(std::move(opts)), _parent(factory) {}
@@ -142,6 +142,7 @@ public:
     Status set_flush_all_call_back(const FlushAllCallBack& callback, RuntimeState* state, IOTaskExecutor& executor,
                                    const MemGuard& guard) {
         auto flush_call_back = [this, callback, state, &executor, guard]() {
+            RETURN_IF(!guard.scoped_begin(), Status::Cancelled("cancelled"));
             RETURN_IF_ERROR(callback());
             if (!_is_cancel && spilled()) {
                 RETURN_IF_ERROR(_acquire_input_stream(state));

--- a/be/src/exec/spillable_chunks_sorter_full_sort.cpp
+++ b/be/src/exec/spillable_chunks_sorter_full_sort.cpp
@@ -36,7 +36,7 @@ Status SpillableChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr
     bool first_time_spill = _spiller->spilled_append_rows() == 0;
     CHECK(!_spill_channel->has_task());
 
-    RETURN_IF_ERROR(_spiller->spill(state, chunk, io_executor(), RESOURCE_TLS_MEMTRACER_GUARD(state)));
+    RETURN_IF_ERROR(_spiller->spill(state, chunk, io_executor(), TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
 
     if (first_time_spill) {
         auto process_task = _spill_process_task();
@@ -45,7 +45,7 @@ Status SpillableChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr
             if (chunk_st.ok()) {
                 if (!chunk_st.value()->is_empty()) {
                     RETURN_IF_ERROR(_spiller->spill(state, chunk_st.value(), io_executor(),
-                                                    RESOURCE_TLS_MEMTRACER_GUARD(state)));
+                                                    TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
                 }
             } else if (chunk_st.status().is_end_of_file()) {
                 return Status::OK();
@@ -66,14 +66,14 @@ Status SpillableChunksSorterFullSort::do_done(RuntimeState* state) {
 
     if (_sorted_chunks.empty() && _unsorted_chunk == nullptr) {
         // force flush
-        RETURN_IF_ERROR(_spiller->flush(state, io_executor(), RESOURCE_TLS_MEMTRACER_GUARD(state)));
+        RETURN_IF_ERROR(_spiller->flush(state, io_executor(), TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
     } else {
         // TODO: avoid sort multi times
         // spill sorted chunks
         auto spill_process_task = _spill_process_task();
         _spill_channel->add_spill_task({std::move(spill_process_task)});
         std::function<StatusOr<ChunkPtr>()> flush_task = [this, state]() -> StatusOr<ChunkPtr> {
-            RETURN_IF_ERROR(_spiller->flush(state, io_executor(), RESOURCE_TLS_MEMTRACER_GUARD(state)));
+            RETURN_IF_ERROR(_spiller->flush(state, io_executor(), TRACKER_WITH_SPILLER_GUARD(state, _spiller)));
             return Status::EndOfFile("eos");
         };
         _spill_channel->add_spill_task({std::move(flush_task)});
@@ -156,7 +156,7 @@ std::function<StatusOr<ChunkPtr>()> SpillableChunksSorterFullSort::_spill_proces
 }
 
 Status SpillableChunksSorterFullSort::_get_result_from_spiller(ChunkPtr* chunk, bool* eos) {
-    auto chunk_st = _spiller->restore(_state, io_executor(), RESOURCE_TLS_MEMTRACER_GUARD(_state));
+    auto chunk_st = _spiller->restore(_state, io_executor(), TRACKER_WITH_SPILLER_GUARD(_state, _spiller));
     if (chunk_st.status().is_end_of_file()) {
         *eos = true;
     }


### PR DESCRIPTION
For short-circuiting cases, this may result in the spiller being destructed early but the querycontext not being destructed, which can lead to use-after-free

fix such problem:
```
*** Aborted at 1688627331 (unix time) try "date -d @1688627331" if you are using GNU date ***
PC: @     0x7f7b534e69d5 __GI_raise
*** SIGABRT (@0x3e900237c64) received by PID 2325604 (TID 0x7f7a69fef640) from PID 2325604; stack trace: ***
    @          0x59bd9c2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f7b5369b1d0 (unknown)
    @     0x7f7b534e69d5 __GI_raise
    @     0x7f7b534cf894 __GI_abort
    @          0x237c0d2 _ZN9__gnu_cxx27__verbose_terminate_handlerEv.cold
    @          0x787cad6 __cxxabiv1::__terminate()
    @          0x787cb41 std::terminate()
    @          0x787d1ff __cxa_pure_virtual
    @          0x2997fab starrocks::spill::RawSpillerWriter::acquire_stream()
    @          0x28f7603 _ZZN9starrocks5spill24PartitionedSpillerWriter5flushIRNS0_14IOTaskExecutorERNS0_23ResourceMemTrackerGuardIJSt8weak_ptrINS_8pipeline12QueryContextEEEEEEENS_6StatusEPNS_12RuntimeStateEOT_OT0_ENKUlvE0_clEv
    @          0x28f8c84 _ZNSt17_Function_handlerIFvvEZN9starrocks5spill24PartitionedSpillerWriter5flushIRNS2_14IOTaskExecutorERNS2_23ResourceMemTrackerGuardIJSt8weak_ptrINS1_8pipeline12QueryContextEEEEEEENS1_6StatusEPNS1_12RuntimeStateEOT_OT0_EUlvE0_E9_M_invokeERKSt9_Any_data
    @          0x2624271 starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x488f0f2 starrocks::ThreadPool::dispatch_thread()
    @          0x4889bea starrocks::Thread::supervise_thread()
    @     0x7f7b536903fb start_thread
    @     0x7f7b535acc23 __GI___clone
    @                0x0 (unknown)
start time: Thu Jul 6 03:09:15 PM CST 2023
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
