### PR TITLE
[Enhancement] Support convert float column to double column in parquet

### DIFF
--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -494,6 +494,10 @@ TEST_F(ColumnConverterTest, FloatTest) {
             check(file_path, col_type, col_name, "[-5.55]", expected_rows);
         }
         {
+            const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_DOUBLE);
+            check(file_path, col_type, col_name, "[-5.55]", expected_rows);
+        }
+        {
             const TypeDescriptor col_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_INT);
             check(file_path, col_type, col_name, "[-5.55]", expected_rows, true);
         }


### PR DESCRIPTION
Fix `ERROR 1064 (HY000): parquet column reader: not supported convert from parquet FLOAT to DOUBLE` error msg in parquet.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
