### PR TITLE
[Refactor] Extract JobSpec

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Status.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Status.java
@@ -55,6 +55,14 @@ public class Status {
     private TStatusCode errorCode; // anything other than OK
     private String errorMsg;
 
+    public static Status internalError(String errorMsg) {
+        return new Status(TStatusCode.INTERNAL_ERROR, errorMsg);
+    }
+
+    public static Status thriftRPCError(String errorMsg) {
+        return new Status(TStatusCode.THRIFT_RPC_ERROR, errorMsg);
+    }
+
     public Status() {
         this.errorCode = TStatusCode.OK;
         this.errorMsg = null;
@@ -82,6 +90,10 @@ public class Status {
 
     public boolean isCancelled() {
         return this.errorCode == TStatusCode.CANCELLED;
+    }
+
+    public boolean isTimeout() {
+        return this.errorCode == TStatusCode.TIMEOUT;
     }
 
     public boolean isRpcError() {

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpResultSender.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpResultSender.java
@@ -34,7 +34,7 @@ package com.starrocks.http;
 import com.google.gson.JsonObject;
 import com.starrocks.qe.RowBatch;
 import com.starrocks.qe.ShowResultSet;
-import com.starrocks.qe.scheduler.ICoordinator;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TResultBatch;
 import io.netty.buffer.ByteBuf;
@@ -67,7 +67,7 @@ public class HttpResultSender {
     }
 
     // for select
-    public RowBatch sendQueryResult(ICoordinator coord, ExecPlan execPlan) throws Exception {
+    public RowBatch sendQueryResult(Coordinator coord, ExecPlan execPlan) throws Exception {
         RowBatch batch;
         ChannelHandlerContext nettyChannel = context.getNettyChannel();
         sendHeader(nettyChannel);

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpResultSender.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpResultSender.java
@@ -32,9 +32,9 @@
 package com.starrocks.http;
 
 import com.google.gson.JsonObject;
-import com.starrocks.qe.Coordinator;
 import com.starrocks.qe.RowBatch;
 import com.starrocks.qe.ShowResultSet;
+import com.starrocks.qe.scheduler.ICoordinator;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TResultBatch;
 import io.netty.buffer.ByteBuf;
@@ -67,7 +67,7 @@ public class HttpResultSender {
     }
 
     // for select
-    public RowBatch sendQueryResult(Coordinator coord, ExecPlan execPlan) throws Exception {
+    public RowBatch sendQueryResult(ICoordinator coord, ExecPlan execPlan) throws Exception {
         RowBatch batch;
         ChannelHandlerContext nettyChannel = context.getNettyChannel();
         sendHeader(nettyChannel);

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -81,6 +81,7 @@ import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.proto.UnlockTabletMetadataRequest;
 import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.scheduler.ICoordinator;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
@@ -130,7 +131,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
     private final Set<String> exportedTempFiles = Sets.newConcurrentHashSet();
     private Set<String> exportedFiles = Sets.newConcurrentHashSet();
     private final Analyzer analyzer;
-    private final List<Coordinator> coordList = Lists.newArrayList();
+    private final List<ICoordinator> coordList = Lists.newArrayList();
     private final AtomicInteger nextId = new AtomicInteger(0);
     // backedn_address => snapshot path
     private List<Pair<TNetworkAddress, String>> snapshotPaths = Lists.newArrayList();
@@ -431,16 +432,19 @@ public class ExportJob implements Writable, GsonPostProcessable {
         return outputExprs;
     }
 
+    private ICoordinator.Factory getCoordinatorFactory() {
+        return new Coordinator.Factory();
+    }
+
     private void genCoordinators(ExportStmt stmt, List<PlanFragment> fragments, List<ScanNode> nodes) {
         UUID uuid = UUID.randomUUID();
         for (int i = 0; i < fragments.size(); ++i) {
             PlanFragment fragment = fragments.get(i);
             ScanNode scanNode = nodes.get(i);
             TUniqueId queryId = new TUniqueId(uuid.getMostSignificantBits() + i, uuid.getLeastSignificantBits());
-            Coordinator coord = new Coordinator(
+            ICoordinator coord = getCoordinatorFactory().createBrokerExportScheduler(
                     id, queryId, desc, Lists.newArrayList(fragment), Lists.newArrayList(scanNode),
-                    TimeUtils.DEFAULT_TIME_ZONE, stmt.getExportStartTime(), Maps.newHashMap());
-            coord.setExecMemoryLimit(getMemLimit());
+                    TimeUtils.DEFAULT_TIME_ZONE, stmt.getExportStartTime(), Maps.newHashMap(), getMemLimit());
             this.coordList.add(coord);
             LOG.info("split export job to tasks. job id: {}, job query id: {}, task idx: {}, task query id: {}",
                     id, DebugUtil.printId(this.queryId), i, DebugUtil.printId(queryId));
@@ -455,8 +459,8 @@ public class ExportJob implements Writable, GsonPostProcessable {
     // Also, if the version has been compacted in one BE's tablet, coord will return 
     // 'version already been compacted' error msg, find a new replica may be able to 
     // alleviate this problem.
-    public Coordinator resetCoord(int taskIndex, TUniqueId newQueryId) throws UserException {
-        Coordinator coord = coordList.get(taskIndex);
+    public ICoordinator resetCoord(int taskIndex, TUniqueId newQueryId) throws UserException {
+        ICoordinator coord = coordList.get(taskIndex);
         OlapScanNode olapScanNode = (OlapScanNode) coord.getScanNodes().get(0);
         List<TScanRangeLocations> locations = olapScanNode.getScanRangeLocations(0);
         if (locations.size() == 0) {
@@ -482,10 +486,9 @@ public class ExportJob implements Writable, GsonPostProcessable {
         OlapScanNode newTaskScanNode = genOlapScanNodeByLocation(newLocations);
         PlanFragment newFragment = genPlanFragment(exportTable.getType(), newTaskScanNode, taskIndex);
 
-        Coordinator newCoord = new Coordinator(
+        ICoordinator newCoord = getCoordinatorFactory().createBrokerExportScheduler(
                 id, newQueryId, desc, Lists.newArrayList(newFragment), Lists.newArrayList(newTaskScanNode),
-                TimeUtils.DEFAULT_TIME_ZONE, coord.getStartTime(), Maps.newHashMap());
-        newCoord.setExecMemoryLimit(getMemLimit());
+                TimeUtils.DEFAULT_TIME_ZONE, coord.getStartTimeMs(), Maps.newHashMap(), getMemLimit());
         this.coordList.set(taskIndex, newCoord);
         LOG.info("reset coordinator for export job: {}, taskIdx: {}", id, taskIndex);
         return newCoord;
@@ -643,7 +646,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
         this.doExportingThread = isExportingThread;
     }
 
-    public List<Coordinator> getCoordList() {
+    public List<ICoordinator> getCoordList() {
         return coordList;
     }
 
@@ -796,7 +799,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
             }
 
             // cancel all running coordinators
-            for (Coordinator coord : coordList) {
+            for (ICoordinator coord : coordList) {
                 coord.cancel();
             }
 
@@ -1090,7 +1093,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
         public ExportUpdateInfo() {
             this.jobId = -1;
             this.state = JobState.CANCELLED;
-            this.snapshotPaths =  Lists.newArrayList();
+            this.snapshotPaths = Lists.newArrayList();
             this.exportTempPath = "";
             this.exportedFiles = Sets.newConcurrentHashSet();
             this.failMsg = new ExportFailMsg();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -66,8 +66,8 @@ import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.AlterLoadJobOperationLog;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.Coordinator;
 import com.starrocks.qe.QeProcessorImpl;
+import com.starrocks.qe.scheduler.ICoordinator;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterLoadStmt;
 import com.starrocks.sql.ast.LoadStmt;
@@ -637,7 +637,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
         // cancel all running coordinators, so that the scheduler's worker thread will be released
         for (TUniqueId loadId : loadIds) {
-            Coordinator coordinator = QeProcessorImpl.INSTANCE.getCoordinator(loadId);
+            ICoordinator coordinator = QeProcessorImpl.INSTANCE.getCoordinator(loadId);
             if (coordinator != null) {
                 coordinator.cancel();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -67,7 +67,7 @@ import com.starrocks.persist.AlterLoadJobOperationLog;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QeProcessorImpl;
-import com.starrocks.qe.scheduler.ICoordinator;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterLoadStmt;
 import com.starrocks.sql.ast.LoadStmt;
@@ -637,7 +637,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
         // cancel all running coordinators, so that the scheduler's worker thread will be released
         for (TUniqueId loadId : loadIds) {
-            ICoordinator coordinator = QeProcessorImpl.INSTANCE.getCoordinator(loadId);
+            Coordinator coordinator = QeProcessorImpl.INSTANCE.getCoordinator(loadId);
             if (coordinator != null) {
                 coordinator.cancel();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -55,11 +55,11 @@ import com.starrocks.qe.Coordinator;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.scheduler.ICoordinator;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.thrift.TBrokerFileStatus;
 import com.starrocks.thrift.TLoadJobType;
 import com.starrocks.thrift.TPartialUpdateMode;
-import com.starrocks.thrift.TQueryType;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletFailInfo;
@@ -103,12 +103,12 @@ public class LoadLoadingTask extends LoadTask {
     private final OriginStatement originStmt;
 
     public LoadLoadingTask(Database db, OlapTable table, BrokerDesc brokerDesc, List<BrokerFileGroup> fileGroups,
-            long jobDeadlineMs, long execMemLimit, boolean strictMode,
-            long txnId, LoadTaskCallback callback, String timezone,
-            long timeoutS, long createTimestamp, boolean partialUpdate, String mergeConditionStr,
-            Map<String, String> sessionVariables,
-            ConnectContext context, TLoadJobType loadJobType, int priority, OriginStatement originStmt, 
-            TPartialUpdateMode partialUpdateMode) {
+                           long jobDeadlineMs, long execMemLimit, boolean strictMode,
+                           long txnId, LoadTaskCallback callback, String timezone,
+                           long timeoutS, long createTimestamp, boolean partialUpdate, String mergeConditionStr,
+                           Map<String, String> sessionVariables,
+                           ConnectContext context, TLoadJobType loadJobType, int priority, OriginStatement originStmt,
+                           TPartialUpdateMode partialUpdateMode) {
         super(callback, TaskType.LOADING, priority);
         this.db = db;
         this.table = table;
@@ -142,8 +142,8 @@ public class LoadLoadingTask extends LoadTask {
             planner.plan(loadId, fileStatusList, fileNum);
         } else {
             loadPlanner = new LoadPlanner(callback.getCallbackId(), loadId, txnId, db.getId(), table, strictMode,
-                timezone, timeoutS, createTimestamp, partialUpdate, context, sessionVariables, execMemLimit, execMemLimit, 
-                brokerDesc, fileGroups, fileStatusList, fileNum);
+                    timezone, timeoutS, createTimestamp, partialUpdate, context, sessionVariables, execMemLimit, execMemLimit,
+                    brokerDesc, fileGroups, fileStatusList, fileNum);
             loadPlanner.plan();
         }
     }
@@ -164,26 +164,23 @@ public class LoadLoadingTask extends LoadTask {
         executeOnce();
     }
 
+    private ICoordinator.Factory getCoordinatorFactory() {
+        return new Coordinator.Factory();
+    }
+
     private void executeOnce() throws Exception {
         // New one query id,
-        Coordinator curCoordinator;
+        ICoordinator curCoordinator;
         if (!Config.enable_pipeline_load) {
-            curCoordinator = new Coordinator(callback.getCallbackId(), loadId, planner.getDescTable(),
+            curCoordinator = getCoordinatorFactory().createNonPipelineBrokerLoadScheduler(
+                    callback.getCallbackId(), loadId,
+                    planner.getDescTable(),
                     planner.getFragments(), planner.getScanNodes(),
-                    planner.getTimezone(), planner.getStartTime(), sessionVariables, context);
-            /*
-            * For broker load job, user only need to set mem limit by 'exec_mem_limit' property.
-            * And the variable 'load_mem_limit' does not make any effect.
-            * However, in order to ensure the consistency of semantics when executing on the BE side,
-            * and to prevent subsequent modification from incorrectly setting the load_mem_limit,
-            * here we use exec_mem_limit to directly override the load_mem_limit property.
-            */
-            curCoordinator.setQueryType(TQueryType.LOAD);
-            curCoordinator.setExecMemoryLimit(execMemLimit);
-            curCoordinator.setLoadMemLimit(execMemLimit);
-            curCoordinator.setTimeout((int) (getLeftTimeMs() / 1000));
+                    planner.getTimezone(), planner.getStartTime(), sessionVariables, context, execMemLimit);
+
+            curCoordinator.setTimeoutSecond((int) (getLeftTimeMs() / 1000));
         } else {
-            curCoordinator = new Coordinator(loadPlanner);
+            curCoordinator = getCoordinatorFactory().createBrokerLoadScheduler(loadPlanner);
         }
         curCoordinator.setLoadJobType(loadJobType);
 
@@ -252,7 +249,7 @@ public class LoadLoadingTask extends LoadTask {
         }
     }
 
-    private void actualExecute(Coordinator curCoordinator) throws Exception {
+    private void actualExecute(ICoordinator curCoordinator) throws Exception {
         int waitSecond = (int) (getLeftTimeMs() / 1000);
         if (waitSecond <= 0) {
             throw new LoadException("Load timeout. Increase the timeout and retry");

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -51,11 +51,11 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.load.BrokerFileGroup;
 import com.starrocks.load.FailMsg;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.SessionVariable;
-import com.starrocks.qe.scheduler.ICoordinator;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.thrift.TBrokerFileStatus;
 import com.starrocks.thrift.TLoadJobType;
@@ -164,13 +164,13 @@ public class LoadLoadingTask extends LoadTask {
         executeOnce();
     }
 
-    private ICoordinator.Factory getCoordinatorFactory() {
-        return new Coordinator.Factory();
+    private Coordinator.Factory getCoordinatorFactory() {
+        return new DefaultCoordinator.Factory();
     }
 
     private void executeOnce() throws Exception {
         // New one query id,
-        ICoordinator curCoordinator;
+        Coordinator curCoordinator;
         if (!Config.enable_pipeline_load) {
             curCoordinator = getCoordinatorFactory().createNonPipelineBrokerLoadScheduler(
                     callback.getCallbackId(), loadId,
@@ -249,7 +249,7 @@ public class LoadLoadingTask extends LoadTask {
         }
     }
 
-    private void actualExecute(ICoordinator curCoordinator) throws Exception {
+    private void actualExecute(Coordinator curCoordinator) throws Exception {
         int waitSecond = (int) (getLeftTimeMs() / 1000);
         if (waitSecond <= 0) {
             throw new LoadException("Load timeout. Increase the timeout and retry");

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -73,12 +73,12 @@ import com.starrocks.persist.RoutineLoadOperation;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.planner.StreamLoadPlanner;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SqlModeHelper;
-import com.starrocks.qe.scheduler.ICoordinator;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ColumnSeparator;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
@@ -811,8 +811,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     public void prepare() throws UserException {
     }
 
-    private ICoordinator.Factory getCoordinatorFactory() {
-        return new Coordinator.Factory();
+    private Coordinator.Factory getCoordinatorFactory() {
+        return new DefaultCoordinator.Factory();
     }
 
     public TExecPlanFragmentParams plan(TUniqueId loadId, long txnId, String label) throws UserException {
@@ -842,7 +842,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
                 streamLoadTask.setTUniqueId(loadId);
                 streamLoadManager.addLoadTask(streamLoadTask);
 
-                ICoordinator coord =
+                Coordinator coord =
                         getCoordinatorFactory().createSyncStreamLoadScheduler(planner, planParams.getCoord());
                 streamLoadTask.setCoordinator(coord);
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -41,12 +41,12 @@ import com.starrocks.persist.gson.GsonPreProcessable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.Coordinator;
 import com.starrocks.qe.QeProcessorImpl;
+import com.starrocks.qe.scheduler.ICoordinator;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.task.LoadEtlTask;
 import com.starrocks.thrift.BackendService;
-import com.starrocks.thrift.TLoadJobType;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
@@ -154,7 +154,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
     private List<State> channels;
     private StreamLoadParam streamLoadParam;
     private StreamLoadInfo streamLoadInfo;
-    private Coordinator coord;
+    private ICoordinator coord;
     private Map<Integer, TNetworkAddress> channelIdToBEHTTPAddress;
     private Map<Integer, TNetworkAddress> channelIdToBEHTTPPort;
     private OlapTable table;
@@ -189,8 +189,9 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             type = Type.STREAM_LOAD;
         }
     }
+
     public StreamLoadTask(long id, Database db, OlapTable table, String label,
-            long timeoutMs, int channelNum, int channelId, long createTimeMs) {
+                          long timeoutMs, int channelNum, int channelId, long createTimeMs) {
         this.id = id;
         UUID uuid = UUID.randomUUID();
         this.loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
@@ -238,8 +239,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         writeLock();
         try {
             if (channelNum != this.channelNum) {
-                throw new Exception("channel num " + String.valueOf(channelNum) + " does not equal to original channel num "
-                    + String.valueOf(this.channelNum));
+                throw new Exception("channel num " + channelNum + " does not equal to original channel num " + this.channelNum);
             }
             if (channelId >= this.channelNum || channelId < 0) {
                 throw new Exception("channel id should be between [0, " + String.valueOf(this.channelNum - 1) + "].");
@@ -339,7 +339,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                     TNetworkAddress redirectAddr = channelIdToBEHTTPAddress.get(channelId);
                     if (redirectAddr == null) {
                         throw new Exception(
-                            "can not find redirect address for stream load label " + label + ", channel id " + channelId);
+                                "can not find redirect address for stream load label " + label + ", channel id " + channelId);
                     }
                     return redirectAddr;
                 }
@@ -420,7 +420,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                     TNetworkAddress redirectAddr = channelIdToBEHTTPAddress.get(channelId);
                     if (redirectAddr == null) {
                         throw new Exception(
-                            "can not find redirect address for stream load label " + label + ", channel id " + channelId);
+                                "can not find redirect address for stream load label " + label + ", channel id " + channelId);
                     }
                     return redirectAddr;
                 }
@@ -463,7 +463,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         return null;
     }
 
-    public void prepareChannel(int channelId,  HttpHeaders headers, TransactionResult resp) {
+    public void prepareChannel(int channelId, HttpHeaders headers, TransactionResult resp) {
         long startTimeMs = System.currentTimeMillis();
         boolean needUnLock = true;
         boolean exception = false;
@@ -486,7 +486,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                     this.preparedChannelNum += 1;
                     LOG.info("stream load {} channel_id {} start preparing. db: {}, tbl: {}, txn_id: {}",
                             label, channelId, dbName, tableName, txnId);
-                    
+
                     resp.addResultEntry("Label", this.label);
                     resp.addResultEntry("TxnId", this.txnId);
                     resp.addResultEntry("ChannelId", channelId);
@@ -502,7 +502,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                             && this.channels.get(channelId) != State.LOADING) {
                         throw new Exception(
                                 "channel state should be BEGIN | BEFORE_LOAD | LOADING when task is going to prepare, " +
-                                " cur state is " + this.state);
+                                        " cur state is " + this.state);
                     }
                     this.channels.set(channelId, State.PREPARING);
                     this.state = State.PREPARING;
@@ -518,7 +518,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                     writeUnlock();
                     needUnLock = false;
                     unprotectedFinishStreamLoadChannel(channelId);
-                    return; 
+                    return;
                 }
                 case PREPARING: {
                     if (this.channels.get(channelId) != State.BEGIN
@@ -526,7 +526,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                             && this.channels.get(channelId) != State.LOADING) {
                         throw new Exception(
                                 "channel state should be BEGIN | BEFORE_LOAD | LOADING when channel is ready for prepare, " +
-                                "cur state is " + this.state);
+                                        "cur state is " + this.state);
                     }
                     this.channels.set(channelId, State.PREPARING);
                     this.state = State.PREPARING;
@@ -539,8 +539,8 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                     resp.addResultEntry("Prepared Channel Num", this.preparedChannelNum);
                     writeUnlock();
                     needUnLock = false;
-                    unprotectedFinishStreamLoadChannel(channelId);        
-                    return; 
+                    unprotectedFinishStreamLoadChannel(channelId);
+                    return;
                 }
                 case PREPARED: {
                     resp.setOKMsg("stream load task " + label + " has already been prepared");
@@ -604,12 +604,12 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             }
             if (this.state != State.PREPARING) {
                 throw new UserException("stream load task " + this.label
-                         + " s state (" + this.state + ") is not preparing, can not prepare txn");
+                        + " s state (" + this.state + ") is not preparing, can not prepare txn");
             }
             unprotectedWaitCoordFinish();
             if (!checkDataQuality()) {
-                throw new UserException("abnormal data more than max filter rate, tracking_url: " + 
-                    this.trackingUrl);
+                throw new UserException("abnormal data more than max filter rate, tracking_url: " +
+                        this.trackingUrl);
             }
         } catch (Exception e) {
             this.errorMsg = new LogBuilder(LogKey.STREAM_LOAD_TASK, id, ':').add("label", label)
@@ -626,7 +626,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             resp.setErrorMsg(this.errorMsg);
             return;
         }
-        
+
         try {
             unprotectedPrepareTxn();
         } catch (Exception e) {
@@ -642,7 +642,6 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             resp.setErrorMsg(this.errorMsg);
             return;
         }
-            
 
         resp.addResultEntry("NumberTotalRows", numRowsNormal + numRowsAbnormal + numRowsUnselected);
         resp.addResultEntry("NumberLoadedRows", numRowsNormal);
@@ -697,7 +696,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         }
 
         LOG.info("stream load {} finish commiting. db: {}, tbl: {}, txn_id: {}",
-                    label, dbName, tableName, txnId);
+                label, dbName, tableName, txnId);
         resp.addResultEntry("NumberTotalRows", numRowsNormal + numRowsAbnormal + numRowsUnselected);
         resp.addResultEntry("NumberLoadedRows", numRowsNormal);
         resp.addResultEntry("NumberFilteredRows", numRowsAbnormal);
@@ -715,11 +714,11 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             if (isCommitting) {
                 resp.setOKMsg("txn can not be cancelled because task state is committing");
                 return;
-            } 
+            }
         } finally {
             readUnlock();
         }
-        
+
         String errorMsg = cancelTask("manual abort");
         if (errorMsg != null) {
             resp.setOKMsg("stream load " + label + " abort fail");
@@ -730,6 +729,10 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         }
     }
 
+    private ICoordinator.Factory getCoordinatorFactory() {
+        return new Coordinator.Factory();
+    }
+
     public void unprotectedExecute(HttpHeaders headers) throws UserException {
         streamLoadParam = StreamLoadParam.parseHttpHeader(headers);
         streamLoadInfo = StreamLoadInfo.fromStreamLoadContext(loadId, txnId, (int) timeoutMs / 1000, streamLoadParam);
@@ -738,14 +741,13 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         }
         LoadPlanner loadPlanner = new LoadPlanner(id, loadId, txnId, dbId, dbName, table,
                 streamLoadInfo.isStrictMode(), streamLoadInfo.getTimezone(), streamLoadInfo.isPartialUpdate(),
-                null, null, streamLoadInfo.getLoadMemLimit(), streamLoadInfo.getExecMemLimit(), 
+                null, null, streamLoadInfo.getLoadMemLimit(), streamLoadInfo.getExecMemLimit(),
                 streamLoadInfo.getNegative(), channelNum, streamLoadInfo.getColumnExprDescs(), streamLoadInfo, label,
                 streamLoadInfo.getTimeout());
-        
+
         loadPlanner.plan();
 
-        coord = new Coordinator(loadPlanner);
-        coord.setLoadJobType(TLoadJobType.STREAM_LOAD);
+        coord = getCoordinatorFactory().createStreamLoadScheduler(loadPlanner);
 
         try {
             QeProcessorImpl.INSTANCE.registerQuery(loadId, coord);
@@ -760,7 +762,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             this.channelIdToBEHTTPPort = coord.getChannelIdToBEPortMap();
         } catch (Exception e) {
             throw new UserException(e.getMessage());
-        } 
+        }
     }
 
     private void unprotectedFinishStreamLoadChannel(int channelId) throws UserException {
@@ -830,7 +832,6 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         }
     }
 
-
     public void cancelTask() {
         cancelTask(null);
     }
@@ -846,12 +847,12 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         try {
             if (isFinalState()) {
                 if (state == State.CANCELLED) {
-                    return "cur task state is: " + state 
+                    return "cur task state is: " + state
                             + ", error_msg: " + errorMsg;
                 } else {
                     return "cur task state is: " + state;
                 }
-            } 
+            }
         } finally {
             readUnlock();
         }
@@ -872,7 +873,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             return e.getMessage();
         }
         LOG.info("stream load {} cancel. db: {}, tbl: {}, txn_id: {}",
-                    label, dbName, tableName, txnId);
+                label, dbName, tableName, txnId);
         return null;
     }
 
@@ -882,7 +883,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                 new TxnCoordinator(TxnSourceType.FE, FrontendOptions.getLocalHostAddress()),
                 TransactionState.LoadJobSourceType.FRONTEND_STREAMING, id,
                 timeoutMs / 1000);
-    } 
+    }
 
     public void unprotectedPrepareTxn() throws UserException {
         List<TabletCommitInfo> commitInfos = TabletCommitInfo.fromThrift(coord.getCommitInfos());
@@ -892,7 +893,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
                 beforeLoadTimeMs, startLoadingTimeMs, startPreparingTimeMs, finishPreparingTimeMs,
                 endTimeMs, numRowsNormal, numRowsAbnormal, numRowsUnselected, numLoadBytesTotal,
                 trackingUrl);
-        GlobalStateMgr.getCurrentGlobalTransactionMgr().prepareTransaction(dbId, 
+        GlobalStateMgr.getCurrentGlobalTransactionMgr().prepareTransaction(dbId,
                 txnId, commitInfos, failInfos, txnCommitAttachment);
     }
 
@@ -1067,7 +1068,6 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         this.errorMsg = errorMsg;
     }
 
-
     @Override
     public void replayOnCommitted(TransactionState txnState) {
         writeLock();
@@ -1082,7 +1082,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         } finally {
             writeUnlock();
         }
-    } 
+    }
 
     @Override
     public void afterAborted(TransactionState txnState, boolean txnOperated, String txnStatusChangeReason)
@@ -1206,7 +1206,6 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         this.numLoadBytesTotal = attachment.getNumLoadBytesTotal();
     }
 
-
     public OlapTable getTable() throws MetaNotFoundException {
         Database database = GlobalStateMgr.getCurrentState().getDb(dbId);
         if (database == null) {
@@ -1275,7 +1274,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
     public String getStateName() {
         return state.name();
     }
-    
+
     public void setTUniqueId(TUniqueId loadId) {
         this.loadId = loadId;
     }
@@ -1299,8 +1298,9 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
     public boolean isRoutineLoadTask() {
         return type == Type.ROUTINE_LOAD;
     }
+
     // for sync stream load
-    public void setCoordinator(Coordinator coord) {
+    public void setCoordinator(ICoordinator coord) {
         this.coord = coord;
     }
 
@@ -1332,7 +1332,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
             row.add(trackingUrl);
             row.add(String.valueOf(channelNum));
             row.add(String.valueOf(preparedChannelNum));
-            
+
             row.add(String.valueOf(numRowsNormal));
             row.add(String.valueOf(numRowsAbnormal));
             row.add(String.valueOf(numRowsUnselected));

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -39,9 +39,9 @@ import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonPreProcessable;
 import com.starrocks.persist.gson.GsonUtils;
-import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.QeProcessorImpl;
-import com.starrocks.qe.scheduler.ICoordinator;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.LoadPlanner;
@@ -154,7 +154,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
     private List<State> channels;
     private StreamLoadParam streamLoadParam;
     private StreamLoadInfo streamLoadInfo;
-    private ICoordinator coord;
+    private Coordinator coord;
     private Map<Integer, TNetworkAddress> channelIdToBEHTTPAddress;
     private Map<Integer, TNetworkAddress> channelIdToBEHTTPPort;
     private OlapTable table;
@@ -729,8 +729,8 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         }
     }
 
-    private ICoordinator.Factory getCoordinatorFactory() {
-        return new Coordinator.Factory();
+    private Coordinator.Factory getCoordinatorFactory() {
+        return new DefaultCoordinator.Factory();
     }
 
     public void unprotectedExecute(HttpHeaders headers) throws UserException {
@@ -1300,7 +1300,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
     }
 
     // for sync stream load
-    public void setCoordinator(ICoordinator coord) {
+    public void setCoordinator(Coordinator coord) {
         this.coord = coord;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
@@ -19,7 +19,7 @@ import com.google.common.collect.Queues;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.proto.PPlanFragmentCancelReason;
-import com.starrocks.qe.scheduler.ICoordinator;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -87,8 +87,8 @@ public class CoordinatorMonitor {
                     deadBackendIDs.add(backendID);
                 }
 
-                final List<ICoordinator> coordinators = QeProcessorImpl.INSTANCE.getCoordinators();
-                for (ICoordinator coord : coordinators) {
+                final List<Coordinator> coordinators = QeProcessorImpl.INSTANCE.getCoordinators();
+                for (Coordinator coord : coordinators) {
                     boolean isUsingDeadBackend = deadBackendIDs.stream().anyMatch(coord::isUsingBackend);
                     if (isUsingDeadBackend) {
                         if (LOG.isWarnEnabled()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Queues;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.proto.PPlanFragmentCancelReason;
+import com.starrocks.qe.scheduler.ICoordinator;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -86,8 +87,8 @@ public class CoordinatorMonitor {
                     deadBackendIDs.add(backendID);
                 }
 
-                final List<Coordinator> coordinators = QeProcessorImpl.INSTANCE.getCoordinators();
-                for (Coordinator coord : coordinators) {
+                final List<ICoordinator> coordinators = QeProcessorImpl.INSTANCE.getCoordinators();
+                for (ICoordinator coord : coordinators) {
                     boolean isUsingDeadBackend = deadBackendIDs.stream().anyMatch(coord::isUsingBackend);
                     if (isUsingDeadBackend) {
                         if (LOG.isWarnEnabled()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -267,9 +267,6 @@ public class DefaultCoordinator extends Coordinator {
     /**
      * Only used for sync stream load profile,
      * so only init relative data structure.
-     * @param jobSpec
-     * @param planner
-     * @param address
      */
     public DefaultCoordinator(JobSpec jobSpec, StreamLoadPlanner planner, TNetworkAddress address) {
         this.connectContext = planner.getConnectContext();
@@ -751,7 +748,7 @@ public class DefaultCoordinator extends Coordinator {
                         } catch (ExecutionException e) {
                             LOG.warn("catch a execute exception", e);
                             code = TStatusCode.THRIFT_RPC_ERROR;
-                        } catch (InterruptedException e) {
+                        } catch (InterruptedException e) { // NOSONAR
                             LOG.warn("catch a interrupt exception", e);
                             code = TStatusCode.INTERNAL_ERROR;
                         } catch (TimeoutException e) {
@@ -1070,7 +1067,7 @@ public class DefaultCoordinator extends Coordinator {
                         } catch (ExecutionException e) {
                             LOG.warn("catch a execute exception", e);
                             code = TStatusCode.THRIFT_RPC_ERROR;
-                        } catch (InterruptedException e) {
+                        } catch (InterruptedException e) { // NOSONAR
                             LOG.warn("catch a interrupt exception", e);
                             code = TStatusCode.INTERNAL_ERROR;
                         } catch (TimeoutException e) {
@@ -1622,7 +1619,7 @@ public class DefaultCoordinator extends Coordinator {
                 if (!profileDoneSignal.await(timeout, TimeUnit.SECONDS)) {
                     LOG.warn("failed to get profile within {} seconds", timeout);
                 }
-            } catch (InterruptedException e) {
+            } catch (InterruptedException e) { // NOSONAR
                 LOG.warn("signal await error", e);
             }
         }
@@ -1660,7 +1657,7 @@ public class DefaultCoordinator extends Coordinator {
             boolean awaitRes = false;
             try {
                 awaitRes = profileDoneSignal.await(waitTime, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
+            } catch (InterruptedException e) { // NOSONAR
                 // Do nothing
             }
             if (awaitRes) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessor.java
@@ -18,7 +18,7 @@
 package com.starrocks.qe;
 
 import com.starrocks.common.UserException;
-import com.starrocks.qe.scheduler.ICoordinator;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
 import com.starrocks.thrift.TNetworkAddress;
@@ -35,7 +35,7 @@ public interface QeProcessor {
 
     TBatchReportExecStatusResult batchReportExecStatus(TBatchReportExecStatusParams params, TNetworkAddress beAddr);
 
-    void registerQuery(TUniqueId queryId, ICoordinator coord) throws UserException;
+    void registerQuery(TUniqueId queryId, Coordinator coord) throws UserException;
 
     void registerQuery(TUniqueId queryId, QeProcessorImpl.QueryInfo info) throws UserException;
 
@@ -43,7 +43,7 @@ public interface QeProcessor {
 
     Map<String, QueryStatisticsItem> getQueryStatistics();
 
-    ICoordinator getCoordinator(TUniqueId queryId);
+    Coordinator getCoordinator(TUniqueId queryId);
 
-    List<ICoordinator> getCoordinators();
+    List<Coordinator> getCoordinators();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessor.java
@@ -18,6 +18,7 @@
 package com.starrocks.qe;
 
 import com.starrocks.common.UserException;
+import com.starrocks.qe.scheduler.ICoordinator;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
 import com.starrocks.thrift.TNetworkAddress;
@@ -34,7 +35,7 @@ public interface QeProcessor {
 
     TBatchReportExecStatusResult batchReportExecStatus(TBatchReportExecStatusParams params, TNetworkAddress beAddr);
 
-    void registerQuery(TUniqueId queryId, Coordinator coord) throws UserException;
+    void registerQuery(TUniqueId queryId, ICoordinator coord) throws UserException;
 
     void registerQuery(TUniqueId queryId, QeProcessorImpl.QueryInfo info) throws UserException;
 
@@ -42,7 +43,7 @@ public interface QeProcessor {
 
     Map<String, QueryStatisticsItem> getQueryStatistics();
 
-    Coordinator getCoordinator(TUniqueId queryId);
+    ICoordinator getCoordinator(TUniqueId queryId);
 
-    List<Coordinator> getCoordinators();
+    List<ICoordinator> getCoordinators();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.MvId;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.qe.scheduler.ICoordinator;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
 import com.starrocks.thrift.TNetworkAddress;
@@ -70,7 +71,7 @@ public final class QeProcessorImpl implements QeProcessor {
     }
 
     @Override
-    public Coordinator getCoordinator(TUniqueId queryId) {
+    public ICoordinator getCoordinator(TUniqueId queryId) {
         QueryInfo queryInfo = coordinatorMap.get(queryId);
         if (queryInfo != null) {
             return queryInfo.getCoord();
@@ -79,14 +80,14 @@ public final class QeProcessorImpl implements QeProcessor {
     }
 
     @Override
-    public List<Coordinator> getCoordinators() {
+    public List<ICoordinator> getCoordinators() {
         return coordinatorMap.values().stream()
                 .map(QueryInfo::getCoord)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public void registerQuery(TUniqueId queryId, Coordinator coord) throws UserException {
+    public void registerQuery(TUniqueId queryId, ICoordinator coord) throws UserException {
         registerQuery(queryId, new QueryInfo(coord));
     }
 
@@ -210,19 +211,19 @@ public final class QeProcessorImpl implements QeProcessor {
 
     public static final class QueryInfo {
         private final ConnectContext connectContext;
-        private final Coordinator coord;
+        private final ICoordinator coord;
         private final String sql;
         private final long startExecTime;
 
         private boolean isMVJob = false;
 
         // from Export, Pull load, Insert 
-        public QueryInfo(Coordinator coord) {
+        public QueryInfo(ICoordinator coord) {
             this(null, null, coord);
         }
 
         // from query
-        public QueryInfo(ConnectContext connectContext, String sql, Coordinator coord) {
+        public QueryInfo(ConnectContext connectContext, String sql, ICoordinator coord) {
             this.connectContext = connectContext;
             this.coord = coord;
             this.sql = sql;
@@ -240,7 +241,7 @@ public final class QeProcessorImpl implements QeProcessor {
             return connectContext;
         }
 
-        public Coordinator getCoord() {
+        public ICoordinator getCoord() {
             return coord;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -38,7 +38,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.MvId;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
-import com.starrocks.qe.scheduler.ICoordinator;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
 import com.starrocks.thrift.TNetworkAddress;
@@ -71,7 +71,7 @@ public final class QeProcessorImpl implements QeProcessor {
     }
 
     @Override
-    public ICoordinator getCoordinator(TUniqueId queryId) {
+    public Coordinator getCoordinator(TUniqueId queryId) {
         QueryInfo queryInfo = coordinatorMap.get(queryId);
         if (queryInfo != null) {
             return queryInfo.getCoord();
@@ -80,14 +80,14 @@ public final class QeProcessorImpl implements QeProcessor {
     }
 
     @Override
-    public List<ICoordinator> getCoordinators() {
+    public List<Coordinator> getCoordinators() {
         return coordinatorMap.values().stream()
                 .map(QueryInfo::getCoord)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public void registerQuery(TUniqueId queryId, ICoordinator coord) throws UserException {
+    public void registerQuery(TUniqueId queryId, Coordinator coord) throws UserException {
         registerQuery(queryId, new QueryInfo(coord));
     }
 
@@ -211,19 +211,19 @@ public final class QeProcessorImpl implements QeProcessor {
 
     public static final class QueryInfo {
         private final ConnectContext connectContext;
-        private final ICoordinator coord;
+        private final Coordinator coord;
         private final String sql;
         private final long startExecTime;
 
         private boolean isMVJob = false;
 
         // from Export, Pull load, Insert 
-        public QueryInfo(ICoordinator coord) {
+        public QueryInfo(Coordinator coord) {
             this(null, null, coord);
         }
 
         // from query
-        public QueryInfo(ConnectContext connectContext, String sql, ICoordinator coord) {
+        public QueryInfo(ConnectContext connectContext, String sql, Coordinator coord) {
             this.connectContext = connectContext;
             this.coord = coord;
             this.sql = sql;
@@ -241,7 +241,7 @@ public final class QeProcessorImpl implements QeProcessor {
             return connectContext;
         }
 
-        public ICoordinator getCoord() {
+        public Coordinator getCoord() {
             return coord;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -38,13 +38,13 @@ public class QueryQueueManager {
     private static final Logger LOG = LogManager.getLogger(QueryQueueManager.class);
 
     private static class PendingQueryInfo {
-        private final Coordinator coordinator;
+        private final DefaultCoordinator coordinator;
         private final ConnectContext connectCtx;
         private final ReentrantLock lock;
         private final Condition condition;
         private boolean isCancelled = false;
 
-        private PendingQueryInfo(ConnectContext connectCtx, ReentrantLock lock, Coordinator coordinator) {
+        private PendingQueryInfo(ConnectContext connectCtx, ReentrantLock lock, DefaultCoordinator coordinator) {
             Preconditions.checkState(connectCtx != null);
             this.coordinator = coordinator;
             this.connectCtx = connectCtx;
@@ -117,7 +117,7 @@ public class QueryQueueManager {
         }
     }
 
-    public void maybeWait(ConnectContext connectCtx, Coordinator coord) throws UserException, InterruptedException {
+    public void maybeWait(ConnectContext connectCtx, DefaultCoordinator coord) throws UserException, InterruptedException {
         if (!needCheckQueue(coord)) {
             return;
         }
@@ -195,7 +195,7 @@ public class QueryQueueManager {
         }
     }
 
-    public boolean enableCheckQueue(Coordinator coord) {
+    public boolean enableCheckQueue(DefaultCoordinator coord) {
         if (coord.isLoadType()) {
             return GlobalVariable.isEnableQueryQueueLoad();
         }
@@ -213,7 +213,7 @@ public class QueryQueueManager {
         return false;
     }
 
-    public boolean needCheckQueue(Coordinator coord) {
+    public boolean needCheckQueue(DefaultCoordinator coord) {
         // The queries only using schema meta will never been queued, because a MySQL client will
         // query schema meta after the connection is established.
         List<ScanNode> scanNodes = coord.getScanNodes();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1322,6 +1322,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return queryTimeoutS;
     }
 
+    public void setQueryDeliveryTimeoutS(int queryDeliveryTimeoutS) {
+        this.queryDeliveryTimeoutS = queryDeliveryTimeoutS;
+    }
+
+    public int getQueryDeliveryTimeoutS() {
+        return queryDeliveryTimeoutS;
+    }
+
     public boolean isEnableProfile() {
         return enableProfile;
     }
@@ -1692,6 +1700,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public float getGlobalRuntimeFilterProbeMinSelectivity() {
         return globalRuntimeFilterProbeMinSelectivity;
+    }
+
+    public void setEnableDeliverBatchFragments(boolean enableDeliverBatchFragments) {
+        this.enableDeliverBatchFragments = enableDeliverBatchFragments;
     }
 
     public boolean isEnableDeliverBatchFragments() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -99,7 +99,7 @@ import com.starrocks.privilege.PrivilegeType;
 import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.proto.QueryStatisticsItemPB;
 import com.starrocks.qe.QueryState.MysqlStateType;
-import com.starrocks.qe.scheduler.ICoordinator;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -209,7 +209,7 @@ public class StmtExecutor {
     private final OriginStatement originStmt;
     private StatementBase parsedStmt;
     private RuntimeProfile profile;
-    private ICoordinator coord = null;
+    private Coordinator coord = null;
     private LeaderOpExecutor leaderOpExecutor = null;
     private RedirectStatus redirectStatus = null;
     private final boolean isProxy;
@@ -245,7 +245,7 @@ public class StmtExecutor {
         this.isProxy = false;
     }
 
-    public ICoordinator getCoordinator() {
+    public Coordinator getCoordinator() {
         return this.coord;
     }
 
@@ -795,7 +795,7 @@ public class StmtExecutor {
                     sub.cancel();
                 }
             }
-            ICoordinator coordRef = coord;
+            Coordinator coordRef = coord;
             if (coordRef != null) {
                 coordRef.cancel();
             }
@@ -838,8 +838,8 @@ public class StmtExecutor {
         context.getState().setOk();
     }
 
-    private ICoordinator.Factory getCoordinatorFactory() {
-        return new Coordinator.Factory();
+    private Coordinator.Factory getCoordinatorFactory() {
+        return new DefaultCoordinator.Factory();
     }
 
     // Process a select statement.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -39,35 +39,35 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-public abstract class ICoordinator {
+public abstract class Coordinator {
     public interface Factory {
-        ICoordinator createQueryScheduler(ConnectContext context,
+        Coordinator createQueryScheduler(ConnectContext context,
+                                         List<PlanFragment> fragments,
+                                         List<ScanNode> scanNodes,
+                                         TDescriptorTable descTable);
+
+        Coordinator createInsertScheduler(ConnectContext context,
                                           List<PlanFragment> fragments,
                                           List<ScanNode> scanNodes,
                                           TDescriptorTable descTable);
 
-        ICoordinator createInsertScheduler(ConnectContext context,
-                                           List<PlanFragment> fragments,
-                                           List<ScanNode> scanNodes,
-                                           TDescriptorTable descTable);
+        Coordinator createBrokerLoadScheduler(LoadPlanner loadPlanner);
 
-        ICoordinator createBrokerLoadScheduler(LoadPlanner loadPlanner);
+        Coordinator createStreamLoadScheduler(LoadPlanner loadPlanner);
 
-        ICoordinator createStreamLoadScheduler(LoadPlanner loadPlanner);
+        Coordinator createSyncStreamLoadScheduler(StreamLoadPlanner planner, TNetworkAddress address);
 
-        ICoordinator createSyncStreamLoadScheduler(StreamLoadPlanner planner, TNetworkAddress address);
+        Coordinator createNonPipelineBrokerLoadScheduler(Long jobId, TUniqueId queryId, DescriptorTable descTable,
+                                                         List<PlanFragment> fragments,
+                                                         List<ScanNode> scanNodes, String timezone, long startTime,
+                                                         Map<String, String> sessionVariables,
+                                                         ConnectContext context, long execMemLimit);
 
-        ICoordinator createNonPipelineBrokerLoadScheduler(Long jobId, TUniqueId queryId, DescriptorTable descTable,
-                                                          List<PlanFragment> fragments,
-                                                          List<ScanNode> scanNodes, String timezone, long startTime,
-                                                          Map<String, String> sessionVariables,
-                                                          ConnectContext context, long execMemLimit);
-
-        ICoordinator createBrokerExportScheduler(Long jobId, TUniqueId queryId, DescriptorTable descTable,
-                                                 List<PlanFragment> fragments,
-                                                 List<ScanNode> scanNodes, String timezone, long startTime,
-                                                 Map<String, String> sessionVariables,
-                                                 long execMemLimit);
+        Coordinator createBrokerExportScheduler(Long jobId, TUniqueId queryId, DescriptorTable descTable,
+                                                List<PlanFragment> fragments,
+                                                List<ScanNode> scanNodes, String timezone, long startTime,
+                                                Map<String, String> sessionVariables,
+                                                long execMemLimit);
     }
 
     // ------------------------------------------------------------------------------------

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/ICoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/ICoordinator.java
@@ -1,0 +1,175 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.analysis.DescriptorTable;
+import com.starrocks.common.Status;
+import com.starrocks.common.util.RuntimeProfile;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.planner.StreamLoadPlanner;
+import com.starrocks.proto.PPlanFragmentCancelReason;
+import com.starrocks.proto.PQueryStatistics;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryStatisticsItem;
+import com.starrocks.qe.RowBatch;
+import com.starrocks.sql.LoadPlanner;
+import com.starrocks.thrift.TDescriptorTable;
+import com.starrocks.thrift.TLoadJobType;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TReportExecStatusParams;
+import com.starrocks.thrift.TSinkCommitInfo;
+import com.starrocks.thrift.TTabletCommitInfo;
+import com.starrocks.thrift.TTabletFailInfo;
+import com.starrocks.thrift.TUniqueId;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public abstract class ICoordinator {
+    public interface Factory {
+        ICoordinator createQueryScheduler(ConnectContext context,
+                                          List<PlanFragment> fragments,
+                                          List<ScanNode> scanNodes,
+                                          TDescriptorTable descTable);
+
+        ICoordinator createInsertScheduler(ConnectContext context,
+                                           List<PlanFragment> fragments,
+                                           List<ScanNode> scanNodes,
+                                           TDescriptorTable descTable);
+
+        ICoordinator createBrokerLoadScheduler(LoadPlanner loadPlanner);
+
+        ICoordinator createStreamLoadScheduler(LoadPlanner loadPlanner);
+
+        ICoordinator createSyncStreamLoadScheduler(StreamLoadPlanner planner, TNetworkAddress address);
+
+        ICoordinator createNonPipelineBrokerLoadScheduler(Long jobId, TUniqueId queryId, DescriptorTable descTable,
+                                                          List<PlanFragment> fragments,
+                                                          List<ScanNode> scanNodes, String timezone, long startTime,
+                                                          Map<String, String> sessionVariables,
+                                                          ConnectContext context, long execMemLimit);
+
+        ICoordinator createBrokerExportScheduler(Long jobId, TUniqueId queryId, DescriptorTable descTable,
+                                                 List<PlanFragment> fragments,
+                                                 List<ScanNode> scanNodes, String timezone, long startTime,
+                                                 Map<String, String> sessionVariables,
+                                                 long execMemLimit);
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Common methods for scheduling.
+    // ------------------------------------------------------------------------------------
+
+    public void exec() throws Exception {
+        startScheduling();
+    }
+
+    public abstract void startScheduling() throws Exception;
+
+    public abstract void updateFragmentExecStatus(TReportExecStatusParams params);
+
+    public void cancel() {
+        cancel(PPlanFragmentCancelReason.USER_CANCEL, "");
+    }
+
+    public abstract void cancel(PPlanFragmentCancelReason reason, String message);
+
+    public abstract void onFinished();
+
+    // ------------------------------------------------------------------------------------
+    // Methods for query.
+    // ------------------------------------------------------------------------------------
+
+    public abstract RowBatch getNext() throws Exception;
+
+    // ------------------------------------------------------------------------------------
+    // Methods for load.
+    // ------------------------------------------------------------------------------------
+
+    public abstract boolean join(int timeoutSecond);
+
+    public abstract boolean checkBackendState();
+
+    public abstract boolean isThriftServerHighLoad();
+
+    public abstract void setLoadJobType(TLoadJobType type);
+
+    public abstract long getLoadJobId();
+
+    public abstract void setLoadJobId(Long jobId);
+
+    public abstract Map<Integer, TNetworkAddress> getChannelIdToBEHTTPMap();
+
+    public abstract Map<Integer, TNetworkAddress> getChannelIdToBEPortMap();
+
+    public abstract boolean isEnableLoadProfile();
+
+    public abstract void clearExportStatus();
+
+    // ------------------------------------------------------------------------------------
+    // Methods for profile.
+    // ------------------------------------------------------------------------------------
+
+    public abstract void endProfile();
+
+    public abstract void setTopProfileSupplier(Supplier<RuntimeProfile> topProfileSupplier);
+
+    public abstract RuntimeProfile buildMergedQueryProfile(PQueryStatistics statistics);
+
+    public abstract RuntimeProfile getQueryProfile();
+
+    public abstract List<String> getDeltaUrls();
+
+    public abstract Map<String, String> getLoadCounters();
+
+    public abstract List<TTabletFailInfo> getFailInfos();
+
+    public abstract List<TTabletCommitInfo> getCommitInfos();
+
+    public abstract List<TSinkCommitInfo> getSinkCommitInfos();
+
+    public abstract List<String> getExportFiles();
+
+    public abstract String getTrackingUrl();
+
+    public abstract List<String> getRejectedRecordPaths();
+
+    public abstract List<QueryStatisticsItem.FragmentInstanceInfo> getFragmentInstanceInfos();
+
+    // ------------------------------------------------------------------------------------
+    // Common methods.
+    // ------------------------------------------------------------------------------------
+
+    public abstract Status getExecStatus();
+
+    public abstract boolean isUsingBackend(Long backendID);
+
+    public abstract boolean isDone();
+
+    public abstract TUniqueId getQueryId();
+
+    public abstract void setQueryId(TUniqueId queryId);
+
+    public abstract List<ScanNode> getScanNodes();
+
+    public abstract long getStartTimeMs();
+
+    public abstract void setTimeoutSecond(int timeoutSecond);
+
+    public abstract boolean isProfileAlreadyReported();
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -1,0 +1,523 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.dag;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.analysis.DescriptorTable;
+import com.starrocks.catalog.ResourceGroupClassifier;
+import com.starrocks.common.util.CompressionUtils;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.load.loadv2.BulkLoadJob;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.planner.StreamLoadPlanner;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.LoadPlanner;
+import com.starrocks.thrift.TCompressionType;
+import com.starrocks.thrift.TDescriptorTable;
+import com.starrocks.thrift.TExecPlanFragmentParams;
+import com.starrocks.thrift.TLoadJobType;
+import com.starrocks.thrift.TQueryGlobals;
+import com.starrocks.thrift.TQueryOptions;
+import com.starrocks.thrift.TQueryType;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TWorkGroup;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.starrocks.qe.CoordinatorPreprocessor.genQueryGlobals;
+import static com.starrocks.qe.CoordinatorPreprocessor.prepareResourceGroup;
+
+public class JobSpec {
+
+    private static final long UNINITIALIZED_LOAD_JOB_ID = -1;
+    private long loadJobId;
+
+    private TUniqueId queryId;
+
+    private final List<PlanFragment> fragments;
+    private final List<ScanNode> scanNodes;
+    /**
+     * copied from TQueryExecRequest; constant across all fragments
+     */
+    private final TDescriptorTable descTable;
+
+    private final boolean enablePipeline;
+    private final boolean enableStreamPipeline;
+    private final boolean isBlockQuery;
+
+    /**
+     * Why we use query global?
+     * When `NOW()` function is in sql, we need only one now(),
+     * but, we execute `NOW()` distributed.
+     * So we make a query global value here to make one `now()` value in one query process.
+     */
+    private final TQueryGlobals queryGlobals;
+    private final TQueryOptions queryOptions;
+    private final TWorkGroup resourceGroup;
+
+    public static class Factory {
+        private Factory() {
+        }
+
+        public static JobSpec fromQuerySpec(ConnectContext context,
+                                            List<PlanFragment> fragments,
+                                            List<ScanNode> scanNodes,
+                                            TDescriptorTable descTable,
+                                            TQueryType queryType) {
+            TQueryOptions queryOptions = context.getSessionVariable().toThrift();
+            queryOptions.setQuery_type(queryType);
+
+            TQueryGlobals queryGlobals = genQueryGlobals(context.getStartTime(),
+                    context.getSessionVariable().getTimeZone());
+            if (context.getLastQueryId() != null) {
+                queryGlobals.setLast_query_id(context.getLastQueryId().toString());
+            }
+
+            return new Builder()
+                    .queryId(context.getExecutionId())
+                    .fragments(fragments)
+                    .scanNodes(scanNodes)
+                    .descTable(descTable)
+                    .enableStreamPipeline(false)
+                    .isBlockQuery(false)
+                    .queryGlobals(queryGlobals)
+                    .queryOptions(queryOptions)
+                    .commonProperties(context)
+                    .build();
+        }
+
+        public static JobSpec fromMVMaintenanceJobSpec(ConnectContext context,
+                                                       List<PlanFragment> fragments,
+                                                       List<ScanNode> scanNodes,
+                                                       TDescriptorTable descTable) {
+            TQueryOptions queryOptions = context.getSessionVariable().toThrift();
+
+            TQueryGlobals queryGlobals = genQueryGlobals(context.getStartTime(),
+                    context.getSessionVariable().getTimeZone());
+            if (context.getLastQueryId() != null) {
+                queryGlobals.setLast_query_id(context.getLastQueryId().toString());
+            }
+
+            return new Builder()
+                    .queryId(context.getExecutionId())
+                    .fragments(fragments)
+                    .scanNodes(scanNodes)
+                    .descTable(descTable)
+                    .enableStreamPipeline(true)
+                    .isBlockQuery(false)
+                    .queryGlobals(queryGlobals)
+                    .queryOptions(queryOptions)
+                    .commonProperties(context)
+                    .build();
+        }
+
+        public static JobSpec fromBrokerLoadJobSpec(LoadPlanner loadPlanner) {
+            ConnectContext context = loadPlanner.getContext();
+
+            TQueryOptions queryOptions = createBrokerLoadQueryOptions(loadPlanner);
+
+            TQueryGlobals queryGlobals = genQueryGlobals(context.getStartTime(),
+                    context.getSessionVariable().getTimeZone());
+            if (context.getLastQueryId() != null) {
+                queryGlobals.setLast_query_id(context.getLastQueryId().toString());
+            }
+
+            return new JobSpec.Builder()
+                    .loadJobId(loadPlanner.getLoadJobId())
+                    .queryId(loadPlanner.getLoadId())
+                    .fragments(loadPlanner.getFragments())
+                    .scanNodes(loadPlanner.getScanNodes())
+                    .descTable(loadPlanner.getDescTable().toThrift())
+                    .enableStreamPipeline(false)
+                    .isBlockQuery(true)
+                    .queryGlobals(queryGlobals)
+                    .queryOptions(queryOptions)
+                    .commonProperties(context)
+                    .build();
+        }
+
+        public static JobSpec fromStreamLoadJobSpec(LoadPlanner loadPlanner) {
+            JobSpec jobSpec = fromBrokerLoadJobSpec(loadPlanner);
+            jobSpec.getQueryOptions().setLoad_job_type((TLoadJobType.STREAM_LOAD));
+            return jobSpec;
+        }
+
+        public static JobSpec fromBrokerExportSpec(ConnectContext context,
+                                                   Long loadJobId, TUniqueId queryId,
+                                                   DescriptorTable descTable,
+                                                   List<PlanFragment> fragments,
+                                                   List<ScanNode> scanNodes, String timezone,
+                                                   long startTime,
+                                                   Map<String, String> sessionVariables,
+                                                   long execMemLimit) {
+            TQueryOptions queryOptions = new TQueryOptions();
+            setSessionVariablesToLoadQueryOptions(queryOptions, sessionVariables);
+            queryOptions.setMem_limit(execMemLimit);
+
+            TQueryGlobals queryGlobals = genQueryGlobals(startTime, timezone);
+
+            return new JobSpec.Builder()
+                    .loadJobId(loadJobId)
+                    .queryId(queryId)
+                    .fragments(fragments)
+                    .scanNodes(scanNodes)
+                    .descTable(descTable.toThrift())
+                    .enableStreamPipeline(false)
+                    .isBlockQuery(true)
+                    .queryGlobals(queryGlobals)
+                    .queryOptions(queryOptions)
+                    .commonProperties(context)
+                    .build();
+        }
+
+        public static JobSpec fromNonPipelineBrokerLoadJobSpec(ConnectContext context,
+                                                               Long loadJobId, TUniqueId queryId,
+                                                               DescriptorTable descTable,
+                                                               List<PlanFragment> fragments,
+                                                               List<ScanNode> scanNodes,
+                                                               String timezone,
+                                                               long startTime,
+                                                               Map<String, String> sessionVariables,
+                                                               long execMemLimit) {
+            TQueryOptions queryOptions = new TQueryOptions();
+            setSessionVariablesToLoadQueryOptions(queryOptions, sessionVariables);
+            queryOptions.setQuery_type(TQueryType.LOAD);
+            /*
+             * For broker load job, user only need to set mem limit by 'exec_mem_limit' property.
+             * And the variable 'load_mem_limit' does not make any effect.
+             * However, in order to ensure the consistency of semantics when executing on the BE side,
+             * and to prevent subsequent modification from incorrectly setting the load_mem_limit,
+             * here we use exec_mem_limit to directly override the load_mem_limit property.
+             */
+            queryOptions.setMem_limit(execMemLimit);
+            queryOptions.setLoad_mem_limit(execMemLimit);
+
+            TQueryGlobals queryGlobals = genQueryGlobals(startTime, timezone);
+
+            return new JobSpec.Builder()
+                    .loadJobId(loadJobId)
+                    .queryId(queryId)
+                    .fragments(fragments)
+                    .scanNodes(scanNodes)
+                    .descTable(descTable.toThrift())
+                    .enableStreamPipeline(false)
+                    .isBlockQuery(true)
+                    .queryGlobals(queryGlobals)
+                    .queryOptions(queryOptions)
+                    .commonProperties(context)
+                    .build();
+        }
+
+        public static JobSpec fromSyncStreamLoadSpec(StreamLoadPlanner planner) {
+            TExecPlanFragmentParams params = planner.getExecPlanFragmentParams();
+            TUniqueId queryId = params.getParams().getFragment_instance_id();
+
+            return new Builder()
+                    .queryId(queryId)
+                    .fragments(Collections.emptyList())
+                    .scanNodes(null)
+                    .descTable(null)
+                    .enableStreamPipeline(false)
+                    .isBlockQuery(true)
+                    .queryGlobals(null)
+                    .queryOptions(null)
+                    .enablePipeline(false)
+                    .resourceGroup(null)
+                    .build();
+        }
+
+        public static JobSpec mockJobSpec(ConnectContext context,
+                                          List<PlanFragment> fragments,
+                                          List<ScanNode> scanNodes) {
+            TQueryOptions queryOptions = context.getSessionVariable().toThrift();
+
+            TQueryGlobals queryGlobals = genQueryGlobals(context.getStartTime(),
+                    context.getSessionVariable().getTimeZone());
+            if (context.getLastQueryId() != null) {
+                queryGlobals.setLast_query_id(context.getLastQueryId().toString());
+            }
+
+            return new Builder()
+                    .queryId(context.getExecutionId())
+                    .fragments(fragments)
+                    .scanNodes(scanNodes)
+                    .descTable(null)
+                    .enableStreamPipeline(false)
+                    .isBlockQuery(false)
+                    .queryGlobals(queryGlobals)
+                    .queryOptions(queryOptions)
+                    .enablePipeline(true)
+                    .resourceGroup(null)
+                    .build();
+        }
+
+        private static TQueryOptions createBrokerLoadQueryOptions(LoadPlanner loadPlanner) {
+            ConnectContext context = loadPlanner.getContext();
+            TQueryOptions queryOptions = context.getSessionVariable().toThrift();
+
+            queryOptions
+                    .setQuery_type(TQueryType.LOAD)
+                    .setQuery_timeout((int) loadPlanner.getTimeout())
+                    .setLoad_mem_limit(loadPlanner.getLoadMemLimit());
+
+            // Don't set it explicit when zero. otherwise backend will take limit as zero.
+            long execMemLimit = loadPlanner.getExecMemLimit();
+            if (execMemLimit > 0) {
+                queryOptions.setMem_limit(execMemLimit);
+                queryOptions.setQuery_mem_limit(execMemLimit);
+            }
+
+            setSessionVariablesToLoadQueryOptions(queryOptions, loadPlanner.getSessionVariables());
+
+            return queryOptions;
+        }
+
+        private static void setSessionVariablesToLoadQueryOptions(TQueryOptions queryOptions,
+                                                                  Map<String, String> sessionVariables) {
+            if (sessionVariables == null) {
+                return;
+            }
+
+            if (sessionVariables.containsKey(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE)) {
+                final TCompressionType loadCompressionType = CompressionUtils.findTCompressionByName(
+                        sessionVariables.get(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE));
+                if (loadCompressionType != null) {
+                    queryOptions.setLoad_transmission_compression_type(loadCompressionType);
+                }
+            }
+            if (sessionVariables.containsKey(BulkLoadJob.LOG_REJECTED_RECORD_NUM_SESSION_VARIABLE_KEY)) {
+                queryOptions.setLog_rejected_record_num(
+                        Long.parseLong(sessionVariables.get(BulkLoadJob.LOG_REJECTED_RECORD_NUM_SESSION_VARIABLE_KEY)));
+            }
+        }
+    }
+
+    private JobSpec(Builder builder) {
+        this.loadJobId = builder.loadJobId;
+
+        this.queryId = builder.queryId;
+
+        this.fragments = builder.fragments;
+        this.scanNodes = builder.scanNodes;
+        this.descTable = builder.descTable;
+
+        this.enablePipeline = builder.enablePipeline;
+        this.enableStreamPipeline = builder.enableStreamPipeline;
+        this.isBlockQuery = builder.isBlockQuery;
+
+        this.queryGlobals = builder.queryGlobals;
+        this.queryOptions = builder.queryOptions;
+        this.resourceGroup = builder.resourceGroup;
+    }
+
+    @Override
+    public String toString() {
+        return "jobSpecrmation{" +
+                "loadJobId=" + loadJobId +
+                ", queryId=" + DebugUtil.printId(queryId) +
+                ", enablePipeline=" + enablePipeline +
+                ", enableStreamPipeline=" + enableStreamPipeline +
+                ", isBlockQuery=" + isBlockQuery +
+                ", resourceGroup=" + resourceGroup +
+                '}';
+    }
+
+    public boolean isLoadType() {
+        return queryOptions.getQuery_type() == TQueryType.LOAD;
+    }
+
+    public long getLoadJobId() {
+        return loadJobId;
+    }
+
+    public void setLoadJobId(long loadJobId) {
+        this.loadJobId = loadJobId;
+    }
+
+    public boolean isSetLoadJobId() {
+        return loadJobId != UNINITIALIZED_LOAD_JOB_ID;
+    }
+
+    public TUniqueId getQueryId() {
+        return queryId;
+    }
+
+    public void setQueryId(TUniqueId queryId) {
+        this.queryId = queryId;
+    }
+
+    public List<PlanFragment> getFragments() {
+        return fragments;
+    }
+
+    public List<ScanNode> getScanNodes() {
+        return scanNodes;
+    }
+
+    public TDescriptorTable getDescTable() {
+        return descTable;
+    }
+
+    public boolean isEnablePipeline() {
+        return enablePipeline;
+    }
+
+    public boolean isEnableStreamPipeline() {
+        return enableStreamPipeline;
+    }
+
+    public TQueryGlobals getQueryGlobals() {
+        return queryGlobals;
+    }
+
+    public TQueryOptions getQueryOptions() {
+        return queryOptions;
+    }
+
+    public void setLoadJobType(TLoadJobType type) {
+        queryOptions.setLoad_job_type(type);
+    }
+
+    public long getStartTimeMs() {
+        return this.queryGlobals.getTimestamp_ms();
+    }
+
+    public void setQueryTimeout(int timeoutSecond) {
+        this.queryOptions.setQuery_timeout(timeoutSecond);
+    }
+
+    public TWorkGroup getResourceGroup() {
+        return resourceGroup;
+    }
+
+    public boolean isBlockQuery() {
+        return isBlockQuery;
+    }
+
+    public boolean isStreamLoad() {
+        return queryOptions.getLoad_job_type() == TLoadJobType.STREAM_LOAD;
+    }
+
+    public void reset() {
+        fragments.forEach(PlanFragment::reset);
+    }
+
+    public static class Builder {
+        private long loadJobId = UNINITIALIZED_LOAD_JOB_ID;
+
+        private TUniqueId queryId;
+        private List<PlanFragment> fragments;
+        private List<ScanNode> scanNodes;
+        private TDescriptorTable descTable;
+
+        private boolean enablePipeline;
+        private boolean enableStreamPipeline;
+        private boolean isBlockQuery;
+
+        private TQueryGlobals queryGlobals;
+        private TQueryOptions queryOptions;
+        private TWorkGroup resourceGroup;
+
+        public JobSpec build() {
+            return new JobSpec(this);
+        }
+
+        public Builder commonProperties(ConnectContext context) {
+            TWorkGroup newResourceGroup = prepareResourceGroup(
+                    context, ResourceGroupClassifier.QueryType.fromTQueryType(queryOptions.getQuery_type()));
+            this.enablePipeline(isEnablePipeline(context, fragments))
+                    .resourceGroup(newResourceGroup);
+
+            return this;
+        }
+
+        public Builder loadJobId(long loadJobId) {
+            this.loadJobId = loadJobId;
+            return this;
+        }
+
+        public Builder queryId(TUniqueId queryId) {
+            this.queryId = Preconditions.checkNotNull(queryId);
+            return this;
+        }
+
+        public Builder fragments(List<PlanFragment> fragments) {
+            this.fragments = fragments;
+            return this;
+        }
+
+        public Builder scanNodes(List<ScanNode> scanNodes) {
+            this.scanNodes = scanNodes;
+            return this;
+        }
+
+        public Builder descTable(TDescriptorTable descTable) {
+            if (descTable != null) {
+                descTable.setIs_cached(false);
+            }
+            this.descTable = descTable;
+            return this;
+        }
+
+        public Builder enableStreamPipeline(boolean enableStreamPipeline) {
+            this.enableStreamPipeline = enableStreamPipeline;
+            return this;
+        }
+
+        public Builder isBlockQuery(boolean isBlockQuery) {
+            this.isBlockQuery = isBlockQuery;
+            return this;
+        }
+
+        public Builder queryGlobals(TQueryGlobals queryGlobals) {
+            this.queryGlobals = queryGlobals;
+            return this;
+        }
+
+        public Builder queryOptions(TQueryOptions queryOptions) {
+            this.queryOptions = queryOptions;
+            return this;
+        }
+
+        private Builder enablePipeline(boolean enablePipeline) {
+            this.enablePipeline = enablePipeline;
+            return this;
+        }
+
+        private Builder resourceGroup(TWorkGroup resourceGroup) {
+            this.resourceGroup = resourceGroup;
+            return this;
+        }
+
+        /**
+         * Whether it can use pipeline engine.
+         *
+         * @param connectContext It is null for broker broker export.
+         * @param fragments      All the fragments need to execute.
+         * @return true if enabling pipeline in the session variable and all the fragments can use pipeline,
+         * otherwise false.
+         */
+        private static boolean isEnablePipeline(ConnectContext connectContext, List<PlanFragment> fragments) {
+            return connectContext != null &&
+                    connectContext.getSessionVariable().isEnablePipelineEngine() &&
+                    fragments.stream().allMatch(PlanFragment::canUsePipeline);
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -105,6 +105,7 @@ public class TaskRun implements Comparable<TaskRun> {
     public TaskRunProcessor getProcessor() {
         return processor;
     }
+
     public void setProcessor(TaskRunProcessor processor) {
         this.processor = processor;
     }
@@ -117,7 +118,7 @@ public class TaskRun implements Comparable<TaskRun> {
         return this.type;
     }
 
-    public Map<String, String>  refreshTaskProperties(ConnectContext ctx) {
+    public Map<String, String> refreshTaskProperties(ConnectContext ctx) {
         Map<String, String> newProperties = Maps.newHashMap();
         if (task.getSource() != Constants.TaskSource.MV) {
             return newProperties;
@@ -222,7 +223,7 @@ public class TaskRun implements Comparable<TaskRun> {
                 if (runCtx != null) {
                     StmtExecutor executor = runCtx.getExecutor();
                     if (executor != null && executor.getCoordinator() != null) {
-                        long jobId = executor.getCoordinator().getJobId();
+                        long jobId = executor.getCoordinator().getLoadJobId();
                         if (jobId != -1) {
                             InsertLoadJob job = (InsertLoadJob) GlobalStateMgr.getCurrentState()
                                     .getLoadMgr().getLoadJob(jobId);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -117,6 +117,7 @@ import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.QueryQueueManager;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.qe.scheduler.ICoordinator;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskManager;
@@ -1487,6 +1488,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         return result;
     }
 
+    private ICoordinator.Factory getCoordinatorFactory() {
+        return new Coordinator.Factory();
+    }
+
     private TExecPlanFragmentParams streamLoadPutImpl(TStreamLoadPutRequest request) throws UserException {
         String cluster = request.getCluster();
         if (Strings.isNullOrEmpty(cluster)) {
@@ -1530,7 +1535,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
                 streamLoadTask.setTUniqueId(request.getLoadId());
 
-                Coordinator coord = new Coordinator(planner, getClientAddr());
+                ICoordinator coord = getCoordinatorFactory().createSyncStreamLoadScheduler(planner, getClientAddr());
                 streamLoadTask.setCoordinator(coord);
 
                 QeProcessorImpl.INSTANCE.registerQuery(streamLoadInfo.getId(), coord);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -112,12 +112,12 @@ import com.starrocks.privilege.PrivilegeBuiltinConstants;
 import com.starrocks.privilege.PrivilegeType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectProcessor;
-import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.QueryQueueManager;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.VariableMgr;
-import com.starrocks.qe.scheduler.ICoordinator;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskManager;
@@ -1488,8 +1488,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         return result;
     }
 
-    private ICoordinator.Factory getCoordinatorFactory() {
-        return new Coordinator.Factory();
+    private Coordinator.Factory getCoordinatorFactory() {
+        return new DefaultCoordinator.Factory();
     }
 
     private TExecPlanFragmentParams streamLoadPutImpl(TStreamLoadPutRequest request) throws UserException {
@@ -1535,7 +1535,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
                 streamLoadTask.setTUniqueId(request.getLoadId());
 
-                ICoordinator coord = getCoordinatorFactory().createSyncStreamLoadScheduler(planner, getClientAddr());
+                Coordinator coord = getCoordinatorFactory().createSyncStreamLoadScheduler(planner, getClientAddr());
                 streamLoadTask.setCoordinator(coord);
 
                 QeProcessorImpl.INSTANCE.registerQuery(streamLoadInfo.getId(), coord);

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
@@ -49,8 +49,8 @@ import com.starrocks.fs.HdfsUtil;
 import com.starrocks.load.ExportChecker;
 import com.starrocks.load.ExportFailMsg;
 import com.starrocks.load.ExportJob;
-import com.starrocks.qe.Coordinator;
 import com.starrocks.qe.QeProcessorImpl;
+import com.starrocks.qe.scheduler.ICoordinator;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
@@ -77,7 +77,7 @@ public class ExportExportingTask extends PriorityLeaderTask {
     public ExportExportingTask(ExportJob job) {
         this.job = job;
         this.signature = job.getId();
-        this.subTasksDoneSignal = new MarkedCountDownLatch<Integer, Integer>(job.getCoordList().size());
+        this.subTasksDoneSignal = new MarkedCountDownLatch<>(job.getCoordList().size());
     }
 
     @Override
@@ -110,11 +110,11 @@ public class ExportExportingTask extends PriorityLeaderTask {
         }
 
         // sub tasks execute in parallel
-        List<Coordinator> coords = job.getCoordList();
+        List<ICoordinator> coords = job.getCoordList();
         int coordSize = coords.size();
         List<ExportExportingSubTask> subTasks = Lists.newArrayList();
         for (int i = 0; i < coordSize; i++) {
-            Coordinator coord = coords.get(i);
+            ICoordinator coord = coords.get(i);
             ExportExportingSubTask subTask = new ExportExportingSubTask(coord, i, coordSize, job);
             subTasks.add(subTask);
             subTasksDoneSignal.addMark(i, -1);
@@ -292,12 +292,12 @@ public class ExportExportingTask extends PriorityLeaderTask {
     }
 
     private class ExportExportingSubTask extends PriorityLeaderTask {
-        private Coordinator coord;
+        private ICoordinator coord;
         private final int taskIdx;
         private final int coordSize;
         private final ExportJob exportJob;
 
-        public ExportExportingSubTask(Coordinator coord, int taskIdx, int coordSize, ExportJob exportJob) {
+        public ExportExportingSubTask(ICoordinator coord, int taskIdx, int coordSize, ExportJob exportJob) {
             this.coord = coord;
             this.taskIdx = taskIdx;
             this.coordSize = coordSize;
@@ -336,7 +336,7 @@ public class ExportExportingTask extends PriorityLeaderTask {
                     failMsg = e.getMessage();
                     TUniqueId queryId = coord.getQueryId();
                     LOG.warn("export sub task internal error. task idx: {}, task query id: {}",
-                            taskIdx, getQueryId(), e);
+                            taskIdx, queryId, e);
                 }
 
                 if (i < RETRY_NUM - 1) {
@@ -349,11 +349,11 @@ public class ExportExportingTask extends PriorityLeaderTask {
                     String errorMsg = coord.getExecStatus().getErrorMsg();
                     if (exportJob.needResetCoord()) {
                         try {
-                            Coordinator newCoord = exportJob.resetCoord(taskIdx, newQueryId);
+                            ICoordinator newCoord = exportJob.resetCoord(taskIdx, newQueryId);
                             coord = newCoord;
                         } catch (UserException e) {
                             // still use old coord if there are any problems when reseting Coord
-                            LOG.warn("fail to reset coord for task idx: {}, task query id: {}, reason: {}", taskIdx, 
+                            LOG.warn("fail to reset coord for task idx: {}, task query id: {}, reason: {}", taskIdx,
                                     getQueryId(), e.getMessage());
                             coord.clearExportStatus();
                         }
@@ -379,7 +379,7 @@ public class ExportExportingTask extends PriorityLeaderTask {
             }
         }
 
-        private void execOneCoord(Coordinator coord) throws Exception {
+        private void execOneCoord(ICoordinator coord) throws Exception {
             TUniqueId queryId = coord.getQueryId();
             QeProcessorImpl.INSTANCE.registerQuery(queryId, coord);
             try {
@@ -389,13 +389,13 @@ public class ExportExportingTask extends PriorityLeaderTask {
             }
         }
 
-        private void actualExecCoord(Coordinator coord) throws Exception {
+        private void actualExecCoord(ICoordinator coord) throws Exception {
             int leftTimeSecond = getLeftTimeSecond();
             if (leftTimeSecond <= 0) {
                 throw new UserException("timeout");
             }
 
-            coord.setTimeout(leftTimeSecond);
+            coord.setTimeoutSecond(leftTimeSecond);
             coord.exec();
 
             if (coord.join(leftTimeSecond)) {
@@ -419,7 +419,7 @@ public class ExportExportingTask extends PriorityLeaderTask {
             LOG.info("export sub task finish. task idx: {}, task query id: {}", taskIdx, getQueryId());
         }
 
-        private void onSubTaskFailed(Coordinator coordinator, String failMsg) {
+        private void onSubTaskFailed(ICoordinator coordinator, String failMsg) {
             Status coordStatus = coordinator.getExecStatus();
             String taskFailMsg = "export job fail. query id: " + DebugUtil.printId(coordinator.getQueryId())
                     + ", fail msg: ";

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorMonitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorMonitorTest.java
@@ -31,14 +31,14 @@ import java.util.concurrent.TimeUnit;
 public class CoordinatorMonitorTest {
 
     @Test
-    public void testDeadBackendAndComputeNodeChecker(@Mocked Coordinator coord1,
-                                                     @Mocked Coordinator coord2,
-                                                     @Mocked Coordinator coord3) throws InterruptedException {
+    public void testDeadBackendAndComputeNodeChecker(@Mocked DefaultCoordinator coord1,
+                                                     @Mocked DefaultCoordinator coord2,
+                                                     @Mocked DefaultCoordinator coord3) throws InterruptedException {
         int prevHeartbeatTimeout = Config.heartbeat_timeout_second;
         Config.heartbeat_timeout_second = 1;
 
         try {
-            List<Coordinator> coordinators = ImmutableList.of(coord1, coord2, coord3);
+            List<DefaultCoordinator> coordinators = ImmutableList.of(coord1, coord2, coord3);
 
             final QeProcessor qeProcessor = QeProcessorImpl.INSTANCE;
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorMonitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorMonitorTest.java
@@ -18,6 +18,7 @@ package com.starrocks.qe;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.common.Config;
 import com.starrocks.proto.PPlanFragmentCancelReason;
+import com.starrocks.thrift.TUniqueId;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
@@ -46,6 +47,24 @@ public class CoordinatorMonitorTest {
                 {
                     qeProcessor.getCoordinators();
                     result = coordinators;
+                }
+
+                {
+                    coord1.getQueryId();
+                    result = new TUniqueId();
+                    minTimes = 0;
+                }
+
+                {
+                    coord2.getQueryId();
+                    result = new TUniqueId();
+                    minTimes = 0;
+                }
+
+                {
+                    coord3.getQueryId();
+                    result = new TUniqueId();
+                    minTimes = 0;
                 }
 
                 {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -71,7 +71,8 @@ public class CoordinatorTest extends PlanTestBase {
         ctx.setExecutionId(new TUniqueId(0xdeadbeef, 0xdeadbeef));
         ConnectContext.threadLocalInfo.set(ctx);
 
-        coordinator = new Coordinator(ctx, Lists.newArrayList(), Lists.newArrayList(), new TDescriptorTable());
+        coordinator = new Coordinator.Factory().createQueryScheduler(ctx, Lists.newArrayList(), Lists.newArrayList(),
+                new TDescriptorTable());
         coordinatorPreprocessor = coordinator.getPrepareInfo();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -62,7 +62,7 @@ import static com.starrocks.qe.ColocatedBackendSelector.BucketSeqToScanRange;
 
 public class CoordinatorTest extends PlanTestBase {
     ConnectContext ctx;
-    Coordinator coordinator;
+    DefaultCoordinator coordinator;
     CoordinatorPreprocessor coordinatorPreprocessor;
 
     @Before
@@ -71,7 +71,7 @@ public class CoordinatorTest extends PlanTestBase {
         ctx.setExecutionId(new TUniqueId(0xdeadbeef, 0xdeadbeef));
         ConnectContext.threadLocalInfo.set(ctx);
 
-        coordinator = new Coordinator.Factory().createQueryScheduler(ctx, Lists.newArrayList(), Lists.newArrayList(),
+        coordinator = new DefaultCoordinator.Factory().createQueryScheduler(ctx, Lists.newArrayList(), Lists.newArrayList(),
                 new TDescriptorTable());
         coordinatorPreprocessor = coordinator.getPrepareInfo();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryQueueManagerTest.java
@@ -47,7 +47,7 @@ import java.util.stream.Stream;
 
 public class QueryQueueManagerTest {
     @Mocked
-    private Coordinator coordinator;
+    private DefaultCoordinator coordinator;
 
     private boolean taskQueueEnable;
     private int taskQueueConcurrencyHardLimit;
@@ -103,7 +103,7 @@ public class QueryQueueManagerTest {
         QueryQueueManager manager = QueryQueueManager.getInstance();
         new Expectations(manager) {
             {
-                manager.needCheckQueue((Coordinator) any);
+                manager.needCheckQueue((DefaultCoordinator) any);
                 result = true;
             }
         };
@@ -113,7 +113,7 @@ public class QueryQueueManagerTest {
         QueryQueueManager manager = QueryQueueManager.getInstance();
         new Expectations(manager) {
             {
-                manager.needCheckQueue((Coordinator) any);
+                manager.needCheckQueue((DefaultCoordinator) any);
                 result = false;
             }
         };
@@ -123,7 +123,7 @@ public class QueryQueueManagerTest {
         QueryQueueManager manager = QueryQueueManager.getInstance();
         new Expectations(manager) {
             {
-                manager.enableCheckQueue((Coordinator) any);
+                manager.enableCheckQueue((DefaultCoordinator) any);
                 result = true;
             }
         };
@@ -133,7 +133,7 @@ public class QueryQueueManagerTest {
         QueryQueueManager manager = QueryQueueManager.getInstance();
         new Expectations(manager) {
             {
-                manager.enableCheckQueue((Coordinator) any);
+                manager.enableCheckQueue((DefaultCoordinator) any);
                 result = false;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/qe/TPCDSCoordTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/TPCDSCoordTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.qe;
 
 import com.starrocks.common.FeConstants;
@@ -88,8 +87,8 @@ public class TPCDSCoordTest extends TPCDSPlanTestBase {
 
         System.out.println(plan);
         ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(ctx, sql).second;
-        Coordinator coord = new Coordinator(ctx, execPlan.getFragments(), execPlan.getScanNodes(),
-                execPlan.getDescTbl().toThrift());
+        Coordinator coord = new Coordinator.Factory().createQueryScheduler(
+                ctx, execPlan.getFragments(), execPlan.getScanNodes(), execPlan.getDescTbl().toThrift());
         coord.prepareExec();
 
         PlanFragmentId topFragmentId = coord.getFragments().get(0).getFragmentId();
@@ -136,8 +135,8 @@ public class TPCDSCoordTest extends TPCDSPlanTestBase {
         System.out.println(filterLines.size());
         Assert.assertTrue(filterLines.size() == 5);
         ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(ctx, sql).second;
-        Coordinator coord = new Coordinator(ctx, execPlan.getFragments(), execPlan.getScanNodes(),
-                execPlan.getDescTbl().toThrift());
+        Coordinator coord = new Coordinator.Factory().createQueryScheduler(
+                ctx, execPlan.getFragments(), execPlan.getScanNodes(), execPlan.getDescTbl().toThrift());
         coord.prepareExec();
 
         int filterId = 2;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/TPCDSCoordTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/TPCDSCoordTest.java
@@ -87,7 +87,7 @@ public class TPCDSCoordTest extends TPCDSPlanTestBase {
 
         System.out.println(plan);
         ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(ctx, sql).second;
-        Coordinator coord = new Coordinator.Factory().createQueryScheduler(
+        DefaultCoordinator coord = new DefaultCoordinator.Factory().createQueryScheduler(
                 ctx, execPlan.getFragments(), execPlan.getScanNodes(), execPlan.getDescTbl().toThrift());
         coord.prepareExec();
 
@@ -135,7 +135,7 @@ public class TPCDSCoordTest extends TPCDSPlanTestBase {
         System.out.println(filterLines.size());
         Assert.assertTrue(filterLines.size() == 5);
         ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(ctx, sql).second;
-        Coordinator coord = new Coordinator.Factory().createQueryScheduler(
+        DefaultCoordinator coord = new DefaultCoordinator.Factory().createQueryScheduler(
                 ctx, execPlan.getFragments(), execPlan.getScanNodes(), execPlan.getDescTbl().toThrift());
         coord.prepareExec();
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/GetNextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/GetNextTest.java
@@ -1,0 +1,292 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.common.Reference;
+import com.starrocks.common.UserException;
+import com.starrocks.proto.PCancelPlanFragmentRequest;
+import com.starrocks.proto.PCancelPlanFragmentResult;
+import com.starrocks.proto.PFetchDataResult;
+import com.starrocks.proto.PQueryStatistics;
+import com.starrocks.proto.StatusPB;
+import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.RowBatch;
+import com.starrocks.qe.SimpleScheduler;
+import com.starrocks.rpc.PFetchDataRequest;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.thrift.FrontendServiceVersion;
+import com.starrocks.thrift.TReportExecStatusParams;
+import com.starrocks.thrift.TResultBatch;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TUniqueId;
+import org.apache.thrift.TException;
+import org.apache.thrift.TSerializer;
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.starrocks.utframe.MockedBackend.MockPBackendService;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GetNextTest extends SchedulerTestBase {
+    private boolean originalEnableProfile;
+
+    @Before
+    public void before() {
+        originalEnableProfile = connectContext.getSessionVariable().isEnableProfile();
+    }
+
+    @After
+    public void after() {
+        connectContext.getSessionVariable().setEnableProfile(originalEnableProfile);
+    }
+
+    @Test
+    public void testGetNextFinishSuccessfully() throws Exception {
+        final int NUM_PACKAGES = 2;
+        AtomicLong nexPacketIdx = new AtomicLong(0L);
+        setBackendService(new MockPBackendService() {
+            @Override
+            public Future<PFetchDataResult> fetchDataAsync(PFetchDataRequest request) {
+                return submit(() -> {
+                    long packetIdx = nexPacketIdx.getAndIncrement();
+                    if (packetIdx + 1 < NUM_PACKAGES) {
+                        request.setSerializedResult(genResultBatch(2));
+                        return genDataResult(false, packetIdx);
+                    } else {
+                        return genDataResult(true, packetIdx);
+                    }
+                });
+            }
+        });
+
+        String sql = "select count(1) from lineitem";
+        Coordinator scheduler = startScheduling(sql);
+
+        RowBatch batch;
+        for (int i = 0; i < NUM_PACKAGES; i++) {
+            batch = scheduler.getNext();
+            if (i + 1 < NUM_PACKAGES) {
+                Assert.assertNotNull(batch.getBatch());
+                Assert.assertFalse(batch.isEos());
+            } else {
+                Assert.assertNull(batch.getBatch());
+                Assert.assertTrue(batch.isEos());
+            }
+        }
+    }
+
+    @Test
+    public void testGetNextReceiveErrorPacketSeq() throws Exception {
+        setBackendService(new MockPBackendService() {
+            @Override
+            public Future<PFetchDataResult> fetchDataAsync(PFetchDataRequest request) {
+                return submit(() -> {
+                    request.setSerializedResult(genResultBatch(2));
+                    // packetSeq is incorrectly always 0 for all the packet.
+                    return genDataResult(false, 0);
+                });
+            }
+        });
+
+        String sql = "select count(1) from lineitem";
+        Coordinator scheduler = startScheduling(sql);
+
+        RowBatch batch = scheduler.getNext();
+        Assert.assertNotNull(batch.getBatch());
+        Assert.assertFalse(batch.isEos());
+
+        Assert.assertThrows("rpc failed: receive error packet", RpcException.class, scheduler::getNext);
+    }
+
+    @Test
+    public void testGetNextThrowException() throws Exception {
+        setBackendService(new MockPBackendService() {
+            @Override
+            public Future<PFetchDataResult> fetchDataAsync(PFetchDataRequest request) {
+                throw new RuntimeException("test runtime exception");
+            }
+        });
+
+        String sql = "select count(1) from lineitem";
+        Coordinator scheduler = startScheduling(sql);
+
+        Assert.assertThrows("rpc failed: test runtime exception", RpcException.class, scheduler::getNext);
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() ->
+                !SimpleScheduler.isInBlacklist(BACKEND1_ID) && !SimpleScheduler.isInBlacklist(backend2.getId()) &&
+                        !SimpleScheduler.isInBlacklist(backend3.getId()));
+    }
+
+    @Test
+    public void testGetNextFutureThrowErrorStatus() throws Exception {
+        Reference<TStatusCode> fetchDataResultStatusCode = new Reference<>();
+        setBackendService(new MockPBackendService() {
+            @Override
+            public Future<PFetchDataResult> fetchDataAsync(PFetchDataRequest request) {
+                return submit(() -> {
+                    request.setSerializedResult(genResultBatch(2));
+                    PFetchDataResult dataResult = genDataResult(false, 0);
+                    dataResult.status.statusCode = fetchDataResultStatusCode.getRef().getValue();
+                    return dataResult;
+                });
+            }
+        });
+
+        String sql = "select count(1) from lineitem";
+        Coordinator scheduler;
+
+        fetchDataResultStatusCode.setRef(TStatusCode.INTERNAL_ERROR);
+        scheduler = startScheduling(sql);
+        Assert.assertThrows("Internal_error", UserException.class, scheduler::getNext);
+
+        fetchDataResultStatusCode.setRef(TStatusCode.THRIFT_RPC_ERROR);
+        scheduler = startScheduling(sql);
+        Assert.assertThrows("rpc failed: Thrift_rpc_error", RpcException.class, scheduler::getNext);
+    }
+
+    @Test
+    public void testGetNextReachLimit() throws Exception {
+        final int NUM_PACKAGES = 2;
+        AtomicLong nexPacketIdx = new AtomicLong(0L);
+        Set<TUniqueId> cancelledInstanceIds = new ConcurrentSkipListSet<>();
+        setBackendService(new MockPBackendService() {
+            @Override
+            public Future<PFetchDataResult> fetchDataAsync(PFetchDataRequest request) {
+                return submit(() -> {
+                    long packetIdx = nexPacketIdx.getAndIncrement();
+                    if (packetIdx + 1 < NUM_PACKAGES) {
+                        request.setSerializedResult(genResultBatch(2));
+                        return genDataResult(false, packetIdx);
+                    } else {
+                        return genDataResult(true, packetIdx);
+                    }
+                });
+            }
+
+            @Override
+            public Future<PCancelPlanFragmentResult> cancelPlanFragmentAsync(PCancelPlanFragmentRequest request) {
+                TUniqueId id = new TUniqueId(request.finstId.hi, request.finstId.lo);
+                cancelledInstanceIds.add(id);
+                return super.cancelPlanFragmentAsync(request);
+            }
+        });
+
+        String sql = "select count(1) from lineitem limit 2";
+        Coordinator scheduler = startScheduling(sql);
+
+        RowBatch batch;
+
+        for (int i = 0; i < NUM_PACKAGES; i++) {
+            batch = scheduler.getNext();
+            if (i + 1 < NUM_PACKAGES) {
+                Assert.assertNotNull(batch.getBatch());
+                Assert.assertFalse(batch.isEos());
+            } else {
+                Assert.assertNull(batch.getBatch());
+                Assert.assertTrue(batch.isEos());
+            }
+        }
+
+        assertThat(cancelledInstanceIds).containsOnlyOnceElementsOf(scheduler.getInstanceIds());
+        Assert.assertTrue(scheduler.getExecStatus().ok());
+
+        // Receive cancelled report.
+        scheduler.getBackendExecutions().forEach(execution -> {
+            TReportExecStatusParams request = new TReportExecStatusParams(FrontendServiceVersion.V1);
+            request.setBackend_num(execution.getIndexInJob());
+            request.setDone(true);
+            request.setStatus(new TStatus(TStatusCode.CANCELLED));
+            request.setFragment_instance_id(execution.getInstanceId());
+
+            scheduler.updateFragmentExecStatus(request);
+        });
+
+        Assert.assertTrue(scheduler.isDone());
+        Assert.assertTrue(scheduler.getExecStatus().ok());
+    }
+
+    @Test
+    public void testCancelAndGetNext() throws Exception {
+        connectContext.getSessionVariable().setEnableProfile(true);
+
+        setBackendService(new MockPBackendService());
+
+        String sql = "select count(1) from lineitem";
+        Coordinator scheduler = startScheduling(sql);
+
+        scheduler.cancel();
+
+        Assert.assertThrows("Cancelled", UserException.class, scheduler::getNext);
+
+        Assert.assertFalse(scheduler.isDone());
+        Assert.assertTrue(scheduler.getExecStatus().isCancelled());
+
+        // Receive execution reports.
+        scheduler.getBackendExecutions().forEach(execution -> {
+            TReportExecStatusParams request = new TReportExecStatusParams(FrontendServiceVersion.V1);
+            request.setBackend_num(execution.getIndexInJob());
+            request.setDone(true);
+            request.setStatus(new TStatus(TStatusCode.CANCELLED));
+            request.setFragment_instance_id(execution.getInstanceId());
+
+            scheduler.updateFragmentExecStatus(request);
+        });
+        Assert.assertTrue(scheduler.isDone());
+        Assert.assertTrue(scheduler.getExecStatus().isCancelled());
+    }
+
+    private static PFetchDataResult genDataResult(boolean eos, long packetSeq) {
+        PFetchDataResult result = new PFetchDataResult();
+        StatusPB pStatus = new StatusPB();
+        pStatus.statusCode = TStatusCode.OK.getValue();
+
+        PQueryStatistics pQueryStatistics = new PQueryStatistics();
+        pQueryStatistics.scanRows = 0L;
+        pQueryStatistics.scanBytes = 0L;
+        pQueryStatistics.cpuCostNs = 0L;
+        pQueryStatistics.memCostBytes = 0L;
+
+        result.status = pStatus;
+        result.packetSeq = packetSeq;
+        result.queryStatistics = pQueryStatistics;
+        result.eos = eos;
+
+        return result;
+    }
+
+    private static byte[] genResultBatch(int numRows) throws TException {
+        List<ByteBuffer> rows = new ArrayList<>(numRows);
+        for (int i = 0; i < numRows; i++) {
+            rows.add(ByteBuffer.allocate(8));
+        }
+        TResultBatch resultBatch = new TResultBatch(rows, false, 0);
+
+        TSerializer serializer = new TSerializer();
+        return serializer.serialize(resultBatch);
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/GetNextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/GetNextTest.java
@@ -21,7 +21,7 @@ import com.starrocks.proto.PCancelPlanFragmentResult;
 import com.starrocks.proto.PFetchDataResult;
 import com.starrocks.proto.PQueryStatistics;
 import com.starrocks.proto.StatusPB;
-import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.RowBatch;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.rpc.PFetchDataRequest;
@@ -85,7 +85,7 @@ public class GetNextTest extends SchedulerTestBase {
         });
 
         String sql = "select count(1) from lineitem";
-        Coordinator scheduler = startScheduling(sql);
+        DefaultCoordinator scheduler = startScheduling(sql);
 
         RowBatch batch;
         for (int i = 0; i < NUM_PACKAGES; i++) {
@@ -114,7 +114,7 @@ public class GetNextTest extends SchedulerTestBase {
         });
 
         String sql = "select count(1) from lineitem";
-        Coordinator scheduler = startScheduling(sql);
+        DefaultCoordinator scheduler = startScheduling(sql);
 
         RowBatch batch = scheduler.getNext();
         Assert.assertNotNull(batch.getBatch());
@@ -133,7 +133,7 @@ public class GetNextTest extends SchedulerTestBase {
         });
 
         String sql = "select count(1) from lineitem";
-        Coordinator scheduler = startScheduling(sql);
+        DefaultCoordinator scheduler = startScheduling(sql);
 
         Assert.assertThrows("rpc failed: test runtime exception", RpcException.class, scheduler::getNext);
         Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() ->
@@ -157,7 +157,7 @@ public class GetNextTest extends SchedulerTestBase {
         });
 
         String sql = "select count(1) from lineitem";
-        Coordinator scheduler;
+        DefaultCoordinator scheduler;
 
         fetchDataResultStatusCode.setRef(TStatusCode.INTERNAL_ERROR);
         scheduler = startScheduling(sql);
@@ -196,7 +196,7 @@ public class GetNextTest extends SchedulerTestBase {
         });
 
         String sql = "select count(1) from lineitem limit 2";
-        Coordinator scheduler = startScheduling(sql);
+        DefaultCoordinator scheduler = startScheduling(sql);
 
         RowBatch batch;
 
@@ -236,7 +236,7 @@ public class GetNextTest extends SchedulerTestBase {
         setBackendService(new MockPBackendService());
 
         String sql = "select count(1) from lineitem";
-        Coordinator scheduler = startScheduling(sql);
+        DefaultCoordinator scheduler = startScheduling(sql);
 
         scheduler.cancel();
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JobSpecTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JobSpecTest.java
@@ -25,7 +25,7 @@ import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.planner.StreamLoadPlanner;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.scheduler.dag.JobSpec;
 import com.starrocks.sql.LoadPlanner;
@@ -57,7 +57,7 @@ public class JobSpecTest extends SchedulerTestBase {
     private static final TWorkGroup QUERY_RESOURCE_GROUP = new TWorkGroup();
     private static final TWorkGroup LOAD_RESOURCE_GROUP = new TWorkGroup();
 
-    private static final Coordinator.Factory COORDINATOR_FACTORY = new Coordinator.Factory();
+    private static final DefaultCoordinator.Factory COORDINATOR_FACTORY = new DefaultCoordinator.Factory();
 
     static {
         QUERY_RESOURCE_GROUP.setId(0L);
@@ -107,7 +107,7 @@ public class JobSpecTest extends SchedulerTestBase {
         List<PlanFragment> fragments = execPlan.getFragments();
         List<ScanNode> scanNodes = execPlan.getScanNodes();
 
-        Coordinator coordinator = COORDINATOR_FACTORY.createQueryScheduler(
+        DefaultCoordinator coordinator = COORDINATOR_FACTORY.createQueryScheduler(
                 connectContext, fragments, scanNodes, descTable.toThrift());
         JobSpec jobSpec = coordinator.getJobSpec();
 
@@ -174,7 +174,7 @@ public class JobSpecTest extends SchedulerTestBase {
                 timeout, startTime, false, connectContext, sessionVariables, loadMemLimit, execMemLimit,
                 null, null, null, 0);
 
-        Coordinator coordinator = COORDINATOR_FACTORY.createBrokerLoadScheduler(loadPlanner);
+        DefaultCoordinator coordinator = COORDINATOR_FACTORY.createBrokerLoadScheduler(loadPlanner);
         JobSpec jobSpec = coordinator.getJobSpec();
 
         // Check created jobSpec.
@@ -243,7 +243,7 @@ public class JobSpecTest extends SchedulerTestBase {
                 timeout, startTime, false, connectContext, sessionVariables, loadMemLimit, execMemLimit,
                 null, null, null, 0);
 
-        Coordinator coordinator = COORDINATOR_FACTORY.createStreamLoadScheduler(loadPlanner);
+        DefaultCoordinator coordinator = COORDINATOR_FACTORY.createStreamLoadScheduler(loadPlanner);
         JobSpec jobSpec = coordinator.getJobSpec();
 
         // Check created jobSpec.
@@ -310,7 +310,7 @@ public class JobSpecTest extends SchedulerTestBase {
         Map<String, String> sessionVariables = ImmutableMap.of();
         long execMemLimit = 4L;
 
-        Coordinator coordinator = COORDINATOR_FACTORY.createNonPipelineBrokerLoadScheduler(
+        DefaultCoordinator coordinator = COORDINATOR_FACTORY.createNonPipelineBrokerLoadScheduler(
                 loadJobId, queryId, descTable, fragments, scanNodes, timezone, startTime,
                 sessionVariables,
                 connectContext,
@@ -362,7 +362,7 @@ public class JobSpecTest extends SchedulerTestBase {
         Map<String, String> sessionVariables = ImmutableMap.of();
         long execMemLimit = 4L;
 
-        Coordinator coordinator = COORDINATOR_FACTORY.createBrokerExportScheduler(
+        DefaultCoordinator coordinator = COORDINATOR_FACTORY.createBrokerExportScheduler(
                 loadJobId, queryId, descTable, fragments, scanNodes, timezone, startTime,
                 sessionVariables,
                 execMemLimit);
@@ -406,7 +406,7 @@ public class JobSpecTest extends SchedulerTestBase {
             }
         };
 
-        Coordinator coordinator = COORDINATOR_FACTORY.createSyncStreamLoadScheduler(planner, new TNetworkAddress());
+        DefaultCoordinator coordinator = COORDINATOR_FACTORY.createSyncStreamLoadScheduler(planner, new TNetworkAddress());
         JobSpec jobSpec = coordinator.getJobSpec();
 
         // Check created jobSpec.

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JobSpecTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JobSpecTest.java
@@ -1,0 +1,419 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.analysis.DescriptorTable;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.ResourceGroupClassifier;
+import com.starrocks.catalog.ResourceGroupMgr;
+import com.starrocks.common.Config;
+import com.starrocks.load.loadv2.BulkLoadJob;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.planner.StreamLoadPlanner;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.scheduler.dag.JobSpec;
+import com.starrocks.sql.LoadPlanner;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.thrift.TCompressionType;
+import com.starrocks.thrift.TExecPlanFragmentParams;
+import com.starrocks.thrift.TLoadJobType;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TPlanFragmentExecParams;
+import com.starrocks.thrift.TQueryType;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TWorkGroup;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+public class JobSpecTest extends SchedulerTestBase {
+    private static final TWorkGroup QUERY_RESOURCE_GROUP = new TWorkGroup();
+    private static final TWorkGroup LOAD_RESOURCE_GROUP = new TWorkGroup();
+
+    private static final Coordinator.Factory COORDINATOR_FACTORY = new Coordinator.Factory();
+
+    static {
+        QUERY_RESOURCE_GROUP.setId(0L);
+        LOAD_RESOURCE_GROUP.setId(1L);
+    }
+
+    private boolean prevEnablePipelineLoad;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        SchedulerTestBase.beforeClass();
+
+        new MockUp<ResourceGroupMgr>() {
+            @Mock
+            public TWorkGroup chooseResourceGroup(ConnectContext ctx, ResourceGroupClassifier.QueryType queryType,
+                                                  Set<Long> databases) {
+                if (queryType != ResourceGroupClassifier.QueryType.SELECT) {
+                    return LOAD_RESOURCE_GROUP;
+                } else {
+                    return QUERY_RESOURCE_GROUP;
+                }
+            }
+        };
+    }
+
+    @Before
+    public void before() {
+        prevEnablePipelineLoad = Config.enable_pipeline_load;
+    }
+
+    @After
+    public void after() {
+        Config.enable_pipeline_load = prevEnablePipelineLoad;
+    }
+
+    @Test
+    public void testFromQuerySpec() throws Exception {
+        // Prepare input arguments.
+        String sql = "select * from lineitem";
+        ExecPlan execPlan = getExecPlan(sql);
+
+        TUniqueId queryId = new TUniqueId(2, 3);
+        connectContext.setExecutionId(queryId);
+        UUID lastQueryId = new UUID(4L, 5L);
+        connectContext.setLastQueryId(lastQueryId);
+        DescriptorTable descTable = new DescriptorTable();
+        List<PlanFragment> fragments = execPlan.getFragments();
+        List<ScanNode> scanNodes = execPlan.getScanNodes();
+
+        Coordinator coordinator = COORDINATOR_FACTORY.createQueryScheduler(
+                connectContext, fragments, scanNodes, descTable.toThrift());
+        JobSpec jobSpec = coordinator.getJobSpec();
+
+        // Check created jobSpec.
+        Assert.assertEquals(queryId, jobSpec.getQueryId());
+        Assert.assertEquals(lastQueryId.toString(), jobSpec.getQueryGlobals().getLast_query_id());
+        Assert.assertEquals(TQueryType.SELECT, jobSpec.getQueryOptions().getQuery_type());
+        Assert.assertTrue(jobSpec.isEnablePipeline());
+        Assert.assertFalse(jobSpec.isEnableStreamPipeline());
+        Assert.assertFalse(jobSpec.isBlockQuery());
+        Assert.assertEquals(QUERY_RESOURCE_GROUP, jobSpec.getResourceGroup());
+
+        coordinator = COORDINATOR_FACTORY.createInsertScheduler(
+                connectContext, fragments, scanNodes, descTable.toThrift());
+        jobSpec = coordinator.getJobSpec();
+        Assert.assertEquals(LOAD_RESOURCE_GROUP, jobSpec.getResourceGroup());
+    }
+
+    @Test
+    public void testFromMVMaintenanceJobSpec() throws Exception {
+        // Prepare input arguments.
+        String sql = "select * from lineitem";
+        ExecPlan execPlan = getExecPlan(sql);
+
+        TUniqueId queryId = new TUniqueId(2, 3);
+        connectContext.setExecutionId(queryId);
+        UUID lastQueryId = new UUID(4L, 5L);
+        connectContext.setLastQueryId(lastQueryId);
+        DescriptorTable descTable = new DescriptorTable();
+        List<PlanFragment> fragments = execPlan.getFragments();
+        List<ScanNode> scanNodes = execPlan.getScanNodes();
+
+        JobSpec jobSpec = JobSpec.Factory.fromMVMaintenanceJobSpec(
+                connectContext, fragments, scanNodes, descTable.toThrift());
+
+        // Check created jobSpec.
+        Assert.assertEquals(queryId, jobSpec.getQueryId());
+        Assert.assertEquals(lastQueryId.toString(), jobSpec.getQueryGlobals().getLast_query_id());
+        Assert.assertEquals(TQueryType.SELECT, jobSpec.getQueryOptions().getQuery_type());
+        Assert.assertTrue(jobSpec.isEnablePipeline());
+        Assert.assertTrue(jobSpec.isEnableStreamPipeline());
+        Assert.assertFalse(jobSpec.isBlockQuery());
+        Assert.assertEquals(QUERY_RESOURCE_GROUP, jobSpec.getResourceGroup());
+    }
+
+    @Test
+    public void testFromBrokerLoadJobSpec() throws Exception {
+        // Prepare input arguments.
+        String sql = "insert into lineitem select * from lineitem";
+
+        long loadJobId = 1L;
+        TUniqueId queryId = new TUniqueId(2, 3);
+        UUID lastQueryId = new UUID(4L, 5L);
+        connectContext.setLastQueryId(lastQueryId);
+        String timezone = connectContext.getSessionVariable().getTimeZone();
+        long startTime = connectContext.getStartTime();
+        Map<String, String> sessionVariables = ImmutableMap.of();
+        long execMemLimit = 4L;
+        long loadMemLimit = 5L;
+        int timeout = 6;
+
+        LoadPlanner loadPlanner = new LoadPlanner(loadJobId, queryId, 0L, 0L,
+                new OlapTable(), false, timezone,
+                timeout, startTime, false, connectContext, sessionVariables, loadMemLimit, execMemLimit,
+                null, null, null, 0);
+
+        Coordinator coordinator = COORDINATOR_FACTORY.createBrokerLoadScheduler(loadPlanner);
+        JobSpec jobSpec = coordinator.getJobSpec();
+
+        // Check created jobSpec.
+        Assert.assertEquals(loadJobId, jobSpec.getLoadJobId());
+        Assert.assertEquals(queryId, jobSpec.getQueryId());
+        Assert.assertEquals(lastQueryId.toString(), jobSpec.getQueryGlobals().getLast_query_id());
+        Assert.assertEquals(TQueryType.LOAD, jobSpec.getQueryOptions().getQuery_type());
+        Assert.assertEquals(timeout, jobSpec.getQueryOptions().getQuery_timeout());
+        Assert.assertEquals(loadMemLimit, jobSpec.getQueryOptions().getLoad_mem_limit());
+        Assert.assertEquals(execMemLimit, jobSpec.getQueryOptions().getMem_limit());
+        Assert.assertEquals(execMemLimit, jobSpec.getQueryOptions().getQuery_mem_limit());
+        Assert.assertTrue(jobSpec.isEnablePipeline());
+        Assert.assertFalse(jobSpec.isEnableStreamPipeline());
+        Assert.assertTrue(jobSpec.isBlockQuery());
+        Assert.assertEquals(LOAD_RESOURCE_GROUP, jobSpec.getResourceGroup());
+
+        // Check created jobSpec for sessionVariables.
+        Assert.assertEquals(TCompressionType.NO_COMPRESSION,
+                jobSpec.getQueryOptions().getLoad_transmission_compression_type());
+        Assert.assertFalse(jobSpec.getQueryOptions().isSetLog_rejected_record_num());
+
+        sessionVariables = ImmutableMap.of(
+                SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE, "LZ4",
+                BulkLoadJob.LOG_REJECTED_RECORD_NUM_SESSION_VARIABLE_KEY, "10"
+        );
+        loadPlanner = new LoadPlanner(loadJobId, queryId, 0L, 0L,
+                new OlapTable(), false, timezone,
+                timeout, startTime, false, connectContext, sessionVariables, loadMemLimit, execMemLimit,
+                null, null, null, 0);
+        coordinator = COORDINATOR_FACTORY.createBrokerLoadScheduler(loadPlanner);
+        jobSpec = coordinator.getJobSpec();
+        Assert.assertEquals(TCompressionType.LZ4, jobSpec.getQueryOptions().getLoad_transmission_compression_type());
+        Assert.assertEquals(10L, jobSpec.getQueryOptions().getLog_rejected_record_num());
+
+        // Check negative execMemLimit.
+        execMemLimit = -1;
+        loadPlanner = new LoadPlanner(loadJobId, queryId, 0L, 0L,
+                new OlapTable(), false, timezone,
+                timeout, startTime, false, connectContext, sessionVariables, loadMemLimit, execMemLimit,
+                null, null, null, 0);
+        coordinator = COORDINATOR_FACTORY.createBrokerLoadScheduler(loadPlanner);
+        jobSpec = coordinator.getJobSpec();
+        Assert.assertEquals(loadMemLimit, jobSpec.getQueryOptions().getLoad_mem_limit());
+        Assert.assertTrue(jobSpec.getQueryOptions().isSetMem_limit());
+        Assert.assertFalse(jobSpec.getQueryOptions().isSetQuery_mem_limit());
+    }
+
+    @Test
+    public void testFromStreamLoadJobSpec() throws Exception {
+        // Prepare input arguments.
+        String sql = "insert into lineitem select * from lineitem";
+
+        long loadJobId = 1L;
+        TUniqueId queryId = new TUniqueId(2, 3);
+        UUID lastQueryId = new UUID(4L, 5L);
+        connectContext.setLastQueryId(lastQueryId);
+        String timezone = connectContext.getSessionVariable().getTimeZone();
+        long startTime = connectContext.getStartTime();
+        Map<String, String> sessionVariables = ImmutableMap.of();
+        long execMemLimit = 4L;
+        long loadMemLimit = 5L;
+        int timeout = 6;
+
+        LoadPlanner loadPlanner = new LoadPlanner(loadJobId, queryId, 0L, 0L,
+                new OlapTable(), false, timezone,
+                timeout, startTime, false, connectContext, sessionVariables, loadMemLimit, execMemLimit,
+                null, null, null, 0);
+
+        Coordinator coordinator = COORDINATOR_FACTORY.createStreamLoadScheduler(loadPlanner);
+        JobSpec jobSpec = coordinator.getJobSpec();
+
+        // Check created jobSpec.
+        Assert.assertEquals(loadJobId, jobSpec.getLoadJobId());
+        Assert.assertEquals(queryId, jobSpec.getQueryId());
+        Assert.assertEquals(lastQueryId.toString(), jobSpec.getQueryGlobals().getLast_query_id());
+        Assert.assertEquals(TQueryType.LOAD, jobSpec.getQueryOptions().getQuery_type());
+        Assert.assertEquals(TLoadJobType.STREAM_LOAD, jobSpec.getQueryOptions().getLoad_job_type());
+        Assert.assertEquals(timeout, jobSpec.getQueryOptions().getQuery_timeout());
+        Assert.assertEquals(loadMemLimit, jobSpec.getQueryOptions().getLoad_mem_limit());
+        Assert.assertEquals(execMemLimit, jobSpec.getQueryOptions().getMem_limit());
+        Assert.assertEquals(execMemLimit, jobSpec.getQueryOptions().getQuery_mem_limit());
+        Assert.assertTrue(jobSpec.isEnablePipeline());
+        Assert.assertFalse(jobSpec.isEnableStreamPipeline());
+        Assert.assertTrue(jobSpec.isBlockQuery());
+        Assert.assertEquals(LOAD_RESOURCE_GROUP, jobSpec.getResourceGroup());
+
+        // Check created jobSpec for sessionVariables.
+        Assert.assertEquals(TCompressionType.NO_COMPRESSION,
+                jobSpec.getQueryOptions().getLoad_transmission_compression_type());
+        Assert.assertFalse(jobSpec.getQueryOptions().isSetLog_rejected_record_num());
+
+        sessionVariables = ImmutableMap.of(
+                SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE, "LZ4",
+                BulkLoadJob.LOG_REJECTED_RECORD_NUM_SESSION_VARIABLE_KEY, "10"
+        );
+        loadPlanner = new LoadPlanner(loadJobId, queryId, 0L, 0L,
+                new OlapTable(), false, timezone,
+                timeout, startTime, false, connectContext, sessionVariables, loadMemLimit, execMemLimit,
+                null, null, null, 0);
+        coordinator = COORDINATOR_FACTORY.createStreamLoadScheduler(loadPlanner);
+        jobSpec = coordinator.getJobSpec();
+        Assert.assertEquals(TCompressionType.LZ4, jobSpec.getQueryOptions().getLoad_transmission_compression_type());
+        Assert.assertEquals(10L, jobSpec.getQueryOptions().getLog_rejected_record_num());
+
+        // Check negative execMemLimit.
+        execMemLimit = -1;
+        loadPlanner = new LoadPlanner(loadJobId, queryId, 0L, 0L,
+                new OlapTable(), false, timezone,
+                timeout, startTime, false, connectContext, sessionVariables, loadMemLimit, execMemLimit,
+                null, null, null, 0);
+        coordinator = COORDINATOR_FACTORY.createStreamLoadScheduler(loadPlanner);
+        jobSpec = coordinator.getJobSpec();
+        Assert.assertEquals(loadMemLimit, jobSpec.getQueryOptions().getLoad_mem_limit());
+        Assert.assertTrue(jobSpec.getQueryOptions().isSetMem_limit());
+        Assert.assertFalse(jobSpec.getQueryOptions().isSetQuery_mem_limit());
+    }
+
+    @Test
+    public void testFromNonPipelineBrokerLoadJobSpec() throws Exception {
+        Config.enable_pipeline_load = false;
+
+        // Prepare input arguments.
+        String sql = "insert into lineitem select * from lineitem";
+        ExecPlan execPlan = getExecPlan(sql);
+
+        long loadJobId = 1L;
+        TUniqueId queryId = new TUniqueId(2, 3);
+        DescriptorTable descTable = new DescriptorTable();
+        List<PlanFragment> fragments = execPlan.getFragments();
+        List<ScanNode> scanNodes = execPlan.getScanNodes();
+        String timezone = connectContext.getSessionVariable().getTimeZone();
+        long startTime = connectContext.getStartTime();
+        Map<String, String> sessionVariables = ImmutableMap.of();
+        long execMemLimit = 4L;
+
+        Coordinator coordinator = COORDINATOR_FACTORY.createNonPipelineBrokerLoadScheduler(
+                loadJobId, queryId, descTable, fragments, scanNodes, timezone, startTime,
+                sessionVariables,
+                connectContext,
+                execMemLimit);
+        JobSpec jobSpec = coordinator.getJobSpec();
+
+        // Check created jobSpec.
+        Assert.assertEquals(loadJobId, jobSpec.getLoadJobId());
+        Assert.assertEquals(queryId, jobSpec.getQueryId());
+        Assert.assertEquals(TQueryType.LOAD, jobSpec.getQueryOptions().getQuery_type());
+        Assert.assertEquals(execMemLimit, jobSpec.getQueryOptions().getMem_limit());
+        Assert.assertEquals(execMemLimit, jobSpec.getQueryOptions().getLoad_mem_limit());
+        Assert.assertFalse(jobSpec.isEnablePipeline());
+        Assert.assertFalse(jobSpec.isEnableStreamPipeline());
+        Assert.assertTrue(jobSpec.isBlockQuery());
+        Assert.assertEquals(LOAD_RESOURCE_GROUP, jobSpec.getResourceGroup());
+
+        // Check created jobSpec for sessionVariables.
+        Assert.assertFalse(jobSpec.getQueryOptions().isSetLoad_transmission_compression_type());
+        Assert.assertFalse(jobSpec.getQueryOptions().isSetLog_rejected_record_num());
+
+        sessionVariables = ImmutableMap.of(
+                SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE, "LZ4",
+                BulkLoadJob.LOG_REJECTED_RECORD_NUM_SESSION_VARIABLE_KEY, "10"
+        );
+        coordinator = COORDINATOR_FACTORY.createNonPipelineBrokerLoadScheduler(
+                loadJobId, queryId, descTable, fragments, scanNodes, timezone, startTime,
+                sessionVariables,
+                connectContext,
+                execMemLimit);
+        jobSpec = coordinator.getJobSpec();
+        Assert.assertEquals(TCompressionType.LZ4, jobSpec.getQueryOptions().getLoad_transmission_compression_type());
+        Assert.assertEquals(10L, jobSpec.getQueryOptions().getLog_rejected_record_num());
+    }
+
+    @Test
+    public void testFromBrokerExportSpec() throws Exception {
+        // Prepare input arguments.
+        String sql = "insert into lineitem select * from lineitem";
+        ExecPlan execPlan = getExecPlan(sql);
+
+        long loadJobId = 1L;
+        TUniqueId queryId = new TUniqueId(2, 3);
+        DescriptorTable descTable = new DescriptorTable();
+        List<PlanFragment> fragments = execPlan.getFragments();
+        List<ScanNode> scanNodes = execPlan.getScanNodes();
+        String timezone = connectContext.getSessionVariable().getTimeZone();
+        long startTime = connectContext.getStartTime();
+        Map<String, String> sessionVariables = ImmutableMap.of();
+        long execMemLimit = 4L;
+
+        Coordinator coordinator = COORDINATOR_FACTORY.createBrokerExportScheduler(
+                loadJobId, queryId, descTable, fragments, scanNodes, timezone, startTime,
+                sessionVariables,
+                execMemLimit);
+        JobSpec jobSpec = coordinator.getJobSpec();
+
+        // Check created jobSpec.
+        Assert.assertEquals(loadJobId, jobSpec.getLoadJobId());
+        Assert.assertEquals(queryId, jobSpec.getQueryId());
+        Assert.assertEquals(execMemLimit, jobSpec.getQueryOptions().getMem_limit());
+        Assert.assertTrue(jobSpec.isEnablePipeline());
+        Assert.assertFalse(jobSpec.isEnableStreamPipeline());
+        Assert.assertTrue(jobSpec.isBlockQuery());
+        Assert.assertEquals(QUERY_RESOURCE_GROUP, jobSpec.getResourceGroup()); // Export job doesn't setTQueryType.
+
+        // Check created jobSpec for sessionVariables.
+        Assert.assertFalse(jobSpec.getQueryOptions().isSetLoad_transmission_compression_type());
+        Assert.assertFalse(jobSpec.getQueryOptions().isSetLog_rejected_record_num());
+
+        sessionVariables = ImmutableMap.of(
+                SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE, "LZ4",
+                BulkLoadJob.LOG_REJECTED_RECORD_NUM_SESSION_VARIABLE_KEY, "10"
+        );
+        coordinator = COORDINATOR_FACTORY.createBrokerExportScheduler(
+                loadJobId, queryId, descTable, fragments, scanNodes, timezone, startTime,
+                sessionVariables,
+                execMemLimit);
+        jobSpec = coordinator.getJobSpec();
+
+        Assert.assertEquals(TCompressionType.LZ4, jobSpec.getQueryOptions().getLoad_transmission_compression_type());
+        Assert.assertEquals(10L, jobSpec.getQueryOptions().getLog_rejected_record_num());
+    }
+
+    @Test
+    public void testFromSyncStreamLoadSpec(@Mocked StreamLoadPlanner planner) throws Exception {
+        TUniqueId queryId = new TUniqueId(2, 3);
+        new Expectations(planner) {
+            {
+                planner.getExecPlanFragmentParams();
+                result = new TExecPlanFragmentParams().setParams(
+                        new TPlanFragmentExecParams().setFragment_instance_id(queryId));
+            }
+        };
+
+        Coordinator coordinator = COORDINATOR_FACTORY.createSyncStreamLoadScheduler(planner, new TNetworkAddress());
+        JobSpec jobSpec = coordinator.getJobSpec();
+
+        // Check created jobSpec.
+        Assert.assertEquals(queryId, jobSpec.getQueryId());
+        Assert.assertFalse(jobSpec.isEnablePipeline());
+        Assert.assertFalse(jobSpec.isEnableStreamPipeline());
+        Assert.assertNull(jobSpec.getResourceGroup());
+
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JoinTest.java
@@ -19,7 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.load.loadv2.LoadJob;
-import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.task.LoadEtlTask;
 import com.starrocks.thrift.FrontendServiceVersion;
@@ -49,7 +49,7 @@ public class JoinTest extends SchedulerTestBase {
     @Test
     public void testCancelAtJoining() throws Exception {
         String sql = "insert into lineitem select * from lineitem";
-        Coordinator scheduler = startScheduling(sql);
+        DefaultCoordinator scheduler = startScheduling(sql);
 
         AtomicBoolean joinFinished = new AtomicBoolean(false);
         Thread joinThread = new Thread(() -> joinFinished.set(scheduler.join(300)));
@@ -67,7 +67,7 @@ public class JoinTest extends SchedulerTestBase {
     @Test
     public void testBackendBecomeDeadAtJoining() throws Exception {
         String sql = "insert into lineitem select * from lineitem";
-        Coordinator scheduler = startScheduling(sql);
+        DefaultCoordinator scheduler = startScheduling(sql);
 
         AtomicBoolean joinFinished = new AtomicBoolean(false);
         Thread joinThread = new Thread(() -> joinFinished.set(scheduler.join(300)));
@@ -89,7 +89,7 @@ public class JoinTest extends SchedulerTestBase {
     @Test
     public void testReportFailedExecutionAtJoining() throws Exception {
         String sql = "insert into lineitem select * from lineitem";
-        Coordinator scheduler = startScheduling(sql);
+        DefaultCoordinator scheduler = startScheduling(sql);
 
         AtomicBoolean joinFinished = new AtomicBoolean(false);
         Thread joinThread = new Thread(() -> joinFinished.set(scheduler.join(300)));
@@ -113,7 +113,7 @@ public class JoinTest extends SchedulerTestBase {
     @Test
     public void testJoinFinishSuccessfully() throws Exception {
         String sql = "insert into lineitem select * from lineitem";
-        Coordinator scheduler = startScheduling(sql);
+        DefaultCoordinator scheduler = startScheduling(sql);
 
         AtomicBoolean joinFinished = new AtomicBoolean(false);
         Thread joinThread = new Thread(() -> joinFinished.set(scheduler.join(300)));
@@ -128,7 +128,7 @@ public class JoinTest extends SchedulerTestBase {
 
             scheduler.updateFragmentExecStatus(request);
         });
-        for (Coordinator.BackendExecState execution : scheduler.getBackendExecutions()) {
+        for (DefaultCoordinator.BackendExecState execution : scheduler.getBackendExecutions()) {
             Assert.assertFalse(execution.isFinished());
         }
         Assert.assertFalse(joinFinished.get());
@@ -199,7 +199,7 @@ public class JoinTest extends SchedulerTestBase {
                 scheduler.updateFragmentExecStatus(request);
             });
         }
-        for (Coordinator.BackendExecState execution : scheduler.getBackendExecutions()) {
+        for (DefaultCoordinator.BackendExecState execution : scheduler.getBackendExecutions()) {
             Assert.assertTrue(execution.isFinished());
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/JoinTest.java
@@ -1,0 +1,224 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.load.loadv2.LoadJob;
+import com.starrocks.qe.Coordinator;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.task.LoadEtlTask;
+import com.starrocks.thrift.FrontendServiceVersion;
+import com.starrocks.thrift.TReportExecStatusParams;
+import com.starrocks.thrift.TSinkCommitInfo;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TTabletCommitInfo;
+import com.starrocks.thrift.TTabletFailInfo;
+import mockit.Mock;
+import mockit.MockUp;
+import org.awaitility.Awaitility;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+public class JoinTest extends SchedulerTestBase {
+
+    @Test
+    public void testCancelAtJoining() throws Exception {
+        String sql = "insert into lineitem select * from lineitem";
+        Coordinator scheduler = startScheduling(sql);
+
+        AtomicBoolean joinFinished = new AtomicBoolean(false);
+        Thread joinThread = new Thread(() -> joinFinished.set(scheduler.join(300)));
+        joinThread.start();
+
+        Thread.sleep(2_000L);
+        scheduler.cancel();
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(joinFinished::get);
+
+        Assert.assertTrue(scheduler.isDone());
+        Assert.assertTrue(scheduler.checkBackendState());
+        Assert.assertTrue(scheduler.getExecStatus().isCancelled());
+    }
+
+    @Test
+    public void testBackendBecomeDeadAtJoining() throws Exception {
+        String sql = "insert into lineitem select * from lineitem";
+        Coordinator scheduler = startScheduling(sql);
+
+        AtomicBoolean joinFinished = new AtomicBoolean(false);
+        Thread joinThread = new Thread(() -> joinFinished.set(scheduler.join(300)));
+        joinThread.start();
+
+        new MockUp<ComputeNode>() {
+            @Mock
+            public long getLastMissingHeartbeatTime() {
+                return 10L;
+            }
+        };
+        Awaitility.await().atMost(7, TimeUnit.SECONDS).until(joinFinished::get);
+
+        Assert.assertFalse(scheduler.isDone());
+        Assert.assertFalse(scheduler.checkBackendState());
+        Assert.assertEquals(TStatusCode.INTERNAL_ERROR, scheduler.getExecStatus().getErrorCode());
+    }
+
+    @Test
+    public void testReportFailedExecutionAtJoining() throws Exception {
+        String sql = "insert into lineitem select * from lineitem";
+        Coordinator scheduler = startScheduling(sql);
+
+        AtomicBoolean joinFinished = new AtomicBoolean(false);
+        Thread joinThread = new Thread(() -> joinFinished.set(scheduler.join(300)));
+        joinThread.start();
+
+        scheduler.getBackendNums().forEach(indexInJob -> {
+            TReportExecStatusParams request = new TReportExecStatusParams(FrontendServiceVersion.V1);
+            request.setBackend_num(indexInJob);
+            request.setDone(true);
+            request.setStatus(new TStatus(TStatusCode.INTERNAL_ERROR));
+
+            scheduler.updateFragmentExecStatus(request);
+        });
+
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(joinFinished::get);
+
+        Assert.assertTrue(scheduler.isDone());
+        Assert.assertEquals(TStatusCode.INTERNAL_ERROR, scheduler.getExecStatus().getErrorCode());
+    }
+
+    @Test
+    public void testJoinFinishSuccessfully() throws Exception {
+        String sql = "insert into lineitem select * from lineitem";
+        Coordinator scheduler = startScheduling(sql);
+
+        AtomicBoolean joinFinished = new AtomicBoolean(false);
+        Thread joinThread = new Thread(() -> joinFinished.set(scheduler.join(300)));
+        joinThread.start();
+
+        // Receive non-EOS updateFragmentExecStatus for each Execution.
+        scheduler.getBackendNums().forEach(indexInJob -> {
+            TReportExecStatusParams request = new TReportExecStatusParams(FrontendServiceVersion.V1);
+            request.setBackend_num(indexInJob);
+            request.setDone(false);
+            request.setStatus(new TStatus(TStatusCode.OK));
+
+            scheduler.updateFragmentExecStatus(request);
+        });
+        for (Coordinator.BackendExecState execution : scheduler.getBackendExecutions()) {
+            Assert.assertFalse(execution.isFinished());
+        }
+        Assert.assertFalse(joinFinished.get());
+
+        // Receive duplicated EOS updateFragmentExecStatus for each Execution.
+        final List<String> deltaUrls = Lists.newArrayList();
+        final Map<String, Long> loadCounters = Maps.newHashMap();
+        String trackingUrl = "track_url";
+        final List<String> exportFiles = Lists.newArrayList();
+        final List<TTabletCommitInfo> commitInfos = Lists.newArrayList();
+        final List<TTabletFailInfo> failInfos = Lists.newArrayList();
+        final Set<String> rejectedRecordPaths = Sets.newHashSet();
+        final List<TSinkCommitInfo> sinkCommitInfos = Lists.newArrayList();
+        for (int i = 0; i < 2; i++) {
+            final int finalIndex = i;
+            scheduler.getBackendExecutions().forEach(execution -> {
+                int indexInJob = execution.getIndexInJob();
+
+                TReportExecStatusParams request = new TReportExecStatusParams(FrontendServiceVersion.V1);
+
+                request.setBackend_num(indexInJob)
+                        .setDone(true)
+                        .setStatus(new TStatus(TStatusCode.OK))
+                        .setFragment_instance_id(execution.getInstanceId());
+
+                String deltaUrl = "delta_url-" + indexInJob + "-" + finalIndex;
+                request.setDelta_urls(Collections.singletonList(deltaUrl));
+
+                request.setTracking_url(trackingUrl);
+
+                String exportFile = "export_file-" + indexInJob + "-" + finalIndex;
+                request.setExport_files(Collections.singletonList(exportFile));
+
+                TTabletCommitInfo commitInfo = new TTabletCommitInfo(indexInJob, indexInJob);
+                request.setCommitInfos(Collections.singletonList(commitInfo));
+
+                TTabletFailInfo failInfo = new TTabletFailInfo();
+                request.setFailInfos(Collections.singletonList(failInfo));
+
+                String rejectedRecordPath = "rejectedRecordPath-" + indexInJob + "-" + finalIndex;
+                request.setRejected_record_path(rejectedRecordPath);
+
+                TSinkCommitInfo sinkCommitInfo = new TSinkCommitInfo();
+                request.setSink_commit_infos(Collections.singletonList(sinkCommitInfo));
+
+                Map<String, String> currLoadCounters = ImmutableMap.of(
+                        LoadEtlTask.DPP_NORMAL_ALL, String.valueOf(finalIndex + 10),
+                        LoadEtlTask.DPP_ABNORMAL_ALL, String.valueOf(finalIndex + 20),
+                        LoadJob.UNSELECTED_ROWS, String.valueOf(finalIndex + 30),
+                        LoadJob.LOADED_BYTES, String.valueOf(finalIndex + 40)
+                );
+                request.setLoad_counters(currLoadCounters);
+
+                if (finalIndex == 0) {
+                    deltaUrls.add(deltaUrl);
+                    exportFiles.add(exportFile);
+                    commitInfos.add(commitInfo);
+                    failInfos.add(failInfo);
+                    rejectedRecordPaths.add(execution.getAddress().getHostname() + ":" + rejectedRecordPath);
+                    sinkCommitInfos.add(sinkCommitInfo);
+
+                    currLoadCounters.forEach((key, value) -> {
+                        long longValue = Long.parseLong(value);
+                        loadCounters.compute(key, (k, v) -> v == null ? longValue : v + longValue);
+                    });
+                }
+
+                scheduler.updateFragmentExecStatus(request);
+            });
+        }
+        for (Coordinator.BackendExecState execution : scheduler.getBackendExecutions()) {
+            Assert.assertTrue(execution.isFinished());
+        }
+
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(joinFinished::get);
+
+        Assert.assertTrue(scheduler.isDone());
+        Assert.assertTrue(scheduler.getExecStatus().ok());
+
+        // Check updateLoadInformation.
+        Assert.assertEquals(deltaUrls, scheduler.getDeltaUrls());
+        Assert.assertEquals(trackingUrl, scheduler.getTrackingUrl());
+        Assert.assertEquals(exportFiles, scheduler.getExportFiles());
+        Assert.assertEquals(commitInfos, scheduler.getCommitInfos());
+        Assert.assertEquals(failInfos, scheduler.getFailInfos());
+        Assert.assertEquals(new ArrayList<>(rejectedRecordPaths), scheduler.getRejectedRecordPaths());
+        Assert.assertEquals(sinkCommitInfos, scheduler.getSinkCommitInfos());
+
+        Map<String, String> stringLoadCounters = loadCounters.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> String.valueOf(entry.getValue())));
+        Assert.assertEquals(stringLoadCounters, scheduler.getLoadCounters());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerConnectorTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerConnectorTestBase.java
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.google.common.collect.Maps;
+import com.starrocks.common.DdlException;
+import com.starrocks.connector.MockedMetadataMgr;
+import com.starrocks.connector.hive.MockedHiveMetadata;
+import com.starrocks.server.GlobalStateMgr;
+import org.junit.BeforeClass;
+
+import java.util.Map;
+
+public class SchedulerConnectorTestBase extends SchedulerTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        SchedulerTestBase.beforeClass();
+
+        GlobalStateMgr gsmMgr = connectContext.getGlobalStateMgr();
+        MockedMetadataMgr metadataMgr = new MockedMetadataMgr(gsmMgr.getLocalMetastore(), gsmMgr.getConnectorMgr());
+        gsmMgr.setMetadataMgr(metadataMgr);
+
+        mockHiveCatalogImpl(metadataMgr);
+    }
+
+    private static void mockHiveCatalogImpl(MockedMetadataMgr metadataMgr) throws DdlException {
+        Map<String, String> properties = Maps.newHashMap();
+
+        properties.put("type", "hive");
+        properties.put("hive.metastore.uris", "thrift://127.0.0.1:9083");
+        GlobalStateMgr.getCurrentState().getCatalogMgr().createCatalog("hive", "hive0", "", properties);
+
+        MockedHiveMetadata mockedHiveMetadata = new MockedHiveMetadata();
+        metadataMgr.registerMockedMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME, mockedHiveMetadata);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestBase.java
@@ -1,0 +1,222 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.MockTpchStatisticStorage;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class SchedulerTestBase extends SchedulerTestNoneDBBase {
+    private static final String DB_NAME = "test";
+    private static final AtomicLong COLOCATE_GROUP_INDEX = new AtomicLong(0L);
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        SchedulerTestNoneDBBase.beforeClass();
+
+        starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
+
+        final String tpchGroup = "tpch_group_" + COLOCATE_GROUP_INDEX.getAndIncrement();
+
+        // NOTE: Please do not change the order of the following create table statements.
+        // Modifying the order will result in changes to the partition ids and tablet ids of a table,
+        // which are relied upon by the scheduler plan.
+        starRocksAssert.withTable("CREATE TABLE lineitem (\n" +
+                "    L_ORDERKEY INTEGER NOT NULL,\n" +
+                "    L_PARTKEY INTEGER NOT NULL,\n" +
+                "    L_SUPPKEY INTEGER NOT NULL,\n" +
+                "    L_LINENUMBER INTEGER NOT NULL,\n" +
+                "    L_QUANTITY double NOT NULL,\n" +
+                "    L_EXTENDEDPRICE double NOT NULL,\n" +
+                "    L_DISCOUNT double NOT NULL,\n" +
+                "    L_TAX double NOT NULL,\n" +
+                "    L_RETURNFLAG CHAR(1) NOT NULL,\n" +
+                "    L_LINESTATUS CHAR(1) NOT NULL,\n" +
+                "    L_SHIPDATE DATE NOT NULL,\n" +
+                "    L_COMMITDATE DATE NOT NULL,\n" +
+                "    L_RECEIPTDATE DATE NOT NULL,\n" +
+                "    L_SHIPINSTRUCT CHAR(25) NOT NULL,\n" +
+                "    L_SHIPMODE CHAR(10) NOT NULL,\n" +
+                "    L_COMMENT VARCHAR(44) NOT NULL,\n" +
+                "    PAD char(1) NOT NULL\n" +
+                ") ENGINE = OLAP \n" +
+                "DUPLICATE KEY(`l_orderkey`) \n" +
+                "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 20 \n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");\n");
+
+        starRocksAssert.withTable("CREATE TABLE `lineitem_partition` (\n" +
+                "  `L_ORDERKEY` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `L_PARTKEY` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `L_SUPPKEY` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `L_LINENUMBER` int(11) NOT NULL COMMENT \"\",\n" +
+                "  `L_QUANTITY` double NOT NULL COMMENT \"\",\n" +
+                "  `L_EXTENDEDPRICE` double NOT NULL COMMENT \"\",\n" +
+                "  `L_DISCOUNT` double NOT NULL COMMENT \"\",\n" +
+                "  `L_TAX` double NOT NULL COMMENT \"\",\n" +
+                "  `L_RETURNFLAG` char(1) NOT NULL COMMENT \"\",\n" +
+                "  `L_LINESTATUS` char(1) NOT NULL COMMENT \"\",\n" +
+                "  `L_SHIPDATE` date NOT NULL COMMENT \"\",\n" +
+                "  `L_COMMITDATE` date NOT NULL COMMENT \"\",\n" +
+                "  `L_RECEIPTDATE` date NOT NULL COMMENT \"\",\n" +
+                "  `L_SHIPINSTRUCT` char(25) NOT NULL COMMENT \"\",\n" +
+                "  `L_SHIPMODE` char(10) NOT NULL COMMENT \"\",\n" +
+                "  `L_COMMENT` varchar(44) NOT NULL COMMENT \"\",\n" +
+                "  `PAD` char(1) NOT NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`L_ORDERKEY`, `L_PARTKEY`, `L_SUPPKEY`)\n" +
+                "PARTITION BY RANGE(`L_SHIPDATE`)\n" +
+                "(PARTITION p1992 VALUES [('1992-01-01'), ('1993-01-01')),\n" +
+                "PARTITION p1993 VALUES [('1993-01-01'), ('1994-01-01')),\n" +
+                "PARTITION p1994 VALUES [('1994-01-01'), ('1995-01-01')),\n" +
+                "PARTITION p1995 VALUES [('1995-01-01'), ('1996-01-01')),\n" +
+                "PARTITION p1996 VALUES [('1996-01-01'), ('1997-01-01')),\n" +
+                "PARTITION p1997 VALUES [('1997-01-01'), ('1998-01-01')),\n" +
+                "PARTITION p1998 VALUES [('1998-01-01'), ('1999-01-01')))\n" +
+                "DISTRIBUTED BY HASH(`L_ORDERKEY`) BUCKETS 18\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\",\n" +
+                "    \"colocate_with\" = \"" + tpchGroup + "\"\n" +
+                ");");
+
+        starRocksAssert.withTable("CREATE TABLE customer (\n" +
+                "    c_custkey       INT NOT NULL,\n" +
+                "    c_name          VARCHAR(25) NOT NULL,\n" +
+                "    c_address       VARCHAR(40) NOT NULL,\n" +
+                "    c_nationkey     INT NOT NULL,\n" +
+                "    c_phone         VARCHAR(15) NOT NULL,\n" +
+                "    c_acctbal       DECIMAL(15, 2) NOT NULL,\n" +
+                "    c_mktsegment    VARCHAR(10) NOT NULL,\n" +
+                "    c_comment       VARCHAR(117) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`c_custkey`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 24\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");");
+
+        starRocksAssert.withTable("CREATE TABLE `nation` (\n" +
+                "    n_nationkey   INT(11) NOT NULL,\n" +
+                "    n_name        VARCHAR(25) NOT NULL,\n" +
+                "    n_regionkey   INT(11) NOT NULL,\n" +
+                "    n_comment     VARCHAR(152) NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`N_NATIONKEY`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`N_NATIONKEY`) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");");
+
+        starRocksAssert.withTable("CREATE TABLE orders (\n" +
+                "    o_orderkey       INT NOT NULL,\n" +
+                "    o_orderdate      DATE NOT NULL,\n" +
+                "    o_custkey        INT NOT NULL,\n" +
+                "    o_orderstatus    VARCHAR(1) NOT NULL,\n" +
+                "    o_totalprice     DECIMAL(15, 2) NOT NULL,\n" +
+                "    o_orderpriority  VARCHAR(15) NOT NULL,\n" +
+                "    o_clerk          VARCHAR(15) NOT NULL,\n" +
+                "    o_shippriority   INT NOT NULL,\n" +
+                "    o_comment        VARCHAR(79) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`o_orderkey`, `o_orderdate`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`o_orderkey`) BUCKETS 18\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\",\n" +
+                "    \"colocate_with\" = \"" + tpchGroup + "\"\n" +
+                ");");
+
+        starRocksAssert.withTable("CREATE TABLE part (\n" +
+                "    p_partkey       INT NOT NULL,\n" +
+                "    p_name          VARCHAR(55) NOT NULL,\n" +
+                "    p_mfgr          VARCHAR(25) NOT NULL,\n" +
+                "    p_brand         VARCHAR(10) NOT NULL,\n" +
+                "    p_type          VARCHAR(25) NOT NULL,\n" +
+                "    p_size          INT NOT NULL,\n" +
+                "    p_container     VARCHAR(10) NOT NULL,\n" +
+                "    p_retailprice   DECIMAL(15, 2) NOT NULL,\n" +
+                "    p_comment       VARCHAR(23) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`p_partkey`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`p_partkey`) BUCKETS 18\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\",\n" +
+                "    \"colocate_with\" = \"" + tpchGroup + "\"\n" +
+                ");");
+
+        starRocksAssert.withTable("CREATE TABLE partsupp (\n" +
+                "    ps_partkey      INT NOT NULL,\n" +
+                "    ps_suppkey      INT NOT NULL,\n" +
+                "    ps_availqty     INT NOT NULL,\n" +
+                "    ps_supplycost   DECIMAL(15, 2) NOT NULL,\n" +
+                "    ps_comment      VARCHAR(199) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`ps_partkey`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`ps_partkey`) BUCKETS 18\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\",\n" +
+                "    \"colocate_with\" = \"" + tpchGroup + "\"\n" +
+                ");");
+
+        starRocksAssert.withTable("CREATE TABLE region (\n" +
+                "    r_regionkey     INT NOT NULL,\n" +
+                "    r_name          VARCHAR(25) NOT NULL,\n" +
+                "    r_comment       VARCHAR(152)\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`r_regionkey`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`r_regionkey`) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");");
+
+        starRocksAssert.withTable("CREATE TABLE supplier (\n" +
+                "    s_suppkey       INT NOT NULL,\n" +
+                "    s_name          VARCHAR(25) NOT NULL,\n" +
+                "    s_address       VARCHAR(40) NOT NULL,\n" +
+                "    s_nationkey     INT NOT NULL,\n" +
+                "    s_phone         VARCHAR(15) NOT NULL,\n" +
+                "    s_acctbal       DECIMAL(15, 2) NOT NULL,\n" +
+                "    s_comment       VARCHAR(101) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`s_suppkey`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "DISTRIBUTED BY HASH(`s_suppkey`) BUCKETS 12\n" +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\"\n" +
+                ");");
+
+        connectContext.getGlobalStateMgr().setStatisticStorage(new MockTpchStatisticStorage(connectContext, 100));
+        GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().clear();
+
+        FeConstants.runningUnitTest = true;
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        FeConstants.runningUnitTest = false;
+
+        SchedulerTestNoneDBBase.afterClass();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestNoneDBBase.java
@@ -1,0 +1,186 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.catalog.CatalogIdGenerator;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.qe.Coordinator;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.PBackendService;
+import com.starrocks.sql.plan.PlanTestNoneDBBase;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class SchedulerTestNoneDBBase extends PlanTestNoneDBBase {
+    protected static final long BACKEND1_ID = 10001L;
+    protected static Backend backend2 = null;
+    protected static Backend backend3 = null;
+
+    private static final String FILE_UNIT_TEST_ROOT_PATH =
+            Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResource("sql")).getPath();
+
+    public static List<String> listTestFileNames(String directory) {
+        File folder = new File(FILE_UNIT_TEST_ROOT_PATH + "/" + directory);
+        return Arrays.stream(Objects.requireNonNull(folder.listFiles()))
+                .filter(file -> file.isFile() && file.getName().endsWith(".sql"))
+                .map(file -> directory + file.getName().replace(".sql", ""))
+                .collect(Collectors.toList());
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestNoneDBBase.beforeClass(); // Added mockBackend(10001).
+        backend2 = UtFrameUtils.addMockBackend(10002, "127.0.0.2", 9060);
+        backend3 = UtFrameUtils.addMockBackend(10003, "127.0.0.3", 9060);
+
+        makeCreateTabletStable();
+
+        Config.tablet_sched_disable_colocate_overall_balance = true;
+        connectContext.getSessionVariable().setPipelineDop(16);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        try {
+            UtFrameUtils.dropMockBackend(10002);
+            UtFrameUtils.dropMockBackend(10003);
+        } catch (DdlException e) {
+            e.printStackTrace();
+        }
+
+        Config.tablet_sched_disable_colocate_overall_balance = false;
+        connectContext.getSessionVariable().setPipelineDop(0);
+    }
+
+    @Before
+    public void makeQueryRandomStableBeforeTestCase() {
+        makeQueryRandomStable();
+    }
+
+    public Coordinator startScheduling(String sql) throws Exception {
+        return UtFrameUtils.startScheduling(connectContext, sql);
+    }
+
+    public Coordinator getScheduler(String sql) throws Exception {
+        return UtFrameUtils.getScheduler(connectContext, sql);
+    }
+
+    public static void makeQueryRandomStable() {
+        resetNextBackendIndex();
+        resetRandomNextInt();
+    }
+
+    public static void makeCreateTabletStable() {
+        resetCatalogIdGenerator();
+        resetChooseBackendIds();
+    }
+
+    public static void setBackendService(PBackendService backendService) {
+        new MockUp<BrpcProxy>() {
+            @Mock
+            private synchronized PBackendService getBackendService(TNetworkAddress address) {
+                return backendService;
+            }
+        };
+    }
+
+    public static void setBackendService(Function<TNetworkAddress, PBackendService> supplier) {
+        new MockUp<BrpcProxy>() {
+            @Mock
+            private synchronized PBackendService getBackendService(TNetworkAddress address) {
+                return supplier.apply(address);
+            }
+        };
+    }
+
+    private static void resetNextBackendIndex() {
+        Thread currentThread = Thread.currentThread();
+        AtomicInteger currentThreadIndex = new AtomicInteger(0);
+        AtomicInteger otherThreadIndex = new AtomicInteger(0);
+        new MockUp<WorkerProvider>() {
+            @Mock
+            int getNextBackendIndex() {
+                if (currentThread == Thread.currentThread()) {
+                    return currentThreadIndex.getAndIncrement();
+                } else {
+                    return otherThreadIndex.getAndIncrement();
+                }
+            }
+        };
+    }
+
+    private static void resetRandomNextInt() {
+        Thread currentThread = Thread.currentThread();
+        AtomicInteger currentThreadIndex = new AtomicInteger(0);
+        AtomicInteger otherThreadIndex = new AtomicInteger(0);
+        new MockUp<Random>() {
+            @Mock
+            public int nextInt(int bound) {
+                if (currentThread == Thread.currentThread()) {
+                    return currentThreadIndex.getAndIncrement() % bound;
+                } else {
+                    return otherThreadIndex.getAndIncrement() % bound;
+                }
+            }
+        };
+    }
+
+    private static void resetCatalogIdGenerator() {
+        AtomicLong nextId = new AtomicLong(1000L);
+        new MockUp<CatalogIdGenerator>() {
+            @Mock
+            public synchronized long getNextId() {
+                return nextId.getAndIncrement();
+            }
+        };
+    }
+
+    private static void resetChooseBackendIds() {
+        AtomicInteger nextBackendIndex = new AtomicInteger(0);
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public synchronized List<Long> seqChooseBackendIds(int backendNum, boolean needAvailable, boolean isCreate,
+                                                               final List<Backend> srcBackends) {
+                List<Long> backendIds = new ArrayList<>(backendNum);
+                for (int i = 0; i < backendNum; i++) {
+                    int index = nextBackendIndex.getAndIncrement();
+                    long id = srcBackends.get(index % srcBackends.size()).getId();
+                    backendIds.add(id);
+                }
+                return backendIds;
+            }
+        };
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestNoneDBBase.java
@@ -17,7 +17,7 @@ package com.starrocks.qe.scheduler;
 import com.starrocks.catalog.CatalogIdGenerator;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
-import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.PBackendService;
 import com.starrocks.sql.plan.PlanTestNoneDBBase;
@@ -88,11 +88,11 @@ public class SchedulerTestNoneDBBase extends PlanTestNoneDBBase {
         makeQueryRandomStable();
     }
 
-    public Coordinator startScheduling(String sql) throws Exception {
+    public DefaultCoordinator startScheduling(String sql) throws Exception {
         return UtFrameUtils.startScheduling(connectContext, sql);
     }
 
-    public Coordinator getScheduler(String sql) throws Exception {
+    public DefaultCoordinator getScheduler(String sql) throws Exception {
         return UtFrameUtils.getScheduler(connectContext, sql);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/StartSchedulingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/StartSchedulingTest.java
@@ -18,7 +18,7 @@ import com.starrocks.common.Reference;
 import com.starrocks.common.UserException;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.StatusPB;
-import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.SimpleScheduler;
 import com.starrocks.rpc.PExecPlanFragmentRequest;
 import com.starrocks.rpc.RpcException;
@@ -63,7 +63,7 @@ public class StartSchedulingTest extends SchedulerTestBase {
         setBackendService(new MockPBackendService());
 
         String sql = "select count(1) from lineitem";
-        Coordinator scheduler = startScheduling(sql);
+        DefaultCoordinator scheduler = startScheduling(sql);
 
         Assert.assertTrue(scheduler.getExecStatus().ok());
     }
@@ -113,7 +113,7 @@ public class StartSchedulingTest extends SchedulerTestBase {
         Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> !SimpleScheduler.isInBlacklist(backend3.getId()));
 
         deployFuture.setRef(mockFutureWithException(new InterruptedException("test interrupted exception")));
-        Coordinator scheduler = getScheduler(sql);
+        DefaultCoordinator scheduler = getScheduler(sql);
         Assert.assertThrows("test interrupted exception", UserException.class, () -> scheduler.startScheduling());
 
         // The deployed executions haven't reported.
@@ -181,7 +181,7 @@ public class StartSchedulingTest extends SchedulerTestBase {
             });
 
             String sql = "select count(1) from lineitem t1 JOIN [shuffle] lineitem t2 using(l_orderkey)";
-            Coordinator scheduler = getScheduler(sql);
+            DefaultCoordinator scheduler = getScheduler(sql);
             Assert.assertThrows("deploy query timeout", UserException.class, () -> scheduler.startScheduling());
         } finally {
             connectContext.getSessionVariable().setQueryDeliveryTimeoutS(prevQueryDeliveryTimeoutSecond);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/StartSchedulingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/StartSchedulingTest.java
@@ -1,0 +1,231 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.common.Reference;
+import com.starrocks.common.UserException;
+import com.starrocks.proto.PExecPlanFragmentResult;
+import com.starrocks.proto.StatusPB;
+import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.SimpleScheduler;
+import com.starrocks.rpc.PExecPlanFragmentRequest;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.thrift.FrontendServiceVersion;
+import com.starrocks.thrift.TReportExecStatusParams;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import org.awaitility.Awaitility;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.starrocks.utframe.MockedBackend.MockPBackendService;
+
+public class StartSchedulingTest extends SchedulerTestBase {
+    private boolean originalEnableProfile;
+
+    @Before
+    public void before() {
+        originalEnableProfile = connectContext.getSessionVariable().isEnableProfile();
+
+        connectContext.getSessionVariable().setEnableDeliverBatchFragments(false);
+    }
+
+    @After
+    public void after() {
+        connectContext.getSessionVariable().setEnableProfile(originalEnableProfile);
+
+        connectContext.getSessionVariable().setEnableDeliverBatchFragments(true);
+    }
+
+    @Test
+    public void testDeploySuccess() throws Exception {
+        setBackendService(new MockPBackendService());
+
+        String sql = "select count(1) from lineitem";
+        Coordinator scheduler = startScheduling(sql);
+
+        Assert.assertTrue(scheduler.getExecStatus().ok());
+    }
+
+    @Test
+    public void testDeployReturnErrorStatus() {
+        setBackendService(new MockPBackendService() {
+            @Override
+            public Future<PExecPlanFragmentResult> execPlanFragmentAsync(PExecPlanFragmentRequest request) {
+                return submit(() -> {
+                    PExecPlanFragmentResult result = new PExecPlanFragmentResult();
+                    StatusPB pStatus = new StatusPB();
+                    pStatus.statusCode = TStatusCode.INTERNAL_ERROR.getValue();
+                    pStatus.errorMsgs = Collections.singletonList("test error message");
+                    result.status = pStatus;
+                    return result;
+                });
+            }
+        });
+
+        String sql = "select count(1) from lineitem";
+        Assert.assertThrows("test error message", UserException.class, () -> startScheduling(sql));
+    }
+
+    @Test
+    public void testDeployFutureThrowException() throws Exception {
+        connectContext.getSessionVariable().setEnableProfile(true);
+
+        Reference<Future<PExecPlanFragmentResult>> deployFuture = new Reference<>();
+        setBackendService(address -> {
+            if (!backend3.getHost().equals(address.getHostname())) {
+                return new MockPBackendService();
+            }
+            return new MockPBackendService() {
+                @Override
+                public Future<PExecPlanFragmentResult> execPlanFragmentAsync(PExecPlanFragmentRequest request) {
+                    return deployFuture.getRef();
+                }
+            };
+        });
+
+        String sql = "select count(1) from lineitem t1 JOIN [shuffle] lineitem t2 using(l_orderkey)";
+
+        deployFuture.setRef(
+                mockFutureWithException(new ExecutionException("test execution exception", new Exception())));
+        Assert.assertThrows("test execution exception", RpcException.class, () -> startScheduling(sql));
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> !SimpleScheduler.isInBlacklist(backend3.getId()));
+
+        deployFuture.setRef(mockFutureWithException(new InterruptedException("test interrupted exception")));
+        Coordinator scheduler = getScheduler(sql);
+        Assert.assertThrows("test interrupted exception", UserException.class, () -> scheduler.startScheduling());
+
+        // The deployed executions haven't reported.
+        Assert.assertFalse(scheduler.isDone());
+
+        // Shouldn't deploy the rest instances, when the previous instance deployment failed.
+        Assert.assertTrue(scheduler.getBackendNums().size() < scheduler.getInstanceIds().size());
+        // Receive execution reports.
+        scheduler.getBackendExecutions().forEach(execution -> {
+            TReportExecStatusParams request = new TReportExecStatusParams(FrontendServiceVersion.V1);
+            request.setBackend_num(execution.getIndexInJob());
+            request.setDone(true);
+            request.setStatus(new TStatus(TStatusCode.CANCELLED));
+            request.setFragment_instance_id(execution.getInstanceId());
+
+            scheduler.updateFragmentExecStatus(request);
+        });
+        Assert.assertTrue(scheduler.isDone());
+    }
+
+    @Test
+    public void testDeployThrowException() {
+        setBackendService(address -> {
+            if (!backend3.getHost().equals(address.getHostname())) {
+                return new MockPBackendService();
+            }
+            return new MockPBackendService() {
+                @Override
+                public Future<PExecPlanFragmentResult> execPlanFragmentAsync(PExecPlanFragmentRequest request) {
+                    throw new RuntimeException("test runtime exception");
+                }
+            };
+        });
+
+        String sql = "select count(1) from lineitem";
+
+        Assert.assertThrows("test runtime exception", RpcException.class, () -> startScheduling(sql));
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> !SimpleScheduler.isInBlacklist(backend3.getId()));
+    }
+
+    @Test
+    public void testDeployTimeout() throws Exception {
+        int prevQueryDeliveryTimeoutSecond = connectContext.getSessionVariable().getQueryDeliveryTimeoutS();
+
+        try {
+            connectContext.getSessionVariable().setQueryDeliveryTimeoutS(1);
+
+            setBackendService(new MockPBackendService() {
+                @Override
+                public Future<PExecPlanFragmentResult> execPlanFragmentAsync(PExecPlanFragmentRequest request) {
+                    return submit(() -> {
+                        try {
+                            Thread.sleep(5_000L);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+
+                        PExecPlanFragmentResult result = new PExecPlanFragmentResult();
+                        StatusPB pStatus = new StatusPB();
+                        pStatus.statusCode = 0;
+                        result.status = pStatus;
+                        return result;
+                    });
+                }
+            });
+
+            String sql = "select count(1) from lineitem t1 JOIN [shuffle] lineitem t2 using(l_orderkey)";
+            Coordinator scheduler = getScheduler(sql);
+            Assert.assertThrows("deploy query timeout", UserException.class, () -> scheduler.startScheduling());
+        } finally {
+            connectContext.getSessionVariable().setQueryDeliveryTimeoutS(prevQueryDeliveryTimeoutSecond);
+        }
+    }
+
+    private static Future<PExecPlanFragmentResult> mockFutureWithException(Exception exception) {
+
+        return new Future<PExecPlanFragmentResult>() {
+
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                return false;
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return false;
+            }
+
+            @Override
+            public boolean isDone() {
+                return false;
+            }
+
+            @Override
+            public PExecPlanFragmentResult get() {
+                return null;
+            }
+
+            @Override
+            public PExecPlanFragmentResult get(long timeout, @NotNull TimeUnit unit)
+                    throws InterruptedException, ExecutionException, TimeoutException {
+                if (exception instanceof InterruptedException) {
+                    throw (InterruptedException) exception;
+                } else if (exception instanceof ExecutionException) {
+                    throw (ExecutionException) exception;
+                } else if (exception instanceof TimeoutException) {
+                    throw (TimeoutException) exception;
+                } else {
+                    throw new IllegalArgumentException("mockFutureWithException with illegal exception: " + exception);
+                }
+            }
+        };
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.scheduler;
 
 import com.google.common.collect.ImmutableList;
@@ -847,7 +846,6 @@ public class PartitionBasedMvRefreshProcessorTest {
         starRocksAssert.useDatabase("test").dropMaterializedView("hive_tbl_mv1");
     }
 
-
     public void testAutoPartitionRefreshWithPartitionedHiveTable1() throws Exception {
         starRocksAssert.useDatabase("test").withMaterializedView("CREATE MATERIALIZED VIEW `hive_parttbl_mv1`\n" +
                 "COMMENT \"MATERIALIZED_VIEW\"\n" +
@@ -940,18 +938,17 @@ public class PartitionBasedMvRefreshProcessorTest {
         starRocksAssert.useDatabase("test").dropMaterializedView("hive_tbl_mv2");
     }
 
-
     public void testAutoPartitionRefreshWithPartitionedHiveTableJoinInternalTable() throws Exception {
         starRocksAssert.useDatabase("test").withMaterializedView(
                 "CREATE MATERIALIZED VIEW `hive_join_internal_mv`\n" +
-                "COMMENT \"MATERIALIZED_VIEW\"\n" +
-                "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
-                "REFRESH DEFERRED MANUAL\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"storage_medium\" = \"HDD\"\n" +
-                ")\n" +
-                "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a" +
+                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                        "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a" +
                         " join test.tbl1 b on a.l_suppkey=b.k2;");
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("hive_join_internal_mv"));
@@ -1290,11 +1287,12 @@ public class PartitionBasedMvRefreshProcessorTest {
                 UUID uuid = UUID.randomUUID();
                 TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
                 System.out.println("register query id: " + DebugUtil.printId(connectContext.getExecutionId()));
-                QeProcessorImpl.INSTANCE.registerQuery(connectContext.getExecutionId(),
-                        new Coordinator(new LoadPlanner(1, loadId, 1, 1, null,
-                                false, "UTC", 10, System.currentTimeMillis(),
-                                false, connectContext, null, 10,
-                                10, null, null, null, 1)));
+                LoadPlanner loadPlanner = new LoadPlanner(1, loadId, 1, 1, null,
+                        false, "UTC", 10, System.currentTimeMillis(),
+                        false, connectContext, null, 10,
+                        10, null, null, null, 1);
+                Coordinator coordinator = new Coordinator.Factory().createBrokerLoadScheduler(loadPlanner);
+                QeProcessorImpl.INSTANCE.registerQuery(connectContext.getExecutionId(), coordinator);
             }
         };
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
@@ -1333,7 +1331,6 @@ public class PartitionBasedMvRefreshProcessorTest {
                 materializedView.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         MaterializedView.BasePartitionInfo newP0PartitionInfo = baseTableVisibleVersionMap2.get(tbl1.getId()).get("p0");
         Assert.assertEquals(3, newP0PartitionInfo.getVersion());
-
 
         MaterializedView.BasePartitionInfo p1PartitionInfo = baseTableVisibleVersionMap2.get(tbl1.getId()).get("p1");
         Assert.assertEquals(2, p1PartitionInfo.getVersion());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -36,7 +36,7 @@ import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.hive.MockedHiveMetadata;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -1291,7 +1291,7 @@ public class PartitionBasedMvRefreshProcessorTest {
                         false, "UTC", 10, System.currentTimeMillis(),
                         false, connectContext, null, 10,
                         10, null, null, null, 1);
-                Coordinator coordinator = new Coordinator.Factory().createBrokerLoadScheduler(loadPlanner);
+                DefaultCoordinator coordinator = new DefaultCoordinator.Factory().createBrokerLoadScheduler(loadPlanner);
                 QeProcessorImpl.INSTANCE.registerQuery(connectContext.getExecutionId(), coordinator);
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -91,6 +91,7 @@ import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -123,27 +124,41 @@ public class MockedBackend {
 
     private final MockPBackendService pbService;
 
-    public MockedBackend(String host) throws Exception {
+    public MockedBackend(String host) {
+        this(host, BASE_PORT.getAndIncrement());
+    }
+
+    public MockedBackend(String host, int beThriftPort) {
         this.host = host;
+        this.beThriftPort = beThriftPort;
+
         brpcPort = BASE_PORT.getAndIncrement();
         heartBeatPort = BASE_PORT.getAndIncrement();
-        beThriftPort = BASE_PORT.getAndIncrement();
         httpPort = BASE_PORT.getAndIncrement();
 
         heatBeatClient = new MockHeatBeatClient(beThriftPort, httpPort, brpcPort);
         thriftClient = new MockBeThriftClient(this);
         pbService = new MockPBackendService();
 
-        ((MockGenericPool) ClientPool.heartbeatPool).register(this);
-        ((MockGenericPool) ClientPool.backendPool).register(this);
+        ((MockGenericPool<?>) ClientPool.heartbeatPool).register(this);
+        ((MockGenericPool<?>) ClientPool.backendPool).register(this);
 
         new MockUp<BrpcProxy>() {
             @Mock
-            protected synchronized PBackendService getBackendService(TNetworkAddress address) {
+            private synchronized PBackendService getBackendService(TNetworkAddress address) {
                 return pbService;
             }
         };
 
+    }
+
+    public void setBackendService(PBackendService backendService) {
+        new MockUp<BrpcProxy>() {
+            @Mock
+            private synchronized PBackendService getBackendService(TNetworkAddress address) {
+                return backendService;
+            }
+        };
     }
 
     public String getHost() {
@@ -327,12 +342,16 @@ public class MockedBackend {
         }
     }
 
-    private static class MockPBackendService implements PBackendService {
+    public static class MockPBackendService implements PBackendService {
         private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        public <T> Future<T> submit(Callable<T> task) {
+            return executor.submit(task);
+        }
 
         @Override
         public Future<PExecPlanFragmentResult> execPlanFragmentAsync(PExecPlanFragmentRequest request) {
-            return executor.submit(() -> {
+            return submit(() -> {
                 PExecPlanFragmentResult result = new PExecPlanFragmentResult();
                 StatusPB pStatus = new StatusPB();
                 pStatus.statusCode = 0;
@@ -344,7 +363,7 @@ public class MockedBackend {
         @Override
         public Future<PExecBatchPlanFragmentsResult> execBatchPlanFragmentsAsync(
                 PExecBatchPlanFragmentsRequest request) {
-            return executor.submit(() -> {
+            return submit(() -> {
                 PExecBatchPlanFragmentsResult result = new PExecBatchPlanFragmentsResult();
                 StatusPB pStatus = new StatusPB();
                 pStatus.statusCode = 0;
@@ -355,7 +374,7 @@ public class MockedBackend {
 
         @Override
         public Future<PCancelPlanFragmentResult> cancelPlanFragmentAsync(PCancelPlanFragmentRequest request) {
-            return executor.submit(() -> {
+            return submit(() -> {
                 PCancelPlanFragmentResult result = new PCancelPlanFragmentResult();
                 StatusPB pStatus = new StatusPB();
                 pStatus.statusCode = 0;
@@ -366,7 +385,7 @@ public class MockedBackend {
 
         @Override
         public Future<PFetchDataResult> fetchDataAsync(PFetchDataRequest request) {
-            return executor.submit(() -> {
+            return submit(() -> {
                 PFetchDataResult result = new PFetchDataResult();
                 StatusPB pStatus = new StatusPB();
                 pStatus.statusCode = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -63,7 +63,7 @@ import com.starrocks.persist.EditLog;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.privilege.PrivilegeBuiltinConstants;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.Coordinator;
+import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.CatalogMgr;
@@ -458,10 +458,10 @@ public class UtFrameUtils {
                         execPlan));
     }
 
-    public static Coordinator startScheduling(ConnectContext connectContext, String originStmt) throws Exception {
+    public static DefaultCoordinator startScheduling(ConnectContext connectContext, String originStmt) throws Exception {
         return buildPlan(connectContext, originStmt,
                 (context, statementBase, execPlan) -> {
-                    Coordinator scheduler = createScheduler(context, statementBase, execPlan);
+                    DefaultCoordinator scheduler = createScheduler(context, statementBase, execPlan);
 
                     scheduler.startScheduling();
 
@@ -469,23 +469,23 @@ public class UtFrameUtils {
                 });
     }
 
-    public static Coordinator getScheduler(ConnectContext connectContext, String originStmt) throws Exception {
+    public static DefaultCoordinator getScheduler(ConnectContext connectContext, String originStmt) throws Exception {
         return buildPlan(connectContext, originStmt, UtFrameUtils::createScheduler);
     }
 
-    private static Coordinator createScheduler(ConnectContext context, StatementBase statementBase, ExecPlan execPlan) {
+    private static DefaultCoordinator createScheduler(ConnectContext context, StatementBase statementBase, ExecPlan execPlan) {
         context.setExecutionId(new TUniqueId(1, 2));
-        Coordinator scheduler;
+        DefaultCoordinator scheduler;
         if (statementBase instanceof DmlStmt) {
             if (statementBase instanceof InsertStmt) {
-                scheduler = new Coordinator.Factory().createInsertScheduler(context,
+                scheduler = new DefaultCoordinator.Factory().createInsertScheduler(context,
                         execPlan.getFragments(), execPlan.getScanNodes(),
                         execPlan.getDescTbl().toThrift());
             } else {
                 throw new RuntimeException("can only handle insert DML");
             }
         } else {
-            scheduler = new Coordinator.Factory().createQueryScheduler(context,
+            scheduler = new DefaultCoordinator.Factory().createQueryScheduler(context,
                     execPlan.getFragments(), execPlan.getScanNodes(), execPlan.getDescTbl().toThrift());
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -63,6 +63,7 @@ import com.starrocks.persist.EditLog;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.privilege.PrivilegeBuiltinConstants;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.Coordinator;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.CatalogMgr;
@@ -75,6 +76,7 @@ import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.CreateViewStmt;
+import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectRelation;
@@ -103,6 +105,7 @@ import com.starrocks.system.Backend;
 import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TResultSinkType;
+import com.starrocks.thrift.TUniqueId;
 import org.apache.commons.codec.binary.Hex;
 import org.junit.Assert;
 
@@ -258,11 +261,21 @@ public class UtFrameUtils {
         createMinStarRocksCluster(false);
     }
 
+    public static Backend addMockBackend(int backendId, String host, int beThriftPort) throws Exception {
+        // start be
+        MockedBackend backend = new MockedBackend(host, beThriftPort);
+        // add be
+        return addMockBackend(backend, backendId);
+    }
+
     public static Backend addMockBackend(int backendId) throws Exception {
         // start be
         MockedBackend backend = new MockedBackend("127.0.0.1");
-
         // add be
+        return addMockBackend(backend, backendId);
+    }
+
+    private static Backend addMockBackend(MockedBackend backend, int backendId) {
         Backend be = new Backend(backendId, backend.getHost(), backend.getHeartBeatPort());
         Map<String, DiskInfo> disks = Maps.newHashMap();
         DiskInfo diskInfo1 = new DiskInfo(backendId + "/path1");
@@ -390,8 +403,12 @@ public class UtFrameUtils {
         }
     }
 
-    public static Pair<String, ExecPlan> getPlanAndFragment(ConnectContext connectContext, String originStmt)
-            throws Exception {
+    private interface GetPlanHook<R> {
+        R apply(ConnectContext context, StatementBase statementBase, ExecPlan execPlan) throws Exception;
+    }
+
+    private static <R> R buildPlan(ConnectContext connectContext, String originStmt,
+                                   GetPlanHook<R> returnedSupplier) throws Exception {
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
         originStmt = LogUtil.removeCommentAndLineSeparator(originStmt);
 
@@ -427,11 +444,52 @@ public class UtFrameUtils {
             testView(connectContext, originStmt, statementBase);
 
             validatePlanConnectedness(execPlan);
-            return new Pair<>(printPhysicalPlan(execPlan.getPhysicalPlan()), execPlan);
+            return returnedSupplier.apply(connectContext, statementBase, execPlan);
         } finally {
             // before returning we have to restore session variable.
             connectContext.setSessionVariable(oldSessionVariable);
         }
+    }
+
+    public static Pair<String, ExecPlan> getPlanAndFragment(ConnectContext connectContext, String originStmt)
+            throws Exception {
+        return buildPlan(connectContext, originStmt,
+                (context, statementBase, execPlan) -> new Pair<>(printPhysicalPlan(execPlan.getPhysicalPlan()),
+                        execPlan));
+    }
+
+    public static Coordinator startScheduling(ConnectContext connectContext, String originStmt) throws Exception {
+        return buildPlan(connectContext, originStmt,
+                (context, statementBase, execPlan) -> {
+                    Coordinator scheduler = createScheduler(context, statementBase, execPlan);
+
+                    scheduler.startScheduling();
+
+                    return scheduler;
+                });
+    }
+
+    public static Coordinator getScheduler(ConnectContext connectContext, String originStmt) throws Exception {
+        return buildPlan(connectContext, originStmt, UtFrameUtils::createScheduler);
+    }
+
+    private static Coordinator createScheduler(ConnectContext context, StatementBase statementBase, ExecPlan execPlan) {
+        context.setExecutionId(new TUniqueId(1, 2));
+        Coordinator scheduler;
+        if (statementBase instanceof DmlStmt) {
+            if (statementBase instanceof InsertStmt) {
+                scheduler = new Coordinator.Factory().createInsertScheduler(context,
+                        execPlan.getFragments(), execPlan.getScanNodes(),
+                        execPlan.getDescTbl().toThrift());
+            } else {
+                throw new RuntimeException("can only handle insert DML");
+            }
+        } else {
+            scheduler = new Coordinator.Factory().createQueryScheduler(context,
+                    execPlan.getFragments(), execPlan.getScanNodes(), execPlan.getDescTbl().toThrift());
+        }
+
+        return scheduler;
     }
 
     public static String printPhysicalPlan(OptExpression execPlan) {


### PR DESCRIPTION
Relates to #27846.

Move the configurations and the common fields to a new class `JobSpec`.
- loadJobId
- queryId
- 
- fragments
- scanNodes
- descTable
- resourceGroup
- 
- queryGlobals
- queryOptions
- enablePipeline
- enableStreamPipeline
- isBlockQuery

In the next PR, the classes about `ExecutionDAG` could reuse `JobSpec`.

BTW, make `Coordinator` implements the interface `ICoordinator`. `ICoordinator` just collects the methods which are used by the outside callers, and doesn't modify declaration of the methods.


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
