### PR TITLE
[BugFix] fix write boolean type value to iceberg table

### DIFF
--- a/be/src/exec/pipeline/sink/iceberg_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/iceberg_table_sink_operator.cpp
@@ -328,12 +328,15 @@ Status IcebergTableSinkOperator::partition_value_to_string(Column* column, std::
                     using T = std::decay_t<decltype(arg)>;
                     if constexpr (std::is_same_v<T, Slice>) {
                         partition_value = arg.to_string();
-                    } else if constexpr (std::is_same_v<T, int8_t> || std::is_same_v<T, uint8_t> ||
-                                         std::is_same_v<T, int16_t> || std::is_same_v<T, uint16_t> ||
-                                         std::is_same_v<T, uint24_t> || std::is_same_v<T, int32_t> ||
-                                         std::is_same_v<T, uint32_t> || std::is_same_v<T, int64_t> ||
-                                         std::is_same_v<T, uint64_t>) {
+                    } else if constexpr (std::is_same_v<T, uint8_t> || std::is_same_v<T, int16_t> ||
+                                         std::is_same_v<T, uint16_t> || std::is_same_v<T, uint24_t> ||
+                                         std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t> ||
+                                         std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
                         partition_value = std::to_string(arg);
+                    } else if constexpr (std::is_same_v<T, int8_t>) {
+                        LOG(ERROR) << typeid(arg).name();
+                        // iceberg has no smallint type. we can safely use int8 as boolean.
+                        partition_value = arg == 0 ? "false" : "true";
                     } else {
                         not_support = true;
                     }

--- a/be/test/exec/iceberg/iceberg_table_sink_operator_test.cpp
+++ b/be/test/exec/iceberg/iceberg_table_sink_operator_test.cpp
@@ -76,4 +76,16 @@ TEST_F(IcebergTableSinkTest, TestFloatValueToString) {
     ASSERT_EQ("Partition value can't be float-4", st.message());
 }
 
+TEST_F(IcebergTableSinkTest, TestBooleanValueToString) {
+    auto boolean_column = BooleanColumn::create();
+    std::vector<uint8_t> values = {0};
+    boolean_column->append_numbers(values.data(), values.size() * sizeof(uint8_t));
+
+    std::string boolean_partition_value;
+    auto st = pipeline::IcebergTableSinkOperator::partition_value_to_string(boolean_column.get(),
+                                                                            boolean_partition_value);
+    ASSERT_OK(st);
+    ASSERT_EQ("false", boolean_partition_value);
+}
+
 } // namespace starrocks


### PR DESCRIPTION
Fixes #issue
The boolean type is used as an iceberg partition column, and the partition value must be "true" or "false" like "hdfs://xxx:9000/user/hive/warehouse/ice_leo.db/b1/data/k2=false". So we need to convert boolean type to string when processing column value. But starrocks used uint_8 as boolean value and iceberg has no smallint type.  we can safely use int8 as boolean.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
