### PR TITLE
[BugFix] fix limit not being pushdown correctly

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/StarRocksPlannerException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/StarRocksPlannerException.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.sql.common;
 
+import com.google.common.base.Strings;
+
 public class StarRocksPlannerException extends RuntimeException {
     private final ErrorType type;
 
@@ -25,6 +27,13 @@ public class StarRocksPlannerException extends RuntimeException {
         super(message);
         this.type = type;
     }
+
+    public StarRocksPlannerException(ErrorType type, String messageTemplate,  Object... errorMessageArgs) {
+        super(Strings.lenientFormat(messageTemplate, errorMessageArgs));
+        this.type = type;
+    }
+
+
 
     @Override
     public String getMessage() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/LimitImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/LimitImplementationRule.java
@@ -15,8 +15,9 @@
 
 package com.starrocks.sql.optimizer.rule.implementation;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -35,7 +36,10 @@ public class LimitImplementationRule extends ImplementationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalLimitOperator limit = (LogicalLimitOperator) input.getOp();
-        Preconditions.checkState(limit.isGlobal());
+        if (!limit.isGlobal()) {
+            throw new StarRocksPlannerException(ErrorType.INTERNAL_ERROR,
+                    "cannot contains local limit operator in implementation phase.\n%s", input.explain());
+        }
         return Lists.newArrayList(OptExpression
                 .create(new PhysicalLimitOperator(limit.getOffset(), limit.getLimit(), limit.getProjection()),
                         input.getInputs()));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitDirectRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitDirectRule.java
@@ -19,17 +19,13 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
-import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
-import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
-import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class MergeLimitDirectRule extends TransformationRule {
     public static final MergeLimitDirectRule AGGREGATE = new MergeLimitDirectRule(OperatorType.LOGICAL_AGGR);
@@ -62,19 +58,7 @@ public class MergeLimitDirectRule extends TransformationRule {
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {
         LogicalLimitOperator limit = (LogicalLimitOperator) input.getOp();
-        Operator op = input.inputAt(0).getOp();
-        // Merging limit into AggregateOperator with multi distinct aggregations prohibits
-        // RewriteMultiDistinctByCTERule from transform such a AggregateOperator into MulticastSink+HashJoin or
-        // MulticastSink+NestLoopJoin Plan.
-        if (op instanceof LogicalAggregationOperator) {
-            LogicalAggregationOperator aggOp = op.cast();
-            List<CallOperator> distinctAggOperatorList = aggOp.getAggregations().values().stream()
-                    .filter(CallOperator::isDistinct).collect(Collectors.toList());
-            boolean hasMultiColumns = distinctAggOperatorList.stream().anyMatch(f -> f.getChildren().size() > 1);
-            return (!hasMultiColumns || distinctAggOperatorList.size() > 1) && limit.isLocal();
-        } else {
-            return limit.isLocal();
-        }
+        return limit.isLocal();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeProjectWithChildRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeProjectWithChildRule.java
@@ -40,27 +40,28 @@ public class MergeProjectWithChildRule extends TransformationRule {
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalProjectOperator logicalProjectOperator = (LogicalProjectOperator) input.getOp();
+        LogicalOperator child = (LogicalOperator) input.inputAt(0).getOp();
+        boolean isPushLimit = logicalProjectOperator.hasLimit() && (!child.hasLimit() || child.getLimit() >
+                logicalProjectOperator.getLimit());
+        Operator.Builder builder = OperatorBuilderFactory.build(child);
+        builder.withOperator(child);
+        if (isPushLimit) {
+            builder.setLimit(logicalProjectOperator.getLimit());
+        }
 
         if (logicalProjectOperator.getColumnRefMap().isEmpty()) {
-            return Lists.newArrayList(input.getInputs().get(0));
+            return Lists.newArrayList(OptExpression.create(builder.build(), input.inputAt(0).getInputs()));
         }
-        LogicalOperator child = (LogicalOperator) input.inputAt(0).getOp();
+
 
         ColumnRefSet projectColumns = logicalProjectOperator.getOutputColumns(
                 new ExpressionContext(input));
         ColumnRefSet childOutputColumns = child.getOutputColumns(new ExpressionContext(input.inputAt(0)));
         if (projectColumns.equals(childOutputColumns)) {
-            return input.getInputs();
+            return Lists.newArrayList(OptExpression.create(builder.build(), input.inputAt(0).getInputs()));
         }
 
-        Operator.Builder builder = OperatorBuilderFactory.build(child);
-        builder.withOperator(child).setProjection(new Projection(logicalProjectOperator.getColumnRefMap()));
-
-        if (logicalProjectOperator.hasLimit()) {
-            builder.setLimit(Math.min(logicalProjectOperator.getLimit(), child.getLimit()));
-        } else {
-            builder.setLimit(child.getLimit());
-        }
+        builder.setProjection(new Projection(logicalProjectOperator.getColumnRefMap()));
 
         return Lists.newArrayList(OptExpression.create(builder.build(), input.inputAt(0).getInputs()));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
@@ -149,10 +150,6 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
             return true;
         }
 
-        if (agg.getLimit() >= 0) {
-            return false;
-        }
-
         if (!hasMultiColumns && agg.getGroupingKeys().size() > 1) {
             return false;
         }
@@ -183,10 +180,6 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = Maps.newHashMap();
         LinkedList<OptExpression> allCteConsumes = buildDistinctAggCTEConsume(aggregate, distinctAggList, cteProduce,
                 columnRefFactory, columnRefMap);
-        // For inner join(with group by), distinct aggregate cannot have limitation
-        if (hasGroupBy) {
-            allCteConsumes.forEach(opt -> opt.getOp().setLimit(Operator.DEFAULT_LIMIT));
-        }
 
         if (otherAggregate.size() > 0) {
             allCteConsumes.offer(
@@ -217,6 +210,7 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
             }
             allCteConsumes.offerFirst(join);
         }
+
         // Add project node
         LogicalProjectOperator.Builder builder = new LogicalProjectOperator.Builder();
         builder.setColumnRefMap(columnRefMap);
@@ -226,6 +220,12 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
         // Add filter node
         if (aggregate.getPredicate() != null) {
             rightTree = OptExpression.create(new LogicalFilterOperator(aggregate.getPredicate()), rightTree);
+        }
+
+        if (aggregate.hasLimit()) {
+            Operator.Builder opBuilder = OperatorBuilderFactory.build(rightTree.getOp());
+            opBuilder.withOperator(rightTree.getOp()).setLimit(aggregate.getLimit());
+            rightTree = OptExpression.create(opBuilder.build(), rightTree.getInputs());
         }
 
         context.getCteContext().addForceCTE(cteId);
@@ -375,7 +375,8 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
 
         LogicalAggregationOperator newAggregate = new LogicalAggregationOperator.Builder().withOperator(aggregate).
                 setAggregations(aggregateFn).setGroupingKeys(rewriteGroupingKeys).
-                setPartitionByColumns(rewriteGroupingKeys).setPredicate(null).build();
+                setPartitionByColumns(rewriteGroupingKeys).setPredicate(null).
+                setLimit(Operator.DEFAULT_LIMIT).build();
         return OptExpression.create(newAggregate, OptExpression.create(cteConsume));
     }
 
@@ -411,7 +412,8 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
 
         LogicalAggregationOperator newAggregate = new LogicalAggregationOperator.Builder().withOperator(aggregate).
                 setAggregations(aggregateFn).setGroupingKeys(rewriteGroupingKeys).
-                setPartitionByColumns(rewriteGroupingKeys).setPredicate(null).build();
+                setPartitionByColumns(rewriteGroupingKeys).
+                setLimit(Operator.DEFAULT_LIMIT).setPredicate(null).build();
 
         return OptExpression.create(newAggregate, OptExpression.create(cteConsume));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
@@ -150,6 +150,10 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
             return true;
         }
 
+        if (agg.hasLimit()) {
+            return false;
+        }
+
         if (!hasMultiColumns && agg.getGroupingKeys().size() > 1) {
             return false;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -43,23 +43,22 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class SelectStmtTest {
     private static StarRocksAssert starRocksAssert;
 
-    @Rule
-    public ExpectedException expectedEx = ExpectedException.none();
-
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
         String createTblStmtStr = "create table db1.tbl1(k1 varchar(32), k2 varchar(32), k3 varchar(32), k4 int) "
@@ -109,13 +108,13 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testGroupByConstantExpression() throws Exception {
+    void testGroupByConstantExpression() throws Exception {
         String sql = "SELECT k1 - 4*60*60 FROM baseall GROUP BY k1 - 4*60*60";
         starRocksAssert.query(sql).explainQuery();
     }
 
     @Test
-    public void testWithWithoutDatabase() throws Exception {
+    void testWithWithoutDatabase() throws Exception {
         String sql = "with tmp as (select count(*) from db1.tbl1) select * from tmp;";
         starRocksAssert.withoutUseDatabase();
         starRocksAssert.query(sql).explainQuery();
@@ -128,7 +127,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testDataGripSupport() throws Exception {
+    void testDataGripSupport() throws Exception {
         String sql = "select schema();";
         starRocksAssert.query(sql).explainQuery();
         sql = "select\n" +
@@ -140,7 +139,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testEqualExprNotMonotonic() throws Exception {
+    void testEqualExprNotMonotonic() throws Exception {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
         String sql = "select k1 from db1.baseall where (k1=10) = true";
         String expectString =
@@ -154,7 +153,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testCurrentUserFunSupport() throws Exception {
+    void testCurrentUserFunSupport() throws Exception {
         String sql = "select current_user()";
         starRocksAssert.query(sql).explainQuery();
         sql = "select current_user";
@@ -162,7 +161,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testTimeFunSupport() throws Exception {
+    void testTimeFunSupport() throws Exception {
         String sql = "select current_timestamp()";
         starRocksAssert.query(sql).explainQuery();
         sql = "select current_timestamp";
@@ -186,14 +185,14 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testDateTruncUpperCase() throws Exception {
+    void testDateTruncUpperCase() throws Exception {
         String sql = "select date_trunc('MONTH', CAST('2020-11-04 11:12:13' AS DATE));";
         ConnectContext ctx = starRocksAssert.getCtx();
         UtFrameUtils.parseStmtWithNewParser(sql, ctx);
     }
 
     @Test
-    public void testSelectFromTabletIds() throws Exception {
+    void testSelectFromTabletIds() throws Exception {
         FeConstants.runningUnitTest = true;
         ShowResultSet tablets = starRocksAssert.showTablet("db1", "partition_table");
         List<String> tabletIds = tablets.getResultRows().stream().map(r -> r.get(0)).collect(Collectors.toList());
@@ -214,7 +213,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testNegateEqualForNullInWhereClause() throws Exception {
+    void testNegateEqualForNullInWhereClause() throws Exception {
         String[] queryList = {
                 "select * from db1.tbl1 where not(k1 <=> NULL)",
                 "select * from db1.tbl1 where not(k1 <=> k2)",
@@ -228,7 +227,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testSimplifiedPredicateRuleApplyToNegateEuqualForNull() throws Exception {
+    void testSimplifiedPredicateRuleApplyToNegateEuqualForNull() throws Exception {
         String[] queryList = {
                 "select not(k1 <=> NULL) from db1.tbl1",
                 "select not(NULL <=> k1) from db1.tbl1",
@@ -251,7 +250,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testFoldCastOfChildExprsOfSetOperation() throws Exception {
+    void testFoldCastOfChildExprsOfSetOperation() throws Exception {
         String sql0 = "select cast('abcdefg' as varchar(2)) a, cast('abc' as  varchar(3)) b\n" +
                 "intersect\n" +
                 "select cast('aa123456789' as varchar) a, cast('abcd' as varchar(4)) b";
@@ -278,8 +277,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testBanSubqueryAppearsInLeftSideChildOfInPredicates()
-            throws Exception {
+    void testBanSubqueryAppearsInLeftSideChildOfInPredicates() {
         String sql = "select k1, count(k2) from db1.tbl1 group by k1 " +
                 "having (exists (select k1 from db1.tbl1 where NULL)) in (select k1 from db1.tbl1 where NULL);";
         try {
@@ -290,7 +288,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testGroupByCountDistinctWithSkewHint() throws Exception {
+    void testGroupByCountDistinctWithSkewHint() throws Exception {
         FeConstants.runningUnitTest = true;
         String sql =
                 "select cast(k1 as int), count(distinct [skew] cast(k2 as int)) from db1.tbl1 group by cast(k1 as int)";
@@ -303,7 +301,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testGroupByCountDistinctArrayWithSkewHint() throws Exception {
+    void testGroupByCountDistinctArrayWithSkewHint() throws Exception {
         FeConstants.runningUnitTest = true;
         // array is not supported now
         String sql = "select b1, count(distinct [skew] a1) as cnt from (select split('a,b,c', ',') as a1, 'aaa' as b1) t1 group by b1";
@@ -340,7 +338,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testGroupByMultiColumnCountDistinctWithSkewHint() throws Exception {
+    void testGroupByMultiColumnCountDistinctWithSkewHint() throws Exception {
         FeConstants.runningUnitTest = true;
         String sql =
                 "select cast(k1 as int), k3, count(distinct [skew] cast(k2 as int)) from db1.tbl1 group by cast(k1 as int), k3";
@@ -368,7 +366,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testGroupByCountDistinctUseTheSameColumn()
+    void testGroupByCountDistinctUseTheSameColumn()
             throws Exception {
         FeConstants.runningUnitTest = true;
         String sql =
@@ -379,7 +377,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testScalarCorrelatedSubquery() {
+    void testScalarCorrelatedSubquery() {
         try {
             String sql = "select *, (select [a.k1,a.k2] from db1.tbl1 a where a.k4 = b.k1) as r from db1.baseall b;";
             UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
@@ -398,37 +396,89 @@ public class SelectStmtTest {
         }
     }
 
-    @Test
-    public void testMultiDistinctMultiColumnWithLimit() throws Exception {
-        String[] sqlList = {
-                "select count(distinct k1, k2), count(distinct k3) from db1.tbl1 limit 1",
-                "select * from (select count(distinct k1, k2), count(distinct k3) from db1.tbl1) t1 limit 1",
-                "with t1 as (select count(distinct k1, k2) as a, count(distinct k3) as b from db1.tbl1) " +
-                        "select * from t1 limit 1",
-                "select count(distinct k1, k2), count(distinct k3) from db1.tbl1 group by k4 limit 1",
-                "select * from (select count(distinct k1, k2), count(distinct k3) from db1.tbl1 group by k4, k3) t1" +
-                        " limit 1",
-                "with t1 as (select count(distinct k1, k2) as a, count(distinct k3) as b from db1.tbl1 " +
-                        "group by k2, k3, k4) select * from t1 limit 1",
-        };
-        boolean cboCteReuse = starRocksAssert.getCtx().getSessionVariable().isCboCteReuse();
-        try {
-            starRocksAssert.getCtx().getSessionVariable().setCboCteReuse(true);
-            for (String sql : sqlList) {
-                UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
-            }
-            starRocksAssert.getCtx().getSessionVariable().setCboCteReuse(false);
-            for (String sql : sqlList) {
-                UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
-            }
+    @ParameterizedTest
+    @MethodSource("multiDistinctMultiColumnWithLimitSqls")
+    void testMultiDistinctMultiColumnWithLimit(String sql, String pattern) throws Exception {
+        starRocksAssert.getCtx().getSessionVariable().setOptimizerExecuteTimeout(30000000);
+        String plan = UtFrameUtils.getFragmentPlan(starRocksAssert.getCtx(), sql);
+        System.out.println(plan);
+        Assert.assertTrue(plan, plan.contains(pattern));
+    }
 
-        } finally {
-            starRocksAssert.getCtx().getSessionVariable().setCboCteReuse(cboCteReuse);
-        }
+
+    private static Stream<Arguments> multiDistinctMultiColumnWithLimitSqls() {
+        String[][] sqlList = {
+                {"select count(distinct k1, k2), count(distinct k3) from db1.tbl1 limit 1",
+                        "18:NESTLOOP JOIN\n" +
+                                "  |  join op: CROSS JOIN\n" +
+                                "  |  colocate: false, reason: \n" +
+                                "  |  limit: 1\n" +
+                                "  |  \n" +
+                                "  |----17:EXCHANGE"},
+                {"select * from (select count(distinct k1, k2), count(distinct k3) from db1.tbl1) t1 limit 1",
+                     "18:NESTLOOP JOIN\n" +
+                             "  |  join op: CROSS JOIN\n" +
+                             "  |  colocate: false, reason: \n" +
+                             "  |  limit: 1\n" +
+                             "  |  \n" +
+                             "  |----17:EXCHANGE"
+                },
+                {"with t1 as (select count(distinct k1, k2) as a, count(distinct k3) as b from db1.tbl1) " +
+                        "select * from t1 limit 1",
+                        "18:NESTLOOP JOIN\n" +
+                                "  |  join op: CROSS JOIN\n" +
+                                "  |  colocate: false, reason: \n" +
+                                "  |  limit: 1\n" +
+                                "  |  \n" +
+                                "  |----17:EXCHANGE"
+                },
+                {"select count(distinct k1, k2), count(distinct k3) from db1.tbl1 group by k4 limit 1",
+                    "18:Project\n" +
+                            "  |  <slot 5> : 5: count\n" +
+                            "  |  <slot 6> : 6: count\n" +
+                            "  |  limit: 1\n" +
+                            "  |  \n" +
+                            "  17:HASH JOIN\n" +
+                            "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                            "  |  colocate: false, reason: \n" +
+                            "  |  equal join conjunct: 9: k4 <=> 11: k4\n" +
+                            "  |  limit: 1"
+                },
+                {"select * from (select count(distinct k1, k2), count(distinct k3) from db1.tbl1 group by k4, k3) t1" +
+                        " limit 1",
+                       "16:Project\n" +
+                               "  |  <slot 5> : 5: count\n" +
+                               "  |  <slot 6> : 6: count\n" +
+                               "  |  limit: 1\n" +
+                               "  |  \n" +
+                               "  15:HASH JOIN\n" +
+                               "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                               "  |  colocate: false, reason: \n" +
+                               "  |  equal join conjunct: 10: k4 <=> 12: k4\n" +
+                               "  |  equal join conjunct: 9: k3 <=> 11: k3\n" +
+                               "  |  limit: 1"
+                },
+                {"with t1 as (select count(distinct k1, k2) as a, count(distinct k3) as b from db1.tbl1 " +
+                        "group by k2, k3, k4) select * from t1 limit 1",
+                        "16:Project\n" +
+                                "  |  <slot 11> : 11: count\n" +
+                                "  |  <slot 12> : 12: count\n" +
+                                "  |  limit: 1\n" +
+                                "  |  \n" +
+                                "  15:HASH JOIN\n" +
+                                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                                "  |  colocate: false, reason: \n" +
+                                "  |  equal join conjunct: 14: k2 <=> 17: k2\n" +
+                                "  |  equal join conjunct: 15: k3 <=> 18: k3\n" +
+                                "  |  equal join conjunct: 16: k4 <=> 19: k4\n" +
+                                "  |  limit: 1"
+                }
+        };
+        return Arrays.stream(sqlList).map(e -> Arguments.of(e[0], e[1]));
     }
 
     @Test
-    public void testSubstringConstantFolding() {
+    void testSubstringConstantFolding() {
         try {
             String sql = "select * from db1.t where dt = \"2022-01-02\" or dt = cast(substring(\"2022-01-03\", 1, 10) as date);";
             String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
@@ -439,7 +489,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testAnalyzeDecimalArithmeticExprIdempotently()
+    void testAnalyzeDecimalArithmeticExprIdempotently()
             throws Exception {
         {
             String sql = "select c0, sum(c2/(1+c1)) as a, sum(c2/(1+c1)) as b from t0 group by c0;";

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -271,7 +271,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testCatalogFunSupport() throws Exception {
+    void testCatalogFunSupport() throws Exception {
         String sql = "select catalog()";
         starRocksAssert.query(sql).explainQuery();
     }
@@ -352,7 +352,7 @@ public class SelectStmtTest {
     }
 
     @Test
-    public void testGroupByMultiColumnMultiCountDistinctWithSkewHint() throws Exception {
+    void testGroupByMultiColumnMultiCountDistinctWithSkewHint() throws Exception {
         FeConstants.runningUnitTest = true;
         String sql =
                 "select k1, k3, count(distinct [skew] k2), count(distinct k4) from db1.tbl1 group by k1, k3";

--- a/test/sql/test_agg/R/test_distinct_agg
+++ b/test/sql/test_agg/R/test_distinct_agg
@@ -198,3 +198,23 @@ select     /*+ SET_VAR (streaming_preaggregation_mode = 'force_streaming',new_pl
 -- result:
 1
 -- !result
+select count(distinct c1, c2) from skew_agg limit 5;
+-- result:
+1
+-- !result
+select count(distinct c1, c2, c3) from skew_agg group by c4 limit 500;
+-- result:
+1
+-- !result
+select count(distinct c1, c2), count(distinct c2, c3), sum(c2) from skew_agg limit 5;
+-- result:
+1	1	3750
+-- !result
+select count(distinct c1, c2, c3), count(distinct c2, c3), sum(c2) from skew_agg group by c4 limit 500;
+-- result:
+1	1	3750
+-- !result
+select count(distinct t1.c1, if(t2.c3 is null, 1, 0)), sum(t1.c2 + if(t2.c3 is null, 1, 0)) from skew_agg t1 left join skew_agg t2 on t1.c4 > t2.c4 group by t1.c4 limit 500;
+-- result:
+1	5000
+-- !result

--- a/test/sql/test_agg/T/test_distinct_agg
+++ b/test/sql/test_agg/T/test_distinct_agg
@@ -84,3 +84,9 @@ select     /*+ SET_VAR (streaming_preaggregation_mode = 'force_streaming',new_pl
 
 select     /*+ SET_VAR (streaming_preaggregation_mode = 'force_streaming',new_planner_agg_stage='2') */  array_length(array_agg(a1)) as cnt from (select split('a,b,c', ',') as a1, 'aaa' as b1) t1 group by b1;
 select     /*+ SET_VAR (streaming_preaggregation_mode = 'force_streaming',new_planner_agg_stage='3') */  array_length(array_agg(a1)) as cnt from (select split('a,b,c', ',') as a1, 'aaa' as b1) t1 group by b1;
+
+select count(distinct c1, c2) from skew_agg limit 5;
+select count(distinct c1, c2, c3) from skew_agg group by c4 limit 500;
+select count(distinct c1, c2), count(distinct c2, c3), sum(c2) from skew_agg limit 5;
+select count(distinct c1, c2, c3), count(distinct c2, c3), sum(c2) from skew_agg group by c4 limit 500;
+select count(distinct t1.c1, if(t2.c3 is null, 1, 0)), sum(t1.c2 + if(t2.c3 is null, 1, 0)) from skew_agg t1 left join skew_agg t2 on t1.c4 > t2.c4 group by t1.c4 limit 500;


### PR DESCRIPTION
Fixes #issue
```
select count(distinct user_id, name) from test_primary_001 limit 5;
```
The plan of the above sql is wrong because a local limit operator not being pushdown to its child.

We can remove the limitation when rewriting multiple distinct agg funs into CTE if there exists a limit above the agg operator by just add a limit above the rewrite result.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
