### PR TITLE
[BugFix] crash when apply in table with AUTO_INCREMENT column (#27176)

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -400,6 +400,11 @@ Status DeltaWriterImpl::finish(DeltaWriter::FinishMode mode) {
             for (auto i = 0; i < _tablet_schema->num_columns(); ++i) {
                 auto col = _tablet_schema->column(i);
                 if (col.is_auto_increment()) {
+                    /*
+                        The auto increment id set here is inconsistent with the id in
+                        full tablet schema. The id here is indicate the offset id of
+                        auto increment column in partial segment file.
+                    */
                     op_write->mutable_txn_meta()->set_auto_increment_partial_update_column_id(i);
                     break;
                 }

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -265,7 +265,13 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(const Tx
     _auto_increment_partial_update_states.resize(num_segments);
     _auto_increment_delete_pks.resize(num_segments);
 
-    uint32_t auto_increment_column_id = txn_meta.auto_increment_partial_update_column_id();
+    uint32_t auto_increment_column_id = 0;
+    for (int i = 0; i < tablet_schema.num_columns(); ++i) {
+        if (tablet_schema.column(i).is_auto_increment()) {
+            auto_increment_column_id = i;
+            break;
+        }
+    }
     std::vector<uint32_t> column_id{auto_increment_column_id};
     auto read_column_schema = ChunkHelper::convert_schema(tablet_schema, column_id);
     auto column = ChunkHelper::column_from_field(*read_column_schema.field(0).get());
@@ -284,7 +290,7 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(const Tx
     }
 
     for (size_t i = 0; i < num_segments; i++) {
-        _auto_increment_partial_update_states[i].init(schema, column_id[0], i);
+        _auto_increment_partial_update_states[i].init(schema, txn_meta.auto_increment_partial_update_column_id(), i);
         _auto_increment_partial_update_states[i].src_rss_rowids.resize(_upserts[i]->size());
         read_column[i].resize(1);
         read_column[i][0] = column->clone_empty();
@@ -669,8 +675,14 @@ Status RowsetUpdateState::_resolve_conflict_auto_increment(const TxnLogPB_OpWrit
             }
         }
 
-        std::vector<uint32_t> column_id{
-                static_cast<uint32_t>(op_write.txn_meta().auto_increment_partial_update_column_id())};
+        uint32_t auto_increment_column_id = 0;
+        for (int i = 0; i < tablet_schema->num_columns(); ++i) {
+            if (tablet_schema->column(i).is_auto_increment()) {
+                auto_increment_column_id = i;
+                break;
+            }
+        }
+        std::vector<uint32_t> column_id{auto_increment_column_id};
         std::vector<std::unique_ptr<Column>> auto_increment_read_column;
         auto_increment_read_column.resize(1);
         auto_increment_read_column[0] = _auto_increment_partial_update_states[segment_id].write_column->clone_empty();

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -34,6 +34,8 @@ struct AutoIncrementPartialUpdateState {
     std::vector<uint64_t> src_rss_rowids;
     std::unique_ptr<Column> write_column;
     std::shared_ptr<TabletSchema> schema;
+    // auto increment column id in partial segment file
+    // but not in full tablet schema
     uint32_t id;
     uint32_t segment_id;
     std::vector<uint32_t> rowids;

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -173,6 +173,11 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
                 for (auto i = 0; i < _context.tablet_schema->num_columns(); ++i) {
                     auto col = _context.tablet_schema->column(i);
                     if (col.is_auto_increment()) {
+                        /*
+                            The auto increment id set here is inconsistent with the id in
+                            full tablet schema. The id here is indicate the offset id of
+                            auto increment column in partial segment file.
+                        */
                         _rowset_txn_meta_pb->set_auto_increment_partial_update_column_id(i);
                         break;
                     }
@@ -188,6 +193,7 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
             for (auto i = 0; i < _context.tablet_schema->num_columns(); ++i) {
                 auto col = _context.tablet_schema->column(i);
                 if (col.is_auto_increment()) {
+                    // same above
                     _rowset_txn_meta_pb->set_auto_increment_partial_update_column_id(i);
                     break;
                 }

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -78,7 +78,13 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
 
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dest_path));
 
-    uint32_t auto_increment_column_id = auto_increment_partial_update_state.id;
+    uint32_t auto_increment_column_id = 0;
+    for (const auto& col : tschema.columns()) {
+        if (col.is_auto_increment()) {
+            break;
+        }
+        ++auto_increment_column_id;
+    }
     uint32_t segment_id = auto_increment_partial_update_state.segment_id;
     Rowset* rowset = auto_increment_partial_update_state.rowset;
     rowset->load();
@@ -161,7 +167,13 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
 
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dest_path));
 
-    uint32_t auto_increment_column_id = auto_increment_partial_update_state.id;
+    uint32_t auto_increment_column_id = 0;
+    for (const auto& col : tschema.columns()) {
+        if (col.is_auto_increment()) {
+            break;
+        }
+        ++auto_increment_column_id;
+    }
     uint32_t segment_id = auto_increment_partial_update_state.segment_id;
 
     std::vector<uint32_t> src_column_ids;

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -383,7 +383,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
 
 Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t idx,
                                                                         EditVersion latest_applied_version,
-                                                                        std::vector<uint32_t> column_id) {
+                                                                        const std::vector<uint32_t>& column_id) {
     if (_auto_increment_partial_update_states.size() == 0) {
         _auto_increment_partial_update_states.resize(rowset->num_segments());
     }
@@ -402,7 +402,7 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(Tablet* 
 
     _auto_increment_partial_update_states[idx].init(
             rowset, schema != nullptr ? schema.get() : const_cast<TabletSchema*>(&tablet->tablet_schema()),
-            column_id[0], idx);
+            rowset_meta_pb.txn_meta().auto_increment_partial_update_column_id(), idx);
     _auto_increment_partial_update_states[idx].src_rss_rowids.resize(_upserts[idx]->size());
 
     auto column = ChunkHelper::column_from_field(*read_column_schema.field(0).get());
@@ -610,9 +610,16 @@ Status RowsetUpdateState::apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_
     }
 
     if (txn_meta.has_auto_increment_partial_update_column_id()) {
-        uint32_t id = txn_meta.auto_increment_partial_update_column_id();
-        RETURN_IF_ERROR(_prepare_auto_increment_partial_update_states(
-                tablet, rowset, segment_id, latest_applied_version, std::vector<uint32_t>(1, id)));
+        uint32_t id = 0;
+        for (int i = 0; i < tablet->tablet_schema().num_columns(); ++i) {
+            if (tablet->tablet_schema().column(i).is_auto_increment()) {
+                id = i;
+                break;
+            }
+        }
+        std::vector<uint32_t> column_id(1, id);
+        RETURN_IF_ERROR(_prepare_auto_increment_partial_update_states(tablet, rowset, segment_id,
+                                                                      latest_applied_version, column_id));
     }
 
     auto src_path = Rowset::segment_file_path(tablet->schema_hash_path(), rowset->rowset_id(), segment_id);

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -48,6 +48,8 @@ struct AutoIncrementPartialUpdateState {
     std::unique_ptr<Column> write_column;
     Rowset* rowset;
     TabletSchema* schema;
+    // auto increment column id in partial segment file
+    // but not in full tablet schema
     uint32_t id;
     uint32_t segment_id;
     std::vector<uint32_t> rowids;
@@ -130,7 +132,7 @@ private:
 
     Status _prepare_auto_increment_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t idx,
                                                          EditVersion latest_applied_version,
-                                                         std::vector<uint32_t> column_id);
+                                                         const std::vector<uint32_t>& column_id);
 
     Status _check_and_resolve_conflict(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, uint32_t segment_id,
                                        EditVersion latest_applied_version, std::vector<uint32_t>& read_column_ids,


### PR DESCRIPTION
problem:
suppose we have a table created by:

```
CREATE TABLE t (id BIGINT NOT NULL,  name BIGINT NOT NULL,  v1 string, v2 string null, v3 BIGINT AUTO_INCREMENT) PRIMARY KEY (id, name) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES(replication_num = 1, replicated_storage=true);
```

and then insert into a new record: 
```
INSERT INTO t VALUES (1,2,3,4, DEFAULT);
```

and we have a CSV file with: 1,2,3 and 2,3,4

we want to partial update the v2 and v3, and we will get a crash when we apply.

The reason is that, in the apply phase, we need to get the column id in auto increment to do some work, but the id is incorrect in this case.

Fixes #27176

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
