### PR TITLE
[BugFix] Fix crash caused by script bind method call with null pointer

### DIFF
--- a/be/src/thirdparty/wrenbind17/wrenbind17/caller.hpp
+++ b/be/src/thirdparty/wrenbind17/wrenbind17/caller.hpp
@@ -86,6 +86,9 @@ struct ForeignMethodCaller {
     template <R (T::*Fn)(Args...), size_t... Is>
     static void callFrom(WrenVM* vm, detail::index_list<Is...>) {
         auto self = PopHelper<T*>::f(vm, 0);
+        if (self == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
         // R ret = (self->*Fn)(PopHelper<typename std::remove_const<Args>::type>::f(vm, Is + 1)...);
         // PushHelper<R>::f(vm, 0, ret);
         ForeginMethodReturnHelper<R>::push(
@@ -104,6 +107,9 @@ struct ForeignMethodCaller {
     template <R (T::*Fn)(Args...) const, size_t... Is>
     static void callFrom(WrenVM* vm, detail::index_list<Is...>) {
         auto self = PopHelper<T*>::f(vm, 0);
+        if (self == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
         // R ret = (self->*Fn)(PopHelper<typename std::remove_const<Args>::type>::f(vm, Is + 1)...);
         // PushHelper<R>::f(vm, 0, ret);
         ForeginMethodReturnHelper<R>::push(
@@ -125,6 +131,9 @@ struct ForeignMethodCaller<void, T, Args...> {
     template <void (T::*Fn)(Args...), size_t... Is>
     static void callFrom(WrenVM* vm, detail::index_list<Is...>) {
         auto self = PopHelper<T*>::f(vm, 0);
+        if (self == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
         (self->*Fn)(PopHelper<typename std::remove_const<Args>::type>::f(vm, Is + 1)...);
     }
 
@@ -140,6 +149,9 @@ struct ForeignMethodCaller<void, T, Args...> {
     template <void (T::*Fn)(Args...) const, size_t... Is>
     static void callFrom(WrenVM* vm, detail::index_list<Is...>) {
         auto self = PopHelper<T*>::f(vm, 0);
+        if (self == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
         (self->*Fn)(PopHelper<typename std::remove_const<Args>::type>::f(vm, Is + 1)...);
     }
 
@@ -158,6 +170,9 @@ struct ForeignMethodExtCaller {
     template <R (*Fn)(T&, Args...), size_t... Is>
     static void callFrom(WrenVM* vm, detail::index_list<Is...>) {
         auto self = PopHelper<T*>::f(vm, 0);
+        if (self == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
         // R ret = (*Fn)(*self, PopHelper<typename std::remove_const<Args>::type>::f(vm, Is + 1)...);
         // PushHelper<R>::f(vm, 0, ret);
         ForeginMethodReturnHelper<R>::push(
@@ -179,6 +194,9 @@ struct ForeignMethodExtCaller<void, T, Args...> {
     template <void (*Fn)(T&, Args...), size_t... Is>
     static void callFrom(WrenVM* vm, detail::index_list<Is...>) {
         auto self = PopHelper<T*>::f(vm, 0);
+        if (self == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
         (*Fn)(*self, PopHelper<typename std::remove_const<Args>::type>::f(vm, Is + 1)...);
     }
 
@@ -233,11 +251,17 @@ template <typename T, typename V, V T::*Ptr>
 struct ForeignPropCaller {
     static void setter(WrenVM* vm) {
         auto self = PopHelper<T*>::f(vm, 0);
+        if (self == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
         self->*Ptr = PopHelper<V>::f(vm, 1);
     }
 
     static void getter(WrenVM* vm) {
         auto self = PopHelper<T*>::f(vm, 0);
+        if (self == nullptr) {
+            throw std::runtime_error("null pointer");
+        }
         PushHelper<V>::f(vm, 0, std::forward<decltype(self->*Ptr)>(self->*Ptr));
     }
 };


### PR DESCRIPTION
This  PR fixes crash caused by script bind method call with null pointer, it will check object is null before call it's method, and an exception will be thrown. 

```
mysql> admin execute on 10006 'var t = StorageEngine.get_tablet(39703) 
    '> System.print("info: %(t.updates().toPB().toString())")';
+-----------------------------+
| result                      |
+-----------------------------+
| Runtime error: null pointer |
|   at: main:2                |
+-----------------------------+
2 rows in set (0.08 sec)

```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
