### PR TITLE
[BugFix] query cols file crash causing by drop column (#27651)

### DIFF
--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -158,6 +158,8 @@ public:
 
     bool keep_in_memory() const { return _tablet_schema->is_in_memory(); }
 
+    const TabletSchema& tablet_schema() const { return *_tablet_schema; }
+
     const std::string& file_name() const { return _fname; }
 
     uint32_t num_rows() const { return _num_rows; }


### PR DESCRIPTION
Problem:
If a table with cols file has been drop some columns, crash may happen. Because the dcg column_id maybe inconsistent with the cols file open schema.

Fixes #27651

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
