### PR TITLE
[BugFix] Using UTC timezone when read time which less then unix epoch time in orc timestamp type

### DIFF
--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -498,7 +498,6 @@ OrcChunkReader::~OrcChunkReader() {
     _slot_id_to_position.clear();
     _cast_exprs.clear();
     _column_readers.clear();
-    //    _fill_functions.clear();
 }
 
 Status OrcChunkReader::read_next(orc::RowReader::ReadPosition* pos) {
@@ -565,8 +564,6 @@ Status OrcChunkReader::_fill_chunk(ChunkPtr* chunk, const std::vector<SlotDescri
             }
         }
         ColumnPtr& col = (*chunk)->get_column_by_slot_id(slot_desc->id());
-        //        _fill_functions[src_index](cvb, col, 0, _batch->numElements, _src_types[src_index],
-        //                                   _root_selected_mapping->get_orc_type_child_mapping(src_index).orc_mapping, this);
         _column_readers[src_index]->get_next(cvb, col, 0, _batch->numElements);
     }
 

--- a/be/src/formats/orc/utils.h
+++ b/be/src/formats/orc/utils.h
@@ -90,7 +90,11 @@ public:
             seconds = is_instant ? seconds + tzoffset : seconds;
             orc_ts_to_native_ts_after_unix_epoch(tv, seconds, nanoseconds);
         } else {
-            orc_ts_to_native_ts_before_unix_epoch(tv, tz, seconds, nanoseconds);
+            if (is_instant) {
+                orc_ts_to_native_ts_before_unix_epoch(tv, tz, seconds, nanoseconds);
+            } else {
+                orc_ts_to_native_ts_before_unix_epoch(tv, cctz::utc_time_zone(), seconds, nanoseconds);
+            }
         }
     }
 };

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -912,6 +912,7 @@ std::vector<TimestampValue> convert_orc_to_starrocks_timestamp(RuntimeState* sta
 }
 
 TEST_F(OrcChunkReaderTest, TestTimestamp) {
+    // clang-format off
     const std::vector<int64_t> orc_values = {
             // 2021.5.25 1:18:40 GMT
             // 2021.5.25 9:18:40 Asia/Shanghai
@@ -927,6 +928,7 @@ TEST_F(OrcChunkReaderTest, TestTimestamp) {
             // before unix epoch, time conversion is totoally a mess.
             -8444232248
     };
+    // clang-format on
     {
         // Instant Timestamp
         const std::vector<std::string> exp_values = {
@@ -935,7 +937,8 @@ TEST_F(OrcChunkReaderTest, TestTimestamp) {
                 "1702-06-01 04:01:35",
         };
         ObjectPool pool;
-        auto res = convert_orc_to_starrocks_timestamp(_runtime_state.get(), &pool, "Asia/Shanghai", "UTC", orc_values, true);
+        auto res = convert_orc_to_starrocks_timestamp(_runtime_state.get(), &pool, "Asia/Shanghai", "UTC", orc_values,
+                                                      true);
         EXPECT_EQ(res.size(), orc_values.size());
         for (size_t i = 0; i < res.size(); i++) {
             std::string o = res[i].to_string();
@@ -951,7 +954,8 @@ TEST_F(OrcChunkReaderTest, TestTimestamp) {
                 "1702-05-31 19:55:52",
         };
         ObjectPool pool;
-        auto res = convert_orc_to_starrocks_timestamp(_runtime_state.get(), &pool, "Asia/Shanghai", "UTC", orc_values, false);
+        auto res = convert_orc_to_starrocks_timestamp(_runtime_state.get(), &pool, "Asia/Shanghai", "UTC", orc_values,
+                                                      false);
         EXPECT_EQ(res.size(), orc_values.size());
         for (size_t i = 0; i < res.size(); i++) {
             std::string o = res[i].to_string();

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -840,11 +840,17 @@ TEST_F(OrcChunkReaderTest, TestDecimal128) {
 std::vector<TimestampValue> convert_orc_to_starrocks_timestamp(RuntimeState* state, ObjectPool* pool,
                                                                const std::string& reader_tz,
                                                                const std::string& write_tz,
-                                                               const std::vector<int64_t>& values) {
+                                                               const std::vector<int64_t>& values,
+                                                               const bool isInstant) {
     const char* filename = "orc_scanner_test_timestamp.orc";
     std::filesystem::remove(filename);
     ORC_UNIQUE_PTR<orc::OutputStream> outStream = orc::writeLocalFile(filename);
-    ORC_UNIQUE_PTR<orc::Type> schema(orc::Type::buildTypeFromString("struct<c0:timestamp with local time zone>"));
+    ORC_UNIQUE_PTR<orc::Type> schema;
+    if (isInstant) {
+        schema = orc::Type::buildTypeFromString("struct<c0:timestamp with local time zone>");
+    } else {
+        schema = orc::Type::buildTypeFromString("struct<c0:timestamp>");
+    }
 
     orc::WriterOptions writer_options;
     writer_options.setTimezoneName(write_tz);
@@ -906,34 +912,51 @@ std::vector<TimestampValue> convert_orc_to_starrocks_timestamp(RuntimeState* sta
 }
 
 TEST_F(OrcChunkReaderTest, TestTimestamp) {
-    // clang-format off
     const std::vector<int64_t> orc_values = {
-        // 2021.5.25 1:18:40 GMT
-        // 2021.5.25 9:18:40 Asia/Shanghai
-        1621905520,
-        // 1970.1.1 0:0:0 GMT
-        // 1970.1.1 8:00:0 Asia/Shanghai
-        0,
-        // 1702.5.31 19:55:52 GMT
-        // to Asia/Shanghai, it's supposed to be
-        // 1702.6.01 03:55:52
-        // but acutally it's
-        // 1702-06-01 04:01:35
-        // before unix epoch, time conversion is totoally a mess.
-        -8444232248
+            // 2021.5.25 1:18:40 GMT
+            // 2021.5.25 9:18:40 Asia/Shanghai
+            1621905520,
+            // 1970.1.1 0:0:0 GMT
+            // 1970.1.1 8:00:0 Asia/Shanghai
+            0,
+            // 1702.5.31 19:55:52 GMT
+            // to Asia/Shanghai, it's supposed to be
+            // 1702.6.01 03:55:52
+            // but acutally it's
+            // 1702-06-01 04:01:35
+            // before unix epoch, time conversion is totoally a mess.
+            -8444232248
     };
-    const std::vector<std::string> exp_values = {
-        "2021-05-25 09:18:40",
-        "1970-01-01 08:00:00",
-        "1702-06-01 04:01:35",
-    };
-    // clang-format on
-    ObjectPool pool;
-    auto res = convert_orc_to_starrocks_timestamp(_runtime_state.get(), &pool, "Asia/Shanghai", "UTC", orc_values);
-    EXPECT_EQ(res.size(), orc_values.size());
-    for (size_t i = 0; i < res.size(); i++) {
-        std::string o = res[i].to_string();
-        EXPECT_EQ(o, exp_values[i]);
+    {
+        // Instant Timestamp
+        const std::vector<std::string> exp_values = {
+                "2021-05-25 09:18:40",
+                "1970-01-01 08:00:00",
+                "1702-06-01 04:01:35",
+        };
+        ObjectPool pool;
+        auto res = convert_orc_to_starrocks_timestamp(_runtime_state.get(), &pool, "Asia/Shanghai", "UTC", orc_values, true);
+        EXPECT_EQ(res.size(), orc_values.size());
+        for (size_t i = 0; i < res.size(); i++) {
+            std::string o = res[i].to_string();
+            EXPECT_EQ(o, exp_values[i]);
+        }
+    }
+    {
+        // Timestamp
+        // Instant Timestamp
+        const std::vector<std::string> exp_values = {
+                "2021-05-25 01:18:40",
+                "1970-01-01 00:00:00",
+                "1702-05-31 19:55:52",
+        };
+        ObjectPool pool;
+        auto res = convert_orc_to_starrocks_timestamp(_runtime_state.get(), &pool, "Asia/Shanghai", "UTC", orc_values, false);
+        EXPECT_EQ(res.size(), orc_values.size());
+        for (size_t i = 0; i < res.size(); i++) {
+            std::string o = res[i].to_string();
+            EXPECT_EQ(o, exp_values[i]);
+        }
     }
 }
 


### PR DESCRIPTION
If orc's type is Timestamp Instant, we should add a timezone offset.
If orc's type is Timestamp, we should use UTC timezone directly.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
