### PR TITLE
[BugFix] error when adding generated column using constant expression (#27473)

### DIFF
--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -301,6 +301,12 @@ Status LinkedSchemaChange::generate_delta_column_group_and_cols(const Tablet* ne
     std::sort(all_ref_columns_ids.begin(), all_ref_columns_ids.end());
     std::sort(new_columns_ids.begin(), new_columns_ids.end());
 
+    // If all expression is constant, all_ref_columns_ids will be empty.
+    // we just append 0 into it to construct the read schema for simplicity.
+    if (all_ref_columns_ids.size() == 0) {
+        all_ref_columns_ids.emplace_back(0);
+    }
+
     Schema read_schema = ChunkHelper::convert_schema(base_tablet->tablet_schema(), all_ref_columns_ids);
     ChunkPtr read_chunk = ChunkHelper::new_chunk(read_schema, config::vector_chunk_size);
 

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -503,9 +503,11 @@ Status ChunkChanger::fill_materialized_columns(ChunkPtr& new_chunk) {
             new_chunk->get_column_by_index(it.first).swap(tmp);
         } else {
             // materialized column must be a nullable column. If tmp is not nullable column,
-            // new_chunk can not swap it directly
+            // it maybe a constant column or some other column type.
+            // Unpack normal const column
+            ColumnPtr output_column = ColumnHelper::unpack_and_duplicate_const_column(new_chunk->num_rows(), tmp);
             std::dynamic_pointer_cast<NullableColumn>(new_chunk->get_column_by_index(it.first))
-                    ->swap_by_data_column(tmp);
+                    ->swap_by_data_column(output_column);
         }
     }
 
@@ -568,9 +570,11 @@ Status ChunkChanger::append_materialized_columns(ChunkPtr& read_chunk, ChunkPtr&
             tmp_new_chunk->get_column_by_index(cid).swap(tmp);
         } else {
             // materialized column must be a nullable column. If tmp is not nullable column,
-            // read_chunk can not swap it directly
+            // it maybe a constant column or some other column type
+            // Unpack normal const column
+            ColumnPtr output_column = ColumnHelper::unpack_and_duplicate_const_column(read_chunk->num_rows(), tmp);
             std::dynamic_pointer_cast<NullableColumn>(tmp_new_chunk->get_column_by_index(cid))
-                    ->swap_by_data_column(tmp);
+                    ->swap_by_data_column(output_column);
         }
     }
 

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -797,3 +797,135 @@ DROP TABLE t;
 DROP DATABASE test_schema_change_for_add_optimization;
 -- result:
 -- !result
+-- name: test_schema_change_for_constant_expression
+CREATE DATABASE test_schema_change_for_constant_expression;
+-- result:
+-- !result
+USE test_schema_change_for_constant_expression;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL) PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t VALUES (1),(2),(3);
+-- result:
+-- !result
+ALTER TABLE t ADD COLUMN newcol1 TINYINT AS 1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT * FROM t ORDER BY id;
+-- result:
+1	1
+2	1
+3	1
+-- !result
+ALTER TABLE t ADD COLUMN (newcol2 TINYINT AS 2, newcol3 TINYINT AS 3);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT * FROM t ORDER BY id;
+-- result:
+1	1	2	3
+2	1	2	3
+3	1	2	3
+-- !result
+ALTER TABLE t ADD COLUMN (newcol4 TINYINT AS 4, newcol5 BIGINT AS id * 5, newcol6 TINYINT AS 6);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT * FROM t ORDER BY id;
+-- result:
+1	1	2	3	4	5	6
+2	1	2	3	4	10	6
+3	1	2	3	4	15	6
+-- !result
+ALTER TABLE t ADD COLUMN (newcol7 BIGINT AS id * 7, newcol8 TINYINT AS 8, newcol9 BIGINT AS id * 9);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT * FROM t ORDER BY id;
+-- result:
+1	1	2	3	4	5	6	7	8	9
+2	1	2	3	4	10	6	14	8	18
+3	1	2	3	4	15	6	21	8	27
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+CREATE TABLE t ( id BIGINT NOT NULL) DUPLICATE KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t VALUES (1),(2),(3);
+-- result:
+-- !result
+ALTER TABLE t ADD COLUMN newcol1 TINYINT AS 1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT * FROM t ORDER BY id;
+-- result:
+1	1
+2	1
+3	1
+-- !result
+ALTER TABLE t ADD COLUMN (newcol2 TINYINT AS 2, newcol3 TINYINT AS 3);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT * FROM t ORDER BY id;
+-- result:
+1	1	2	3
+2	1	2	3
+3	1	2	3
+-- !result
+ALTER TABLE t ADD COLUMN (newcol4 TINYINT AS 4, newcol5 BIGINT AS id * 5, newcol6 TINYINT AS 6);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT * FROM t ORDER BY id;
+-- result:
+1	1	2	3	4	5	6
+2	1	2	3	4	10	6
+3	1	2	3	4	15	6
+-- !result
+ALTER TABLE t ADD COLUMN (newcol7 BIGINT AS id * 7, newcol8 TINYINT AS 8, newcol9 BIGINT AS id * 9);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT * FROM t ORDER BY id;
+-- result:
+1	1	2	3	4	5	6	7	8	9
+2	1	2	3	4	10	6	14	8	18
+3	1	2	3	4	15	6	21	8	27
+-- !result
+DROP TABLE t;
+-- result:
+-- !result
+DROP DATABASE test_schema_change_for_constant_expression;
+-- result:
+-- !result

