### PR TITLE
[Enhancement] introduce loose query rewrite mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -346,8 +346,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
             // old version use the boolean value
             boolean boolValue = Boolean.parseBoolean(value);
-            res = boolValue ? FORCE_EXTERNAL_TABLE_REWRITE_LOOSE :
-                    FORCE_EXTERNAL_TABLE_REWRITE_DISABLE;
+            res = boolValue ? FORCE_EXTERNAL_TABLE_REWRITE_CHECKED : FORCE_EXTERNAL_TABLE_REWRITE_DISABLE;
         } else {
             res = Integer.parseInt(value);
             if (res < 0 || res > 2) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -375,7 +375,8 @@ public class TableProperty implements Writable, GsonPostProcessable {
             if (res == null) {
                 String allValues = EnumUtils.getEnumList(QueryRewriteConsistencyMode.class)
                         .stream().map(Enum::name).collect(Collectors.joining(","));
-                throw new AnalysisException("force_external_table_query_rewrite could only be " + allValues);
+                throw new AnalysisException(
+                        "force_external_table_query_rewrite could only be " + allValues + " but got " + value);
             }
             return res;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -384,13 +384,24 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public TableProperty buildForceExternalTableQueryRewrite() {
         // NOTE: keep compatible with previous version
-        String value =
-                properties.getOrDefault(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE, "0");
-        try {
-            forceExternalTableQueryRewrite = analyzeQueryRewriteMode(value);
-        } catch (AnalysisException e) {
-            LOG.error("analyze force_external_table_query_rewrite failed", e);
+        String value = properties.get(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE);
+        if (value != null) {
+            try {
+                forceExternalTableQueryRewrite = analyzeQueryRewriteMode(value);
+            } catch (AnalysisException e) {
+                LOG.error("analyze {} failed", PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE, e);
+            }
         }
+
+        value = properties.get(PropertyAnalyzer.PROPERTIES_OLAP_TABLE_QUERY_REWRITE);
+        if (value != null) {
+            try {
+                olapTableQueryRewrite = analyzeQueryRewriteMode(value);
+            } catch (AnalysisException e) {
+                LOG.error("analyze {} failed", PropertyAnalyzer.PROPERTIES_OLAP_TABLE_QUERY_REWRITE, e);
+            }
+        }
+
         return this;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -54,7 +54,6 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Type;
 import com.starrocks.catalog.UniqueConstraint;
 import com.starrocks.common.AnalysisException;
@@ -149,6 +148,7 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_PARTITION_REFRESH_NUMBER = "partition_refresh_number";
     public static final String PROPERTIES_EXCLUDED_TRIGGER_TABLES = "excluded_trigger_tables";
     public static final String PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE = "force_external_table_query_rewrite";
+    public static final String PROPERTIES_OLAP_TABLE_QUERY_REWRITE = "olap_table_query_rewrite_consistency";
     public static final String PROPERTIES_RESOURCE_GROUP = "resource_group";
 
     public static final String PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX = "session.";
@@ -370,16 +370,6 @@ public class PropertyAnalyzer {
             properties.remove(PROPERTIES_MV_REWRITE_STALENESS_SECOND);
         }
         return maxMVRewriteStaleness;
-    }
-
-    public static int analyzeForceExternalTableQueryRewrite(Map<String, String> properties) throws AnalysisException {
-        int res = 0;
-        if (properties != null && properties.containsKey(PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)) {
-            String valueStr = properties.get(PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE);
-            res = TableProperty.analyzeForceExternalTableQueryRewrite(valueStr);
-            properties.remove(PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE);
-        }
-        return res;
     }
 
     public static Short analyzeReplicationNum(Map<String, String> properties, short oldReplicationNum)

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -54,6 +54,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Type;
 import com.starrocks.catalog.UniqueConstraint;
 import com.starrocks.common.AnalysisException;
@@ -371,14 +372,14 @@ public class PropertyAnalyzer {
         return maxMVRewriteStaleness;
     }
 
-    public static boolean analyzeForceExternalTableQueryRewrite(Map<String, String> properties) {
-        boolean forceExternalTableQueryRewrite = false;
+    public static int analyzeForceExternalTableQueryRewrite(Map<String, String> properties) throws AnalysisException {
+        int res = 0;
         if (properties != null && properties.containsKey(PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)) {
-            forceExternalTableQueryRewrite = Boolean.parseBoolean(properties.
-                    get(PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE));
+            String valueStr = properties.get(PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE);
+            res = TableProperty.analyzeForceExternalTableQueryRewrite(valueStr);
             properties.remove(PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE);
         }
-        return forceExternalTableQueryRewrite;
+        return res;
     }
 
     public static Short analyzeReplicationNum(Map<String, String> properties, short oldReplicationNum)

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2957,10 +2957,20 @@ public class LocalMetastore implements ConnectorMetadata {
                 materializedView.getTableProperty().setResourceGroup(resourceGroup);
             }
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)) {
-                int value = PropertyAnalyzer.analyzeForceExternalTableQueryRewrite(properties);
+                String propertyValue = properties.get(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE);
+                TableProperty.QueryRewriteConsistencyMode value = TableProperty.analyzeQueryRewriteMode(propertyValue);
+                properties.remove(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE);
                 materializedView.getTableProperty().getProperties().
                         put(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE, String.valueOf(value));
                 materializedView.getTableProperty().setForceExternalTableQueryRewrite(value);
+            }
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_OLAP_TABLE_QUERY_REWRITE)) {
+                String propertyValue = properties.get(PropertyAnalyzer.PROPERTIES_OLAP_TABLE_QUERY_REWRITE);
+                TableProperty.QueryRewriteConsistencyMode value = TableProperty.analyzeQueryRewriteMode(propertyValue);
+                properties.remove(PropertyAnalyzer.PROPERTIES_OLAP_TABLE_QUERY_REWRITE);
+                materializedView.getTableProperty().getProperties().
+                        put(PropertyAnalyzer.PROPERTIES_OLAP_TABLE_QUERY_REWRITE, String.valueOf(value));
+                materializedView.getTableProperty().setOlapTableQueryRewrite(value);
             }
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)) {
                 List<UniqueConstraint> uniqueConstraints = PropertyAnalyzer.analyzeUniqueConstraint(properties, db,

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2957,12 +2957,10 @@ public class LocalMetastore implements ConnectorMetadata {
                 materializedView.getTableProperty().setResourceGroup(resourceGroup);
             }
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)) {
-                boolean forceExternalTableQueryReWrite = PropertyAnalyzer.
-                        analyzeForceExternalTableQueryRewrite(properties);
+                int value = PropertyAnalyzer.analyzeForceExternalTableQueryRewrite(properties);
                 materializedView.getTableProperty().getProperties().
-                        put(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE,
-                                String.valueOf(forceExternalTableQueryReWrite));
-                materializedView.getTableProperty().setForceExternalTableQueryRewrite(forceExternalTableQueryReWrite);
+                        put(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE, String.valueOf(value));
+                materializedView.getTableProperty().setForceExternalTableQueryRewrite(value);
             }
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)) {
                 List<UniqueConstraint> uniqueConstraints = PropertyAnalyzer.analyzeUniqueConstraint(properties, db,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -579,7 +579,8 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
                         "\"replication_num\" = \"1\",\n" +
                         "\"force_external_table_query_rewrite\" = \"checked\"\n" +
                         ")\n" +
-                        "AS SELECT `l_shipdate`, sum(`l_orderkey`)  FROM `hive0`.`partitioned_db`.`lineitem_par` GROUP BY l_shipdate");
+                        "AS SELECT `l_shipdate`, sum(`l_orderkey`)  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                        "GROUP BY l_shipdate");
 
         query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
                 "where l_shipdate >= '1998-01-04'";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -541,4 +541,75 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
             starRocksAssert.dropMaterializedView("partial_mv_13");
         }
     }
