### PR TITLE
[BugFix] Remove incorrect exception throws

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -523,8 +523,6 @@ public class OlapTableSink extends DataSink {
                                 selectedBackedIds.add(replicas.get(0).getBackendId());
                             } else {
                                 LOG.warn("Tablet {} replicas {} all has write fail flag", tablet.getId(), replicas);
-                                throw new UserException(InternalErrorCode.REPLICA_FEW_ERR,
-                                        String.format("Tablet %d replicas %s all has write fail flag", tablet.getId(), replicas));
                             }
                         }
                         locationParam


### PR DESCRIPTION
If we enable replicated storage, we will try to pick a replica as the primary replica. We will record the last write status and skip the write fail replica. However, if all replica failed during last write, we should pick a replica as primary replica at random. But we throw a exception right now.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
