### PR TITLE
[BugFix] check null as default catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
@@ -47,6 +48,7 @@ import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.thrift.TSinkCommitInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.parquet.Strings;
 
 import java.util.HashMap;
 import java.util.List;
@@ -70,7 +72,15 @@ public class MetadataMgr {
         this.connectorTblMetaInfoMgr = connectorTblMetaInfoMgr;
     }
 
+    /** get ConnectorMetadata by catalog name
+     * if catalog is null or empty will return localMetastore
+     * @param catalogName catalog's name
+     * @return ConnectorMetadata
+     */
     public Optional<ConnectorMetadata> getOptionalMetadata(String catalogName) {
+        if (Strings.isNullOrEmpty(catalogName)) {
+            catalogName = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+        }
         if (CatalogMgr.isInternalCatalog(catalogName)) {
             return Optional.of(localMetastore);
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -123,6 +123,14 @@ public class MetadataMgrTest {
     }
 
     @Test
+    public void testGetTableWithDefaultCatalog() {
+        MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+        Assert.assertTrue(metadataMgr.getOptionalMetadata("").isPresent());
+        com.starrocks.catalog.Table internalTable = metadataMgr.getTable("default_catalog", "db1", "tbl1");
+        Assert.assertEquals(internalTable.getName(), "tbl1");
+    }
+
+    @Test
     public void testGetTable(@Mocked HiveMetaStoreClient metaStoreThriftClient) throws TException {
         List<FieldSchema> partKeys = Lists.newArrayList(new FieldSchema("col1", "BIGINT", ""));
         List<FieldSchema> unPartKeys = Lists.newArrayList(new FieldSchema("col2", "INT", ""));


### PR DESCRIPTION
Fixes #26942

mv partitionRefTableExprs  do not save catalog after restart fe will cause exception

TableName   do not save default catalog
```
    public String toString() {
        StringBuilder stringBuilder = new StringBuilder();
        if (catalog != null && !CatalogMgr.isInternalCatalog(catalog)) {
            stringBuilder.append(catalog).append(".");
        }
        if (db != null) {
            stringBuilder.append(db).append(".");
        }
        stringBuilder.append(tbl);
        return stringBuilder.toString();
    }
```
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [x] 2.5
  - [ ] 2.4
