### PR TITLE
[Enhancement] table function FILES() error enhancement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -428,8 +428,8 @@ public class HdfsFsManager {
                 host = loadProperties.get(FS_DEFAULTFS_KEY);
                 LOG.info("no schema and authority in path. use fs.defaultFs");
             } else {
-                LOG.warn("invalid hdfs path. authority is null,path:" + path);
-                throw new UserException("invalid hdfs path. authority is null");
+                LOG.warn("invalid hdfs path. failed to parse authority, path:" + path);
+                throw new UserException("invalid hdfs path. failed to parse authority");
             }
         }
         String username = loadProperties.getOrDefault(USER_NAME_KEY, "");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/StorageAccessException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/StorageAccessException.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.analyzer;
 
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.UserException;
 import org.apache.commons.lang.exception.ExceptionUtils;
 
 /**
@@ -40,7 +41,8 @@ public class StorageAccessException extends RuntimeException {
             AmazonS3Exception s3Exception = (AmazonS3Exception) rootCause;
             builder.append("Error code: ").append(s3Exception.getErrorCode()).append(". ");
             builder.append("Error message: ").append(s3Exception.getErrorMessage()).append(". ");
-        } else if (rootCause instanceof DdlException) {
+        } else if (rootCause instanceof DdlException || rootCause instanceof IllegalArgumentException
+                || rootCause instanceof UserException) {
             builder.append("Error message: ").append(rootCause.getMessage());
         } else {
             builder.append("Unknown error");

--- a/fe/fe-core/src/test/java/com/starrocks/fs/TestHdfsFsManager.java
+++ b/fe/fe-core/src/test/java/com/starrocks/fs/TestHdfsFsManager.java
@@ -51,7 +51,14 @@ public class TestHdfsFsManager extends TestCase {
         } catch (UserException e) {
             Assert.fail(e.getMessage());
         }
-    } 
+    }
+
+    @Test
+    public void testGetHDFSFileSystemFailure() {
+        Map<String, String> properties = new HashMap<String, String>();
+        Assert.assertThrows(UserException.class,  () -> {
+            fileSystemManager.getFileSystem("hdfs:///127.0.0.1:9000/parquet/student.parquet", properties, null); });
+    }
     
     @Test
     public void testGetFileSystemForS3aScheme() throws IOException {


### PR DESCRIPTION
Fixes #issue
This PR includes 2 changes.
1. `select * from  files("path"="hdfs:///127.0.0.1:9000/parquet/student.parquet","format"="parquet")` 

origin result:
```
ERROR 1064 (HY000): Access storage error. Unknown error
```
new result:
```
ERROR 1064 (HY000): Access storage error. Error message: invalid hdfs path. failed to parse authority
```
2. `select * from  files("path"="hdfs://127.0.0.1:9000//parquet/student.parquet","format"="parquet")`

origin result:
```
ERROR 1064 (HY000): Access storage error. Unknown error
```
new result:
```
ERROR 1064 (HY000): Access storage error. Error message: Wrong FS: hdfs://parquet/student.parquet, expected: hdfs://127.0.0.1:9000
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
