### PR TITLE
[Enhancement] Add trace to debug slow load channel open

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -393,6 +393,9 @@ CONF_Int32(make_snapshot_rpc_timeout_ms, "20000");
 // OlapTableSink sender's send interval, should be less than the real response time of a tablet writer rpc.
 CONF_mInt32(olap_table_sink_send_interval_ms, "10");
 
+CONF_mInt32(olap_table_sink_slow_rpc_threshold_us, "25000000");
+CONF_mInt32(olap_table_sink_slow_rpc_log_interval_ms, "1000")
+
 // Fragment thread pool
 CONF_Int32(fragment_pool_thread_num_min, "64");
 CONF_Int32(fragment_pool_thread_num_max, "4096");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -394,7 +394,7 @@ CONF_Int32(make_snapshot_rpc_timeout_ms, "20000");
 CONF_mInt32(olap_table_sink_send_interval_ms, "10");
 
 CONF_mInt32(olap_table_sink_slow_rpc_threshold_us, "25000000");
-CONF_mInt32(olap_table_sink_slow_rpc_log_interval_ms, "1000")
+CONF_mInt32(olap_table_sink_slow_rpc_log_interval_ms, "1000");
 
 // Fragment thread pool
 CONF_Int32(fragment_pool_thread_num_min, "64");

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -223,6 +223,7 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
     // we need use is_vectorized to make other BE open vectorized delta writer
     request.set_is_vectorized(true);
     request.set_timeout_ms(_rpc_timeout_ms);
