### PR TITLE
[BugFix] Support count(1)/count(*)/count(col) rewrite when col is not nullable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
@@ -417,6 +417,11 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                     throw new UnsupportedMVException("Any single column should be before agg column. " +
                             "Column %s at wrong location", selectListItemExpr.toMySql());
                 }
+                // NOTE: If `selectListItemExpr` contains aggregate function, we can not support it.
+                if (selectListItemExpr.containsAggregate()) {
+                    throw new UnsupportedMVException("Aggregate function with function expr is not supported yet",
+                            selectListItemExpr.toMySql());
+                }
 
                 mvColumnItem = buildNonAggColumnItem(selectListItem, slots);
                 if (!mvColumnNameSet.add(mvColumnItem.getName())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -234,7 +234,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         equationRewriter.setAggregateFunctionRewriter(aggregateFunctionRewriter);
         equationRewriter.setOutputMapping(columnMapping);
         ScalarOperator rewritten = equationRewriter.replaceExprWithTarget(scalarOp);
-        if (rewritten == null) {
+        if (rewritten == null || scalarOp == rewritten) {
             return null;
         }
         if (!isAllExprReplaced(rewritten, originalColumnSet)) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMVStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMVStmtTest.java
@@ -389,6 +389,23 @@ public class CreateMVStmtTest {
             }
         }
     }
+
+    @Test
+    public void testCreateMVWithAggFunctionAndOtherExprs() {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        List<String> invalidSqls = Lists.newArrayList();
+        invalidSqls.add("create materialized view mv_01 as select c_1_2, cast(sum(c_1_4) as string) from t1 group by " +
+                "c_1_2");
+        for (String sql : invalidSqls) {
+            try {
+                UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+                fail("wrong sql, should fail");
+            } catch (Exception ex) {
+                Assert.assertTrue(ex.getMessage()
+                        .contains("Aggregate function with function expr is not supported yet"));
+            }
+        }
+    }
 }
 
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -715,6 +715,110 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     }
 
     @Test
