### PR TITLE
[Enhancement] support dynamice config apply thread count (backport #24948)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -112,7 +112,6 @@ CONF_Int32(push_worker_count_high_priority, "3");
 // The count of thread to publish version per transaction
 CONF_mInt32(transaction_publish_version_worker_count, "0");
 
-CONF_mInt32(get_pindex_worker_count, "0");
 // The count of thread to apply rowset in primary key table
 // 0 means apply worker count is equal to cpu core count
 CONF_mInt32(transaction_apply_worker_count, "0");

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -118,13 +118,6 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             auto tablet_mgr = _exec_env->lake_tablet_manager();
             if (tablet_mgr != nullptr) tablet_mgr->update_metacache_limit(config::lake_metadata_cache_limit);
         });
-        _config_callback.emplace("get_pindex_worker_count", [&]() {
-            int max_thread_cnt = CpuInfo::num_cores();
-            if (config::get_pindex_worker_count > 0) {
-                max_thread_cnt = config::get_pindex_worker_count;
-            }
-            StorageEngine::instance()->update_manager()->get_pindex_thread_pool()->update_max_threads(max_thread_cnt);
-        });
         _config_callback.emplace("transaction_apply_worker_count", [&]() {
             int max_thread_cnt = CpuInfo::num_cores();
             if (config::transaction_apply_worker_count > 0) {

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -81,16 +81,8 @@ Status UpdateManager::init() {
     if (config::transaction_apply_worker_count > 0) {
         max_thread_cnt = config::transaction_apply_worker_count;
     }
-    RETURN_IF_ERROR(ThreadPoolBuilder("update_apply").set_max_threads(max_thread_cnt).build(&_apply_thread_pool));
-    REGISTER_GAUGE_STARROCKS_METRIC(update_apply_queue_count,
-                                    [this]() { return _apply_thread_pool->num_queued_tasks(); });
-    max_thread_cnt = CpuInfo::num_cores();
-    int max_get_thread_cnt =
-            config::get_pindex_worker_count > max_thread_cnt ? config::get_pindex_worker_count : max_thread_cnt * 2;
-    RETURN_IF_ERROR(
-            ThreadPoolBuilder("get_pindex").set_max_threads(max_get_thread_cnt).build(&_get_pindex_thread_pool));
-
-    return Status::OK();
+    auto st = ThreadPoolBuilder("update_apply").set_max_threads(max_thread_cnt).build(&_apply_thread_pool);
+    return st;
 }
 
 Status UpdateManager::get_del_vec_in_meta(KVStore* meta, const TabletSegmentId& tsid, int64_t version,


### PR DESCRIPTION
Add config item `transaction_apply_worker_count` and make apply thread count configable. When `transaction_apply_worker_count` = 0, using cpu number as worker count.

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
