### PR TITLE
[Enhancement] use pointer instead copy group metadata

### DIFF
--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -38,7 +38,7 @@ struct ColumnReaderOptions {
     int chunk_size = 0;
     HdfsScanStats* stats = nullptr;
     RandomAccessFile* file = nullptr;
-    tparquet::RowGroup* row_group_meta = nullptr;
+    const tparquet::RowGroup* row_group_meta = nullptr;
     ColumnReaderContext* context = nullptr;
 };
 

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -37,8 +37,7 @@ constexpr static const LogicalType kDictCodeFieldType = TYPE_INT;
 GroupReader::GroupReader(GroupReaderParam& param, int row_group_number, const std::set<int64_t>* need_skip_rowids,
                          int64_t row_group_first_row)
         : _row_group_first_row(row_group_first_row), _need_skip_rowids(need_skip_rowids), _param(param) {
-    _row_group_metadata =
-            std::make_shared<tparquet::RowGroup>(param.file_metadata->t_metadata().row_groups[row_group_number]);
+    _row_group_metadata = &_param.file_metadata->t_metadata().row_groups[row_group_number];
 }
 
 Status GroupReader::init() {
@@ -190,7 +189,7 @@ Status GroupReader::_init_column_readers() {
     opts.chunk_size = _param.chunk_size;
     opts.stats = _param.stats;
     opts.file = _param.file;
-    opts.row_group_meta = _row_group_metadata.get();
+    opts.row_group_meta = _row_group_metadata;
     opts.context = _obj_pool.add(new ColumnReaderContext);
     for (const auto& column : _param.read_cols) {
         RETURN_IF_ERROR(_create_column_reader(column));

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -146,7 +146,7 @@ private:
                                  std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset);
 
     // row group meta
-    std::shared_ptr<tparquet::RowGroup> _row_group_metadata;
+    const tparquet::RowGroup* _row_group_metadata = nullptr;
     int64_t _row_group_first_row = 0;
     const std::set<int64_t>* _need_skip_rowids;
     int64_t _raw_rows_read = 0;

--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -170,8 +170,6 @@ public:
     }
 
 private:
-    // TODO(zc): No need copy
-    const tparquet::ColumnChunk _chunk_metadata;
     const ParquetField* _field = nullptr;
 };
 


### PR DESCRIPTION
Fixes #issue

For rowgroup with many columns, copy row group metadata is very wasteful, use pointer.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
