### PR TITLE
[BugFix] date_trunc fmt in upper case

### DIFF
--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -2130,6 +2130,10 @@ Status TimeFunctions::datetime_trunc_prepare(FunctionContext* context, FunctionC
     Slice slice = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
     auto format_value = slice.to_string();
 
+    // to lower case
+    std::transform(format_value.begin(), format_value.end(), format_value.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+
     ScalarFunction function;
     if (format_value == "second") {
         function = &TimeFunctions::datetime_trunc_second;
@@ -2245,6 +2249,10 @@ Status TimeFunctions::date_trunc_prepare(FunctionContext* context, FunctionConte
 
     Slice slice = ColumnHelper::get_const_value<TYPE_VARCHAR>(column);
     auto format_value = slice.to_string();
+
+    // to lower case
+    std::transform(format_value.begin(), format_value.end(), format_value.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
 
     ScalarFunction function;
     if (format_value == "day") {


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/27022
When target table is created with `PARTITION BY date_trunc('YEAR', event_time)`, in which the fmt is in upper case, the insert would get failure. This PR fixes the issue.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
