### PR TITLE
[Enhancement] Support runtime profile(4)

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -619,6 +619,12 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chu
     return Status::OK();
 }
 
+void ExchangeSinkOperator::update_metrics(RuntimeState* state) {
+    if (_driver_sequence == 0) {
+        _buffer->update_profile(_unique_metrics.get());
+    }
+}
+
 Status ExchangeSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 
@@ -645,7 +651,9 @@ Status ExchangeSinkOperator::set_finishing(RuntimeState* state) {
 }
 
 void ExchangeSinkOperator::close(RuntimeState* state) {
-    _buffer->update_profile(_unique_metrics.get());
+    if (_driver_sequence == 0) {
+        _buffer->update_profile(_unique_metrics.get());
+    }
     Operator::close(state);
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -75,6 +75,8 @@ public:
 
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
+    void update_metrics(RuntimeState* state) override;
+
     // For the first chunk , serialize the chunk data and meta to ChunkPB both.
     // For other chunk, only serialize the chunk data to ChunkPB.
     Status serialize_chunk(const Chunk* chunk, ChunkPB* dst, bool* is_first_chunk, int num_receivers = 1);

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -173,7 +173,6 @@ private:
     std::atomic<int64_t> _rpc_cumulative_time = 0;
 
     // RuntimeProfile counters
-    std::atomic_bool _is_profile_updated = false;
     std::atomic<int64_t> _bytes_enqueued = 0;
     std::atomic<int64_t> _request_enqueued = 0;
     std::atomic<int64_t> _bytes_sent = 0;

--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -124,12 +124,28 @@ void FragmentContext::report_exec_state_if_necessary() {
     if (!query_ctx->enable_profile()) {
         return;
     }
-    auto now = MonotonicNanos();
-    auto last_report_exec_state_ns = _last_report_exec_state_ns.load();
-    if (now - last_report_exec_state_ns < query_ctx->get_runtime_profile_report_interval_ns()) {
+    const auto now = MonotonicNanos();
+    const auto interval_ns = query_ctx->get_runtime_profile_report_interval_ns();
+    auto last_report_ns = _last_report_exec_state_ns.load();
+    if (now - last_report_ns < interval_ns) {
         return;
     }
-    if (_last_report_exec_state_ns.compare_exchange_strong(last_report_exec_state_ns, now)) {
+
+    for (auto& pipeline : _pipelines) {
+        for (auto& driver : pipeline->drivers()) {
+            driver->runtime_report_action();
+        }
+    }
+
+    int64_t normalized_report_ns;
+    if (now - last_report_ns > 2 * interval_ns) {
+        // Maybe the first time, then initialized it.
+        normalized_report_ns = now;
+    } else {
+        // Fix the report interval regardless the noise.
+        normalized_report_ns = last_report_ns + interval_ns;
+    }
+    if (_last_report_exec_state_ns.compare_exchange_strong(last_report_ns, normalized_report_ns)) {
         state->exec_env()->wg_driver_executor()->report_exec_state(query_ctx, this, Status::OK(), false, true);
     }
 }

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -135,7 +135,7 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const UnifiedExec
         _query_ctx->set_profile_level(query_options.pipeline_profile_level);
     }
     if (query_options.__isset.runtime_profile_report_interval) {
-        _query_ctx->set_runtime_profile_report_interval(query_options.runtime_profile_report_interval);
+        _query_ctx->set_runtime_profile_report_interval(std::max(1L, query_options.runtime_profile_report_interval));
     }
 
     bool enable_query_trace = false;

--- a/be/src/exec/pipeline/operator.h
+++ b/be/src/exec/pipeline/operator.h
@@ -131,6 +131,10 @@ public:
     // 3. operators decorated by MultilaneOperator except case 2: e.g. ProjectOperator, Chunk AccumulateOperator and etc.
     virtual Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) { return Status::OK(); }
 
+    // Some operator's metrics are updated in the finishing stage, which is not suitable to the runtime profile mechanism.
+    // So we add this function for manual updation of metrics when reporting the runtime profile.
+    virtual void update_metrics(RuntimeState* state) {}
+
     virtual size_t output_amplification_factor() const { return 1; }
     enum class OutputAmplificationType { ADD, MAX };
     virtual OutputAmplificationType intra_pipeline_amplification_type() const { return OutputAmplificationType::MAX; }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -440,15 +440,19 @@ void PipelineDriver::report_exec_state_if_necessary() {
         return;
     }
 
+    _fragment_ctx->report_exec_state_if_necessary();
+}
+
+void PipelineDriver::runtime_report_action() {
     COUNTER_SET(_total_timer, static_cast<int64_t>(_total_timer_sw->elapsed_time()));
     COUNTER_SET(_schedule_timer, _total_timer->value() - _active_timer->value() - _pending_timer->value());
+    _update_overhead_timer();
     for (auto& op : _operators) {
         COUNTER_SET(op->_total_timer, op->_pull_timer->value() + op->_push_timer->value() +
                                               op->_finishing_timer->value() + op->_finished_timer->value() +
                                               op->_close_timer->value());
+        op->update_metrics(_fragment_ctx->runtime_state());
     }
-
-    _fragment_ctx->report_exec_state_if_necessary();
 }
 
 void PipelineDriver::mark_precondition_not_ready() {

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -413,6 +413,7 @@ public:
 
     bool need_report_exec_state();
     void report_exec_state_if_necessary();
+    void runtime_report_action();
 
     std::string to_readable_string() const;
 

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -56,6 +56,8 @@ public:
 
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
 
+    void update_metrics(RuntimeState* state) override { _merge_chunk_source_profiles(state); }
+
     void set_scan_executor(workgroup::ScanExecutor* scan_executor) { _scan_executor = scan_executor; }
 
     void set_workgroup(workgroup::WorkGroupPtr wg) { _workgroup = std::move(wg); }
@@ -77,7 +79,7 @@ public:
     void set_query_ctx(const QueryContextPtr& query_ctx);
 
     virtual int available_pickup_morsel_count() { return _io_tasks_per_scan_operator; }
-    void begin_pull_chunk(ChunkPtr res) {
+    void begin_pull_chunk(const ChunkPtr& res) {
         _op_pull_chunks += 1;
         _op_pull_rows += res->num_rows();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -1523,6 +1523,32 @@ public class Coordinator {
             profileAlreadyReported = true;
         }
 
+        // Update runtime profile when query is still in process.
+        //
+        // We need to export profile to ProfileManager before update this profile, because:
+        // Each fragment instance will report its state based on their on own timer, and basically, these
+        // timers are consistent. So we can assume that all the instances will report profile in a very short
+        // time range, if we choose to export the profile to profile manager after update this instance's profile,
+        // the whole profile may include the information from the previous report, except for the current instance,
+        // which leads to inconsistency.
+        //
+        // So the profile update strategy looks like this: During a short time interval, each instance will report
+        // its execution information. However, when receiving the information reported by the first instance of the
+        // current batch, the previous reported state will be synchronized to the profile manager.
+        if (!execState.done) {
+            long now = System.currentTimeMillis();
+            long lastTime = lastRuntimeProfileUpdateTime.get();
+            if (topProfileSupplier != null &&
+                    connectContext != null &&
+                    connectContext.getSessionVariable().isEnableProfile() &&
+                    now - lastTime > connectContext.getSessionVariable().getRuntimeProfileReportInterval() * 1000L &&
+                    lastRuntimeProfileUpdateTime.compareAndSet(lastTime, now)) {
+                RuntimeProfile profile = topProfileSupplier.get();
+                profile.addChild(buildMergedQueryProfile(null));
+                ProfileManager.getInstance().pushProfile(profile);
+            }
+        }
+
         lock();
         try {
             if (!execState.updateProfile(params)) {
@@ -1581,18 +1607,6 @@ public class Coordinator {
                 sinkCommitInfos.addAll(params.sink_commit_infos);
             }
             profileDoneSignal.markedCountDown(params.getFragment_instance_id(), -1L);
-        } else {
-            long now = System.currentTimeMillis();
-            long lastTime = lastRuntimeProfileUpdateTime.get();
-            if (topProfileSupplier != null &&
-                    connectContext != null &&
-                    connectContext.getSessionVariable().isEnableProfile() &&
-                    now - lastTime > connectContext.getSessionVariable().getRuntimeProfileReportInterval() * 1000L &&
-                    lastRuntimeProfileUpdateTime.compareAndSet(lastTime, now)) {
-                RuntimeProfile profile = topProfileSupplier.get();
-                profile.addChild(buildMergedQueryProfile(null));
-                ProfileManager.getInstance().pushProfile(profile);
-            }
         }
 
         if (params.isSetLoad_type()) {


### PR DESCRIPTION
This pr is an continuation work of https://github.com/StarRocks/starrocks/pull/26973

## Main Work

**1. Update the profile upgrade strategy**

```java
// Update runtime profile when query is still in process.
//
// We need to export profile to ProfileManager before update this profile, because:
// Each fragment instance will report its state based on their on own timer, and basically, these
// timers are consistent. So we can assume that all the instances will report profile in a very short
// time range, if we choose to export the profile to profile manager after update this instance's profile,
// the whole profile may include the information from the previous report, except for the current instance,
// which leads to inconsistency.
//
// So the profile update strategy looks like this: During a short time interval, each instance will report
// its execution information. However, when receiving the information reported by the first instance of the
// current batch, the previous reported state will be synchronized to the profile manager.
```

**2. Normalize the report interval at be side**

* When does each instance report it's exec state? Every time after they are scheduled and executed, they'll have a chance to determine whether need to report exec state. If we change the `last_report_exec_state_ns` by current timestamp, then the noise may be included in, leading to the report interval not consistent.
* So we normalize this updation by add the fixed time interval based on the previous report timestamp.

**3. Add an interface `update_metrics` in the class Operator, used to update some special metrics that requires mannual updation**

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