+    request.set_request_time_ns(GetCurrentTimeNanos());
 
     // set global dict
     const auto& global_dict = _runtime_state->get_load_global_dict_map();

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -59,7 +59,7 @@
 namespace starrocks {
 
 LoadChannelOpenTimeStat::LoadChannelOpenTimeStat()
-        : _tablets_channel_stat(std::make_shared<LocalTabletsChannelOpenTimeStat>()) {}
+        : _tablets_channel_stat(std::make_shared<TabletsChannelOpenTimeStat>()) {}
 
 std::string LoadChannelOpenTimeStat::to_string() {
     std::stringstream ss;

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -63,7 +63,8 @@ LoadChannelOpenTimeStat::LoadChannelOpenTimeStat()
 
 std::string LoadChannelOpenTimeStat::to_string() {
     std::stringstream ss;
-    ss << "LoadChannel={start_time_ns=" << get_start_time() << ", lock_cost_ns=" << (get_lock_time() - get_start_time())
+    ss << "LoadChannel={start_time_ns=" << get_start_time() << ", total_cost_ns=" << get_total_time()
+       << ", lock_cost_ns=" << (get_lock_time() - get_start_time())
        << ", tablets_channel_cost_ns=" << _tablets_channel_stat->get_total_time()
        << ", other_cost_ns=" << (get_end_time() - _tablets_channel_stat->get_end_time()) << "}, "
        << _tablets_channel_stat->to_string();

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -64,10 +64,41 @@ class TabletsChannel;
 class LoadChannel;
 class LoadChannelMgr;
 class OlapTableSchemaParam;
+class TabletsChannelOpenTimeStat;
 
 namespace lake {
 class TabletManager;
 }
+
+class LoadChannelOpenTimeStat {
+public:
+    LoadChannelOpenTimeStat();
+
+    int64_t get_start_time() { return _start_time_ns; }
+
+    void set_start_time(int64_t start_time_ns) { _start_time_ns = start_time_ns; }
+
+    int64_t get_lock_time() { return _lock_time_ns; }
+
+    void set_lock_time(int64_t lock_time_ns) { _lock_time_ns = lock_time_ns; }
+
+    TabletsChannelOpenTimeStat* getTabletsChannelStat() { return _tablets_channel_stat.get(); }
+
+    int64_t get_end_time() { return _end_time_ns; }
+
+    void set_end_time(int64_t end_time_ns) { _end_time_ns = end_time_ns; }
+
+    int64_t get_total_time() { return _end_time_ns - _start_time_ns; }
+
+    std::string to_string();
+
+private:
+    int64_t _start_time_ns;
+    int64_t _lock_time_ns;
+    // TODO not support LakeTabletsChannel currently
+    std::shared_ptr<TabletsChannelOpenTimeStat> _tablets_channel_stat;
+    int64_t _end_time_ns;
+};
 
 // A LoadChannel manages tablets channels for all indexes
 // corresponding to a certain load job
@@ -85,7 +116,7 @@ public:
     // Open a new load channel if it does not exist.
     // NOTE: This method may be called multiple times, and each time with a different |request|.
     void open(brpc::Controller* cntl, const PTabletWriterOpenRequest& request, PTabletWriterOpenResult* response,
-              google::protobuf::Closure* done);
+              google::protobuf::Closure* done, LoadChannelOpenTimeStat* open_time_stat);
 
     void add_chunk(const PTabletWriterAddChunkRequest& request, PTabletWriterAddBatchResult* response);
 

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -87,7 +87,7 @@ static void log_slow_open_if_needed(const PTabletWriterOpenRequest& request, Loa
     ss << "LoadChannel open slow, txn_id: " << request.txn_id() << ", load_id: " << print_id(request.id())
        << ", end to end cost: " << end_to_end_duration_ns / 1000
        << " us, server cost: " << time_stat.get_total_time() / 1000 << "us, wait request cost: " << wait_request_us
-       << "us, client request time: " << request.request_time_ns() << " ns, " << time_stat.to_string();
+       << " us, client request time: " << request.request_time_ns() << " ns, " << time_stat.to_string();
 
     LOG(INFO) << ss.str();
 }

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -62,6 +62,35 @@ namespace starrocks {
 
 class Cache;
 
+class LoadChannelMgrOpenTimeStat {
+public:
+    LoadChannelMgrOpenTimeStat();
+
+    int64_t get_start_time() { return _start_time_ns; }
+
+    void set_start_time(int64_t start_time_ns) { _start_time_ns = start_time_ns; }
+
+    int64_t get_lock_time() { return _lock_time_ns; }
+
+    void set_lock_time(int64_t lock_time_ns) { _lock_time_ns = lock_time_ns; }
+
+    LoadChannelOpenTimeStat* get_load_channel_stat() { return _load_channel_stat.get(); }
+
+    int64_t get_end_time() { return _end_time_ns; }
+
+    void set_end_time(int64_t end_time_ns) { _end_time_ns = end_time_ns; }
+
+    int64_t get_total_time() { return _end_time_ns - _start_time_ns; }
+
+    std::string to_string();
+
+private:
+    int64_t _start_time_ns;
+    int64_t _lock_time_ns;
+    std::shared_ptr<LoadChannelOpenTimeStat> _load_channel_stat;
+    int64_t _end_time_ns;
+};
+
 // LoadChannelMgr -> LoadChannel -> TabletsChannel -> DeltaWriter
 // All dispatched load data for this backend is routed from this class
 class LoadChannelMgr {

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -45,7 +45,7 @@ public:
     const TabletsChannelKey& key() const { return _key; }
 
     Status open(const PTabletWriterOpenRequest& params, std::shared_ptr<OlapTableSchemaParam> schema,
-                bool is_incremental) override;
+                bool is_incremental, TabletsChannelOpenTimeStat* open_time_stat) override;
 
     void add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequest& request,
                    PTabletWriterAddBatchResult* response) override;
@@ -154,7 +154,7 @@ private:
         std::shared_ptr<WriteContext> _context;
     };
 
-    Status _open_all_writers(const PTabletWriterOpenRequest& params);
+    Status _open_all_writers(const PTabletWriterOpenRequest& params, TabletsChannelOpenTimeStat* stat);
 
     StatusOr<std::shared_ptr<WriteContext>> _create_write_context(Chunk* chunk,
                                                                   const PTabletWriterAddChunkRequest& request,

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -74,7 +74,7 @@ protected:
 inline std::string TabletsChannelOpenTimeStat::to_string() {
     std::stringstream ss;
     ss << "TabletsChannel={start_time_ns=" << get_start_time() << ", num_writers=" << _num_writers
-       << ", open_writer_cost_ns=" << _open_writer_cost_ns
+       << ", total_cost_ns=" << get_total_time() << ", open_writer_cost_ns=" << _open_writer_cost_ns
        << ", other_cost_ns=" << (get_total_time() - _open_writer_cost_ns) << "}";
     return ss.str();
 }

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -43,13 +43,48 @@ class PTabletWriterAddChunkRequest;
 class PTabletWriterAddSegmentRequest;
 class PTabletWriterAddSegmentResult;
 
+class TabletsChannelOpenTimeStat {
+public:
+    TabletsChannelOpenTimeStat() = default;
+
+    int64_t get_start_time() { return _start_time_ns; }
+
+    void set_start_time(int64_t start_time_ns) { _start_time_ns = start_time_ns; }
+
+    int64_t get_end_time() { return _end_time_ns; }
+
+    void set_end_time(int64_t end_time_ns) { _end_time_ns = end_time_ns; }
+
+    int64_t get_total_time() { return _end_time_ns - _start_time_ns; }
+
+    void add_open_writer_cost(int64_t cost_ns) {
+        _open_writer_cost_ns += cost_ns;
+        _num_writers += 1;
+    }
+
+    std::string to_string();
+
+protected:
+    int64_t _start_time_ns;
+    int64_t _end_time_ns;
+    int64_t _open_writer_cost_ns;
+    int64_t _num_writers;
+};
+
+std::string TabletsChannelOpenTimeStat::to_string() {
+    std::stringstream ss;
+    ss << "TabletsChannel={start_time_ns=" << get_start_time();
+    return ss.str();
+}
+
 class TabletsChannel {
 public:
     TabletsChannel() = default;
     virtual ~TabletsChannel() = default;
 
     [[nodiscard]] virtual Status open(const PTabletWriterOpenRequest& params,
-                                      std::shared_ptr<OlapTableSchemaParam> schema, bool is_incremental) = 0;
+                                      std::shared_ptr<OlapTableSchemaParam> schema, bool is_incremental,
+                                      TabletsChannelOpenTimeStat* open_time_stat) = 0;
 
     virtual Status incremental_open(const PTabletWriterOpenRequest& params,
                                     std::shared_ptr<OlapTableSchemaParam> schema) = 0;

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -73,7 +73,9 @@ protected:
 
 std::string TabletsChannelOpenTimeStat::to_string() {
     std::stringstream ss;
-    ss << "TabletsChannel={start_time_ns=" << get_start_time();
+    ss << "TabletsChannel={start_time_ns=" << get_start_time() << ", num_writers=" << _num_writers
+       << ", open_writer_cost_ns=" << _open_writer_cost_ns
+       << ", other_cost_ns=" << (get_total_time() - _open_writer_cost_ns) << "}";
     return ss.str();
 }
 

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -71,7 +71,7 @@ protected:
     int64_t _num_writers;
 };
 
-std::string TabletsChannelOpenTimeStat::to_string() {
+inline std::string TabletsChannelOpenTimeStat::to_string() {
     std::stringstream ss;
     ss << "TabletsChannel={start_time_ns=" << get_start_time() << ", num_writers=" << _num_writers
        << ", open_writer_cost_ns=" << _open_writer_cost_ns

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -264,8 +264,8 @@ protected:
 TEST_F(LakeTabletsChannelTest, test_simple_write) {
     auto open_request = _open_request;
     open_request.set_num_senders(1);
-
-    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false));
+    TabletsChannelOpenTimeStat open_time_stat;
+    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false, &open_time_stat));
 
     constexpr int kChunkSize = 128;
     constexpr int kChunkSizePerTablet = kChunkSize / 4;
