### PR TITLE
[Enhancement] Enlarge parquet footer init read size

### DIFF
--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -37,7 +37,7 @@ namespace starrocks::parquet {
 
 // contains magic number (4 bytes) and footer length (4 bytes)
 constexpr static const uint32_t PARQUET_FOOTER_SIZE = 8;
-constexpr static const uint64_t DEFAULT_FOOTER_BUFFER_SIZE = 16 * 1024;
+constexpr static const uint64_t DEFAULT_FOOTER_BUFFER_SIZE = 64 * 1024;
 constexpr static const char* PARQUET_MAGIC_NUMBER = "PAR1";
 constexpr static const char* PARQUET_EMAIC_NUMBER = "PARE";
 


### PR DESCRIPTION
Like Arrow, we enlarge the parquet footer init read size to 64KB.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
