### PR TITLE
[BugFix] Remove force scheduling logic for runtime profile report

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -431,10 +431,6 @@ void PipelineDriver::check_short_circuit() {
     }
 }
 
-bool PipelineDriver::need_report_exec_state() {
-    return _fragment_ctx->need_report_exec_state();
-}
-
 void PipelineDriver::report_exec_state_if_necessary() {
     if (_state == DriverState::NOT_READY || _state == DriverState::FINISH || _state == DriverState::CANCELED ||
         _state == DriverState::INTERNAL_ERROR) {

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -411,7 +411,6 @@ public:
     // Check whether an operator can be short-circuited, when is_precondition_block() becomes false from true.
     void check_short_circuit();
 
-    bool need_report_exec_state();
     void report_exec_state_if_necessary();
     void runtime_report_action();
 

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -139,7 +139,7 @@ void PipelineDriverPoller::run_internal() {
                 } else if (driver->is_finished()) {
                     remove_blocked_driver(_local_blocked_drivers, driver_it);
                     ready_drivers.emplace_back(driver);
-                } else if (driver->is_not_blocked() || driver->need_report_exec_state()) {
+                } else if (driver->is_not_blocked()) {
                     driver->set_driver_state(DriverState::READY);
                     remove_blocked_driver(_local_blocked_drivers, driver_it);
                     ready_drivers.emplace_back(driver);


### PR DESCRIPTION
This issue is introduced by https://github.com/StarRocks/starrocks/pull/25131, which allows the drivers to be re-scheduled even if it's not actual ready in order to trigger the report exec state process.

But if the dirver is waiting it's dependency to be finished, it may fail when calling the has_output or other status checking interface.

And this pr is to remove the force scheduling mechanism.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
