### PR TITLE
[BugFix] Fix the cast exceptions while reading paimon table with string type filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
@@ -170,7 +170,7 @@ public class PaimonPredicateConverter extends ScalarOperatorVisitor<Predicate, V
         int idx = fieldNames.indexOf(columnName);
         if (operator.getLikeType() == LikePredicateOperator.LikeType.LIKE) {
             if (operator.getChild(1).getType().isStringType()) {
-                String literal = (String) getLiteral(operator.getChild(1));
+                String literal = ((BinaryString) getLiteral(operator.getChild(1))).toString();
                 if (literal != null && literal.length() > 1 &&
                         literal.indexOf("%") == literal.length() - 1 &&
                         literal.charAt(0) != '%') {
@@ -213,7 +213,7 @@ public class PaimonPredicateConverter extends ScalarOperatorVisitor<Predicate, V
             case HLL:
             case VARCHAR:
             case CHAR:
-                return constValue.getVarchar();
+                return BinaryString.fromString(constValue.getVarchar());
             case DATE:
                 LocalDate localDate = constValue.getDate().toLocalDate();
                 LocalDate epochDay = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC).toLocalDate();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
@@ -244,4 +244,14 @@ public class PaimonPredicateConverterTest {
         Assert.assertTrue(p2.function() instanceof LessOrEqual);
         Assert.assertEquals(22, p2.literals().get(0));
     }
+
+    @Test
+    public void testBinaryString() {
+        ConstantOperator value = ConstantOperator.createVarchar("ttt");
+        ScalarOperator op = new BinaryPredicateOperator(BinaryType.EQ, F1, value);;
+        Predicate result = CONVERTER.convert(op);
+        Assert.assertTrue(result instanceof LeafPredicate);
+        LeafPredicate leafPredicate = (LeafPredicate) result;
+        Assert.assertEquals(BinaryString.fromString("ttt"), leafPredicate.literals().get(0));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.predicate.And;
 import org.apache.paimon.predicate.CompoundPredicate;
 import org.apache.paimon.predicate.Equal;


### PR DESCRIPTION
Fixes #26988 

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
