### PR TITLE
[BugFix] Fix the mem statistics bug of ordinal index (#26819)

### DIFF
--- a/be/src/storage/rowset/ordinal_page_index.h
+++ b/be/src/storage/rowset/ordinal_page_index.h
@@ -112,7 +112,12 @@ private:
     void _reset();
 
     size_t _mem_usage() const {
-        return sizeof(OrdinalIndexReader) + (_num_pages + 1) * sizeof(ordinal_t) + (_num_pages + 1) * sizeof(uint64_t);
+        if (_num_pages == 0) {
+            return sizeof(OrdinalIndexReader);
+        } else {
+            return sizeof(OrdinalIndexReader) + (_num_pages + 1) * sizeof(ordinal_t) +
+                   (_num_pages + 1) * sizeof(uint64_t);
+        }
     }
 
     Status _do_load(fs::BlockManager* fs, const std::string& filename, const OrdinalIndexPB& meta, ordinal_t num_values,


### PR DESCRIPTION
Fixes #issue

This bug is import by the pr:
https://github.com/StarRocks/starrocks/pull/22195

If the ordinal index is not loaded, the num pages is 0, so size of the `_ordinals` and `_pages` is also 0, The new algorithm wrongly counts this part of memory.
