### PR TITLE
[BugFix] skip update replica version which is not been commited

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -417,6 +417,9 @@ public class DatabaseTransactionMgr {
         if (Config.empty_load_as_error && (tabletCommitInfos == null || tabletCommitInfos.isEmpty())) {
             throw new TransactionCommitFailedException(TransactionCommitFailedException.NO_DATA_TO_LOAD_MSG);
         }
+        if (tabletCommitInfos != null && !tabletCommitInfos.isEmpty()) {
+            transactionState.setTabletCommitInfos(tabletCommitInfos);
+        }
 
         // update transaction state extra if exists
         if (txnCommitAttachment != null) {
@@ -965,6 +968,11 @@ public class DatabaseTransactionMgr {
                                         && replica.getLastFailedVersion() < 0) {
                                     // if replica not in can load state, skip it.
                                     if (!replica.getState().canLoad()) {
+                                        continue;
+                                    }
+                                    // if replica not commit yet, skip it. This may happen when it's just create by clone.
+                                    if (!transactionState.tabletCommitInfosContainsReplica(tablet.getId(), 
+                                            replica.getBackendId())) {
                                         continue;
                                     }
                                     // this means the replica is a healthy replica,

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TabletCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TabletCommitInfo.java
@@ -124,4 +124,22 @@ public class TabletCommitInfo implements Writable {
         Gson gson = new Gson();
         return gson.toJson(this);
     }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(tabletId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof TabletCommitInfo)) {
+            return false;
+        }
+
+        TabletCommitInfo info = (TabletCommitInfo) obj;
+        return (tabletId == info.tabletId) && (backendId == info.backendId);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -301,6 +301,7 @@ public class TransactionState implements Writable {
     private long checkerCreationTime = 0;
     private Span txnSpan = null;
     private String traceParent = null;
+    private Set<TabletCommitInfo> tabletCommitInfos = null;
 
     public TransactionState() {
         this.dbId = -1;
@@ -357,6 +358,21 @@ public class TransactionState implements Writable {
 
     public boolean isRunning() {
         return transactionStatus == TransactionStatus.PREPARE || transactionStatus == TransactionStatus.COMMITTED;
+    }
+
+    public void setTabletCommitInfos(List<TabletCommitInfo> infos) {
+        this.tabletCommitInfos = Sets.newHashSet();
+        this.tabletCommitInfos.addAll(infos);
+    }
+
+    public boolean tabletCommitInfosContainsReplica(long tabletId, long backendId) {
+        TabletCommitInfo info = new TabletCommitInfo(tabletId, backendId);
+        if (this.tabletCommitInfos == null || this.tabletCommitInfos.contains(info)) {
+            // if tabletCommitInfos is null, skip this check and return true
+            return true;
+        } else {
+            return false;
+        }
     }
 
     // Only for OlapTable


### PR DESCRIPTION
Skip update replica's version, when this replica isn't committed yet. This can happen when this replica is just created by balance clone.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
