### PR TITLE
[BugFix] remove unnecessary check in statistic calculate phase 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -18,8 +18,10 @@ import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
@@ -107,16 +109,12 @@ public final class ColumnRefOperator extends ScalarOperator {
         return id + ": " + name;
     }
 
-    public static String toString(List<ColumnRefOperator> columns) {
-        StringBuilder sb = new StringBuilder();
-        int i = 0;
+    public static String toString(Collection<ColumnRefOperator> columns) {
+        StringJoiner joiner = new StringJoiner("{", ", ", "}");
         for (ColumnRefOperator column : columns) {
-            if (i++ != 0) {
-                sb.append(",");
-            }
-            sb.append(column);
+            joiner.add(column.toString());
         }
-        return sb.toString();
+        return joiner.toString();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
@@ -139,6 +139,7 @@ public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStats
         ColumnStatistic.Builder builder = ColumnStatistic.builder();
         double minValue = Double.NEGATIVE_INFINITY;
         double maxValue = Double.POSITIVE_INFINITY;
+        double distinctValues = statisticData.countDistinct;
         try {
             if (column.getPrimitiveType().isCharFamily()) {
                 // do nothing
@@ -171,9 +172,20 @@ public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStats
                     db.getFullName(), table.getName(), column.getName(), e.getMessage());
         }
 
+        if (minValue > maxValue) {
+            LOG.warn("Min: {}, Max: {} values abnormal for db : {}, table : {}, column : {}", minValue, maxValue,
+                    db.getFullName(), table.getName(), column.getName());
+            minValue = Double.NEGATIVE_INFINITY;
+            maxValue = Double.POSITIVE_INFINITY;
+        }
+
+        if (distinctValues <= 0) {
+            distinctValues = 1;
+        }
+
         return builder.setMinValue(minValue).
                 setMaxValue(maxValue).
-                setDistinctValuesCount(statisticData.countDistinct).
+                setDistinctValuesCount(distinctValues).
                 setAverageRowSize(statisticData.dataSize / Math.max(statisticData.rowCount, 1)).
                 setNullsFraction(statisticData.nullCount * 1.0 / Math.max(statisticData.rowCount, 1)).build();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
@@ -25,7 +25,8 @@ public final class ColumnDict {
     private long versionTime;
 
     public ColumnDict(ImmutableMap<ByteBuffer, Integer> dict, long versionTime) {
-        Preconditions.checkState(dict.size() > 0 && dict.size() <= 256);
+        Preconditions.checkState(dict.size() > 0 && dict.size() <= 256,
+                "dict size %s is illegal", dict.size());
         this.dict = dict;
         this.collectedVersionTime = versionTime;
         this.versionTime = versionTime;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
@@ -143,9 +143,22 @@ public class ColumnStatistic {
         Preconditions.checkState(valueArray.length == 5,
                 "statistic value: %s is illegal", valueString);
 
-        Builder builder = new Builder(Double.parseDouble(valueArray[0]), Double.parseDouble(valueArray[1]),
+        double minValue = Double.parseDouble(valueArray[0]);
+        double maxValue = Double.parseDouble(valueArray[1]);
+        double distinctValues = Double.parseDouble(valueArray[4]);
+
+        if (minValue > maxValue) {
+            minValue = Double.NEGATIVE_INFINITY;
+            maxValue = Double.POSITIVE_INFINITY;
+        }
+
+        if (distinctValues <= 0) {
+            distinctValues = 1;
+        }
+
+        Builder builder = new Builder(minValue, maxValue,
                 Double.parseDouble(valueArray[2]), Double.parseDouble(valueArray[3]),
-                Double.parseDouble(valueArray[4]));
+                distinctValues);
         if (!typeString.isEmpty()) {
             builder.setType(StatisticType.valueOf(typeString));
         } else if (builder.build().isUnknownValue()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
@@ -140,7 +140,8 @@ public class ColumnStatistic {
         String typeString = endIndex == columnStatistic.length() - 1 ? "" : columnStatistic.substring(endIndex + 2);
 
         String[] valueArray = valueString.split(",");
-        Preconditions.checkState(valueArray.length == 5);
+        Preconditions.checkState(valueArray.length == 5,
+                "statistic value: %s is illegal", valueString);
 
         Builder builder = new Builder(Double.parseDouble(valueArray[0]), Double.parseDouble(valueArray[1]),
                 Double.parseDouble(valueArray[2]), Double.parseDouble(valueArray[3]),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -157,7 +157,9 @@ public class ExpressionStatisticCalculator {
         public ColumnStatistic visitCall(CallOperator call, Void context) {
             List<ColumnStatistic> childrenColumnStatistics =
                     call.getChildren().stream().map(child -> child.accept(this, context)).collect(Collectors.toList());
-            Preconditions.checkState(childrenColumnStatistics.size() == call.getChildren().size());
+            Preconditions.checkState(childrenColumnStatistics.size() == call.getChildren().size(),
+                    "column statistics missing for expr: %s. column statistics: %s",
+                    call, childrenColumnStatistics);
             if (childrenColumnStatistics.stream().anyMatch(ColumnStatistic::isUnknown) ||
                     inputStatistics.getColumnStatistics().values().stream().allMatch(ColumnStatistic::isUnknown)) {
                 return ColumnStatistic.unknown();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -212,7 +212,6 @@ public class PredicateStatisticsCalculator {
             if (!checkNeedEvalEstimate(predicate)) {
                 return statistics;
             }
-            Preconditions.checkState(predicate.getChildren().size() == 2);
             ScalarOperator leftChild = predicate.getChild(0);
             ScalarOperator rightChild = predicate.getChild(1);
             Preconditions.checkState(!(leftChild.isConstantRef() && rightChild.isConstantRef()),
@@ -302,7 +301,6 @@ public class PredicateStatisticsCalculator {
 
                 return StatisticsEstimateUtils.adjustStatisticsByRowCount(cumulativeStatistics, rowCount);
             } else {
-                Preconditions.checkState(predicate.getChildren().size() == 1);
                 Statistics inputStatistics = predicate.getChild(0).accept(this, null);
                 double rowCount = Math.max(0, statistics.getOutputRowCount() - inputStatistics.getOutputRowCount());
                 return StatisticsEstimateUtils.adjustStatisticsByRowCount(
@@ -336,7 +334,6 @@ public class PredicateStatisticsCalculator {
 
         private ScalarOperator getChildForCastOperator(ScalarOperator operator) {
             if (operator instanceof CastOperator) {
-                Preconditions.checkState(operator.getChildren().size() == 1);
                 operator = getChildForCastOperator(operator.getChild(0));
             }
             return operator;
@@ -359,15 +356,12 @@ public class PredicateStatisticsCalculator {
             }
 
             if (predicate.isAnd()) {
-                Preconditions.checkState(predicate.getChildren().size() == 2);
                 Statistics leftStatistics = predicate.getChild(0).accept(this, null);
                 Statistics andStatistics = predicate.getChild(1)
                         .accept(new LargeOrCalculatingVisitor(leftStatistics), null);
                 return StatisticsEstimateUtils.adjustStatisticsByRowCount(andStatistics,
                         andStatistics.getOutputRowCount());
             } else if (predicate.isOr()) {
-                Preconditions.checkState(predicate.getChildren().size() == 2);
-
                 List<ScalarOperator> disjunctive = Utils.extractDisjunctive(predicate);
                 Statistics baseStatistics = disjunctive.get(0).accept(this, null);
                 double rowCount = baseStatistics.getOutputRowCount();
@@ -383,7 +377,6 @@ public class PredicateStatisticsCalculator {
 
                 return StatisticsEstimateUtils.adjustStatisticsByRowCount(baseStatistics, rowCount);
             } else {
-                Preconditions.checkState(predicate.getChildren().size() == 1);
                 Statistics inputStatistics = predicate.getChild(0).accept(this, null);
                 double rowCount = Math.max(0, statistics.getOutputRowCount() - inputStatistics.getOutputRowCount());
                 return StatisticsEstimateUtils.adjustStatisticsByRowCount(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticRangeValues.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticRangeValues.java
@@ -16,7 +16,6 @@
 package com.starrocks.sql.optimizer.statistics;
 
 import java.util.Objects;
-
 import javax.validation.constraints.NotNull;
 
 import static java.lang.Double.NaN;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticRangeValues.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticRangeValues.java
@@ -15,18 +15,16 @@
 
 package com.starrocks.sql.optimizer.statistics;
 
-import com.google.common.base.Preconditions;
-
 import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import javax.validation.constraints.NotNull;
+
 import static java.lang.Double.NaN;
 import static java.lang.Double.isFinite;
 import static java.lang.Double.isInfinite;
 import static java.lang.Double.isNaN;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.util.Objects.requireNonNull;
 
 // Calculate the cross range and ratio between column statistics
 public class StatisticRangeValues {
@@ -35,16 +33,8 @@ public class StatisticRangeValues {
     private final double distinctValues;
 
     public StatisticRangeValues(double low, double high, double distinctValues) {
-        Preconditions.checkArgument(
-                low <= high || (isNaN(low) && isNaN(high)),
-                "low value must be less than or equal to high value or both values have to be NaN, got %s and %s respectively",
-                low,
-                high);
         this.low = low;
         this.high = high;
-
-        checkArgument(distinctValues >= 0 || isNaN(distinctValues),
-                "Distinct values count should be non-negative, got: %s", distinctValues);
         this.distinctValues = distinctValues;
     }
 
@@ -81,9 +71,7 @@ public class StatisticRangeValues {
     }
 
     // Calculate the proportion of coverage between column statistic range
-    public double overlapPercentWith(StatisticRangeValues other) {
-        requireNonNull(other, "other is null");
-
+    public double overlapPercentWith(@NotNull StatisticRangeValues other) {
         if (this.isEmpty() || other.isEmpty()) {
             return 0.0;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/Statistics.java
@@ -14,8 +14,9 @@
 
 package com.starrocks.sql.optimizer.statistics;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
@@ -65,9 +66,13 @@ public class Statistics {
     }
 
     public ColumnStatistic getColumnStatistic(ColumnRefOperator column) {
-        ColumnStatistic result = columnStatistics.get(column);
-        Preconditions.checkState(result != null, "cannot find statistics of col: %s", column);
-        return result;
+        if (columnStatistics.get(column) == null) {
+            throw new StarRocksPlannerException(ErrorType.INTERNAL_ERROR,
+                    "only found column statistics: %s, but missing statistic of col: %s.",
+                    ColumnRefOperator.toString(columnStatistics.keySet()), column);
+        } else {
+            return columnStatistics.get(column);
+        }
     }
 
     public Map<ColumnRefOperator, ColumnStatistic> getColumnStatistics() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -27,6 +27,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.Group;
 import com.starrocks.sql.optimizer.GroupExpression;
@@ -616,5 +617,19 @@ public class StatisticsCalculatorTest {
         ConnectContext.get().getSessionVariable().setUseCorrelatedJoinEstimate(false);
         statisticsCalculator.estimatorStats();
         Assert.assertEquals(expressionContext.getStatistics().getOutputRowCount(), 200000.0, 0.0001);
+    }
+
+    @Test
+    public void testNotFoundColumnStatistics() {
+        ColumnRefOperator v1 = columnRefFactory.create("v1", Type.INT, true);
+        ColumnRefOperator v2 = columnRefFactory.create("v2", Type.INT, true);
+
+        ColumnRefOperator v3 = columnRefFactory.create("v3", Type.INT, true);
+        Statistics.Builder builder = Statistics.builder();
+        builder.setOutputRowCount(10000);
+        builder.addColumnStatistics(ImmutableMap.of(v1, new ColumnStatistic(0, 100, 0, 10, 50)));
+        builder.addColumnStatistics(ImmutableMap.of(v2, new ColumnStatistic(0, 100, 0, 10, 50)));
+        Statistics statistics = builder.build();
+        Assert.assertThrows(StarRocksPlannerException.class, () -> statistics.getColumnStatistic(v3));
     }
 }


### PR DESCRIPTION
Fixes #issue
- When the statistical information query results are abnormal, set the statistical information column to an unknown value to prevent the failure of dervie statistics in the planning stage. 
- Delete unnecessary check items, and supplement the exception information when the check fails.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
