### PR TITLE
[BugFix] Exception in columns in create routine load stmt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/Load.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/Load.java
@@ -77,11 +77,13 @@ import com.starrocks.load.loadv2.JobState;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeState;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
 import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.UserIdentity;
@@ -777,7 +779,11 @@ public class Load {
             }
             Expr expr = entry.getValue().clone(smap);
 
-            expr = Expr.analyzeAndCastFold(expr);
+            try {
+                expr = Expr.analyzeAndCastFold(expr);
+            } catch (SemanticException e) {
+                throw new UserException("expression is not supported: " + AstToSQLBuilder.toSQL(expr));
+            }
 
             // check if contain aggregation
             List<FunctionCallExpr> funcs = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -109,10 +109,6 @@ public class ExpressionAnalyzer {
     private final ConnectContext session;
 
     public ExpressionAnalyzer(ConnectContext session) {
-        if (session == null) {
-            // For some load requests, the ConnectContext will be null
-            session = new ConnectContext();
-        }
         this.session = session;
     }
 
@@ -574,7 +570,7 @@ public class ExpressionAnalyzer {
                 Expr child = node.getChild(i);
                 if (child.getType().isBoolean() || child.getType().isNull()) {
                     // do nothing
-                } else if (!session.getSessionVariable().isEnableStrictType() &&
+                } else if (session != null && !session.getSessionVariable().isEnableStrictType() &&
                         Type.canCastTo(child.getType(), Type.BOOLEAN)) {
                     node.getChildren().set(i, new CastExpr(Type.BOOLEAN, child));
                 } else {

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadTest.java
@@ -105,8 +105,7 @@ public class LoadTest {
         List<Expr> params1 = Lists.newArrayList();
         params1.add(new SlotRef(null, c1Name));
         Expr mapping1 = new FunctionCallExpr(FunctionSet.YEAR, params1);
-        CompoundPredicate compoundPredicate = new CompoundPredicate(CompoundPredicate.Operator.OR,
-                mapping1, new SlotRef(null, c0Name));
+        columnExprs.add(new ImportColumnDesc(c1Name, mapping1));
         columnExprs.add(new ImportColumnDesc(c1Name, compoundPredicate));
 
         // c1 is from path


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/27085
This PR fixes the NPE in routine load column stmt. The new output would be like `ErrorReason{errCode = 2, msg='failed to create task: expression is not supported: str_to_date((`appt_date` OR ' ') OR `appt_time`)'}`

```
                  Id: 22019
                Name: appointments_load
          CreateTime: 2023-07-18 16:00:21
           PauseTime: 2023-07-18 16:45:52
             EndTime: NULL
              DbName: db0
           TableName: appointments
               State: PAUSED
      DataSourceType: KAFKA
      CurrentTaskNum: 0
       JobProperties: {"partitions":"*","partial_update":"false","columnToColumnExpr":"id,location_id,person_id,appt_date,appt_time,appointment_dt=str_to_date(((appt_date) OR (' ')) OR (appt_time))","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","dataFormat":"json","timezone":"GMT+08:00","format":"json","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"[\"$.id\", \"$.location_id\", \"$.person_id\", \"$.appointment_date\", \"$.appointment_time\"]","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"1","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"topic-appointment","currentKafkaPartitions":"0","brokerList":"127.0.0.1:49092"}
    CustomProperties: {"kafka_default_offsets":"OFFSET_BEGINNING","group.id":"appointments_load_4c722fe4-4137-44f8-b090-fe20baf7ec50"}
           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":16,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
            Progress: {"0":"OFFSET_ZERO"}
ReasonOfStateChanged: ErrorReason{errCode = 2, msg='failed to create task: expression is not supported: str_to_date((`appt_date` OR ' ') OR `appt_time`)'}
        ErrorLogUrls: 
         TrackingSQL: 
            OtherMsg: 
2 rows in set (0.001 sec)

```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