+    public void testAggregate12() {
+        String mv = "select empid, deptno,\n" +
+                " sum(salary) as total, count(salary) as cnt \n" +
+                " from emps group by empid, deptno ";
+        // count(salary): salary is nullable
+        testRewriteOK(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(salary)  as cnt\n" +
+                " from emps group by empid, deptno");
+        testRewriteOK(mv, "select empid,\n" +
+                " sum(salary) as total, count(salary)  as cnt\n" +
+                " from emps group by empid");
+        testRewriteFail(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(1)  as cnt\n" +
+                " from emps group by empid, deptno");
+        testRewriteFail(mv, "select empid,\n" +
+                " sum(salary) as total, count(1)  as cnt\n" +
+                " from emps group by empid");
+    }
+
+    @Test
+    public void testAggregate13() {
+        String mv = "select empid, deptno,\n" +
+                " sum(salary) as total, count(empid) as cnt \n" +
+                " from emps group by empid, deptno ";
+        // count(empid): empid is not nullable
+        testRewriteOK(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(empid)  as cnt\n" +
+                " from emps group by empid, deptno");
+        testRewriteOK(mv, "select empid,\n" +
+                " sum(salary) as total, count(empid)  as cnt\n" +
+                " from emps group by empid");
+        testRewriteOK(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(1) as cnt\n" +
+                " from emps group by empid, deptno");
+        testRewriteOK(mv, "select empid,\n" +
+                " sum(salary) as total, count(1)  as cnt\n" +
+                " from emps group by empid");
+        testRewriteOK(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(*) as cnt\n" +
+                " from emps group by empid, deptno");
+        testRewriteOK(mv, "select empid,\n" +
+                " sum(salary) as total, count(*)  as cnt\n" +
+                " from emps group by empid");
+    }
+
+    @Test
+    public void testAggregate14() {
+        String mv = "select empid, deptno,\n" +
+                " sum(salary) as total, count(1)  as cnt\n" +
+                " from emps group by empid, deptno ";
+        // count(salary): salary is nullable
+        testRewriteFail(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(salary)  as cnt\n" +
+                " from emps group by empid, deptno");
+        testRewriteFail(mv, "select empid,\n" +
+                " sum(salary) as total, count(salary)  as cnt\n" +
+                " from emps group by empid");
+
+        // count(empid): empid is not nullable
+        testRewriteOK(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(empid)  as cnt\n" +
+                " from emps group by empid, deptno");
+        testRewriteOK(mv, "select empid,\n" +
+                " sum(salary) as total, count(empid)  as cnt\n" +
+                " from emps group by empid");
+
+        testRewriteOK(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(1)  as cnt\n" +
+                " from emps group by empid, deptno");
+        testRewriteOK(mv, "select empid,\n" +
+                " sum(salary) as total, count(1)  as cnt\n" +
+                " from emps group by empid");
+    }
+
+    @Test
+    public void testAggregate15() {
+        String mv = "select empid, deptno,\n" +
+                " sum(salary) as total, count(*)  as cnt\n" +
+                " from emps group by empid, deptno ";
+        // count(salary): salary is nullable
+        testRewriteFail(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(salary)  as cnt\n" +
+                " from emps group by empid, deptno");
+        testRewriteFail(mv, "select empid,\n" +
+                " sum(salary) as total, count(salary)  as cnt\n" +
+                " from emps group by empid");
+
+        // count(empid): empid is not nullable
+        testRewriteOK(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(empid)  as cnt\n" +
+                " from emps group by empid, deptno");
+        testRewriteOK(mv, "select empid,\n" +
+                " sum(salary) as total, count(empid)  as cnt\n" +
+                " from emps group by empid");
+
+        testRewriteOK(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(1)  as cnt\n" +
+                " from emps group by empid, deptno");
+        testRewriteOK(mv, "select empid,\n" +
+                " sum(salary) as total, count(1)  as cnt\n" +
+                " from emps group by empid");
+    }
+
+    @Test
     public void testAggregateWithAggExpr() {
         // support agg expr: empid -> abs(empid)
         testRewriteOK("select empid, deptno," +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -476,11 +476,15 @@ public class MVRewriteTest {
                 + "from " + EMPS_TABLE_NAME + " group by empid, deptno;";
         starRocksAssert.withMaterializedView(createEmpsMVSQL);
 
+        String query = "select deptno, empid, count(salary) "
+                + "from " + EMPS_TABLE_NAME + " group by empid, deptno;";
+        starRocksAssert.query(query).explainContains(EMPS_MV_NAME);
+
         // TODO: support this later.
-        String query = "select deptno, sum(if(empid=0,0,1)) from " + EMPS_TABLE_NAME + " group by deptno";
+        query = "select deptno, sum(if(empid=0,0,1)) from " + EMPS_TABLE_NAME + " group by deptno";
         starRocksAssert.query(query).explainWithout(EMPS_MV_NAME);
     }
-
+    
     @Test
     public void testAggregateMVCalcGroupByQuery1() throws Exception {
         String createEmpsMVSQL = "create materialized view " + EMPS_MV_NAME + " as select deptno, empid, sum(salary) "

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv2.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv2.sql
@@ -1,5 +1,4 @@
 -- query1
--- query9?
 create materialized view lineitem_agg_mv1
 distributed by hash(l_orderkey,
                l_shipdate,
@@ -16,15 +15,12 @@ as select  /*+ SET_VAR(query_timeout = 7200) */
               l_shipdate,
               l_returnflag,
               l_linestatus,
+              count(1) as total_cnt,
               sum(l_quantity) as sum_qty,
-              count(l_quantity) as count_qty,
               sum(l_extendedprice) as sum_base_price,
-              count(l_extendedprice) as count_base_price,
               sum(l_discount) as sum_discount,
-              count(l_discount) as count_discount,
               sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
-              sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
-              count(*) as count_order
+              sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge
    from
               lineitem
    group by
@@ -46,11 +42,8 @@ properties (
 as select  /*+ SET_VAR(query_timeout = 7200) */
               l_suppkey, l_shipdate, l_partkey,
               sum(l_quantity) as sum_qty,
-              count(l_quantity) as count_qty,
               sum(l_extendedprice) as sum_base_price,
-              count(l_extendedprice) as count_base_price,
               sum(l_discount) as sum_discount,
-              count(l_discount) as count_discount,
               sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
               sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge
    from

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q1.sql
@@ -23,7 +23,7 @@ order by
 [result]
 TOP-N (order by [[10: l_returnflag ASC NULLS FIRST, 11: l_linestatus ASC NULLS FIRST]])
     TOP-N (order by [[10: l_returnflag ASC NULLS FIRST, 11: l_linestatus ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{118: count=sum(32: count_qty), 119: sum=sum(31: sum_qty), 120: count=sum(34: count_base_price), 121: sum=sum(33: sum_base_price), 122: sum=sum(35: sum_discount), 123: sum=sum(37: sum_disc_price), 124: count=sum(36: count_discount), 125: sum=sum(38: sum_charge), 126: count=sum(39: count_order)}] group by [[29: l_returnflag, 30: l_linestatus]] having [null]
-            SCAN (mv[lineitem_agg_mv1] columns[28: l_shipdate, 29: l_returnflag, 30: l_linestatus, 31: sum_qty, 32: count_qty, 33: sum_base_price, 34: count_base_price, 35: sum_discount, 36: count_discount, 37: sum_disc_price, 38: sum_charge, 39: count_order] predicate[28: l_shipdate <= 1998-12-01])
+        AGGREGATE ([GLOBAL] aggregate [{118: count=sum(32: count_qty), 119: sum=sum(31: sum_qty), 120: count=sum(32: count_qty), 121: sum=sum(33: sum_base_price), 122: sum=sum(35: sum_discount), 123: sum=sum(37: sum_disc_price), 124: count=sum(32: count_qty), 125: sum=sum(38: sum_charge), 126: count=sum(32: count_qty)}] group by [[29: l_returnflag, 30: l_linestatus]] having [null]
+            SCAN (mv[lineitem_agg_mv1] columns[28: l_shipdate, 29: l_returnflag, 30: l_linestatus, 31: sum_qty, 32: count_qty, 33: sum_base_price, 35: sum_discount, 37: sum_disc_price, 38: sum_charge] predicate[28: l_shipdate <= 1998-12-01])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q1.sql
@@ -23,7 +23,7 @@ order by
 [result]
 TOP-N (order by [[10: l_returnflag ASC NULLS FIRST, 11: l_linestatus ASC NULLS FIRST]])
     TOP-N (order by [[10: l_returnflag ASC NULLS FIRST, 11: l_linestatus ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{118: count=sum(32: count_qty), 119: sum=sum(31: sum_qty), 120: count=sum(32: count_qty), 121: sum=sum(33: sum_base_price), 122: sum=sum(35: sum_discount), 123: sum=sum(37: sum_disc_price), 124: count=sum(32: count_qty), 125: sum=sum(38: sum_charge), 126: count=sum(32: count_qty)}] group by [[29: l_returnflag, 30: l_linestatus]] having [null]
-            SCAN (mv[lineitem_agg_mv1] columns[28: l_shipdate, 29: l_returnflag, 30: l_linestatus, 31: sum_qty, 32: count_qty, 33: sum_base_price, 35: sum_discount, 37: sum_disc_price, 38: sum_charge] predicate[28: l_shipdate <= 1998-12-01])
+        AGGREGATE ([GLOBAL] aggregate [{113: sum=sum(33: sum_base_price), 114: sum=sum(35: sum_disc_price), 115: sum=sum(36: sum_charge), 116: count=sum(31: total_cnt), 117: count=sum(31: total_cnt), 118: count=sum(31: total_cnt), 119: sum=sum(34: sum_discount), 120: count=sum(31: total_cnt), 112: sum=sum(32: sum_qty)}] group by [[29: l_returnflag, 30: l_linestatus]] having [null]
+            SCAN (mv[lineitem_agg_mv1] columns[28: l_shipdate, 29: l_returnflag, 30: l_linestatus, 31: total_cnt, 32: sum_qty, 33: sum_base_price, 34: sum_discount, 35: sum_disc_price, 36: sum_charge] predicate[28: l_shipdate <= 1998-12-01])
 [end]
 


### PR DESCRIPTION
Fixes #27715

fix some bugs:
- Sync MV should not support expr(aggregate func) syntax;
- Async MV should take whether scalarOp is rewritten in `rewriteScalarOperator `.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
