### PR TITLE
[Refactor] Change some interfaces of ExecEnv to non-static

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -253,11 +253,8 @@ void init_minidump() {
 #endif
 }
 
-void Daemon::init(int argc, char** argv, const std::vector<StorePath>& paths) {
-    // google::SetVersionString(get_build_version(false));
-    // google::ParseCommandLineFlags(&argc, &argv, true);
-    google::ParseCommandLineFlags(&argc, &argv, true);
-    if (FLAGS_cn) {
+void Daemon::init(bool as_cn, const std::vector<StorePath>& paths) {
+    if (as_cn) {
         init_glog("cn", true);
     } else {
         init_glog("be", true);

--- a/be/src/common/daemon.h
+++ b/be/src/common/daemon.h
@@ -47,7 +47,7 @@ public:
     Daemon() = default;
     ~Daemon() = default;
 
-    void init(int argc, char** argv, const std::vector<StorePath>& paths);
+    void init(bool as_cn, const std::vector<StorePath>& paths);
     void stop();
     bool stopped();
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -54,7 +54,6 @@ class BfdParser;
 class BrokerMgr;
 class BrpcStubCache;
 class DataStreamMgr;
-class DiskIoMgr;
 class EvHttpServer;
 class ExternalScanContextMgr;
 class FragmentMgr;
@@ -74,7 +73,6 @@ class WebPageHandler;
 class StreamLoadExecutor;
 class RoutineLoadTaskExecutor;
 class SmallFileMgr;
-class PluginMgr;
 class RuntimeFilterWorker;
 class RuntimeFilterCache;
 class ProfileReportWorker;
@@ -109,11 +107,12 @@ class DirManager;
 // once to properly initialise service state.
 class ExecEnv {
 public:
-    // Initial exec environment. must call this to init all
-    static Status init(ExecEnv* env, const std::vector<StorePath>& store_paths, bool as_cn = false);
     static bool is_init();
-    static void stop(ExecEnv* exec_env);
-    static void destroy(ExecEnv* exec_env);
+
+    // Initial exec environment. must call this to init all
+    Status init(const std::vector<StorePath>& store_paths, bool as_cn = false);
+    void stop();
+    void destroy();
 
     /// Returns the first created exec env instance. In a normal starrocks, this is
     /// the only instance. In test setups with multiple ExecEnv's per process,
@@ -236,9 +235,6 @@ public:
     spill::DirManager* spill_dir_mgr() const { return _spill_dir_mgr.get(); }
 
 private:
-    Status _init(const std::vector<StorePath>& store_paths, bool as_cn);
-    void _stop();
-    void _destroy();
     void _reset_tracker();
     template <class... Args>
     std::shared_ptr<MemTracker> regist_tracker(Args&&... args);

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -238,7 +238,7 @@ int main(int argc, char** argv) {
     apache::thrift::GlobalOutput.setOutputFunction(starrocks::thrift_output);
 
     std::unique_ptr<starrocks::Daemon> daemon(new starrocks::Daemon());
-    daemon->init(argc, argv, paths);
+    daemon->init(as_cn, paths);
 
     // init jdbc driver manager
     EXIT_IF_ERROR(starrocks::JDBCDriverManager::getInstance()->init(std::string(getenv("STARROCKS_HOME")) +
@@ -267,7 +267,7 @@ int main(int argc, char** argv) {
     }
 
     // Init exec env.
-    EXIT_IF_ERROR(starrocks::ExecEnv::init(exec_env, paths, as_cn));
+    EXIT_IF_ERROR(exec_env->init(paths, as_cn));
 
     // Start all background threads of storage engine.
     // SHOULD be called after exec env is initialized.
@@ -360,10 +360,10 @@ int main(int argc, char** argv) {
 
     exec_env->agent_server()->stop();
 
-    starrocks::ExecEnv::stop(exec_env);
+    exec_env->stop();
     engine->stop();
     delete engine;
-    starrocks::ExecEnv::destroy(exec_env);
+    exec_env->destroy();
 
     return 0;
 }

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -128,6 +128,7 @@ int main(int argc, char** argv) {
             as_cn = true;
         }
     }
+    google::ParseCommandLineFlags(&argc, &argv, true);
 
     if (getenv("STARROCKS_HOME") == nullptr) {
         fprintf(stderr, "you need set STARROCKS_HOME environment variable.\n");

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -372,7 +372,7 @@ int main(int argc, char** argv) {
     }
     auto* exec_env = starrocks::ExecEnv::GetInstance();
     exec_env->init_mem_tracker();
-    starrocks::ExecEnv::init(exec_env, paths);
+    exec_env->init(paths);
     int r = RUN_ALL_TESTS();
 
     // clear some trash objects kept in tablet_manager so mem_tracker checks will not fail
@@ -384,7 +384,7 @@ int main(int argc, char** argv) {
     delete engine;
     // destroy exec env
     starrocks::tls_thread_status.set_mem_tracker(nullptr);
-    starrocks::ExecEnv::destroy(exec_env);
+    exec_env->destroy();
 
     return r;
 }

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
     // for managing it.
     starrocks::config::disable_storage_page_cache = true;
     exec_env->init_mem_tracker();
-    starrocks::ExecEnv::init(exec_env, paths);
+    exec_env->init(paths);
 
     int r = RUN_ALL_TESTS();
 
@@ -102,7 +102,7 @@ int main(int argc, char** argv) {
     starrocks::StorageEngine::instance()->stop();
     // destroy exec env
     starrocks::tls_thread_status.set_mem_tracker(nullptr);
-    starrocks::ExecEnv::destroy(exec_env);
+    exec_env->destroy();
 
     starrocks::shutdown_logging();
 


### PR DESCRIPTION
Fixes #27417 

Graceful startup and exit step 2: Change some interfaces of ExecEnv to non-static

1. Change some interfaces of ExecEnv to non-static
2. Move some interface from destroy to stop
3. Modify the paramter of Daemon::init()

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