@@ -365,8 +365,8 @@ TEST_F(LakeTabletsChannelTest, test_simple_write) {
 TEST_F(LakeTabletsChannelTest, test_write_partial_partition) {
     auto open_request = _open_request;
     open_request.set_num_senders(1);
-
-    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false));
+    TabletsChannelOpenTimeStat open_time_stat;
+    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false, &open_time_stat));
 
     constexpr int kChunkSize = 128;
     constexpr int kChunkSizePerTablet = kChunkSize / 2;
@@ -422,7 +422,8 @@ TEST_F(LakeTabletsChannelTest, test_write_partial_partition) {
 }
 
 TEST_F(LakeTabletsChannelTest, test_write_concurrently) {
-    ASSERT_OK(_tablets_channel->open(_open_request, _schema_param, false));
+    TabletsChannelOpenTimeStat open_time_stat;
+    ASSERT_OK(_tablets_channel->open(_open_request, _schema_param, false, &open_time_stat));
 
     constexpr int kChunkSize = 128;
     constexpr int kChunkSizePerTablet = kChunkSize / 4;
@@ -488,8 +489,8 @@ TEST_F(LakeTabletsChannelTest, test_write_concurrently) {
 TEST_F(LakeTabletsChannelTest, DISABLED_test_abort) {
     auto open_request = _open_request;
     open_request.set_num_senders(1);
-
-    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false));
+    TabletsChannelOpenTimeStat open_time_stat;
+    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false, &open_time_stat));
 
     constexpr int kChunkSize = 128;
     constexpr int kChunkSizePerTablet = kChunkSize / 4;
