### PR TITLE
[Enhancement] Support Hive OpenCSVSerde

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -333,14 +333,19 @@ public class HiveMetastoreApiConverter {
         // https://issues.apache.org/jira/browse/HIVE-16922
         String collectionDelim;
         if (serdeParams.containsKey("colelction.delim")) {
-            collectionDelim = serdeParams.get("colelction.delim");
+            collectionDelim = serdeParams.getOrDefault("colelction.delim", "");
         } else {
-            collectionDelim = serdeParams.getOrDefault("collection.delim", DEFAULT_COLLECTION_DELIM);
+            collectionDelim = serdeParams.getOrDefault("collection.delim", "");
         }
 
-        String fieldDelim = serdeParams.getOrDefault("field.delim", DEFAULT_FIELD_DELIM);
-        String lineDelim = serdeParams.getOrDefault("line.delim", DEFAULT_LINE_DELIM);
-        String mapkeyDelim = serdeParams.getOrDefault("mapkey.delim", DEFAULT_MAPKEY_DELIM);
+        String fieldDelim = serdeParams.getOrDefault("field.delim", "");
+        if (fieldDelim.isEmpty()) {
+            // Support for hive org.apache.hadoop.hive.serde2.OpenCSVSerde
+            // https://cwiki.apache.org/confluence/display/hive/csv+serde
+            fieldDelim = serdeParams.getOrDefault("separatorChar", "");
+        }
+        String lineDelim = serdeParams.getOrDefault("line.delim", "");
+        String mapkeyDelim = serdeParams.getOrDefault("mapkey.delim", "");
 
         // check is empty
         fieldDelim = fieldDelim.isEmpty() ? DEFAULT_FIELD_DELIM : fieldDelim;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
@@ -169,6 +169,15 @@ public class HiveMetaClientTest {
         Assert.assertEquals("\002", blankDesc.getCollectionDelim());
         Assert.assertEquals("\003", blankDesc.getMapkeyDelim());
 
+        // Check is using OpenCSVSerde
+        Map<String, String> openCSVParameters = new HashMap<>();
+        openCSVParameters.put("separatorChar", ",");
+        TextFileFormatDesc openCSVDesc = HiveMetastoreApiConverter.toTextFileFormatDesc(openCSVParameters);
+        Assert.assertEquals(",", openCSVDesc.getFieldDelim());
+        Assert.assertEquals("\n", openCSVDesc.getLineDelim());
+        Assert.assertEquals("\002", openCSVDesc.getCollectionDelim());
+        Assert.assertEquals("\003", openCSVDesc.getMapkeyDelim());
+
         // Check is using custom delimiter
         Map<String, String> parameters = new HashMap<>();
         parameters.put("field.delim", ",");


### PR DESCRIPTION
If the user create a hive CSV table with the below grammar:
```sql
CREATE EXTERNAL TABLE `csv_wrong_parse`(
  `open` string COMMENT 'from deserializer',
  `union` string COMMENT 'from deserializer',
  `id` string COMMENT 'from deserializer')
COMMENT '数据'
ROW FORMAT SERDE
  'org.apache.hadoop.hive.serde2.OpenCSVSerde'
WITH SERDEPROPERTIES (
  'escapeChar'='\\',
  'quoteChar'='"',
  'separatorChar'=',',
  'serialization.encoding'='GBK')
STORED AS INPUTFORMAT
  'org.apache.hadoop.mapred.TextInputFormat'
OUTPUTFORMAT
  'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';
```

SR will not recognize `separatorChar` parameter as a field delimiter.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
