### PR TITLE
[UT] Make table pruning test cases stable

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningTest.java
@@ -658,11 +658,16 @@ public class TablePruningTest extends TablePruningTestBase {
                 {"sum(coalesce(B2.b_c0,0)+coalesce(B1.b_c0,0))", 1},
                 {"sum(A0.a_c0+A1.a_c1)", 0},
         };
-        for (Object[] tc : cases) {
-            String selectStmt = (String) tc[0];
-            int numHashJoins = (Integer) tc[1];
-            String sql = String.format("select %s from %s", selectStmt, fromClause);
-            checkHashJoinCountWithOnlyRBOLessThan(sql, 12);
+        try {
+            ctx.getSessionVariable().setOptimizerExecuteTimeout(20000);
+            for (Object[] tc : cases) {
+                String selectStmt = (String) tc[0];
+                int numHashJoins = (Integer) tc[1];
+                String sql = String.format("select %s from %s", selectStmt, fromClause);
+                checkHashJoinCountWithOnlyRBOLessThan(sql, 12);
+            }
+        } finally {
+            ctx.getSessionVariable().setOptimizerExecuteTimeout(3000);
         }
     }
 


### PR DESCRIPTION
TablePruningTest.testIntraGroupJoiningOnTheSamePKAndInterGroupInnerJoiningOnFKPK is unstable, fixed
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