@@ -552,8 +553,8 @@ TEST_F(LakeTabletsChannelTest, DISABLED_test_abort) {
 TEST_F(LakeTabletsChannelTest, test_write_failed) {
     auto open_request = _open_request;
     open_request.set_num_senders(1);
-
-    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false));
+    TabletsChannelOpenTimeStat open_time_stat;
+    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false, &open_time_stat));
 
     constexpr int kChunkSize = 128;
     constexpr int kChunkSizePerTablet = kChunkSize / 4;
@@ -589,8 +590,8 @@ TEST_F(LakeTabletsChannelTest, test_write_failed) {
 TEST_F(LakeTabletsChannelTest, test_empty_tablet) {
     auto open_request = _open_request;
     open_request.set_num_senders(1);
-
-    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false));
+    TabletsChannelOpenTimeStat open_time_stat;
+    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false, &open_time_stat));
 
     constexpr int kChunkSize = 12;
     auto chunk = generate_data(kChunkSize);
@@ -654,8 +655,8 @@ TEST_F(LakeTabletsChannelTest, test_empty_tablet) {
 TEST_F(LakeTabletsChannelTest, test_finish_failed) {
     auto open_request = _open_request;
     open_request.set_num_senders(1);
-
-    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false));
+    TabletsChannelOpenTimeStat open_time_stat;
+    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false, &open_time_stat));
 
     constexpr int kChunkSize = 12;
     auto chunk = generate_data(kChunkSize);
