### PR TITLE
[Feature] Suppport SHOW CREATE ROUTINE LOAD SQL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
@@ -275,6 +275,11 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
     }
 
     @Override
+    public String dataSourcePropertiesToSql() {
+        return "";
+    }
+
+    @Override
     protected void updateProgress(RLTaskTxnCommitAttachment attachment) throws UserException {
         super.updateProgress(attachment);
         this.progress.update(attachment);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -95,6 +95,7 @@ import com.starrocks.transaction.AbstractTxnStateChangeCallback;
 import com.starrocks.transaction.TransactionException;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -1536,6 +1537,73 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         return gson.toJson(jobProperties);
     }
 
+    public String jobPropertiesToSql() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("(\n");
+        sb.append("\"").append(CreateRoutineLoadStmt.DESIRED_CONCURRENT_NUMBER_PROPERTY).append("\"=\"");
+        sb.append(String.valueOf(desireTaskConcurrentNum)).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.MAX_ERROR_NUMBER_PROPERTY).append("\"=\"");
+        sb.append(String.valueOf(maxErrorNum)).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.MAX_FILTER_RATIO_PROPERTY).append("\"=\"");
+        sb.append(String.valueOf(maxFilterRatio)).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.MAX_BATCH_INTERVAL_SEC_PROPERTY).append("\"=\"");
+        sb.append(String.valueOf(taskSchedIntervalS)).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.MAX_BATCH_ROWS_PROPERTY).append("\"=\"");
+        sb.append(String.valueOf(maxBatchRows)).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.TASK_CONSUME_SECOND).append("\"=\"");
+        sb.append(String.valueOf(taskConsumeSecond)).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.TASK_TIMEOUT_SECOND).append("\"=\"");
+        sb.append(String.valueOf(taskTimeoutSecond)).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.FORMAT).append("\"=\"");
+        sb.append(getFormat()).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.JSONPATHS).append("\"=\"");
+        sb.append(getJsonPaths()).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.STRIP_OUTER_ARRAY).append("\"=\"");
+        sb.append(Boolean.toString(isStripOuterArray())).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.JSONROOT).append("\"=\"");
+        sb.append(getJsonRoot()).append("\",\n");
+
+        sb.append("\"").append(LoadStmt.STRICT_MODE).append("\"=\"");
+        sb.append(Boolean.toString(isStrictMode())).append("\",\n");
+
+        sb.append("\"").append(LoadStmt.TIMEZONE).append("\"=\"");
+        sb.append(getTimezone()).append("\",\n");
+
+        sb.append("\"").append(LoadStmt.PARTIAL_UPDATE).append("\"=\"");
+        sb.append(Boolean.toString(isPartialUpdate())).append("\",\n");
+
+        if (getMergeCondition() != null) {
+            sb.append("\"").append(LoadStmt.MERGE_CONDITION).append("\"=\"");
+            sb.append(getMergeCondition()).append("\",\n");
+        }
+
+        sb.append("\"").append(CreateRoutineLoadStmt.TRIMSPACE).append("\"=\"");
+        sb.append(Boolean.toString(isTrimspace())).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.ENCLOSE).append("\"=\"");
+        sb.append(StringEscapeUtils.escapeJava(String.valueOf(enclose))).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.ESCAPE).append("\"=\"");
+        sb.append(StringEscapeUtils.escapeJava(String.valueOf(escape))).append("\",\n");
+
+        sb.append("\"").append(CreateRoutineLoadStmt.LOG_REJECTED_RECORD_NUM_PROPERTY).append("\"=\"");
+        sb.append(String.valueOf(getLogRejectedRecordNum())).append("\"\n");
+
+        sb.append(")\n");
+        return sb.toString();
+    }
+
+    public abstract String dataSourcePropertiesToSql();
     abstract String dataSourcePropertiesJsonToString();
 
     abstract String customPropertiesJsonToString();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1408,7 +1408,9 @@ public class ShowExecutor {
         }
         StringBuilder createRoutineLoadSql = new StringBuilder();
         try {
-            createRoutineLoadSql.append("CREATE ROUTINE LOAD ").append(showCreateRoutineLoadStmt.getName())
+            String dbName = routineLoadJob.getDbFullName();
+            createRoutineLoadSql.append("CREATE ROUTINE LOAD ").append(dbName).append(".")
+                    .append(showCreateRoutineLoadStmt.getName())
                     .append(" on ").append(routineLoadJob.getTableName());
         } catch (MetaNotFoundException e) {
             LOG.warn(e.getMessage(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1423,25 +1423,25 @@ public class ShowExecutor {
         }
 
         if (routineLoadJob.getColumnDescs() != null) {
-            createRoutineLoadSql.append("\nCOLUMNS (");
+            createRoutineLoadSql.append(",\nCOLUMNS (");
             List<ImportColumnDesc> descs = routineLoadJob.getColumnDescs();
             for (int i = 0; i < descs.size(); i++) {
                 ImportColumnDesc desc = descs.get(i);
                 createRoutineLoadSql.append(desc.toString());
                 if (descs.size() == 1 || i == descs.size() - 1) {
-                    createRoutineLoadSql.append(")\n");
+                    createRoutineLoadSql.append(")");
                 } else {
                     createRoutineLoadSql.append(", ");
                 }
             }
         }
         if (routineLoadJob.getPartitions() != null) {
-            createRoutineLoadSql.append("\n")
-                            .append(routineLoadJob.getPartitions().toString()).append("\n");
+            createRoutineLoadSql.append(",\n");
+            createRoutineLoadSql.append(routineLoadJob.getPartitions().toString());
         }
         if (routineLoadJob.getWhereExpr() != null) {
-            createRoutineLoadSql.append("\n")
-                    .append(routineLoadJob.getWhereExpr().toSql()).append("\n");
+            createRoutineLoadSql.append(",\nWHERE ");
+            createRoutineLoadSql.append(routineLoadJob.getWhereExpr().toSql());
         }
 
         createRoutineLoadSql.append("\nPROPERTIES\n").append(routineLoadJob.jobPropertiesToSql());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -142,6 +142,7 @@ import com.starrocks.sql.ast.DescribeStmt;
 import com.starrocks.sql.ast.GrantPrivilegeStmt;
 import com.starrocks.sql.ast.GrantRevokeClause;
 import com.starrocks.sql.ast.HelpStmt;
+import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.ast.ShowAlterStmt;
 import com.starrocks.sql.ast.ShowAnalyzeJobStmt;
@@ -160,6 +161,7 @@ import com.starrocks.sql.ast.ShowColumnStmt;
 import com.starrocks.sql.ast.ShowComputeNodesStmt;
 import com.starrocks.sql.ast.ShowCreateDbStmt;
 import com.starrocks.sql.ast.ShowCreateExternalCatalogStmt;
+import com.starrocks.sql.ast.ShowCreateRoutineLoadStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.sql.ast.ShowDataStmt;
 import com.starrocks.sql.ast.ShowDbStmt;
@@ -291,6 +293,8 @@ public class ShowExecutor {
             handleShowLoad();
         } else if (stmt instanceof ShowRoutineLoadStmt) {
             handleShowRoutineLoad();
+        } else if (stmt instanceof ShowCreateRoutineLoadStmt) {
+            handleShowCreateRoutineLoad();
         } else if (stmt instanceof ShowRoutineLoadTaskStmt) {
             handleShowRoutineLoadTask();
         } else if (stmt instanceof ShowStreamLoadStmt) {
@@ -1379,6 +1383,71 @@ public class ShowExecutor {
         }
 
         resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
+    }
+
+    private void handleShowCreateRoutineLoad() throws AnalysisException {
+        ShowCreateRoutineLoadStmt showCreateRoutineLoadStmt = (ShowCreateRoutineLoadStmt) stmt;
+        List<List<String>> rows = Lists.newArrayList();
+        List<RoutineLoadJob> routineLoadJobList;
+        try {
+            routineLoadJobList = GlobalStateMgr.getCurrentState().getRoutineLoadMgr()
+                    .getJob(showCreateRoutineLoadStmt.getDbFullName(),
+                            showCreateRoutineLoadStmt.getName(),
+                            false);
+        } catch (MetaNotFoundException e) {
+            LOG.warn(e.getMessage(), e);
+            throw new AnalysisException(e.getMessage());
+        }
+        if (routineLoadJobList == null || routineLoadJobList.size() == 0) {
+            resultSet = new ShowResultSet(showCreateRoutineLoadStmt.getMetaData(), rows);
+            return;
+        }
+        RoutineLoadJob routineLoadJob = routineLoadJobList.get(0);
+        if (routineLoadJob.getDataSourceTypeName().equals("PULSAR")) {
+            throw new AnalysisException("not support pulsar datasource");
+        }
+        StringBuilder createRoutineLoadSql = new StringBuilder();
+        try {
+            createRoutineLoadSql.append("CREATE ROUTINE LOAD ").append(showCreateRoutineLoadStmt.getName())
+                    .append(" on ").append(routineLoadJob.getTableName());
+        } catch (MetaNotFoundException e) {
+            LOG.warn(e.getMessage(), e);
+            throw new AnalysisException(e.getMessage());
+        }
+
+        if (routineLoadJob.getColumnSeparator() != null) {
+            createRoutineLoadSql.append("\n COLUMNS TERMINATED BY ")
+                    .append(routineLoadJob.getColumnSeparator().toSql(true));
+        }
+
+        if (routineLoadJob.getColumnDescs() != null) {
+            createRoutineLoadSql.append("\nCOLUMNS (");
+            List<ImportColumnDesc> descs = routineLoadJob.getColumnDescs();
+            for (int i = 0; i < descs.size(); i++) {
+                ImportColumnDesc desc = descs.get(i);
+                createRoutineLoadSql.append(desc.toString());
+                if (descs.size() == 1 || i == descs.size() - 1) {
+                    createRoutineLoadSql.append(")\n");
+                } else {
+                    createRoutineLoadSql.append(", ");
+                }
+            }
+        }
+        if (routineLoadJob.getPartitions() != null) {
+            createRoutineLoadSql.append("\n")
+                            .append(routineLoadJob.getPartitions().toString()).append("\n");
+        }
+        if (routineLoadJob.getWhereExpr() != null) {
+            createRoutineLoadSql.append("\n")
+                    .append(routineLoadJob.getWhereExpr().toSql()).append("\n");
+        }
+
+        createRoutineLoadSql.append("\nPROPERTIES\n").append(routineLoadJob.jobPropertiesToSql());
+        createRoutineLoadSql.append("FROM ").append(routineLoadJob.getDataSourceTypeName()).append("\n");
+        createRoutineLoadSql.append(routineLoadJob.dataSourcePropertiesToSql());
+        createRoutineLoadSql.append(";");
+        rows.add(Lists.newArrayList(showCreateRoutineLoadStmt.getName(), createRoutineLoadSql.toString()));
+        resultSet = new ShowResultSet(showCreateRoutineLoadStmt.getMetaData(), rows);
     }
 
     private void handleShowRoutineLoad() throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -343,6 +343,10 @@ public abstract class AstVisitor<R, C> {
         return visitShowStatement(statement, context);
     }
 
+    public R visitShowCreateRoutineLoadStatement(ShowCreateRoutineLoadStmt statement, C context) {
+        return visitShowStatement(statement, context);
+    }
+
     public R visitShowRoutineLoadTaskStatement(ShowRoutineLoadTaskStmt statement, C context) {
         return visitShowStatement(statement, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnSeparator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnSeparator.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.Delimiter;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.sql.parser.NodePosition;
+import org.apache.commons.text.StringEscapeUtils;
 
 public class ColumnSeparator implements ParseNode {
     private final String oriSeparator;
@@ -38,6 +39,13 @@ public class ColumnSeparator implements ParseNode {
 
     public String getColumnSeparator() {
         return separator;
+    }
+
+    public String toSql(boolean escape) {
+        if (!escape) {
+            return toSql();
+        }
+        return "'" + StringEscapeUtils.escapeJava(oriSeparator) + "'";
     }
 
     public String toSql() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowCreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowCreateRoutineLoadStmt.java
@@ -38,7 +38,6 @@ public class ShowCreateRoutineLoadStmt extends ShowStmt {
         this.labelName = labelName;
     }
 
-    // 返回的是jobName
     public String getName() {
         return labelName.getLabelName();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowCreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowCreateRoutineLoadStmt.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.analysis.LabelName;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.qe.ShowResultSetMetaData;
+import com.starrocks.sql.parser.NodePosition;
+
+public class ShowCreateRoutineLoadStmt extends ShowStmt {
+    private static final ShowResultSetMetaData META_DATA =
+            ShowResultSetMetaData.builder()
+                    .addColumn(new Column("Job", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("Create Job", ScalarType.createVarchar(30)))
+                    .build();
+
+    private LabelName labelName;
+
+    public ShowCreateRoutineLoadStmt(LabelName labelName) {
+        this(labelName, NodePosition.ZERO);
+    }
+
+    public ShowCreateRoutineLoadStmt(LabelName labelName, NodePosition pos) {
+        super(pos);
+        this.labelName = labelName;
+    }
+
+    // 返回的是jobName
+    public String getName() {
+        return labelName.getLabelName();
+    }
+
+    public String getDbFullName() {
+        return labelName.getDbName();
+    }
+
+    public void setLabelName(LabelName labelName) {
+        this.labelName = labelName;
+    }
+
+    @Override
+    public ShowResultSetMetaData getMetaData() {
+        return META_DATA;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitShowCreateRoutineLoadStatement(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1867,7 +1867,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitShowCreateRoutineLoadStatement(StarRocksParser.ShowCreateRoutineLoadStatementContext context) {
-        return new ShowCreateRoutineLoadStmt(createLabelName(null, context.name));
+        return new ShowCreateRoutineLoadStmt(createLabelName(context.db, context.name));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -314,6 +314,7 @@ import com.starrocks.sql.ast.ShowColumnStmt;
 import com.starrocks.sql.ast.ShowComputeNodesStmt;
 import com.starrocks.sql.ast.ShowCreateDbStmt;
 import com.starrocks.sql.ast.ShowCreateExternalCatalogStmt;
+import com.starrocks.sql.ast.ShowCreateRoutineLoadStmt;
 import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.sql.ast.ShowDataStmt;
 import com.starrocks.sql.ast.ShowDbStmt;
@@ -1862,6 +1863,11 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         return new CreateRoutineLoadStmt(createLabelName(context.db, context.name),
                 tableName == null ? null : tableName.toString(), loadPropertyList, jobProperties, typeName,
                 dataSourceProperties, createPos(context));
+    }
+
+    @Override
+    public ParseNode visitShowCreateRoutineLoadStatement(StarRocksParser.ShowCreateRoutineLoadStatementContext context) {
+        return new ShowCreateRoutineLoadStmt(createLabelName(null, context.name));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1079,7 +1079,7 @@ showRoutineLoadTaskStatement
     ;
 
 showCreateRoutineLoadStatement
-    : SHOW CREATE ROUTINE LOAD FOR name=identifier
+    : SHOW CREATE ROUTINE LOAD FOR (db=qualifiedName '.')? name=identifier
     ;
 
 showStreamLoadStatement

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -110,6 +110,7 @@ statement
     | pauseRoutineLoadStatement
     | showRoutineLoadStatement
     | showRoutineLoadTaskStatement
+    | showCreateRoutineLoadStatement
 
     // StreamLoad Statement
     | showStreamLoadStatement
@@ -1075,6 +1076,10 @@ showRoutineLoadTaskStatement
     : SHOW ROUTINE LOAD TASK
         (FROM db=qualifiedName)?
         WHERE expression
+    ;
+
+showCreateRoutineLoadStatement
+    : SHOW CREATE ROUTINE LOAD FOR name=identifier
     ;
 
 showStreamLoadStatement

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1079,7 +1079,7 @@ showRoutineLoadTaskStatement
     ;
 
 showCreateRoutineLoadStatement
-    : SHOW CREATE ROUTINE LOAD FOR (db=qualifiedName '.')? name=identifier
+    : SHOW CREATE ROUTINE LOAD (db=qualifiedName '.')? name=identifier
     ;
 
 showStreamLoadStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateRoutineLoadStmtTest.java
@@ -50,10 +50,11 @@ public class ShowCreateRoutineLoadStmtTest {
 
     @Test
     public void testBackquote() throws SecurityException, IllegalArgumentException {
-        String sql = "SHOW CREATE ROUTINE LOAD FOR `rl_test`";
+        String sql = "SHOW CREATE ROUTINE LOAD FOR testDb.rl_test";
         List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(sql, ctx.getSessionVariable());
 
         ShowCreateRoutineLoadStmt stmt = (ShowCreateRoutineLoadStmt) stmts.get(0);
+        Assert.assertEquals("testDb", stmt.getDbFullName());
         Assert.assertEquals("rl_test", stmt.getName());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateRoutineLoadStmtTest.java
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.analysis;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.ShowCreateRoutineLoadStmt;
+import com.starrocks.sql.ast.ShowRoutineLoadStmt;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+public class ShowCreateRoutineLoadStmtTest {
+    private static ConnectContext ctx;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // create connect context
+        ctx = UtFrameUtils.createDefaultCtx();
+    }
+
+    @Test
+    public void testNormal() throws Exception {
+        ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setDatabase("testDb");
+        ShowCreateRoutineLoadStmt stmt = new ShowCreateRoutineLoadStmt(new LabelName("testDb", "testJob"));
+        com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
+        Assert.assertEquals("testJob", stmt.getName());
+        Assert.assertEquals("testDb", stmt.getDbFullName());
+        Assert.assertEquals(2, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals("Job", stmt.getMetaData().getColumn(0).getName());
+        Assert.assertEquals("Create Job", stmt.getMetaData().getColumn(1).getName());
+    }
+
+    @Test
+    public void testBackquote() throws SecurityException, IllegalArgumentException {
+        String sql = "SHOW CREATE ROUTINE LOAD FOR `rl_test`";
+        List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(sql, ctx.getSessionVariable());
+
+        ShowCreateRoutineLoadStmt stmt = (ShowCreateRoutineLoadStmt) stmts.get(0);
+        Assert.assertEquals("rl_test", stmt.getName());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateRoutineLoadStmtTest.java
@@ -50,7 +50,7 @@ public class ShowCreateRoutineLoadStmtTest {
 
     @Test
     public void testBackquote() throws SecurityException, IllegalArgumentException {
-        String sql = "SHOW CREATE ROUTINE LOAD FOR testDb.rl_test";
+        String sql = "SHOW CREATE ROUTINE LOAD testDb.rl_test";
         List<StatementBase> stmts = com.starrocks.sql.parser.SqlParser.parse(sql, ctx.getSessionVariable());
 
         ShowCreateRoutineLoadStmt stmt = (ShowCreateRoutineLoadStmt) stmts.get(0);

--- a/test/sql/test_routine_load/R/test_show_create_routine_load
+++ b/test/sql/test_routine_load/R/test_show_create_routine_load
@@ -11,17 +11,17 @@ create table herbavro (
     advertiser_ad_width int not null,
     advertiser_currency_type varchar(60) not null
 )
-DUPLICATE KEY(advertiser_id) COMMENT "OLAP"
-DISTRIBUTED BY HASH(advertiser_id) BUCKETS 3
+DUPLICATE KEY(advertiser_id) COMMENT "OLAP" 
+DISTRIBUTED BY HASH(advertiser_id) BUCKETS 3 
 PROPERTIES ( "replication_num" = "1", "storage_format" = "v2" );
 -- result:
 -- !result
-CREATE ROUTINE LOAD test_show_create_routine_load.testherbavro on herbavro COLUMNS TERMINATED BY '\t'
+CREATE ROUTINE LOAD test_show_create_routine_load.testherbavro on herbavro COLUMNS TERMINATED BY '\t' 
 PROPERTIES (
 "desired_concurrent_number"="1",
 "max_error_number"="1000",
 "max_batch_interval"="5",
-"format"="avro")
+"format"="avro") 
 FROM KAFKA (
 "confluent.schema.registry.url"="http://172.26.194.240:8081",
 "kafka_broker_list"="172.26.194.239:9092",
@@ -64,4 +64,7 @@ FROM KAFKA
 "kafka_offsets"="OFFSET_BEGINNING",
 "confluent.schema.registry.url"="http://172.26.194.240:8081"
 );
+-- !result
+STOP ROUTINE LOAD for testherbavro;
+-- result:
 -- !result

--- a/test/sql/test_routine_load/R/test_show_create_routine_load
+++ b/test/sql/test_routine_load/R/test_show_create_routine_load
@@ -35,7 +35,7 @@ E: (1064, 'Unexpected exception: Name testherbavro already used in db herb')
 -- !result
 SHOW CREATE ROUTINE LOAD FOR testherbavro;
 -- result:
-testherbavro	CREATE ROUTINE LOAD testherbavro on herbavro
+testherbavro	CREATE ROUTINE LOAD herb.testherbavro on herbavro
  COLUMNS TERMINATED BY '\t'
 PROPERTIES
 (
@@ -63,7 +63,6 @@ FROM KAFKA
 "kafka_broker_list"="172.26.194.239:9092",
 "kafka_topic"="herb-avro",
 "kafka_partitions"="0",
-"kafka_offsets"="OFFSET_BEGINNING",
-"confluent.schema.registry.url"="http://172.26.194.240:8081"
+"kafka_offsets"="OFFSET_BEGINNING"
 );
 -- !result

--- a/test/sql/test_routine_load/R/test_show_create_routine_load
+++ b/test/sql/test_routine_load/R/test_show_create_routine_load
@@ -9,14 +9,24 @@ create table herbavro (
 	advertiser_id int not null,
     advertiser_ad_type int not null,
     advertiser_ad_width int not null,
-    advertiser_currency_type varchar(60) not null
+    advertiser_currency_type varchar(60) not null,
+    event_day DATE
 )
 DUPLICATE KEY(advertiser_id) COMMENT "OLAP" 
+PARTITION BY RANGE (event_day) (
+    PARTITION p1 VALUES LESS THAN ("2020-01-31"),
+    PARTITION p2 VALUES LESS THAN ("2020-02-29"),
+    PARTITION p3 VALUES LESS THAN ("2030-03-31")
+)
 DISTRIBUTED BY HASH(advertiser_id) BUCKETS 3 
 PROPERTIES ( "replication_num" = "1", "storage_format" = "v2" );
 -- result:
 -- !result
-CREATE ROUTINE LOAD test_show_create_routine_load.testherbavro on herbavro COLUMNS TERMINATED BY '\t' 
+CREATE ROUTINE LOAD test_show_create_routine_load.testherbavro on herbavro 
+COLUMNS TERMINATED BY '\t',
+COLUMNS (advertiser_id, advertiser_ad_type, advertiser_ad_width, advertiser_currency_type),
+PARTITIONS (p1, p2, p3),
+WHERE advertiser_id > -10
 PROPERTIES (
 "desired_concurrent_number"="1",
 "max_error_number"="1000",
@@ -34,7 +44,10 @@ FROM KAFKA (
 SHOW CREATE ROUTINE LOAD FOR testherbavro;
 -- result:
 testherbavro	CREATE ROUTINE LOAD test_show_create_routine_load.testherbavro on herbavro
- COLUMNS TERMINATED BY '\t'
+ COLUMNS TERMINATED BY '\t',
+COLUMNS (advertiser_id, advertiser_ad_type, advertiser_ad_width, advertiser_currency_type),
+PARTITIONS (p1, p2, p3),
+WHERE `advertiser_id` > -10
 PROPERTIES
 (
 "desired_concurrent_number"="1",

--- a/test/sql/test_routine_load/R/test_show_create_routine_load
+++ b/test/sql/test_routine_load/R/test_show_create_routine_load
@@ -1,0 +1,69 @@
+-- name: test_show_create_routine_load
+create database test_show_create_routine_load;
+-- result:
+-- !result
+use test_show_create_routine_load;
+-- result:
+-- !result
+create table herbavro (
+	advertiser_id int not null,
+    advertiser_ad_type int not null,
+    advertiser_ad_width int not null,
+    advertiser_currency_type varchar(60) not null
+)
+DUPLICATE KEY(advertiser_id) COMMENT "OLAP"
+DISTRIBUTED BY HASH(advertiser_id) BUCKETS 3
+PROPERTIES ( "replication_num" = "1", "storage_format" = "v2" );
+-- result:
+-- !result
+-- name: test_show_create_routine_load_basic
+CREATE ROUTINE LOAD herb.testherbavro on herbavro COLUMNS TERMINATED BY '\t'
+PROPERTIES (
+"desired_concurrent_number"="1",
+"max_error_number"="1000",
+"max_batch_interval"="5",
+"format"="avro")
+FROM KAFKA (
+"confluent.schema.registry.url"="http://172.26.194.240:8081",
+"kafka_broker_list"="172.26.194.239:9092",
+"kafka_topic"="herb-avro",
+"kafka_partitions"="0",
+"kafka_offsets"="OFFSET_BEGINNING"
+);
+-- result:
+E: (1064, 'Unexpected exception: Name testherbavro already used in db herb')
+-- !result
+SHOW CREATE ROUTINE LOAD FOR testherbavro;
+-- result:
+testherbavro	CREATE ROUTINE LOAD testherbavro on herbavro
+ COLUMNS TERMINATED BY '\t'
+PROPERTIES
+(
+"desired_concurrent_number"="1",
+"max_error_number"="1000",
+"max_filter_ratio"="1.0",
+"max_batch_interval"="5",
+"max_batch_rows"="200000",
+"task_consume_second"="15",
+"task_timeout_second"="60",
+"format"="avro",
+"jsonpaths"="",
+"strip_outer_array"="false",
+"json_root"="",
+"strict_mode"="false",
+"timezone"="Asia/Shanghai",
+"partial_update"="false",
+"trim_space"="false",
+"enclose"="0",
+"escape"="0",
+"log_rejected_record_num"="0"
+)
+FROM KAFKA
+(
+"kafka_broker_list"="172.26.194.239:9092",
+"kafka_topic"="herb-avro",
+"kafka_partitions"="0",
+"kafka_offsets"="OFFSET_BEGINNING",
+"confluent.schema.registry.url"="http://172.26.194.240:8081"
+);
+-- !result

--- a/test/sql/test_routine_load/R/test_show_create_routine_load
+++ b/test/sql/test_routine_load/R/test_show_create_routine_load
@@ -1,4 +1,4 @@
--- name: test_show_create_routine_load
+-- name: test_show_create_routine_load_basic
 create database test_show_create_routine_load;
 -- result:
 -- !result
@@ -16,8 +16,7 @@ DISTRIBUTED BY HASH(advertiser_id) BUCKETS 3
 PROPERTIES ( "replication_num" = "1", "storage_format" = "v2" );
 -- result:
 -- !result
--- name: test_show_create_routine_load_basic
-CREATE ROUTINE LOAD herb.testherbavro on herbavro COLUMNS TERMINATED BY '\t'
+CREATE ROUTINE LOAD test_show_create_routine_load.testherbavro on herbavro COLUMNS TERMINATED BY '\t'
 PROPERTIES (
 "desired_concurrent_number"="1",
 "max_error_number"="1000",
@@ -31,11 +30,10 @@ FROM KAFKA (
 "kafka_offsets"="OFFSET_BEGINNING"
 );
 -- result:
-E: (1064, 'Unexpected exception: Name testherbavro already used in db herb')
 -- !result
 SHOW CREATE ROUTINE LOAD FOR testherbavro;
 -- result:
-testherbavro	CREATE ROUTINE LOAD herb.testherbavro on herbavro
+testherbavro	CREATE ROUTINE LOAD test_show_create_routine_load.testherbavro on herbavro
  COLUMNS TERMINATED BY '\t'
 PROPERTIES
 (
@@ -63,6 +61,7 @@ FROM KAFKA
 "kafka_broker_list"="172.26.194.239:9092",
 "kafka_topic"="herb-avro",
 "kafka_partitions"="0",
-"kafka_offsets"="OFFSET_BEGINNING"
+"kafka_offsets"="OFFSET_BEGINNING",
+"confluent.schema.registry.url"="http://172.26.194.240:8081"
 );
 -- !result

--- a/test/sql/test_routine_load/R/test_show_create_routine_load
+++ b/test/sql/test_routine_load/R/test_show_create_routine_load
@@ -41,7 +41,7 @@ FROM KAFKA (
 );
 -- result:
 -- !result
-SHOW CREATE ROUTINE LOAD FOR testherbavro;
+SHOW CREATE ROUTINE LOAD testherbavro;
 -- result:
 testherbavro	CREATE ROUTINE LOAD test_show_create_routine_load.testherbavro on herbavro
  COLUMNS TERMINATED BY '\t',

--- a/test/sql/test_routine_load/T/test_show_create_routine_load
+++ b/test/sql/test_routine_load/T/test_show_create_routine_load
@@ -1,0 +1,31 @@
+-- name: test_show_create_routine_load
+create database test_show_create_routine_load;
+
+use test_show_create_routine_load;
+
+create table herbavro (
+	advertiser_id int not null,
+    advertiser_ad_type int not null,
+    advertiser_ad_width int not null,
+    advertiser_currency_type varchar(60) not null
+)
+DUPLICATE KEY(advertiser_id) COMMENT "OLAP" 
+DISTRIBUTED BY HASH(advertiser_id) BUCKETS 3 
+PROPERTIES ( "replication_num" = "1", "storage_format" = "v2" );
+
+-- name: test_show_create_routine_load_basic
+CREATE ROUTINE LOAD herb.testherbavro on herbavro COLUMNS TERMINATED BY '\t' 
+PROPERTIES (
+"desired_concurrent_number"="1",
+"max_error_number"="1000",
+"max_batch_interval"="5",
+"format"="avro") 
+FROM KAFKA (
+"confluent.schema.registry.url"="http://172.26.194.240:8081",
+"kafka_broker_list"="172.26.194.239:9092",
+"kafka_topic"="herb-avro",
+"kafka_partitions"="0",
+"kafka_offsets"="OFFSET_BEGINNING"
+);
+
+SHOW CREATE ROUTINE LOAD FOR testherbavro;

--- a/test/sql/test_routine_load/T/test_show_create_routine_load
+++ b/test/sql/test_routine_load/T/test_show_create_routine_load
@@ -7,13 +7,23 @@ create table herbavro (
 	advertiser_id int not null,
     advertiser_ad_type int not null,
     advertiser_ad_width int not null,
-    advertiser_currency_type varchar(60) not null
+    advertiser_currency_type varchar(60) not null,
+    event_day DATE
 )
 DUPLICATE KEY(advertiser_id) COMMENT "OLAP" 
+PARTITION BY RANGE (event_day) (
+    PARTITION p1 VALUES LESS THAN ("2020-01-31"),
+    PARTITION p2 VALUES LESS THAN ("2020-02-29"),
+    PARTITION p3 VALUES LESS THAN ("2030-03-31")
+)
 DISTRIBUTED BY HASH(advertiser_id) BUCKETS 3 
 PROPERTIES ( "replication_num" = "1", "storage_format" = "v2" );
 
-CREATE ROUTINE LOAD test_show_create_routine_load.testherbavro on herbavro COLUMNS TERMINATED BY '\t' 
+CREATE ROUTINE LOAD test_show_create_routine_load.testherbavro on herbavro 
+COLUMNS TERMINATED BY '\t',
+COLUMNS (advertiser_id, advertiser_ad_type, advertiser_ad_width, advertiser_currency_type),
+PARTITIONS (p1, p2, p3),
+WHERE advertiser_id > -10
 PROPERTIES (
 "desired_concurrent_number"="1",
 "max_error_number"="1000",

--- a/test/sql/test_routine_load/T/test_show_create_routine_load
+++ b/test/sql/test_routine_load/T/test_show_create_routine_load
@@ -28,3 +28,5 @@ FROM KAFKA (
 );
 
 SHOW CREATE ROUTINE LOAD FOR testherbavro;
+
+STOP ROUTINE LOAD for testherbavro;

--- a/test/sql/test_routine_load/T/test_show_create_routine_load
+++ b/test/sql/test_routine_load/T/test_show_create_routine_load
@@ -1,4 +1,4 @@
--- name: test_show_create_routine_load
+-- name: test_show_create_routine_load_basic
 create database test_show_create_routine_load;
 
 use test_show_create_routine_load;
@@ -13,8 +13,7 @@ DUPLICATE KEY(advertiser_id) COMMENT "OLAP"
 DISTRIBUTED BY HASH(advertiser_id) BUCKETS 3 
 PROPERTIES ( "replication_num" = "1", "storage_format" = "v2" );
 
--- name: test_show_create_routine_load_basic
-CREATE ROUTINE LOAD herb.testherbavro on herbavro COLUMNS TERMINATED BY '\t' 
+CREATE ROUTINE LOAD test_show_create_routine_load.testherbavro on herbavro COLUMNS TERMINATED BY '\t' 
 PROPERTIES (
 "desired_concurrent_number"="1",
 "max_error_number"="1000",

--- a/test/sql/test_routine_load/T/test_show_create_routine_load
+++ b/test/sql/test_routine_load/T/test_show_create_routine_load
@@ -37,6 +37,6 @@ FROM KAFKA (
 "kafka_offsets"="OFFSET_BEGINNING"
 );
 
-SHOW CREATE ROUTINE LOAD FOR testherbavro;
+SHOW CREATE ROUTINE LOAD testherbavro;
 
 STOP ROUTINE LOAD for testherbavro;


### PR DESCRIPTION
Sometimes users need to know how they created a routine load job, similar to SHOW CREATE TABLE. This PR allows users to obtain the SQL statement for creating the routine load job using SQL.

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
