### PR TITLE
[Enhancement] Reduce S3AFileSystem timeout time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -125,7 +125,7 @@ public class FileTable extends Table {
             }
             return remoteFileDescs;
         } catch (StarRocksConnectorException e) {
-            throw new DdlException("doesn't get file with path: " + getTableLocation());
+            throw new DdlException("doesn't get file with path: " + getTableLocation(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfiguration.java
@@ -60,6 +60,13 @@ public class AWSCloudConfiguration implements CloudConfiguration {
         configuration.set("fs.tos.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
         configuration.set("fs.cosn.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
 
+        // By default, S3AFileSystem will need 4 minutes to timeout when endpoint is unreachable,
+        // after change, it will need 30 seconds.
+        // Default value is 7.
+        configuration.set("fs.s3a.retry.limit", "3");
+        // Default value is 20
+        configuration.set("fs.s3a.attempts.maximum", "5");
+
         configuration.set("fs.s3a.path.style.access", String.valueOf(enablePathStyleAccess));
         configuration.set("fs.s3a.connection.ssl.enabled", String.valueOf(enableSSL));
         awsCloudCredential.applyToConfiguration(configuration);


### PR DESCRIPTION
If we are using the default configuration for S3AFileSystem, it will need almost 4 minutes to timeout, which means will hang FE for 4 minutes.

After this pr, will reduce the timeout to 30 seconds.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
