### PR TITLE
[BugFix][Cherry-pick][Branch-2.5] Fix incorrect estimation of average row size when doing partial update (#27485)

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -184,6 +184,16 @@ Status Rowset::reload_segment(int32_t segment_id) {
     return Status::OK();
 }
 
+int64_t Rowset::total_segment_data_size() {
+    int64_t res = 0;
+    for (auto& seg : _segments) {
+        if (seg != nullptr) {
+            res += seg->get_data_size();
+        }
+    }
+    return res;
+}
+
 StatusOr<int64_t> Rowset::estimate_compaction_segment_iterator_num() {
     if (num_segments() == 0) {
         return 0;

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -141,6 +141,7 @@ public:
     // reload this rowset after the underlying segment file is changed
     Status reload();
     Status reload_segment(int32_t segment_id);
+    int64_t total_segment_data_size();
 
     const TabletSchema& schema() const { return *_schema; }
     void set_schema(const TabletSchema* schema) { _schema = schema; }

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -79,9 +79,17 @@ public:
 
     int64_t total_row_size() { return _rowset_meta_pb->total_row_size(); }
 
+    void set_total_row_size(int64_t total_size) { _rowset_meta_pb->set_total_row_size(total_size); }
+
+    int64_t total_update_row_size() { return _rowset_meta_pb->total_update_row_size(); }
+
     size_t total_disk_size() const { return _rowset_meta_pb->total_disk_size(); }
 
+    void set_total_disk_size(size_t disk_size) { _rowset_meta_pb->set_total_disk_size(disk_size); }
+
     size_t data_disk_size() const { return _rowset_meta_pb->data_disk_size(); }
+
+    void set_data_disk_size(size_t data_size) { _rowset_meta_pb->set_data_disk_size(data_size); }
 
     size_t index_disk_size() const { return _rowset_meta_pb->index_disk_size(); }
 

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -81,8 +81,6 @@ public:
 
     void set_total_row_size(int64_t total_size) { _rowset_meta_pb->set_total_row_size(total_size); }
 
-    int64_t total_update_row_size() { return _rowset_meta_pb->total_update_row_size(); }
-
     size_t total_disk_size() const { return _rowset_meta_pb->total_disk_size(); }
 
     void set_total_disk_size(size_t disk_size) { _rowset_meta_pb->set_total_disk_size(disk_size); }

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -153,6 +153,14 @@ public:
 
     int64_t mem_usage() { return _basic_info_mem_usage() + _short_key_index_mem_usage(); }
 
+    int64_t get_data_size() {
+        auto res = _fs->get_file_size(_fname);
+        if (res.ok()) {
+            return res.value();
+        }
+        return 0;
+    }
+
     // read short_key_index, for data check, just used in unit test now
     Status get_short_key_index(std::vector<std::string>* sk_index_values);
 

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -356,6 +356,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
         _memory_usage += _partial_update_states[idx].write_columns[col_idx]->memory_usage();
     }
     int64_t t_end = MonotonicMillis();
+    _partial_update_states[idx].update_byte_size();
     _partial_update_states[idx].inited = true;
 
     LOG(INFO) << strings::Substitute(
@@ -452,7 +453,8 @@ Status RowsetUpdateState::_check_and_resolve_conflict(Tablet* tablet, Rowset* ro
 }
 
 Status RowsetUpdateState::apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, uint32_t segment_id,
-                                EditVersion latest_applied_version, const PrimaryIndex& index) {
+                                EditVersion latest_applied_version, const PrimaryIndex& index,
+                                int64_t* append_column_size) {
     const auto& rowset_meta_pb = rowset->rowset_meta()->get_meta_pb();
     if (!rowset_meta_pb.has_txn_meta() || rowset->num_segments() == 0 ||
         rowset_meta_pb.txn_meta().has_merge_condition()) {
@@ -505,8 +507,9 @@ Status RowsetUpdateState::apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_
         if (_partial_update_states[segment_id].write_columns[col_idx] != nullptr) {
             _memory_usage -= _partial_update_states[segment_id].write_columns[col_idx]->memory_usage();
         }
+        *append_column_size += _partial_update_states[segment_id].byte_size;
+        _partial_update_states[segment_id].release();
     }
-    _partial_update_states[segment_id].release();
     return Status::OK();
 }
 

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -18,6 +18,15 @@ struct PartialUpdateState {
     std::vector<std::unique_ptr<vectorized::Column>> write_columns;
     bool inited = false;
     EditVersion read_version;
+    int64_t byte_size = 0;
+
+    void update_byte_size() {
+        for (size_t i = 0; i < write_columns.size(); i++) {
+            if (write_columns[i] != nullptr) {
+                byte_size += write_columns[i]->byte_size();
+            }
+        }
+    }
 
     void release() {
         src_rss_rowids.clear();
@@ -41,7 +50,7 @@ public:
     Status load(Tablet* tablet, Rowset* rowset);
 
     Status apply(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, uint32_t segment_id,
-                 EditVersion latest_applied_version, const PrimaryIndex& index);
+                 EditVersion latest_applied_version, const PrimaryIndex& index, int64_t* append_column_size);
 
     const std::vector<ColumnUniquePtr>& upserts() const { return _upserts; }
     const std::vector<ColumnUniquePtr>& deletes() const { return _deletes; }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -912,8 +912,7 @@ void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
             auto& upserts = state.upserts();
             if (upserts[i] != nullptr) {
                 // apply partial rowset segment
-                st = state.apply(&_tablet, rowset.get(), rowset_id, i, latest_applied_version, index,
-                                 &full_row_size);
+                st = state.apply(&_tablet, rowset.get(), rowset_id, i, latest_applied_version, index, &full_row_size);
                 if (!st.ok()) {
                     manager->update_state_cache().remove(state_entry);
                     std::string msg =

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -302,6 +302,7 @@ private:
         size_t num_rows = 0;
         size_t num_dels = 0;
         size_t byte_size = 0;
+        size_t row_size = 0;
         int64_t compaction_score = 0;
         std::string to_string() const;
     };


### PR DESCRIPTION
When we do partial update, we first write a partial rowset and we will load the left columns data into memory during the following apply phase and we process the rowset data by segment. So if one segment file has too many rows, a large memory is needed. So we will get the average row size of historical data to avoid large memory alloc.

The following code is how we get the average row size. However, when we do partial update, the `data_size` is the compressed partial rowset data size which far less than total row size, so the `average_row_size` may far less than real average row size. So we may write too many rows into one segment which cause large memory alloc.
```
int64_t TabletUpdates::get_average_row_size() {
    TTabletInfo info;
    get_tablet_info_extra(&info);
    int64_t total_row = info.row_count;
    int64_t total_size = info.data_size;
    if (total_row != 0) {
        return total_size / total_row;
    } else {
        return 0;
    }
```
This pr fixes the issue and return the correct average row size of historical data.
