### PR TITLE
[Refactor] ExecNode::close should not return err

### DIFF
--- a/be/src/exec/aggregate/aggregate_base_node.cpp
+++ b/be/src/exec/aggregate/aggregate_base_node.cpp
@@ -51,9 +51,9 @@ Status AggregateBaseNode::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-Status AggregateBaseNode::close(RuntimeState* state) {
+void AggregateBaseNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
     if (_aggregator != nullptr) {
         if (_aggregator->is_hash_set()) {
@@ -65,7 +65,7 @@ Status AggregateBaseNode::close(RuntimeState* state) {
         _aggregator->close(state);
         _aggregator.reset();
     }
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 void AggregateBaseNode::push_down_join_runtime_filter(RuntimeState* state, RuntimeFilterProbeCollector* collector) {

--- a/be/src/exec/aggregate/aggregate_base_node.h
+++ b/be/src/exec/aggregate/aggregate_base_node.h
@@ -27,7 +27,7 @@ public:
     ~AggregateBaseNode() override;
     Status init(const TPlanNode& tnode, RuntimeState* state = nullptr) override;
     Status prepare(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
     void push_down_join_runtime_filter(RuntimeState* state, RuntimeFilterProbeCollector* collector) override;
 
 protected:

--- a/be/src/exec/analytic_node.cpp
+++ b/be/src/exec/analytic_node.cpp
@@ -118,9 +118,9 @@ Status AnalyticNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     return Status::OK();
 }
 
-Status AnalyticNode::close(RuntimeState* state) {
+void AnalyticNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
 
     if (_analytor != nullptr) {
@@ -128,7 +128,7 @@ Status AnalyticNode::close(RuntimeState* state) {
         _analytor.reset();
     }
 
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 Status AnalyticNode::_get_next_for_unbounded_frame(RuntimeState* state, ChunkPtr* chunk, bool* eos) {

--- a/be/src/exec/analytic_node.h
+++ b/be/src/exec/analytic_node.h
@@ -35,7 +35,7 @@ public:
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     pipeline::OpFactories decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override;
 

--- a/be/src/exec/assert_num_rows_node.cpp
+++ b/be/src/exec/assert_num_rows_node.cpp
@@ -153,11 +153,11 @@ Status AssertNumRowsNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* e
     return Status::OK();
 }
 
-Status AssertNumRowsNode::close(RuntimeState* state) {
+void AssertNumRowsNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 pipeline::OpFactories AssertNumRowsNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {

--- a/be/src/exec/assert_num_rows_node.h
+++ b/be/src/exec/assert_num_rows_node.h
@@ -41,7 +41,7 @@ public:
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
             pipeline::PipelineBuilderContext* context) override;

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -564,9 +564,9 @@ void ConnectorScanNode::_fill_chunk_pool(int count) {
     }
 }
 
-Status ConnectorScanNode::close(RuntimeState* state) {
+void ConnectorScanNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
     _closed = true;
     _update_status(Status::Cancelled("closed"));
@@ -576,8 +576,7 @@ Status ConnectorScanNode::close(RuntimeState* state) {
     }
     _close_pending_scanners();
     _data_source_provider->close(state);
-    RETURN_IF_ERROR(ScanNode::close(state));
-    return Status::OK();
+    ScanNode::close(state);
 }
 
 Status ConnectorScanNode::set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) {

--- a/be/src/exec/connector_scan_node.h
+++ b/be/src/exec/connector_scan_node.h
@@ -37,7 +37,7 @@ public:
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
     bool accept_empty_scan_ranges() const override;
 

--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -509,9 +509,9 @@ Status CrossJoinNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) 
             });
 }
 
-Status CrossJoinNode::close(RuntimeState* state) {
+void CrossJoinNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
 
     if (_build_chunk != nullptr) {
@@ -522,7 +522,7 @@ Status CrossJoinNode::close(RuntimeState* state) {
     }
 
     Expr::close(_join_conjuncts, state);
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 void CrossJoinNode::_init_row_desc() {

--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -587,7 +587,7 @@ Status CrossJoinNode::_build(RuntimeState* state) {
         _build_chunks_size = (_number_of_build_rows / runtime_state()->chunk_size()) * runtime_state()->chunk_size();
     }
 
-    RETURN_IF_ERROR(child(1)->close(state));
+    child(1)->close(state);
     return Status::OK();
 }
 

--- a/be/src/exec/cross_join_node.h
+++ b/be/src/exec/cross_join_node.h
@@ -40,7 +40,7 @@ public:
     Status get_next_internal(RuntimeState* state, ChunkPtr* chunk, bool* eos,
                              ScopedTimer<MonotonicStopWatch>& probe_timer);
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
             pipeline::PipelineBuilderContext* context) override;

--- a/be/src/exec/dict_decode_node.cpp
+++ b/be/src/exec/dict_decode_node.cpp
@@ -150,15 +150,13 @@ Status DictDecodeNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos)
     return Status::OK();
 }
 
-Status DictDecodeNode::close(RuntimeState* state) {
+void DictDecodeNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
-    RETURN_IF_ERROR(ExecNode::close(state));
+    ExecNode::close(state);
     Expr::close(_expr_ctxs, state);
     _dict_optimize_parser.close(state);
-
-    return Status::OK();
 }
 
 pipeline::OpFactories DictDecodeNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {

--- a/be/src/exec/dict_decode_node.h
+++ b/be/src/exec/dict_decode_node.h
@@ -42,7 +42,7 @@ public:
 
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
             pipeline::PipelineBuilderContext* context) override;

--- a/be/src/exec/except_node.cpp
+++ b/be/src/exec/except_node.cpp
@@ -212,9 +212,9 @@ Status ExceptNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     return Status::OK();
 }
 
