### PR TITLE
[BugFix] Fix mv rewrite bugs for tpch

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -410,6 +410,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ANALYZE_FOR_MV = "analyze_mv";
     public static final String QUERY_EXCLUDING_MV_NAMES = "query_excluding_mv_names";
     public static final String QUERY_INCLUDING_MV_NAMES = "query_including_mv_names";
+    public static final String ENABLE_MATERIALIZED_VIEW_REWRITE_FAST_WITHDRAW =
+            "enable_materialized_view_rewrite_fast_withdraw";
 
     public static final String ENABLE_BIG_QUERY_LOG = "enable_big_query_log";
     public static final String BIG_QUERY_LOG_CPU_SECOND_THRESHOLD = "big_query_log_cpu_second_threshold";
@@ -1129,6 +1131,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     //      try to rewrite by single table mvs and is determined by rule rather than by cost.
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_SINGLE_TABLE_VIEW_DELTA_REWRITE, flag = VariableMgr.INVISIBLE)
     private boolean enableMaterializedViewSingleTableViewDeltaRewrite = false;
+
+    // Enable fast withdraw rewrite to cut down optimizer time for mv rewrite.
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_REWRITE_FAST_WITHDRAW, flag = VariableMgr.INVISIBLE)
+    private boolean enableMaterializedViewRewriteFastWithDraw = true;
 
     @VarAttr(name = QUERY_EXCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
     private String queryExcludingMVNames = "";
@@ -2201,6 +2207,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setEnableMaterializedViewSingleTableViewDeltaRewrite(
             boolean enableMaterializedViewSingleTableViewDeltaRewrite) {
         this.enableMaterializedViewSingleTableViewDeltaRewrite = enableMaterializedViewSingleTableViewDeltaRewrite;
+    }
+
+    public void setEnableMaterializedViewRewriteFastWithDraw(boolean enableMaterializedViewRewriteFastWithDraw) {
+        this.enableMaterializedViewRewriteFastWithDraw = enableMaterializedViewRewriteFastWithDraw;
+    }
+
+    public boolean isEnableMaterializedViewRewriteFastWithDraw() {
+        return this.enableMaterializedViewRewriteFastWithDraw;
     }
 
     public String getQueryExcludingMVNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -218,7 +218,8 @@ public class MvRewritePreprocessor {
         }
 
         MaterializedView.MVRewriteContextCache mvRewriteContextCache = mv.getPlanContext();
-        if (mvRewriteContextCache == null) {
+        if (!connectContext.getSessionVariable().isEnableMaterializedViewRewriteFastWithDraw() ||
+                mvRewriteContextCache == null) {
             // build mv query logical plan
             MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();
             // optimize the sql by rule and disable rule based materialized view rewrite

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
@@ -44,6 +44,22 @@ import java.util.stream.Collectors;
 import static com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil.findArithmeticFunction;
 
 public class MvNormalizePredicateRule extends NormalizePredicateRule {
+    // Comparator to normalize predicates, only use scalar operators' string to compare.
+    private static final Comparator<ScalarOperator> SCALAR_OPERATOR_COMPARATOR = new Comparator<ScalarOperator>() {
+        @Override
+        public int compare(ScalarOperator o1, ScalarOperator o2) {
+            if (o1 == null && o2 == null) {
+                return 0;
+            } else if (o1 == null) {
+                return -1;
+            } else if (o2 == null) {
+                return 1;
+            } else {
+                return o1.toString().compareTo(o2.toString());
+            }
+        }
+    };
+
     // Normalize Binary Predicate
     // for integer type:
     // a < 3 => a <= 2
@@ -54,17 +70,17 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
     @Override
     public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator predicate,
                                                ScalarOperatorRewriteContext context) {
-        ScalarOperator tmp = super.visitBinaryPredicate(predicate, context);
-        Preconditions.checkState(tmp instanceof BinaryPredicateOperator);
-        BinaryPredicateOperator binary = (BinaryPredicateOperator) tmp;
+        ScalarOperator binaryPredicate = super.visitBinaryPredicate(predicate, context);
+        Preconditions.checkState(binaryPredicate instanceof BinaryPredicateOperator);
+        BinaryPredicateOperator binary = (BinaryPredicateOperator) binaryPredicate;
         if (binary.getChild(0).isVariable() && binary.getChild(1).isConstantRef()) {
             ConstantOperator constantOperator = (ConstantOperator) binary.getChild(1);
             if (!constantOperator.getType().isIntegerType()) {
-                return tmp;
+                return binaryPredicate;
             }
             ConstantOperator one = createConstantIntegerOne(constantOperator.getType());
             if (one == null) {
-                return tmp;
+                return binaryPredicate;
             }
             Type[] argsType = {constantOperator.getType(), constantOperator.getType()};
             switch (binary.getBinaryType()) {
@@ -93,8 +109,17 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
                 default:
                     break;
             }
+        } else {
+            // Normalize left and right, eg: `a < b` should be the same with `b > a`.
+            ScalarOperator l = binary.getChild(0);
+            ScalarOperator r = binary.getChild(1);
+            if (SCALAR_OPERATOR_COMPARATOR.compare(l, r) > 0) {
+                return binary.commutative();
+            } else {
+                return binaryPredicate;
+            }
         }
-        return tmp;
+        return binaryPredicate;
     }
 
     // should maintain sequence for case:
@@ -103,9 +128,7 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
     @Override
     public ScalarOperator visitCompoundPredicate(CompoundPredicateOperator predicate,
                                                  ScalarOperatorRewriteContext context) {
-        Comparator<ScalarOperator> byToString =
-                (ScalarOperator o1, ScalarOperator o2) -> o1.toString().compareTo(o2.toString());
-        Set<ScalarOperator> after = Sets.newTreeSet(byToString);
+        Set<ScalarOperator> after = Sets.newTreeSet(SCALAR_OPERATOR_COMPARATOR);
         if (predicate.isAnd()) {
             List<ScalarOperator> before = Utils.extractConjuncts(predicate);
             after.addAll(before);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -261,7 +261,7 @@ public class MaterializedViewRewriter {
                 // for outer join, we should check some extra conditions
                 boolean ret = checkJoinMatch(queryJoinType, queryExpr, mvExpr);
                 if (!ret) {
-                    logMVRewrite(mvRewriteContext, "join match check failed, joinType: %s", queryJoinType);
+                    logMVRewrite(mvRewriteContext, "join match check failed, joinType: {}", queryJoinType);
                 }
                 return ret;
             }
@@ -355,7 +355,7 @@ public class MaterializedViewRewriter {
         if (!isEqual) {
             logMVRewrite(
                     mvRewriteContext,
-                    "join child predicate not matched, queryPredicates: %s, mvPredicates: %s, index: %s",
+                    "join child predicate not matched, queryPredicates: {}, mvPredicates: {}, index: {}",
                     queryPredicates, mvPredicates, index);
         }
         return isEqual;
@@ -2260,7 +2260,7 @@ public class MaterializedViewRewriter {
                 getCompensationPredicate(srcPr, targetPr, columnRewriter, true, isQueryToMV);
         if (compensationPr == null) {
             logMVRewrite(mvRewriteContext, "Compensate range predicates failed," +
-                    "srcPr:%s, targetPr:%s", MvUtils.toString(srcPr), MvUtils.toString(targetPr));
+                    "srcPr:{}, targetPr:{}", MvUtils.toString(srcPr), MvUtils.toString(targetPr));
             return null;
         }
 
@@ -2282,7 +2282,7 @@ public class MaterializedViewRewriter {
                 getCompensationPredicate(srcPu, targetPu, columnRewriter, false, isQueryToMV);
         if (compensationPu == null) {
             logMVRewrite(mvRewriteContext, "Compensate residual predicates failed," +
-                    "srcPr:%s, targetPr:%s", MvUtils.toString(srcPu), MvUtils.toString(targetPu));
+                    "srcPr:{}, targetPr:{}", MvUtils.toString(srcPu), MvUtils.toString(targetPu));
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1921,6 +1921,8 @@ public class MaterializedViewRewriter {
         MatchMode matchMode = MatchMode.NOT_MATCH;
         if (queryTables.size() == mvTables.size() && Sets.newHashSet(queryTables).containsAll(mvTables)) {
             matchMode = MatchMode.COMPLETE;
+        } else if (queryTables.size() > mvTables.size() && queryTables.containsAll(mvTables)) {
+            matchMode = MatchMode.QUERY_DELTA;
         } else if (queryTables.size() < mvTables.size() && Sets.newHashSet(mvTables).containsAll(queryTables)) {
             matchMode = MatchMode.VIEW_DELTA;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -145,6 +145,19 @@ public class MaterializedViewRewriter {
         // because optimizer will match MV's pattern which is subset of query opt tree
         // from top-down iteration.
         if (matchMode == MatchMode.COMPLETE) {
+            // Q  : A JOIN B JOIN C JOIN D
+            // MV : A JOIN B JOIN C
+            // To fast rewrite, only need to check `A JOIN B JOIN C` pattern rather than
+            // `A JOIN B JOIN C JOIN D`.
+            if (optimizerContext.getSessionVariable().isEnableMaterializedViewRewriteFastWithDraw()) {
+                for (OptExpression child : queryExpression.getInputs()) {
+                    final List<Table> childTables = MvUtils.getAllTables(child);
+                    if (Sets.newHashSet(childTables).contains(mvTables)) {
+                        return false;
+                    }
+                }
+            }
+
             // If all join types are inner/cross, no need check join orders: eg a inner join b or b inner join a.
             boolean isQueryAllEqualInnerJoin = MvUtils.isAllEqualInnerOrCrossJoin(queryExpression);
             boolean isMVAllEqualInnerJoin = MvUtils.isAllEqualInnerOrCrossJoin(mvExpression);
@@ -169,15 +182,20 @@ public class MaterializedViewRewriter {
                 return false;
             }
             // only consider query with most common tables to optimize performance
-            if (!queryTables.containsAll(materializationContext.getIntersectingTables())) {
+            // To avoid join reorder producing plan bomb, record query's max tables to be only matched.
+            // But if query contains non inner/left outer joins which cannot be used to view delta join,
+            // not use `intersectingTables` anymore.
+            if (optimizerContext.getSessionVariable().isEnableMaterializedViewRewriteFastWithDraw() &&
+                    !queryTables.containsAll(materializationContext.getIntersectingTables())) {
                 return false;
             }
-            if (!MvUtils.getAllJoinOperators(queryExpression).stream().allMatch(joinOperator ->
-                    joinOperator.isLeftOuterJoin() || joinOperator.isInnerJoin())) {
+
+            if (!MvUtils.isSupportViewDelta(queryExpression)) {
                 logMVRewrite(mvRewriteContext, "MV is not applicable in view delta mode: " +
                         "only support inner/left outer join type for now");
                 return false;
             }
+
             List<TableScanDesc> queryTableScanDescs = MvUtils.getTableScanDescs(queryExpression);
             List<TableScanDesc> mvTableScanDescs = MvUtils.getTableScanDescs(mvExpression);
             // there should be at least one same join type in mv scan descs for every query scan desc.
@@ -1089,8 +1107,8 @@ public class MaterializedViewRewriter {
         final PredicateSplit compensationPredicates = getCompensationPredicatesQueryToView(columnRewriter,
                 rewriteContext, compensationJoinColumns);
         if (compensationPredicates == null) {
-            logMVRewrite(mvRewriteContext, "Rewrite query failed: cannot get compensation predicates from MV, " +
-                    "Try to use union rewrite.");
+            logMVRewrite(mvRewriteContext, "Cannot compensate predicates from mv rewrite, " +
+                    "try to use union rewrite.");
             if (!optimizerContext.getSessionVariable().isEnableMaterializedViewUnionRewrite()) {
                 return null;
             }
@@ -1901,12 +1919,9 @@ public class MaterializedViewRewriter {
 
     private MatchMode getMatchMode(List<Table> queryTables, List<Table> mvTables) {
         MatchMode matchMode = MatchMode.NOT_MATCH;
-        if (queryTables.size() == mvTables.size() && new HashSet<>(queryTables).containsAll(mvTables)) {
+        if (queryTables.size() == mvTables.size() && Sets.newHashSet(queryTables).containsAll(mvTables)) {
             matchMode = MatchMode.COMPLETE;
-        } else if (queryTables.size() > mvTables.size() && queryTables.containsAll(mvTables)) {
-            // TODO: query delta
-            matchMode = MatchMode.QUERY_DELTA;
-        } else if (queryTables.size() < mvTables.size() && mvTables.containsAll(queryTables)) {
+        } else if (queryTables.size() < mvTables.size() && Sets.newHashSet(mvTables).containsAll(queryTables)) {
             matchMode = MatchMode.VIEW_DELTA;
         }
         return matchMode;
@@ -2234,7 +2249,7 @@ public class MaterializedViewRewriter {
         final ScalarOperator compensationEqualPredicate =
                 getCompensationEqualPredicate(sourceEquivalenceClasses, targetEquivalenceClasses);
         if (compensationEqualPredicate == null) {
-            logMVRewrite(mvRewriteContext, "Rewrite query failed: get equal compensation predicates failed");
+            logMVRewrite(mvRewriteContext, "Compensate equal predicates failed");
             return null;
         }
 
@@ -2244,8 +2259,8 @@ public class MaterializedViewRewriter {
         ScalarOperator compensationPr =
                 getCompensationPredicate(srcPr, targetPr, columnRewriter, true, isQueryToMV);
         if (compensationPr == null) {
-            logMVRewrite(mvRewriteContext, "Rewrite query failed: get range compensation predicates failed," +
-                    "srcPr:{}, targetPr:{}", MvUtils.toString(srcPr), MvUtils.toString(targetPr));
+            logMVRewrite(mvRewriteContext, "Compensate range predicates failed," +
+                    "srcPr:%s, targetPr:%s", MvUtils.toString(srcPr), MvUtils.toString(targetPr));
             return null;
         }
 
@@ -2266,8 +2281,8 @@ public class MaterializedViewRewriter {
         ScalarOperator compensationPu =
                 getCompensationPredicate(srcPu, targetPu, columnRewriter, false, isQueryToMV);
         if (compensationPu == null) {
-            logMVRewrite(mvRewriteContext, "Rewrite query failed: get residual compensation predicates failed," +
-                    "srcPr:{}, targetPr:{}", MvUtils.toString(srcPu), MvUtils.toString(targetPu));
+            logMVRewrite(mvRewriteContext, "Compensate residual predicates failed," +
+                    "srcPr:%s, targetPr:%s", MvUtils.toString(srcPu), MvUtils.toString(targetPu));
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -91,11 +91,8 @@ import com.starrocks.sql.parser.ParsingException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -484,7 +481,7 @@ public class MvUtils {
     public static ScalarOperator getCompensationPredicateForDisjunctive(ScalarOperator src, ScalarOperator target) {
         List<ScalarOperator> srcItems = Utils.extractDisjunctive(src);
         List<ScalarOperator> targetItems = Utils.extractDisjunctive(target);
-        if (!new HashSet<>(targetItems).containsAll(srcItems)) {
+        if (!Sets.newHashSet(targetItems).containsAll(srcItems)) {
             return null;
         }
         targetItems.removeAll(srcItems);
@@ -1023,43 +1020,11 @@ public class MvUtils {
         return o.toString();
     }
 
-    /**
-     * Return the max refresh timestamp of all partition infos.
-     */
-    public static long  getMaxTablePartitionInfoRefreshTime(
-            Collection<Map<String, MaterializedView.BasePartitionInfo>> partitionInfos) {
-        return partitionInfos.stream()
-                .flatMap(x -> x.values().stream())
-                .map(x -> x.getLastRefreshTime())
-                .max(Long::compareTo)
-                .filter(Objects::nonNull)
-                .orElse(System.currentTimeMillis());
+    public static boolean isSupportViewDelta(OptExpression optExpression) {
+        return getAllJoinOperators(optExpression).stream().allMatch(x -> isSupportViewDelta(x));
     }
 
-    public static List<ScalarOperator> collectOnPredicate(OptExpression optExpression) {
-        List<ScalarOperator> onPredicates = Lists.newArrayList();
-        collectOnPredicate(optExpression, onPredicates, false);
-        return onPredicates;
-    }
-
-    public static List<ScalarOperator> collectOuterAntiJoinOnPredicate(OptExpression optExpression) {
-        List<ScalarOperator> onPredicates = Lists.newArrayList();
-        collectOnPredicate(optExpression, onPredicates, true);
-        return onPredicates;
-    }
-
-    public static void collectOnPredicate(
-            OptExpression optExpression, List<ScalarOperator> onPredicates, boolean onlyOuterAntiJoin) {
-        for (OptExpression child : optExpression.getInputs()) {
-            collectOnPredicate(child, onPredicates, onlyOuterAntiJoin);
-        }
-        if (optExpression.getOp() instanceof LogicalJoinOperator) {
-            LogicalJoinOperator joinOperator = optExpression.getOp().cast();
-            if (onlyOuterAntiJoin &&
-                    !(joinOperator.getJoinType().isOuterJoin() || joinOperator.getJoinType().isAntiJoin())) {
-                return;
-            }
-            onPredicates.addAll(Utils.extractConjuncts(joinOperator.getOnPredicate()));
-        }
+    public static boolean isSupportViewDelta(JoinOperator joinOperator) {
+        return  joinOperator.isLeftOuterJoin() || joinOperator.isInnerJoin();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -111,7 +111,9 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery16() {
+        connectContext.getSessionVariable().setEnableMaterializedViewRewriteFastWithDraw(false);
         runFileUnitTest("materialized-view/tpch/q16");
+        connectContext.getSessionVariable().setEnableMaterializedViewRewriteFastWithDraw(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -1825,7 +1825,6 @@ public class PartitionBasedMvRefreshProcessorTest {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            System.out.println(plan);
             Assert.assertTrue(plan.contains("partitions=2/2\n" +
                     "     rollup: list_partition_tbl1"));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -865,7 +865,6 @@ public class MVRewriteTest {
         starRocksAssert.withMaterializedView(createUserTagMVSql);
         String query = "select `" + FunctionSet.HLL_UNION + "`(" + FunctionSet.HLL_HASH + "(tag_id)) from " +
                 USER_TAG_TABLE_NAME + ";";
-        System.out.println(starRocksAssert.query(query).explainQuery());
         starRocksAssert.query(query).explainContains(USER_TAG_MV_NAME);
         query = "select hll_union_agg(" + FunctionSet.HLL_HASH + "(tag_id)) from " + USER_TAG_TABLE_NAME + ";";
         starRocksAssert.query(query).explainContains(USER_TAG_MV_NAME, FunctionSet.HLL_UNION_AGG);
@@ -907,7 +906,6 @@ public class MVRewriteTest {
         starRocksAssert.withMaterializedView(createUserTagMVSql);
         String query =
                 "select empid, percentile_approx(salary, 1), percentile_approx(commission, 1) from emps group by empid";
-        System.out.println(starRocksAssert.query(query).explainQuery());
         starRocksAssert.query(query).explainContains(QUERY_USE_EMPS_MV, "  2:AGGREGATE (update serialize)\n",
                 "output: percentile_union");
         starRocksAssert.assertMVWithoutComplexExpression(HR_DB_NAME, EMPS_TABLE_NAME);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
@@ -100,7 +100,6 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/agg_with_having1"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains("TEST_MV_2"));
     }
 
@@ -109,7 +108,6 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/agg_with_having2"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains("TEST_MV_2"));
     }
 
@@ -118,7 +116,6 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/agg_with_having3"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains("TEST_MV_3"));
     }
 }

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv1.sql
@@ -1,4 +1,4 @@
--- partsupp_mv
+-- partsupp_mv, query2/query11/query18
 create materialized view partsupp_mv
 distributed by hash(ps_partkey, ps_suppkey) buckets 24
 refresh deferred manual
@@ -7,7 +7,7 @@ properties (
 )
 as select
               n_name,
-              p_mfgr,p_size,p_type,
+              p_mfgr,p_size,p_type,p_brand,
               ps_partkey, ps_suppkey,ps_supplycost,
               r_name,
               s_acctbal,s_address,s_comment,s_name,s_nationkey,s_phone,

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv2.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv2.sql
@@ -1,4 +1,4 @@
--- query1
+-- query1,query18
 create materialized view lineitem_agg_mv1
 distributed by hash(l_orderkey,
                l_shipdate,
@@ -52,6 +52,7 @@ as select  /*+ SET_VAR(query_timeout = 7200) */
        l_suppkey, l_shipdate, l_partkey
 ;
 
+-- query6
 create materialized view lineitem_agg_mv3
 distributed by hash(l_shipdate, l_discount, l_quantity) buckets 24
 partition by l_shipdate

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv3.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv3.sql
@@ -2,7 +2,7 @@
 create materialized view lineitem_mv_agg_mv1
  distributed by hash(p_name,
                o_orderyear,
-               n_name1) buckets 96
+               n_name2) buckets 96
  refresh deferred manual
  properties (
      "replication_num" = "1"
@@ -10,14 +10,15 @@ create materialized view lineitem_mv_agg_mv1
  as select /*+ SET_VAR(query_timeout = 7200) */
                p_name,
                o_orderyear,
-               n_name1,
+               n_name2,
                sum(l_amount) as sum_amount
     from
                lineitem_mv
+    where c_nationkey = s_nationkey
     group by
         p_name,
         o_orderyear,
-        n_name1
+        n_name2
 ;
 
 -- query7

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q16.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q16.sql
@@ -37,11 +37,8 @@ TOP-N (order by [[23: count DESC NULLS LAST, 9: p_brand ASC NULLS FIRST, 10: p_t
                 EXCHANGE SHUFFLE[9, 10, 11]
                     AGGREGATE ([LOCAL] aggregate [{}] group by [[2: ps_suppkey, 9: p_brand, 10: p_type, 11: p_size]] having [null]
                         NULL AWARE LEFT ANTI JOIN (join-predicate [2: ps_suppkey = 15: s_suppkey] post-join-predicate [null])
-                            INNER JOIN (join-predicate [6: p_partkey = 1: ps_partkey] post-join-predicate [null])
-                                SCAN (table[part] columns[6: p_partkey, 9: p_brand, 10: p_type, 11: p_size] predicate[9: p_brand != Brand#43 AND NOT 10: p_type LIKE PROMO BURNISHED% AND 11: p_size IN (31, 43, 9, 6, 18, 11, 25, 1)])
-                                EXCHANGE SHUFFLE[1]
-                                    SCAN (table[partsupp] columns[1: ps_partkey, 2: ps_suppkey] predicate[null])
+                            SCAN (mv[partsupp_mv] columns[109: p_size, 110: p_type, 111: p_brand, 113: ps_suppkey] predicate[109: p_size = 1 OR 109: p_size = 11 OR 109: p_size = 18 OR 109: p_size = 25 OR 109: p_size = 31 OR 109: p_size = 43 OR 109: p_size = 6 OR 109: p_size = 9 AND 111: p_brand < Brand#43 OR 111: p_brand > Brand#43 AND NOT 110: p_type LIKE PROMO BURNISHED%])
                             EXCHANGE BROADCAST
                                 SCAN (table[supplier] columns[21: s_comment, 15: s_suppkey] predicate[21: s_comment LIKE %Customer%Complaints%])
-[end]
+end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q17.sql
@@ -11,7 +11,6 @@ where
   and l_quantity < (
     select
             0.2 * avg(l_quantity)
---         0.2 * sum(l_quantity) / count(l_quantity)
     from
         lineitem
     where

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q9.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q9.sql
@@ -34,9 +34,9 @@ order by
 [result]
 TOP-N (order by [[48: n_name ASC NULLS FIRST, 51: year DESC NULLS LAST]])
     TOP-N (order by [[48: n_name ASC NULLS FIRST, 51: year DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{53: sum=sum(53: sum)}] group by [[48: n_name, 51: year]] having [null]
-            EXCHANGE SHUFFLE[48, 51]
-                AGGREGATE ([LOCAL] aggregate [{53: sum=sum(52: expr)}] group by [[48: n_name, 51: year]] having [null]
-                    SCAN (mv[lineitem_mv] columns[114: c_nationkey, 136: p_name, 140: s_nationkey, 143: l_amount, 145: o_orderyear, 148: n_name2] predicate[114: c_nationkey = 140: s_nationkey AND 136: p_name LIKE %peru%])
+        AGGREGATE ([GLOBAL] aggregate [{1286: sum=sum(1286: sum)}] group by [[99: n_name2, 98: o_orderyear]] having [null]
+            EXCHANGE SHUFFLE[99, 98]
+                AGGREGATE ([LOCAL] aggregate [{1286: sum=sum(100: sum_amount)}] group by [[99: n_name2, 98: o_orderyear]] having [null]
+                    SCAN (mv[lineitem_mv_agg_mv1] columns[97: p_name, 98: o_orderyear, 99: n_name2, 100: sum_amount] predicate[97: p_name LIKE %peru%])
 [end]
 


### PR DESCRIPTION
Fixes #issue

Fix bugs to support more tpch queries by MV rewrite:
-  if query contains non inner/left outer joins which cannot be used to view delta join, not use `intersectingTables` anymore to generate more possible
- Normalize binary scalar operator, eg: `a < b` should be the same with `b > a`.
-  Add more debug logs.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
