### PR TITLE
[Enhancement] Make tablet checker blockingly add tablet to scheduler(#27648) (#27798)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -409,6 +409,8 @@ public class TabletInvertedIndex {
                     } else {
                         backendTabletNumReport.get(backendId).first++;
                     }
+
+                    tabletMeta.resetToBeCleanedTime();
                 } finally {
                     database.readUnlock();
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletMeta.java
@@ -38,6 +38,8 @@ public class TabletMeta {
 
     private final boolean isLakeTablet;
 
+    private Long toBeCleanedTimeMs = null;
+
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     public TabletMeta(long dbId, long tableId, long partitionId, long indexId, int schemaHash,
@@ -100,6 +102,18 @@ public class TabletMeta {
         } finally {
             lock.readLock().unlock();
         }
+    }
+
+    public Long getToBeCleanedTime() {
+        return toBeCleanedTimeMs;
+    }
+
+    public void setToBeCleanedTime(Long time) {
+        toBeCleanedTimeMs = time;
+    }
+
+    public void resetToBeCleanedTime() {
+        toBeCleanedTimeMs = null;
     }
 
     public boolean containsSchemaHash(int schemaHash) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -37,9 +37,9 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.clone.TabletSchedCtx.Priority;
-import com.starrocks.clone.TabletScheduler.AddResult;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.server.GlobalStateMgr;
@@ -677,6 +677,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
                                  TabletScheduler tabletScheduler) {
         long checkStartTime = System.currentTimeMillis();
         long lockTotalTime = 0;
+        long waitTotalTimeMs = 0;
         List<Long> tableIds = colocateIndex.getAllTableIds(groupId);
         Database db = globalStateMgr.getDbIncludeRecycleBin(groupId.dbId);
         if (db == null) {
@@ -788,16 +789,12 @@ public class ColocateTableBalancer extends LeaderDaemon {
                                                 && st == TabletStatus.COLOCATE_MISMATCH);
 
                                         // For bad replica, we ignore the size limit of scheduler queue
-                                        AddResult res = tabletScheduler.addTablet(tabletCtx,
-                                                needToForceRepair(st, tablet,
+                                        Pair<Boolean, Long> result =
+                                                tabletScheduler.blockingAddTabletCtxToScheduler(db, tabletCtx,
+                                                        needToForceRepair(st, tablet,
                                                         bucketsSeq) || isPartitionUrgent /* forcefully add or not */);
-                                        if (res == AddResult.LIMIT_EXCEED) {
-                                            // tablet in scheduler exceed limit, skip this group and check next one.
-                                            LOG.info("number of scheduling tablets in tablet scheduler"
-                                                    + " exceed to limit. stop colocate table check");
-                                            break TABLE;
-                                        }
-                                        if (res == AddResult.ADDED && tabletCtx.getRelocationForRepair()) {
+                                        waitTotalTimeMs += result.second;
+                                        if (result.first && tabletCtx.getRelocationForRepair()) {
                                             LOG.info("add tablet relocation task to scheduler, tablet id: {}, " +
                                                             "bucket sequence before: {}, bucket sequence now: {}",
                                                     tableId,
@@ -840,7 +837,7 @@ public class ColocateTableBalancer extends LeaderDaemon {
             db.readUnlock();
         }
 
-        return lockTotalTime;
+        return lockTotalTime - waitTotalTimeMs * 1000000;
     }
 
     private long matchOneGroupUrgent(GroupId groupId,

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -116,6 +116,8 @@ public class TabletScheduler extends LeaderDaemon {
      */
     private static final double COLOCATE_BACKEND_RESET_RATIO = 0.3;
 
+    private static final int BLOCKING_ADD_SLEEP_DURATION_MS = 200;
+
     /*
      * Tablet is added to pendingTablets as well it's id in allTabletIds.
      * TabletScheduler will take tablet from pendingTablets but will not remove its id from allTabletIds when
@@ -288,6 +290,33 @@ public class TabletScheduler extends LeaderDaemon {
         allTabletIds.add(tablet.getTabletId());
         pendingTablets.offer(tablet);
         return AddResult.ADDED;
+    }
+
+    public Pair<Boolean, Long> blockingAddTabletCtxToScheduler(Database db, TabletSchedCtx tabletSchedCtx,
+                                                               boolean forceAdd) {
+        // first: added or not, second: total sleep time in ms
+        Pair<Boolean, Long> result = new Pair<>(false, 0L);
+        try {
+            do {
+                AddResult res = addTablet(tabletSchedCtx, forceAdd /* force or not */);
+                if (res == AddResult.LIMIT_EXCEED) {
+                    db.readUnlock();
+                    // It's ok to sleep a relative long time here so that the scheduler will spare more
+                    // slots after the sleep and the following adding won't block.
+                    Thread.sleep(BLOCKING_ADD_SLEEP_DURATION_MS);
+                    result.second += BLOCKING_ADD_SLEEP_DURATION_MS;
+                    db.readLock();
+                } else {
+                    result.first = (res == AddResult.ADDED);
+                    break;
+                }
+            } while (true);
+        } catch (InterruptedException e) {
+            LOG.warn(e);
+            db.readLock();
+        }
+
+        return result;
     }
 
     public void forceCleanSchedQ() {
@@ -1468,6 +1497,11 @@ public class TabletScheduler extends LeaderDaemon {
         allTabletIds.remove(tabletCtx.getTabletId());
         schedHistory.add(tabletCtx);
         LOG.info("remove the tablet {}. because: {}", tabletCtx.getTabletId(), reason);
+    }
+
+    @VisibleForTesting
+    public void removeOneFromPendingQ() {
+        pendingTablets.poll();
     }
 
     // get next batch of tablets from queue.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1068,7 +1068,7 @@ public class Config extends ConfigBase {
     // if the number of scheduled tablets in TabletScheduler exceed max_scheduling_tablets
     // skip checking.
     @ConfField(mutable = true, aliases = {"max_scheduling_tablets"})
-    public static int tablet_sched_max_scheduling_tablets = 2000;
+    public static int tablet_sched_max_scheduling_tablets = 10000;
 
     /**
      * if set to true, TabletScheduler will not do balance.
@@ -1141,7 +1141,7 @@ public class Config extends ConfigBase {
     // if the number of balancing tablets in TabletScheduler exceed max_balancing_tablets,
     // no more balance check
     @ConfField(mutable = true, aliases = {"max_balancing_tablets"})
-    public static int tablet_sched_max_balancing_tablets = 100;
+    public static int tablet_sched_max_balancing_tablets = 500;
 
     /**
      * When create a table(or partition), you can specify its storage medium(HDD or SSD).

--- a/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/consistency/ConsistencyCheckerTest.java
@@ -76,4 +76,13 @@ public class ConsistencyCheckerTest {
         table.setState(OlapTable.OlapTableState.RESTORE);
         Assert.assertEquals(0, new ConsistencyChecker().chooseTablets().size());
     }
+
+    @Test
+    public void testResetToBeCleanedTime() {
+        TabletMeta tabletMeta = new TabletMeta(1, 2, 3,
+                4, 5, TStorageMedium.HDD);
+        tabletMeta.setToBeCleanedTime(123L);
+        tabletMeta.resetToBeCleanedTime();
+        Assert.assertNull(tabletMeta.getToBeCleanedTime());
+    }
 }


### PR DESCRIPTION
Fixes SR-19074

1. Make `TabletChecker` blockingly add tablet to `TabletScheduler`, this is to avoid meaningless loop and also avoid the situation that tablets which have failed reparing for many times continuously added to pending queue, and tablet which could be repaired successfully cannot get the chance to be added to scheduling queue.
2. Adjust the default value of `tablet_sched_max_balancing_tablets` and `tablet_sched_max_scheduling_tablets` configurations, because we always need to tell the user to increase those values.

This is a backport from pr #27648.
