### PR TITLE
[BugFix] filter invalid plan generated by reorder algorithm

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
@@ -134,12 +134,11 @@ public abstract class Operator {
     }
 
     public RowOutputInfo getRowOutputInfo(List<OptExpression> inputs) {
-        if (rowOutputInfo != null) {
-            return rowOutputInfo;
+        if (rowOutputInfo == null) {
+            rowOutputInfo = deriveRowOutputInfo(inputs);
         }
 
-
-        rowOutputInfo = deriveRowOutputInfo(inputs);
+        // transformation may update the projection, so update the rowOutputInfo at the same time
         if (projection != null) {
             rowOutputInfo = new RowOutputInfo(projection.getColumnRefMap(), projection.getCommonSubOperatorMap(),
                     rowOutputInfo.getOriginalColOutputInfo(), rowOutputInfo.getEndogenousCols());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalJoinOperator.java
@@ -262,11 +262,6 @@ public class LogicalJoinOperator extends LogicalOperator {
             return this;
         }
 
-        public Builder setRowOutputInfo(RowOutputInfo rowOutputInfo) {
-            builder.rowOutputInfo = rowOutputInfo;
-            return this;
-        }
-
         public Builder setOriginalOnPredicate(ScalarOperator originalOnPredicate) {
             builder.originalOnPredicate = originalOnPredicate;
             return this;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTableFunctionOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalTableFunctionOperator.java
@@ -108,7 +108,7 @@ public class LogicalTableFunctionOperator extends LogicalOperator {
         for (ColumnRefOperator col : outerColRefs) {
             outputInfoList.add(new ColumnOutputInfo(col, col));
         }
-        return new RowOutputInfo(outputInfoList, outerColRefs);
+        return new RowOutputInfo(outputInfoList, fnResultColRefs);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderCardinalityPreserving.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderCardinalityPreserving.java
@@ -257,15 +257,19 @@ public class JoinReorderCardinalityPreserving extends JoinOrder {
             used[index] = true;
 
             GroupInfo rightGroup = atoms.get(index);
-            ExpressionInfo joinExpr = buildJoinExpr(leftGroup, atoms.get(index));
-            joinExpr.expr.deriveLogicalPropertyItself();
+            Optional<ExpressionInfo> joinExpr = buildJoinExpr(leftGroup, atoms.get(index));
+            if (!joinExpr.isPresent()) {
+                return;
+            }
+
+            joinExpr.get().expr.deriveLogicalPropertyItself();
 
             BitSet joinBitSet = new BitSet();
             joinBitSet.or(leftGroup.atoms);
             joinBitSet.or(rightGroup.atoms);
 
             leftGroup = new GroupInfo(joinBitSet);
-            leftGroup.bestExprInfo = joinExpr;
+            leftGroup.bestExprInfo = joinExpr.get();
         }
         bestPlanRoot = Optional.of(leftGroup.bestExprInfo.expr);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderDP.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderDP.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
@@ -87,12 +88,15 @@ public class JoinReorderDP extends JoinOrder {
                     continue;
                 }
 
-                ExpressionInfo joinExpr = buildJoinExpr(leftGroup, rightGroup);
+                Optional<ExpressionInfo> joinExpr = buildJoinExpr(leftGroup, rightGroup);
+                if (!joinExpr.isPresent())  {
+                    continue;
+                }
 
-                joinExpr.expr.deriveLogicalPropertyItself();
-                calculateStatistics(joinExpr.expr);
-                computeCost(joinExpr);
-                results.add(joinExpr);
+                joinExpr.get().expr.deriveLogicalPropertyItself();
+                calculateStatistics(joinExpr.get().expr);
+                computeCost(joinExpr.get());
+                results.add(joinExpr.get());
             }
             ExpressionInfo minCostPlan = resultComparator.min(results);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderGreedy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderGreedy.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import java.util.BitSet;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -95,17 +96,20 @@ public class JoinReorderGreedy extends JoinOrder {
                     continue;
                 }
 
-                ExpressionInfo joinExpr = buildJoinExpr(leftGroup, rightGroup);
-                joinExpr.expr.deriveLogicalPropertyItself();
-                calculateStatistics(joinExpr.expr);
+                Optional<ExpressionInfo> joinExpr = buildJoinExpr(leftGroup, rightGroup);
+                if (!joinExpr.isPresent()) {
+                    continue;
+                }
+                joinExpr.get().expr.deriveLogicalPropertyItself();
+                calculateStatistics(joinExpr.get().expr);
 
                 BitSet joinBitSet = new BitSet();
                 joinBitSet.or(leftBitset);
                 joinBitSet.or(rightBitset);
 
-                computeCost(joinExpr);
-                getOrCreateGroupInfo(curLevel, joinBitSet, joinExpr);
-                double joinCost = joinExpr.cost;
+                computeCost(joinExpr.get());
+                getOrCreateGroupInfo(curLevel, joinBitSet, joinExpr.get());
+                double joinCost = joinExpr.get().cost;
                 if (joinCost < bestCost) {
                     bestCost = joinCost;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderLeftDeep.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinReorderLeftDeep.java
@@ -16,16 +16,17 @@
 package com.starrocks.sql.optimizer.rule.join;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 public class JoinReorderLeftDeep extends JoinOrder {
-    OptExpression bestPlanRoot;
+    Optional<OptExpression> bestPlanRoot = Optional.empty();
 
     public JoinReorderLeftDeep(OptimizerContext context) {
         super(context);
@@ -87,24 +88,27 @@ public class JoinReorderLeftDeep extends JoinOrder {
             used[index] = true;
 
             GroupInfo rightGroup = atoms.get(index);
-            ExpressionInfo joinExpr = buildJoinExpr(leftGroup, atoms.get(index));
-            joinExpr.expr.deriveLogicalPropertyItself();
-            calculateStatistics(joinExpr.expr);
-            computeCost(joinExpr);
+            Optional<ExpressionInfo> joinExpr = buildJoinExpr(leftGroup, atoms.get(index));
+            if (!joinExpr.isPresent()) {
+                return;
+            }
+            joinExpr.get().expr.deriveLogicalPropertyItself();
+            calculateStatistics(joinExpr.get().expr);
+            computeCost(joinExpr.get());
 
             BitSet joinBitSet = new BitSet();
             joinBitSet.or(leftGroup.atoms);
             joinBitSet.or(rightGroup.atoms);
 
             leftGroup = new GroupInfo(joinBitSet);
-            leftGroup.bestExprInfo = joinExpr;
-            leftGroup.lowestExprCost = joinExpr.cost;
+            leftGroup.bestExprInfo = joinExpr.get();
+            leftGroup.lowestExprCost = joinExpr.get().cost;
         }
-        bestPlanRoot = leftGroup.bestExprInfo.expr;
+        bestPlanRoot = Optional.of(leftGroup.bestExprInfo.expr);
     }
 
     @Override
     public List<OptExpression> getResult() {
-        return Lists.newArrayList(bestPlanRoot);
+        return bestPlanRoot.map(Collections::singletonList).orElse(Collections.emptyList());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -919,4 +919,12 @@ public class ReplayFromDumpTest {
         Assert.assertTrue(replayPair.second.contains("mv2"));
         FeConstants.isReplayFromQueryDump = false;
     }
+
+    @Test
+    public void test() throws Exception {
+        Pair<QueryDumpInfo, String> replayPair =
+                getPlanFragment(getDumpInfoFromFile("query_dump/test"),
+                        null, TExplainLevel.NORMAL);
+        System.out.println(replayPair.second);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -920,11 +920,4 @@ public class ReplayFromDumpTest {
         FeConstants.isReplayFromQueryDump = false;
     }
 
-    @Test
-    public void test() throws Exception {
-        Pair<QueryDumpInfo, String> replayPair =
-                getPlanFragment(getDumpInfoFromFile("query_dump/test"),
-                        null, TExplainLevel.NORMAL);
-        System.out.println(replayPair.second);
-    }
 }


### PR DESCRIPTION
Fixes #14257
For sql like:
```
select  
  ref_0.N_NAME as c0, 
  case when ref_3.C_NATIONKEY > ref_3.C_ACCTBAL then ref_1.O_ORDERPRIORITY else ref_1.O_SHIPPRIORITY end as c1
from 
  nation as ref_0 inner join orders as ref_1
            on (ref_0.N_REGIONKEY = ref_1.O_CUSTKEY )
          left join t2 as ref_2
          on (ref_0.N_NATIONKEY = ref_2.v8 )
        inner join customer as ref_3
        on (ref_1.O_ORDERPRIORITY = ref_3.C_NAME )
      inner join supplier as ref_4
      on (ref_1.O_CLERK = ref_4.S_PHONE )
    left join supplier as ref_5
    on (ref_2.v9 = ref_5.S_SUPPKEY )
where cast(coalesce(ref_3.C_MKTSEGMENT, ref_0.N_NAME) as VARCHAR) = ref_5.S_ADDRESS
```
The  logical plan with a on predicate `46: coalesce = 38: S_ADDRESS ` generated by two tables `ref_3` and `ref_0`. So when reorder, if we need build a join with on predicate `46: coalesce = 38: S_ADDRESS`, the `ref_3` and `ref_0` should be in oneside of the join. But our reorder algorithm may generate a plan which the outermost  join's left child contains `ref_3` and its right child contains `ref_0` which failes to yield a valid plan.
This pr add a check step to filter these planes. For `DP algorithm`, it enumerate all posibility, so it can yield at least one valid plan. For other algorithm, it may yield empty result.

Anohter changes:
Forcibly update rowOutputInfo when there is a projection, to avoid invalidation of rowOutputInfo because only the projection is updated in the transformation rule.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
