### PR TITLE
[BugFix] Fix the mem leak of AvroScanner

### DIFF
--- a/be/src/exec/avro_scanner.cpp
+++ b/be/src/exec/avro_scanner.cpp
@@ -84,7 +84,7 @@ AvroScanner::~AvroScanner() {
     avro_file_reader_close(_dbreader);
 #else
     if (_serdes != nullptr) {
-        free(_serdes);
+        serdes_destroy(_serdes);
     }
 #endif
 }


### PR DESCRIPTION
Fixes #issue

```
/**
 * Create a new serializer/deserializer handle using the optional `conf`.
 * If `conf` is non-NULL the serdes will assume ownership of the pointer
 * and the application shall consider the pointer freed.
 *
 * Use `serdes_destroy()` to free up resources associated with the serdes.
 *
 * Returns a new serdes object on success or NULL on failure (error string
 * written to `errstr`.
 */
SERDES_EXPORT
serdes_t *serdes_new (serdes_conf_t *conf, char *errstr, size_t errstr_size);


/**
 * Frees up any resources associated with the serdes, including schemas.
 * The serdes is no longer usable after this call.
 */
SERDES_EXPORT
void serdes_destroy (serdes_t *serdes);
```

```
void serdes_destroy (serdes_t *sd) {
        serdes_schema_t *ss;

        while ((ss = LIST_FIRST(&sd->sd_schemas)))
                serdes_schema_destroy(ss);

        serdes_conf_destroy0(&sd->sd_conf);

        mtx_destroy(&sd->sd_lock);
        free(sd);
}
```

```
Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x97925e8 in __interceptor_realloc ../../.././libsanitizer/asan/asan_malloc_linux.cpp:164
    #1 0x1553f8d9 in url_list_parse /root/starrocks/thirdparty/src/libserdes-7.3.1/src/rest.c:184
    #2 0x1553ee6f in serdes_conf_copy0 /root/starrocks/thirdparty/src/libserdes-7.3.1/src/serdes.c:67
    #3 0x1553ee6f in serdes_new /root/starrocks/thirdparty/src/libserdes-7.3.1/src/serdes.c:241
    #4 0xa6086ee in starrocks::AvroScanner::open() /root/starrocks/be/src/exec/avro_scanner.cpp:148
    #5 0x128ef83d in starrocks::connector::FileDataSource::_create_scanner() /root/starrocks/be/src/connector/file_connector.cpp:95
    #6 0x128eeb0d in starrocks::connector::FileDataSource::open(starrocks::RuntimeState*) /root/starrocks/be/src/connector/file_connector.cpp:67
    #7 0xab58faf in starrocks::ConnectorScanner::open(starrocks::RuntimeState*) /root/starrocks/be/src/exec/connector_scan_node.cpp:56
    #8 0xab53e16 in starrocks::ConnectorScanNode::_scanner_thread(starrocks::ConnectorScanner*) /root/starrocks/be/src/exec/connector_scan_node.cpp:438
    #9 0xab52ee9 in operator() /root/starrocks/be/src/exec/connector_scan_node.cpp:366
    #10 0xab57143 in __invoke_impl<void, starrocks::ConnectorScanNode::_submit_scanner(starrocks::ConnectorScanner*, bool)::<lambda()>&> /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:60
    #11 0xab56fe3 in __invoke_r<void, starrocks::ConnectorScanNode::_submit_scanner(starrocks::ConnectorScanner*, bool)::<lambda()>&> /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:110
    #12 0xab56e4b in _M_invoke /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:291
    #13 0x992a271 in std::function<void ()>::operator()() const /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
    #14 0x112141c1 in starrocks::PriorityThreadPool::work_thread(int) /root/starrocks/be/src/util/priority_thread_pool.hpp:198
    #15 0x112404ee in void std::__invoke_impl<void, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(std::__invoke_memfun_deref, void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&) /opt/gcc/u
sr/include/c++/10.3.0/bits/invoke.h:73
    #16 0x1124032e in std::__invoke_result<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>::type std::__invoke<void (starrocks::PriorityThreadPool::* const&)(int), starrocks::PriorityThreadPool*&, int&>(void (starrocks::PriorityTh
readPool::* const&)(int), starrocks::PriorityThreadPool*&, int&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:95
    #17 0x112402d8 in decltype (__invoke((*this)._M_pmf, (forward<starrocks::PriorityThreadPool*&>)({parm#1}), (forward<int&>)({parm#1}))) std::_Mem_fn_base<void (starrocks::PriorityThreadPool::*)(int), true>::operator()<starrocks::PriorityThreadPool*&, int&>(starrocks::Pri
orityThreadPool*&, int&) const /opt/gcc/usr/include/c++/10.3.0/functional:122
    #18 0x11240289 in void std::__invoke_impl<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>(std::__invoke_other, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&) /
opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:60
    #19 0x112401e0 in std::enable_if<is_invocable_r_v<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&>, void>::type std::__invoke_r<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::Priorit
yThreadPool*&, int&>(std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)>&, starrocks::PriorityThreadPool*&, int&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:110
    #20 0x112400bd in void std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) /opt/gcc/usr/include/c++/10.3.0/functional:566
    #21 0x1123fd7b in void std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)>::operator()<>() /opt/gcc/usr/include/c++/10.3.0/functional:625
    #22 0x1123f30f in boost::detail::thread_data<std::_Bind_result<void, std::_Mem_fn<void (starrocks::PriorityThreadPool::*)(int)> (starrocks::PriorityThreadPool*, int)> >::run() /var/local/thirdparty/installed/include/boost/thread/detail/thread.hpp:120
    #23 0x13d40bc6 in thread_proxy libs/thread/src/pthread/thread.cpp:179
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
