### PR TITLE
[Enhancement] Make tablet checker blockingly add tablet to scheduler (#27648)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -444,6 +444,8 @@ public class TabletInvertedIndex {
                     } else {
                         backendTabletNumReport.get(backendId).first++;
                     }
+
+                    tabletMeta.resetToBeCleanedTime();
                 } finally {
                     database.readUnlock();
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
@@ -151,6 +151,10 @@ public class TabletMeta {
         toBeCleanedTimeMs = time;
     }
 
+    public void resetToBeCleanedTime() {
+        toBeCleanedTimeMs = null;
+    }
+
     public boolean containsSchemaHash(int schemaHash) {
         lock.readLock().lock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -37,8 +37,8 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.clone.TabletSchedCtx.Priority;
-import com.starrocks.clone.TabletScheduler.AddResult;
 import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.MasterDaemon;
 import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.server.GlobalStateMgr;
@@ -289,6 +289,7 @@ public class ColocateTableBalancer extends MasterDaemon {
                                  TabletScheduler tabletScheduler) {
         long checkStartTime = System.currentTimeMillis();
         long lockTotalTime = 0;
+        long waitTotalTimeMs = 0;
         List<Long> tableIds = colocateIndex.getAllTableIds(groupId);
         Database db = globalStateMgr.getDbIncludeRecycleBin(groupId.dbId);
         if (db == null) {
@@ -400,16 +401,12 @@ public class ColocateTableBalancer extends MasterDaemon {
                                                 && st == TabletStatus.COLOCATE_MISMATCH);
 
                                         // For bad replica, we ignore the size limit of scheduler queue
-                                        AddResult res = tabletScheduler.addTablet(tabletCtx,
-                                                needToForceRepair(st, tablet,
+                                        Pair<Boolean, Long> result =
+                                                tabletScheduler.blockingAddTabletCtxToScheduler(db, tabletCtx,
+                                                        needToForceRepair(st, tablet,
                                                         bucketsSeq) || isPartitionUrgent /* forcefully add or not */);
-                                        if (res == AddResult.LIMIT_EXCEED) {
-                                            // tablet in scheduler exceed limit, skip this group and check next one.
-                                            LOG.info("number of scheduling tablets in tablet scheduler"
-                                                    + " exceed to limit. stop colocate table check");
-                                            break TABLE;
-                                        }
-                                        if (res == AddResult.ADDED && tabletCtx.getRelocationForRepair()) {
+                                        waitTotalTimeMs += result.second;
+                                        if (result.first && tabletCtx.getRelocationForRepair()) {
                                             LOG.info("add tablet relocation task to scheduler, tablet id: {}, " +
                                                             "bucket sequence before: {}, bucket sequence now: {}",
                                                     tableId,
@@ -452,7 +449,7 @@ public class ColocateTableBalancer extends MasterDaemon {
             db.readUnlock();
         }
 
-        return lockTotalTime;
+        return lockTotalTime - waitTotalTimeMs * 1000000;
     }
 
     private long matchOneGroupUrgent(GroupId groupId,

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -39,7 +39,6 @@ import com.starrocks.catalog.Partition.PartitionState;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Table.TableType;
 import com.starrocks.catalog.Tablet;
-import com.starrocks.clone.TabletScheduler.AddResult;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
@@ -255,6 +254,7 @@ public class TabletChecker extends MasterDaemon {
         long tabletNotReady = 0;
 
         long lockTotalTime = 0;
+        long waitTotalTime = 0;
         long lockStart;
         List<Long> dbIds = globalStateMgr.getDbIdsIncludeRecycleBin();
         DATABASE:
@@ -380,14 +380,10 @@ public class TabletChecker extends MasterDaemon {
                                     continue;
                                 }
 
-                                // ignore the scheduler queue length limitation if it's an urgent repair
-                                AddResult res = tabletScheduler.addTablet(tabletCtx,
-                                        isPartitionUrgent /* force or not */);
-                                if (res == AddResult.LIMIT_EXCEED) {
-                                    LOG.info("number of scheduling tablets in tablet scheduler"
-                                            + " exceed to limit. stop tablet checker");
-                                    break DATABASE;
-                                } else if (res == AddResult.ADDED) {
+                                Pair<Boolean, Long> result =
+                                        tabletScheduler.blockingAddTabletCtxToScheduler(db, tabletCtx, isPartitionUrgent);
+                                waitTotalTime += result.second;
+                                if (result.first) {
                                     addToSchedulerTabletNum++;
                                 }
                             }
@@ -419,9 +415,9 @@ public class TabletChecker extends MasterDaemon {
 
         LOG.info("finished to check tablets. isUrgent: {}, " +
                         "unhealthy/total/added/in_sched/not_ready: {}/{}/{}/{}/{}, " +
-                        "cost: {} ms, in lock time: {} ms",
+                        "cost: {} ms, in lock time: {} ms, wait time: {}ms",
                 isUrgent, unhealthyTabletNum, totalTabletNum, addToSchedulerTabletNum,
-                tabletInScheduler, tabletNotReady, cost, lockTotalTime);
+                tabletInScheduler, tabletNotReady, cost, lockTotalTime - waitTotalTime, waitTotalTime);
     }
 
     public boolean isUrgentTable(long dbId, long tblId) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1044,7 +1044,7 @@ public class Config extends ConfigBase {
      * TODO(cmy): remove this config and dynamically adjust it by clone task statistic
      */
     @ConfField(mutable = true)
-    public static int schedule_slot_num_per_path = 2;
+    public static int schedule_slot_num_per_path = 8;
 
     @ConfField
     public static String tablet_balancer_strategy = "disk_and_tablet";
@@ -1078,12 +1078,12 @@ public class Config extends ConfigBase {
     // if the number of scheduled tablets in TabletScheduler exceed max_scheduling_tablets
     // skip checking.
     @ConfField(mutable = true)
-    public static int max_scheduling_tablets = 2000;
+    public static int max_scheduling_tablets = 10000;
 
     // if the number of balancing tablets in TabletScheduler exceed max_balancing_tablets,
     // no more balance check
     @ConfField(mutable = true)
-    public static int max_balancing_tablets = 100;
+    public static int max_balancing_tablets = 500;
 
     /**
      * After checked tablet_checker_partition_batch_num partitions, db lock will be released,

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
@@ -74,4 +74,13 @@ public class ConsistencyCheckerTest {
         table.setState(OlapTable.OlapTableState.RESTORE);
         Assert.assertEquals(0, new ConsistencyChecker().chooseTablets().size());
     }
+
+    @Test
+    public void testResetToBeCleanedTime() {
+        TabletMeta tabletMeta = new TabletMeta(1, 2, 3,
+                4, 5, TStorageMedium.HDD);
+        tabletMeta.setToBeCleanedTime(123L);
+        tabletMeta.resetToBeCleanedTime();
+        Assert.assertNull(tabletMeta.getToBeCleanedTime());
+    }
 }


### PR DESCRIPTION
Fixes SR-19074

1. Make `TabletChecker` blockingly add tablet to `TabletScheduler`, this is to avoid meaningless loop and also avoid the situation that tablets
which have failed reparing for many times continuously added to pending queue, and tablet which could be repaired successfully cannot get the
    chance to be added to scheduling queue.
2. Adjust the default value of `tablet_sched_max_balancing_tablets` and `tablet_sched_max_scheduling_tablets` configurations, because we always need to tell the user to increase those values.

This is a backport from #27648.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