+
+    @Test
+    public void testHivePartitionQueryRewrite() throws Exception {
+        starRocksAssert.getCtx().getSessionVariable().setEnableMaterializedViewUnionRewrite(true);
+        String mvName = "hive_query_rewrite";
+
+        // Disable
+        createAndRefreshMv("test", mvName,
+                "CREATE MATERIALIZED VIEW `hive_query_rewrite`\n" +
+                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                        "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                        "REFRESH MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"force_external_table_query_rewrite\" = \"disable\"\n" +
+                        ")\n" +
+                        "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
+
+        MaterializedView ttlMv = getMv("test", mvName);
+        GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler().runOnceForTest();
+        Assert.assertEquals(1, ttlMv.getPartitions().size());
+
+        String query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                "where l_shipdate >= '1998-01-04'";
+        PlanTestBase.assertNotContains(getFragmentPlan(query), mvName);
+        dropMv("test", mvName);
+
+        // Checked
+        createMv("test", mvName,
+                "CREATE MATERIALIZED VIEW `hive_query_rewrite`\n" +
+                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                        "DISTRIBUTED BY HASH(`l_shipdate`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"force_external_table_query_rewrite\" = \"checked\"\n" +
+                        ")\n" +
+                        "AS SELECT `l_shipdate`, sum(`l_orderkey`)  FROM `hive0`.`partitioned_db`.`lineitem_par` GROUP BY l_shipdate");
+
+        query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                "where l_shipdate >= '1998-01-04'";
+        PlanTestBase.assertNotContains(getFragmentPlan(query), mvName);
+        // refresh mv
+        refreshMaterializedView("test", mvName);
+        query =
+                "SELECT `l_shipdate`, sum(`l_orderkey`)  FROM `hive0`.`partitioned_db`.`lineitem_par` GROUP BY l_shipdate";
+        PlanTestBase.assertContains(getFragmentPlan(query), mvName);
+        dropMv("test", mvName);
+
+        // Loose
+        createAndRefreshMv("test", mvName,
+                "CREATE MATERIALIZED VIEW `hive_query_rewrite`\n" +
+                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                        "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"force_external_table_query_rewrite\" = \"loose\"\n" +
+                        ")\n" +
+                        "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
+
+        query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                "where l_shipdate >= '1998-01-04'";
+        PlanTestBase.assertContains(getFragmentPlan(query), mvName);
+        // refresh mv
+        refreshMaterializedView("test", mvName);
+        query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                "where l_shipdate >= '1998-01-04'";
+        PlanTestBase.assertContains(getFragmentPlan(query), mvName);
+        dropMv("test", mvName);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -556,6 +556,7 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
                         "REFRESH MANUAL\n" +
                         "PROPERTIES (\n" +
                         "\"replication_num\" = \"1\",\n" +
+                        "'olap_table_query_rewrite_consistency' = 'checked', " +
                         "\"force_external_table_query_rewrite\" = \"disable\"\n" +
                         ")\n" +
                         "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -69,7 +69,6 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
         dropMv("test", "partial_mv_2");
     }
 
-
     @Test
     public void testPartialPartition3_1() throws Exception {
         createAndRefreshMv("test", "partial_mv_3_1",
@@ -343,8 +342,9 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
         String plan = getFragmentPlan(query);
         PlanTestBase.assertContains(plan, "hive_parttbl_mv");
 
-        MockedHiveMetadata mockedHiveMetadata = (MockedHiveMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
-                getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
+        MockedHiveMetadata mockedHiveMetadata =
+                (MockedHiveMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
+                        getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
         mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
                 ImmutableList.of("l_shipdate=" + HiveMetaClient.PARTITION_NULL_VALUE));
 
@@ -360,8 +360,9 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
 
         query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` ";
         plan = getFragmentPlan(query);
-        PlanTestBase.assertContains(plan, "hive_parttbl_mv", "UNION", "PARTITION PREDICATES: ((22: l_shipdate < '1998-01-01')" +
-                " OR (22: l_shipdate >= '1998-01-06')) OR (22: l_shipdate IS NULL)");
+        PlanTestBase.assertContains(plan, "hive_parttbl_mv", "UNION",
+                "PARTITION PREDICATES: ((22: l_shipdate < '1998-01-01')" +
+                        " OR (22: l_shipdate >= '1998-01-06')) OR (22: l_shipdate IS NULL)");
         dropMv("test", "hive_parttbl_mv");
 
         createAndRefreshMv("test", "hive_parttbl_mv_2",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -285,9 +285,15 @@ public class MvRewriteTestBase {
 
     protected void refreshMaterializedView(String dbName, String mvName) throws SQLException {
         cluster.runSql(dbName, String.format("refresh materialized view %s with sync mode", mvName));
+        cluster.runSql(dbName, String.format("analyze table %s with sync mode", mvName));
     }
 
     protected void createAndRefreshMv(String dbName, String mvName, String sql) throws Exception {
+        starRocksAssert.withMaterializedView(sql);
+        cluster.runSql(dbName, String.format("refresh materialized view %s with sync mode", mvName));
+    }
+
+    protected void createMv(String dbName, String mvName, String sql) throws Exception {
         starRocksAssert.withMaterializedView(sql);
         cluster.runSql(dbName, String.format("refresh materialized view %s with sync mode", mvName));
     }


### PR DESCRIPTION
Fixes #issue

Change the semantic of table property `force_external_table_query_rewrite`:
- `DISABLE` 0: disable query rewrite
- `LOOSE` 1: enable query rewrite, and skip the partition version check
- `CHECKED` 2: enable query rewrite, and rewrite only if mv partition version is consistent with table meta

And introduce another table property `olap_table_query_rewrite_consistency` to control the behavior of OLAP table rewrite. The default value is `CHECKED`. 

Example: 
```sql
CREATE MATERIALIZED VIEW mv1 
REFRESH ASYNC
properties ( 'force_external_table_query_rewrite' = 'LOOSE' ) 
AS select * from hive_tbl;

```


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
