### PR TITLE
[BugFix] Fix show grants for resource group priv obj

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ResourceGroupPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ResourceGroupPEntryObject.java
@@ -122,7 +122,7 @@ public class ResourceGroupPEntryObject implements PEntryObject {
             if (resourceGroup == null) {
                 throw new MetaNotFoundException("Can't find resource group : " + id);
             }
-            return resourceGroup.toString();
+            return resourceGroup.getName();
         }
     }
 }


### PR DESCRIPTION
`ResourceGroupPEntryObject.toString()` should return
corresponding resource group name.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
