### PR TITLE
[BugFix] open Once for mapElement and in predict which optimize const inputs

### DIFF
--- a/be/src/exprs/in_const_predicate.hpp
+++ b/be/src/exprs/in_const_predicate.hpp
@@ -128,48 +128,49 @@ public:
 
     Status open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override {
         RETURN_IF_ERROR(Expr::open(state, context, scope));
-
-        if (Type != _children[0]->type().type) {
-            if (!isSliceLT<Type> || !_children[0]->type().is_string_type()) {
-                return Status::InternalError("VectorizedInPredicate type is error");
-            }
-        }
-
-        bool use_array = is_use_array();
-        for (int i = 1; i < _children.size(); ++i) {
-            if ((_children[0]->type().is_string_type() && _children[i]->type().is_string_type()) ||
-                (_children[0]->type().type == _children[i]->type().type) ||
-                (LogicalType::TYPE_NULL == _children[i]->type().type)) {
-                // pass
-            } else {
-                return Status::InternalError("VectorizedInPredicate type not same");
-            }
-
-            ASSIGN_OR_RETURN(ColumnPtr value, _children[i]->evaluate_checked(context, nullptr));
-            if (!value->is_constant() && !value->only_null()) {
-                return Status::InternalError("VectorizedInPredicate value not const");
-            }
-
-            ColumnViewer<Type> viewer(value);
-            if (viewer.is_null(0)) {
-                _null_in_set = true;
-                continue;
-            }
-
-            // insert into set
-            if constexpr (isSliceLT<Type>) {
-                if (_hash_set.emplace(viewer.value(0)).second) {
-                    _string_values.emplace_back(value);
+        if (scope == FunctionContext::FRAGMENT_LOCAL) {
+            if (Type != _children[0]->type().type) {
+                if (!isSliceLT<Type> || !_children[0]->type().is_string_type()) {
+                    return Status::InternalError("VectorizedInPredicate type is error");
                 }
-                continue;
             }
 
-            if (use_array) {
-                if constexpr (can_use_array()) {
-                    _set_array_index(viewer.value(0));
+            bool use_array = is_use_array();
+            for (int i = 1; i < _children.size(); ++i) {
+                if ((_children[0]->type().is_string_type() && _children[i]->type().is_string_type()) ||
+                    (_children[0]->type().type == _children[i]->type().type) ||
+                    (LogicalType::TYPE_NULL == _children[i]->type().type)) {
+                    // pass
+                } else {
+                    return Status::InternalError("VectorizedInPredicate type not same");
                 }
-            } else {
-                _hash_set.emplace(viewer.value(0));
+
+                ASSIGN_OR_RETURN(ColumnPtr value, _children[i]->evaluate_checked(context, nullptr));
+                if (!value->is_constant() && !value->only_null()) {
+                    return Status::InternalError("VectorizedInPredicate value not const");
+                }
+
+                ColumnViewer<Type> viewer(value);
+                if (viewer.is_null(0)) {
+                    _null_in_set = true;
+                    continue;
+                }
+
+                // insert into set
+                if constexpr (isSliceLT<Type>) {
+                    if (_hash_set.emplace(viewer.value(0)).second) {
+                        _string_values.emplace_back(value);
+                    }
+                    continue;
+                }
+
+                if (use_array) {
+                    if constexpr (can_use_array()) {
+                        _set_array_index(viewer.value(0));
+                    }
+                } else {
+                    _hash_set.emplace(viewer.value(0));
+                }
             }
         }
         return Status::OK();
@@ -405,7 +406,7 @@ public:
             : Predicate(node), _is_not_in(node.in_predicate.is_not_in) {}
 
     VectorizedInConstPredicateGeneric(const VectorizedInConstPredicateGeneric& other)
-            : Predicate(other), _is_not_in(other._is_not_in) {}
+            : Predicate(other), _is_not_in(other._is_not_in), _const_input(other._const_input) {}
 
     ~VectorizedInConstPredicateGeneric() override = default;
 
@@ -413,14 +414,18 @@ public:
 
     Status open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override {
         RETURN_IF_ERROR(Expr::open(state, context, scope));
-        _const_input.resize(_children.size());
-        for (auto i = 0; i < _children.size(); ++i) {
-            if (_children[i]->is_constant()) {
-                // _const_input[i] maybe not be of ConstColumn
-                ASSIGN_OR_RETURN(_const_input[i], _children[i]->evaluate_checked(context, nullptr));
-            } else {
-                _const_input[i] = nullptr;
+        if (scope == FunctionContext::FRAGMENT_LOCAL) {
+            _const_input.resize(_children.size());
+            for (auto i = 0; i < _children.size(); ++i) {
+                if (_children[i]->is_constant()) {
+                    // _const_input[i] maybe not be of ConstColumn
+                    ASSIGN_OR_RETURN(_const_input[i], _children[i]->evaluate_checked(context, nullptr));
+                } else {
+                    _const_input[i] = nullptr;
+                }
             }
+        } else {
+            DCHECK_EQ(_const_input.size(), _const_input.size());
         }
         return Status::OK();
     }

--- a/be/src/exprs/in_const_predicate.hpp
+++ b/be/src/exprs/in_const_predicate.hpp
@@ -431,6 +431,7 @@ public:
     }
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override {
+        DCHECK_EQ(_const_input.size(), _children.size());
         auto child_size = _children.size();
         Columns input_data(child_size);
         std::vector<NullColumnPtr> input_null(child_size);

--- a/be/src/exprs/map_element_expr.cpp
+++ b/be/src/exprs/map_element_expr.cpp
@@ -29,10 +29,11 @@ public:
     explicit MapElementExpr(const TExprNode& node) : Expr(node) {}
 
     MapElementExpr(const MapElementExpr& m) : Expr(m) { _const_input = m._const_input; }
-    MapElementExpr(MapElementExpr&& m) : Expr(m) { _const_input = m._const_input; }
+    MapElementExpr(MapElementExpr&& m) noexcept : Expr(m) { _const_input = m._const_input; }
 
     Status open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override {
         RETURN_IF_ERROR(Expr::open(state, context, scope));
+        DCHECK_EQ(2, _children.size());
         if (scope == FunctionContext::FRAGMENT_LOCAL) {
             _const_input.resize(_children.size());
             for (auto i = 0; i < _children.size(); ++i) {
@@ -50,7 +51,7 @@ public:
     }
 
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* chunk) override {
-        DCHECK_EQ(2, _children.size());
+        DCHECK_EQ(_const_input.size(), _children.size());
         // check the map's value type is the same as the expr's type
 #ifndef BE_TEST
         DCHECK_EQ(_type, _children[0]->type().children[1]);

--- a/be/test/exprs/in_predicate_test.cpp
+++ b/be/test/exprs/in_predicate_test.cpp
@@ -113,7 +113,7 @@ TEST_F(VectorizedInPredicateTest, sliceInTrue) {
 
         {
             ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
             ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
             ASSERT_TRUE(ptr->is_numeric());
 
@@ -157,7 +157,7 @@ TEST_F(VectorizedInPredicateTest, dateInFalse) {
 
         {
             ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
             ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
             ASSERT_TRUE(ptr->is_numeric());
 
@@ -201,7 +201,7 @@ TEST_F(VectorizedInPredicateTest, intNotInTrue) {
 
         {
             ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
             ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
             ASSERT_TRUE(ptr->is_numeric());
 
@@ -244,7 +244,7 @@ TEST_F(VectorizedInPredicateTest, nullSliceIn) {
 
         {
             ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
             ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
             ASSERT_TRUE(ptr->is_nullable());
 
@@ -298,7 +298,7 @@ TEST_F(VectorizedInPredicateTest, sliceNotInNull) {
 
         {
             ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
             ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
             ASSERT_TRUE(ptr->is_nullable());
 
@@ -340,7 +340,7 @@ TEST_F(VectorizedInPredicateTest, inConstPred) {
 
         {
             ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
             ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
             ASSERT_TRUE(ptr->size() == 5);
         }
@@ -381,7 +381,7 @@ TEST_F(VectorizedInPredicateTest, inArray) {
 
         {
             ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
             ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
             ASSERT_TRUE(ptr->is_nullable());
             auto data = down_cast<NullableColumn*>(ptr.get())->data_column();
@@ -428,7 +428,7 @@ TEST_F(VectorizedInPredicateTest, inArrayConstAll) {
 
         {
             ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
+            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
             ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
             ASSERT_TRUE(ptr->is_constant());
             auto v = down_cast<BooleanColumn*>(down_cast<ConstColumn*>(ptr.get())->data_column().get());
@@ -470,6 +470,8 @@ TEST_F(VectorizedInPredicateTest, inArrayConstAllNULL) {
 
         {
             ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
+            ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+            // corner test
             ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
             ColumnPtr ptr = expr->evaluate(nullptr, nullptr);
             ASSERT_TRUE(ptr->only_null());

--- a/be/test/exprs/map_element_expr_test.cpp
+++ b/be/test/exprs/map_element_expr_test.cpp
@@ -140,7 +140,7 @@ TEST_F(MapElementExprTest, test_map_int_int) {
         expr->add_child(new_fake_col_expr(column, type_map_int_int));
         expr->add_child(new_fake_const_expr(const_int_column(2, column->size()), type_int));
         ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-        ASSERT_TRUE(expr->open(nullptr, nullptr).ok());
+        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FRAGMENT_LOCAL).ok());
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_nullable());
         EXPECT_EQ(5, result->size());
@@ -180,7 +180,7 @@ TEST_F(MapElementExprTest, test_map_int_int) {
         expr->add_child(new_fake_col_expr(column, type_map_int_int));
         expr->add_child(new_fake_const_expr(const_int_column(3, column->size()), type_int));
         ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-        ASSERT_TRUE(expr->open(nullptr, nullptr).ok());
+        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FRAGMENT_LOCAL).ok());
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_nullable());
         EXPECT_EQ(5, result->size());
@@ -220,7 +220,7 @@ TEST_F(MapElementExprTest, test_map_int_int) {
         auto type = TypeDescriptor(LogicalType::TYPE_INT);
         expr->add_child(new_fake_col_expr(ColumnTestHelper::build_column<int32_t>({3, 3, 3, 0, 0}), type));
         ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-        ASSERT_TRUE(expr->open(nullptr, nullptr).ok());
+        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FRAGMENT_LOCAL).ok());
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_nullable());
         EXPECT_EQ(5, result->size());
@@ -301,7 +301,7 @@ TEST_F(MapElementExprTest, test_map_varchar_int) {
         expr->add_child(new_fake_col_expr(column, type_map_varchar_int));
         expr->add_child(new_fake_const_expr(const_varchar_column("b", column->size()), type_varchar));
         ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-        ASSERT_TRUE(expr->open(nullptr, nullptr).ok());
+        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FRAGMENT_LOCAL).ok());
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_nullable());
         EXPECT_EQ(6, result->size());
@@ -344,7 +344,7 @@ TEST_F(MapElementExprTest, test_map_varchar_int) {
         expr->add_child(new_fake_col_expr(column, type_map_varchar_int));
         expr->add_child(new_fake_const_expr(const_varchar_column("c", column->size()), type_varchar));
         ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-        ASSERT_TRUE(expr->open(nullptr, nullptr).ok());
+        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FRAGMENT_LOCAL).ok());
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_nullable());
         EXPECT_EQ(6, result->size());
@@ -417,7 +417,7 @@ TEST_F(MapElementExprTest, test_map_const) {
         expr->add_child(new_fake_col_expr(column, type_map_int_int));
         expr->add_child(new_fake_const_expr(ColumnHelper::create_const_null_column(column->size()), type_int));
         ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-        ASSERT_TRUE(expr->open(nullptr, nullptr).ok());
+        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FRAGMENT_LOCAL).ok());
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_nullable());
         EXPECT_EQ(5, result->size());
@@ -433,7 +433,7 @@ TEST_F(MapElementExprTest, test_map_const) {
         expr->add_child(new_fake_const_expr(ColumnHelper::create_const_null_column(column->size()), type_int));
         expr->add_child(new_fake_const_expr(ColumnHelper::create_const_null_column(column->size()), type_int));
         ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-        ASSERT_TRUE(expr->open(nullptr, nullptr).ok());
+        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FRAGMENT_LOCAL).ok());
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->only_null());
     }
@@ -455,7 +455,9 @@ TEST_F(MapElementExprTest, test_map_const) {
         expr->add_child(new_fake_col_expr(const_map, type_map_int_int));
         expr->add_child(new_fake_const_expr(const_int_column(3, column->size()), type_int));
         ASSERT_TRUE(expr->prepare(nullptr, nullptr).ok());
-        ASSERT_TRUE(expr->open(nullptr, nullptr).ok());
+        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FRAGMENT_LOCAL).ok());
+        // corner test
+        ASSERT_TRUE(expr->open(nullptr, nullptr, FunctionContext::FunctionStateScope::THREAD_LOCAL).ok());
         auto result = expr->evaluate(nullptr, nullptr);
         EXPECT_TRUE(result->is_constant());
         EXPECT_EQ(33, result->get(0).get_int32());


### PR DESCRIPTION

Fixes  concurrently open expression trees during scan

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
