### PR TITLE
[BugFix] Fix date type as partition value when inserting iceberg table (#26760)

### DIFF
--- a/be/src/exec/pipeline/sink/iceberg_table_sink_operator.h
+++ b/be/src/exec/pipeline/sink/iceberg_table_sink_operator.h
@@ -70,10 +70,12 @@ public:
 
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
+    static void add_iceberg_commit_info(starrocks::parquet::AsyncFileWriter* writer, RuntimeState* state);
+
+    static Status partition_value_to_string(Column* column, std::string& partition_value);
+
 private:
     std::string _get_partition_location(const std::vector<std::string>& names, const std::vector<std::string>& values);
-
-    std::string _value_to_string(const ColumnPtr& column);
 
     std::string _location;
     std::string _iceberg_table_data_location;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -33,6 +33,7 @@ set(EXEC_FILES
         ./exec/es/es_scan_reader_test.cpp
         ./exec/es/es_scroll_parser_test.cpp
         ./exec/iceberg/iceberg_delete_builder_test.cpp
+        ./exec/iceberg/iceberg_table_sink_operator_test.cpp
         ./exec/workgroup/scan_task_queue_test.cpp
         ./exec/pipeline/pipeline_control_flow_test.cpp
         ./exec/pipeline/pipeline_driver_queue_test.cpp

--- a/be/test/exec/iceberg/iceberg_table_sink_operator_test.cpp
+++ b/be/test/exec/iceberg/iceberg_table_sink_operator_test.cpp
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/sink/iceberg_table_sink_operator.h"
+
+#include <gtest/gtest.h>
+
+#include "column/column_helper.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class IcebergTableSinkTest : public testing::Test {
+public:
+    IcebergTableSinkTest() = default;
+    ~IcebergTableSinkTest() override = default;
+};
+
+TEST_F(IcebergTableSinkTest, TestDateValueToString) {
+    auto type_date = TypeDescriptor::from_logical_type(TYPE_DATE);
+    std::vector<TypeDescriptor> type_descs{type_date};
+
+    auto data_column = DateColumn::create();
+    {
+        Datum datum;
+        datum.set_date(DateValue::create(2023, 7, 9));
+        data_column->append_datum(datum);
+    }
+    std::string date_partition_value;
+    auto st = pipeline::IcebergTableSinkOperator::partition_value_to_string(data_column.get(), date_partition_value);
+    ASSERT_OK(st);
+    ASSERT_EQ("2023-07-09", date_partition_value);
+}
+
+TEST_F(IcebergTableSinkTest, TestIntValueToString) {
+    auto int32_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
+    std::vector<int32_t> int32_nums{33};
+    auto count = int32_col->append_numbers(int32_nums.data(), size(int32_nums) * sizeof(int32_t));
+    ASSERT_EQ(1, count);
+
+    std::string int32_partition_value;
+    auto st = pipeline::IcebergTableSinkOperator::partition_value_to_string(int32_col.get(), int32_partition_value);
+    ASSERT_OK(st);
+    ASSERT_EQ("33", int32_partition_value);
+}
+
+TEST_F(IcebergTableSinkTest, TestStringValueToString) {
+    auto string_col = BinaryColumn::create();
+    string_col->append("hello");
+
+    std::string string_partition_value;
+    auto st = pipeline::IcebergTableSinkOperator::partition_value_to_string(string_col.get(), string_partition_value);
+    ASSERT_OK(st);
+    ASSERT_EQ("hello", string_partition_value);
+}
+
+TEST_F(IcebergTableSinkTest, TestFloatValueToString) {
+    auto float_column = FloatColumn::create();
+    std::vector<float> values = {0.1};
+    float_column->append_numbers(values.data(), values.size() * sizeof(float));
+
+    std::string float_partition_value;
+    auto st = pipeline::IcebergTableSinkOperator::partition_value_to_string(float_column.get(), float_partition_value);
+    ASSERT_TRUE(st.is_not_supported());
+    ASSERT_EQ("Partition value can't be float-4", st.message());
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
@@ -17,6 +17,7 @@ package com.starrocks.planner;
 import com.google.common.base.Preconditions;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Type;
 import com.starrocks.connector.Connector;
 import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
 import com.starrocks.credential.CloudConfiguration;
@@ -92,6 +93,10 @@ public class IcebergTableSink extends DataSink {
 
         Preconditions.checkState(cloudConfiguration != null,
                 String.format("cloudConfiguration of catalog %s should not be null", catalogName));
+    }
+
+    public static boolean isUnSupportedPartitionColumnType(Type type) {
+        return type.isFloat() || type.isDecimalOfAnyVersion() || type.isDatetime();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -32,6 +32,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.planner.IcebergTableSink;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.sql.ast.DefaultValueExpr;
@@ -159,6 +160,13 @@ public class InsertAnalyzer {
                 }
             } else if (insertStmt.isStaticKeyPartitionInsert()) {
                 checkStaticKeyPartitionInsert(insertStmt, icebergTable, targetPartitionNames);
+            }
+
+            for (Column column : icebergTable.getPartitionColumns()) {
+                if (IcebergTableSink.isUnSupportedPartitionColumnType(column.getType())) {
+                    throw new SemanticException("Unsupported partition column type [%s] for iceberg table sink",
+                            column.getType().canonicalName());
+                }
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.stream.Stream;
 
-
 public class InsertPlanTest extends PlanTestBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -819,6 +818,9 @@ public class InsertPlanTest extends PlanTestBase {
 
                 icebergTable.getPartitionColumnNames();
                 result = new ArrayList<>();
+
+                icebergTable.getPartitionColumns();
+                result = Lists.newArrayList(new Column("k1", Type.INT), new Column("k2", Type.INT));
             }
         };
 


### PR DESCRIPTION

Fixes #issue
We need to get date string like "YYYY-MM-dd" from Datum. But the value in the DateColumn is JuLian of DateValue. It's an int_32 type. So we need to transform it to date string. Additionally, we should restrict unsupported data types from being used as partition columns.
port: https://github.com/StarRocks/starrocks/pull/26760

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
