### PR TITLE
[BugFix] query cols file crash causing by drop column (#27651)

### DIFF
--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -158,6 +158,8 @@ public:
 
     bool keep_in_memory() const { return _tablet_schema->is_in_memory(); }
 
+    const TabletSchema& tablet_schema() const { return *_tablet_schema; }
+
     const std::string& file_name() const { return _fname; }
 
     uint32_t num_rows() const { return _num_rows; }

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -442,7 +442,32 @@ StatusOr<std::shared_ptr<Segment>> SegmentIterator::_get_dcg_segment(uint32_t uc
                 _dcg_segments[column_file] = dcg_segment;
             }
             if (col_index != nullptr) {
-                *col_index = idx;
+                /*
+                    If the number of cols file columns is less than corresponding dcg meta column_ids vector
+                    size, it means that drop column has been done. We should assign col_index more carefully.
+                    The column offset is not the offset in dcg column_ids vector but it should be the column
+                    offset of the loaded cols file.
+                */
+                DCHECK(_dcg_segments[column_file]->num_columns() <= dcg->column_ids().size());
+                if (_dcg_segments[column_file]->num_columns() < dcg->column_ids().size()) {
+                    const auto& new_schema =
+                            TabletSchema::create_with_uid(_segment->tablet_schema(), dcg->column_ids());
+
+                    *col_index = INT32_MIN;
+                    for (int i = 0; i < new_schema->columns().size(); ++i) {
+                        const auto& col = new_schema->column(i);
+                        if (col.unique_id() == dcg->column_ids()[idx]) {
+                            *col_index = i;
+                            break;
+                        }
+                    }
+                    if (*col_index == INT32_MIN) {
+                        return Status::InternalError("Can not find suitable column in cols file, filename: " +
+                                                     _dcg_segments[column_file]->file_name());
+                    }
+                } else {
+                    *col_index = idx;
+                }
             }
             return _dcg_segments[column_file];
         }


### PR DESCRIPTION
Problem:
If a table with cols file has been drop some columns, crash may happen. Because the dcg column_id maybe inconsistent with the cols file open schema.

Fixes #27651

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
