### PR TITLE
[BugFix] Set ColocateGroupSchema bucketNum to the calculated num

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -240,6 +240,13 @@ public class ColocateTableIndex implements Writable {
                     groupAlreadyExist = false;
                 }
                 HashDistributionInfo distributionInfo = (HashDistributionInfo) tbl.getDefaultDistributionInfo();
+                if (!(tbl instanceof ExternalOlapTable)) {
+                    // Colocate table should keep the same bucket number across the partitions
+                    if (distributionInfo.getBucketNum() == 0) {
+                        int bucketNum = CatalogUtils.calBucketNumAccordingToBackends();
+                        distributionInfo.setBucketNum(bucketNum);
+                    }
+                }
                 ColocateGroupSchema groupSchema = new ColocateGroupSchema(groupId,
                         distributionInfo.getDistributionColumns(), distributionInfo.getBucketNum(),
                         tbl.getDefaultReplicationNum());

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -374,11 +374,6 @@ public class OlapTableFactory implements AbstractTableFactory {
 
                 boolean addedToColocateGroup = colocateTableIndex.addTableToGroup(db, table,
                         colocateGroup, false /* expectLakeTable */);
-                if (!(table instanceof ExternalOlapTable) && addedToColocateGroup) {
-                    // Colocate table should keep the same bucket number across the partitions
-                    DistributionInfo defaultDistributionInfo = table.getDefaultDistributionInfo();
-                    table.inferDistribution(defaultDistributionInfo);
-                }
             }
 
             // get base index storage type. default is COLUMN

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableAutoTabletTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.analysis;
 
+import com.starrocks.catalog.ColocateGroupSchema;
+import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -252,6 +254,12 @@ public class CreateTableAutoTabletTest {
             db.readUnlock();
         }
         Assert.assertEquals(bucketNum, 10);
+
+        Long dbId = db.getId();
+        String fullGroupName = dbId + "_g1";
+        ColocateTableIndex index = GlobalStateMgr.getCurrentColocateIndex();
+        ColocateGroupSchema groupSchema = index.getGroupSchema(fullGroupName);
+        Assert.assertEquals(groupSchema.getBucketsNum(), 10);
     }
 
 


### PR DESCRIPTION
When creating a table with colocate group, the colocate group will be auto-created.
If the table with zero bucket num, the bucket num will be modified when colocated. Under this time, the colocate group schema should be set to the calculated bucket num.

#SR-18808

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