--- a/test/sql/test_materialized_column/T/test_materialized_column
+++ b/test/sql/test_materialized_column/T/test_materialized_column
@@ -323,3 +323,41 @@ DROP TABLE t;
 
 
 DROP DATABASE test_schema_change_for_add_optimization;
+
+-- name: test_schema_change_for_constant_expression
+CREATE DATABASE test_schema_change_for_constant_expression;
+USE test_schema_change_for_constant_expression;
+
+CREATE TABLE t ( id BIGINT NOT NULL) PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1");
+INSERT INTO t VALUES (1),(2),(3);
+ALTER TABLE t ADD COLUMN newcol1 TINYINT AS 1;
+function: wait_alter_table_finish()
+SELECT * FROM t ORDER BY id;
+ALTER TABLE t ADD COLUMN (newcol2 TINYINT AS 2, newcol3 TINYINT AS 3);
+function: wait_alter_table_finish()
+SELECT * FROM t ORDER BY id;
+ALTER TABLE t ADD COLUMN (newcol4 TINYINT AS 4, newcol5 BIGINT AS id * 5, newcol6 TINYINT AS 6);
+function: wait_alter_table_finish()
+SELECT * FROM t ORDER BY id;
+ALTER TABLE t ADD COLUMN (newcol7 BIGINT AS id * 7, newcol8 TINYINT AS 8, newcol9 BIGINT AS id * 9);
+function: wait_alter_table_finish()
+SELECT * FROM t ORDER BY id;
+DROP TABLE t;
+
+CREATE TABLE t ( id BIGINT NOT NULL) DUPLICATE KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("replication_num" = "1");
+INSERT INTO t VALUES (1),(2),(3);
+ALTER TABLE t ADD COLUMN newcol1 TINYINT AS 1;
+function: wait_alter_table_finish()
+SELECT * FROM t ORDER BY id;
+ALTER TABLE t ADD COLUMN (newcol2 TINYINT AS 2, newcol3 TINYINT AS 3);
+function: wait_alter_table_finish()
+SELECT * FROM t ORDER BY id;
+ALTER TABLE t ADD COLUMN (newcol4 TINYINT AS 4, newcol5 BIGINT AS id * 5, newcol6 TINYINT AS 6);
+function: wait_alter_table_finish()
+SELECT * FROM t ORDER BY id;
+ALTER TABLE t ADD COLUMN (newcol7 BIGINT AS id * 7, newcol8 TINYINT AS 8, newcol9 BIGINT AS id * 9);
+function: wait_alter_table_finish()
+SELECT * FROM t ORDER BY id;
+DROP TABLE t;
+
+DROP DATABASE test_schema_change_for_constant_expression;


### PR DESCRIPTION
Problem:
If we add some generated column with some constant expression, the following two case will cause some problem:
1. If we add columns combined with constant expression and non-constant expression, the value of column with constant expression is incorrect.
2. If we add columns generated column with only have constant expression will throw a error.

Fixes #27473

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