@@ -698,8 +699,8 @@ TEST_F(LakeTabletsChannelTest, test_finish_failed) {
 TEST_F(LakeTabletsChannelTest, test_finish_after_abort) {
     auto open_request = _open_request;
     open_request.set_num_senders(2);
-
-    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false));
+    TabletsChannelOpenTimeStat open_time_stat;
+    ASSERT_OK(_tablets_channel->open(open_request, _schema_param, false, &open_time_stat));
 
     {
         constexpr int kChunkSize = 128;

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -258,7 +258,8 @@ TEST_F(LoadChannelTestForLakeTablet, test_simple_write) {
     PTabletWriterOpenRequest open_request = _open_request;
     PTabletWriterOpenResult open_response;
     open_request.set_num_senders(1);
-    _load_channel->open(nullptr, open_request, &open_response, nullptr);
+    LoadChannelOpenTimeStat open_time_stat;
+    _load_channel->open(nullptr, open_request, &open_response, nullptr, &open_time_stat);
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -327,7 +328,8 @@ TEST_F(LoadChannelTestForLakeTablet, test_simple_write) {
 TEST_F(LoadChannelTestForLakeTablet, test_write_concurrently) {
     PTabletWriterOpenRequest open_request = _open_request;
     PTabletWriterOpenResult open_response;
-    _load_channel->open(nullptr, open_request, &open_response, nullptr);
+    LoadChannelOpenTimeStat open_time_stat;
+    _load_channel->open(nullptr, open_request, &open_response, nullptr, &open_time_stat);
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -396,7 +398,8 @@ TEST_F(LoadChannelTestForLakeTablet, test_abort) {
     PTabletWriterOpenRequest open_request = _open_request;
     PTabletWriterOpenResult open_response;
     open_request.set_num_senders(1);
-    _load_channel->open(nullptr, open_request, &open_response, nullptr);
+    LoadChannelOpenTimeStat open_time_stat;
+    _load_channel->open(nullptr, open_request, &open_response, nullptr, &open_time_stat);
     ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
 
     constexpr int kChunkSize = 128;
@@ -463,7 +466,8 @@ TEST_F(LoadChannelTestForLakeTablet, test_incremental_open) {
         PTabletWriterOpenResult open_response;
         open_request.set_num_senders(1);
         open_request.set_is_incremental(true);
-        _load_channel->open(nullptr, open_request, &open_response, nullptr);
+        LoadChannelOpenTimeStat open_time_stat;
+        _load_channel->open(nullptr, open_request, &open_response, nullptr, &open_time_stat);
         ASSERT_EQ(TStatusCode::OK, open_response.status().status_code()) << open_response.status().error_msgs(0);
     }
 
@@ -471,7 +475,8 @@ TEST_F(LoadChannelTestForLakeTablet, test_incremental_open) {
         PTabletWriterOpenRequest open_request = _open_request;
         PTabletWriterOpenResult open_response;
         open_request.set_is_incremental(true);
-        _load_channel->open(nullptr, open_request, &open_response, nullptr);
+        LoadChannelOpenTimeStat open_time_stat;
+        _load_channel->open(nullptr, open_request, &open_response, nullptr, &open_time_stat);
         EXPECT_EQ(TStatusCode::NOT_IMPLEMENTED_ERROR, open_response.status().status_code());
         EXPECT_EQ("incremental open not supported by this tablets channel", open_response.status().error_msgs(0));
     }
@@ -482,7 +487,8 @@ TEST_F(LoadChannelTestForLakeTablet, test_add_segment) {
         PTabletWriterOpenRequest open_request = _open_request;
         PTabletWriterOpenResult open_response;
         open_request.set_num_senders(1);
-        _load_channel->open(nullptr, open_request, &open_response, nullptr);
+        LoadChannelOpenTimeStat open_time_stat;
+        _load_channel->open(nullptr, open_request, &open_response, nullptr, &open_time_stat);
         ASSERT_EQ(TStatusCode::OK, open_response.status().status_code());
     }
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -174,6 +174,7 @@ message PTabletWriterOpenRequest {
     // When the data load in progress, the partition created by automatic partition needs incremental open
     optional bool is_incremental = 29 [default = false];
     optional int32 sender_id = 30;
+    optional int64 request_time_ns = 31;
 };
 
 message PTabletWriterOpenResult {


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

When ingesting via flink connector or routine load, tablet could open failed because rpc timeout, and we want to add some traces to find where the time spends on the tablet open path. 

```
tablet_sink.cpp:1175] NodeChannel[11395865], tablet open failed, load_id=cdc318f1-057d-11ee-b613-525400aad046, txn_id:  14424202, parallel=1, compress_type=2, node=10.128.8.78:8060, errmsg=[E1008]Reached timeout=60000ms @10.128.8.78:8060
```
This PR only considers the tablet open RPC, and we could add traces for other RPC if needed later.
Note: this is a draft base on branch-3.0 for testing currently, and the final pr will be based on main after resolve the conflicts.

The log is like
```
I0719 21:48:54.882392 199992 load_channel_mgr.cpp:92] LoadChannel open slow, txn_id: 9, load_id: 0e4947ed-6ed5-3fec-199b-9a9d96608580, end to end cost: 297 us, server cost: 159us, wait request cost: 137 us, client request time: 1689774534882079177 ns, LoadChannelMgr={start_time_ns=1689774534882216892, lock_cost_ns=489, load_channel_cost_ns=85385, other_cost_ns=54906}, LoadChannel={start_time_ns=1689774534882236411, total_cost_ns=85385, lock_cost_ns=2865, tablets_channel_cost_ns=74632, other_cost_ns=1201}, TabletsChannel={start_time_ns=1689774534882245963, num_writers=3, total_cost_ns=74632, open_writer_cost_ns=43124, other_cost_ns=31508}
```



## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
