### PR TITLE
[BugFix] Fixed some bugs of table pruning

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -260,6 +260,7 @@ public class Optimizer {
             // projection as LogicalProjectionOperator from the operator by applying SeparateProjectRule.
             ruleRewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule());
             tree = new UniquenessBasedTablePruneRule().rewrite(tree, rootTaskContext);
+            deriveLogicalProperty(tree);
             tree = new ReorderJoinRule().rewrite(tree, context);
             tree = new SeparateProjectRule().rewrite(tree, rootTaskContext);
             deriveLogicalProperty(tree);


### PR DESCRIPTION
Fixed two bugs:
1. A plan consisting  of multiple inner joins interleaved by left/right joins, after reorder the joins, a worse plan that contains cross join is generated finally, so we should reorder the plan conservatively only when all the atoms in the multi-join are scan operators and adopt the reorder result only when the number of cross joins is reduced.

```
before reorder, the plan only contains inner join and left join.
logical tree anchor
    logical aggregate () (sum(col))
        logical cte anchor
            logical cte produce
                logical left outer join (131: n_regionkey = 133: r_regionkey)
                    logical scan(129: n_nationkey, 130: n_name, 131: n_regionkey)
                    logical scan(133: r_regionkey, 134: r_name, 135: r_comment)
            logical inner join (189: l_orderkey = 233: o_orderkey)
                logical inner join (191: l_suppkey = 219: s_suppkey)
                    logical left outer join (190: l_partkey = 210: p_partkey)
                        logical left outer join (190: l_partkey = 205: ps_partkey AND 191: l_suppkey = 206: ps_suppkey)
                            logical scan(193: l_quantity, 199: l_shipdate, 202: l_shipinstruct, 189: l_orderkey, 190: l_partkey, 191: l_suppkey)
                            logical scan(205: ps_partkey, 206: ps_suppkey)
                        logical scan(210: p_partkey, 211: p_name)
                    logical inner join (222: s_nationkey = 226: n_nationkey)
                        logical scan(219: s_suppkey, 222: s_nationkey)
                        logical cte consume
                            logical left outer join (228: n_regionkey = 230: r_regionkey)
                                logical scan(226: n_nationkey, 227: n_name, 228: n_regionkey)
                                logical scan(230: r_regionkey, 232: r_comment)
                logical inner join (234: o_custkey = 242: c_custkey)
                    logical scan(233: o_orderkey, 234: o_custkey)
                    logical inner join (245: c_nationkey = 250: n_nationkey)
                        logical scan(242: c_custkey, 245: c_nationkey)
                        logical cte consume
                            logical left outer join (252: n_regionkey = 254: r_regionkey)
                                logical scan(250: n_nationkey, 251: n_name, 252: n_regionkey)
                                logical scan(254: r_regionkey, 255: r_name)
after order, the cross join generate:
logical tree anchor
    logical aggregate () (sum(col))
        logical project (add(add(add(add(add(cast(murmur_hash3_32(ifnull(255: r_name, 0)) as bigint(20)), cast(murmur_hash3_32(cast(ifnull(193: l_quantity, 0.0) as varchar)) as bigint(20))), cast(murmur_hash3_32(cast(ifnull(cast(199: l_shipdate as int(11)), 0) as varchar)) as bigint(20))), cast(murmur_hash3_32(ifnull(202: l_shipinstruct, 0)) as bigint(20))), cast(murmur_hash3_32(ifnull(211: p_name, 0)) as bigint(20))), cast(murmur_hash3_32(ifnull(232: r_comment, 0)) as bigint(20))))
            logical cte anchor
                logical cte produce
                    logical project (129: n_nationkey,130: n_name,134: r_name,135: r_comment)
                        logical left outer join (131: n_regionkey = 133: r_regionkey)
                            logical scan(129: n_nationkey, 130: n_name, 131: n_regionkey)
                            logical scan(133: r_regionkey, 134: r_name, 135: r_comment)
                logical project (193: l_quantity,211: p_name,199: l_shipdate,232: r_comment,202: l_shipinstruct,255: r_name)
                    logical inner join (245: c_nationkey = 250: n_nationkey)
                        logical cte consume
                            logical project (250: n_nationkey,251: n_name,255: r_name)
                                logical left outer join (252: n_regionkey = 254: r_regionkey)
                                    logical scan(250: n_nationkey, 251: n_name, 252: n_regionkey)
                                    logical scan(254: r_regionkey, 255: r_name)
                        logical project (193: l_quantity,211: p_name,245: c_nationkey,199: l_shipdate,232: r_comment,202: l_shipinstruct)
                            logical inner join (222: s_nationkey = 226: n_nationkey)
                                logical cte consume
                                    logical project (226: n_nationkey,227: n_name,232: r_comment)
                                        logical left outer join (228: n_regionkey = 230: r_regionkey)
                                            logical scan(226: n_nationkey, 227: n_name, 228: n_regionkey)
                                            logical scan(230: r_regionkey, 232: r_comment)
                                logical project (193: l_quantity,211: p_name,245: c_nationkey,199: l_shipdate,202: l_shipinstruct,222: s_nationkey)
                                    logical inner join (191: l_suppkey = 219: s_suppkey AND 189: l_orderkey = 233: o_orderkey)
                                        logical project (193: l_quantity,211: p_name,199: l_shipdate,202: l_shipinstruct,189: l_orderkey,191: l_suppkey)
                                            logical left outer join (190: l_partkey = 210: p_partkey)
                                                logical project (193: l_quantity,199: l_shipdate,202: l_shipinstruct,189: l_orderkey,190: l_partkey,191: l_suppkey)
                                                    logical scan(193: l_quantity, 199: l_shipdate, 202: l_shipinstruct, 189: l_orderkey, 190: l_partkey, 191: l_suppkey)
                                                logical scan(210: p_partkey, 211: p_name)
                                        logical cross join
                                            logical scan(219: s_suppkey, 222: s_nationkey)
                                            logical project (245: c_nationkey,233: o_orderkey)
                                                logical inner join (234: o_custkey = 242: c_custkey)
                                                    logical scan(233: o_orderkey, 234: o_custkey)
                                                    logical scan(242: c_custkey, 245: c_nationkey)

```
2. Same tables join on PK, we should prune the higher Scan operator and retain the lower Scan Operator, but we use a wrong ordinal assignment that walks in the left deep travel, but we should use a pre-order travel. the former assigment can not works because the top-right most ScanOperators always gives a large oridinal.
3. New Operator is created when UniquenessBasedPruneRule applied to the plan successfully, so we need re-compute logical properties,  otherwise NPE is throwed
```
	at com.starrocks.sql.optimizer.ExpressionContext.getChildOutputColumns(ExpressionContext.java:111)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.computeJoinNode(StatisticsCalculator.java:721)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalJoin(StatisticsCalculator.java:695)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.visitLogicalJoin(StatisticsCalculator.java:153)
	at com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator.accept(LogicalJoinOperator.java:185)
	at com.starrocks.sql.optimizer.statistics.StatisticsCalculator.estimatorStats(StatisticsCalculator.java:169)
	at com.starrocks.sql.optimizer.rule.join.JoinOrder.calculateStatistics(JoinOrder.java:268)
	at com.starrocks.sql.optimizer.rule.join.JoinOrder.init(JoinOrder.java:181)
	at com.starrocks.sql.optimizer.rule.join.JoinReorderCardinalityPreserving.init(JoinReorderCardinalityPreserving.java:61)
	at com.starrocks.sql.optimizer.rule.join.JoinOrder.reorder(JoinOrder.java:217)
	at com.starrocks.sql.optimizer.rule.join.ReorderJoinRule.enumerate(ReorderJoinRule.java:93)
	at com.starrocks.sql.optimizer.rule.join.ReorderJoinRule.rewrite(ReorderJoinRule.java:181)
	at com.starrocks.sql.optimizer.Optimizer.pruneTables(Optimizer.java:265)
```
Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
