### PR TITLE
[BugFix] Use leader fe to get tracking logs and load tasks

### DIFF
--- a/be/src/exec/schema_scanner/schema_helper.cpp
+++ b/be/src/exec/schema_scanner/schema_helper.cpp
@@ -16,6 +16,7 @@
 
 #include <sstream>
 
+#include "agent/master_info.h"
 #include "gen_cpp/FrontendService.h"
 #include "gen_cpp/FrontendService_types.h"
 #include "runtime/client_cache.h"
@@ -131,40 +132,52 @@ Status SchemaHelper::get_task_runs(const std::string& ip, const int32_t port, co
                                                        });
 }
 
-Status SchemaHelper::get_loads(const std::string& ip, const int32_t port, const TGetLoadsParams& var_params,
-                               TGetLoadsResult* var_result, int timeout_ms) {
+Status SchemaHelper::get_tablet_schedules(const std::string& ip, const int32_t port,
+                                          const TGetTabletScheduleRequest& request,
+                                          TGetTabletScheduleResponse* response) {
+    return ThriftRpcHelper::rpc<FrontendServiceClient>(ip, port,
+                                                       [&request, &response](FrontendServiceConnection& client) {
+                                                           client->getTabletSchedule(*response, request);
+                                                       });
+}
+
+Status SchemaHelper::get_loads(const TGetLoadsParams& var_params, TGetLoadsResult* var_result, int timeout_ms) {
+    TNetworkAddress network_address = get_master_address();
     return ThriftRpcHelper::rpc<FrontendServiceClient>(
-            ip, port,
+            network_address.hostname, network_address.port,
             [&var_params, &var_result](FrontendServiceConnection& client) {
                 client->getLoads(*var_result, var_params);
             },
             timeout_ms);
 }
 
-Status SchemaHelper::get_tracking_loads(const std::string& ip, const int32_t port, const TGetLoadsParams& var_params,
-                                        TGetTrackingLoadsResult* var_result, int timeout_ms) {
+Status SchemaHelper::get_tracking_loads(const TGetLoadsParams& var_params, TGetTrackingLoadsResult* var_result,
+                                        int timeout_ms) {
+    TNetworkAddress network_address = get_master_address();
     return ThriftRpcHelper::rpc<FrontendServiceClient>(
-            ip, port,
+            network_address.hostname, network_address.port,
             [&var_params, &var_result](FrontendServiceConnection& client) {
                 client->getTrackingLoads(*var_result, var_params);
             },
             timeout_ms);
 }
 
-Status SchemaHelper::get_routine_load_jobs(const std::string& ip, const int32_t port, const TGetLoadsParams& var_params,
-                                           TGetRoutineLoadJobsResult* var_result, int timeout_ms) {
+Status SchemaHelper::get_routine_load_jobs(const TGetLoadsParams& var_params, TGetRoutineLoadJobsResult* var_result,
+                                           int timeout_ms) {
+    TNetworkAddress network_address = get_master_address();
     return ThriftRpcHelper::rpc<FrontendServiceClient>(
-            ip, port,
+            network_address.hostname, network_address.port,
             [&var_params, &var_result](FrontendServiceConnection& client) {
                 client->getRoutineLoadJobs(*var_result, var_params);
             },
             timeout_ms);
 }
 
-Status SchemaHelper::get_stream_loads(const std::string& ip, const int32_t port, const TGetLoadsParams& var_params,
-                                      TGetStreamLoadsResult* var_result, int timeout_ms) {
+Status SchemaHelper::get_stream_loads(const TGetLoadsParams& var_params, TGetStreamLoadsResult* var_result,
+                                      int timeout_ms) {
+    TNetworkAddress network_address = get_master_address();
     return ThriftRpcHelper::rpc<FrontendServiceClient>(
-            ip, port,
+            network_address.hostname, network_address.port,
             [&var_params, &var_result](FrontendServiceConnection& client) {
                 client->getStreamLoads(*var_result, var_params);
             },

--- a/be/src/exec/schema_scanner/schema_helper.h
+++ b/be/src/exec/schema_scanner/schema_helper.h
@@ -62,17 +62,16 @@ public:
     static Status get_tasks(const std::string& ip, const int32_t port, const TGetTasksParams& var_params,
                             TGetTaskInfoResult* var_result);
 
-    static Status get_loads(const std::string& ip, const int32_t port, const TGetLoadsParams& var_params,
-                            TGetLoadsResult* var_result, int timeout_ms);
+    static Status get_loads(const TGetLoadsParams& var_params, TGetLoadsResult* var_result, int timeout_ms);
 
-    static Status get_tracking_loads(const std::string& ip, const int32_t port, const TGetLoadsParams& var_params,
-                                     TGetTrackingLoadsResult* var_result, int timeout_ms);
+    static Status get_tracking_loads(const TGetLoadsParams& var_params, TGetTrackingLoadsResult* var_result,
+                                     int timeout_ms);
 
-    static Status get_routine_load_jobs(const std::string& ip, const int32_t port, const TGetLoadsParams& var_params,
-                                        TGetRoutineLoadJobsResult* var_result, int timeout_ms);
+    static Status get_routine_load_jobs(const TGetLoadsParams& var_params, TGetRoutineLoadJobsResult* var_result,
+                                        int timeout_ms);
 
-    static Status get_stream_loads(const std::string& ip, const int32_t port, const TGetLoadsParams& var_params,
-                                   TGetStreamLoadsResult* var_result, int timeout_ms);
+    static Status get_stream_loads(const TGetLoadsParams& var_params, TGetStreamLoadsResult* var_result,
+                                   int timeout_ms);
 
     static Status get_task_runs(const std::string& ip, const int32_t port, const TGetTasksParams& var_params,
                                 TGetTaskRunInfoResult* var_result);

--- a/be/src/exec/schema_scanner/schema_load_tracking_logs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_load_tracking_logs_scanner.cpp
@@ -54,11 +54,7 @@ Status SchemaLoadTrackingLogsScanner::start(RuntimeState* state) {
     }
 
     int32_t timeout = static_cast<int32_t>(std::min(state->query_options().query_timeout * 1000 / 2, INT_MAX));
-    if (nullptr != _param->ip && 0 != _param->port) {
-        RETURN_IF_ERROR(SchemaHelper::get_tracking_loads(*(_param->ip), _param->port, load_params, &_result, timeout));
-    } else {
-        return Status::InternalError("IP or port doesn't exists");
-    }
+    RETURN_IF_ERROR(SchemaHelper::get_tracking_loads(load_params, &_result, timeout));
     _start_ts = UnixSeconds();
     _state = state;
 

--- a/be/src/exec/schema_scanner/schema_loads_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_loads_scanner.cpp
@@ -66,11 +66,7 @@ Status SchemaLoadsScanner::start(RuntimeState* state) {
     }
 
     int32_t timeout = static_cast<int32_t>(std::min(state->query_options().query_timeout * 1000 / 2, INT_MAX));
-    if (nullptr != _param->ip && 0 != _param->port) {
-        RETURN_IF_ERROR(SchemaHelper::get_loads(*(_param->ip), _param->port, load_params, &_result, timeout));
-    } else {
-        return Status::InternalError("IP or port doesn't exists");
-    }
+    RETURN_IF_ERROR(SchemaHelper::get_loads(load_params, &_result, timeout));
 
     _cur_idx = 0;
     return Status::OK();

--- a/be/src/exec/schema_scanner/schema_routine_load_jobs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_routine_load_jobs_scanner.cpp
@@ -62,12 +62,7 @@ Status SchemaRoutineLoadJobsScanner::start(RuntimeState* state) {
     }
 
     int32_t timeout = static_cast<int32_t>(std::min(state->query_options().query_timeout * 1000 / 2, INT_MAX));
-    if (nullptr != _param->ip && 0 != _param->port) {
-        RETURN_IF_ERROR(
-                SchemaHelper::get_routine_load_jobs(*(_param->ip), _param->port, load_params, &_result, timeout));
-    } else {
-        return Status::InternalError("IP or port doesn't exists");
-    }
+    RETURN_IF_ERROR(SchemaHelper::get_routine_load_jobs(load_params, &_result, timeout));
 
     _cur_idx = 0;
     return Status::OK();

--- a/be/src/exec/schema_scanner/schema_stream_loads_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_stream_loads_scanner.cpp
@@ -68,11 +68,7 @@ Status SchemaStreamLoadsScanner::start(RuntimeState* state) {
     }
 
     int32_t timeout = static_cast<int32_t>(std::min(state->query_options().query_timeout * 1000 / 2, INT_MAX));
-    if (nullptr != _param->ip && 0 != _param->port) {
-        RETURN_IF_ERROR(SchemaHelper::get_stream_loads(*(_param->ip), _param->port, load_params, &_result, timeout));
-    } else {
-        return Status::InternalError("IP or port doesn't exists");
-    }
+    RETURN_IF_ERROR(SchemaHelper::get_stream_loads(load_params, &_result, timeout));
 
     _cur_idx = 0;
     return Status::OK();


### PR DESCRIPTION
In current implementation, the execution of `show load`, `show routine load`, etc will be forwarded to leader fe. The `show` result set is consistent across multiple fe, no matter it's a follower or leader.

We have introduced features which use `information_schema` to track loading jobs/tasks and their tracking error logs. In order to align with `show` result for loads, the data that filled the information_schema tables should be acquired from leader fe too. Otherwise some loading properties (such as `errorLogUrls` of routine load job) that were computed on the fly would be lost if data were acquired from a follower fe.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
