### PR TITLE
[Refactor] Simplify and staticize BackendSelector

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/BackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/BackendSelector.java
@@ -14,17 +14,8 @@
 
 package com.starrocks.qe;
 
-import java.util.Map;
+import com.starrocks.common.UserException;
 
 public interface BackendSelector {
-    void computeScanRangeAssignment() throws Exception;
-
-    static <K, V> V findOrInsert(Map<K, V> m, final K key, final V defaultVal) {
-        V value = m.get(key);
-        if (value == null) {
-            m.put(key, defaultVal);
-            value = defaultVal;
-        }
-        return value;
-    }
+    void computeScanRangeAssignment() throws UserException;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/FragmentScanRangeAssignment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/FragmentScanRangeAssignment.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.qe;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
@@ -29,11 +31,24 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * map from an backend host address to the per-node assigned scan ranges;
+ * map from a backend host address to the per-node assigned scan ranges;
  * records scan range assignment for a single fragment
  */
-class FragmentScanRangeAssignment extends
+public class FragmentScanRangeAssignment extends
         HashMap<Long, Map<Integer, List<TScanRangeParams>>> {
+
+    public void put(Long workerId, int scanNodeId, TScanRangeParams scanRange) {
+        computeIfAbsent(workerId, k -> Maps.newHashMap())
+                .computeIfAbsent(scanNodeId, k -> Lists.newArrayList())
+                .add(scanRange);
+    }
+
+    public void putAll(Long workerId, int scanNodeId, List<TScanRangeParams> scanRanges) {
+        computeIfAbsent(workerId, k -> Maps.newHashMap())
+                .computeIfAbsent(scanNodeId, k -> Lists.newArrayList())
+                .addAll(scanRanges);
+    }
+
     public String toDebugString() {
         StringBuilder sb = new StringBuilder();
         sb.append("---------- FragmentScanRangeAssignment ----------\n");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -23,6 +23,7 @@ import com.google.common.hash.Funnel;
 import com.google.common.hash.Hashing;
 import com.google.common.hash.PrimitiveSink;
 import com.starrocks.catalog.PartitionKey;
+import com.starrocks.common.UserException;
 import com.starrocks.common.util.ConsistentHashRing;
 import com.starrocks.common.util.HashRing;
 import com.starrocks.common.util.RendezvousHashRing;
@@ -48,7 +49,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -215,7 +215,7 @@ public class HDFSBackendSelector implements BackendSelector {
     }
 
     @Override
-    public void computeScanRangeAssignment() throws Exception {
+    public void computeScanRangeAssignment() throws UserException {
         if (locations.size() == 0) {
             return;
         }
@@ -282,14 +282,9 @@ public class HDFSBackendSelector implements BackendSelector {
         long addedScans = scanRangeLocations.scan_range.hdfs_scan_range.length;
         assignedScansPerComputeNode.put(worker, assignedScansPerComputeNode.get(worker) + addedScans);
 
-        // add in assignment
-        Map<Integer, List<TScanRangeParams>> scanRanges =
-                BackendSelector.findOrInsert(assignment, worker.getId(), new HashMap<>());
-        List<TScanRangeParams> scanRangeParamsList =
-                BackendSelector.findOrInsert(scanRanges, scanNode.getId().asInt(), new ArrayList<>());
         // add scan range params
         TScanRangeParams scanRangeParams = new TScanRangeParams();
         scanRangeParams.scan_range = scanRangeLocations.scan_range;
-        scanRangeParamsList.add(scanRangeParams);
+        assignment.put(worker.getId(), scanNode.getId().asInt(), scanRangeParams);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -58,6 +58,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.starrocks.qe.CoordinatorPreprocessor.ColocatedBackendSelector.BucketSeqToScanRange;
+
 public class CoordinatorTest extends PlanTestBase {
     ConnectContext ctx;
     Coordinator coordinator;
@@ -137,8 +139,7 @@ public class CoordinatorTest extends PlanTestBase {
                                                              List<Map<Integer, Integer>> expectedDriverSeq2NumScanRangesList) {
         CoordinatorPreprocessor.FragmentExecParams params =
                 coordinatorPreprocessor.new FragmentExecParams(genFragment());
-        CoordinatorPreprocessor.BucketSeqToScanRange bucketSeqToScanRange =
-                new CoordinatorPreprocessor.BucketSeqToScanRange();
+        BucketSeqToScanRange bucketSeqToScanRange = new BucketSeqToScanRange();
         for (Integer bucketSeq : bucketSeqToWorkerId.keySet()) {
             bucketSeqToScanRange.put(bucketSeq, createScanId2scanRanges(scanId, 1));
         }


### PR DESCRIPTION
1. Make all the `BackendSelector`s static, and will move them to separated class files.
2. Move all the `fragmentIdToXxxx information` to `ColocatedBackendSelector.Assignment.Xxxx`.

```java
    private final Map<PlanFragmentId, Map<Integer, Long>> fragmentIdToSeqToWorkerIdMap = Maps.newHashMap();
    // fragment_id -> < bucket_seq -> < scannode_id -> scan_range_params >>
    private final Map<PlanFragmentId, BucketSeqToScanRange> fragmentIdBucketSeqToScanRangeMap = Maps.newHashMap();
    // fragment_id -> bucket_num
    private final Map<PlanFragmentId, Integer> fragmentIdToBucketNumMap = Maps.newHashMap();
    // fragment_id -> < be_id -> bucket_count >
    private final Map<PlanFragmentId, Map<Long, Integer>> fragmentIdToBackendIdBucketCountMap = Maps.newHashMap();
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
