### PR TITLE
[Enhancement] optimize count distinct

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -66,12 +66,13 @@ import org.apache.commons.collections.CollectionUtils;
 
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.Optional;
 import java.util.Map;
-import java.util.Set;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
+
+import static com.starrocks.qe.SessionVariableConstants.FORCE_PREAGGREGATION;
+import static com.starrocks.qe.SessionVariableConstants.FORCE_STREAMING;
 
 public class AggregationNode extends PlanNode {
     private final AggregateInfo aggInfo;
@@ -121,8 +122,8 @@ public class AggregationNode extends PlanNode {
      * Sets this node as a preaggregation. Only valid to call this if it is not marked
      * as a preaggregation
      */
-    public void setIsPreagg(boolean canUseStreamingPreAgg) {
-        useStreamingPreagg = canUseStreamingPreAgg && aggInfo.getGroupingExprs().size() > 0;
+    public void setIsPreagg(boolean useStreamingPreAgg) {
+        useStreamingPreagg = useStreamingPreAgg;
     }
 
     public AggregateInfo getAggInfo() {
@@ -239,9 +240,9 @@ public class AggregationNode extends PlanNode {
         }
 
         msg.agg_node.setHas_outer_join_child(hasNullableGenerateChild);
-        if (streamingPreaggregationMode.equalsIgnoreCase("force_streaming")) {
+        if (streamingPreaggregationMode.equalsIgnoreCase(FORCE_STREAMING)) {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.FORCE_STREAMING);
-        } else if (streamingPreaggregationMode.equalsIgnoreCase("force_preaggregation")) {
+        } else if (streamingPreaggregationMode.equalsIgnoreCase(FORCE_PREAGGREGATION)) {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.FORCE_PREAGGREGATION);
         } else {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.AUTO);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -655,7 +655,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final int PIPELINE_BATCH_SIZE = 4096;
 
     @VariableMgr.VarAttr(name = STREAMING_PREAGGREGATION_MODE)
-    private String streamingPreaggregationMode = "auto"; // auto, force_streaming, force_preaggregation
+    private String streamingPreaggregationMode = SessionVariableConstants.AUTO; // auto, force_streaming, force_preaggregation
 
     @VariableMgr.VarAttr(name = DISABLE_COLOCATE_JOIN)
     private boolean disableColocateJoin = false;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -1,0 +1,24 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+public class SessionVariableConstants {
+
+    public static final String AUTO = "auto";
+
+    public static final String FORCE_STREAMING = "force_streaming";
+
+    public static final String FORCE_PREAGGREGATION = "force_preaggregation";
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -16,6 +16,8 @@ package com.starrocks.qe;
 
 public class SessionVariableConstants {
 
+    private SessionVariableConstants() {}
+
     public static final String AUTO = "auto";
 
     public static final String FORCE_STREAMING = "force_streaming";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
@@ -35,7 +35,6 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
-import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -164,12 +163,6 @@ public class LogicalAggregationOperator extends LogicalOperator {
     public boolean hasSkew() {
         return this.getAggregations().values().stream().anyMatch(call ->
                 call.isDistinct() && call.getFnName().equals(FunctionSet.COUNT) && call.getHints().contains("skew"));
-    }
-
-    // only split local agg with group by keys and a child not distinct local agg can use streaming preAgg
-    public boolean canUseStreamingPreAgg() {
-        return type.isLocal() && isSplit && CollectionUtils.isNotEmpty(groupingKeys)
-                && singleDistinctFunctionPos == -1;
     }
 
     public boolean checkGroupByCountDistinctWithSkewHint() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -19,6 +19,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariableConstants;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.RowOutputInfo;
@@ -32,6 +34,7 @@ import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -63,8 +66,10 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
     // The flag for this aggregate operator has split to
     // two stage aggregate or three stage aggregate
     private final boolean isSplit;
-    // flg for this aggregate operator could use streaming pre-aggregation
-    private boolean useStreamingPreAgg;
+
+    // TODO introduce builder mode to change these fields to final fields
+    // flg for this aggregate operator's parent had been pruned
+    private boolean mergedLocalAgg;
 
     private boolean useSortAgg = false;
 
@@ -77,8 +82,7 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
                                          boolean isSplit,
                                          long limit,
                                          ScalarOperator predicate,
-                                         Projection projection,
-                                         boolean useStreamingPreAgg) {
+                                         Projection projection) {
         super(OperatorType.PHYSICAL_HASH_AGG);
         this.type = type;
         this.groupBys = groupBys;
@@ -89,7 +93,6 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
         this.limit = limit;
         this.predicate = predicate;
         this.projection = projection;
-        this.useStreamingPreAgg = useStreamingPreAgg;
     }
 
     public List<ColumnRefOperator> getGroupBys() {
@@ -111,12 +114,15 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
     /**
      * Whether it is the first phase in three/four-phase agg whose second phase is pruned.
      * Hence, the input data distribution has satisfied with the agg requirement. The local
-     * agg can directly do a global blocking agg job. Only local agg without distinct
-     * agg callOperator and cannot use streaming agg means it's the result from
-     * PruneAggregateNodeRule.
+     * agg can directly do a global blocking agg job. Only local agg cannot use streaming agg
+     * means it's the result from PruneAggregateNodeRule.
      */
     public boolean isMergedLocalAgg() {
-        return type.isLocal() && !useStreamingPreAgg && !hasSingleDistinct();
+        return mergedLocalAgg;
+    }
+
+    public void setMergedLocalAgg(boolean mergedLocalAgg) {
+        this.mergedLocalAgg = mergedLocalAgg;
     }
 
     public List<ColumnRefOperator> getPartitionByColumns() {
@@ -135,12 +141,23 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
         return isSplit;
     }
 
-    public void setUseStreamingPreAgg(boolean useStreamingPreAgg) {
-        this.useStreamingPreAgg = useStreamingPreAgg;
+    public boolean canUseStreamingPreAgg() {
+        if (type.isGlobal() || type.isDistinctGlobal()) {
+            return false;
+        } else if (type.isDistinctLocal()) {
+            return CollectionUtils.isNotEmpty(groupBys);
+        } else {
+            return isSplit && CollectionUtils.isNotEmpty(groupBys) && !mergedLocalAgg;
+        }
     }
 
-    public boolean isUseStreamingPreAgg() {
-        return this.useStreamingPreAgg;
+
+    public String getNeededPreaggregationMode() {
+        String mode = ConnectContext.get().getSessionVariable().getStreamingPreaggregationMode();
+        if (canUseStreamingPreAgg() && (type.isDistinctLocal() || hasSingleDistinct())) {
+            mode = SessionVariableConstants.FORCE_PREAGGREGATION;
+        }
+        return mode;
     }
 
     public boolean isUseSortAgg() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HashAggImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HashAggImplementationRule.java
@@ -43,8 +43,7 @@ public class HashAggImplementationRule extends ImplementationRule {
                 logical.isSplit(),
                 logical.getLimit(),
                 logical.getPredicate(),
-                logical.getProjection(),
-                logical.canUseStreamingPreAgg());
+                logical.getProjection());
         physical.setDistinctColumnDataSkew(logical.getDistinctColumnDataSkew());
         OptExpression result = OptExpression.create(physical, input.getInputs());
         return Lists.newArrayList(result);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -46,7 +46,7 @@ import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
-import com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient;
+import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;
@@ -58,6 +58,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF;
+import static com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient.LOW_AGGREGATE_EFFECT_COEFFICIENT;
+import static com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient.MEDIUM_AGGREGATE_EFFECT_COEFFICIENT;
 
 public class SplitAggregateRule extends TransformationRule {
     private SplitAggregateRule() {
@@ -152,49 +154,45 @@ public class SplitAggregateRule extends TransformationRule {
         }
     }
 
-    // True means good cases for two phase agg. It requires both group by keys and distinct cols are
-    // low cardinality which helps deduplication in the local stage.
-    private boolean hasAggregateEffect(OptExpression input, List<ColumnRefOperator> distinctColumns) {
-        Statistics statistics = input.getGroupExpression().getGroup().getStatistics();
-        Statistics inputStatistics = input.getGroupExpression().getInputs().get(0).getStatistics();
+    private boolean isTwoStageMoreEfficient(OptExpression input, List<ColumnRefOperator> distinctColumns) {
+        LogicalAggregationOperator aggOp = input.getOp().cast();
+        Statistics inputStatistics = input.getGroupExpression().inputAt(0).getStatistics();
         Collection<ColumnStatistic> inputsColumnStatistics = inputStatistics.getColumnStatistics().values();
-
-        if (inputsColumnStatistics.stream().anyMatch(ColumnStatistic::isUnknown)) {
+        if (inputsColumnStatistics.stream().anyMatch(ColumnStatistic::isUnknown) || !aggOp.hasLimit()) {
             return false;
         }
-        double inputRowCount = Math.max(1, inputStatistics.getOutputRowCount());
-        double rowCount = Math.max(1, statistics.getOutputRowCount());
+        double inputRowCount = inputStatistics.getOutputRowCount();
+        double aggOutputRow = StatisticsCalculator.computeGroupByStatistics(aggOp.getGroupingKeys(), inputStatistics,
+                Maps.newHashMap());
 
-        if (CollectionUtils.isNotEmpty(distinctColumns)) {
-            for (ColumnRefOperator distinctCol : distinctColumns) {
-                double ndv = inputStatistics.getColumnStatistic(distinctCol).getDistinctValuesCount();
-                rowCount = rowCount > ndv ? rowCount : ndv;
-            }
-        }
+        double distinctOutputRow = StatisticsCalculator.computeGroupByStatistics(distinctColumns, inputStatistics,
+                Maps.newHashMap());
 
-
-        if (rowCount * StatisticsEstimateCoefficient.LOW_AGGREGATE_EFFECT_COEFFICIENT < inputRowCount) {
-            return true;
-        }
-        return false;
+        // both group by key and distinct key cannot with high cardinality
+        return aggOutputRow * MEDIUM_AGGREGATE_EFFECT_COEFFICIENT < inputRowCount
+                && distinctOutputRow * LOW_AGGREGATE_EFFECT_COEFFICIENT < inputRowCount
+                && aggOutputRow > aggOp.getLimit();
     }
 
 
-    // True means good cases for parallel deduplication. It requires group by keys have a relatively high
-    // cardinality (number of distinct value > 1000) to distribute data across multiple cores which helps
-    // parallel deduplication in the distinct global stage.
-    private boolean isSuitableForParallelDeduplication(OptExpression input) {
-        Statistics statistics = input.getGroupExpression().getGroup().getStatistics();
-        Statistics inputStatistics = input.getGroupExpression().getInputs().get(0).getStatistics();
+    private boolean isThreeStageMoreEfficient(OptExpression input, List<ColumnRefOperator> groupKeys) {
+        Statistics inputStatistics = input.getGroupExpression().inputAt(0).getStatistics();
         Collection<ColumnStatistic> inputsColumnStatistics = inputStatistics.getColumnStatistics().values();
-
         if (inputsColumnStatistics.stream().anyMatch(ColumnStatistic::isUnknown)) {
-            // split agg into more phase if no statistic info available
-            return false;
+            return true;
         }
-        double inputRowCount = Math.max(1, inputStatistics.getOutputRowCount());
-        double rowCount = Math.max(1, statistics.getOutputRowCount());
-        return inputRowCount / StatisticsEstimateCoefficient.LOW_AGGREGATE_EFFECT_COEFFICIENT < rowCount;
+
+        LogicalAggregationOperator aggOp = input.getOp().cast();
+
+        double inputRowCount = inputStatistics.getOutputRowCount();
+        double aggOutputRow = StatisticsCalculator.computeGroupByStatistics(aggOp.getGroupingKeys(), inputStatistics,
+                Maps.newHashMap());
+
+        double distinctOutputRow = StatisticsCalculator.computeGroupByStatistics(groupKeys, inputStatistics,
+                Maps.newHashMap());
+
+        return aggOutputRow > LOW_AGGREGATE_EFFECT_COEFFICIENT
+                || distinctOutputRow * MEDIUM_AGGREGATE_EFFECT_COEFFICIENT < inputRowCount;
     }
 
     @Override
@@ -281,7 +279,7 @@ public class SplitAggregateRule extends TransformationRule {
 
         return CollectionUtils.isNotEmpty(operator.getGroupingKeys())
                 && aggMode == AUTO_MODE
-                && hasAggregateEffect(input, distinctColumns);
+                && isTwoStageMoreEfficient(input, distinctColumns);
     }
 
     private boolean canGenerateTwoStageAggregate(LogicalAggregationOperator operator,
@@ -371,7 +369,7 @@ public class SplitAggregateRule extends TransformationRule {
         List<ColumnRefOperator> partitionByCols;
 
         boolean shouldFurtherSplit = false;
-        if (isSuitableForParallelDeduplication(input)
+        if (isThreeStageMoreEfficient(input, distinctGlobal.getGroupingKeys())
                 || oldAgg.getGroupingKeys().containsAll(distinctGlobal.getGroupingKeys())) {
             partitionByCols = oldAgg.getGroupingKeys();
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -739,7 +739,8 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
             final PhysicalHashAggregateOperator newHashAggregator =
                     new PhysicalHashAggregateOperator(aggOperator.getType(), newGroupBys, newPartitionsBy, newAggMap,
                             aggOperator.getSingleDistinctFunctionPos(), aggOperator.isSplit(), aggOperator.getLimit(),
-                            aggOperator.getPredicate(), aggOperator.getProjection(), aggOperator.isUseStreamingPreAgg());
+                            aggOperator.getPredicate(), aggOperator.getProjection());
+            newHashAggregator.setMergedLocalAgg(aggOperator.isMergedLocalAgg());
             newHashAggregator.setUseSortAgg(aggOperator.isUseSortAgg());
             return newHashAggregator;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneAggregateNodeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneAggregateNodeRule.java
@@ -90,7 +90,7 @@ public class PruneAggregateNodeRule implements TreeRewriteRule {
 
             if (parentOperator.getType().isDistinctGlobal() && childOperator instanceof PhysicalHashAggregateOperator) {
                 PhysicalHashAggregateOperator hashAggregateOperator = (PhysicalHashAggregateOperator) childOperator;
-                hashAggregateOperator.setUseStreamingPreAgg(false);
+                hashAggregateOperator.setMergedLocalAgg(true);
                 hashAggregateOperator.setProjection(parentOperator.getProjection());
                 return optExpression.inputAt(0);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateCollector.java
@@ -541,7 +541,7 @@ class PushDownAggregateCollector extends OptExpressionVisitor<Void, AggregatePus
                 return true;
             }
             return statistics.getOutputRowCount() >=
-                    StatisticsEstimateCoefficient.DEFAULT_PUSH_DOWN_AGGREGATE_ROWS_LIMIT;
+                    StatisticsEstimateCoefficient.SMALL_SCALE_ROWS_LIMIT;
         }
 
         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -50,8 +50,8 @@ public class StatisticsEstimateCoefficient {
     public static final double DEFAULT_ANTI_JOIN_SELECTIVITY_COEFFICIENT = 0.4;
     // default shuffle column row count limit
     public static final double DEFAULT_PRUNE_SHUFFLE_COLUMN_ROWS_LIMIT = 200000;
-    // default push down aggregate row count limit, 100w
-    public static final long DEFAULT_PUSH_DOWN_AGGREGATE_ROWS_LIMIT = 1000000;
+    // a small scale rows, such as default push down aggregate row count limit, 100w
+    public static final long SMALL_SCALE_ROWS_LIMIT = 1000000;
     // default or predicate limit
     public static final int DEFAULT_OR_OPERATOR_LIMIT = 16;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1706,7 +1706,7 @@ public class PlanFragmentBuilder {
                 aggregationNode =
                         new AggregationNode(context.getNextNodeId(), inputFragment.getPlanRoot(), aggInfo);
                 aggregationNode.unsetNeedsFinalize();
-                aggregationNode.setIsPreagg(node.isUseStreamingPreAgg());
+                aggregationNode.setIsPreagg(node.canUseStreamingPreAgg());
                 aggregationNode.setIntermediateTuple();
                 if (!partitionExpressions.isEmpty()) {
                     inputFragment.setOutputPartition(DataPartition.hashPartitioned(partitionExpressions));
@@ -1794,15 +1794,14 @@ public class PlanFragmentBuilder {
                 aggregationNode =
                         new AggregationNode(context.getNextNodeId(), inputFragment.getPlanRoot(), aggInfo);
                 aggregationNode.unsetNeedsFinalize();
-                aggregationNode.setIsPreagg(node.isUseStreamingPreAgg());
+                aggregationNode.setIsPreagg(node.canUseStreamingPreAgg());
                 aggregationNode.setIntermediateTuple();
             } else {
                 throw unsupportedException("Not support aggregate type : " + node.getType());
             }
 
             aggregationNode.setUseSortAgg(node.isUseSortAgg());
-            aggregationNode.setStreamingPreaggregationMode(context.getConnectContext().
-                    getSessionVariable().getStreamingPreaggregationMode());
+            aggregationNode.setStreamingPreaggregationMode(node.getNeededPreaggregationMode());
             aggregationNode.setHasNullableGenerateChild();
             aggregationNode.computeStatistics(optExpr.getStatistics());
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -317,6 +317,7 @@ public class SelectStmtTest {
                 "  |  group by: 3: expr\n" +
                 "  |  \n" +
                 "  4:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
                 "  |  output: count(2: split)\n" +
                 "  |  group by: 3: expr\n" +
                 "  |  \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -434,12 +434,12 @@ public class SelectStmtTest {
                                 "  |----17:EXCHANGE"
                 },
                 {"select count(distinct k1, k2), count(distinct k3) from db1.tbl1 group by k4 limit 1",
-                    "18:Project\n" +
+                    "14:Project\n" +
                             "  |  <slot 5> : 5: count\n" +
                             "  |  <slot 6> : 6: count\n" +
                             "  |  limit: 1\n" +
                             "  |  \n" +
-                            "  17:HASH JOIN\n" +
+                            "  13:HASH JOIN\n" +
                             "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
                             "  |  colocate: false, reason: \n" +
                             "  |  equal join conjunct: 9: k4 <=> 11: k4\n" +
@@ -447,12 +447,12 @@ public class SelectStmtTest {
                 },
                 {"select * from (select count(distinct k1, k2), count(distinct k3) from db1.tbl1 group by k4, k3) t1" +
                         " limit 1",
-                       "16:Project\n" +
+                       "14:Project\n" +
                                "  |  <slot 5> : 5: count\n" +
                                "  |  <slot 6> : 6: count\n" +
                                "  |  limit: 1\n" +
                                "  |  \n" +
-                               "  15:HASH JOIN\n" +
+                               "  13:HASH JOIN\n" +
                                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
                                "  |  colocate: false, reason: \n" +
                                "  |  equal join conjunct: 10: k4 <=> 12: k4\n" +
@@ -461,12 +461,12 @@ public class SelectStmtTest {
                 },
                 {"with t1 as (select count(distinct k1, k2) as a, count(distinct k3) as b from db1.tbl1 " +
                         "group by k2, k3, k4) select * from t1 limit 1",
-                        "16:Project\n" +
+                        "14:Project\n" +
                                 "  |  <slot 11> : 11: count\n" +
                                 "  |  <slot 12> : 12: count\n" +
                                 "  |  limit: 1\n" +
                                 "  |  \n" +
-                                "  15:HASH JOIN\n" +
+                                "  13:HASH JOIN\n" +
                                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
                                 "  |  colocate: false, reason: \n" +
                                 "  |  equal join conjunct: 14: k2 <=> 17: k2\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -498,31 +498,11 @@ public class ReplayFromDumpTest {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/multi_count_distinct"), null, TExplainLevel.NORMAL);
         String plan = replayPair.second;
-        System.out.println(plan);
-        Assert.assertTrue(plan, plan.contains("36:AGGREGATE (update finalize)\n" +
+        Assert.assertTrue(plan, plan.contains("34:AGGREGATE (update finalize)\n" +
                 "  |  output: multi_distinct_count(6: order_id), multi_distinct_count(11: delivery_phone)," +
                 " multi_distinct_count(128: case), max(103: count)\n" +
                 "  |  group by: 40: city, 116: division_en, 104: department, 106: category, 126: concat, " +
                 "127: concat, 9: upc, 108: upc_desc"));
-        Assert.assertTrue(plan, plan.contains("20:AGGREGATE (update serialize)\n" +
-                "  |  output: count(60: order_id)\n" +
-                "  |  group by: 88: city\n" +
-                "  |  \n" +
-                "  19:AGGREGATE (merge serialize)\n" +
-                "  |  group by: 88: city, 60: order_id\n" +
-                "  |  \n" +
-                "  18:EXCHANGE"));
-
-    }
-
-    @Test
-    public void testJoinWithPipelineDop() throws Exception {
-        Pair<QueryDumpInfo, String> replayPair =
-                getPlanFragment(getDumpInfoFromFile("query_dump/join_pipeline_dop"), null, TExplainLevel.NORMAL);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("25:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 5: ss_customer_sk = 52: c_customer_sk"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -520,15 +520,15 @@ public class ReplayFromDumpTest {
 
     @Test
     public void testCountDistinctWithLimit() throws Exception {
-        // check use two stage agg
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/count_distinct_limit"), null, TExplainLevel.NORMAL);
         Assert.assertTrue(replayPair.second, replayPair.second.contains("1:AGGREGATE (update serialize)\n" +
                 "  |  STREAMING\n" +
-                "  |  output: multi_distinct_count(5: lo_suppkey)"));
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("3:AGGREGATE (merge finalize)\n" +
-                "  |  output: multi_distinct_count(18: count)\n" +
-                "  |  group by: 10: lo_extendedprice, 13: lo_revenue"));
+                "  |  group by: 5: lo_suppkey, 10: lo_extendedprice, 13: lo_revenue"));
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("4:AGGREGATE (update finalize)\n" +
+                "  |  output: count(5: lo_suppkey)\n" +
+                "  |  group by: 10: lo_extendedprice, 13: lo_revenue\n" +
+                "  |  limit: 1"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #issue
Main work
1. For scenarios where pre-aggregation needs to be forced in the distinct local and local stages, using stream agg operator with force_streaming mode instead of setting them to blocking agg operator.
2. According the test result, redesign the strategy about how to choose two-stage, three-stage or four-stage agg.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
