### PR TITLE
[Enhancement] Support runtime profile(3)

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -412,7 +412,7 @@ public:
     void check_short_circuit();
 
     bool need_report_exec_state();
-    void report_exec_state();
+    void report_exec_state_if_necessary();
 
     std::string to_readable_string() const;
 

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -183,7 +183,7 @@ std::shared_ptr<QueryStatistics> QueryContext::final_query_statistic() {
     DCHECK(_is_result_sink) << "must be the result sink";
     auto res = std::make_shared<QueryStatistics>();
     res->add_scan_stats(_total_scan_rows_num, _total_scan_bytes);
-    res->add_cpu_costs(_total_cpu_cost_ns);
+    res->add_cpu_costs(cpu_cost());
     res->add_mem_costs(mem_cost_bytes());
 
     _sub_plan_query_statistics_recvr->aggregate(res.get());

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
@@ -226,7 +226,7 @@ public class RuntimeProfileTest {
             profiles.add(profile2);
         }
 
-        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles, null);
         Assert.assertNotNull(mergedProfile);
 
         Counter mergedTime1 = mergedProfile.getCounter("time1");
@@ -299,7 +299,7 @@ public class RuntimeProfileTest {
             profiles.add(profile2);
         }
 
-        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles, null);
         Assert.assertNotNull(mergedProfile);
 
         Counter mergedTime1 = mergedProfile.getCounter("time1");
@@ -374,7 +374,7 @@ public class RuntimeProfileTest {
             profiles.add(profile2);
         }
 
-        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles, null);
         Assert.assertNotNull(mergedProfile);
 
         Counter mergedTime1 = mergedProfile.getCounter("time1");
@@ -482,7 +482,7 @@ public class RuntimeProfileTest {
             profiles.add(profile2);
         }
 
-        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles, null);
         Assert.assertNotNull(mergedProfile);
 
         Assert.assertEquals(13, mergedProfile.getCounterMap().size());
@@ -538,7 +538,7 @@ public class RuntimeProfileTest {
             profiles.add(profile5);
         }
 
-        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles);
+        RuntimeProfile mergedProfile = RuntimeProfile.mergeIsomorphicProfiles(profiles, null);
         Assert.assertNotNull(mergedProfile);
 
         Set<String> expectedValues = Sets.newHashSet("value1", "value2", "value3", "value4", "value5", "value6");


### PR DESCRIPTION
This is an continuation work of https://github.com/StarRocks/starrocks/pull/26150. The main works of this pr is:

* Update some common metrics while update runtime profile, like `OperatorTotalTime`, `DriverTotalTime`
* Before this pr, `QueryPeakMemoryUsage` can be only provided through `result_sink`'s message, result in `0` in the runtime profile(because `result_sink` hasn't sent any message). And after this pr, query level metrics can also be provided through profile, and shows the right value in the profile content.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
