### PR TITLE
[BugFix] Limit bytes returned by left_bytes_string

### DIFF
--- a/be/src/exec/json_parser.cpp
+++ b/be/src/exec/json_parser.cpp
@@ -90,7 +90,9 @@ std::string JsonDocumentStreamParser::left_bytes_string(size_t sz) noexcept {
     if (off >= _len) {
         return {};
     }
-    return std::string(reinterpret_cast<char*>(_data) + off, _len - off);
+
+    auto len = std::min(_len - off, sz);
+    return std::string(reinterpret_cast<char*>(_data) + off, len);
 }
 
 Status JsonArrayParser::parse(char* data, size_t len, size_t allocated) noexcept {
@@ -174,7 +176,8 @@ std::string JsonArrayParser::left_bytes_string(size_t sz) noexcept {
         return {};
     }
 
-    return std::string(reinterpret_cast<const char*>(_data) + off, _len - off);
+    auto len = std::min(_len - off, sz);
+    return std::string(reinterpret_cast<const char*>(_data) + off, len);
 }
 
 Status JsonDocumentStreamParserWithRoot::get_current(simdjson::ondemand::object* row) noexcept {

--- a/be/test/exec/json_parser_test.cpp
+++ b/be/test/exec/json_parser_test.cpp
@@ -486,7 +486,6 @@ PARALLEL_TEST(JsonParserTest, test_illegal_json_array) {
     {"key4": 4}])");
 }
 
-
 PARALLEL_TEST(JsonParserTest, test_big_illegal_json_array) {
     // json array with ' ', '/t', '\n'
     std::string input = R"( [  {"key1": 1}, "key2": "123456789012345678901234567890"},    {"key3": 3},
@@ -518,7 +517,6 @@ PARALLEL_TEST(JsonParserTest, test_big_illegal_json_array) {
     ASSERT_TRUE(st.is_data_quality_error());
     ASSERT_STREQ(parser->left_bytes_string(10).data(), R"("key2": "1)");
 }
-
 
 PARALLEL_TEST(JsonParserTest, test_big_value) {
     simdjson::ondemand::parser simdjson_parser;

--- a/be/test/exec/json_parser_test.cpp
+++ b/be/test/exec/json_parser_test.cpp
@@ -424,6 +424,35 @@ PARALLEL_TEST(JsonParserTest, test_illegal_document_stream) {
     {"key4": 4})");
 }
 
+PARALLEL_TEST(JsonParserTest, test_big_illegal_document_stream) {
+    // ndjson with ' ', '/t', '\n'
+    std::string input = R"(   {"key1": 1} "key2": 012345678901234567890123456789012345678901234567890"} {"key3": 3})";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParser(&simdjson_parser));
+
+    auto st = parser->parse(reinterpret_cast<uint8_t*>(input.data()), size, padded_size);
+
+    simdjson::ondemand::object row;
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    int64_t val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.is_data_quality_error());
+    ASSERT_STREQ(parser->left_bytes_string(10).data(), R"("key2": 01)");
+}
+
 PARALLEL_TEST(JsonParserTest, test_illegal_json_array) {
     // json array with ' ', '/t', '\n'
     std::string input = R"( [  {"key1": 1}, "key2": 2},    {"key3": 3},
@@ -456,6 +485,40 @@ PARALLEL_TEST(JsonParserTest, test_illegal_json_array) {
     ASSERT_STREQ(parser->left_bytes_string(64).data(), R"("key2": 2},    {"key3": 3},
     {"key4": 4}])");
 }
+
+
+PARALLEL_TEST(JsonParserTest, test_big_illegal_json_array) {
+    // json array with ' ', '/t', '\n'
+    std::string input = R"( [  {"key1": 1}, "key2": "123456789012345678901234567890"},    {"key3": 3},
+    {"key4": 4}])";
+    // Reserved for simdjson padding.
+    auto size = input.size();
+    input.resize(input.size() + simdjson::SIMDJSON_PADDING);
+    auto padded_size = input.size();
+
+    simdjson::ondemand::parser simdjson_parser;
+
+    std::unique_ptr<JsonParser> parser(new JsonArrayParser(&simdjson_parser));
+
+    auto st = parser->parse(reinterpret_cast<uint8_t*>(input.data()), size, padded_size);
+
+    ASSERT_TRUE(st.ok());
+
+    simdjson::ondemand::object row;
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.ok());
+    int64_t val = row.find_field("key1").get_int64();
+    ASSERT_EQ(val, 1);
+
+    st = parser->advance();
+    ASSERT_TRUE(st.ok());
+
+    st = parser->get_current(&row);
+    ASSERT_TRUE(st.is_data_quality_error());
+    ASSERT_STREQ(parser->left_bytes_string(10).data(), R"("key2": "1)");
+}
+
 
 PARALLEL_TEST(JsonParserTest, test_big_value) {
     simdjson::ondemand::parser simdjson_parser;

--- a/be/test/exec/json_parser_test.cpp
+++ b/be/test/exec/json_parser_test.cpp
@@ -436,7 +436,7 @@ PARALLEL_TEST(JsonParserTest, test_big_illegal_document_stream) {
 
     std::unique_ptr<JsonParser> parser(new JsonDocumentStreamParser(&simdjson_parser));
 
-    auto st = parser->parse(reinterpret_cast<uint8_t*>(input.data()), size, padded_size);
+    auto st = parser->parse(input.data(), size, padded_size);
 
     simdjson::ondemand::object row;
 
@@ -499,7 +499,7 @@ PARALLEL_TEST(JsonParserTest, test_big_illegal_json_array) {
 
     std::unique_ptr<JsonParser> parser(new JsonArrayParser(&simdjson_parser));
 
-    auto st = parser->parse(reinterpret_cast<uint8_t*>(input.data()), size, padded_size);
+    auto st = parser->parse(input.data(), size, padded_size);
 
     ASSERT_TRUE(st.ok());
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
The `JsonParser::left_bytes_string(size_t sz)` returns all left bytes now, while the argument `sz` dose not work at all.

Fixes 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
