### PR TITLE
[Enhancement] Optimize generatePartitionRefMap performance when there are many partitions in base table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionRange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionRange.java
@@ -1,0 +1,90 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import com.google.common.collect.Range;
+import com.starrocks.catalog.PartitionKey;
+
+import java.util.Objects;
+
+/**
+ * `PartitionRange` contains a `PartitionKey` range and the partition's name to represent a table's partition range info.
+ */
+public class PartitionRange implements Comparable<PartitionRange> {
+    private final Range<PartitionKey> partitionKeyRange;
+    private final String partitionName;
+
+    public PartitionRange(String partitionName, Range<PartitionKey> partitionKeyRange) {
+        this.partitionName = partitionName;
+        this.partitionKeyRange = partitionKeyRange;
+    }
+
+    public Range<PartitionKey> getPartitionKeyRange() {
+        return partitionKeyRange;
+    }
+
+    public String getPartitionName() {
+        return partitionName;
+    }
+
+    /**
+     * `PartitionRange`'s compareTo method is not an exact comparator, but it can work for Partition Ranges:
+     *   1. Partitions are serial un-connected ranges which are not interact between each other, so we can just compare
+     * `lowerEndPoint` directly.
+     *   2. Choose two interact partition ranges as `equal` to let callers handle it directly.
+     */
+    @Override
+    public int compareTo(PartitionRange o) {
+        if (isInteract(o)) {
+            return 0;
+        }
+        return this.partitionKeyRange.lowerEndpoint().compareTo(o.partitionKeyRange.lowerEndpoint());
+    }
+
+    /**
+     * Check two partition range is `interact` which is a bit different from Range's `isConnected` method, eg:
+     * [2, 4) and [4, 6) are not interact;
+     * [2, 4) and [4, 6) are connected, because both enclose the empty range [4, 4).
+     *
+     * public boolean isConnected(Range<C> other) {
+     *     return lowerBound.compareTo(other.upperBound) <= 0
+     *         && other.lowerBound.compareTo(upperBound) <= 0;
+     *   }
+     */
+    public boolean isInteract(PartitionRange o) {
+        return this.partitionKeyRange.upperEndpoint().compareTo(o.partitionKeyRange.lowerEndpoint()) > 0 &&
+                this.partitionKeyRange.lowerEndpoint().compareTo(o.partitionKeyRange.upperEndpoint()) < 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (o == this) {
+            return true;
+        }
+        if (o == null || !(o instanceof PartitionRange)) {
+            return false;
+        }
+        PartitionRange range = (PartitionRange) o;
+
+        return this.partitionName.equals(((PartitionRange) o).partitionName) &&
+                this.partitionKeyRange.equals(range.partitionKeyRange);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partitionName, partitionKeyRange);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionRange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionRange.java
@@ -47,7 +47,7 @@ public class PartitionRange implements Comparable<PartitionRange> {
      */
     @Override
     public int compareTo(PartitionRange o) {
-        if (isInteract(o)) {
+        if (isIntersected(o)) {
             return 0;
         }
         return this.partitionKeyRange.lowerEndpoint().compareTo(o.partitionKeyRange.lowerEndpoint());
@@ -63,7 +63,7 @@ public class PartitionRange implements Comparable<PartitionRange> {
      *         && other.lowerBound.compareTo(upperBound) <= 0;
      *   }
      */
-    public boolean isInteract(PartitionRange o) {
+    public boolean isIntersected(PartitionRange o) {
         return this.partitionKeyRange.upperEndpoint().compareTo(o.partitionKeyRange.lowerEndpoint()) > 0 &&
                 this.partitionKeyRange.lowerEndpoint().compareTo(o.partitionKeyRange.upperEndpoint()) < 0;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -225,13 +225,13 @@ public class SyncPartitionUtils {
             addedSet.add(dstRanges.get(mid).getPartitionName());
 
             int lower = mid - 1;
-            while (lower >= 0 && dstRanges.get(lower).isInteract(srcRange)) {
+            while (lower >= 0 && dstRanges.get(lower).isIntersected(srcRange)) {
                 addedSet.add(dstRanges.get(lower).getPartitionName());
                 lower--;
             }
 
             int higher = mid + 1;
-            while (higher < dstRanges.size() && dstRanges.get(higher).isInteract(srcRange)) {
+            while (higher < dstRanges.size() && dstRanges.get(higher).isIntersected(srcRange)) {
                 addedSet.add(dstRanges.get(higher).getPartitionName());
                 higher++;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -119,7 +119,7 @@ public class SyncPartitionUtils {
                 rollupRange.get(name))).collect(Collectors.toList());
         List<PartitionRange> baseRanges = baseRangeMap.keySet().stream().map(name -> new PartitionRange(name,
                 baseRangeMap.get(name))).collect(Collectors.toList());
-        List<PartitionRange> mvRanges = baseRangeMap.keySet().stream().map(name -> new PartitionRange(name,
+        List<PartitionRange> mvRanges = mvRangeMap.keySet().stream().map(name -> new PartitionRange(name,
                 mvRangeMap.get(name))).collect(Collectors.toList());
         Map<String, Set<String>> partitionRefMap = generatePartitionRefMap(rollupRanges, baseRanges);
         Map<String, Range<PartitionKey>> adds = diffRange(rollupRanges, mvRanges);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionBench.java
@@ -320,13 +320,13 @@ public class SyncPartitionBench {
             addedSet.add(dstRanges.get(mid).getPartitionName());
 
             int lower = mid - 1;
-            while (lower >= 0 && dstRanges.get(lower).isInteract(srcRange)) {
+            while (lower >= 0 && dstRanges.get(lower).isIntersected(srcRange)) {
                 addedSet.add(dstRanges.get(lower).getPartitionName());
                 lower--;
             }
 
             int higher = mid + 1;
-            while (higher < dstRanges.size() && dstRanges.get(higher).isInteract(srcRange)) {
+            while (higher < dstRanges.size() && dstRanges.get(higher).isIntersected(srcRange)) {
                 addedSet.add(dstRanges.get(higher).getPartitionName());
                 higher++;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionBench.java
@@ -15,8 +15,10 @@
 
 package com.starrocks.sql.common;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.ScalarType;
@@ -42,27 +44,17 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
 
-/**
- * Before:
- * Benchmark                          (diffRatio)  (times)  Mode  Cnt     Score       Error  Units
- * SyncPartitionBench.diffRangeBench          0.0    10000  avgt    3     9.707 ±    28.411  ms/op
- * SyncPartitionBench.diffRangeBench          0.2    10000  avgt    3  1065.355 ±  2022.494  ms/op
- * SyncPartitionBench.diffRangeBench          0.5    10000  avgt    3  3559.056 ±  3291.629  ms/op
- * SyncPartitionBench.diffRangeBench          0.8    10000  avgt    3  8779.244 ± 44517.617  ms/op
- * SyncPartitionBench.diffRangeBench          1.0    10000  avgt    3  3225.946 ±  2554.938  ms/op
- *
- * After(Optimize):
- * Benchmark                          (diffRatio)  (times)  Mode  Cnt  Score    Error  Units
- *  SyncPartitionBench.diffRangeBench          0.0    10000  avgt    3  0.539 ±  1.183  ms/op
- *  SyncPartitionBench.diffRangeBench          0.2    10000  avgt    3  0.875 ±  1.059  ms/op
- *  SyncPartitionBench.diffRangeBench          0.5    10000  avgt    3  1.007 ±  2.012  ms/op
- *  SyncPartitionBench.diffRangeBench          0.8    10000  avgt    3  1.219 ±  2.082  ms/op
- *  SyncPartitionBench.diffRangeBench          1.0    10000  avgt    3  6.453 ± 15.021  ms/op
- */
+import static com.starrocks.sql.common.SyncPartitionUtils.PartitionRange.PARTITION_RANGE_COMPARATOR;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -91,6 +83,25 @@ public class SyncPartitionBench {
 
     private final Map<String, Range<PartitionKey>> srcRangeMap = Maps.newHashMap();
     private final Map<String, Range<PartitionKey>> dstRangeMap = Maps.newHashMap();
+
+    static class RangeComparator implements Comparator<Range<PartitionKey>> {
+        @Override
+        public int compare(Range<PartitionKey> a, Range<PartitionKey> b) {
+            int lower = a.lowerEndpoint().compareTo(b.lowerEndpoint());
+            int higher = a.upperEndpoint().compareTo(b.upperEndpoint());
+            if (lower < 0 && higher < 0) {
+                return -1;
+            } else if (lower > 0 && higher > 0) {
+                return 1;
+            } else {
+                return 0;
+            }
+        }
+    }
+
+    public static final RangeComparator RANGE_COMPARATOR = new RangeComparator();
+    private final NavigableMap<Range<PartitionKey>, String> sortedSrcRangeMap = Maps.newTreeMap(RANGE_COMPARATOR);
+    private final NavigableMap<Range<PartitionKey>, String> sortedDstRangeMap = Maps.newTreeMap(RANGE_COMPARATOR);
 
     private static Range<PartitionKey> createRangeImpl(PartitionValue lowerValue, PartitionValue upperValue)
             throws AnalysisException {
@@ -126,8 +137,10 @@ public class SyncPartitionBench {
             String curDateFormat = dateToString(curDate);
             String nextDateFormat = dateToString(nextDate);
             srcRangeMap.put(curDateFormat, createRange(curDateFormat, nextDateFormat));
+            sortedSrcRangeMap.put(createRange(curDateFormat, nextDateFormat), curDateFormat);
             if (((double) i / times) < diffRatio) {
                 dstRangeMap.put(curDateFormat, createRange(curDateFormat, nextDateFormat));
+                sortedDstRangeMap.put(createRange(curDateFormat, nextDateFormat), curDateFormat);
             }
 
             Date tmpDate = nextHour(nextDate, 1);
@@ -140,8 +153,189 @@ public class SyncPartitionBench {
         System.out.println("dstRangeMap size =" + dstRangeMap.size());
     }
 
+    /**
+     * Before:
+     * Benchmark                          (diffRatio)  (times)  Mode  Cnt     Score       Error  Units
+     * SyncPartitionBench.diffRangeBench          0.0    10000  avgt    3     9.707 ±    28.411  ms/op
+     * SyncPartitionBench.diffRangeBench          0.2    10000  avgt    3  1065.355 ±  2022.494  ms/op
+     * SyncPartitionBench.diffRangeBench          0.5    10000  avgt    3  3559.056 ±  3291.629  ms/op
+     * SyncPartitionBench.diffRangeBench          0.8    10000  avgt    3  8779.244 ± 44517.617  ms/op
+     * SyncPartitionBench.diffRangeBench          1.0    10000  avgt    3  3225.946 ±  2554.938  ms/op
+     *
+     * After(Optimize):
+     * Benchmark                          (diffRatio)  (times)  Mode  Cnt  Score    Error  Units
+     *  SyncPartitionBench.diffRangeBench          0.0    10000  avgt    3  0.539 ±  1.183  ms/op
+     *  SyncPartitionBench.diffRangeBench          0.2    10000  avgt    3  0.875 ±  1.059  ms/op
+     *  SyncPartitionBench.diffRangeBench          0.5    10000  avgt    3  1.007 ±  2.012  ms/op
+     *  SyncPartitionBench.diffRangeBench          0.8    10000  avgt    3  1.219 ±  2.082  ms/op
+     *  SyncPartitionBench.diffRangeBench          1.0    10000  avgt    3  6.453 ± 15.021  ms/op
+     */
     @Benchmark
     public void diffRangeBench() {
         SyncPartitionUtils.diffRange(srcRangeMap, dstRangeMap);
+    }
+
+    /**
+     * Benchmark                                          (diffRatio)  (times)  Mode  Cnt     Score      Error  Units
+     * SyncPartitionBench.generatePartitionRefMapBench            0.0    10000  avgt    3     0.519 ±    0.294  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBench            0.2    10000  avgt    3  1151.045 ± 1253.707  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBench            0.5    10000  avgt    3  2930.250 ±  559.559  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBench            0.8    10000  avgt    3  5429.398 ± 5800.045  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBench            1.0    10000  avgt    3  7270.963 ± 8934.326  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV2          0.0    10000  avgt    3     0.608 ±    0.220  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV2          0.2    10000  avgt    3     9.022 ±    1.003  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV2          0.5    10000  avgt    3    12.499 ±    1.411  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV2          0.8    10000  avgt    3    29.210 ±  195.279  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV2          1.0    10000  avgt    3    26.178 ±   14.617  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV3          0.0    10000  avgt    3     9.289 ±    3.088  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV3          0.2    10000  avgt    3    15.637 ±    5.514  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV3          0.5    10000  avgt    3    53.742 ±  259.085  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV3          0.8    10000  avgt    3    55.790 ±   13.173  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV3          1.0    10000  avgt    3    43.172 ±   16.877  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV4          0.0    10000  avgt    3   0.456 ±  0.491  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV4          0.2    10000  avgt    3  19.407 ± 12.175  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV4          0.5    10000  avgt    3  23.905 ±  9.250  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV4          0.8    10000  avgt    3  28.735 ± 34.026  ms/op
+     * SyncPartitionBench.generatePartitionRefMapBenchV4          1.0    10000  avgt    3  33.426 ± 18.251  ms/op
+     */
+    @Benchmark
+    public void generatePartitionRefMapBench() {
+        generatePartitionRefMap(srcRangeMap, dstRangeMap);
+    }
+    @Benchmark
+    public void generatePartitionRefMapBenchV2() {
+        generatePartitionRefMapV2(sortedSrcRangeMap, sortedDstRangeMap);
+    }
+    @Benchmark
+    public void generatePartitionRefMapBenchV3() {
+        generatePartitionRefMapV3(srcRangeMap, dstRangeMap);
+    }
+    @Benchmark
+    public void generatePartitionRefMapBenchV4() {
+        generatePartitionRefMapV4(srcRangeMap, dstRangeMap);
+    }
+
+    public static Map<String, Set<String>> generatePartitionRefMap(Map<String, Range<PartitionKey>> srcRangeMap,
+                                                                   Map<String, Range<PartitionKey>> dstRangeMap) {
+        Map<String, Set<String>> result = Maps.newHashMap();
+        for (Map.Entry<String, Range<PartitionKey>> srcEntry : srcRangeMap.entrySet()) {
+            Iterator<Map.Entry<String, Range<PartitionKey>>> dstIter = dstRangeMap.entrySet().iterator();
+            result.put(srcEntry.getKey(), Sets.newHashSet());
+            while (dstIter.hasNext()) {
+                Map.Entry<String, Range<PartitionKey>> dstEntry = dstIter.next();
+                Range<PartitionKey> dstRange = dstEntry.getValue();
+                int upperLowerCmp = srcEntry.getValue().upperEndpoint().compareTo(dstRange.lowerEndpoint());
+                if (upperLowerCmp <= 0) {
+                    continue;
+                }
+                int lowerUpperCmp = srcEntry.getValue().lowerEndpoint().compareTo(dstRange.upperEndpoint());
+                if (lowerUpperCmp >= 0) {
+                    continue;
+                }
+                Set<String> dstNames = result.get(srcEntry.getKey());
+                dstNames.add(dstEntry.getKey());
+            }
+        }
+        return result;
+    }
+
+    public static Map<String, Set<String>> generatePartitionRefMapV2(NavigableMap<Range<PartitionKey>, String> srcRangeMap,
+                                                                     NavigableMap<Range<PartitionKey>, String> dstRangeMap) {
+        Map<String, Set<String>> result = Maps.newHashMap();
+        srcRangeMap.values().stream().forEach(x -> result.put(x, Sets.newHashSet()));
+        if (dstRangeMap.isEmpty()) {
+            return result;
+        }
+
+        Range<PartitionKey> dstLowestKey = dstRangeMap.firstKey();
+        Range<PartitionKey> dstHighestKey = dstRangeMap.lastKey();
+
+        for (Map.Entry<Range<PartitionKey>, String> srcEntry : srcRangeMap.entrySet()) {
+            Range<PartitionKey> srcRange = srcEntry.getKey();
+            if (srcRange.upperEndpoint().compareTo(dstLowestKey.lowerEndpoint()) < 0 ||
+                    srcRange.lowerEndpoint().compareTo(dstHighestKey.upperEndpoint()) > 0) {
+                continue;
+            }
+            dstLowestKey = dstRangeMap.lowerKey(srcRange);
+            dstHighestKey = dstRangeMap.higherKey(srcRange);
+            if (dstLowestKey == null && dstHighestKey == null) {
+                continue;
+            }
+            if (dstLowestKey == null) {
+                dstLowestKey = dstRangeMap.firstKey();
+            }
+            if (dstHighestKey == null) {
+                dstHighestKey = dstRangeMap.lastKey();
+            }
+            SortedMap<Range<PartitionKey>, String> subDstRangeMap =
+                    dstRangeMap.subMap(dstLowestKey, true, dstHighestKey, true);
+            Iterator<Map.Entry<Range<PartitionKey>, String>> dstIter = subDstRangeMap.entrySet().iterator();
+            while (dstIter.hasNext()) {
+                Map.Entry<Range<PartitionKey>, String> dstEntry = dstIter.next();
+                Range<PartitionKey> dstRange = dstEntry.getKey();
+                // NOTE: cannot use Range::isConnected yet!
+                if (srcRange.upperEndpoint().compareTo(dstRange.lowerEndpoint()) > 0 &&
+                        srcRange.lowerEndpoint().compareTo(dstRange.upperEndpoint()) < 0) {
+                    result.computeIfAbsent(srcEntry.getValue(), x -> Sets.newHashSet())
+                            .add(dstEntry.getValue());
+                }
+            }
+        }
+        return result;
+    }
+
+    public static Map<String, Set<String>> generatePartitionRefMapV3(Map<String, Range<PartitionKey>> srcRangeMap,
+                                                                     Map<String, Range<PartitionKey>> dstRangeMap) {
+        NavigableMap<Range<PartitionKey>, String> sortedSrcRangeMap = Maps.newTreeMap(RANGE_COMPARATOR);
+        NavigableMap<Range<PartitionKey>, String> sortedDstRangeMap = Maps.newTreeMap(RANGE_COMPARATOR);
+        for (Map.Entry<String, Range<PartitionKey>> e : srcRangeMap.entrySet()) {
+            sortedSrcRangeMap.put(e.getValue(), e.getKey());
+        }
+        for (Map.Entry<String, Range<PartitionKey>> e : dstRangeMap.entrySet()) {
+            sortedDstRangeMap.put(e.getValue(), e.getKey());
+        }
+        return generatePartitionRefMapV2(sortedSrcRangeMap, sortedDstRangeMap);
+    }
+
+    public static Map<String, Set<String>> generatePartitionRefMapV4(Map<String, Range<PartitionKey>> srcRangeMap,
+                                                                     Map<String, Range<PartitionKey>> dstRangeMap) {
+        Map<String, Set<String>> result = Maps.newHashMap();
+        srcRangeMap.keySet().stream().forEach(x -> result.put(x, Sets.newHashSet()));
+        if (dstRangeMap.isEmpty()) {
+            return result;
+        }
+
+        List<SyncPartitionUtils.PartitionRange> sortedSrcRangeMap = com.google.common.collect.Lists.newArrayList();
+        List<SyncPartitionUtils.PartitionRange> sortedDstRangeMap = Lists.newArrayList();
+        for (Map.Entry<String, Range<PartitionKey>> e : srcRangeMap.entrySet()) {
+            sortedSrcRangeMap.add(new SyncPartitionUtils.PartitionRange(e.getKey(), e.getValue()));
+        }
+        for (Map.Entry<String, Range<PartitionKey>> e : dstRangeMap.entrySet()) {
+            sortedDstRangeMap.add(new SyncPartitionUtils.PartitionRange(e.getKey(), e.getValue()));
+        }
+        Collections.sort(sortedSrcRangeMap, PARTITION_RANGE_COMPARATOR);
+        Collections.sort(sortedDstRangeMap, PARTITION_RANGE_COMPARATOR);
+
+        for (SyncPartitionUtils.PartitionRange srcRange : sortedSrcRangeMap) {
+            int mid = Collections.binarySearch(sortedDstRangeMap, srcRange);
+            if (mid < 0) {
+                continue;
+            }
+            Set<String> addedSet = result.get(srcRange.getPartitionName());
+            addedSet.add(sortedDstRangeMap.get(mid).getPartitionName());
+
+            int lower = mid - 1;
+            while (lower >= 0 && sortedDstRangeMap.get(lower).isInteract(srcRange)) {
+                addedSet.add(sortedDstRangeMap.get(lower).getPartitionName());
+                lower--;
+            }
+
+            int higher = mid + 1;
+            while (higher < sortedDstRangeMap.size() && sortedDstRangeMap.get(higher).isInteract(srcRange)) {
+                addedSet.add(sortedDstRangeMap.get(higher).getPartitionName());
+                higher++;
+            }
+        }
+        return result;
     }
 }


### PR DESCRIPTION
- Optimize `generatePartitionRefMapBench` performance by binary search method.

Before:
```
   * Benchmark                                          (diffRatio)  (times)  Mode  Cnt     Score      Error  Units
     * SyncPartitionBench.generatePartitionRefMapBench            0.0    10000  avgt    3     0.519 ±    0.294  ms/op
     * SyncPartitionBench.generatePartitionRefMapBench            0.2    10000  avgt    3  1151.045 ± 1253.707  ms/op
     * SyncPartitionBench.generatePartitionRefMapBench            0.5    10000  avgt    3  2930.250 ±  559.559  ms/op
     * SyncPartitionBench.generatePartitionRefMapBench            0.8    10000  avgt    3  5429.398 ± 5800.045  ms/op
     * SyncPartitionBench.generatePartitionRefMapBench            1.0    10000  avgt    3  7270.963 ± 8934.326  ms/op
```

After:
```
     * SyncPartitionBench.generatePartitionRefMapBenchV4          0.0    10000  avgt    3   0.456 ±  0.491  ms/op
     * SyncPartitionBench.generatePartitionRefMapBenchV4          0.2    10000  avgt    3  19.407 ± 12.175  ms/op
     * SyncPartitionBench.generatePartitionRefMapBenchV4          0.5    10000  avgt    3  23.905 ±  9.250  ms/op
     * SyncPartitionBench.generatePartitionRefMapBenchV4          0.8    10000  avgt    3  28.735 ± 34.026  ms/op
     * SyncPartitionBench.generatePartitionRefMapBenchV4          1.0    10000  avgt    3  33.426 ± 18.251  ms/op
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
