### PR TITLE
[BugFix] crash when apply in table with AUTO_INCREMENT column (#27176)

### DIFF
--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -172,6 +172,11 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
                 for (auto i = 0; i < _context.tablet_schema->num_columns(); ++i) {
                     auto col = _context.tablet_schema->column(i);
                     if (col.is_auto_increment()) {
+                        /*
+                            The auto increment id set here is inconsistent with the id in
+                            full tablet schema. The id here is indicate the offset id of
+                            auto increment column in partial segment file.
+                        */
                         _rowset_txn_meta_pb->set_auto_increment_partial_update_column_id(i);
                         break;
                     }
@@ -185,6 +190,7 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
             for (auto i = 0; i < _context.tablet_schema->num_columns(); ++i) {
                 auto col = _context.tablet_schema->column(i);
                 if (col.is_auto_increment()) {
+                    // same above
                     _rowset_txn_meta_pb->set_auto_increment_partial_update_column_id(i);
                     break;
                 }

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -77,7 +77,13 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
 
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dest_path));
 
-    uint32_t auto_increment_column_id = auto_increment_partial_update_state.id;
+    uint32_t auto_increment_column_id = 0;
+    for (const auto& col : tschema.columns()) {
+        if (col.is_auto_increment()) {
+            break;
+        }
+        ++auto_increment_column_id;
+    }
     uint32_t segment_id = auto_increment_partial_update_state.segment_id;
     Rowset* rowset = auto_increment_partial_update_state.rowset;
     rowset->load();

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -48,6 +48,8 @@ struct AutoIncrementPartialUpdateState {
     std::unique_ptr<Column> write_column;
     Rowset* rowset;
     TabletSchema* schema;
+    // auto increment column id in partial segment file
+    // but not in full tablet schema
     uint32_t id;
     uint32_t segment_id;
     std::vector<uint32_t> rowids;
@@ -129,7 +131,7 @@ private:
     Status _prepare_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t idx, bool need_lock);
 
     Status _prepare_auto_increment_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t idx,
-                                                         std::vector<uint32_t> column_id);
+                                                         const std::vector<uint32_t>& column_id);
 
     Status _check_and_resolve_conflict(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, uint32_t segment_id,
                                        EditVersion latest_applied_version, std::vector<uint32_t>& read_column_ids,


### PR DESCRIPTION
problem:
suppose we have a table created by:

and then insert into a new record:

and we have a CSV file with: 1,2,3 and 2,3,4

we want to partial update the v2 and v3, and we will get a crash when we apply.

The reason is that, in the apply phase, we need to get the column id in auto increment to do some work, but the id is incorrect in this case.

Fixes #27176

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
