### PR TITLE
[Enhancement] avoid collect metrics hang if trigger hook is slow

### DIFF
--- a/be/src/util/metrics.h
+++ b/be/src/util/metrics.h
@@ -351,7 +351,7 @@ public:
     bool register_metric(const std::string& name, const MetricLabels& labels, Metric* metric);
     // Now this function is not used frequently, so this is a little time consuming
     void deregister_metric(Metric* metric) {
-        std::shared_lock lock(_mutex);
+        std::shared_lock lock(_collector_mutex);
         _deregister_locked(metric);
     }
     Metric* get_metric(const std::string& name) const { return get_metric(name, MetricLabels::EmptyLabels); }
@@ -362,19 +362,20 @@ public:
     void deregister_hook(const std::string& name);
 
     void collect(MetricsVisitor* visitor) {
-        std::shared_lock lock(_mutex);
         if (!config::enable_metric_calculator) {
             // Before we collect, need to call hooks
+            std::shared_lock lock(_hooks_mutex);
             unprotected_trigger_hook();
         }
 
+        std::shared_lock lock(_collector_mutex);
         for (auto& it : _collectors) {
             it.second->collect(_name, it.first, visitor);
         }
     }
 
     void trigger_hook() {
-        std::shared_lock lock(_mutex);
+        std::shared_lock lock(_hooks_mutex);
         unprotected_trigger_hook();
     }
 
@@ -391,7 +392,8 @@ private:
     const std::string _name;
 
     // mutable SpinLock _lock;
-    mutable std::shared_mutex _mutex;
+    mutable std::shared_mutex _collector_mutex;
+    mutable std::shared_mutex _hooks_mutex;
     std::map<std::string, MetricCollector*> _collectors;
     std::map<std::string, std::function<void()>> _hooks;
 };


### PR DESCRIPTION
When we get metrics info by HTTP, the `MetricRegistry-> collect` will be called. And if `MetricRegistry->trigger_hook` is slow because it have to wait lock, then `MetricRegistry-> collect` and `MetricRegistry->register_metric` will be hang and get metrics will be timeout.
The waiting chain will be :
```
Hold read lock <- trigger_hook [slow]
         |
Acquire write lock <- register_metric
        |
Acquire read lock <- collect [timeout]
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
