### PR TITLE
[Refactor] change the return type of Column::update_rows to void

### DIFF
--- a/be/src/column/adaptive_nullable_column.cpp
+++ b/be/src/column/adaptive_nullable_column.cpp
@@ -240,9 +240,9 @@ void AdaptiveNullableColumn::update_has_null() {
     _has_null = SIMD::contain_nonzero(_null_column->get_data(), 0);
 }
 
-Status AdaptiveNullableColumn::update_rows(const Column& src, const uint32_t* indexes) {
+void AdaptiveNullableColumn::update_rows(const Column& src, const uint32_t* indexes) {
     materialized_nullable();
-    return NullableColumn::update_rows(src, indexes);
+    NullableColumn::update_rows(src, indexes);
 }
 
 int AdaptiveNullableColumn::compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const {

--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -334,7 +334,7 @@ public:
 
     void append_default(size_t count) override { append_nulls(count); }
 
-    Status update_rows(const Column& src, const uint32_t* indexes) override;
+    void update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t max_one_element_serialize_size() const override {
         materialized_nullable();

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -170,7 +170,7 @@ void ArrayColumn::fill_default(const Filter& filter) {
     update_rows(*default_column, indexes.data());
 }
 
-Status ArrayColumn::update_rows(const Column& src, const uint32_t* indexes) {
+void ArrayColumn::update_rows(const Column& src, const uint32_t* indexes) {
     const auto& array_column = down_cast<const ArrayColumn&>(src);
 
     const UInt32Column& src_offsets = array_column.offsets();
@@ -193,7 +193,7 @@ Status ArrayColumn::update_rows(const Column& src, const uint32_t* indexes) {
                 element_idxes.emplace_back(element_offset + j);
             }
         }
-        RETURN_IF_ERROR(_elements->update_rows(array_column.elements(), element_idxes.data()));
+        _elements->update_rows(array_column.elements(), element_idxes.data());
     } else {
         MutableColumnPtr new_array_column = clone_empty();
         size_t idx_begin = 0;
@@ -209,8 +209,6 @@ Status ArrayColumn::update_rows(const Column& src, const uint32_t* indexes) {
         }
         swap_column(*new_array_column.get());
     }
-
-    return Status::OK();
 }
 
 void ArrayColumn::remove_first_n_values(size_t count) {

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -99,7 +99,7 @@ public:
 
     void fill_default(const Filter& filter) override;
 
-    Status update_rows(const Column& src, const uint32_t* indexes) override;
+    void update_rows(const Column& src, const uint32_t* indexes) override;
 
     void remove_first_n_values(size_t count) override;
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -322,7 +322,7 @@ void BinaryColumnBase<T>::fill_default(const Filter& filter) {
 }
 
 template <typename T>
-Status BinaryColumnBase<T>::update_rows(const Column& src, const uint32_t* indexes) {
+void BinaryColumnBase<T>::update_rows(const Column& src, const uint32_t* indexes) {
     const auto& src_column = down_cast<const BinaryColumnBase<T>&>(src);
     size_t replace_num = src.size();
     bool need_resize = false;
@@ -360,8 +360,6 @@ Status BinaryColumnBase<T>::update_rows(const Column& src, const uint32_t* index
         }
         swap_column(*new_binary_column);
     }
-
-    return Status::OK();
 }
 
 template <typename T>

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -215,7 +215,7 @@ public:
 
     void fill_default(const Filter& filter) override;
 
-    Status update_rows(const Column& src, const uint32_t* indexes) override;
+    void update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t max_one_element_serialize_size() const override;
 

--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -128,13 +128,12 @@ void Chunk::set_num_rows(size_t count) {
     }
 }
 
-Status Chunk::update_rows(const Chunk& src, const uint32_t* indexes) {
+void Chunk::update_rows(const Chunk& src, const uint32_t* indexes) {
     DCHECK(_columns.size() == src.num_columns());
     for (int i = 0; i < _columns.size(); i++) {
         ColumnPtr& c = _columns[i];
-        RETURN_IF_ERROR(c->update_rows(*src.columns()[i], indexes));
+        c->update_rows(*src.columns()[i], indexes);
     }
-    return Status::OK();
 }
 
 std::string_view Chunk::get_column_name(size_t idx) const {

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -116,7 +116,7 @@ public:
     void update_column(ColumnPtr column, SlotId slot_id);
     void update_column_by_index(ColumnPtr column, size_t idx);
 
-    Status update_rows(const Chunk& src, const uint32_t* indexes);
+    void update_rows(const Chunk& src, const uint32_t* indexes);
 
     void append_tuple_column(const ColumnPtr& column, TupleId tuple_id);
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -196,7 +196,7 @@ public:
     //      src_column data: [5, 6]
     // After call this function, column data will be set as [5, 1, 2, 6, 4]
     // The values in indexes is incremented
-    virtual Status update_rows(const Column& src, const uint32_t* indexes) = 0;
+    virtual void update_rows(const Column& src, const uint32_t* indexes) = 0;
 
     // This function will append data from src according to the input indexes. 'indexes' contains
     // the row index of the src.

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -56,8 +56,8 @@ void ConstColumn::fill_default(const Filter& filter) {
     CHECK(false) << "ConstColumn does not support update";
 }
 
-Status ConstColumn::update_rows(const Column& src, const uint32_t* indexes) {
-    return Status::NotSupported("ConstColumn does not support update");
+void ConstColumn::update_rows(const Column& src, const uint32_t* indexes) {
+    CHECK(false) << "ConstColumn does not support update_rows";
 }
 
 void ConstColumn::fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const {

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -57,7 +57,7 @@ void ConstColumn::fill_default(const Filter& filter) {
 }
 
 void ConstColumn::update_rows(const Column& src, const uint32_t* indexes) {
-    CHECK(false) << "ConstColumn does not support update_rows";
+    throw std::runtime_error("ConstColumn does not support update_rows");
 }
 
 void ConstColumn::fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const {

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -131,7 +131,7 @@ public:
 
     void fill_default(const Filter& filter) override;
 
-    Status update_rows(const Column& src, const uint32_t* indexes) override;
+    void update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t serialize(size_t idx, uint8_t* pos) override { return _data->serialize(0, pos); }
 

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -105,14 +105,13 @@ Status FixedLengthColumnBase<T>::fill_range(const Buffer<T>& ids, const std::vec
 }
 
 template <typename T>
-Status FixedLengthColumnBase<T>::update_rows(const Column& src, const uint32_t* indexes) {
+void FixedLengthColumnBase<T>::update_rows(const Column& src, const uint32_t* indexes) {
     const T* src_data = reinterpret_cast<const T*>(src.raw_data());
     size_t replace_num = src.size();
     for (uint32_t i = 0; i < replace_num; ++i) {
         DCHECK_LT(indexes[i], _data.size());
         _data[indexes[i]] = src_data[i];
     }
-    return Status::OK();
 }
 
 template <typename T>

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -158,7 +158,7 @@ public:
 
     Status fill_range(const Buffer<T>& ids, const std::vector<uint8_t>& filter);
 
-    Status update_rows(const Column& src, const uint32_t* indexes) override;
+    void update_rows(const Column& src, const uint32_t* indexes) override;
 
     // The `_data` support one size(> 2^32), but some interface such as update_rows() will use uint32_t to
     // access the item, so we should use 2^32 as the limit

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -176,7 +176,7 @@ void MapColumn::fill_default(const Filter& filter) {
     update_rows(*default_column, indexes.data());
 }
 
-Status MapColumn::update_rows(const Column& src, const uint32_t* indexes) {
+void MapColumn::update_rows(const Column& src, const uint32_t* indexes) {
     const auto& map_column = down_cast<const MapColumn&>(src);
 
     const UInt32Column& src_offsets = map_column.offsets();
@@ -199,8 +199,8 @@ Status MapColumn::update_rows(const Column& src, const uint32_t* indexes) {
                 element_idxes.emplace_back(element_offset + j);
             }
         }
-        RETURN_IF_ERROR(_keys->update_rows(map_column.keys(), element_idxes.data()));
-        RETURN_IF_ERROR(_values->update_rows(map_column.values(), element_idxes.data()));
+        _keys->update_rows(map_column.keys(), element_idxes.data());
+        _values->update_rows(map_column.values(), element_idxes.data());
     } else {
         MutableColumnPtr new_map_column = clone_empty();
         size_t idx_begin = 0;
@@ -216,8 +216,6 @@ Status MapColumn::update_rows(const Column& src, const uint32_t* indexes) {
         }
         swap_column(*new_map_column.get());
     }
-
-    return Status::OK();
 }
 
 void MapColumn::remove_first_n_values(size_t count) {

--- a/be/src/column/map_column.h
+++ b/be/src/column/map_column.h
@@ -98,7 +98,7 @@ public:
 
     void fill_default(const Filter& filter) override;
 
-    Status update_rows(const Column& src, const uint32_t* indexes) override;
+    void update_rows(const Column& src, const uint32_t* indexes) override;
 
     void remove_first_n_values(size_t count) override;
 

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -171,7 +171,7 @@ public:
 
     void append_default(size_t count) override { append_nulls(count); }
 
-    Status update_rows(const Column& src, const uint32_t* indexes) override;
+    void update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t max_one_element_serialize_size() const override {
         return sizeof(bool) + _data_column->max_one_element_serialize_size();

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -193,7 +193,7 @@ void ObjectColumn<T>::fill_default(const Filter& filter) {
 }
 
 template <typename T>
-Status ObjectColumn<T>::update_rows(const Column& src, const uint32_t* indexes) {
+void ObjectColumn<T>::update_rows(const Column& src, const uint32_t* indexes) {
     const auto& obj_col = down_cast<const ObjectColumn<T>&>(src);
     size_t replace_num = src.size();
     for (size_t i = 0; i < replace_num; i++) {
@@ -201,7 +201,6 @@ Status ObjectColumn<T>::update_rows(const Column& src, const uint32_t* indexes) 
         _pool[indexes[i]] = *obj_col.get_object(i);
     }
     _cache_ok = false;
-    return Status::OK();
 }
 
 template <typename T>

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -127,7 +127,7 @@ public:
 
     void fill_default(const Filter& filter) override;
 
-    Status update_rows(const Column& src, const uint32_t* indexes) override;
+    void update_rows(const Column& src, const uint32_t* indexes) override;
 
     uint32_t serialize(size_t idx, uint8_t* pos) override;
     uint32_t serialize_default(uint8_t* pos) override;

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -142,14 +142,13 @@ void StructColumn::fill_default(const Filter& filter) {
     }
 }
 
-Status StructColumn::update_rows(const Column& src, const uint32_t* indexes) {
+void StructColumn::update_rows(const Column& src, const uint32_t* indexes) {
     DCHECK(src.is_struct());
     const auto& src_column = down_cast<const StructColumn&>(src);
     DCHECK_EQ(_fields.size(), src_column._fields.size());
     for (size_t i = 0; i < _fields.size(); i++) {
-        RETURN_IF_ERROR(_fields[i]->update_rows(*src_column._fields[i], indexes));
+        _fields[i]->update_rows(*src_column._fields[i], indexes);
     }
-    return Status::OK();
 }
 
 void StructColumn::append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) {

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -102,7 +102,7 @@ public:
 
     void fill_default(const Filter& filter) override;
 
-    Status update_rows(const Column& src, const uint32_t* indexes) override;
+    void update_rows(const Column& src, const uint32_t* indexes) override;
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -450,3 +450,12 @@ struct StatusInstance {
             return ret;               \
         }                             \
     } while (0)
+
+#define RETURN_IF_EXCEPTION(stmt)                   \
+    do {                                            \
+        try {                                       \
+            { stmt; }                               \
+        } catch (const std::exception& e) {         \
+            return Status::InternalError(e.what()); \
+        }                                           \
+    } while (0)

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -607,8 +607,8 @@ Status RowsetUpdateState::_resolve_conflict_partial_update(const TxnLogPB_OpWrit
             std::unique_ptr<Column> new_write_column =
                     _partial_update_states[segment_id].write_columns[col_idx]->clone_empty();
             new_write_column->append_selective(*read_columns[col_idx], read_idxes.data(), 0, read_idxes.size());
-            _partial_update_states[segment_id].write_columns[col_idx]->update_rows(
-                    *new_write_column, conflict_idxes.data());
+            RETURN_IF_EXCEPTION(_partial_update_states[segment_id].write_columns[col_idx]->update_rows(
+                    *new_write_column, conflict_idxes.data()));
         }
     }
 
@@ -681,8 +681,8 @@ Status RowsetUpdateState::_resolve_conflict_auto_increment(const TxnLogPB_OpWrit
         std::unique_ptr<Column> new_write_column =
                 _auto_increment_partial_update_states[segment_id].write_column->clone_empty();
         new_write_column->append_selective(*auto_increment_read_column[0], idxes.data(), 0, idxes.size());
-        _auto_increment_partial_update_states[segment_id].write_column->update_rows(
-                *new_write_column, conflict_idxes.data());
+        RETURN_IF_EXCEPTION(_auto_increment_partial_update_states[segment_id].write_column->update_rows(
+                *new_write_column, conflict_idxes.data()));
 
         // reslove delete-partial update conflict base on latest column values
         _auto_increment_delete_pks[segment_id].reset();

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -607,8 +607,8 @@ Status RowsetUpdateState::_resolve_conflict_partial_update(const TxnLogPB_OpWrit
             std::unique_ptr<Column> new_write_column =
                     _partial_update_states[segment_id].write_columns[col_idx]->clone_empty();
             new_write_column->append_selective(*read_columns[col_idx], read_idxes.data(), 0, read_idxes.size());
-            RETURN_IF_ERROR(_partial_update_states[segment_id].write_columns[col_idx]->update_rows(
-                    *new_write_column, conflict_idxes.data()));
+            _partial_update_states[segment_id].write_columns[col_idx]->update_rows(
+                    *new_write_column, conflict_idxes.data());
         }
     }
 
@@ -681,8 +681,8 @@ Status RowsetUpdateState::_resolve_conflict_auto_increment(const TxnLogPB_OpWrit
         std::unique_ptr<Column> new_write_column =
                 _auto_increment_partial_update_states[segment_id].write_column->clone_empty();
         new_write_column->append_selective(*auto_increment_read_column[0], idxes.data(), 0, idxes.size());
-        RETURN_IF_ERROR(_auto_increment_partial_update_states[segment_id].write_column->update_rows(
-                *new_write_column, conflict_idxes.data()));
+        _auto_increment_partial_update_states[segment_id].write_column->update_rows(
+                *new_write_column, conflict_idxes.data());
 
         // reslove delete-partial update conflict base on latest column values
         _auto_increment_delete_pks[segment_id].reset();

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -501,7 +501,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, const P
         RETURN_IF_ERROR(_read_chunk_from_update(each.second, update_file_iters, rowids, update_chunk_ptr.get()));
         int64_t t3 = MonotonicMillis();
         // 4.3 merge source chunk and update chunk
-        source_chunk_ptr->update_rows(*update_chunk_ptr, rowids.data());
+        RETURN_IF_EXCEPTION(source_chunk_ptr->update_rows(*update_chunk_ptr, rowids.data()));
         // 4.4 write column to delta column file
         int64_t t4 = MonotonicMillis();
         uint64_t segment_file_size = 0;

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -501,7 +501,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, const P
         RETURN_IF_ERROR(_read_chunk_from_update(each.second, update_file_iters, rowids, update_chunk_ptr.get()));
         int64_t t3 = MonotonicMillis();
         // 4.3 merge source chunk and update chunk
-        RETURN_IF_ERROR(source_chunk_ptr->update_rows(*update_chunk_ptr, rowids.data()));
+        source_chunk_ptr->update_rows(*update_chunk_ptr, rowids.data());
         // 4.4 write column to delta column file
         int64_t t4 = MonotonicMillis();
         uint64_t segment_file_size = 0;

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -560,8 +560,8 @@ Status RowsetUpdateState::_check_and_resolve_conflict(Tablet* tablet, Rowset* ro
             std::unique_ptr<Column> new_write_column =
                     _partial_update_states[segment_id].write_columns[col_idx]->clone_empty();
             new_write_column->append_selective(*read_columns[col_idx], read_idxes.data(), 0, read_idxes.size());
-            _partial_update_states[segment_id].write_columns[col_idx]->update_rows(
-                    *new_write_column, conflict_idxes.data());
+            RETURN_IF_EXCEPTION(_partial_update_states[segment_id].write_columns[col_idx]->update_rows(
+                    *new_write_column, conflict_idxes.data()));
         }
     }
     int64_t t_end = MonotonicMillis();

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -560,8 +560,8 @@ Status RowsetUpdateState::_check_and_resolve_conflict(Tablet* tablet, Rowset* ro
             std::unique_ptr<Column> new_write_column =
                     _partial_update_states[segment_id].write_columns[col_idx]->clone_empty();
             new_write_column->append_selective(*read_columns[col_idx], read_idxes.data(), 0, read_idxes.size());
-            RETURN_IF_ERROR(_partial_update_states[segment_id].write_columns[col_idx]->update_rows(
-                    *new_write_column, conflict_idxes.data()));
+            _partial_update_states[segment_id].write_columns[col_idx]->update_rows(
+                    *new_write_column, conflict_idxes.data());
         }
     }
     int64_t t_end = MonotonicMillis();

--- a/be/test/column/array_column_test.cpp
+++ b/be/test/column/array_column_test.cpp
@@ -998,7 +998,7 @@ PARALLEL_TEST(ArrayColumnTest, test_update_rows) {
     offset_col1->append(4);
 
     std::vector<uint32_t> replace_idxes = {1, 3};
-    ASSERT_TRUE(column->update_rows(*replace_col1.get(), replace_idxes.data()).ok());
+    column->update_rows(*replace_col1.get(), replace_idxes.data());
 
     ASSERT_EQ(4, column->size());
     ASSERT_EQ("[1,2,3]", column->debug_item(0));
@@ -1019,7 +1019,7 @@ PARALLEL_TEST(ArrayColumnTest, test_update_rows) {
     element_col2->append_datum(204);
     offset_col2->append(4);
 
-    ASSERT_TRUE(column->update_rows(*replace_col2.get(), replace_idxes.data()).ok());
+    column->update_rows(*replace_col2.get(), replace_idxes.data());
 
     ASSERT_EQ(4, column->size());
     ASSERT_EQ("[1,2,3]", column->debug_item(0));

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -560,7 +560,7 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     auto c2 = BinaryColumn::create();
     c2->append_datum("pq");
     c2->append_datum("rstu");
-    ASSERT_TRUE(c1->update_rows(*c2.get(), replace_idxes.data()).ok());
+    c1->update_rows(*c2.get(), replace_idxes.data());
 
     auto slices = c1->get_data();
     EXPECT_EQ(5, c1->size());
@@ -573,7 +573,7 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     auto c3 = BinaryColumn::create();
     c3->append_datum("ab");
     c3->append_datum("cdef");
-    ASSERT_TRUE(c1->update_rows(*c3.get(), replace_idxes.data()).ok());
+    c1->update_rows(*c3.get(), replace_idxes.data());
 
     slices = c1->get_data();
     EXPECT_EQ(5, c1->size());
@@ -587,7 +587,7 @@ PARALLEL_TEST(BinaryColumnTest, test_update_rows) {
     std::vector<uint32_t> new_replace_idxes = {0, 1};
     c4->append_datum("ab");
     c4->append_datum("cdef");
-    ASSERT_TRUE(c1->update_rows(*c4.get(), new_replace_idxes.data()).ok());
+    c1->update_rows(*c4.get(), new_replace_idxes.data());
 
     slices = c1->get_data();
     EXPECT_EQ(5, c1->size());

--- a/be/test/column/fixed_length_column_test.cpp
+++ b/be/test/column/fixed_length_column_test.cpp
@@ -524,7 +524,7 @@ TEST(FixedLengthColumnTest, test_update_rows) {
     }
 
     std::vector<uint32_t> replace_idxes = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    ASSERT_TRUE(column->update_rows(*replace_column.get(), replace_idxes.data()).ok());
+    column->update_rows(*replace_column.get(), replace_idxes.data());
 
     for (int i = 0; i < 10; i++) {
         ASSERT_EQ(column->get_data()[i], i + 100);

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -1031,7 +1031,7 @@ PARALLEL_TEST(MapColumnTest, test_update_rows) {
     c1->append_datum(map4);
 
     std::vector<uint32_t> replace_idxes = {1, 3};
-    ASSERT_TRUE(c0->update_rows(*c1.get(), replace_idxes.data()).ok());
+    c0->update_rows(*c1.get(), replace_idxes.data());
 
     ASSERT_EQ(4, c0->size());
     ASSERT_EQ("{1:11,2:22,3:33}", c0->debug_item(0));
@@ -1055,7 +1055,7 @@ PARALLEL_TEST(MapColumnTest, test_update_rows) {
     c2->append_datum(map6);
 
     std::vector<uint32_t> replace_idxes_new = {1, 2};
-    ASSERT_TRUE(c0->update_rows(*c2.get(), replace_idxes_new.data()).ok());
+    c0->update_rows(*c2.get(), replace_idxes_new.data());
 
     ASSERT_EQ(4, c0->size());
     ASSERT_EQ("{1:11,2:22,3:33}", c0->debug_item(0));

--- a/be/test/column/nullable_column_test.cpp
+++ b/be/test/column/nullable_column_test.cpp
@@ -257,7 +257,7 @@ PARALLEL_TEST(NullableColumnTest, test_update_rows) {
     replace_col1->append_datum((int32_t)5);
 
     std::vector<uint32_t> replace_idxes = {1, 4};
-    ASSERT_TRUE(column->update_rows(*replace_col1.get(), replace_idxes.data()).ok());
+    column->update_rows(*replace_col1.get(), replace_idxes.data());
     ASSERT_EQ(5, column->size());
     ASSERT_TRUE(column->data_column().unique());
     ASSERT_TRUE(column->null_column().unique());
@@ -281,7 +281,7 @@ PARALLEL_TEST(NullableColumnTest, test_update_rows) {
     replace_col2->append_datum({});
     replace_col2->append_datum("jk");
 
-    ASSERT_TRUE(column1->update_rows(*replace_col2.get(), replace_idxes.data()).ok());
+    column1->update_rows(*replace_col2.get(), replace_idxes.data());
     ASSERT_EQ(5, column1->size());
     ASSERT_TRUE(column1->data_column().unique());
     ASSERT_TRUE(column1->null_column().unique());

--- a/be/test/column/object_column_test.cpp
+++ b/be/test/column/object_column_test.cpp
@@ -254,7 +254,7 @@ TEST(ObjectColumnTest, Percentile_test_swap_column) {
     ASSERT_TRUE(column1->is_object());
 
     std::vector<uint32_t> idx = {1};
-    ASSERT_TRUE(column->update_rows(*column1.get(), idx.data()).ok());
+    column->update_rows(*column1.get(), idx.data());
 
     percentile = ColumnHelper::cast_to<TYPE_PERCENTILE>(column);
     ASSERT_EQ(1, percentile->get_object(0)->quantile(1));

--- a/be/test/column/struct_column_test.cpp
+++ b/be/test/column/struct_column_test.cpp
@@ -499,7 +499,7 @@ TEST(StructColumnTest, test_update_rows) {
     copy->append_datum(struct2);
     copy->append_datum(DatumStruct{uint64_t(4), Slice("world")});
     std::vector<uint32_t> replace_indexes = {0, 2};
-    ASSERT_TRUE(column->update_rows(*copy.get(), replace_indexes.data()).ok());
+    column->update_rows(*copy.get(), replace_indexes.data());
 
     ASSERT_EQ(3, column->size());
     ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(0));


### PR DESCRIPTION
since Column::update_rows never return error status, change the return type to void. 
this is a part job of #27471 

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
