### PR TITLE
[BugFix] Fix regex_replace hyberscan crash problem

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -2932,7 +2932,6 @@ static StatusOr<ColumnPtr> regexp_replace_use_hyperscan(StringFunctionsState* st
             continue;
         }
         match_info_chain.info_chain.clear();
-        match_info_chain.last_to = 0;
 
         auto rpl_value = rpl_viewer.value(row);
 
@@ -2950,10 +2949,9 @@ static StatusOr<ColumnPtr> regexp_replace_use_hyperscan(StringFunctionsState* st
                         value->info_chain.emplace_back(MatchInfo{.from = from, .to = to});
                     } else if (value->info_chain.back().from == from) {
                         value->info_chain.back().to = to;
-                    } else {
+                    } else if (value->info_chain.back().to <= from) {
                         value->info_chain.emplace_back(MatchInfo{.from = from, .to = to});
                     }
-                    value->last_to = to;
                     return 0;
                 },
                 &match_info_chain);

--- a/be/src/exprs/string_functions.h
+++ b/be/src/exprs/string_functions.h
@@ -55,7 +55,6 @@ struct MatchInfo {
 
 struct MatchInfoChain {
     std::vector<MatchInfo> info_chain;
-    unsigned long long last_to = 0;
 };
 
 class StringFunctions {

--- a/test/sql/test_function/R/test_regex
+++ b/test/sql/test_function/R/test_regex
@@ -12,6 +12,15 @@ DISTRIBUTED BY HASH(`str`) BUCKETS 1 PROPERTIES ("replication_num" = "1");
 insert into ts values ('abcd', '.*', 'xx'), ('abcd', 'a.*', 'xx'), ('abcd', '.*abc.*', 'xx'), ('abcd', '.*cd', 'xx'), ('abcd', 'bc', 'xx'), ('', '', 'xx'), (NULL, '', 'xx'), ('abc中文def', '[\\p{Han}]+', 'xx');
 -- result:
 -- !result
+insert into ts values ('a b c', " ", "-"), ('           XXXX', '       ', '');
+-- result:
+-- !result
+insert into ts values ('xxxx', "x", "-"), ('xxxx', "xx", "-"), ('xxxx', "xxx", "-"), ('xxxx', "xxxx", "-");
+-- result:
+-- !result
+insert into ts values ('xxxx', "not", "xxxxxxxx"), ('xxaxx', 'xx', 'aaa'), ('xaxaxax', 'xax', '-');
+-- result:
+-- !result
 select regexp_replace('abcd', '.*', 'xx');
 -- result:
 xx
@@ -51,14 +60,49 @@ select regexp_replace('a b c', " ", "-");
 -- result:
 a-b-c
 -- !result
+select regexp_replace('           XXXX', '       ', '');
+-- result:
+    XXXX
+-- !result
+select regexp_replace('xxxx', "x", "-");
+-- result:
+----
+-- !result
+select regexp_replace('xxxx', "xx", "-"); 
+select regexp_replace('xxxx', "xxx", "-");
+-- result:
+--
+-- !result
+select regexp_replace('xxxx', "xxxx", "-");
+-- result:
+-
+-- !result
+select regexp_replace('xxxx', "not", "xxxxxxxx");
+-- result:
+xxxx
+-- !result
+select regexp_replace('xxaxx', 'xx', 'aaa'); 
+select regexp_replace('xaxaxax', 'xax', '-');
+-- result:
+aaaaaaa
+-- !result
 select str, regex, replaced, regexp_replace(str, regex, replaced) from ts order by str, regex, replaced;
 -- result:
 None		xx	None
 		xx	xx
+           XXXX	       		    XXXX
+a b c	 	-	a-b-c
 abcd	.*	xx	xx
 abcd	.*abc.*	xx	xx
 abcd	.*cd	xx	xx
 abcd	a.*	xx	xx
 abcd	bc	xx	axxd
 abc中文def	[\p{Han}]+	xx	abcxxdef
+xaxaxax	xax	-	-a-
+xxaxx	xx	aaa	aaaaaaa
+xxxx	not	xxxxxxxx	xxxx
+xxxx	x	-	----
+xxxx	xx	-	--
+xxxx	xxx	-	-x
+xxxx	xxxx	-	-
 -- !result

--- a/test/sql/test_function/T/test_regex
+++ b/test/sql/test_function/T/test_regex
@@ -10,6 +10,9 @@ COMMENT "OLAP"
 DISTRIBUTED BY HASH(`str`) BUCKETS 1 PROPERTIES ("replication_num" = "1");
 
 insert into ts values ('abcd', '.*', 'xx'), ('abcd', 'a.*', 'xx'), ('abcd', '.*abc.*', 'xx'), ('abcd', '.*cd', 'xx'), ('abcd', 'bc', 'xx'), ('', '', 'xx'), (NULL, '', 'xx'), ('abc中文def', '[\\p{Han}]+', 'xx');
+insert into ts values ('a b c', " ", "-"), ('           XXXX', '       ', '');
+insert into ts values ('xxxx', "x", "-"), ('xxxx', "xx", "-"), ('xxxx', "xxx", "-"), ('xxxx', "xxxx", "-");
+insert into ts values ('xxxx', "not", "xxxxxxxx"), ('xxaxx', 'xx', 'aaa'), ('xaxaxax', 'xax', '-');
 
 select regexp_replace('abcd', '.*', 'xx');
 select regexp_replace('abcd', 'a.*', 'xx');
@@ -21,5 +24,13 @@ select regexp_replace(NULL, '', 'xx');
 select regexp_replace('abc中文def', '中文', 'xx');
 select regexp_replace('abc中文def', '[\\p{Han}]+', 'xx');
 select regexp_replace('a b c', " ", "-");
+select regexp_replace('           XXXX', '       ', '');
+select regexp_replace('xxxx', "x", "-");
+select regexp_replace('xxxx', "xx", "-"); 
+select regexp_replace('xxxx', "xxx", "-");
+select regexp_replace('xxxx', "xxxx", "-");
+select regexp_replace('xxxx', "not", "xxxxxxxx");
+select regexp_replace('xxaxx', 'xx', 'aaa'); 
+select regexp_replace('xaxaxax', 'xax', '-');
 
 select str, regex, replaced, regexp_replace(str, regex, replaced) from ts order by str, regex, replaced;


### PR DESCRIPTION
hyberscan('xxxx', "xx") will return overlap match eg: [(0, 2),(1, 3)...] which will cause a error length

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
