### PR TITLE
[Refactor] Move mem_tracker to GlobalEnv

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -63,7 +63,7 @@ static void alter_tablet(const TAlterTabletReqV2& agent_task_req, int64_t signat
     TSchemaHash new_schema_hash = 0;
     new_tablet_id = agent_task_req.new_tablet_id;
     new_schema_hash = agent_task_req.new_schema_hash;
-    EngineAlterTabletTask engine_task(ExecEnv::GetInstance()->schema_change_mem_tracker(), agent_task_req);
+    EngineAlterTabletTask engine_task(GlobalEnv::GetInstance()->schema_change_mem_tracker(), agent_task_req);
     Status sc_status = StorageEngine::instance()->execute_task(&engine_task);
     AgentStatus status;
     if (!sc_status.ok()) {
@@ -314,7 +314,7 @@ void run_clone_task(const std::shared_ptr<CloneAgentTaskRequest>& agent_task_req
             }
         }
     } else {
-        EngineCloneTask engine_task(ExecEnv::GetInstance()->clone_mem_tracker(), clone_req, agent_task_req->signature,
+        EngineCloneTask engine_task(GlobalEnv::GetInstance()->clone_mem_tracker(), clone_req, agent_task_req->signature,
                                     &error_msgs, &tablet_infos, &status);
         Status res = StorageEngine::instance()->execute_task(&engine_task);
         if (!res.ok()) {
@@ -429,7 +429,7 @@ void run_check_consistency_task(const std::shared_ptr<CheckConsistencyTaskReques
     TStatus task_status;
     uint32_t checksum = 0;
 
-    MemTracker* mem_tracker = ExecEnv::GetInstance()->consistency_mem_tracker();
+    MemTracker* mem_tracker = GlobalEnv::GetInstance()->consistency_mem_tracker();
     Status check_limit_st = mem_tracker->check_mem_limit("Start consistency check.");
     if (!check_limit_st.ok()) {
         LOG(WARNING) << "check consistency failed: " << check_limit_st.message();
@@ -469,7 +469,7 @@ void run_compaction_task(const std::shared_ptr<CompactionTaskRequest>& agent_tas
     TStatus task_status;
 
     for (auto tablet_id : compaction_req.tablet_ids) {
-        EngineManualCompactionTask engine_task(ExecEnv::GetInstance()->compaction_mem_tracker(), tablet_id,
+        EngineManualCompactionTask engine_task(GlobalEnv::GetInstance()->compaction_mem_tracker(), tablet_id,
                                                compaction_req.is_base_compaction);
         StorageEngine::instance()->execute_task(&engine_task);
     }

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -303,7 +303,7 @@ void* PushTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         std::vector<TTabletInfo> tablet_infos;
 
         EngineBatchLoadTask engine_task(push_req, &tablet_infos, agent_task_req->signature, &status,
-                                        ExecEnv::GetInstance()->load_mem_tracker());
+                                        GlobalEnv::GetInstance()->load_mem_tracker());
         StorageEngine::instance()->execute_task(&engine_task);
 
         if (status == STARROCKS_PUSH_HAD_LOADED) {
@@ -418,7 +418,7 @@ void* DeleteTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         std::vector<TTabletInfo> tablet_infos;
 
         EngineBatchLoadTask engine_task(push_req, &tablet_infos, agent_task_req->signature, &status,
-                                        ExecEnv::GetInstance()->load_mem_tracker());
+                                        GlobalEnv::GetInstance()->load_mem_tracker());
         StorageEngine::instance()->execute_task(&engine_task);
 
         if (status == STARROCKS_PUSH_HAD_LOADED) {
@@ -744,8 +744,8 @@ void* ReportResourceUsageTaskWorkerPool::_worker_thread_callback(void* arg_this)
 
         TResourceUsage resource_usage;
         resource_usage.__set_num_running_queries(ExecEnv::GetInstance()->query_context_mgr()->size());
-        resource_usage.__set_mem_used_bytes(ExecEnv::GetInstance()->process_mem_tracker()->consumption());
-        resource_usage.__set_mem_limit_bytes(ExecEnv::GetInstance()->process_mem_tracker()->limit());
+        resource_usage.__set_mem_used_bytes(GlobalEnv::GetInstance()->process_mem_tracker()->consumption());
+        resource_usage.__set_mem_limit_bytes(GlobalEnv::GetInstance()->process_mem_tracker()->limit());
         worker_pool_this->_cpu_usage_recorder.update_interval();
         resource_usage.__set_cpu_used_permille(worker_pool_this->_cpu_usage_recorder.cpu_used_permille());
         request.__set_resource_usage(std::move(resource_usage));

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -110,7 +110,7 @@ static void dump_trace_info() {
         wt = write(STDERR_FILENO, buffer, res);
         // dump memory usage
         // copy trackers
-        auto& trackers = ExecEnv::GetInstance()->mem_trackers();
+        auto& trackers = GlobalEnv::GetInstance()->mem_trackers();
         for (const auto& tracker : trackers) {
             if (tracker) {
                 size_t len = tracker->debug_string(buffer, sizeof(buffer));

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -363,7 +363,7 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
         // Attachment will be released by process_mem_tracker in closure->Run() in bthread, when receiving the response,
         // so decrease the memory usage of attachment from instance_mem_tracker immediately before sending the request.
         _mem_tracker->release(request.attachment_physical_bytes);
-        ExecEnv::GetInstance()->process_mem_tracker()->consume(request.attachment_physical_bytes);
+        GlobalEnv::GetInstance()->process_mem_tracker()->consume(request.attachment_physical_bytes);
 
         closure->cntl.Reset();
         closure->cntl.set_timeout_ms(_brpc_timeout_ms);

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -612,7 +612,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
         int64_t prepare_runtime_state_time = 0;
         int64_t prepare_pipeline_driver_time = 0;
 
-        int64_t process_mem_bytes = ExecEnv::GetInstance()->process_mem_tracker()->consumption();
+        int64_t process_mem_bytes = GlobalEnv::GetInstance()->process_mem_tracker()->consumption();
         size_t num_process_drivers = ExecEnv::GetInstance()->driver_limiter()->num_total_drivers();
     } profiler;
 
@@ -650,7 +650,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     });
 
     SCOPED_RAW_TIMER(&profiler.prepare_time);
-    RETURN_IF_ERROR(exec_env->query_pool_mem_tracker()->check_mem_limit("Start execute plan fragment."));
+    RETURN_IF_ERROR(
+            GlobalEnv::GetInstance()->query_pool_mem_tracker()->check_mem_limit("Start execute plan fragment."));
     {
         SCOPED_RAW_TIMER(&profiler.prepare_query_ctx_time);
         RETURN_IF_ERROR(_prepare_query_ctx(exec_env, request));

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -139,10 +139,10 @@ TWorkGroup WorkGroup::to_thrift_verbose() const {
 
 void WorkGroup::init() {
     _memory_limit_bytes = _memory_limit == ABSENT_MEMORY_LIMIT
-                                  ? ExecEnv::GetInstance()->query_pool_mem_tracker()->limit()
-                                  : ExecEnv::GetInstance()->query_pool_mem_tracker()->limit() * _memory_limit;
+                                  ? GlobalEnv::GetInstance()->query_pool_mem_tracker()->limit()
+                                  : GlobalEnv::GetInstance()->query_pool_mem_tracker()->limit() * _memory_limit;
     _mem_tracker = std::make_shared<starrocks::MemTracker>(MemTracker::RESOURCE_GROUP, _memory_limit_bytes, _name,
-                                                           ExecEnv::GetInstance()->query_pool_mem_tracker());
+                                                           GlobalEnv::GetInstance()->query_pool_mem_tracker());
     _driver_sched_entity.set_queue(std::make_unique<pipeline::QuerySharedDriverQueue>());
     _scan_sched_entity.set_queue(workgroup::create_scan_task_queue());
     _connector_scan_sched_entity.set_queue(workgroup::create_scan_task_queue());

--- a/be/src/http/action/checksum_action.cpp
+++ b/be/src/http/action/checksum_action.cpp
@@ -116,7 +116,7 @@ void ChecksumAction::handle(HttpRequest* req) {
 }
 
 int64_t ChecksumAction::do_checksum(int64_t tablet_id, int64_t version, int32_t schema_hash, HttpRequest* req) {
-    MemTracker* mem_tracker = ExecEnv::GetInstance()->consistency_mem_tracker();
+    MemTracker* mem_tracker = GlobalEnv::GetInstance()->consistency_mem_tracker();
     Status check_limit_st = mem_tracker->check_mem_limit("Start consistency check.");
     if (!check_limit_st.ok()) {
         LOG(WARNING) << "checksum failed: " << check_limit_st.message();

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -115,7 +115,7 @@ Status CompactionAction::do_compaction(uint64_t tablet_id, const string& compact
     TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
     RETURN_IF(tablet == nullptr, Status::InvalidArgument(fmt::format("Not Found tablet:{}", tablet_id)));
 
-    auto* mem_tracker = ExecEnv::GetInstance()->compaction_mem_tracker();
+    auto* mem_tracker = GlobalEnv::GetInstance()->compaction_mem_tracker();
     if (tablet->updates() != nullptr) {
         if (rowset_ids_string.empty()) {
             RETURN_IF_ERROR(tablet->updates()->compaction(mem_tracker));

--- a/be/src/http/action/memory_metrics_action.cpp
+++ b/be/src/http/action/memory_metrics_action.cpp
@@ -30,7 +30,7 @@ namespace starrocks {
 void MemoryMetricsAction::handle(HttpRequest* req) {
     LOG(INFO) << "Start collect memory metrics.";
     auto scoped_span = trace::Scope(Tracer::Instance().start_trace("http_handle_memory_metrics"));
-    MemTracker* process_mem_tracker = ExecEnv::GetInstance()->process_mem_tracker();
+    MemTracker* process_mem_tracker = GlobalEnv::GetInstance()->process_mem_tracker();
     std::stringstream result;
     std::vector<std::string> metric_labels_to_print = {"process",
                                                        "query_pool",
@@ -62,10 +62,10 @@ void MemoryMetricsAction::handle(HttpRequest* req) {
     result << "[";
     getMemoryMetricTree(process_mem_tracker, result, process_mem_tracker->consumption(), metric_labels_to_print);
     result << ",";
-    getMemoryMetricTree(ExecEnv::GetInstance()->metadata_mem_tracker(), result, process_mem_tracker->consumption(),
+    getMemoryMetricTree(GlobalEnv::GetInstance()->metadata_mem_tracker(), result, process_mem_tracker->consumption(),
                         metric_labels_to_print);
     result << ",";
-    getMemoryMetricTree(ExecEnv::GetInstance()->update_mem_tracker(), result, process_mem_tracker->consumption(),
+    getMemoryMetricTree(GlobalEnv::GetInstance()->update_mem_tracker(), result, process_mem_tracker->consumption(),
                         metric_labels_to_print);
     result << "]";
     req->add_output_header(HttpHeaders::CONTENT_TYPE, "text/plain; version=0.0.4");

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -75,16 +75,16 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             _exec_env->thread_pool()->set_num_thread(config::scanner_thread_pool_thread_num);
         });
         _config_callback.emplace("storage_page_cache_limit", [&]() {
-            int64_t cache_limit = _exec_env->get_storage_page_cache_size();
-            cache_limit = _exec_env->check_storage_page_cache_size(cache_limit);
+            int64_t cache_limit = GlobalEnv::GetInstance()->get_storage_page_cache_size();
+            cache_limit = GlobalEnv::GetInstance()->check_storage_page_cache_size(cache_limit);
             StoragePageCache::instance()->set_capacity(cache_limit);
         });
         _config_callback.emplace("disable_storage_page_cache", [&]() {
             if (config::disable_storage_page_cache) {
                 StoragePageCache::instance()->set_capacity(0);
             } else {
-                int64_t cache_limit = _exec_env->get_storage_page_cache_size();
-                cache_limit = _exec_env->check_storage_page_cache_size(cache_limit);
+                int64_t cache_limit = GlobalEnv::GetInstance()->get_storage_page_cache_size();
+                cache_limit = GlobalEnv::GetInstance()->check_storage_page_cache_size(cache_limit);
                 StoragePageCache::instance()->set_capacity(cache_limit);
             }
         });

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -123,37 +123,37 @@ void mem_tracker_handler(MemTracker* mem_tracker, const WebPageHandler::Argument
     iter = args.find("type");
     if (iter != args.end()) {
         if (iter->second == "compaction") {
-            start_mem_tracker = ExecEnv::GetInstance()->compaction_mem_tracker();
+            start_mem_tracker = GlobalEnv::GetInstance()->compaction_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "load") {
-            start_mem_tracker = ExecEnv::GetInstance()->load_mem_tracker();
+            start_mem_tracker = GlobalEnv::GetInstance()->load_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "metadata") {
-            start_mem_tracker = ExecEnv::GetInstance()->metadata_mem_tracker();
+            start_mem_tracker = GlobalEnv::GetInstance()->metadata_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "query_pool") {
-            start_mem_tracker = ExecEnv::GetInstance()->query_pool_mem_tracker();
+            start_mem_tracker = GlobalEnv::GetInstance()->query_pool_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "schema_change") {
-            start_mem_tracker = ExecEnv::GetInstance()->schema_change_mem_tracker();
+            start_mem_tracker = GlobalEnv::GetInstance()->schema_change_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "clone") {
-            start_mem_tracker = ExecEnv::GetInstance()->clone_mem_tracker();
+            start_mem_tracker = GlobalEnv::GetInstance()->clone_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "column_pool") {
-            start_mem_tracker = ExecEnv::GetInstance()->column_pool_mem_tracker();
+            start_mem_tracker = GlobalEnv::GetInstance()->column_pool_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "page_cache") {
-            start_mem_tracker = ExecEnv::GetInstance()->page_cache_mem_tracker();
+            start_mem_tracker = GlobalEnv::GetInstance()->page_cache_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "update") {
-            start_mem_tracker = ExecEnv::GetInstance()->update_mem_tracker();
+            start_mem_tracker = GlobalEnv::GetInstance()->update_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "chunk_allocator") {
-            start_mem_tracker = ExecEnv::GetInstance()->chunk_allocator_mem_tracker();
+            start_mem_tracker = GlobalEnv::GetInstance()->chunk_allocator_mem_tracker();
             cur_level = 2;
         } else if (iter->second == "consistency") {
-            start_mem_tracker = ExecEnv::GetInstance()->consistency_mem_tracker();
+            start_mem_tracker = GlobalEnv::GetInstance()->consistency_mem_tracker();
             cur_level = 2;
         } else {
             start_mem_tracker = mem_tracker;
@@ -168,7 +168,7 @@ void mem_tracker_handler(MemTracker* mem_tracker, const WebPageHandler::Argument
 
     // Metadata memory statistics use the old memory framework,
     // not in RootMemTrackerTree, so it needs to be added here
-    MemTracker* meta_mem_tracker = ExecEnv::GetInstance()->metadata_mem_tracker();
+    MemTracker* meta_mem_tracker = GlobalEnv::GetInstance()->metadata_mem_tracker();
     MemTracker::SimpleItem meta_item{"metadata",
                                      "process",
                                      2,
@@ -178,7 +178,7 @@ void mem_tracker_handler(MemTracker* mem_tracker, const WebPageHandler::Argument
 
     // Update memory statistics use the old memory framework,
     // not in RootMemTrackerTree, so it needs to be added here
-    MemTracker* update_mem_tracker = ExecEnv::GetInstance()->update_mem_tracker();
+    MemTracker* update_mem_tracker = GlobalEnv::GetInstance()->update_mem_tracker();
     MemTracker::SimpleItem update_item{"update",
                                        "process",
                                        2,
@@ -188,7 +188,7 @@ void mem_tracker_handler(MemTracker* mem_tracker, const WebPageHandler::Argument
 
     if (start_mem_tracker != nullptr) {
         start_mem_tracker->list_mem_usage(&items, cur_level, upper_level);
-        if (start_mem_tracker == ExecEnv::GetInstance()->process_mem_tracker()) {
+        if (start_mem_tracker == GlobalEnv::GetInstance()->process_mem_tracker()) {
             items.emplace_back(meta_item);
             items.emplace_back(update_item);
         }

--- a/be/src/runtime/current_thread.cpp
+++ b/be/src/runtime/current_thread.cpp
@@ -31,8 +31,8 @@ CurrentThread::~CurrentThread() {
 
 starrocks::MemTracker* CurrentThread::mem_tracker() {
     if (UNLIKELY(tls_mem_tracker == nullptr)) {
-        if (ExecEnv::is_init()) {
-            tls_mem_tracker = ExecEnv::GetInstance()->process_mem_tracker();
+        if (GlobalEnv::is_init()) {
+            tls_mem_tracker = GlobalEnv::GetInstance()->process_mem_tracker();
         }
     }
     return tls_mem_tracker;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -104,17 +104,6 @@ static int64_t calc_max_load_memory(int64_t process_mem_limit) {
     return std::min<int64_t>(max_load_memory_bytes, config::load_process_max_memory_limit_bytes);
 }
 
-int64_t ExecEnv::calc_max_query_memory(int64_t process_mem_limit, int64_t percent) {
-    if (process_mem_limit <= 0) {
-        // -1 means no limit
-        return -1;
-    }
-    if (percent < 0 || percent > 100) {
-        percent = 90;
-    }
-    return process_mem_limit * percent / 100;
-}
-
 static int64_t calc_max_compaction_memory(int64_t process_mem_limit) {
     int64_t limit = config::compaction_max_memory_limit;
     int64_t percent = config::compaction_max_memory_limit_percent;
@@ -151,15 +140,159 @@ static int64_t calc_max_consistency_memory(int64_t process_mem_limit) {
     return std::min<int64_t>(limit, process_mem_limit * percent / 100);
 }
 
-bool ExecEnv::_is_init = false;
+class SetMemTrackerForColumnPool {
+public:
+    SetMemTrackerForColumnPool(std::shared_ptr<MemTracker> mem_tracker) : _mem_tracker(std::move(mem_tracker)) {}
 
-bool ExecEnv::is_init() {
+    template <typename Pool>
+    void operator()() {
+        Pool::singleton()->set_mem_tracker(_mem_tracker);
+    }
+
+private:
+    std::shared_ptr<MemTracker> _mem_tracker = nullptr;
+};
+
+bool GlobalEnv::_is_init = false;
+
+bool GlobalEnv::is_init() {
     return _is_init;
 }
 
-Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
-    DeferOp op([]() { ExecEnv::_is_init = true; });
+Status GlobalEnv::init() {
+    RETURN_IF_ERROR(_init_mem_tracker());
+    _is_init = true;
+    return Status::OK();
+}
 
+Status GlobalEnv::_init_mem_tracker() {
+    int64_t bytes_limit = 0;
+    std::stringstream ss;
+    // --mem_limit="" means no memory limit
+    bytes_limit = ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem());
+    // use 90% of mem_limit as the soft mem limit of BE
+    bytes_limit = bytes_limit * 0.9;
+    if (bytes_limit <= 0) {
+        ss << "Failed to parse mem limit from '" + config::mem_limit + "'.";
+        return Status::InternalError(ss.str());
+    }
+
+    if (bytes_limit > MemInfo::physical_mem()) {
+        LOG(WARNING) << "Memory limit " << PrettyPrinter::print(bytes_limit, TUnit::BYTES)
+                     << " exceeds physical memory of " << PrettyPrinter::print(MemInfo::physical_mem(), TUnit::BYTES)
+                     << ". Using physical memory instead";
+        bytes_limit = MemInfo::physical_mem();
+    }
+
+    if (bytes_limit <= 0) {
+        ss << "Invalid mem limit: " << bytes_limit;
+        return Status::InternalError(ss.str());
+    }
+
+    _process_mem_tracker = regist_tracker(MemTracker::PROCESS, bytes_limit, "process");
+    int64_t query_pool_mem_limit =
+            calc_max_query_memory(_process_mem_tracker->limit(), config::query_max_memory_limit_percent);
+    _query_pool_mem_tracker =
+            regist_tracker(MemTracker::QUERY_POOL, query_pool_mem_limit, "query_pool", this->process_mem_tracker());
+
+    int64_t load_mem_limit = calc_max_load_memory(_process_mem_tracker->limit());
+    _load_mem_tracker = regist_tracker(MemTracker::LOAD, load_mem_limit, "load", process_mem_tracker());
+
+    // Metadata statistics memory statistics do not use new mem statistics framework with hook
+    _metadata_mem_tracker = regist_tracker(-1, "metadata", nullptr);
+
+    _tablet_metadata_mem_tracker = regist_tracker(-1, "tablet_metadata", _metadata_mem_tracker.get());
+    _rowset_metadata_mem_tracker = regist_tracker(-1, "rowset_metadata", _metadata_mem_tracker.get());
+    _segment_metadata_mem_tracker = regist_tracker(-1, "segment_metadata", _metadata_mem_tracker.get());
+    _column_metadata_mem_tracker = regist_tracker(-1, "column_metadata", _metadata_mem_tracker.get());
+
+    _tablet_schema_mem_tracker = regist_tracker(-1, "tablet_schema", _tablet_metadata_mem_tracker.get());
+    _segment_zonemap_mem_tracker = regist_tracker(-1, "segment_zonemap", _segment_metadata_mem_tracker.get());
+    _short_key_index_mem_tracker = regist_tracker(-1, "short_key_index", _segment_metadata_mem_tracker.get());
+    _column_zonemap_index_mem_tracker = regist_tracker(-1, "column_zonemap_index", _column_metadata_mem_tracker.get());
+    _ordinal_index_mem_tracker = regist_tracker(-1, "ordinal_index", _column_metadata_mem_tracker.get());
+    _bitmap_index_mem_tracker = regist_tracker(-1, "bitmap_index", _column_metadata_mem_tracker.get());
+    _bloom_filter_index_mem_tracker = regist_tracker(-1, "bloom_filter_index", _column_metadata_mem_tracker.get());
+
+    int64_t compaction_mem_limit = calc_max_compaction_memory(_process_mem_tracker->limit());
+    _compaction_mem_tracker = regist_tracker(compaction_mem_limit, "compaction", _process_mem_tracker.get());
+    _schema_change_mem_tracker = regist_tracker(-1, "schema_change", _process_mem_tracker.get());
+    _column_pool_mem_tracker = regist_tracker(-1, "column_pool", _process_mem_tracker.get());
+    _page_cache_mem_tracker = regist_tracker(-1, "page_cache", _process_mem_tracker.get());
+    int32_t update_mem_percent = std::max(std::min(100, config::update_memory_limit_percent), 0);
+    _update_mem_tracker = regist_tracker(bytes_limit * update_mem_percent / 100, "update", nullptr);
+    _chunk_allocator_mem_tracker = regist_tracker(-1, "chunk_allocator", _process_mem_tracker.get());
+    _clone_mem_tracker = regist_tracker(-1, "clone", _process_mem_tracker.get());
+    int64_t consistency_mem_limit = calc_max_consistency_memory(_process_mem_tracker->limit());
+    _consistency_mem_tracker = regist_tracker(consistency_mem_limit, "consistency", _process_mem_tracker.get());
+
+    MemChunkAllocator::init_instance(_chunk_allocator_mem_tracker.get(), config::chunk_reserved_bytes_limit);
+
+    SetMemTrackerForColumnPool op(_column_pool_mem_tracker);
+    ForEach<ColumnPoolList>(op);
+    _init_storage_page_cache(); // TODO: move to StorageEngine
+    return Status::OK();
+}
+
+void GlobalEnv::_reset_tracker() {
+    for (auto iter = _mem_trackers.rbegin(); iter != _mem_trackers.rend(); ++iter) {
+        iter->reset();
+    }
+}
+
+Status GlobalEnv::_init_storage_page_cache() {
+    int64_t storage_cache_limit = get_storage_page_cache_size();
+    storage_cache_limit = check_storage_page_cache_size(storage_cache_limit);
+    StoragePageCache::create_global_cache(page_cache_mem_tracker(), storage_cache_limit);
+
+    // TODO(zc): The current memory usage configuration is a bit confusing,
+    // we need to sort out the use of memory
+    return Status::OK();
+}
+
+int64_t GlobalEnv::get_storage_page_cache_size() {
+    std::lock_guard<std::mutex> l(*config::get_mstring_conf_lock());
+    int64_t mem_limit = MemInfo::physical_mem();
+    if (process_mem_tracker()->has_limit()) {
+        mem_limit = process_mem_tracker()->limit();
+    }
+    return ParseUtil::parse_mem_spec(config::storage_page_cache_limit, mem_limit);
+}
+
+int64_t GlobalEnv::check_storage_page_cache_size(int64_t storage_cache_limit) {
+    if (storage_cache_limit > MemInfo::physical_mem()) {
+        LOG(WARNING) << "Config storage_page_cache_limit is greater than memory size, config="
+                     << config::storage_page_cache_limit << ", memory=" << MemInfo::physical_mem();
+    }
+    if (!config::disable_storage_page_cache) {
+        if (storage_cache_limit < kcacheMinSize) {
+            LOG(WARNING) << "Storage cache limit is too small, use default size.";
+            storage_cache_limit = kcacheMinSize;
+        }
+        LOG(INFO) << "Set storage page cache size " << storage_cache_limit;
+    }
+    return storage_cache_limit;
+}
+
+template <class... Args>
+std::shared_ptr<MemTracker> GlobalEnv::regist_tracker(Args&&... args) {
+    auto mem_tracker = std::make_shared<MemTracker>(std::forward<Args>(args)...);
+    _mem_trackers.emplace_back(mem_tracker);
+    return mem_tracker;
+}
+
+int64_t GlobalEnv::calc_max_query_memory(int64_t process_mem_limit, int64_t percent) {
+    if (process_mem_limit <= 0) {
+        // -1 means no limit
+        return -1;
+    }
+    if (percent < 0 || percent > 100) {
+        percent = 90;
+    }
+    return process_mem_limit * percent / 100;
+}
+
+Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     _store_paths = store_paths;
     _external_scan_context_mgr = new ExternalScanContextMgr(this);
     _metrics = StarRocksMetrics::instance()->metrics();
@@ -216,7 +349,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                             .set_max_queue_size(0)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
                             .build(&_load_rpc_pool));
-    REGISTER_GAUGE_STARROCKS_METRIC(load_rpc_threadpool_size, _load_rpc_pool->num_threads);
+    REGISTER_GAUGE_STARROCKS_METRIC(load_rpc_threadpool_size, _load_rpc_pool->num_threads)
 
     std::unique_ptr<ThreadPool> driver_executor_thread_pool;
     _max_executor_threads = CpuInfo::num_cores();
@@ -264,7 +397,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
                                                 workgroup::WorkGroupScanTaskQueue::SchedEntityType::CONNECTOR));
     _connector_scan_executor->initialize(connector_num_io_threads);
 
-    starrocks::workgroup::DefaultWorkGroupInitialization default_workgroup_init;
+    workgroup::DefaultWorkGroupInitialization default_workgroup_init;
 
     if (store_paths.empty() && as_cn) {
         _load_path_mgr = new DummyLoadPathMgr();
@@ -330,7 +463,8 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
 
 #elif defined(BE_TEST)
     _lake_location_provider = new lake::FixedLocationProvider(_store_paths.front().path);
-    _lake_update_manager = new lake::UpdateManager(_lake_location_provider, update_mem_tracker());
+    _lake_update_manager =
+            new lake::UpdateManager(_lake_location_provider, GlobalEnv::GetInstance()->update_mem_tracker());
     _lake_tablet_manager =
             new lake::TabletManager(_lake_location_provider, _lake_update_manager, config::lake_metadata_cache_limit);
 #endif
@@ -341,7 +475,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     _broker_mgr->init();
     _small_file_mgr->init();
 
-    RETURN_IF_ERROR(_load_channel_mgr->init(load_mem_tracker()));
+    RETURN_IF_ERROR(_load_channel_mgr->init(GlobalEnv::GetInstance()->load_mem_tracker()));
 
     _heartbeat_flags = new HeartbeatFlags();
     auto capacity = std::max<size_t>(config::query_cache_capacity, 4L * 1024 * 1024);
@@ -361,122 +495,6 @@ void ExecEnv::add_rf_event(const RfTracePoint& pt) {
     std::string msg =
             strings::Substitute("$0($1)", pt.msg, pt.network.empty() ? BackendOptions::get_localhost() : pt.network);
     _runtime_filter_cache->add_rf_event(pt.query_id, pt.filter_id, std::move(msg));
-}
-
-class SetMemTrackerForColumnPool {
-public:
-    SetMemTrackerForColumnPool(std::shared_ptr<MemTracker> mem_tracker) : _mem_tracker(std::move(mem_tracker)) {}
-
-    template <typename Pool>
-    void operator()() {
-        Pool::singleton()->set_mem_tracker(_mem_tracker);
-    }
-
-private:
-    std::shared_ptr<MemTracker> _mem_tracker = nullptr;
-};
-
-Status ExecEnv::init_mem_tracker() {
-    int64_t bytes_limit = 0;
-    std::stringstream ss;
-    // --mem_limit="" means no memory limit
-    bytes_limit = ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem());
-    // use 90% of mem_limit as the soft mem limit of BE
-    bytes_limit = bytes_limit * 0.9;
-    if (bytes_limit <= 0) {
-        ss << "Failed to parse mem limit from '" + config::mem_limit + "'.";
-        return Status::InternalError(ss.str());
-    }
-
-    if (bytes_limit > MemInfo::physical_mem()) {
-        LOG(WARNING) << "Memory limit " << PrettyPrinter::print(bytes_limit, TUnit::BYTES)
-                     << " exceeds physical memory of " << PrettyPrinter::print(MemInfo::physical_mem(), TUnit::BYTES)
-                     << ". Using physical memory instead";
-        bytes_limit = MemInfo::physical_mem();
-    }
-
-    if (bytes_limit <= 0) {
-        ss << "Invalid mem limit: " << bytes_limit;
-        return Status::InternalError(ss.str());
-    }
-
-    _process_mem_tracker = regist_tracker(MemTracker::PROCESS, bytes_limit, "process");
-    int64_t query_pool_mem_limit =
-            calc_max_query_memory(_process_mem_tracker->limit(), config::query_max_memory_limit_percent);
-    _query_pool_mem_tracker =
-            regist_tracker(MemTracker::QUERY_POOL, query_pool_mem_limit, "query_pool", this->process_mem_tracker());
-
-    int64_t load_mem_limit = calc_max_load_memory(_process_mem_tracker->limit());
-    _load_mem_tracker = regist_tracker(MemTracker::LOAD, load_mem_limit, "load", process_mem_tracker());
-
-    // Metadata statistics memory statistics do not use new mem statistics framework with hook
-    _metadata_mem_tracker = regist_tracker(-1, "metadata", nullptr);
-
-    _tablet_metadata_mem_tracker = regist_tracker(-1, "tablet_metadata", metadata_mem_tracker());
-    _rowset_metadata_mem_tracker = regist_tracker(-1, "rowset_metadata", metadata_mem_tracker());
-    _segment_metadata_mem_tracker = regist_tracker(-1, "segment_metadata", metadata_mem_tracker());
-    _column_metadata_mem_tracker = regist_tracker(-1, "column_metadata", metadata_mem_tracker());
-
-    _tablet_schema_mem_tracker = regist_tracker(-1, "tablet_schema", tablet_metadata_mem_tracker());
-    _segment_zonemap_mem_tracker = regist_tracker(-1, "segment_zonemap", segment_metadata_mem_tracker());
-    _short_key_index_mem_tracker = regist_tracker(-1, "short_key_index", segment_metadata_mem_tracker());
-    _column_zonemap_index_mem_tracker = regist_tracker(-1, "column_zonemap_index", column_metadata_mem_tracker());
-    _ordinal_index_mem_tracker = regist_tracker(-1, "ordinal_index", column_metadata_mem_tracker());
-    _bitmap_index_mem_tracker = regist_tracker(-1, "bitmap_index", column_metadata_mem_tracker());
-    _bloom_filter_index_mem_tracker = regist_tracker(-1, "bloom_filter_index", column_metadata_mem_tracker());
-
-    int64_t compaction_mem_limit = calc_max_compaction_memory(_process_mem_tracker->limit());
-    _compaction_mem_tracker = regist_tracker(compaction_mem_limit, "compaction", process_mem_tracker());
-    _schema_change_mem_tracker = regist_tracker(-1, "schema_change", process_mem_tracker());
-    _column_pool_mem_tracker = regist_tracker(-1, "column_pool", process_mem_tracker());
-    _page_cache_mem_tracker = regist_tracker(-1, "page_cache", process_mem_tracker());
-    int32_t update_mem_percent = std::max(std::min(100, config::update_memory_limit_percent), 0);
-    _update_mem_tracker = regist_tracker(bytes_limit * update_mem_percent / 100, "update", nullptr);
-    _chunk_allocator_mem_tracker = regist_tracker(-1, "chunk_allocator", process_mem_tracker());
-    _clone_mem_tracker = regist_tracker(-1, "clone", process_mem_tracker());
-    int64_t consistency_mem_limit = calc_max_consistency_memory(process_mem_tracker()->limit());
-    _consistency_mem_tracker = regist_tracker(consistency_mem_limit, "consistency", process_mem_tracker());
-
-    MemChunkAllocator::init_instance(_chunk_allocator_mem_tracker.get(), config::chunk_reserved_bytes_limit);
-
-    SetMemTrackerForColumnPool op(_column_pool_mem_tracker);
-    ForEach<ColumnPoolList>(op);
-    _init_storage_page_cache();
-    return Status::OK();
-}
-
-int64_t ExecEnv::get_storage_page_cache_size() {
-    std::lock_guard<std::mutex> l(*config::get_mstring_conf_lock());
-    int64_t mem_limit = MemInfo::physical_mem();
-    if (process_mem_tracker()->has_limit()) {
-        mem_limit = process_mem_tracker()->limit();
-    }
-    return ParseUtil::parse_mem_spec(config::storage_page_cache_limit, mem_limit);
-}
-
-int64_t ExecEnv::check_storage_page_cache_size(int64_t storage_cache_limit) {
-    if (storage_cache_limit > MemInfo::physical_mem()) {
-        LOG(WARNING) << "Config storage_page_cache_limit is greater than memory size, config="
-                     << config::storage_page_cache_limit << ", memory=" << MemInfo::physical_mem();
-    }
-    if (!config::disable_storage_page_cache) {
-        if (storage_cache_limit < kcacheMinSize) {
-            LOG(WARNING) << "Storage cache limit is too small, use default size.";
-            storage_cache_limit = kcacheMinSize;
-        }
-        LOG(INFO) << "Set storage page cache size " << storage_cache_limit;
-    }
-    return storage_cache_limit;
-}
-
-Status ExecEnv::_init_storage_page_cache() {
-    int64_t storage_cache_limit = get_storage_page_cache_size();
-    storage_cache_limit = check_storage_page_cache_size(storage_cache_limit);
-    StoragePageCache::create_global_cache(page_cache_mem_tracker(), storage_cache_limit);
-
-    // TODO(zc): The current memory usage configuration is a bit confusing,
-    // we need to sort out the use of memory
-    return Status::OK();
 }
 
 void ExecEnv::stop() {
@@ -544,21 +562,6 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_lake_update_manager);
     SAFE_DELETE(_cache_mgr);
     _metrics = nullptr;
-
-    _reset_tracker();
-}
-
-void ExecEnv::_reset_tracker() {
-    for (auto iter = _mem_trackers.rbegin(); iter != _mem_trackers.rend(); ++iter) {
-        iter->reset();
-    }
-}
-
-template <class... Args>
-std::shared_ptr<MemTracker> ExecEnv::regist_tracker(Args&&... args) {
-    auto mem_tracker = std::make_shared<MemTracker>(std::forward<Args>(args)...);
-    _mem_trackers.emplace_back(mem_tracker);
-    return mem_tracker;
 }
 
 int32_t ExecEnv::calc_pipeline_dop(int32_t pipeline_dop) const {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -449,7 +449,8 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
 
 #if defined(USE_STAROS) && !defined(BE_TEST)
     _lake_location_provider = new lake::StarletLocationProvider();
-    _lake_update_manager = new lake::UpdateManager(_lake_location_provider, update_mem_tracker());
+    _lake_update_manager =
+            new lake::UpdateManager(_lake_location_provider, GlobalEnv::GetInstance()->update_mem_tracker());
     _lake_tablet_manager =
             new lake::TabletManager(_lake_location_provider, _lake_update_manager, config::lake_metadata_cache_limit);
     if (config::starlet_cache_dir.empty()) {

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -101,51 +101,23 @@ namespace spill {
 class DirManager;
 }
 
-// Execution environment for queries/plan fragments.
-// Contains all required global structures, and handles to
-// singleton services. Clients must call StartServices exactly
-// once to properly initialise service state.
-class ExecEnv {
+class GlobalEnv {
 public:
+    static GlobalEnv* GetInstance() {
+        static GlobalEnv s_global_env;
+        return &s_global_env;
+    }
+
+    GlobalEnv() = default;
+    ~GlobalEnv() { _is_init = false; }
+
+    Status init();
+    void stop() {
+        _is_init = false;
+        _reset_tracker();
+    }
+
     static bool is_init();
-
-    // Initial exec environment. must call this to init all
-    Status init(const std::vector<StorePath>& store_paths, bool as_cn = false);
-    void stop();
-    void destroy();
-
-    /// Returns the first created exec env instance. In a normal starrocks, this is
-    /// the only instance. In test setups with multiple ExecEnv's per process,
-    /// we return the most recently created instance.
-    static ExecEnv* GetInstance() {
-        static ExecEnv s_exec_env;
-        return &s_exec_env;
-    }
-
-    // only used for test
-    ExecEnv() = default;
-
-    // Empty destructor because the compiler-generated one requires full
-    // declarations for classes in scoped_ptrs.
-    ~ExecEnv() = default;
-
-    std::string token() const;
-    ExternalScanContextMgr* external_scan_context_mgr() { return _external_scan_context_mgr; }
-    MetricRegistry* metrics() const { return _metrics; }
-    DataStreamMgr* stream_mgr() { return _stream_mgr; }
-    ResultBufferMgr* result_mgr() { return _result_mgr; }
-    ResultQueueMgr* result_queue_mgr() { return _result_queue_mgr; }
-    ClientCache<BackendServiceClient>* client_cache() { return _backend_client_cache; }
-    ClientCache<FrontendServiceClient>* frontend_client_cache() { return _frontend_client_cache; }
-    ClientCache<TFileBrokerServiceClient>* broker_client_cache() { return _broker_client_cache; }
-
-    static int64_t calc_max_query_memory(int64_t process_mem_limit, int64_t percent);
-
-    // using template to simplify client cache management
-    template <typename T>
-    ClientCache<T>* get_client_cache() {
-        return nullptr;
-    }
 
     MemTracker* process_mem_tracker() { return _process_mem_tracker.get(); }
     MemTracker* query_pool_mem_tracker() { return _query_pool_mem_tracker.get(); }
@@ -172,87 +144,21 @@ public:
     MemTracker* consistency_mem_tracker() { return _consistency_mem_tracker.get(); }
     std::vector<std::shared_ptr<MemTracker>>& mem_trackers() { return _mem_trackers; }
 
-    PriorityThreadPool* thread_pool() { return _thread_pool; }
-    workgroup::ScanExecutor* scan_executor() { return _scan_executor; }
-    workgroup::ScanExecutor* connector_scan_executor() { return _connector_scan_executor; }
-
-    PriorityThreadPool* udf_call_pool() { return _udf_call_pool; }
-    PriorityThreadPool* pipeline_prepare_pool() { return _pipeline_prepare_pool; }
-    PriorityThreadPool* pipeline_sink_io_pool() { return _pipeline_sink_io_pool; }
-    PriorityThreadPool* query_rpc_pool() { return _query_rpc_pool; }
-    ThreadPool* load_rpc_pool() { return _load_rpc_pool.get(); }
-    FragmentMgr* fragment_mgr() { return _fragment_mgr; }
-    starrocks::pipeline::DriverExecutor* wg_driver_executor() { return _wg_driver_executor; }
-    BaseLoadPathMgr* load_path_mgr() { return _load_path_mgr; }
-    BfdParser* bfd_parser() const { return _bfd_parser; }
-    BrokerMgr* broker_mgr() const { return _broker_mgr; }
-    BrpcStubCache* brpc_stub_cache() const { return _brpc_stub_cache; }
-    LoadChannelMgr* load_channel_mgr() { return _load_channel_mgr; }
-    LoadStreamMgr* load_stream_mgr() { return _load_stream_mgr; }
-    SmallFileMgr* small_file_mgr() { return _small_file_mgr; }
-    StreamContextMgr* stream_context_mgr() { return _stream_context_mgr; }
-    TransactionMgr* transaction_mgr() { return _transaction_mgr; }
-
-    const std::vector<StorePath>& store_paths() const { return _store_paths; }
-    void set_store_paths(const std::vector<StorePath>& paths) { _store_paths = paths; }
-
-    StreamLoadExecutor* stream_load_executor() { return _stream_load_executor; }
-    RoutineLoadTaskExecutor* routine_load_task_executor() { return _routine_load_task_executor; }
-    HeartbeatFlags* heartbeat_flags() { return _heartbeat_flags; }
-
-    ThreadPool* automatic_partition_pool() { return _automatic_partition_pool.get(); }
-
-    RuntimeFilterWorker* runtime_filter_worker() { return _runtime_filter_worker; }
-    Status init_mem_tracker();
-
-    RuntimeFilterCache* runtime_filter_cache() { return _runtime_filter_cache; }
-
-    ProfileReportWorker* profile_report_worker() { return _profile_report_worker; }
-
-    void add_rf_event(const RfTracePoint& pt);
-
-    pipeline::QueryContextManager* query_context_mgr() { return _query_context_mgr; }
-
-    pipeline::DriverLimiter* driver_limiter() { return _driver_limiter; }
-
-    int64_t max_executor_threads() const { return _max_executor_threads; }
-
-    int32_t calc_pipeline_dop(int32_t pipeline_dop) const;
-
-    lake::TabletManager* lake_tablet_manager() const { return _lake_tablet_manager; }
-
-    lake::LocationProvider* lake_location_provider() const { return _lake_location_provider; }
-
-    lake::UpdateManager* lake_update_manager() const { return _lake_update_manager; }
-
-    AgentServer* agent_server() const { return _agent_server; }
-
     int64_t get_storage_page_cache_size();
     int64_t check_storage_page_cache_size(int64_t storage_cache_limit);
-
-    query_cache::CacheManagerRawPtr cache_mgr() const { return _cache_mgr; }
-
-    spill::DirManager* spill_dir_mgr() const { return _spill_dir_mgr.get(); }
-
-private:
-    void _reset_tracker();
-    template <class... Args>
-    std::shared_ptr<MemTracker> regist_tracker(Args&&... args);
-
-    Status _init_storage_page_cache();
+    static int64_t calc_max_query_memory(int64_t process_mem_limit, int64_t percent);
 
 private:
     static bool _is_init;
-    std::vector<StorePath> _store_paths;
-    // Leave protected so that subclasses can override
-    ExternalScanContextMgr* _external_scan_context_mgr = nullptr;
-    MetricRegistry* _metrics = nullptr;
-    DataStreamMgr* _stream_mgr = nullptr;
-    ResultBufferMgr* _result_mgr = nullptr;
-    ResultQueueMgr* _result_queue_mgr = nullptr;
-    ClientCache<BackendServiceClient>* _backend_client_cache = nullptr;
-    ClientCache<FrontendServiceClient>* _frontend_client_cache = nullptr;
-    ClientCache<TFileBrokerServiceClient>* _broker_client_cache = nullptr;
+
+    Status _init_mem_tracker();
+    void _reset_tracker();
+
+    Status _init_storage_page_cache();
+
+    template <class... Args>
+    std::shared_ptr<MemTracker> regist_tracker(Args&&... args);
+
     // root process memory tracker
     std::shared_ptr<MemTracker> _process_mem_tracker;
 
@@ -302,6 +208,119 @@ private:
     std::shared_ptr<MemTracker> _consistency_mem_tracker;
 
     std::vector<std::shared_ptr<MemTracker>> _mem_trackers;
+};
+
+// Execution environment for queries/plan fragments.
+// Contains all required global structures, and handles to
+// singleton services. Clients must call StartServices exactly
+// once to properly initialise service state.
+class ExecEnv {
+public:
+    // Initial exec environment. must call this to init all
+    Status init(const std::vector<StorePath>& store_paths, bool as_cn = false);
+    void stop();
+    void destroy();
+
+    /// Returns the first created exec env instance. In a normal starrocks, this is
+    /// the only instance. In test setups with multiple ExecEnv's per process,
+    /// we return the most recently created instance.
+    static ExecEnv* GetInstance() {
+        static ExecEnv s_exec_env;
+        return &s_exec_env;
+    }
+
+    // only used for test
+    ExecEnv() = default;
+
+    // Empty destructor because the compiler-generated one requires full
+    // declarations for classes in scoped_ptrs.
+    ~ExecEnv() = default;
+
+    std::string token() const;
+    ExternalScanContextMgr* external_scan_context_mgr() { return _external_scan_context_mgr; }
+    MetricRegistry* metrics() const { return _metrics; }
+    DataStreamMgr* stream_mgr() { return _stream_mgr; }
+    ResultBufferMgr* result_mgr() { return _result_mgr; }
+    ResultQueueMgr* result_queue_mgr() { return _result_queue_mgr; }
+    ClientCache<BackendServiceClient>* client_cache() { return _backend_client_cache; }
+    ClientCache<FrontendServiceClient>* frontend_client_cache() { return _frontend_client_cache; }
+    ClientCache<TFileBrokerServiceClient>* broker_client_cache() { return _broker_client_cache; }
+
+    // using template to simplify client cache management
+    template <typename T>
+    ClientCache<T>* get_client_cache() {
+        return nullptr;
+    }
+
+    PriorityThreadPool* thread_pool() { return _thread_pool; }
+    workgroup::ScanExecutor* scan_executor() { return _scan_executor; }
+    workgroup::ScanExecutor* connector_scan_executor() { return _connector_scan_executor; }
+
+    PriorityThreadPool* udf_call_pool() { return _udf_call_pool; }
+    PriorityThreadPool* pipeline_prepare_pool() { return _pipeline_prepare_pool; }
+    PriorityThreadPool* pipeline_sink_io_pool() { return _pipeline_sink_io_pool; }
+    PriorityThreadPool* query_rpc_pool() { return _query_rpc_pool; }
+    ThreadPool* load_rpc_pool() { return _load_rpc_pool.get(); }
+    FragmentMgr* fragment_mgr() { return _fragment_mgr; }
+    starrocks::pipeline::DriverExecutor* wg_driver_executor() { return _wg_driver_executor; }
+    BaseLoadPathMgr* load_path_mgr() { return _load_path_mgr; }
+    BfdParser* bfd_parser() const { return _bfd_parser; }
+    BrokerMgr* broker_mgr() const { return _broker_mgr; }
+    BrpcStubCache* brpc_stub_cache() const { return _brpc_stub_cache; }
+    LoadChannelMgr* load_channel_mgr() { return _load_channel_mgr; }
+    LoadStreamMgr* load_stream_mgr() { return _load_stream_mgr; }
+    SmallFileMgr* small_file_mgr() { return _small_file_mgr; }
+    StreamContextMgr* stream_context_mgr() { return _stream_context_mgr; }
+    TransactionMgr* transaction_mgr() { return _transaction_mgr; }
+
+    const std::vector<StorePath>& store_paths() const { return _store_paths; }
+    void set_store_paths(const std::vector<StorePath>& paths) { _store_paths = paths; }
+
+    StreamLoadExecutor* stream_load_executor() { return _stream_load_executor; }
+    RoutineLoadTaskExecutor* routine_load_task_executor() { return _routine_load_task_executor; }
+    HeartbeatFlags* heartbeat_flags() { return _heartbeat_flags; }
+
+    ThreadPool* automatic_partition_pool() { return _automatic_partition_pool.get(); }
+
+    RuntimeFilterWorker* runtime_filter_worker() { return _runtime_filter_worker; }
+
+    RuntimeFilterCache* runtime_filter_cache() { return _runtime_filter_cache; }
+
+    ProfileReportWorker* profile_report_worker() { return _profile_report_worker; }
+
+    void add_rf_event(const RfTracePoint& pt);
+
+    pipeline::QueryContextManager* query_context_mgr() { return _query_context_mgr; }
+
+    pipeline::DriverLimiter* driver_limiter() { return _driver_limiter; }
+
+    int64_t max_executor_threads() const { return _max_executor_threads; }
+
+    int32_t calc_pipeline_dop(int32_t pipeline_dop) const;
+
+    lake::TabletManager* lake_tablet_manager() const { return _lake_tablet_manager; }
+
+    lake::LocationProvider* lake_location_provider() const { return _lake_location_provider; }
+
+    lake::UpdateManager* lake_update_manager() const { return _lake_update_manager; }
+
+    AgentServer* agent_server() const { return _agent_server; }
+
+    query_cache::CacheManagerRawPtr cache_mgr() const { return _cache_mgr; }
+
+    spill::DirManager* spill_dir_mgr() const { return _spill_dir_mgr.get(); }
+
+private:
+    std::vector<StorePath> _store_paths;
+    // Leave protected so that subclasses can override
+    ExternalScanContextMgr* _external_scan_context_mgr = nullptr;
+    MetricRegistry* _metrics = nullptr;
+    DataStreamMgr* _stream_mgr = nullptr;
+    ResultBufferMgr* _result_mgr = nullptr;
+    ResultQueueMgr* _result_queue_mgr = nullptr;
+    ClientCache<BackendServiceClient>* _backend_client_cache = nullptr;
+    ClientCache<FrontendServiceClient>* _frontend_client_cache = nullptr;
+    ClientCache<TFileBrokerServiceClient>* _broker_client_cache = nullptr;
 
     PriorityThreadPool* _thread_pool = nullptr;
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -424,7 +424,8 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, co
 
 Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, const StartSuccCallback& start_cb,
                                        const FinishCallback& cb) {
-    RETURN_IF_ERROR(_exec_env->query_pool_mem_tracker()->check_mem_limit("Start execute plan fragment."));
+    RETURN_IF_ERROR(
+            GlobalEnv::GetInstance()->query_pool_mem_tracker()->check_mem_limit("Start execute plan fragment."));
 
     const TUniqueId& fragment_instance_id = params.params.fragment_instance_id;
     std::shared_ptr<FragmentExecState> exec_state;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -180,7 +180,7 @@ void RuntimeState::init_mem_trackers(const TUniqueId& query_id, MemTracker* pare
     mem_tracker_counter->set(bytes_limit);
 
     if (parent == nullptr) {
-        parent = _exec_env->query_pool_mem_tracker();
+        parent = GlobalEnv::GetInstance()->query_pool_mem_tracker();
     }
 
     _query_mem_tracker =

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -158,7 +158,7 @@ Status DataStreamRecvr::NonPipelineSenderQueue::get_chunk(Chunk** chunk, const i
         // and the execution thread will call run() to let brpc continue to send packets,
         // and there will be memory release
 #ifndef BE_TEST
-        MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(ExecEnv::GetInstance()->process_mem_tracker());
+        MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(GlobalEnv::GetInstance()->process_mem_tracker());
         DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 #endif
 
@@ -443,7 +443,8 @@ Status DataStreamRecvr::PipelineSenderQueue::get_chunk(Chunk** chunk, const int3
         auto* closure = item.closure;
         if (closure != nullptr) {
 #ifndef BE_TEST
-            MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(ExecEnv::GetInstance()->process_mem_tracker());
+            MemTracker* prev_tracker =
+                    tls_thread_status.set_mem_tracker(GlobalEnv::GetInstance()->process_mem_tracker());
             DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 #endif
             _recvr->_closure_block_timer->update(MonotonicNanos() - item.queue_enter_time);

--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -189,16 +189,20 @@ void bind_exec_env(ForeignModule& m) {
         // uncomment this to enable executing shell commands
         // cls.funcStaticExt<&exec_whitelist>("exec");
         cls.funcStaticExt<&list_stack_trace_of_long_wait_mutex>("list_stack_trace_of_long_wait_mutex");
-        REG_METHOD(ExecEnv, process_mem_tracker);
-        REG_METHOD(ExecEnv, query_pool_mem_tracker);
-        REG_METHOD(ExecEnv, load_mem_tracker);
-        REG_METHOD(ExecEnv, metadata_mem_tracker);
-        REG_METHOD(ExecEnv, tablet_metadata_mem_tracker);
-        REG_METHOD(ExecEnv, rowset_metadata_mem_tracker);
-        REG_METHOD(ExecEnv, segment_metadata_mem_tracker);
-        REG_METHOD(ExecEnv, compaction_mem_tracker);
-        REG_METHOD(ExecEnv, update_mem_tracker);
-        REG_METHOD(ExecEnv, clone_mem_tracker);
+    }
+    {
+        auto& cls = m.klass<GlobalEnv>("GlobalEnv");
+        REG_STATIC_METHOD(GlobalEnv, GetInstance);
+        REG_METHOD(GlobalEnv, process_mem_tracker);
+        REG_METHOD(GlobalEnv, query_pool_mem_tracker);
+        REG_METHOD(GlobalEnv, load_mem_tracker);
+        REG_METHOD(GlobalEnv, metadata_mem_tracker);
+        REG_METHOD(GlobalEnv, tablet_metadata_mem_tracker);
+        REG_METHOD(GlobalEnv, rowset_metadata_mem_tracker);
+        REG_METHOD(GlobalEnv, segment_metadata_mem_tracker);
+        REG_METHOD(GlobalEnv, compaction_mem_tracker);
+        REG_METHOD(GlobalEnv, update_mem_tracker);
+        REG_METHOD(GlobalEnv, clone_mem_tracker);
     }
 }
 
@@ -465,7 +469,7 @@ Status execute_script(const std::string& script, std::string& output) {
     bind_common(m);
     bind_exec_env(m);
     StorageEngineRef::bind(m);
-    vm.runFromSource("main", R"(import "starrocks" for ExecEnv, StorageEngine)");
+    vm.runFromSource("main", R"(import "starrocks" for ExecEnv, GlobalEnv, StorageEngine)");
     try {
         vm.runFromSource("main", script);
     } catch (const std::exception& e) {

--- a/be/src/service/mem_hook.cpp
+++ b/be/src/service/mem_hook.cpp
@@ -224,7 +224,7 @@ void operator delete[](void* p, size_t size, std::align_val_t al) noexcept {
         }                                                                                                \
     } while (0)
 #define SET_EXCEED_MEM_TRACKER() \
-    starrocks::tls_exceed_mem_tracker = starrocks::ExecEnv::GetInstance()->process_mem_tracker()
+    starrocks::tls_exceed_mem_tracker = starrocks::GlobalEnv::GetInstance()->process_mem_tracker()
 #define IS_BAD_ALLOC_CATCHED() starrocks::tls_thread_status.is_catched()
 #else
 std::atomic<int64_t> g_mem_usage(0);

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -81,7 +81,7 @@ HttpServiceBE::~HttpServiceBE() {
 }
 
 Status HttpServiceBE::start() {
-    add_default_path_handlers(_web_page_handler.get(), _env->process_mem_tracker());
+    add_default_path_handlers(_web_page_handler.get(), GlobalEnv::GetInstance()->process_mem_tracker());
 
     // register load
     auto* stream_load_action = new StreamLoadAction(_env, _http_concurrent_limiter.get());

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -249,15 +249,17 @@ int main(int argc, char** argv) {
         exit(-1);
     }
 
+    auto* global_env = starrocks::GlobalEnv::GetInstance();
+    EXIT_IF_ERROR(global_env->init());
+
     auto* exec_env = starrocks::ExecEnv::GetInstance();
-    EXIT_IF_ERROR(exec_env->init_mem_tracker());
 
     // Init and open storage engine.
     starrocks::EngineOptions options;
     options.store_paths = paths;
     options.backend_uid = starrocks::UniqueId::gen_uid();
-    options.compaction_mem_tracker = exec_env->compaction_mem_tracker();
-    options.update_mem_tracker = exec_env->update_mem_tracker();
+    options.compaction_mem_tracker = global_env->compaction_mem_tracker();
+    options.update_mem_tracker = global_env->update_mem_tracker();
     options.need_write_cluster_id = !as_cn;
     starrocks::StorageEngine* engine = nullptr;
 

--- a/be/src/storage/compaction_task_factory.cpp
+++ b/be/src/storage/compaction_task_factory.cpp
@@ -69,7 +69,7 @@ std::shared_ptr<CompactionTask> CompactionTaskFactory::create_compaction_task() 
     compaction_task->set_segment_iterator_num(segment_iterator_num);
     std::unique_ptr<MemTracker> mem_tracker = std::make_unique<MemTracker>(
             MemTracker::COMPACTION, -1, "Compaction-" + std::to_string(compaction_task->task_id()),
-            ExecEnv::GetInstance()->compaction_mem_tracker());
+            GlobalEnv::GetInstance()->compaction_mem_tracker());
     compaction_task->set_mem_tracker(mem_tracker.release());
     return compaction_task;
 }

--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -26,6 +26,6 @@ CompactionTask::CompactionTask(int64_t txn_id, int64_t version, std::shared_ptr<
           _input_rowsets(std::move(input_rowsets)),
           _mem_tracker(std::make_unique<MemTracker>(MemTracker::COMPACTION, -1,
                                                     "Compaction-" + std::to_string(_tablet->id()),
-                                                    ExecEnv::GetInstance()->compaction_mem_tracker())) {}
+                                                    GlobalEnv::GetInstance()->compaction_mem_tracker())) {}
 
 } // namespace starrocks::lake

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -265,7 +265,7 @@ void* StorageEngine::_adjust_pagecache_callback(void* arg_this) {
         if (config::disable_storage_page_cache) {
             continue;
         }
-        MemTracker* memtracker = ExecEnv::GetInstance()->process_mem_tracker();
+        MemTracker* memtracker = GlobalEnv::GetInstance()->process_mem_tracker();
         if (memtracker == nullptr || !memtracker->has_limit() || cache == nullptr) {
             continue;
         }
@@ -305,7 +305,7 @@ void* StorageEngine::_adjust_pagecache_callback(void* arg_this) {
             size_t bytes_to_dec = dec_advisor->bytes_should_gc(MonoTime::Now(), delta_high);
             evict_pagecache(cache, static_cast<int64_t>(bytes_to_dec), _bg_worker_stopped);
         } else {
-            int64_t max_cache_size = std::max(ExecEnv::GetInstance()->get_storage_page_cache_size(), kcacheMinSize);
+            int64_t max_cache_size = std::max(GlobalEnv::GetInstance()->get_storage_page_cache_size(), kcacheMinSize);
             int64_t cur_cache_size = cache->get_capacity();
             if (cur_cache_size >= max_cache_size) {
                 continue;
@@ -431,7 +431,7 @@ void* StorageEngine::_repair_compaction_thread_callback(void* arg) {
             }
             vector<pair<uint32_t, string>> rowset_results;
             for (auto rowsetid : task.second) {
-                auto st = tablet->updates()->compaction(ExecEnv::GetInstance()->compaction_mem_tracker(), {rowsetid});
+                auto st = tablet->updates()->compaction(GlobalEnv::GetInstance()->compaction_mem_tracker(), {rowsetid});
                 if (!st.ok()) {
                     LOG(WARNING) << "repair compaction failed tablet: " << task.first << " rowset: " << rowsetid << " "
                                  << st;

--- a/be/src/storage/page_cache.h
+++ b/be/src/storage/page_cache.h
@@ -134,7 +134,7 @@ public:
         if (_handle != nullptr) {
 #ifndef BE_TEST
             MemTracker* prev_tracker =
-                    tls_thread_status.set_mem_tracker(ExecEnv::GetInstance()->page_cache_mem_tracker());
+                    tls_thread_status.set_mem_tracker(GlobalEnv::GetInstance()->page_cache_mem_tracker());
             DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 #endif
             _cache->release(_handle);

--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -49,18 +49,18 @@ namespace starrocks {
 using Roaring = roaring::Roaring;
 
 BitmapIndexReader::BitmapIndexReader() {
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->bitmap_index_mem_tracker(), sizeof(BitmapIndexReader));
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(), sizeof(BitmapIndexReader));
 }
 
 BitmapIndexReader::~BitmapIndexReader() {
-    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->bitmap_index_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(), _mem_usage());
 }
 
 StatusOr<bool> BitmapIndexReader::load(const IndexReadOptions& opts, const BitmapIndexPB& meta) {
     return success_once(_load_once, [&]() {
         Status st = _do_load(opts, meta);
         if (st.ok()) {
-            MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->bitmap_index_mem_tracker(),
+            MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(),
                                      _mem_usage() - sizeof(BitmapIndexReader));
         } else {
             _reset();

--- a/be/src/storage/rowset/bloom_filter_index_reader.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_reader.cpp
@@ -47,18 +47,19 @@
 namespace starrocks {
 
 BloomFilterIndexReader::BloomFilterIndexReader() {
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->bloom_filter_index_mem_tracker(), sizeof(BloomFilterIndexReader));
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bloom_filter_index_mem_tracker(),
+                             sizeof(BloomFilterIndexReader));
 }
 
 BloomFilterIndexReader::~BloomFilterIndexReader() {
-    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->bloom_filter_index_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->bloom_filter_index_mem_tracker(), _mem_usage());
 }
 
 StatusOr<bool> BloomFilterIndexReader::load(const IndexReadOptions& opts, const BloomFilterIndexPB& meta) {
     return success_once(_load_once, [&]() {
         Status st = _do_load(opts, meta);
         if (st.ok()) {
-            MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->bloom_filter_index_mem_tracker(),
+            MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bloom_filter_index_mem_tracker(),
                                      _mem_usage() - sizeof(BloomFilterIndexReader));
         } else {
             _reset();

--- a/be/src/storage/rowset/ordinal_page_index.cpp
+++ b/be/src/storage/rowset/ordinal_page_index.cpp
@@ -76,11 +76,11 @@ Status OrdinalIndexWriter::finish(WritableFile* wfile, ColumnIndexMetaPB* meta) 
 }
 
 OrdinalIndexReader::OrdinalIndexReader() {
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->ordinal_index_mem_tracker(), sizeof(OrdinalIndexReader));
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->ordinal_index_mem_tracker(), sizeof(OrdinalIndexReader));
 }
 
 OrdinalIndexReader::~OrdinalIndexReader() {
-    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->ordinal_index_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->ordinal_index_mem_tracker(), _mem_usage());
 }
 
 StatusOr<bool> OrdinalIndexReader::load(const IndexReadOptions& opts, const OrdinalIndexPB& meta,
@@ -88,7 +88,7 @@ StatusOr<bool> OrdinalIndexReader::load(const IndexReadOptions& opts, const Ordi
     return success_once(_load_once, [&]() {
         Status st = _do_load(opts, meta, num_values);
         if (st.ok()) {
-            MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->ordinal_index_mem_tracker(),
+            MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->ordinal_index_mem_tracker(),
                                      _mem_usage() - sizeof(OrdinalIndexReader))
         } else {
             _reset();

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -69,11 +69,11 @@ Rowset::Rowset(const TabletSchema* schema, std::string rowset_path, RowsetMetaSh
           _rowset_path(std::move(rowset_path)),
           _rowset_meta(std::move(rowset_meta)),
           _refs_by_reader(0) {
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage());
 }
 
 Rowset::~Rowset() {
-    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage());
 }
 
 Status Rowset::load() {

--- a/be/src/storage/rowset/rowset_meta.cpp
+++ b/be/src/storage/rowset/rowset_meta.cpp
@@ -25,25 +25,25 @@ RowsetMeta::RowsetMeta(std::string_view pb_rowset_meta, bool* parse_ok) {
         _init();
     }
     _mem_usage = _calc_mem_usage();
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
 }
 
 RowsetMeta::RowsetMeta(std::unique_ptr<RowsetMetaPB>& rowset_meta_pb) {
     _rowset_meta_pb = std::move(rowset_meta_pb);
     _init();
     _mem_usage = _calc_mem_usage();
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
 }
 
 RowsetMeta::RowsetMeta(const RowsetMetaPB& rowset_meta_pb) {
     _rowset_meta_pb = std::make_unique<RowsetMetaPB>(rowset_meta_pb);
     _init();
     _mem_usage = _calc_mem_usage();
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
 }
 
 RowsetMeta::~RowsetMeta() {
-    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage);
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -186,7 +186,7 @@ Status Segment::parse_segment_footer(RandomAccessFile* read_file, SegmentFooterP
 Segment::Segment(const private_type&, std::shared_ptr<FileSystem> fs, std::string path, uint32_t segment_id,
                  const TabletSchema* tablet_schema)
         : _fs(std::move(fs)), _fname(std::move(path)), _tablet_schema(tablet_schema), _segment_id(segment_id) {
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->segment_metadata_mem_tracker(), _basic_info_mem_usage());
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->segment_metadata_mem_tracker(), _basic_info_mem_usage());
 }
 
 Segment::Segment(const private_type&, std::shared_ptr<FileSystem> fs, std::string path, uint32_t segment_id,
@@ -195,12 +195,12 @@ Segment::Segment(const private_type&, std::shared_ptr<FileSystem> fs, std::strin
           _fname(std::move(path)),
           _tablet_schema(std::move(tablet_schema)),
           _segment_id(segment_id) {
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->segment_metadata_mem_tracker(), _basic_info_mem_usage());
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->segment_metadata_mem_tracker(), _basic_info_mem_usage());
 }
 
 Segment::~Segment() {
-    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->segment_metadata_mem_tracker(), _basic_info_mem_usage());
-    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->short_key_index_mem_tracker(), _short_key_index_mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->segment_metadata_mem_tracker(), _basic_info_mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->short_key_index_mem_tracker(), _short_key_index_mem_usage());
 }
 
 Status Segment::_open(size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer,
@@ -289,7 +289,7 @@ Status Segment::load_index(bool skip_fill_local_cache) {
 
         Status st = _load_index(skip_fill_local_cache);
         if (st.ok()) {
-            MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->short_key_index_mem_tracker(),
+            MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->short_key_index_mem_tracker(),
                                      _short_key_index_mem_usage());
         } else {
             _reset();

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -255,18 +255,18 @@ Status ZoneMapIndexWriterImpl<type>::finish(WritableFile* wfile, ColumnIndexMeta
 }
 
 ZoneMapIndexReader::ZoneMapIndexReader() {
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->column_zonemap_index_mem_tracker(), sizeof(ZoneMapIndexReader));
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->column_zonemap_index_mem_tracker(), sizeof(ZoneMapIndexReader));
 }
 
 ZoneMapIndexReader::~ZoneMapIndexReader() {
-    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->column_zonemap_index_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->column_zonemap_index_mem_tracker(), _mem_usage());
 }
 
 StatusOr<bool> ZoneMapIndexReader::load(const IndexReadOptions& opts, const ZoneMapIndexPB& meta) {
     return success_once(_load_once, [&]() {
         Status st = _do_load(opts, meta);
         if (st.ok()) {
-            MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->column_zonemap_index_mem_tracker(),
+            MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->column_zonemap_index_mem_tracker(),
                                      _mem_usage() - sizeof(ZoneMapIndexReader));
         } else {
             _reset();

--- a/be/src/storage/segment_replicate_executor.cpp
+++ b/be/src/storage/segment_replicate_executor.cpp
@@ -78,7 +78,7 @@ Status ReplicateChannel::_init() {
         LOG(WARNING) << msg;
         return Status::InternalError(msg);
     }
-    _mem_tracker = ExecEnv::GetInstance()->load_mem_tracker();
+    _mem_tracker = GlobalEnv::GetInstance()->load_mem_tracker();
     if (!_mem_tracker) {
         auto msg = fmt::format("Failed to get load mem tracker for {} failed.", debug_string().c_str());
         LOG(WARNING) << msg;

--- a/be/src/storage/snapshot_manager.cpp
+++ b/be/src/storage/snapshot_manager.cpp
@@ -73,7 +73,7 @@ SnapshotManager* SnapshotManager::instance() {
     if (_s_instance == nullptr) {
         std::lock_guard<std::mutex> lock(_mlock);
         if (_s_instance == nullptr) {
-            _s_instance = new SnapshotManager(ExecEnv::GetInstance()->clone_mem_tracker());
+            _s_instance = new SnapshotManager(GlobalEnv::GetInstance()->clone_mem_tracker());
         }
     }
     return _s_instance;

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -759,7 +759,7 @@ static void do_manual_compaction(TabletManager* tablet_manager, ManualCompaction
         LOG(ERROR) << "manual compaction failed, tablet not primary key tablet found: " << t.tablet_id;
         return;
     }
-    auto* mem_tracker = ExecEnv::GetInstance()->compaction_mem_tracker();
+    auto* mem_tracker = GlobalEnv::GetInstance()->compaction_mem_tracker();
     auto st = tablet->updates()->get_rowsets_for_compaction(t.rowset_size_threshold, t.input_rowset_ids, t.total_bytes);
     if (!st.ok()) {
         t.status = st.to_string();

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -82,15 +82,15 @@ Tablet::Tablet(const TabletMetaSharedPtr& tablet_meta, DataDir* data_dir)
           _cumulative_point(kInvalidCumulativePoint) {
     // change _rs_graph to _timestamped_version_tracker
     _timestamped_version_tracker.construct_versioned_tracker(_tablet_meta->all_rs_metas());
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
 }
 
 Tablet::Tablet() {
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
 }
 
 Tablet::~Tablet() {
-    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
 }
 
 Status Tablet::_init_once_action() {

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -99,15 +99,15 @@ TabletMeta::TabletMeta(int64_t table_id, int64_t partition_id, int64_t tablet_id
     convert_t_schema_to_pb_schema(tablet_schema, next_unique_id, col_ordinal_to_unique_id, schema, compression_type);
 
     init_from_pb(&tablet_meta_pb);
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
 }
 
 TabletMeta::TabletMeta() : _tablet_uid(0, 0) {
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
 }
 
 TabletMeta::~TabletMeta() {
-    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->tablet_metadata_mem_tracker(), _mem_usage());
 }
 
 Status TabletMeta::create_from_file(const string& file_path) {

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -325,16 +325,16 @@ Schema* TabletSchema::schema() const {
 
 TabletSchema::TabletSchema(const TabletSchemaPB& schema_pb) {
     _init_from_pb(schema_pb);
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->tablet_schema_mem_tracker(), mem_usage())
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->tablet_schema_mem_tracker(), mem_usage())
 }
 
 TabletSchema::TabletSchema(const TabletSchemaPB& schema_pb, TabletSchemaMap* schema_map) : _schema_map(schema_map) {
     _init_from_pb(schema_pb);
-    MEM_TRACKER_SAFE_CONSUME(ExecEnv::GetInstance()->tablet_schema_mem_tracker(), mem_usage())
+    MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->tablet_schema_mem_tracker(), mem_usage())
 }
 
 TabletSchema::~TabletSchema() {
-    MEM_TRACKER_SAFE_RELEASE(ExecEnv::GetInstance()->tablet_schema_mem_tracker(), mem_usage())
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->tablet_schema_mem_tracker(), mem_usage())
     if (_schema_map != nullptr) {
         _schema_map->erase(_id);
     }

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -298,9 +298,9 @@ void SystemMetrics::_update_memory_metrics() {
     }
 #endif
 
-#define SET_MEM_METRIC_VALUE(tracker, key)                                                \
-    if (ExecEnv::GetInstance()->tracker() != nullptr) {                                   \
-        _memory_metrics->key.set_value(ExecEnv::GetInstance()->tracker()->consumption()); \
+#define SET_MEM_METRIC_VALUE(tracker, key)                                                  \
+    if (GlobalEnv::GetInstance()->tracker() != nullptr) {                                   \
+        _memory_metrics->key.set_value(GlobalEnv::GetInstance()->tracker()->consumption()); \
     }
 
     SET_MEM_METRIC_VALUE(process_mem_tracker, process_mem_bytes)

--- a/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
+++ b/be/test/exec/pipeline/pipeline_file_scan_node_test.cpp
@@ -69,7 +69,8 @@ public:
         _query_ctx->set_query_expire_seconds(60);
         _query_ctx->extend_delivery_lifetime();
         _query_ctx->extend_query_lifetime();
-        _query_ctx->init_mem_tracker(_exec_env->query_pool_mem_tracker()->limit(), _exec_env->query_pool_mem_tracker());
+        _query_ctx->init_mem_tracker(GlobalEnv::GetInstance()->query_pool_mem_tracker()->limit(),
+                                     GlobalEnv::GetInstance()->query_pool_mem_tracker());
         _query_ctx->set_query_trace(std::make_shared<starrocks::debug::QueryTrace>(query_id, false));
 
         _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -79,7 +79,8 @@ void PipelineTestBase::_prepare() {
     _query_ctx->set_query_expire_seconds(60);
     _query_ctx->extend_delivery_lifetime();
     _query_ctx->extend_query_lifetime();
-    _query_ctx->init_mem_tracker(_exec_env->query_pool_mem_tracker()->limit(), _exec_env->query_pool_mem_tracker());
+    _query_ctx->init_mem_tracker(GlobalEnv::GetInstance()->query_pool_mem_tracker()->limit(),
+                                 GlobalEnv::GetInstance()->query_pool_mem_tracker());
     _query_ctx->set_query_trace(std::make_shared<starrocks::debug::QueryTrace>(query_id, false));
 
     _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);

--- a/be/test/exec/stream/stream_pipeline_test.cpp
+++ b/be/test/exec/stream/stream_pipeline_test.cpp
@@ -46,7 +46,8 @@ Status StreamPipelineTest::prepare() {
     _query_ctx->set_query_expire_seconds(600);
     _query_ctx->extend_delivery_lifetime();
     _query_ctx->extend_query_lifetime();
-    _query_ctx->init_mem_tracker(_exec_env->query_pool_mem_tracker()->limit(), _exec_env->query_pool_mem_tracker());
+    _query_ctx->init_mem_tracker(GlobalEnv::GetInstance()->query_pool_mem_tracker()->limit(),
+                                 GlobalEnv::GetInstance()->query_pool_mem_tracker());
 
     _fragment_ctx = _query_ctx->fragment_mgr()->get_or_register(fragment_id);
     _fragment_ctx->set_query_id(query_id);

--- a/be/test/runtime/exec_env_test.cpp
+++ b/be/test/runtime/exec_env_test.cpp
@@ -18,11 +18,11 @@
 
 namespace starrocks {
 
-TEST(ExecEnvTest, calc_query_mem_limit) {
-    ASSERT_EQ(ExecEnv::calc_max_query_memory(-1, 80), -1);
-    ASSERT_EQ(ExecEnv::calc_max_query_memory(1000000000, -2), 900000000);
-    ASSERT_EQ(ExecEnv::calc_max_query_memory(1000000000, 102), 900000000);
-    ASSERT_EQ(ExecEnv::calc_max_query_memory(1000000000, 70), 700000000);
+TEST(GlobalEnvTest, calc_query_mem_limit) {
+    ASSERT_EQ(GlobalEnv::calc_max_query_memory(-1, 80), -1);
+    ASSERT_EQ(GlobalEnv::calc_max_query_memory(1000000000, -2), 900000000);
+    ASSERT_EQ(GlobalEnv::calc_max_query_memory(1000000000, 102), 900000000);
+    ASSERT_EQ(GlobalEnv::calc_max_query_memory(1000000000, 70), 700000000);
 }
 
 } // namespace starrocks

--- a/be/test/storage/delete_handler_test.cpp
+++ b/be/test/storage/delete_handler_test.cpp
@@ -63,7 +63,7 @@ static std::string k_default_storage_root_path = "";
 
 static void set_up() {
     config::mem_limit = "10g";
-    ExecEnv::GetInstance()->init_mem_tracker();
+    GlobalEnv::GetInstance()->init();
     k_default_storage_root_path = config::storage_root_path;
     config::storage_root_path = std::filesystem::current_path().string() + "/data_test";
     fs::remove_all(config::storage_root_path);

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -370,8 +370,9 @@ int main(int argc, char** argv) {
                 s.to_string().c_str());
         return -1;
     }
+    auto* global_env = starrocks::GlobalEnv::GetInstance();
+    global_env->init();
     auto* exec_env = starrocks::ExecEnv::GetInstance();
-    exec_env->init_mem_tracker();
     exec_env->init(paths);
     int r = RUN_ALL_TESTS();
 
@@ -385,6 +386,7 @@ int main(int argc, char** argv) {
     // destroy exec env
     starrocks::tls_thread_status.set_mem_tracker(nullptr);
     exec_env->destroy();
+    global_env->stop();
 
     return r;
 }

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -83,13 +83,14 @@ int main(int argc, char** argv) {
                 s.to_string().c_str());
         return -1;
     }
+    auto* global_env = starrocks::GlobalEnv::GetInstance();
+    starrocks::config::disable_storage_page_cache = true;
+    global_env->init();
     auto* exec_env = starrocks::ExecEnv::GetInstance();
     // Pagecache is turned on by default, and some test cases require cache to be turned on,
     // and some test cases do not. For easy management, we turn cache off during unit test
     // initialization. If there are test cases that require Pagecache, it must be responsible
     // for managing it.
-    starrocks::config::disable_storage_page_cache = true;
-    exec_env->init_mem_tracker();
     exec_env->init(paths);
 
     int r = RUN_ALL_TESTS();
@@ -103,6 +104,7 @@ int main(int argc, char** argv) {
     // destroy exec env
     starrocks::tls_thread_status.set_mem_tracker(nullptr);
     exec_env->destroy();
+    global_env->stop();
 
     starrocks::shutdown_logging();
 


### PR DESCRIPTION
Fixes #27417 

BE split into 5 modules:

* GlobalEnv: global basic data structure
* ExecEnv: execution engine
* StorageEngine: storage engine
* Daemon: daemon threads
* Server: RpcServer/ThriftServer/AgentServer/HeartbeatServer/HttpServer

boot sequence: GlobalEnv --> Daemon --> StorageEngine -> ExecEnv --> ThriftServer/RpcServer/HttpServer --> HeartbeatServer

exit sequence: HerartbeatServer -> ThriftServer/RpcServer/HttpServer -> ExecEnv -> StorageEngine -> daemon -> GlobalEnv

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
