### PR TITLE
[BugFix] fix mv rewrite for join predicate pushdown

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -133,6 +133,10 @@ public class OptimizerTraceUtil {
         }
     }
 
+    public static void logMVPrepare(String format, Object... object) {
+        logMVPrepare(ConnectContext.get(), null, format, object);
+    }
+
     public static void logMVPrepare(ConnectContext ctx, String format, Object... object) {
         logMVPrepare(ctx, null, format, object);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -162,6 +162,23 @@ public final class ColumnRefOperator extends ScalarOperator {
         return id == column.id;
     }
 
+    @Override
+    public boolean equivalent(Object obj) {
+        if (!(obj instanceof ColumnRefOperator)) {
+            return false;
+        }
+
+        if (obj == this) {
+            return true;
+        }
+
+        ColumnRefOperator leftColumn = (ColumnRefOperator) this;
+        ColumnRefOperator rightColumn = (ColumnRefOperator) obj;
+        return leftColumn.getName().equals(rightColumn.getName())
+                && leftColumn.getType().equals(rightColumn.getType())
+                && leftColumn.isNullable() == rightColumn.isNullable();
+    }
+
     /**
      * return default value "col" to eliminate the influence of
      * column ref id on UT, make ut code can be fuzzy matching

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/PredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/PredicateOperator.java
@@ -88,6 +88,26 @@ public abstract class PredicateOperator extends ScalarOperator {
     }
 
     @Override
+    public boolean equivalent(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        PredicateOperator other = (PredicateOperator) obj;
+        if (this.arguments.size() != other.arguments.size()) {
+            return false;
+        }
+        for (int i = 0; i < this.arguments.size(); i++) {
+            if (!this.arguments.get(i).equivalent(other.arguments.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
     public ScalarOperator clone() {
         PredicateOperator operator = (PredicateOperator) super.clone();
         // Deep copy here

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -137,6 +137,13 @@ public abstract class ScalarOperator implements Cloneable {
     @Override
     public abstract boolean equals(Object other);
 
+    /**
+     * equivalent means logical equals, but may physical different, such as with different id
+     */
+    public boolean equivalent(Object other) {
+        return equals(other);
+    }
+
     public abstract <R, C> R accept(ScalarOperatorVisitor<R, C> visitor, C context);
 
     // Default Shallow Clone for ConstantOperator and ColumnRefOperator
@@ -216,29 +223,22 @@ public abstract class ScalarOperator implements Cloneable {
     }
 
     // whether ScalarOperator are equals without id
-    public static boolean isEqual(ScalarOperator left, ScalarOperator right) {
+    public static boolean isEquivalent(ScalarOperator left, ScalarOperator right) {
         if (!left.getOpType().equals(right.getOpType())) {
             return false;
         }
-        if (left.getOpType().equals(OperatorType.VARIABLE)) {
-            ColumnRefOperator leftColumn = (ColumnRefOperator) left;
-            ColumnRefOperator rightColumn = (ColumnRefOperator) right;
-            return leftColumn.getName().equals(rightColumn.getName())
-                    && leftColumn.getType().equals(rightColumn.getType())
-                    && leftColumn.isNullable() == rightColumn.isNullable();
-        } else {
-            boolean ret = left.equals(right);
-            if (!ret) {
+
+        boolean ret = left.equivalent(right);
+        if (!ret) {
+            return false;
+        }
+        Preconditions.checkState(left.getChildren().size() == right.getChildren().size());
+        for (int i = 0; i < left.getChildren().size(); i++) {
+            if (!isEquivalent(left.getChild(i), right.getChild(i))) {
                 return false;
             }
-            Preconditions.checkState(left.getChildren().size() == right.getChildren().size());
-            for (int i = 0; i < left.getChildren().size(); i++) {
-                if (!isEqual(left.getChild(i), right.getChild(i))) {
-                    return false;
-                }
-            }
-            return true;
         }
+        return true;
     }
 
     public static boolean isColumnEqualBinaryPredicate(ScalarOperator predicate) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1811,11 +1811,14 @@ public class MaterializedViewRewriter {
             ColumnRefOperator left = (ColumnRefOperator) equalPredicate.getChild(0);
             Preconditions.checkState(equalPredicate.getChild(1).isColumnRef());
             ColumnRefOperator right = (ColumnRefOperator) equalPredicate.getChild(1);
-            ColumnRefOperator leftTarget = columnRewriter.rewriteViewToQuery(left).cast();
-            ColumnRefOperator rightTarget = columnRewriter.rewriteViewToQuery(right).cast();
-            if (leftTarget == null || rightTarget == null) {
-                return null;
+            ScalarOperator leftScalar = columnRewriter.rewriteViewToQuery(left);
+            ScalarOperator rightScalar = columnRewriter.rewriteViewToQuery(right);
+            if (leftScalar == null || rightScalar == null) {
+                return ec;
             }
+
+            ColumnRefOperator leftTarget = leftScalar.cast();
+            ColumnRefOperator rightTarget = rightScalar.cast();
             ec.addEquivalence(leftTarget, rightTarget);
         }
         return ec;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -83,7 +83,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 
 /*
@@ -190,7 +189,7 @@ public class MaterializedViewRewriter {
         LogicalOperator queryOp = (LogicalOperator) queryExpr.getOp();
         LogicalOperator mvOp = (LogicalOperator) mvExpr.getOp();
         if (!queryOp.getOpType().equals(mvOp.getOpType())) {
-            logMVPrepare("join type is different {} != {}", queryOp.getOpType(), mvOp.getOpType());
+            logMVRewrite(mvRewriteContext, "join type is different {} != {}", queryOp.getOpType(), mvOp.getOpType());
             return false;
         }
         if (queryOp instanceof LogicalJoinOperator) {
@@ -207,7 +206,7 @@ public class MaterializedViewRewriter {
             JoinOperator mvJoinType = mvJoin.getJoinType();
 
             if (!ScalarOperator.isEquivalent(queryJoin.getOnPredicate(), (mvJoin.getOnPredicate()))) {
-                logMVPrepare("join predicate is different {} != {}", queryJoin.getOnPredicate(),
+                logMVRewrite(mvRewriteContext, "join predicate is different {} != {}", queryJoin.getOnPredicate(),
                         mvJoin.getOnPredicate());
                 return false;
             }
@@ -217,7 +216,8 @@ public class MaterializedViewRewriter {
             }
 
             if (!JOIN_COMPATIBLE_MAP.get(mvJoinType).contains(queryJoinType)) {
-                logMVPrepare("join type is not compatible {} not contains {}", mvJoinType, queryJoinType);
+                logMVRewrite(mvRewriteContext, "join type is not compatible {} not contains {}", mvJoinType,
+                        queryJoinType);
                 return false;
             }
 
@@ -229,7 +229,7 @@ public class MaterializedViewRewriter {
             boolean isSupported =
                     isSupportedPredicate(queryOnPredicate, materializationContext.getQueryRefFactory(), joinColumns);
             if (!isSupported) {
-                logMVPrepare("join predicate is not supported {}", queryOnPredicate);
+                logMVRewrite(mvRewriteContext, "join predicate is not supported {}", queryOnPredicate);
                 return false;
             }
             // use join columns from query
@@ -244,7 +244,7 @@ public class MaterializedViewRewriter {
             boolean isCompatible =
                     isJoinCompatible(usedColumnsToTable, queryJoinType, mvJoinType, leftColumns, rightColumns, joinColumnRefs);
             if (!isCompatible) {
-                logMVPrepare("join columns not compatible {} != {}", leftColumns, rightColumns);
+                logMVRewrite(mvRewriteContext, "join columns not compatible {} != {}", leftColumns, rightColumns);
                 return false;
             }
             JoinDeriveContext joinDeriveContext = new JoinDeriveContext(queryJoinType, mvJoinType, joinColumnRefs);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -1434,4 +1434,67 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 "     PREAGGREGATION: ON");
         dropMv("test", "forbid_mv_1");
     }
+
+    @Test
+    public void testJoinPredicatePushdown() throws Exception {
+        cluster.runSql("test", "CREATE TABLE pushdown_t1 (\n" +
+                "    `c0` string,\n" +
+                "    `c1` string,\n" +
+                "    `c2` string,\n" +
+                "    `c3` string,\n" +
+                "    `c4` string,\n" +
+                "    `c5` string ,\n" +
+                "    `c6` string,\n" +
+                "    `c7`  date\n" +
+                ") \n" +
+                "DUPLICATE KEY (c0)\n" +
+                "DISTRIBUTED BY HASH(c0)\n" +
+                "properties('replication_num' = '1');");
+        cluster.runSql("test", "CREATE TABLE `pushdown_t2` (\n" +
+                "  `c0` varchar(65533) NULL ,\n" +
+                "  `c1` varchar(65533) NULL ,\n" +
+                "  `c2` varchar(65533) NULL ,\n" +
+                "  `c3` varchar(65533) NULL ,\n" +
+                "  `c4` varchar(65533) NULL ,\n" +
+                "  `c5` varchar(65533) NULL ,\n" +
+                "  `c6` varchar(65533) NULL ,\n" +
+                "  `c7` varchar(65533) NULL ,\n" +
+                "  `c8` varchar(65533) NULL ,\n" +
+                "  `c9` varchar(65533) NULL ,\n" +
+                "  `c10` varchar(65533) NULL ,\n" +
+                "  `c11` date NULL ,\n" +
+                "  `c12` datetime NULL \n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY (c0)\n" +
+                "DISTRIBUTED BY HASH(c0)\n" +
+                "PROPERTIES ( \"replication_num\" = \"1\");");
+        createAndRefreshMv("test", "_pushdown_predicate_join_mv1",
+                "CREATE MATERIALIZED VIEW `_pushdown_predicate_join_mv1`  \n" +
+                        "DISTRIBUTED BY HASH(c12) BUCKETS 18 \n" +
+                        "REFRESH MANUAL \n" +
+                        "PROPERTIES ( \"replication_num\" = \"1\", \"storage_medium\" = \"HDD\") \n" +
+                        "AS\n" +
+                        "SELECT t1.c0, t1.c1, t2.c7, t2.c12\n" +
+                        "FROM\n" +
+                        "    ( SELECT `c0`, `c7`, `c12` FROM `pushdown_t2`) t2\n" +
+                        "    LEFT OUTER JOIN \n" +
+                        "    ( SELECT c0, c1, c7 FROM pushdown_t1 ) t1\n" +
+                        "    ON `t2`.`c0` = `t1`.`c0`\n" +
+                        "    AND t2.c0 IS NOT NULL " +
+                        "    AND date(t2.`c12`) = `t1`.`c7`\n" +
+                        "   ;");
+
+        String query = "SELECT t1.c0, t1.c1, t2.c7, t2.c12\n" +
+                "FROM\n" +
+                "    ( SELECT `c0`, `c7`, `c12` FROM `pushdown_t2`) t2\n" +
+                "    LEFT OUTER JOIN \n" +
+                "    ( SELECT c0, c1, c7 FROM pushdown_t1 ) t1\n" +
+                "    ON `t2`.`c0` = `t1`.`c0`\n" +
+                "    AND t2.c0 IS NOT NULL " +
+                "    AND date(t2.`c12`) = `t1`.`c7`\n" +
+                "   ;";
+
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "_pushdown_predicate_join_mv1");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -28,6 +28,7 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -1468,6 +1469,8 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 "DUPLICATE KEY (c0)\n" +
                 "DISTRIBUTED BY HASH(c0)\n" +
                 "PROPERTIES ( \"replication_num\" = \"1\");");
+
+        // With null-rejecting predicate
         createAndRefreshMv("test", "_pushdown_predicate_join_mv1",
                 "CREATE MATERIALIZED VIEW `_pushdown_predicate_join_mv1`  \n" +
                         "DISTRIBUTED BY HASH(c12) BUCKETS 18 \n" +
@@ -1493,8 +1496,71 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 "    AND t2.c0 IS NOT NULL " +
                 "    AND date(t2.`c12`) = `t1`.`c7`\n" +
                 "   ;";
-
         String plan = getFragmentPlan(query);
         PlanTestBase.assertContains(plan, "_pushdown_predicate_join_mv1");
+    }
+
+    @Ignore("outer join and pushdown predicate does not work")
+    @Test
+    public void testJoinPredicatePushdown1() throws Exception {
+        cluster.runSql("test", "CREATE TABLE pushdown_t1 (\n" +
+                "    `c0` string,\n" +
+                "    `c1` string,\n" +
+                "    `c2` string,\n" +
+                "    `c3` string,\n" +
+                "    `c4` string,\n" +
+                "    `c5` string ,\n" +
+                "    `c6` string,\n" +
+                "    `c7`  date\n" +
+                ") \n" +
+                "DUPLICATE KEY (c0)\n" +
+                "DISTRIBUTED BY HASH(c0)\n" +
+                "properties('replication_num' = '1');");
+        cluster.runSql("test", "CREATE TABLE `pushdown_t2` (\n" +
+                "  `c0` varchar(65533) NULL ,\n" +
+                "  `c1` varchar(65533) NULL ,\n" +
+                "  `c2` varchar(65533) NULL ,\n" +
+                "  `c3` varchar(65533) NULL ,\n" +
+                "  `c4` varchar(65533) NULL ,\n" +
+                "  `c5` varchar(65533) NULL ,\n" +
+                "  `c6` varchar(65533) NULL ,\n" +
+                "  `c7` varchar(65533) NULL ,\n" +
+                "  `c8` varchar(65533) NULL ,\n" +
+                "  `c9` varchar(65533) NULL ,\n" +
+                "  `c10` varchar(65533) NULL ,\n" +
+                "  `c11` date NULL ,\n" +
+                "  `c12` datetime NULL \n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY (c0)\n" +
+                "DISTRIBUTED BY HASH(c0)\n" +
+                "PROPERTIES ( \"replication_num\" = \"1\");");
+
+        // Without null-rejecting predicate
+        createAndRefreshMv("test", "_pushdown_predicate_join_mv2",
+                "CREATE MATERIALIZED VIEW `_pushdown_predicate_join_mv2`  \n" +
+                        "DISTRIBUTED BY HASH(c12) BUCKETS 18 \n" +
+                        "REFRESH MANUAL \n" +
+                        "PROPERTIES ( \"replication_num\" = \"1\", \"storage_medium\" = \"HDD\") \n" +
+                        "AS\n" +
+                        "SELECT t1.c0, t1.c1, t2.c7, t2.c12\n" +
+                        "FROM\n" +
+                        "    ( SELECT `c0`, `c7`, `c12` FROM `pushdown_t2`) t2\n" +
+                        "    LEFT OUTER JOIN \n" +
+                        "    ( SELECT c0, c1, c7 FROM pushdown_t1 ) t1\n" +
+                        "    ON `t2`.`c0` = `t1`.`c0`\n" +
+                        "    AND date(t2.`c12`) = `t1`.`c7`\n" +
+                        "   ;");
+
+        String query = "SELECT t1.c0, t1.c1, t2.c7, t2.c12\n" +
+                "FROM\n" +
+                "    ( SELECT `c0`, `c7`, `c12` FROM `pushdown_t2`) t2\n" +
+                "    LEFT OUTER JOIN \n" +
+                "    ( SELECT c0, c1, c7 FROM pushdown_t1 ) t1\n" +
+                "    ON `t2`.`c0` = `t1`.`c0`\n" +
+                "    AND date(t2.`c12`) = `t1`.`c7`\n" +
+                "   ;";
+
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "_pushdown_predicate_join_mv2");
     }
 }


### PR DESCRIPTION
Fixes #27633

1. The join predicate contains `    AND date(t2.`c12`) = t1.c7 `
2. The `date(...)` will be push down under the join operator, and join predicates become `ColumnRef(date) = t1.c7`
3. The `ColumnRef(date)` should be compared with `equivalent` instead of equals, which means comparing with name instead of id 

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
