### PR TITLE
[Enhancement] Don't parse partition value for each chunk when inserting static partition iceberg table

### DIFF
--- a/be/src/exec/pipeline/sink/iceberg_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/iceberg_table_sink_operator.cpp
@@ -101,7 +101,8 @@ Status IcebergTableSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr&
         }
 
         _partition_writers[ICEBERG_UNPARTITIONED_TABLE_LOCATION]->append_chunk(chunk.get(), state);
-        return Status::OK();
+    } else if (_is_static_partition_insert && !_partition_writers.empty()) {
+        _partition_writers.begin()->second->append_chunk(chunk.get(), state);
     } else {
         Columns partitions_columns;
         partitions_columns.resize(_partition_expr.size());
@@ -130,9 +131,8 @@ Status IcebergTableSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr&
         } else {
             partition_writer->second->append_chunk(chunk.get(), state);
         }
-
-        return Status::OK();
     }
+    return Status::OK();
 }
 
 std::string IcebergTableSinkOperator::_get_partition_location(const std::vector<std::string>& names,
@@ -178,11 +178,13 @@ IcebergTableSinkOperatorFactory::IcebergTableSinkOperatorFactory(int32_t id, Fra
           _file_format(thrift_sink.file_format),
           _compression_codec(thrift_sink.compression_type),
           _cloud_conf(thrift_sink.cloud_configuration),
-          _partition_expr_ctxs(std::move(partition_expr_ctxs)) {
+          _partition_expr_ctxs(std::move(partition_expr_ctxs)),
+          is_static_partition_insert(thrift_sink.is_static_partition_sink) {
     DCHECK(thrift_sink.__isset.location);
     DCHECK(thrift_sink.__isset.file_format);
     DCHECK(thrift_sink.__isset.compression_type);
     DCHECK(thrift_sink.__isset.cloud_configuration);
+    DCHECK(thrift_sink.__isset.is_static_partition_sink);
 }
 
 Status IcebergTableSinkOperatorFactory::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/sink/iceberg_table_sink_operator.h
+++ b/be/src/exec/pipeline/sink/iceberg_table_sink_operator.h
@@ -35,7 +35,7 @@ public:
                              const TCloudConfiguration& cloud_conf, IcebergTableDescriptor* iceberg_table,
                              FragmentContext* fragment_ctx, const std::shared_ptr<::parquet::schema::GroupNode>& schema,
                              const std::vector<ExprContext*>& output_expr_ctxs,
-                             const vector<ExprContext*>& partition_output_expr)
+                             const vector<ExprContext*>& partition_output_expr, bool is_static_partition_insert)
             : Operator(factory, id, "iceberg_table_sink", plan_node_id, driver_sequence),
               _location(std::move(location)),
               _iceberg_table_data_location(_location + "/data/"),
@@ -45,7 +45,8 @@ public:
               _iceberg_table(iceberg_table),
               _parquet_file_schema(std::move(schema)),
               _output_expr(output_expr_ctxs),
-              _partition_expr(partition_output_expr) {}
+              _partition_expr(partition_output_expr),
+              _is_static_partition_insert(is_static_partition_insert) {}
 
     ~IcebergTableSinkOperator() override = default;
 
@@ -86,6 +87,7 @@ private:
     std::vector<ExprContext*> _partition_expr;
     std::unordered_map<std::string, std::unique_ptr<starrocks::RollingAsyncParquetWriter>> _partition_writers;
     std::atomic<bool> _is_finished = false;
+    bool _is_static_partition_insert = false;
 };
 
 class IcebergTableSinkOperatorFactory final : public OperatorFactory {
@@ -98,9 +100,10 @@ public:
     ~IcebergTableSinkOperatorFactory() override = default;
 
     OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
-        return std::make_shared<IcebergTableSinkOperator>(
-                this, _id, _plan_node_id, driver_sequence, _location, _file_format, _compression_codec, _cloud_conf,
-                _iceberg_table, _fragment_ctx, _parquet_file_schema, _output_expr_ctxs, _partition_expr_ctxs);
+        return std::make_shared<IcebergTableSinkOperator>(this, _id, _plan_node_id, driver_sequence, _location,
+                                                          _file_format, _compression_codec, _cloud_conf, _iceberg_table,
+                                                          _fragment_ctx, _parquet_file_schema, _output_expr_ctxs,
+                                                          _partition_expr_ctxs, is_static_partition_insert);
     }
 
     Status prepare(RuntimeState* state) override;
@@ -123,6 +126,7 @@ private:
 
     std::shared_ptr<::parquet::schema::GroupNode> _parquet_file_schema;
     std::vector<ExprContext*> _partition_expr_ctxs;
+    bool is_static_partition_insert = false;
 };
 
 } // namespace pipeline


### PR DESCRIPTION

Fixes #issue
create table partitioned_table (k1 int, k2 int) partition by (k2).
For
 `insert into partitioned_table select c1, 5 from source_table` and
 `insert into partition_table partition(k2=5) select c1 from source_table`, we don't need to parse partition value string from each chunk.  Each iceberg sink operator parses the partition value only once, and then directly reuses cached writer. Because there is only on partition value.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