-Status ExceptNode::close(RuntimeState* state) {
+void ExceptNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
 
     for (auto& exprs : _child_expr_lists) {
@@ -233,7 +233,7 @@ Status ExceptNode::close(RuntimeState* state) {
         _hash_set.reset();
     }
 
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 pipeline::OpFactories ExceptNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {

--- a/be/src/exec/except_node.h
+++ b/be/src/exec/except_node.h
@@ -37,7 +37,7 @@ class TupleDescriptor;
 } // namespace starrocks
 
 namespace starrocks {
-class ExceptNode : public ExecNode {
+class ExceptNode final : public ExecNode {
 public:
     ExceptNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
 
@@ -51,7 +51,7 @@ public:
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* row_batch, bool* eos) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     pipeline::OpFactories decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override;
 

--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -110,9 +110,9 @@ Status ExchangeNode::collect_query_statistics(QueryStatistics* statistics) {
     return Status::OK();
 }
 
-Status ExchangeNode::close(RuntimeState* state) {
+void ExchangeNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
     if (_is_merging) {
         _sort_exec_exprs.close(state);
@@ -121,7 +121,7 @@ Status ExchangeNode::close(RuntimeState* state) {
         _stream_recvr->close();
     }
     // _stream_recvr.reset();
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 Status ExchangeNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {

--- a/be/src/exec/exchange_node.h
+++ b/be/src/exec/exchange_node.h
@@ -65,7 +65,7 @@ public:
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
     Status collect_query_statistics(QueryStatistics* statistics) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     // the number of senders needs to be set after the c'tor, because it's not
     // recorded in TPlanNode, and before calling prepare()

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -149,7 +149,7 @@ public:
     // get_next(). The default implementation updates runtime profile counters and calls
     // close() on the children. To ensure that close() is called on the entire plan tree,
     // each implementation should start out by calling the default implementation.
-    virtual Status close(RuntimeState* state);
+    virtual void close(RuntimeState* state);
 
     // Creates exec node tree from list of nodes contained in plan via depth-first
     // traversal. All nodes are placed in pool.

--- a/be/src/exec/file_scan_node.cpp
+++ b/be/src/exec/file_scan_node.cpp
@@ -170,9 +170,9 @@ Status FileScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     return Status::OK();
 }
 
-Status FileScanNode::close(RuntimeState* state) {
+void FileScanNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
     exec_debug_action(TExecNodePhase::CLOSE);
     SCOPED_TIMER(_runtime_profile->total_time_counter());
@@ -188,7 +188,7 @@ Status FileScanNode::close(RuntimeState* state) {
     }
     _cur_mem_usage = 0;
 
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 // This function is called after plan node has been prepared.

--- a/be/src/exec/file_scan_node.h
+++ b/be/src/exec/file_scan_node.h
@@ -48,7 +48,7 @@ public:
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
 
     // Close the scanner, and report errors.
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     // No use
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -415,9 +415,9 @@ Status HashJoinNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     return Status::OK();
 }
 
-Status HashJoinNode::close(RuntimeState* state) {
+void HashJoinNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
 
     Expr::close(_build_expr_ctxs, state);
@@ -426,7 +426,7 @@ Status HashJoinNode::close(RuntimeState* state) {
 
     _ht.close();
 
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 template <class HashJoinerFactory, class HashJoinBuilderFactory, class HashJoinProbeFactory>

--- a/be/src/exec/hash_join_node.h
+++ b/be/src/exec/hash_join_node.h
@@ -46,7 +46,7 @@ public:
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
     pipeline::OpFactories decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override;
 
 private:

--- a/be/src/exec/intersect_node.cpp
+++ b/be/src/exec/intersect_node.cpp
@@ -219,9 +219,9 @@ Status IntersectNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) 
     return Status::OK();
 }
 
-Status IntersectNode::close(RuntimeState* state) {
+void IntersectNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
 
     for (auto& exprs : _child_expr_lists) {
@@ -236,7 +236,7 @@ Status IntersectNode::close(RuntimeState* state) {
         _hash_set.reset();
     }
 
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 pipeline::OpFactories IntersectNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {

--- a/be/src/exec/intersect_node.h
+++ b/be/src/exec/intersect_node.h
@@ -49,7 +49,7 @@ public:
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* row_batch, bool* eos) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     pipeline::OpFactories decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override;
     int64_t mem_usage() const {

--- a/be/src/exec/meta_scan_node.cpp
+++ b/be/src/exec/meta_scan_node.cpp
@@ -63,13 +63,13 @@ Status MetaScanNode::prepare(RuntimeState* state) {
     return Status::OK();
 }
 
-Status MetaScanNode::close(RuntimeState* state) {
+void MetaScanNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
 
     SCOPED_TIMER(_runtime_profile->total_time_counter());
-    return ScanNode::close(state);
+    ScanNode::close(state);
 }
 
 } // namespace starrocks

--- a/be/src/exec/meta_scan_node.h
+++ b/be/src/exec/meta_scan_node.h
@@ -23,7 +23,7 @@ namespace starrocks {
 
 class RuntimeState;
 
-class MetaScanNode final : public starrocks::ScanNode {
+class MetaScanNode : public starrocks::ScanNode {
 public:
     MetaScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
     ~MetaScanNode() override;

--- a/be/src/exec/meta_scan_node.h
+++ b/be/src/exec/meta_scan_node.h
@@ -23,14 +23,14 @@ namespace starrocks {
 
 class RuntimeState;
 
-class MetaScanNode : public starrocks::ScanNode {
+class MetaScanNode final : public starrocks::ScanNode {
 public:
     MetaScanNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
     ~MetaScanNode() override;
 
     Status prepare(RuntimeState* state) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
 
 protected:

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -210,9 +210,9 @@ Status OlapScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     return status.is_end_of_file() ? Status::OK() : status;
 }
 
-Status OlapScanNode::close(RuntimeState* state) {
+void OlapScanNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
     exec_debug_action(TExecNodePhase::CLOSE);
     _update_status(Status::Cancelled("closed"));
@@ -243,7 +243,7 @@ Status OlapScanNode::close(RuntimeState* state) {
         Rowset::release_readers(rowsets_per_tablet);
     }
 
-    return ScanNode::close(state);
+    ScanNode::close(state);
 }
 
 OlapScanNode::~OlapScanNode() {

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -63,7 +63,7 @@ public:
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
-    Status close(RuntimeState* statue) override;
+    void close(RuntimeState* statue) override;
 
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
     StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(

--- a/be/src/exec/project_node.cpp
+++ b/be/src/exec/project_node.cpp
@@ -191,16 +191,16 @@ Status ProjectNode::reset(RuntimeState* state) {
     return Status::OK();
 }
 
-Status ProjectNode::close(RuntimeState* state) {
+void ProjectNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
 
     Expr::close(_expr_ctxs, state);
     Expr::close(_common_sub_expr_ctxs, state);
     _dict_optimize_parser.close(state);
 
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 void ProjectNode::push_down_predicate(RuntimeState* state, std::list<ExprContext*>* expr_ctxs) {

--- a/be/src/exec/project_node.h
+++ b/be/src/exec/project_node.h
@@ -32,7 +32,7 @@ public:
     Status prepare(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
     Status reset(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     void push_down_predicate(RuntimeState* state, std::list<ExprContext*>* expr_ctxs) override;
     void push_down_join_runtime_filter(RuntimeState* state, RuntimeFilterProbeCollector* collector) override;

--- a/be/src/exec/repeat_node.cpp
+++ b/be/src/exec/repeat_node.cpp
@@ -196,11 +196,11 @@ void RepeatNode::extend_and_update_columns(ChunkPtr* curr_chunk, ChunkPtr* chunk
     }
 }
 
-Status RepeatNode::close(RuntimeState* state) {
+void RepeatNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 std::vector<std::shared_ptr<pipeline::OperatorFactory> > RepeatNode::decompose_to_pipeline(

--- a/be/src/exec/repeat_node.h
+++ b/be/src/exec/repeat_node.h
@@ -30,7 +30,7 @@ public:
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
             pipeline::PipelineBuilderContext* context) override;

--- a/be/src/exec/schema_scan_node.cpp
+++ b/be/src/exec/schema_scan_node.cpp
@@ -274,14 +274,14 @@ Status SchemaScanNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos)
     return Status::OK();
 }
 
-Status SchemaScanNode::close(RuntimeState* state) {
+void SchemaScanNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        Status::OK();
     }
     exec_debug_action(TExecNodePhase::CLOSE);
     SCOPED_TIMER(_runtime_profile->total_time_counter());
 
-    return ScanNode::close(state);
+    ScanNode::close(state);
 }
 
 void SchemaScanNode::debug_string(int indentation_level, std::stringstream* out) const {

--- a/be/src/exec/schema_scan_node.h
+++ b/be/src/exec/schema_scan_node.h
@@ -47,7 +47,7 @@ public:
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
 
     // Close the _schema_scanner, and report errors.
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     // this is no use in this class
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;

--- a/be/src/exec/select_node.cpp
+++ b/be/src/exec/select_node.cpp
@@ -96,11 +96,11 @@ Status SelectNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     return Status::OK();
 }
 
-Status SelectNode::close(RuntimeState* state) {
+void SelectNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 pipeline::OpFactories SelectNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {

--- a/be/src/exec/select_node.h
+++ b/be/src/exec/select_node.h
@@ -42,7 +42,7 @@ namespace starrocks {
 // Node that evaluates conjuncts and enforces a limit but otherwise passes along
 // the rows pulled from its child unchanged.
 
-class SelectNode : public ExecNode {
+class SelectNode final : public ExecNode {
 public:
     SelectNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs);
     ~SelectNode() override;
@@ -50,7 +50,7 @@ public:
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
     std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
             pipeline::PipelineBuilderContext* context) override;
 

--- a/be/src/exec/stream/stream_aggregate_node.h
+++ b/be/src/exec/stream/stream_aggregate_node.h
@@ -23,11 +23,11 @@ using StreamAggregatorPtr = std::shared_ptr<stream::StreamAggregator>;
 using StreamAggregatorFactory = AggregatorFactoryBase<stream::StreamAggregator>;
 using StreamAggregatorFactoryPtr = std::shared_ptr<StreamAggregatorFactory>;
 
-class StreamAggregateNode final : public starrocks::ExecNode {
+class StreamAggregateNode final : public ExecNode {
 public:
     StreamAggregateNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
             : ExecNode(pool, tnode, descs), _tnode(tnode) {}
-    ~StreamAggregateNode() override {}
+    ~StreamAggregateNode() override = default;
     Status init(const TPlanNode& tnode, RuntimeState* state) override;
     std::vector<std::shared_ptr<pipeline::OperatorFactory> > decompose_to_pipeline(
             pipeline::PipelineBuilderContext* context) override;

--- a/be/src/exec/table_function_node.cpp
+++ b/be/src/exec/table_function_node.cpp
@@ -220,14 +220,14 @@ Status TableFunctionNode::reset(RuntimeState* state) {
     return Status::OK();
 }
 
-Status TableFunctionNode::close(RuntimeState* state) {
+void TableFunctionNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
     if (_table_function != nullptr && _table_function_state != nullptr) {
         _table_function->close(state, _table_function_state);
     }
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 Status TableFunctionNode::build_chunk(ChunkPtr* chunk, const std::vector<ColumnPtr>& output_columns) {

--- a/be/src/exec/table_function_node.h
+++ b/be/src/exec/table_function_node.h
@@ -34,7 +34,7 @@ public:
     Status prepare(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
     Status reset(RuntimeState* state) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     Status build_chunk(ChunkPtr* chunk, const std::vector<ColumnPtr>& output_columns);
 

--- a/be/src/exec/topn_node.cpp
+++ b/be/src/exec/topn_node.cpp
@@ -204,14 +204,14 @@ Status TopNNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     return Status::OK();
 }
 
-Status TopNNode::close(RuntimeState* state) {
+void TopNNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
     _chunks_sorter = nullptr;
 
     _sort_exec_exprs.close(state);
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 Status TopNNode::_consume_chunks(RuntimeState* state, ExecNode* child) {

--- a/be/src/exec/topn_node.h
+++ b/be/src/exec/topn_node.h
@@ -36,7 +36,7 @@ public:
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
 
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     std::vector<std::shared_ptr<pipeline::OperatorFactory>> decompose_to_pipeline(
             pipeline::PipelineBuilderContext* context) override;

--- a/be/src/exec/union_node.cpp
+++ b/be/src/exec/union_node.cpp
@@ -191,7 +191,7 @@ Status UnionNode::_get_next_passthrough(RuntimeState* state, ChunkPtr* chunk) {
     while (true) {
         RETURN_IF_ERROR(child(_child_idx)->get_next(state, &tmp_chunk, &_child_eos));
         if (_child_eos) {
-            RETURN_IF_ERROR(child(_child_idx)->close(state));
+            child(_child_idx)->close(state);
             _child_idx++;
             break;
         }
@@ -218,7 +218,7 @@ Status UnionNode::_get_next_materialize(RuntimeState* state, ChunkPtr* chunk) {
     while (true) {
         RETURN_IF_ERROR(child(_child_idx)->get_next(state, &tmp_chunk, &_child_eos));
         if (_child_eos) {
-            RETURN_IF_ERROR(child(_child_idx)->close(state));
+            child(_child_idx)->close(state);
             _child_idx++;
             break;
         }

--- a/be/src/exec/union_node.cpp
+++ b/be/src/exec/union_node.cpp
@@ -166,9 +166,9 @@ Status UnionNode::get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) {
     return Status::OK();
 }
 
-Status UnionNode::close(RuntimeState* state) {
+void UnionNode::close(RuntimeState* state) {
     if (is_closed()) {
-        return Status::OK();
+        return;
     }
     for (auto& exprs : _child_expr_lists) {
         Expr::close(exprs, state);
@@ -176,7 +176,7 @@ Status UnionNode::close(RuntimeState* state) {
     for (auto& exprs : _const_expr_lists) {
         Expr::close(exprs, state);
     }
-    return ExecNode::close(state);
+    ExecNode::close(state);
 }
 
 Status UnionNode::_get_next_passthrough(RuntimeState* state, ChunkPtr* chunk) {

--- a/be/src/exec/union_node.h
+++ b/be/src/exec/union_node.h
@@ -29,7 +29,7 @@ public:
     Status prepare(RuntimeState* state) override;
     Status open(RuntimeState* state) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk, bool* eos) override;
-    Status close(RuntimeState* state) override;
+    void close(RuntimeState* state) override;
 
     pipeline::OpFactories decompose_to_pipeline(pipeline::PipelineBuilderContext* context) override;
 

--- a/be/test/exec/file_scan_node_test.cpp
+++ b/be/test/exec/file_scan_node_test.cpp
@@ -192,8 +192,7 @@ TEST_F(FileScanNodeTest, CSVBasic) {
     ASSERT_FALSE(eos);
     ASSERT_EQ(chunk->num_rows(), 3);
 
-    status = file_scan_node->close(_runtime_state.get());
-    ASSERT_TRUE(status.ok());
+    file_scan_node->close(_runtime_state.get());
 }
 
 } // namespace starrocks

--- a/be/test/exec/hdfs_scan_node_test.cpp
+++ b/be/test/exec/hdfs_scan_node_test.cpp
@@ -370,8 +370,7 @@ TEST_F(HdfsScanNodeTest, TestBasic) {
         ASSERT_FALSE(eos);
         ASSERT_EQ(chunk->num_rows(), 4);
 
-        status = hdfs_scan_node->close(_runtime_state.get());
-        ASSERT_TRUE(status.ok());
+        hdfs_scan_node->close(_runtime_state.get());
     }
 
     // test filter partition
@@ -406,8 +405,7 @@ TEST_F(HdfsScanNodeTest, TestBasic) {
         status = hdfs_scan_node->get_next(_runtime_state.get(), &chunk, &eos);
         ASSERT_TRUE(eos);
 
-        status = hdfs_scan_node->close(_runtime_state.get());
-        ASSERT_TRUE(status.ok());
+        hdfs_scan_node->close(_runtime_state.get());
     }
 }
 } // namespace starrocks

--- a/be/test/exec/repeat_node_test.cpp
+++ b/be/test/exec/repeat_node_test.cpp
@@ -71,7 +71,7 @@ public:
 
     Status open(RuntimeState* state) override { return Status::OK(); }
 
-    Status close(RuntimeState* state) override { return Status::OK(); }
+    void close(RuntimeState* state) override {}
 
 private:
     int times{0};

--- a/be/test/exec/table_function_node_test.cpp
+++ b/be/test/exec/table_function_node_test.cpp
@@ -65,6 +65,6 @@ void TableFunctionNodeTest::SetUp() {
 
 TEST_F(TableFunctionNodeTest, close_after_not_init) {
     TableFunctionNode table_function_node(&_object_pool, _tnode, *_desc_tbl);
-    ASSERT_TRUE(table_function_node.close(&_runtime_state).ok());
+    table_function_node.close(&_runtime_state);
 }
 } // namespace starrocks


### PR DESCRIPTION
Fixes #issue

If Err is returned, the developer will misuse it, resulting in an early return, and some resources will not be released in the end

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
