### PR TITLE
[Enhancement] Make tablet checker blockingly add tablet to scheduler

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -447,6 +447,8 @@ public class TabletInvertedIndex {
                     } else {
                         backendTabletNumReport.get(backendId).first++;
                     }
+
+                    tabletMeta.resetToBeCleanedTime();
                 } finally {
                     database.readUnlock();
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
@@ -128,6 +128,10 @@ public class TabletMeta {
         toBeCleanedTimeMs = time;
     }
 
+    public void resetToBeCleanedTime() {
+        toBeCleanedTimeMs = null;
+    }
+
     public boolean containsSchemaHash(int schemaHash) {
         lock.readLock().lock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -50,7 +50,6 @@ import com.starrocks.catalog.Partition.PartitionState;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Table.TableType;
 import com.starrocks.catalog.Tablet;
-import com.starrocks.clone.TabletScheduler.AddResult;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
@@ -258,6 +257,7 @@ public class TabletChecker extends FrontendDaemon {
         long tabletNotReady = 0;
 
         long lockTotalTime = 0;
+        long waitTotalTime = 0;
         long lockStart;
         List<Long> dbIds = GlobalStateMgr.getCurrentState().getDbIdsIncludeRecycleBin();
         DATABASE:
@@ -383,14 +383,10 @@ public class TabletChecker extends FrontendDaemon {
                                     continue;
                                 }
 
-                                // ignore the scheduler queue length limitation if it's an urgent repair
-                                AddResult res = tabletScheduler.addTablet(tabletCtx,
-                                        isPartitionUrgent /* force or not */);
-                                if (res == AddResult.LIMIT_EXCEED) {
-                                    LOG.info("number of scheduling tablets in tablet scheduler"
-                                            + " exceed to limit. stop tablet checker");
-                                    break DATABASE;
-                                } else if (res == AddResult.ADDED) {
+                                Pair<Boolean, Long> result =
+                                        tabletScheduler.blockingAddTabletCtxToScheduler(db, tabletCtx, isPartitionUrgent);
+                                waitTotalTime += result.second;
+                                if (result.first) {
                                     addToSchedulerTabletNum++;
                                 }
                             }
@@ -422,9 +418,9 @@ public class TabletChecker extends FrontendDaemon {
 
         LOG.info("finished to check tablets. isUrgent: {}, " +
                         "unhealthy/total/added/in_sched/not_ready: {}/{}/{}/{}/{}, " +
-                        "cost: {} ms, in lock time: {} ms",
+                        "cost: {} ms, in lock time: {} ms, wait time: {}ms",
                 isUrgent, unhealthyTabletNum, totalTabletNum, addToSchedulerTabletNum,
-                tabletInScheduler, tabletNotReady, cost, lockTotalTime);
+                tabletInScheduler, tabletNotReady, cost, lockTotalTime - waitTotalTime, waitTotalTime);
     }
 
     public boolean isUrgentTable(long dbId, long tblId) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1505,6 +1505,11 @@ public class TabletScheduler extends FrontendDaemon {
         LOG.info("remove the tablet {}. because: {}", tabletCtx.getTabletId(), reason);
     }
 
+    @VisibleForTesting
+    public void removeOneFromPendingQ() {
+        pendingTablets.poll();
+    }
+
     // get next batch of tablets from queue.
     private synchronized List<TabletSchedCtx> getNextTabletCtxBatch() {
         List<TabletSchedCtx> list = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -126,6 +126,8 @@ public class TabletScheduler extends FrontendDaemon {
      */
     private static final double COLOCATE_BACKEND_RESET_RATIO = 0.3;
 
+    private static final int BLOCKING_ADD_SLEEP_DURATION_MS = 200;
+
     /*
      * Tablet is added to pendingTablets as well it's id in allTabletIds.
      * TabletScheduler will take tablet from pendingTablets but will not remove its id from allTabletIds when
@@ -288,6 +290,33 @@ public class TabletScheduler extends FrontendDaemon {
         allTabletIds.add(tablet.getTabletId());
         pendingTablets.offer(tablet);
         return AddResult.ADDED;
+    }
+
+    public Pair<Boolean, Long> blockingAddTabletCtxToScheduler(Database db, TabletSchedCtx tabletSchedCtx,
+                                                               boolean forceAdd) {
+        // first: added or not, second: total sleep time in ms
+        Pair<Boolean, Long> result = new Pair<>(false, 0L);
+        try {
+            do {
+                AddResult res = addTablet(tabletSchedCtx, forceAdd /* force or not */);
+                if (res == AddResult.LIMIT_EXCEED) {
+                    db.readUnlock();
+                    // It's ok to sleep a relative long time here so that the scheduler will spare more
+                    // slots after the sleep and the following adding won't block.
+                    Thread.sleep(BLOCKING_ADD_SLEEP_DURATION_MS);
+                    result.second += BLOCKING_ADD_SLEEP_DURATION_MS;
+                    db.readLock();
+                } else {
+                    result.first = (res == AddResult.ADDED);
+                    break;
+                }
+            } while (true);
+        } catch (InterruptedException e) {
+            LOG.warn(e);
+            db.readLock();
+        }
+
+        return result;
     }
 
     public void forceCleanSchedQ() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1160,7 +1160,7 @@ public class Config extends ConfigBase {
     // if the number of scheduled tablets in TabletScheduler exceed max_scheduling_tablets
     // skip checking.
     @ConfField(mutable = true, aliases = {"max_scheduling_tablets"})
-    public static int tablet_sched_max_scheduling_tablets = 2000;
+    public static int tablet_sched_max_scheduling_tablets = 10000;
 
     /**
      * if set to true, TabletScheduler will not do balance.
@@ -1232,7 +1232,7 @@ public class Config extends ConfigBase {
     // if the number of balancing tablets in TabletScheduler exceed max_balancing_tablets,
     // no more balance check
     @ConfField(mutable = true, aliases = {"max_balancing_tablets"})
-    public static int tablet_sched_max_balancing_tablets = 100;
+    public static int tablet_sched_max_balancing_tablets = 500;
 
     /**
      * When create a table(or partition), you can specify its storage medium(HDD or SSD).

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
@@ -89,4 +89,13 @@ public class ConsistencyCheckerTest {
         table.setState(OlapTable.OlapTableState.RESTORE);
         Assert.assertEquals(0, new ConsistencyChecker().chooseTablets().size());
     }
+
+    @Test
+    public void testResetToBeCleanedTime() {
+        TabletMeta tabletMeta = new TabletMeta(1, 2, 3,
+                4, 5, TStorageMedium.HDD);
+        tabletMeta.setToBeCleanedTime(123L);
+        tabletMeta.resetToBeCleanedTime();
+        Assert.assertNull(tabletMeta.getToBeCleanedTime());
+    }
 }


### PR DESCRIPTION
Fixes SR-19074

1. Make `TabletChecker` blockingly add tablet to `TabletScheduler`,
    this is to avoid meaningless loop and also avoid the situation that tablets
    which have failed reparing for many times continuously added to pending
    queue, and tablet which could be repaired successfully cannot get the
    chance to be added to scheduling queue.
2. Adjust the default value of `tablet_sched_max_balancing_tablets` and
    `tablet_sched_max_scheduling_tablets` configurations, because we
     always need to tell the user to increase those values.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
