### PR TITLE
[BugFix] Fixed the problem of inaccurate memory statistics with auto spill turned on

### DIFF
--- a/be/src/exec/spill/executor.h
+++ b/be/src/exec/spill/executor.h
@@ -65,7 +65,10 @@ struct ResourceMemTrackerGuard {
         return true;
     }
 
-    void scoped_end() const { tls_thread_status.set_mem_tracker(old_tracker); }
+    void scoped_end() const {
+        tls_thread_status.set_mem_tracker(old_tracker);
+        captured = {};
+    }
 
 private:
     auto capture(const std::tuple<WeakPtrs...>& weak_tup) const

--- a/be/src/exec/spill/input_stream.cpp
+++ b/be/src/exec/spill/input_stream.cpp
@@ -98,8 +98,7 @@ StatusOr<ChunkUniquePtr> UnionAllSpilledInputStream::get_next(SerdeContext& cont
 // The raw chunk input stream. all chunks are in memory.
 class RawChunkInputStream final : public SpillInputStream {
 public:
-    RawChunkInputStream(std::vector<ChunkPtr> chunks, Spiller* spiller)
-            : _chunks(std::move(chunks)), _spiller(spiller) {}
+    RawChunkInputStream(std::vector<ChunkPtr> chunks, Spiller* spiller) : _chunks(std::move(chunks)) {}
     StatusOr<ChunkUniquePtr> get_next(SerdeContext& ctx) override;
 
     bool is_ready() override { return true; };
@@ -115,7 +114,6 @@ public:
 private:
     size_t read_idx{};
     std::vector<ChunkPtr> _chunks;
-    Spiller* _spiller = nullptr;
 };
 
 StatusOr<ChunkUniquePtr> RawChunkInputStream::get_next(SerdeContext& context) {

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -142,6 +142,7 @@ public:
     Status set_flush_all_call_back(const FlushAllCallBack& callback, RuntimeState* state, IOTaskExecutor& executor,
                                    const MemGuard& guard) {
         auto flush_call_back = [this, callback, state, &executor, guard]() {
+            auto defer = DeferOp([&]() { guard.scoped_end(); });
             RETURN_IF(!guard.scoped_begin(), Status::Cancelled("cancelled"));
             RETURN_IF_ERROR(callback());
             if (!_is_cancel && spilled()) {

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -73,6 +73,7 @@ private:
 
         bool try_mem_consume(int64_t size) {
             MemTracker* cur_tracker = _loader();
+            int64_t prev_reserved = _reserved_bytes;
             size = _consume_from_reserved(size);
             _cache_size += size;
             _allocated_cache_size += size;
@@ -83,6 +84,7 @@ private:
                     _cache_size = 0;
                     return true;
                 } else {
+                    _reserved_bytes = prev_reserved;
                     _cache_size -= size;
                     _allocated_cache_size -= size;
                     _try_consume_mem_size = size;
@@ -95,7 +97,6 @@ private:
 
         bool try_mem_consume_with_limited_tracker(int64_t size, MemTracker* tracker, int64_t limit) {
             MemTracker* cur_tracker = _loader();
-            size = _consume_from_reserved(size);
             _cache_size += size;
             _allocated_cache_size += size;
             _total_consumed_bytes += size;


### PR DESCRIPTION
We may trigger bad_alloc when the amount of memory we reserve is less than the amount of memory we actually consume, which will cause us to get an error in our memory statistics

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
