### PR TITLE
[BugFix][Cherry-pick][Branch-2.5] The short key index maybe not order by sort key columns (#25591)

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -474,4 +474,12 @@ StatusOr<std::vector<vectorized::ChunkIteratorPtr>> Rowset::get_segment_iterator
     return seg_iterators;
 }
 
+Status Rowset::get_segment_sk_index(std::vector<std::string>* sk_index_values) {
+    RETURN_IF_ERROR(load());
+    for (auto& segment : _segments) {
+        RETURN_IF_ERROR(segment->get_short_key_index(sk_index_values));
+    }
+    return Status::OK();
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -286,6 +286,9 @@ public:
 
     uint64_t refs_by_reader() { return _refs_by_reader; }
 
+    // only used in unit test
+    Status get_segment_sk_index(std::vector<std::string>* sk_index_values);
+
     static StatusOr<size_t> get_segment_num(const std::vector<RowsetSharedPtr>& rowsets) {
         size_t num_segments = 0;
         for (int i = 0; i < rowsets.size(); i++) {

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -367,7 +367,7 @@ Status Segment::new_bitmap_index_iterator(uint32_t cid, BitmapIndexIterator** it
 }
 
 Status Segment::get_short_key_index(std::vector<std::string>* sk_index_values) {
-    RETURN_IF_ERROR(load_index(false));
+    RETURN_IF_ERROR(load_index());
     for (size_t i = 0; i < _sk_index_decoder->num_items(); i++) {
         sk_index_values->emplace_back(_sk_index_decoder->key(i).to_string());
     }

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -366,4 +366,12 @@ Status Segment::new_bitmap_index_iterator(uint32_t cid, BitmapIndexIterator** it
     return Status::OK();
 }
 
+Status Segment::get_short_key_index(std::vector<std::string>* sk_index_values) {
+    RETURN_IF_ERROR(load_index(false));
+    for (size_t i = 0; i < _sk_index_decoder->num_items(); i++) {
+        sk_index_values->emplace_back(_sk_index_decoder->key(i).to_string());
+    }
+    return Status::OK();
+}
+
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -153,6 +153,9 @@ public:
 
     int64_t mem_usage() { return _basic_info_mem_usage() + _short_key_index_mem_usage(); }
 
+    // read short_key_index, for data check, just used in unit test now
+    Status get_short_key_index(std::vector<std::string>* sk_index_values);
+
     DISALLOW_COPY_AND_MOVE(Segment);
 
 private:

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -117,7 +117,9 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
     _column_indexes.insert(_column_indexes.end(), column_indexes.begin(), column_indexes.end());
     _column_writers.reserve(_column_indexes.size());
     size_t num_columns = _tablet_schema->num_columns();
-    for (uint32_t column_index : _column_indexes) {
+    std::map<uint32_t, uint32_t> sort_column_idx_by_column_index;
+    for (uint32_t i = 0; i < _column_indexes.size(); i++) {
+        uint32_t column_index = _column_indexes[i];
         if (column_index >= num_columns) {
             return Status::InternalError(
                     strings::Substitute("column index $0 out of range $1", column_index, num_columns));
@@ -169,6 +171,26 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         ASSIGN_OR_RETURN(auto writer, ColumnWriter::create(opts, &column, _wfile.get()));
         RETURN_IF_ERROR(writer->init());
         _column_writers.push_back(std::move(writer));
+        if (column.is_sort_key()) {
+            sort_column_idx_by_column_index[column_index] = i;
+        }
+    }
+    if (!sort_column_idx_by_column_index.empty()) {
+        for (auto& column_idx : _tablet_schema->sort_key_idxes()) {
+            auto iter = sort_column_idx_by_column_index.find(column_idx);
+            if (iter != sort_column_idx_by_column_index.end()) {
+                _sort_column_indexes.emplace_back(iter->second);
+            } else {
+                // Currently we have the following two scenarios：
+                //  1. data load or horizontal compaction, we will write the whole row data once a time
+                //  2. vertical compaction, we will first write all sort key columns and write value columns by group
+                // So the all sort key columns should be found in `_column_indexes` so far.
+                std::string err_msg =
+                        strings::Substitute("column[$0]: $1 is sort key but not find while init segment writer",
+                                            column_idx, _tablet_schema->column(column_idx).name().data());
+                return Status::InternalError(err_msg);
+            }
+        }
     }
 
     _has_key = has_key;
@@ -313,7 +335,7 @@ Status SegmentWriter::append_chunk(const vectorized::Chunk& chunk) {
                 size_t keys = _tablet_schema->num_short_key_columns();
                 vectorized::SeekTuple tuple(*chunk.schema(), chunk.get(i).datums());
                 std::string encoded_key;
-                encoded_key = tuple.short_key_encode(keys, _tablet_schema->sort_key_idxes(), 0);
+                encoded_key = tuple.short_key_encode(keys, _sort_column_indexes, 0);
                 RETURN_IF_ERROR(_index_builder->add_item(encoded_key));
             }
             ++_num_rows_written;

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -50,6 +50,9 @@ extern const char* const k_segment_magic;
 extern const uint32_t k_segment_magic_length;
 
 struct SegmentWriterOptions {
+#ifdef BE_TEST
+    uint32_t num_rows_per_block = 100;
+#else
     uint32_t num_rows_per_block = 1024;
     vectorized::GlobalDictByNameMaps* global_dicts = nullptr;
     std::vector<int32_t> referenced_column_ids;
@@ -133,6 +136,7 @@ private:
     std::vector<std::unique_ptr<ColumnWriter>> _column_writers;
     std::vector<uint32_t> _column_indexes;
     bool _has_key = true;
+    std::vector<uint32_t> _sort_column_indexes;
 
     // num rows written when appending [partial] columns
     uint32_t _num_rows_written = 0;

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -54,6 +54,7 @@ struct SegmentWriterOptions {
     uint32_t num_rows_per_block = 100;
 #else
     uint32_t num_rows_per_block = 1024;
+#endif
     vectorized::GlobalDictByNameMaps* global_dicts = nullptr;
     std::vector<int32_t> referenced_column_ids;
 };


### PR DESCRIPTION
This bug is introduced by this
pr(https://github.com/StarRocks/starrocks/pull/25286), we fix the bug which short key index and segment data may not be consistent after vertical compaction in the pr. But the fix ignores the following scenario:
if we create a table which order by column `c2` and c1 and `c2` is after `c1`,
```
CREATE TABLE pk1sk2_tbl (
    k1 int,
    c1 varchar(20),
    c2 varchar(20)
PRIMARY KEY(k1)
DISTRIBUTED BY HASH(c1) BUCKETS 3
ORDER BY(c2,c1);
```
The data of column `c2` should be the prefix of short key index, but the following code in `segment_writer.cpp`:
```
    for (uint32_t i = 0; i < _column_indexes.size(); i++) {
        uint32_t column_index = _column_indexes[i];
        ....
        if (column.is_sort_key()) {
            _sort_column_indexes.emplace_back(i);
        }
    }
```
When we import data or do horizontal compaction, segment_writer's init schema is tablet schema, and the `_column_indexes` is ordered by table column. At this time, column `c1` and column `c2` are both sort key columns and we check column `c1` first, so the `_sort_column_indexes` keeps the index of `c1` first. And in the following short key index encoding process, the data of `c1` will be written before `c2` and be the prefix of the short key index.

The solution is to check `_sort_column_indexes` and the elements of `_sort_column_indexes` should be ordered by the sort key column index.
