### PR TITLE
[BugFix] Bugfix of lake service

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -136,11 +136,9 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
     if (enable_trace) {
         trace_gurad = scoped_refptr<Trace>(new Trace());
         trace = trace_gurad.get();
+        TRACE_TO(trace, "got request. txn_id=$0 new_version=$1 #tablets=$2", request->txn_ids(0),
+                 request->new_version(), request->tablet_ids_size());
     }
-
-    ADOPT_TRACE(trace);
-    TRACE("got request. txn_id=$0 new_version=$1 #tablets=$2", request->txn_ids(0), request->new_version(),
-          request->tablet_ids_size());
 
     for (auto tablet_id : request->tablet_ids()) {
         auto task = [&, tablet_id]() {


### PR DESCRIPTION
ScopedAdoptTrace must be created and destroyed on the same thread, but LakeService::publish_version was
executed in a bthread, thread switching may occur.

Fixes #27129

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
