### PR TITLE
[Feature] add support for str_to_jodatime function

### DIFF
--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -779,18 +779,14 @@ TimestampValue timestamp_add(TimestampValue tsv, int count) {
     return tsv.add<UNIT>(count);
 }
 
-#define DEFINE_TIME_ADD_FN(FN, UNIT)                               \
-    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { \
-        return timestamp_add<UNIT>(timestamp, value);              \
-    }                                                              \
-                                                                   \
+#define DEFINE_TIME_ADD_FN(FN, UNIT)                                                                               \
+    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { return timestamp_add<UNIT>(timestamp, value); } \
+                                                                                                                   \
     DEFINE_TIME_CALC_FN(FN, TYPE_DATETIME, TYPE_INT, TYPE_DATETIME);
 
-#define DEFINE_TIME_SUB_FN(FN, UNIT)                               \
-    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { \
-        return timestamp_add<UNIT>(timestamp, -value);             \
-    }                                                              \
-                                                                   \
+#define DEFINE_TIME_SUB_FN(FN, UNIT)                                                                                \
+    DEFINE_BINARY_FUNCTION_WITH_IMPL(FN##Impl, timestamp, value) { return timestamp_add<UNIT>(timestamp, -value); } \
+                                                                                                                    \
     DEFINE_TIME_CALC_FN(FN, TYPE_DATETIME, TYPE_INT, TYPE_DATETIME);
 
 #define DEFINE_TIME_ADD_AND_SUB_FN(FN_PREFIX, UNIT) \

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -1809,7 +1809,7 @@ Status TimeFunctions::parse_joda_close(FunctionContext* context, FunctionContext
     return {};
 }
 
-StatusOr<ColumnPtr> TimeFunctions::parse_datetime(FunctionContext* context, const Columns& columns) {
+StatusOr<ColumnPtr> TimeFunctions::parse_jodatime(FunctionContext* context, const Columns& columns) {
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
     size_t size = columns[0]->size(); // minimum number of rows.

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -590,7 +590,7 @@ public:
     /**
      * Joda Time parse
      */
-    DEFINE_VECTORIZED_FN(parse_datetime);
+    DEFINE_VECTORIZED_FN(parse_jodatime);
     static Status parse_joda_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
     static Status parse_joda_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
 

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -569,6 +569,8 @@ public:
 
     // Try to process string content, based on uncommon string format
     static StatusOr<ColumnPtr> str_to_date_uncommon(FunctionContext* context, const starrocks::Columns& columns);
+
+    static StatusOr<ColumnPtr> str_to_date_joda(FunctionContext* context, const Columns& columns);
     /**
      *
      * cast string to datetime
@@ -817,6 +819,9 @@ public:
         yyyycMMcdd,
         // for string format like "%Y-%m-%d %H:%i:%s"
         yyyycMMcddcHHcmmcss,
+
+        // any joda format
+        joda,
         None
     };
 

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -560,18 +560,12 @@ public:
      */
     DEFINE_VECTORIZED_FN(to_days);
 
-    // try to transfer content to date format based on "%Y-%m-%d",
+    // try to transfer content to date format based on "%Y-%m-%d" or "%Y-%m-%d %H:%i:%s",
     // if successful, return result TimestampValue
     // else take a uncommon approach to process this content.
+    template <bool isYYYYMMDD>
     static StatusOr<ColumnPtr> str_to_date_from_date_format(FunctionContext* context, const starrocks::Columns& columns,
                                                             const char* str_format);
-
-    // try to transfer content to date format based on "%Y-%m-%d %H:%i:%s",
-    // if successful, return result TimestampValue
-    // else take a uncommon approach to process this content.
-    static StatusOr<ColumnPtr> str_to_date_from_datetime_format(FunctionContext* context,
-                                                                const starrocks::Columns& columns,
-                                                                const char* str_format);
 
     // Try to process string content, based on uncommon string format
     static StatusOr<ColumnPtr> str_to_date_uncommon(FunctionContext* context, const starrocks::Columns& columns);

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -570,7 +570,6 @@ public:
     // Try to process string content, based on uncommon string format
     static StatusOr<ColumnPtr> str_to_date_uncommon(FunctionContext* context, const starrocks::Columns& columns);
 
-    static StatusOr<ColumnPtr> str_to_date_joda(FunctionContext* context, const Columns& columns);
     /**
      *
      * cast string to datetime
@@ -586,6 +585,13 @@ public:
      *
      */
     DEFINE_VECTORIZED_FN(str2date);
+
+    /**
+     * Joda Time parse
+     */
+    DEFINE_VECTORIZED_FN(parse_datetime);
+    static Status parse_joda_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+    static Status parse_joda_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
 
     static bool is_date_format(const Slice& slice, char** start);
     static bool is_datetime_format(const Slice& slice, char** start);
@@ -819,9 +825,6 @@ public:
         yyyycMMcdd,
         // for string format like "%Y-%m-%d %H:%i:%s"
         yyyycMMcddcHHcmmcss,
-
-        // any joda format
-        joda,
         None
     };
 

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -19,6 +19,7 @@
 #include "exprs/builtin_functions.h"
 #include "exprs/function_context.h"
 #include "exprs/function_helper.h"
+#include "runtime/datetime_value.h"
 #include "types/logical_type.h"
 #include "util/timezone_hsscan.h"
 namespace starrocks {
@@ -833,6 +834,12 @@ public:
         std::string fmt;
         int len;
         FormatType fmt_type;
+    };
+
+    struct ParseJodaState {
+        std::unique_ptr<joda::JodaFormat> joda;
+
+        Status prepare(std::string_view formt);
     };
 
 private:

--- a/be/src/runtime/datetime_value.cpp
+++ b/be/src/runtime/datetime_value.cpp
@@ -1433,8 +1433,7 @@ static int check_word(const char* lib[], const char* str, const char* end, const
     return pos;
 }
 
-bool DateTimeValue::from_joda_format_str(const char* format, int format_len, const char* value, int value_len,
-                                         const char** sub_val_end) {
+bool DateTimeValue::from_joda_format_str(const char* format, int format_len, const char* value, int value_len) {
     const char* ptr = format;
     const char* end = format + format_len;
     const char* val = value;

--- a/be/src/runtime/datetime_value.cpp
+++ b/be/src/runtime/datetime_value.cpp
@@ -495,9 +495,12 @@ bool JodaFormat::parse(std::string_view str, DateTimeValue* output) {
     date_part_used = false;
     time_part_used = false;
     frac_part_used = false;
+    _year = 2000;
+    _month = 1;
+    _day = 1;
     halfday = 0;
-    weekday = -1;
     yearday = -1;
+    weekday = -1;
     week_num = -1;
     has_timezone = false;
 

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -196,6 +196,9 @@ public:
 
     bool from_joda_format_str(const char* format, int format_len, const char* value, int value_len,
                               const char** sub_val_end);
+    bool from_joda_format(const std::string& format, const std::string& value, const char** sub_val_end) {
+        return from_joda_format_str(format.data(), format.length(), value.data(), value.length(), sub_val_end);
+    }
 
     operator int64_t() const { return to_int64(); }
 

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -194,10 +194,13 @@ public:
         return from_date_format_str(format, format_len, value, value_len, nullptr);
     }
 
-    bool from_joda_format_str(const char* format, int format_len, const char* value, int value_len,
-                              const char** sub_val_end);
-    bool from_joda_format(const std::string& format, const std::string& value, const char** sub_val_end) {
-        return from_joda_format_str(format.data(), format.length(), value.data(), value.length(), sub_val_end);
+    bool from_joda_format_str(const char* format, int format_len, const char* value, int value_len);
+    bool from_joda_format(const std::string& format, const char* value, int value_len) {
+        return from_joda_format_str(format.data(), format.length(), value, value_len);
+    }
+
+    bool from_joda_format(const std::string& format, const std::string& value) {
+        return from_joda_format_str(format.data(), format.length(), value.data(), value.length());
     }
 
     operator int64_t() const { return to_int64(); }

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -194,15 +194,6 @@ public:
         return from_date_format_str(format, format_len, value, value_len, nullptr);
     }
 
-    bool from_joda_format_str(const char* format, int format_len, const char* value, int value_len);
-    bool from_joda_format(const std::string& format, const char* value, int value_len) {
-        return from_joda_format_str(format.data(), format.length(), value, value_len);
-    }
-
-    bool from_joda_format(const std::string& format, const std::string& value) {
-        return from_joda_format_str(format.data(), format.length(), value.data(), value.length());
-    }
-
     operator int64_t() const { return to_int64(); }
 
     // Given days since 0000-01-01, construct the datetime value.
@@ -537,6 +528,44 @@ private:
 };
 
 } // namespace starrocks
+
+namespace starrocks::joda {
+
+class JodaFormat : public starrocks::DateTimeValue {
+public:
+    JodaFormat() = default;
+    ~JodaFormat() = default;
+
+    bool prepare(std::string_view format);
+    bool parse(std::string_view str, DateTimeValue* output);
+
+private:
+    // Token parsers
+    std::vector<std::function<bool()>> _token_parsers;
+
+    // Cursor
+    const char* val = nullptr;
+    const char* val_end = nullptr;
+
+    bool date_part_used = false;
+    bool time_part_used = false;
+    bool frac_part_used = false;
+
+    int halfday = 0;
+    int weekday = -1;
+    int yearday = -1;
+    int week_num = -1;
+
+    cctz::time_zone ctz; // default UTC
+    bool has_timezone = false;
+
+    const bool strict_week_number = false;
+    const bool sunday_first = false;
+    const bool strict_week_number_year_type = false;
+    const int strict_week_number_year = -1;
+};
+
+} // namespace starrocks::joda
 
 namespace std {
 template <>

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -194,6 +194,9 @@ public:
         return from_date_format_str(format, format_len, value, value_len, nullptr);
     }
 
+    bool from_joda_format_str(const char* format, int format_len, const char* value, int value_len,
+                              const char** sub_val_end);
+
     operator int64_t() const { return to_int64(); }
 
     // Given days since 0000-01-01, construct the datetime value.

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -1869,7 +1869,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("01,05,2013"), v->get_data()[0]);
+        ASSERT_EQ(Slice("01,05,13"), v->get_data()[0]);
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyyMMdd"), 1);
@@ -2034,7 +2034,7 @@ TEST_F(TimeFunctionsTest, jodatime_format) {
         ASSERT_TRUE(result->is_binary());
         ASSERT_EQ(1, result->size());
         auto v = ColumnHelper::cast_to<TYPE_VARCHAR>(result);
-        ASSERT_EQ(Slice("25,06,2020"), v->get_data()[0]);
+        ASSERT_EQ(Slice("25,06,20"), v->get_data()[0]);
     }
     {
         auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(Slice("yyyyMMdd"), 1);

--- a/be/test/runtime/datetime_value_test.cpp
+++ b/be/test/runtime/datetime_value_test.cpp
@@ -1422,9 +1422,8 @@ class ParseDateTimeTestFixture : public ::testing::TestWithParam<TestParseDateti
 
 TEST_P(ParseDateTimeTestFixture, parse_datetime) {
     auto& [datetime_str, format] = GetParam();
-    const char* sub_val;
     DateTimeValue datetime;
-    bool res = datetime.from_joda_format(format, datetime_str, &sub_val);
+    bool res = datetime.from_joda_format(format, datetime_str);
     EXPECT_TRUE(res);
     char str[50];
 

--- a/be/test/runtime/datetime_value_test.cpp
+++ b/be/test/runtime/datetime_value_test.cpp
@@ -40,6 +40,7 @@
 #include <string>
 
 #include "common/logging.h"
+#include "testutil/assert.h"
 #include "util/logging.h"
 #include "util/timezone_utils.h"
 
@@ -1423,9 +1424,12 @@ class ParseDateTimeTestFixture : public ::testing::TestWithParam<TestParseDateti
 TEST_P(ParseDateTimeTestFixture, parse_datetime) {
     auto& [datetime_str, format] = GetParam();
     DateTimeValue datetime;
-    bool res = datetime.from_joda_format(format, datetime_str);
-    EXPECT_TRUE(res);
     char str[50];
+    // bool res = datetime.from_joda_format(format, datetime_str);
+    // EXPECT_TRUE(res);
+    joda::JodaFormat joda;
+    EXPECT_TRUE(joda.prepare(format));
+    EXPECT_TRUE(joda.parse(datetime_str, &datetime));
 
     // to joda format
     EXPECT_TRUE(datetime.to_joda_format_string(format.data(), format.length(), str));

--- a/be/test/runtime/datetime_value_test.cpp
+++ b/be/test/runtime/datetime_value_test.cpp
@@ -1442,8 +1442,14 @@ INSTANTIATE_TEST_SUITE_P(
         ParseDateTimeTest, ParseDateTimeTestFixture,
         ::testing::Values(
                 // clang-format: off
+                // Components
+                TestParseDatetimeParam("1994", "yyyy"), TestParseDatetimeParam("04", "MM"),
+                TestParseDatetimeParam("04", "dd"),
+
                 TestParseDatetimeParam("1994-09-09", "yyyy-MM-dd"), TestParseDatetimeParam("1994 09 09", "yyyy MM dd"),
-                TestParseDatetimeParam("1994/09/09", "yyyy/MM/dd"),
+                TestParseDatetimeParam("1994/09/09", "yyyy/MM/dd"), TestParseDatetimeParam("1994-09", "yyyy-MM"),
+                TestParseDatetimeParam("1994 09", "yyyy MM"), TestParseDatetimeParam("1994/09", "yyyy/MM"),
+
                 TestParseDatetimeParam("1994-09-09 01:02:03", "yyyy-MM-dd HH:mm:ss"),
                 TestParseDatetimeParam("1994/09/09 01:02:03", "yyyy/MM/dd HH:mm:ss"),
 
@@ -1468,7 +1474,7 @@ INSTANTIATE_TEST_SUITE_P(
                 TestParseDatetimeParam("1994-09-09 02:02:03 PM", "yyyy-MM-dd KK:mm:ss aa"),
                 TestParseDatetimeParam("1994-09-09 02:02:03", "yyyy-MM-dd KK:mm:ss"),
 
-                //SECOND
+                // Second
                 TestParseDatetimeParam("1994-09-09 01:02:03.123", "yyyy-MM-dd HH:mm:ss.SSS"),
 
                 // Timezone

--- a/be/test/runtime/datetime_value_test.cpp
+++ b/be/test/runtime/datetime_value_test.cpp
@@ -34,6 +34,7 @@
 
 #include "runtime/datetime_value.h"
 
+#include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
 
 #include <string>
@@ -1414,5 +1415,33 @@ TEST_F(DateTimeValueTest, packed_time) {
         ASSERT_EQ(1830650338932162560L, packed_time);
     }
 }
+
+using TestParseDatetimeParam = std::tuple<std::string, std::string, std::string>;
+
+class ParseDateTimeTestFixture : public ::testing::TestWithParam<TestParseDatetimeParam> {};
+
+TEST_P(ParseDateTimeTestFixture, parse_datetime) {
+    auto& [datetime_str, format, parsed] = GetParam();
+    const char* sub_val;
+    DateTimeValue datetime;
+    bool res = datetime.from_joda_format(format, datetime_str, &sub_val);
+    EXPECT_TRUE(res);
+    char str[20];
+    datetime.to_string(str);
+    EXPECT_EQ(parsed, str);
+
+    // to joda format
+    datetime.to_joda_format_string(format.data(), format.length(), str);
+    EXPECT_EQ(datetime_str, str);
+}
+
+INSTANTIATE_TEST_SUITE_P(ParseDateTimeTest, ParseDateTimeTestFixture,
+                         ::testing::Values(
+                                 // clang-format: off
+                                 TestParseDatetimeParam("1994-09-09", "yyyy-MM-dd", "1994-09-09"),
+                                 TestParseDatetimeParam("1994-09-09 01:02:03", "yyyy-MM-dd HH:mm:ss",
+                                                        "1994-09-09 01:02:03")
+                                 // clang-format: on
+                                 ));
 
 } // namespace starrocks

--- a/docs/sql-reference/sql-functions/date-time-functions/parse_datetime.md
+++ b/docs/sql-reference/sql-functions/date-time-functions/parse_datetime.md
@@ -1,0 +1,65 @@
+# parse_datetime
+
+## Description
+
+Converts a string into a DATETIME value according to the specified format.
+
+The format is [Joda DateTime](https://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html), which is like 'yyyy-MM-dd HH:mm:ss'.
+
+## Syntax
+
+```Haskell
+DATETIME PARSE_DATETIME(VARCHAR str, VARCHAR format)
+```
+
+## Parameters
+
+- `str`: the time expression you want to convert. It must be of the VARCHAR type.
+- `format`: the Joda DateTime format
+
+## Return value
+
+- Returns a `DATETIME`` value if parse succeed.  
+- Returns `NULL` if parse failed
+
+## Examples
+
+Example 1: Convert the input into a DATETIME value.
+
+```Plain Text
+MySQL > select parse_datetime('2014-12-21 12:34:56', 'yyyy-MM-dd HH:mm:ss');
++--------------------------------------------------------------+
+| parse_datetime('2014-12-21 12:34:56', 'yyyy-MM-dd HH:mm:ss') |
++--------------------------------------------------------------+
+| 2014-12-21 12:34:56                                          |
++--------------------------------------------------------------+
+```
+
+
+Example 2: Convert the input into a DATETIME value with text-style month
+
+```Plain Text
+MySQL > select parse_datetime('21/December/23 12:34:56', 'dd/MMMM/yy HH:mm:ss');
++------------------------------------------------------------------+
+| parse_datetime('21/December/23 12:34:56', 'dd/MMMM/yy HH:mm:ss') |
++------------------------------------------------------------------+
+| 2023-12-21 12:34:56                                              |
++------------------------------------------------------------------+
+```
+
+
+Example 3: Convert the input into a DATETIME value with milliseconds precision
+
+```Plain Text
+MySQL root@127.1:(none)> select parse_datetime('21/December/23 12:34:56.123', 'dd/MMMM/yy HH:mm:ss.SSS');
++--------------------------------------------------------------------------+
+| parse_datetime('21/December/23 12:34:56.123', 'dd/MMMM/yy HH:mm:ss.SSS') |
++--------------------------------------------------------------------------+
+| 2023-12-21 12:34:56.123000                                               |
++--------------------------------------------------------------------------+
+```
+
+
+## keyword
+
+PARSE_DATETIME, DATETIME

--- a/docs/sql-reference/sql-functions/date-time-functions/str_to_jodatime.md
+++ b/docs/sql-reference/sql-functions/date-time-functions/str_to_jodatime.md
@@ -1,15 +1,15 @@
-# parse_datetime
+# str_to_jodatime
 
 ## Description
 
-Converts a string into a DATETIME value according to the specified format.
+Converts a joda-formatted string into a DATETIME value according to the specified format.
 
 The format is [Joda DateTime](https://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html), which is like 'yyyy-MM-dd HH:mm:ss'.
 
 ## Syntax
 
 ```Haskell
-DATETIME PARSE_DATETIME(VARCHAR str, VARCHAR format)
+DATETIME str_to_jodatime(VARCHAR str, VARCHAR format)
 ```
 
 ## Parameters
@@ -27,9 +27,9 @@ DATETIME PARSE_DATETIME(VARCHAR str, VARCHAR format)
 Example 1: Convert the input into a DATETIME value.
 
 ```Plain Text
-MySQL > select parse_datetime('2014-12-21 12:34:56', 'yyyy-MM-dd HH:mm:ss');
+MySQL > select str_to_jodatime('2014-12-21 12:34:56', 'yyyy-MM-dd HH:mm:ss');
 +--------------------------------------------------------------+
-| parse_datetime('2014-12-21 12:34:56', 'yyyy-MM-dd HH:mm:ss') |
+| str_to_jodatime('2014-12-21 12:34:56', 'yyyy-MM-dd HH:mm:ss') |
 +--------------------------------------------------------------+
 | 2014-12-21 12:34:56                                          |
 +--------------------------------------------------------------+
@@ -39,9 +39,9 @@ MySQL > select parse_datetime('2014-12-21 12:34:56', 'yyyy-MM-dd HH:mm:ss');
 Example 2: Convert the input into a DATETIME value with text-style month
 
 ```Plain Text
-MySQL > select parse_datetime('21/December/23 12:34:56', 'dd/MMMM/yy HH:mm:ss');
+MySQL > select str_to_jodatime('21/December/23 12:34:56', 'dd/MMMM/yy HH:mm:ss');
 +------------------------------------------------------------------+
-| parse_datetime('21/December/23 12:34:56', 'dd/MMMM/yy HH:mm:ss') |
+| str_to_jodatime('21/December/23 12:34:56', 'dd/MMMM/yy HH:mm:ss') |
 +------------------------------------------------------------------+
 | 2023-12-21 12:34:56                                              |
 +------------------------------------------------------------------+
@@ -51,9 +51,9 @@ MySQL > select parse_datetime('21/December/23 12:34:56', 'dd/MMMM/yy HH:mm:ss');
 Example 3: Convert the input into a DATETIME value with milliseconds precision
 
 ```Plain Text
-MySQL root@127.1:(none)> select parse_datetime('21/December/23 12:34:56.123', 'dd/MMMM/yy HH:mm:ss.SSS');
+MySQL root@127.1:(none)> select str_to_jodatime('21/December/23 12:34:56.123', 'dd/MMMM/yy HH:mm:ss.SSS');
 +--------------------------------------------------------------------------+
-| parse_datetime('21/December/23 12:34:56.123', 'dd/MMMM/yy HH:mm:ss.SSS') |
+| str_to_jodatime('21/December/23 12:34:56.123', 'dd/MMMM/yy HH:mm:ss.SSS') |
 +--------------------------------------------------------------------------+
 | 2023-12-21 12:34:56.123000                                               |
 +--------------------------------------------------------------------------+
@@ -62,4 +62,4 @@ MySQL root@127.1:(none)> select parse_datetime('21/December/23 12:34:56.123', 'd
 
 ## keyword
 
-PARSE_DATETIME, DATETIME
+str_to_jodatime, DATETIME

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -430,8 +430,8 @@ vectorized_functions = [
     [50243, 'str2date', 'DATE', ['VARCHAR', 'VARCHAR'], 'TimeFunctions::str2date', 'TimeFunctions::str_to_date_prepare', 'TimeFunctions::str_to_date_close'],
     
     # Joda Time parse & format
-    [50244, 'parse_datetime', 'DATETIME', ['VARCHAR', 'VARCHAR'], 
-            'TimeFunctions::parse_datetime', 
+    [50244, 'str_to_jodatime', 'DATETIME', ['VARCHAR', 'VARCHAR'], 
+            'TimeFunctions::parse_jodatime', 
             'TimeFunctions::parse_joda_prepare', 
             'TimeFunctions::parse_joda_close'],
             

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -428,14 +428,19 @@ vectorized_functions = [
     # the function will call by FE getStrToDateFunction, and is invisible to user
     [50240, 'str_to_date', 'DATETIME', ['VARCHAR', 'VARCHAR'], 'TimeFunctions::str_to_date', 'TimeFunctions::str_to_date_prepare', 'TimeFunctions::str_to_date_close'],
     [50243, 'str2date', 'DATE', ['VARCHAR', 'VARCHAR'], 'TimeFunctions::str2date', 'TimeFunctions::str_to_date_prepare', 'TimeFunctions::str_to_date_close'],
-    [50244, 'parse_datetime', 'DATETIME', ['VARCHAR', 'VARCHAR'], 'TimeFunctions::str_to_date', 'TimeFunctions::str_to_date_prepare', 'TimeFunctions::str_to_date_close'],
-
-    [50250, 'time_to_sec', 'BIGINT', ['TIME'], 'TimeFunctions::time_to_sec'],
+    
+    # Joda Time parse & format
+    [50244, 'parse_datetime', 'DATETIME', ['VARCHAR', 'VARCHAR'], 
+            'TimeFunctions::parse_datetime', 
+            'TimeFunctions::parse_joda_prepare', 
+            'TimeFunctions::parse_joda_close'],
+            
     [50260, 'jodatime_format', 'VARCHAR', ['DATETIME', 'VARCHAR'], 'TimeFunctions::jodadatetime_format', 'TimeFunctions::jodatime_format_prepare', 'TimeFunctions::jodatime_format_close'],
     [50261, 'jodatime_format', 'VARCHAR', ['DATE', 'VARCHAR'], 'TimeFunctions::jodadate_format', 'TimeFunctions::jodatime_format_prepare', 'TimeFunctions::jodatime_format_close'],
 
     [50262, 'to_iso8601', 'VARCHAR', ['DATETIME'], 'TimeFunctions::datetime_to_iso8601'],
     [50263, 'to_iso8601', 'VARCHAR', ['DATE'], 'TimeFunctions::date_to_iso8601'],
+    [50250, 'time_to_sec', 'BIGINT', ['TIME'], 'TimeFunctions::time_to_sec'],
 
     # unix timestamp extended version to int64
     # be sure to put before int32 version, so fe will find signature in order.

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -421,13 +421,15 @@ vectorized_functions = [
     [50221, 'current_date', 'DATE', [], 'TimeFunctions::curdate'],
     [50230, 'from_days', 'DATE', ['INT'], 'TimeFunctions::from_days'],
     [50231, 'to_days', 'INT', ['DATE'], 'TimeFunctions::to_days'],
+    [50241, 'date_format', 'VARCHAR', ['DATETIME', 'VARCHAR'], 'TimeFunctions::datetime_format', 'TimeFunctions::format_prepare', 'TimeFunctions::format_close'],
+    [50242, 'date_format', 'VARCHAR', ['DATE', 'VARCHAR'], 'TimeFunctions::date_format', 'TimeFunctions::format_prepare', 'TimeFunctions::format_close'],
+     
+    # From string to DATE/DATETIME
+    # the function will call by FE getStrToDateFunction, and is invisible to user
     [50240, 'str_to_date', 'DATETIME', ['VARCHAR', 'VARCHAR'], 'TimeFunctions::str_to_date', 'TimeFunctions::str_to_date_prepare', 'TimeFunctions::str_to_date_close'],
-    [50241, 'date_format', 'VARCHAR', ['DATETIME', 'VARCHAR'], 'TimeFunctions::datetime_format',
-     'TimeFunctions::format_prepare', 'TimeFunctions::format_close'],
-    [50242, 'date_format', 'VARCHAR', ['DATE', 'VARCHAR'], 'TimeFunctions::date_format',
-     'TimeFunctions::format_prepare', 'TimeFunctions::format_close'],
-    # cast string to date, the function will call by FE getStrToDateFunction, and is invisible to user
     [50243, 'str2date', 'DATE', ['VARCHAR', 'VARCHAR'], 'TimeFunctions::str2date', 'TimeFunctions::str_to_date_prepare', 'TimeFunctions::str_to_date_close'],
+    [50244, 'parse_datetime', 'DATETIME', ['VARCHAR', 'VARCHAR'], 'TimeFunctions::str_to_date', 'TimeFunctions::str_to_date_prepare', 'TimeFunctions::str_to_date_close'],
+
     [50250, 'time_to_sec', 'BIGINT', ['TIME'], 'TimeFunctions::time_to_sec'],
     [50260, 'jodatime_format', 'VARCHAR', ['DATETIME', 'VARCHAR'], 'TimeFunctions::jodadatetime_format', 'TimeFunctions::jodatime_format_prepare', 'TimeFunctions::jodatime_format_close'],
     [50261, 'jodatime_format', 'VARCHAR', ['DATE', 'VARCHAR'], 'TimeFunctions::jodadate_format', 'TimeFunctions::jodatime_format_prepare', 'TimeFunctions::jodatime_format_close'],


### PR DESCRIPTION
Fixes #26422 

parse and format with Joda format:
```sql
-- format
select jodatime_format(now(), 'MMMM dd yyyy HH:mm:ss');

-- parse
select str_to_jodatime('2023-08-02 14:37:02', 'yyyy-MM-dd HH:mm:ss');
```

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
