### PR TITLE
[Refactor] Add interface close() for GlobalDriverExecutor/DataStreamMgr/DataStreamRecvr/FragmentMgr/PassThroughChunkBufferManager/LoadStreamMgr

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -43,7 +43,9 @@ GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_
                                     [this]() { return _blocked_driver_poller->blocked_driver_queue_len(); });
 }
 
-GlobalDriverExecutor::~GlobalDriverExecutor() = default;
+GlobalDriverExecutor::~GlobalDriverExecutor() {
+    close();
+}
 
 void GlobalDriverExecutor::close() {
     _driver_queue->close();

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -43,7 +43,9 @@ GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_
                                     [this]() { return _blocked_driver_poller->blocked_driver_queue_len(); });
 }
 
-GlobalDriverExecutor::~GlobalDriverExecutor() {
+GlobalDriverExecutor::~GlobalDriverExecutor() = default;
+
+void GlobalDriverExecutor::clear() {
     _driver_queue->close();
 }
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -45,7 +45,7 @@ GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_
 
 GlobalDriverExecutor::~GlobalDriverExecutor() = default;
 
-void GlobalDriverExecutor::clear() {
+void GlobalDriverExecutor::close() {
     _driver_queue->close();
 }
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -41,6 +41,7 @@ public:
     virtual void change_num_threads(int32_t num_threads) {}
     virtual void submit(DriverRawPtr driver) = 0;
     virtual void cancel(DriverRawPtr driver) = 0;
+    virtual void clear() = 0;
 
     // When all the root drivers (the drivers have no successors in the same fragment) have finished,
     // just notify FE timely the completeness of fragment via invocation of report_exec_state, but
@@ -71,6 +72,7 @@ public:
     void change_num_threads(int32_t num_threads) override;
     void submit(DriverRawPtr driver) override;
     void cancel(DriverRawPtr driver) override;
+    void clear() override;
     void report_exec_state(QueryContext* query_ctx, FragmentContext* fragment_ctx, const Status& status, bool done,
                            bool attach_profile) override;
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -41,7 +41,7 @@ public:
     virtual void change_num_threads(int32_t num_threads) {}
     virtual void submit(DriverRawPtr driver) = 0;
     virtual void cancel(DriverRawPtr driver) = 0;
-    virtual void clear() = 0;
+    virtual void close() = 0;
 
     // When all the root drivers (the drivers have no successors in the same fragment) have finished,
     // just notify FE timely the completeness of fragment via invocation of report_exec_state, but
@@ -72,7 +72,7 @@ public:
     void change_num_threads(int32_t num_threads) override;
     void submit(DriverRawPtr driver) override;
     void cancel(DriverRawPtr driver) override;
-    void clear() override;
+    void close() override;
     void report_exec_state(QueryContext* query_ctx, FragmentContext* fragment_ctx, const Status& status, bool done,
                            bool attach_profile) override;
 

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -210,6 +210,18 @@ Status DataStreamMgr::deregister_recvr(const TUniqueId& fragment_instance_id, Pl
     }
 }
 
+void DataStreamMgr::clear() {
+    for (size_t i = 0; i < _receiver_map->size(); i++) {
+        std::lock_guard<Mutex> l(_lock[i]);
+        for (auto& iter : _receiver_map[i]) {
+            for (auto& sub_iter : *iter.second) {
+                sub_iter.second->cancel_stream();
+            }
+        }
+    }
+    _pass_through_chunk_buffer_manager.clear();
+}
+
 void DataStreamMgr::cancel(const TUniqueId& fragment_instance_id) {
     VLOG_QUERY << "cancelling all streams for fragment=" << fragment_instance_id;
     std::vector<std::shared_ptr<DataStreamRecvr>> recvrs;

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -219,7 +219,7 @@ void DataStreamMgr::close() {
             }
         }
     }
-    _pass_through_chunk_buffer_manager.clear();
+    _pass_through_chunk_buffer_manager.close();
 }
 
 void DataStreamMgr::cancel(const TUniqueId& fragment_instance_id) {

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -210,7 +210,7 @@ Status DataStreamMgr::deregister_recvr(const TUniqueId& fragment_instance_id, Pl
     }
 }
 
