### PR TITLE
[Enhancement] Remove the lock for adding chunks to sender queue

### DIFF
--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -14,6 +14,8 @@
 
 #include "runtime/sender_queue.h"
 
+#include <atomic>
+
 #include "column/chunk.h"
 #include "gen_cpp/data.pb.h"
 #include "gen_cpp/internal_service.pb.h"
@@ -731,10 +733,6 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
             ++max_processed_sequence;
         }
     } else {
-        ScopedTimer<MonotonicStopWatch> wait_timer(_recvr->_sender_wait_lock_timer);
-        std::lock_guard<Mutex> l(_lock);
-        wait_timer.stop();
-
         // In order to keep the order of pass through chunks, we need to guarantee that
         // the chunk which is taken out first from pass_throush_context must be enqueued first.
         // So here we put these two steps under the same lock.
@@ -750,7 +748,9 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
 
         // remove the short-circuited chunks
         for (auto iter = chunks.begin(); iter != chunks.end();) {
-            if (_is_pipeline_level_shuffle && _chunk_queue_states[iter->driver_sequence].is_short_circuited) {
+            if (_is_pipeline_level_shuffle &&
+                // First check here for short circuit compatibility without introducing a critical section
+                _chunk_queue_states[iter->driver_sequence].is_short_circuited.load(std::memory_order_relaxed)) {
                 total_chunk_bytes -= iter->chunk_bytes;
                 chunks.erase(iter++);
                 continue;
@@ -776,6 +776,10 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
             }
             _chunk_queue_states[index].blocked_closure_num += closure != nullptr;
             _total_chunks++;
+            // Double check here for short circuit compatibility without introducing a critical section
+            if (_chunk_queue_states[index].is_short_circuited.load(std::memory_order_relaxed)) {
+                short_circuit(index);
+            }
             _recvr->_num_buffered_bytes += chunk_bytes;
             COUNTER_ADD(_recvr->_peak_buffer_mem_bytes, chunk_bytes);
         }
@@ -785,9 +789,8 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
 }
 
 void DataStreamRecvr::PipelineSenderQueue::short_circuit(const int32_t driver_sequence) {
-    std::lock_guard<Mutex> l(_lock);
     auto& chunk_queue_state = _chunk_queue_states[driver_sequence];
-    chunk_queue_state.is_short_circuited = true;
+    chunk_queue_state.is_short_circuited.store(true, std::memory_order_relaxed);
     if (_is_pipeline_level_shuffle) {
         auto& chunk_queue = _chunk_queues[driver_sequence];
         ChunkItem item;

--- a/be/src/runtime/sender_queue.h
+++ b/be/src/runtime/sender_queue.h
@@ -237,7 +237,7 @@ private:
         // In the unplug state, has_output will return true directly if there is a chunk in the queue.
         // Otherwise, it will try to batch enough chunks to reduce the scheduling overhead.
         bool unpluging = false;
-        bool is_short_circuited = false;
+        std::atomic<bool> is_short_circuited = false;
     };
     std::vector<ChunkQueueState> _chunk_queue_states;
 


### PR DESCRIPTION
https://github.com/StarRocks/starrocks/pull/10147 introduces a lock when adding incoming chunks into the sender queue.

But in particular situations where there are many nodes in the cluster and each node with high specification(core nums), this lock may lead to performance reduction.

## Test

1fe/20be, each machine with specification of 64c/128g

sql:

```sql
SELECT COUNT(1) as total FROM (
    select DISTINCT
        l_partkey as "l_partkey"
    from lineitem
) t limit 1
```

session variable:
* pipeline_dop=64

before:
* TotalTime: 1s989ms
* DeserializeChunkTime: 1s940ms
* SenderWaitLockTime: 1s104ms

after:
* TotalTime: 1s917ms
* DeserializeChunkTime: 1s882ms
* SenderWaitLockTime: 146.927us

The lock wait time has been removed. But the overall time does not decrease because the cost of deserialization is still high.

## How to reproduce the dead lock described in https://github.com/StarRocks/starrocks/pull/10147

```sql
select max(l_quantity) from  (
    select * from lineitem join part on p_partkey = l_partkey limit 1000000
) a
```

Execute this query concurrently

```sh
mysqlslap -h127.0.0.1 -P9030 -uroot --concurrency=10 --number-of-queries=10240 --create-schema=tpch_100g --query=query.sql --delimiter=";"
```

And we can observe the pipeline engine by `curl -s ${BE_IP}:${BE_HTTP_PORT}/metrics | grep -E "^starrocks_be.*_pip"`, we can notice that these two metrics
* `starrocks_be_pip_query_ctx_cnt`
* `starrocks_be_pipe_poller_block_queue_len` 

These two metrics keep stable of this pr.
These two metrics will increase as test progresses if the `double check`(memtioned in this pr) is removed.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
  - [x] 2.3