-void DataStreamMgr::clear() {
+void DataStreamMgr::close() {
     for (size_t i = 0; i < _receiver_map->size(); i++) {
         std::lock_guard<Mutex> l(_lock[i]);
         for (auto& iter : _receiver_map[i]) {

--- a/be/src/runtime/data_stream_mgr.h
+++ b/be/src/runtime/data_stream_mgr.h
@@ -104,7 +104,7 @@ public:
     Status transmit_chunk(const PTransmitChunkParams& request, ::google::protobuf::Closure** done);
     // Closes all receivers registered for fragment_instance_id immediately.
     void cancel(const TUniqueId& fragment_instance_id);
-    void clear();
+    void close();
 
     void prepare_pass_through_chunk_buffer(const TUniqueId& query_id);
     void destroy_pass_through_chunk_buffer(const TUniqueId& query_id);

--- a/be/src/runtime/data_stream_mgr.h
+++ b/be/src/runtime/data_stream_mgr.h
@@ -104,6 +104,7 @@ public:
     Status transmit_chunk(const PTransmitChunkParams& request, ::google::protobuf::Closure** done);
     // Closes all receivers registered for fragment_instance_id immediately.
     void cancel(const TUniqueId& fragment_instance_id);
+    void clear();
 
     void prepare_pass_through_chunk_buffer(const TUniqueId& query_id);
     void destroy_pass_through_chunk_buffer(const TUniqueId& query_id);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -499,11 +499,31 @@ void ExecEnv::add_rf_event(const RfTracePoint& pt) {
 }
 
 void ExecEnv::stop() {
-    // Clear load channel should be executed before stopping the storage engine,
-    // otherwise some writing tasks will still be in the MemTableFlushThreadPool of the storage engine,
-    // so when the ThreadPool is destroyed, it will crash.
+    if (_stream_mgr != nullptr) {
+        _stream_mgr->clear();
+    }
+
     if (_load_channel_mgr) {
+        // Clear load channel should be executed before stopping the storage engine,
+        // otherwise some writing tasks will still be in the MemTableFlushThreadPool of the storage engine,
+        // so when the ThreadPool is destroyed, it will crash.
         _load_channel_mgr->clear();
+    }
+
+    if (_load_stream_mgr) {
+        _load_stream_mgr->clear();
+    }
+
+    if (_fragment_mgr) {
+        _fragment_mgr->clear();
+    }
+
+    if (_pipeline_sink_io_pool) {
+        _pipeline_sink_io_pool->shutdown();
+    }
+
+    if (_wg_driver_executor) {
+        _wg_driver_executor->clear();
     }
 
     if (_automatic_partition_pool) {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -500,22 +500,22 @@ void ExecEnv::add_rf_event(const RfTracePoint& pt) {
 
 void ExecEnv::stop() {
     if (_stream_mgr != nullptr) {
-        _stream_mgr->clear();
+        _stream_mgr->close();
     }
 
     if (_load_channel_mgr) {
         // Clear load channel should be executed before stopping the storage engine,
         // otherwise some writing tasks will still be in the MemTableFlushThreadPool of the storage engine,
         // so when the ThreadPool is destroyed, it will crash.
-        _load_channel_mgr->clear();
+        _load_channel_mgr->close();
     }
 
     if (_load_stream_mgr) {
-        _load_stream_mgr->clear();
+        _load_stream_mgr->close();
     }
 
     if (_fragment_mgr) {
-        _fragment_mgr->clear();
+        _fragment_mgr->close();
     }
 
     if (_pipeline_sink_io_pool) {
@@ -523,7 +523,7 @@ void ExecEnv::stop() {
     }
 
     if (_wg_driver_executor) {
-        _wg_driver_executor->clear();
+        _wg_driver_executor->close();
     }
 
     if (_automatic_partition_pool) {

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -532,6 +532,13 @@ void FragmentMgr::receive_runtime_filter(const PTransmitRuntimeFilterParams& par
     }
 }
 
+void FragmentMgr::clear() {
+    std::lock_guard<std::mutex> lock(_lock);
+    for (auto& it : _fragment_map) {
+        cancel(it.second->fragment_instance_id(), PPlanFragmentCancelReason::USER_CANCEL);
+    }
+}
+
 void FragmentMgr::cancel_worker() {
     LOG(INFO) << "FragmentMgr cancel worker start working.";
     while (!_stop) {

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -532,7 +532,7 @@ void FragmentMgr::receive_runtime_filter(const PTransmitRuntimeFilterParams& par
     }
 }
 
-void FragmentMgr::clear() {
+void FragmentMgr::close() {
     std::lock_guard<std::mutex> lock(_lock);
     for (auto& it : _fragment_map) {
         cancel(it.second->fragment_instance_id(), PPlanFragmentCancelReason::USER_CANCEL);

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -80,7 +80,7 @@ public:
     Status exec_plan_fragment(const TExecPlanFragmentParams& params, const StartSuccCallback& start_cb,
                               const FinishCallback& cb);
 
-    void clear();
+    void close();
 
     Status cancel(const TUniqueId& fragment_id) {
         return cancel(fragment_id, PPlanFragmentCancelReason::INTERNAL_ERROR);

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -80,6 +80,8 @@ public:
     Status exec_plan_fragment(const TExecPlanFragmentParams& params, const StartSuccCallback& start_cb,
                               const FinishCallback& cb);
 
+    void clear();
+
     Status cancel(const TUniqueId& fragment_id) {
         return cancel(fragment_id, PPlanFragmentCancelReason::INTERNAL_ERROR);
     }

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -80,7 +80,7 @@ LoadChannelMgr::~LoadChannelMgr() {
     }
 }
 
-void LoadChannelMgr::clear() {
+void LoadChannelMgr::close() {
     std::lock_guard l(_lock);
     for (auto iter = _load_channels.begin(); iter != _load_channels.end();) {
         iter->second->cancel();

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -86,7 +86,7 @@ public:
 
     std::shared_ptr<LoadChannel> remove_load_channel(const UniqueId& load_id);
 
-    void clear();
+    void close();
 
 private:
     static void* load_channel_clean_bg_worker(void* arg);

--- a/be/src/runtime/local_pass_through_buffer.cpp
+++ b/be/src/runtime/local_pass_through_buffer.cpp
@@ -138,6 +138,14 @@ void PassThroughChunkBufferManager::open_fragment_instance(const TUniqueId& quer
     }
 }
 
+void PassThroughChunkBufferManager::clear() {
+    std::unique_lock lock(_mutex);
+    for (auto it = _query_id_to_buffer.begin(); it != _query_id_to_buffer.end();) {
+        delete it->second;
+        it = _query_id_to_buffer.erase(it);
+    }
+}
+
 void PassThroughChunkBufferManager::close_fragment_instance(const TUniqueId& query_id) {
     VLOG_FILE << "PassThroughChunkBufferManager::close_fragment_instance, query_id = " << query_id;
     {

--- a/be/src/runtime/local_pass_through_buffer.cpp
+++ b/be/src/runtime/local_pass_through_buffer.cpp
@@ -138,7 +138,7 @@ void PassThroughChunkBufferManager::open_fragment_instance(const TUniqueId& quer
     }
 }
 
-void PassThroughChunkBufferManager::clear() {
+void PassThroughChunkBufferManager::close() {
     std::unique_lock lock(_mutex);
     for (auto it = _query_id_to_buffer.begin(); it != _query_id_to_buffer.end();) {
         delete it->second;

--- a/be/src/runtime/local_pass_through_buffer.h
+++ b/be/src/runtime/local_pass_through_buffer.h
@@ -80,6 +80,7 @@ public:
     void open_fragment_instance(const TUniqueId& query_id);
     void close_fragment_instance(const TUniqueId& query_id);
     PassThroughChunkBuffer* get(const TUniqueId& query_id);
+    void clear();
 
 private:
     std::mutex _mutex;

--- a/be/src/runtime/local_pass_through_buffer.h
+++ b/be/src/runtime/local_pass_through_buffer.h
@@ -80,7 +80,7 @@ public:
     void open_fragment_instance(const TUniqueId& query_id);
     void close_fragment_instance(const TUniqueId& query_id);
     PassThroughChunkBuffer* get(const TUniqueId& query_id);
-    void clear();
+    void close();
 
 private:
     std::mutex _mutex;

--- a/be/src/runtime/stream_load/load_stream_mgr.h
+++ b/be/src/runtime/stream_load/load_stream_mgr.h
@@ -57,7 +57,7 @@ public:
     }
     ~LoadStreamMgr() = default;
 
-    void clear() {
+    void close() {
         std::lock_guard<std::mutex> l(_lock);
         for (auto iter = _stream_map.begin(); iter != _stream_map.end();) {
             iter->second->close();

--- a/be/src/runtime/stream_load/load_stream_mgr.h
+++ b/be/src/runtime/stream_load/load_stream_mgr.h
@@ -57,6 +57,14 @@ public:
     }
     ~LoadStreamMgr() = default;
 
+    void clear() {
+        std::lock_guard<std::mutex> l(_lock);
+        for (auto iter = _stream_map.begin(); iter != _stream_map.end();) {
+            iter->second->close();
+            iter = _stream_map.erase(iter);
+        }
+    }
+
     Status put(const UniqueId& id, const std::shared_ptr<StreamLoadPipe>& stream) {
         std::lock_guard<std::mutex> l(_lock);
         auto it = _stream_map.find(id);

--- a/be/test/test_main.cpp
+++ b/be/test/test_main.cpp
@@ -103,6 +103,7 @@ int main(int argc, char** argv) {
     starrocks::StorageEngine::instance()->stop();
     // destroy exec env
     starrocks::tls_thread_status.set_mem_tracker(nullptr);
+    exec_env->stop();
     exec_env->destroy();
     global_env->stop();
 


### PR DESCRIPTION
Fixes #27417 

graceful exit step 6: Add interface close() for GlobalDriverExecutor/DataStreamMgr/DataStreamRecvr/FragmentMgr/PassThroughChunkBufferManager/LoadStreamMgr

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
