### PR TITLE
[Feature] add HTTP API /api/v2/warehouses (#27567)

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -242,6 +242,14 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.2</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-api</artifactId>

--- a/fe/fe-core/src/main/java/com/starrocks/backup/AbstractJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/AbstractJob.java
@@ -43,6 +43,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.lake.backup.LakeBackupJob;
 import com.starrocks.lake.backup.LakeRestoreJob;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -121,6 +122,11 @@ public abstract class AbstractJob implements Writable {
         this.timeoutMs = timeoutMs;
         this.globalStateMgr = globalStateMgr;
         this.repoId = repoId;
+    }
+
+    public String getCurrentWarehouse() {
+        // TODO(lzh): pass the current warehouse.
+        return WarehouseManager.DEFAULT_WAREHOUSE_NAME;
     }
 
     public JobType getType() {

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -63,6 +63,7 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.fs.HdfsUtil;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.metric.WarehouseMetricMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
@@ -368,6 +369,7 @@ public class BackupJob extends AbstractJob {
         status = new Status(ErrCode.COMMON_ERROR, "user cancelled");
         cancelInternal();
         MetricRepo.COUNTER_UNFINISHED_BACKUP_JOB.increase(-1L);
+        WarehouseMetricMgr.increaseUnfinishedBackupJobs(getCurrentWarehouse(), -1L);
         return Status.OK;
     }
 
@@ -438,6 +440,7 @@ public class BackupJob extends AbstractJob {
 
     private void prepareAndSendSnapshotTask() {
         MetricRepo.COUNTER_UNFINISHED_BACKUP_JOB.increase(1L);
+        WarehouseMetricMgr.increaseUnfinishedBackupJobs(getCurrentWarehouse(), 1L);
         Database db = globalStateMgr.getDb(dbId);
         if (db == null) {
             status = new Status(ErrCode.NOT_FOUND, "database " + dbId + " does not exist");
@@ -604,7 +607,7 @@ public class BackupJob extends AbstractJob {
                     HdfsUtil.getTProperties(repo.getLocation(), brokerDesc, hdfsProperties);
                 } catch (UserException e) {
                     status = new Status(ErrCode.COMMON_ERROR, "Get properties from " + repo.getLocation() + " error.");
-                    return;    
+                    return;
                 }
             }
 
@@ -741,6 +744,7 @@ public class BackupJob extends AbstractJob {
         LOG.info("job is finished. {}", this);
 
         MetricRepo.COUNTER_UNFINISHED_BACKUP_JOB.increase(-1L);
+        WarehouseMetricMgr.increaseUnfinishedBackupJobs(getCurrentWarehouse(), -1L);
     }
 
     private boolean uploadFile(String localFilePath, String remoteFilePath) {

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -80,6 +80,7 @@ import com.starrocks.common.util.DynamicPartitionUtil;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.fs.HdfsUtil;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.metric.WarehouseMetricMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
@@ -432,6 +433,7 @@ public class RestoreJob extends AbstractJob {
      */
     private void checkAndPrepareMeta() {
         MetricRepo.COUNTER_UNFINISHED_RESTORE_JOB.increase(1L);
+        WarehouseMetricMgr.increaseUnfinishedRestoreJobs(getCurrentWarehouse(), 1L);
         Database db = globalStateMgr.getDb(dbId);
         if (db == null) {
             status = new Status(ErrCode.NOT_FOUND, "database " + dbId + " does not exist");
@@ -1209,7 +1211,6 @@ public class RestoreJob extends AbstractJob {
             unfinishedSignatureToId.put(signature, beId);
         }
     }
-
     protected void sendDownloadTasks() {
         for (AgentTask task : batchTask.getAllTasks()) {
             AgentTaskQueue.addTask(task);
@@ -1260,6 +1261,7 @@ public class RestoreJob extends AbstractJob {
                 status = st;
             }
             MetricRepo.COUNTER_UNFINISHED_RESTORE_JOB.increase(-1L);
+            WarehouseMetricMgr.increaseUnfinishedRestoreJobs(getCurrentWarehouse(), -1L);
             return;
         }
         LOG.info("waiting {} tablets to commit. {}", unfinishedSignatureToId.size(), this);
@@ -1425,6 +1427,7 @@ public class RestoreJob extends AbstractJob {
         status = new Status(ErrCode.COMMON_ERROR, "user cancelled, current state: " + state.name());
         cancelInternal(false);
         MetricRepo.COUNTER_UNFINISHED_RESTORE_JOB.increase(-1L);
+        WarehouseMetricMgr.increaseUnfinishedRestoreJobs(getCurrentWarehouse(), -1L);
         return Status.OK;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -86,6 +86,7 @@ import com.starrocks.http.rest.TableQueryPlanAction;
 import com.starrocks.http.rest.TableRowCountAction;
 import com.starrocks.http.rest.TableSchemaAction;
 import com.starrocks.http.rest.TransactionLoadAction;
+import com.starrocks.http.rest.WarehouseAction;
 import com.starrocks.leader.MetaHelper;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
@@ -143,6 +144,7 @@ public class HttpServer {
         StorageTypeCheckAction.registerAction(controller);
         CancelStreamLoad.registerAction(controller);
         GetStreamLoadState.registerAction(controller);
+        WarehouseAction.registerAction(controller);
 
         // add web action
         IndexAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -66,7 +66,7 @@ public class RestBaseAction extends BaseAction {
     }
 
     @Override
-    public void handleRequest(BaseRequest request) throws Exception {
+    public void handleRequest(BaseRequest request) {
         LOG.info("receive http request. url={}", request.getRequest().uri());
         BaseResponse response = new BaseResponse();
         try {
@@ -80,6 +80,14 @@ public class RestBaseAction extends BaseAction {
             } else {
                 sendResult(request, response, new RestBaseResult(e.getMessage()));
             }
+        } catch (Exception e) {
+            LOG.warn("fail to process url: {}", request.getRequest().uri(), e);
+            String msg = e.getMessage();
+            if (msg == null) {
+                msg = e.toString();
+            }
+            response.appendContent(new RestBaseResult(msg).toJson());
+            writeResponse(request, response, HttpResponseStatus.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestSuccessBaseResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestSuccessBaseResult.java
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.Reader;
+import java.lang.reflect.Type;
+
+// Base restful result
+public class RestSuccessBaseResult<T> extends RestBaseResult {
+    private T result;
+
+    public RestSuccessBaseResult() {
+        super();
+    }
+
+    public RestSuccessBaseResult(String msg) {
+        super(msg);
+    }
+
+    public RestSuccessBaseResult(T result) {
+        super();
+        this.result = result;
+    }
+
+    public T getResult() {
+        return result;
+    }
+
+    public void setResult(T result) {
+        this.result = result;
+    }
+
+    public static <T> RestSuccessBaseResult<T> fromJson(Reader reader, Class<T> resultType) {
+        Type type = TypeToken.getParameterized(RestSuccessBaseResult.class, resultType).getType();
+        Gson gson = new Gson();
+        return gson.fromJson(reader, type);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/WarehouseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/WarehouseAction.java
@@ -1,0 +1,71 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest;
+
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.warehouse.WarehouseInfo;
+import com.starrocks.warehouse.WarehouseInfosBuilder;
+import io.netty.handler.codec.http.HttpMethod;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class WarehouseAction extends RestBaseAction {
+    public static final String URI = "/api/v1/warehouses";
+
+    public WarehouseAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller) throws IllegalArgException {
+        controller.registerHandler(HttpMethod.GET, URI, new WarehouseAction(controller));
+    }
+
+    @Override
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response) {
+        WarehouseInfosBuilder warehouseInfoBuilder = WarehouseInfosBuilder.makeBuilderFromMetricAndMgrs();
+
+        List<WarehouseInfo> infosFromOtherFEs = GlobalStateMgr.getCurrentState().getWarehouseInfosFromOtherFEs();
+        infosFromOtherFEs.forEach(warehouseInfoBuilder::withWarehouseInfo);
+
+        Map<String, WarehouseInfo> warehouseInfo = warehouseInfoBuilder.build();
+        RestSuccessBaseResult<Result> res = new RestSuccessBaseResult<>(new Result(warehouseInfo.values()));
+
+        response.setContentType("application/json");
+        response.getContent().append(res.toJson());
+        sendResult(request, response);
+    }
+
+    public static class Result {
+        private Collection<WarehouseInfo> warehouses;
+
+        public Result(Collection<WarehouseInfo> warehouses) {
+            this.warehouses = warehouses;
+        }
+
+        public Collection<WarehouseInfo> getWarehouses() {
+            return warehouses;
+        }
+
+        public void setWarehouses(Collection<WarehouseInfo> warehouses) {
+            this.warehouses = warehouses;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/LoadJobWithWarehouse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/LoadJobWithWarehouse.java
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load;
+
+public interface LoadJobWithWarehouse {
+    String getCurrentWarehouse();
+
+    boolean isFinal();
+
+    default boolean isInternalJob() {
+        return false;
+    }
+
+    long getFinishTimestampMs();
+}

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -34,8 +34,10 @@
 
 package com.starrocks.load.loadv2;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
+import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
@@ -63,6 +65,7 @@ import com.starrocks.persist.AlterLoadJobOperationLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.ast.AlterLoadStmt;
 import com.starrocks.sql.ast.LoadStmt;
@@ -94,15 +97,20 @@ public class BrokerLoadJob extends BulkLoadJob {
     private ConnectContext context;
     private List<LoadLoadingTask> newLoadingTasks = Lists.newArrayList();
 
+    @SerializedName("wh")
+    private String warehouse;
+
     // only for log replay
     public BrokerLoadJob() {
         super();
         this.jobType = EtlJobType.BROKER;
+        this.warehouse = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
     }
 
-    // for ut
+    @VisibleForTesting
     public void setConnectContext(ConnectContext context) {
         this.context = context;
+        this.warehouse = context == null ? WarehouseManager.DEFAULT_WAREHOUSE_NAME : context.getCurrentWarehouse();
     }
 
     public BrokerLoadJob(long dbId, String label, BrokerDesc brokerDesc, OriginStatement originStmt, ConnectContext context)
@@ -112,6 +120,12 @@ public class BrokerLoadJob extends BulkLoadJob {
         this.brokerDesc = brokerDesc;
         this.jobType = EtlJobType.BROKER;
         this.context = context;
+        this.warehouse = context == null ? WarehouseManager.DEFAULT_WAREHOUSE_NAME : context.getCurrentWarehouse();
+    }
+
+    @Override
+    public String getCurrentWarehouse() {
+        return warehouse;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -62,6 +62,7 @@ import com.starrocks.load.EtlStatus;
 import com.starrocks.load.FailMsg;
 import com.starrocks.load.FailMsg.CancelType;
 import com.starrocks.load.Load;
+import com.starrocks.load.LoadJobWithWarehouse;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.AlterLoadJobOperationLog;
 import com.starrocks.persist.gson.GsonUtils;
@@ -97,7 +98,8 @@ import java.util.Set;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
-public abstract class LoadJob extends AbstractTxnStateChangeCallback implements LoadTaskCallback, Writable {
+public abstract class LoadJob extends AbstractTxnStateChangeCallback implements LoadTaskCallback, Writable,
+        LoadJobWithWarehouse {
 
     private static final Logger LOG = LogManager.getLogger(LoadJob.class);
 
@@ -217,6 +219,16 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
     protected void writeUnlock() {
         lock.writeLock().unlock();
+    }
+
+    @Override
+    public boolean isFinal() {
+        return isCompleted();
+    }
+
+    @Override
+    public long getFinishTimestampMs() {
+        return getFinishTimestamp();
     }
 
     public long getId() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -85,6 +85,7 @@ import com.starrocks.metric.TableMetricsEntity;
 import com.starrocks.metric.TableMetricsRegistry;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.ResourceDesc;
@@ -184,6 +185,12 @@ public class SparkLoadJob extends BulkLoadJob {
         this.resourceDesc = resourceDesc;
         timeoutSecond = Config.spark_load_default_timeout_second;
         jobType = EtlJobType.SPARK;
+    }
+
+    @Override
+    public String getCurrentWarehouse() {
+        // TODO(lzh): pass the current warehouse.
+        return WarehouseManager.DEFAULT_WAREHOUSE_NAME;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
@@ -66,6 +66,8 @@ import com.starrocks.sql.ast.StopRoutineLoadStmt;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.WarehouseLoadInfoBuilder;
+import com.starrocks.warehouse.WarehouseLoadStatusInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -95,6 +97,9 @@ public class RoutineLoadMgr implements Writable {
     // routine load job meta
     private Map<Long, RoutineLoadJob> idToRoutineLoadJob = Maps.newConcurrentMap();
     private Map<Long, Map<String, List<RoutineLoadJob>>> dbToNameToRoutineLoadJob = Maps.newConcurrentMap();
+
+    private final WarehouseLoadInfoBuilder warehouseLoadStatusInfoBuilder =
+            new WarehouseLoadInfoBuilder();
 
     private ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
 
@@ -237,7 +242,7 @@ public class RoutineLoadMgr implements Writable {
             }
             long allSlotNum = beNum * Config.max_routine_load_task_num_per_be;
             List<RoutineLoadJob> jobs = getRoutineLoadJobByState(Sets.newHashSet(RoutineLoadJob.JobState.NEED_SCHEDULE,
-                        RoutineLoadJob.JobState.RUNNING, RoutineLoadJob.JobState.PAUSED));
+                    RoutineLoadJob.JobState.RUNNING, RoutineLoadJob.JobState.PAUSED));
             long curSlotNum = 0;
             for (RoutineLoadJob job : jobs) {
                 curSlotNum += job.calculateCurrentConcurrentTaskNum();
@@ -578,6 +583,8 @@ public class RoutineLoadMgr implements Writable {
         if (dbToNameToRoutineLoadJob.get(routineLoadJob.getDbId()).isEmpty()) {
             dbToNameToRoutineLoadJob.remove(routineLoadJob.getDbId());
         }
+
+        warehouseLoadStatusInfoBuilder.withRemovedJob(routineLoadJob);
     }
 
     public void updateRoutineLoadJob() throws UserException {
@@ -709,6 +716,15 @@ public class RoutineLoadMgr implements Writable {
             }
 
             putJob(routineLoadJob);
+        }
+    }
+
+    public Map<String, WarehouseLoadStatusInfo> getWarehouseLoadInfo() {
+        readLock();
+        try {
+            return warehouseLoadStatusInfoBuilder.buildFromJobs(idToRoutineLoadJob.values());
+        } finally {
+            readUnlock();
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -35,6 +35,7 @@ import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.http.rest.TransactionResult;
+import com.starrocks.load.LoadJobWithWarehouse;
 import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonPreProcessable;
@@ -42,6 +43,7 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.Coordinator;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.task.LoadEtlTask;
@@ -73,7 +75,7 @@ import java.util.UUID;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class StreamLoadTask extends AbstractTxnStateChangeCallback
-        implements Writable, GsonPostProcessable, GsonPreProcessable {
+        implements Writable, GsonPostProcessable, GsonPreProcessable, LoadJobWithWarehouse {
     private static final Logger LOG = LogManager.getLogger(StreamLoadTask.class);
 
     public enum State {
@@ -229,6 +231,22 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         this.streamLoadParam = null;
         this.streamLoadInfo = null;
         this.isCommitting = false;
+    }
+
+    @Override
+    public String getCurrentWarehouse() {
+        // TODO(lzh): pass the current warehouse.
+        return WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+    }
+
+    @Override
+    public boolean isFinal() {
+        return isFinalState();
+    }
+
+    @Override
+    public long getFinishTimestampMs() {
+        return endTimeMs();
     }
 
     public void beginTxn(int channelId, int channelNum, TransactionResult resp) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -430,8 +430,10 @@ public final class MetricRepo {
                 AbstractJob jobI = GlobalStateMgr.getCurrentState().getBackupHandler().getJob(db.getId());
                 if (jobI instanceof BackupJob && !((BackupJob) jobI).isDone()) {
                     COUNTER_UNFINISHED_BACKUP_JOB.increase(1L);
+                    WarehouseMetricMgr.increaseUnfinishedBackupJobs(((BackupJob) jobI).getCurrentWarehouse(), 1L);
                 } else if (jobI instanceof RestoreJob && !((RestoreJob) jobI).isDone()) {
                     COUNTER_UNFINISHED_RESTORE_JOB.increase(1L);
+                    WarehouseMetricMgr.increaseUnfinishedRestoreJobs(((RestoreJob) jobI).getCurrentWarehouse(), 1L);
                 }
 
             }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/WarehouseMetricMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/WarehouseMetricMgr.java
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.metric;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class WarehouseMetricMgr {
+    private static final Logger LOG = LogManager.getLogger(WarehouseMetricMgr.class);
+
+    private static final String UNFINISHED_QUERY = "unfinished_query";
+    private static final String UNFINISHED_BACKUP_JOB = "unfinished_backup_job";
+    private static final String UNFINISHED_RESTORE_JOB = "unfinished_restore_job";
+    private static final String LAST_FINISHED_JOB_TIMESTAMP = "last_finished_job_timestamp";
+
+    private WarehouseMetricMgr() {}
+
+    private static final ConcurrentMap<String, LongCounterMetric> UNFINISHED_QUERY_COUNTER_MAP =
+            new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, LongCounterMetric> UNFINISHED_BACKUP_JOB_COUNTER_MAP =
+            new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, LongCounterMetric> UNFINISHED_RESTORE_JOB_COUNTER_MAP =
+            new ConcurrentHashMap<>();
+    private static final ConcurrentMap<String, GaugeMetricImpl<Long>> LAST_FINISHED_JOB_TIMESTAMP_COUNTER_MAP =
+            new ConcurrentHashMap<>();
+
+    public static Map<String, Long> getUnfinishedQueries() {
+        return metricMapToValueMap(UNFINISHED_QUERY_COUNTER_MAP);
+    }
+
+    public static Map<String, Long> getUnfinishedBackupJobs() {
+        return metricMapToValueMap(UNFINISHED_BACKUP_JOB_COUNTER_MAP);
+    }
+
+    public static Map<String, Long> getUnfinishedRestoreJobs() {
+        return metricMapToValueMap(UNFINISHED_RESTORE_JOB_COUNTER_MAP);
+    }
+
+    public static Map<String, Long> getLastFinishedJobTimestampMs() {
+        return metricMapToValueMap(LAST_FINISHED_JOB_TIMESTAMP_COUNTER_MAP);
+    }
+
+    public static void increaseUnfinishedQueries(String warehouse, Long delta) {
+        if (delta < 0) {
+            setLastFinishedJobTimestamp(warehouse, System.currentTimeMillis());
+        }
+
+        LongCounterMetric metric = getOrCreateMetric(
+                warehouse,
+                UNFINISHED_QUERY_COUNTER_MAP,
+                UNFINISHED_QUERY,
+                () -> new LongCounterMetric(UNFINISHED_QUERY, Metric.MetricUnit.REQUESTS,
+                        "current unfinished queries of the warehouse")
+        );
+        metric.increase(delta);
+    }
+
+    public static void increaseUnfinishedBackupJobs(String warehouse, Long delta) {
+        if (delta < 0) {
+            setLastFinishedJobTimestamp(warehouse, System.currentTimeMillis());
+        }
+
+        LongCounterMetric metric = getOrCreateMetric(
+                warehouse,
+                UNFINISHED_BACKUP_JOB_COUNTER_MAP,
+                UNFINISHED_BACKUP_JOB,
+                () -> new LongCounterMetric(UNFINISHED_BACKUP_JOB, Metric.MetricUnit.REQUESTS,
+                        "current unfinished backup jobs of the warehouse")
+        );
+        metric.increase(delta);
+    }
+
+    public static void increaseUnfinishedRestoreJobs(String warehouse, Long delta) {
+        if (delta < 0) {
+            setLastFinishedJobTimestamp(warehouse, System.currentTimeMillis());
+        }
+
+        LongCounterMetric metric = getOrCreateMetric(
+                warehouse,
+                UNFINISHED_RESTORE_JOB_COUNTER_MAP,
+                UNFINISHED_RESTORE_JOB,
+                () -> new LongCounterMetric(UNFINISHED_RESTORE_JOB, Metric.MetricUnit.REQUESTS,
+                        "current unfinished queries of the warehouse")
+        );
+        metric.increase(delta);
+    }
+
+    private static void setLastFinishedJobTimestamp(String warehouse, Long timestamp) {
+        GaugeMetricImpl<Long> metric = getOrCreateMetric(
+                warehouse,
+                LAST_FINISHED_JOB_TIMESTAMP_COUNTER_MAP,
+                LAST_FINISHED_JOB_TIMESTAMP,
+                () -> new GaugeMetricImpl<>(LAST_FINISHED_JOB_TIMESTAMP, Metric.MetricUnit.MICROSECONDS,
+                        "the timestamp of last finished job")
+        );
+        metric.setValue(timestamp);
+    }
+
+    private static <T extends Metric<Long>> T getOrCreateMetric(String warehouse, Map<String, T> metricMap,
+                                                                String metricName, Supplier<T> metricSupplier) {
+        if (!metricMap.containsKey(warehouse)) {
+            synchronized (WarehouseMetricMgr.class) {
+                if (!metricMap.containsKey(warehouse)) {
+                    T metric = metricSupplier.get();
+                    metric.addLabel(new MetricLabel("warehouse", warehouse));
+
+                    metricMap.put(warehouse, metric);
+                    MetricRepo.addMetric(metric);
+
+                    LOG.info("Add {} metric, warehouse is {}", metricName, warehouse);
+                }
+            }
+        }
+        return metricMap.get(warehouse);
+    }
+
+    private static <T extends Metric<Long>> Map<String, Long> metricMapToValueMap(Map<String, T> metricMap) {
+        return metricMap.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getValue()));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -104,6 +104,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.PlannerProfile;
 import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.PrivilegeChecker;
 import com.starrocks.sql.analyzer.SemanticException;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -81,6 +81,7 @@ import com.starrocks.meta.SqlBlackList;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.metric.TableMetricsEntity;
 import com.starrocks.metric.TableMetricsRegistry;
+import com.starrocks.metric.WarehouseMetricMgr;
 import com.starrocks.mysql.MysqlChannel;
 import com.starrocks.mysql.MysqlEofPacket;
 import com.starrocks.mysql.MysqlSerializer;
@@ -190,6 +191,7 @@ import java.util.stream.Collectors;
 import static com.starrocks.sql.ast.StatementBase.ExplainLevel.OPTIMIZER;
 import static com.starrocks.sql.ast.StatementBase.ExplainLevel.REWRITE;
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
+import static com.starrocks.statistic.StatsConstants.STATISTICS_DB_NAME;
 
 // Do one COM_QUERY process.
 // first: Parse receive byte array to statement struct.
@@ -454,6 +456,10 @@ public class StmtExecutor {
 
             if (parsedStmt instanceof QueryStatement) {
                 context.getState().setIsQuery(true);
+                final boolean isStatisticsJob = isStatisticsJob(parsedStmt);
+                if (!isStatisticsJob) {
+                    WarehouseMetricMgr.increaseUnfinishedQueries(context.getCurrentWarehouse(), 1L);
+                }
 
                 // sql's blacklist is enabled through enable_sql_blacklist.
                 if (Config.enable_sql_blacklist && !parsedStmt.isExplain()) {
@@ -558,8 +564,14 @@ public class StmtExecutor {
                             throw e;
                         }
                     } finally {
-                        if (!needRetry && context.getSessionVariable().isEnableProfile()) {
-                            writeProfile(beginTimeInNanoSecond);
+                        if (!needRetry) {
+                            if (context.getSessionVariable().isEnableProfile()) {
+                                writeProfile(beginTimeInNanoSecond);
+                            }
+
+                            if (!isStatisticsJob) {
+                                WarehouseMetricMgr.increaseUnfinishedQueries(context.getCurrentWarehouse(), -1L);
+                            }
                         }
                         QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
                     }
@@ -654,6 +666,11 @@ public class StmtExecutor {
 
             context.setSessionVariable(sessionVariableBackup);
         }
+    }
+
+    private boolean isStatisticsJob(StatementBase stmt) {
+        Map<String, Database> dbs = AnalyzerUtils.collectAllDatabase(context, stmt);
+        return dbs.values().stream().anyMatch(db -> STATISTICS_DB_NAME.equals(db.getFullName()));
     }
 
     private void handleCreateTableAsSelectStmt(long beginTimeInNanoSecond) throws Exception {
@@ -791,6 +808,7 @@ public class StmtExecutor {
         if (killCtx == null) {
             ErrorReport.reportDdlException(ErrorCode.ERR_NO_SUCH_THREAD, id);
         }
+        Preconditions.checkNotNull(killCtx);
         if (context == killCtx) {
             // Suicide
             context.setKilled();
@@ -1561,7 +1579,9 @@ public class StmtExecutor {
                         createTime,
                         estimateScanRows,
                         type,
-                        ConnectContext.get().getSessionVariable().getQueryTimeoutS());
+                        ConnectContext.get().getSessionVariable().getQueryTimeoutS(),
+                        context.getCurrentWarehouse(),
+                        isStatisticsJob(parsedStmt));
             }
 
             coord.setJobId(jobId);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -301,6 +301,7 @@ import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.PublishVersionDaemon;
 import com.starrocks.transaction.UpdateDbUsedDataQuotaDaemon;
 import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.WarehouseInfo;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -983,6 +984,10 @@ public class GlobalStateMgr {
 
     public WarehouseManager getWarehouseMgr() {
         return warehouseMgr;
+    }
+
+    public List<WarehouseInfo> getWarehouseInfosFromOtherFEs() {
+        return nodeMgr.getWarehouseInfosFromOtherFEs();
     }
 
     public StorageVolumeMgr getStorageVolumeMgr() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -70,6 +70,8 @@ import com.starrocks.sql.ast.ModifyFrontendAddressClause;
 import com.starrocks.staros.StarMgrServer;
 import com.starrocks.system.Frontend;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TGetWarehousesRequest;
+import com.starrocks.thrift.TGetWarehousesResponse;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TResourceUsage;
 import com.starrocks.thrift.TSetConfigRequest;
@@ -78,6 +80,7 @@ import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUpdateResourceUsageRequest;
 import com.starrocks.thrift.TUpdateResourceUsageResponse;
+import com.starrocks.warehouse.WarehouseInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -170,10 +173,14 @@ public class NodeMgr {
         GlobalStateMgr.getCurrentState().unlock();
     }
 
+    public List<Frontend> getAllFrontends() {
+        return Lists.newArrayList(frontends.values());
+    }
+
     public List<Frontend> getFrontends(FrontendNodeType nodeType) {
         if (nodeType == null) {
             // get all
-            return Lists.newArrayList(frontends.values());
+            return getAllFrontends();
         }
 
         List<Frontend> result = Lists.newArrayList();
@@ -422,7 +429,6 @@ public class NodeMgr {
             LOG.error("cluster id is not equal with config item cluster_id. will exit.");
             System.exit(-1);
         }
-
 
         if (Strings.isNullOrEmpty(runMode)) {
             if (isFirstTimeStartUp) {
@@ -1110,6 +1116,37 @@ public class NodeMgr {
                 LOG.warn("UpdateResourceUsage to remote fe: {} failed", fe.getHost(), e);
             }
         }
+    }
+
+    public List<WarehouseInfo> getWarehouseInfosFromOtherFEs() {
+        List<WarehouseInfo> warehouseInfos = Lists.newArrayList();
+        TGetWarehousesRequest request = new TGetWarehousesRequest();
+
+        List<Frontend> allFrontends = getAllFrontends();
+        for (Frontend fe : allFrontends) {
+            if (fe.getHost().equals(getSelfNode().first)) {
+                continue;
+            }
+
+            try {
+                TGetWarehousesResponse response = FrontendServiceProxy
+                        .call(new TNetworkAddress(fe.getHost(), fe.getRpcPort()),
+                                Config.thrift_rpc_timeout_ms,
+                                Config.thrift_rpc_retry_times,
+                                client -> client.getWarehouses(request));
+                if (response.getStatus().getStatus_code() != TStatusCode.OK) {
+                    LOG.warn("getWarehouseInfos to remote fe: {} failed", fe.getHost());
+                } else if (response.isSetWarehouse_infos()) {
+                    response.getWarehouse_infos().stream()
+                            .map(WarehouseInfo::fromThrift)
+                            .forEach(warehouseInfos::add);
+                }
+            } catch (Exception e) {
+                LOG.warn("getWarehouseInfos to remote fe: {} failed", fe.getHost(), e);
+            }
+        }
+
+        return warehouseInfos;
     }
 
     public void setConfig(AdminSetConfigStmt stmt) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.annotations.SerializedName;
 import com.staros.util.LockCloseable;
@@ -24,6 +25,7 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.warehouse.LocalWarehouse;
 import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.WarehouseInfo;
 import com.starrocks.warehouse.WarehouseProcDir;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -34,11 +36,13 @@ import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 public class WarehouseManager implements Writable {
     private static final Logger LOG = LogManager.getLogger(WarehouseManager.class);
@@ -128,6 +132,19 @@ public class WarehouseManager implements Writable {
 
     public List<List<String>> getWarehousesInfo() {
         return new WarehouseProcDir(this).fetchResult().getRows();
+    }
+
+    public List<WarehouseInfo> getWarehouseInfos() {
+        return getWarehouses().stream()
+                .map(WarehouseInfo::fromWarehouse)
+                .collect(Collectors.toList());
+    }
+
+    @VisibleForTesting
+    protected Collection<Warehouse> getWarehouses() {
+        try (LockCloseable lock = new LockCloseable(rwLock.readLock())) {
+            return idToWh.values();
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -184,6 +184,8 @@ import com.starrocks.thrift.TGetTaskRunInfoResult;
 import com.starrocks.thrift.TGetTasksParams;
 import com.starrocks.thrift.TGetUserPrivsParams;
 import com.starrocks.thrift.TGetUserPrivsResult;
+import com.starrocks.thrift.TGetWarehousesRequest;
+import com.starrocks.thrift.TGetWarehousesResponse;
 import com.starrocks.thrift.TIsMethodSupportedRequest;
 import com.starrocks.thrift.TListMaterializedViewStatusResult;
 import com.starrocks.thrift.TListTableStatusResult;
@@ -231,6 +233,7 @@ import com.starrocks.thrift.TUpdateResourceUsageRequest;
 import com.starrocks.thrift.TUpdateResourceUsageResponse;
 import com.starrocks.thrift.TUserPrivDesc;
 import com.starrocks.thrift.TVerboseVariableRecord;
+import com.starrocks.thrift.TWarehouseInfo;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionNotFoundException;
@@ -238,6 +241,8 @@ import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionState.TxnCoordinator;
 import com.starrocks.transaction.TransactionState.TxnSourceType;
 import com.starrocks.transaction.TxnCommitAttachment;
+import com.starrocks.warehouse.WarehouseInfo;
+import com.starrocks.warehouse.WarehouseInfosBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1919,6 +1924,20 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TUpdateResourceUsageResponse res = new TUpdateResourceUsageResponse();
         TStatus status = new TStatus(TStatusCode.OK);
         res.setStatus(status);
+        return res;
+    }
+
+    @Override
+    public TGetWarehousesResponse getWarehouses(TGetWarehousesRequest request) throws TException {
+        Map<String, WarehouseInfo> warehouseToInfo = WarehouseInfosBuilder.makeBuilderFromMetricAndMgrs().build();
+        List<TWarehouseInfo> warehouseInfos = warehouseToInfo.values().stream()
+                .map(WarehouseInfo::toThrift)
+                .collect(Collectors.toList());
+
+        TGetWarehousesResponse res = new TGetWarehousesResponse();
+        res.setStatus(new TStatus(OK));
+        res.setWarehouse_infos(warehouseInfos);
+
         return res;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseInfo.java
@@ -1,0 +1,178 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.warehouse;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.thrift.TWarehouseInfo;
+
+import java.util.Objects;
+
+public class WarehouseInfo {
+    public static final long ABSENT_ID = -1L;
+
+    @SerializedName(value = "warehouse")
+    String warehouse;
+
+    @SerializedName(value = "id")
+    private long id = ABSENT_ID;
+
+    @SerializedName(value = "num_unfinished_query_jobs")
+    private long numUnfinishedQueryJobs = 0L;
+    @SerializedName(value = "num_unfinished_load_jobs")
+    private long numUnfinishedLoadJobs = 0L;
+    @SerializedName(value = "num_unfinished_backup_jobs")
+    private long numUnfinishedBackupJobs = 0L;
+    @SerializedName(value = "num_unfinished_restore_jobs")
+    private long numUnfinishedRestoreJobs = 0L;
+    @SerializedName(value = "last_finished_job_timestamp_ms")
+    private long lastFinishedJobTimestampMs = 0L;
+
+    public WarehouseInfo() {
+    }
+
+    public WarehouseInfo(String warehouse) {
+        this.warehouse = warehouse;
+    }
+
+    public WarehouseInfo(String warehouse, long id) {
+        this.warehouse = warehouse;
+        this.id = id;
+    }
+
+    public WarehouseInfo(String warehouse, long id, long numUnfinishedQueryJobs, long numUnfinishedLoadJobs,
+                         long numUnfinishedBackupJobs, long numUnfinishedRestoreJobs, long lastFinishedJobTimestampMs) {
+        this.warehouse = warehouse;
+        this.id = id;
+        this.numUnfinishedQueryJobs = numUnfinishedQueryJobs;
+        this.numUnfinishedLoadJobs = numUnfinishedLoadJobs;
+        this.numUnfinishedBackupJobs = numUnfinishedBackupJobs;
+        this.numUnfinishedRestoreJobs = numUnfinishedRestoreJobs;
+        this.lastFinishedJobTimestampMs = lastFinishedJobTimestampMs;
+    }
+
+    public void increaseNumUnfinishedQueryJobs(long delta) {
+        numUnfinishedQueryJobs += delta;
+    }
+
+    public void increaseNumUnfinishedLoadJobs(long delta) {
+        numUnfinishedLoadJobs += delta;
+    }
+
+    public void increaseNumUnfinishedBackupJobs(long delta) {
+        numUnfinishedBackupJobs += delta;
+    }
+
+    public void increaseNumUnfinishedRestoreJobs(long delta) {
+        numUnfinishedRestoreJobs += delta;
+    }
+
+    public void updateLastFinishedJobTimeMs(long timestampMs) {
+        lastFinishedJobTimestampMs = Math.max(lastFinishedJobTimestampMs, timestampMs);
+    }
+
+    public String getWarehouse() {
+        return warehouse;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public long getNumUnfinishedQueryJobs() {
+        return numUnfinishedQueryJobs;
+    }
+
+    public long getNumUnfinishedLoadJobs() {
+        return numUnfinishedLoadJobs;
+    }
+
+    public long getNumUnfinishedBackupJobs() {
+        return numUnfinishedBackupJobs;
+    }
+
+    public long getNumUnfinishedRestoreJobs() {
+        return numUnfinishedRestoreJobs;
+    }
+
+    public long getLastFinishedJobTimestampMs() {
+        return lastFinishedJobTimestampMs;
+    }
+
+    public TWarehouseInfo toThrift() {
+        return new TWarehouseInfo()
+                .setWarehouse(warehouse)
+                .setId(id)
+                .setNum_unfinished_query_jobs(numUnfinishedQueryJobs)
+                .setNum_unfinished_load_jobs(numUnfinishedLoadJobs)
+                .setNum_unfinished_backup_jobs(numUnfinishedBackupJobs)
+                .setNum_unfinished_restore_jobs(numUnfinishedRestoreJobs)
+                .setLast_finished_job_timestamp_ms(lastFinishedJobTimestampMs);
+    }
+
+    public static WarehouseInfo fromThrift(TWarehouseInfo tinfo) {
+        WarehouseInfo info = new WarehouseInfo(tinfo.getWarehouse());
+        info.id = tinfo.getId();
+        info.numUnfinishedQueryJobs = tinfo.getNum_unfinished_query_jobs();
+        info.numUnfinishedLoadJobs = tinfo.getNum_unfinished_load_jobs();
+        info.numUnfinishedBackupJobs = tinfo.getNum_unfinished_backup_jobs();
+        info.numUnfinishedRestoreJobs = tinfo.getNum_unfinished_restore_jobs();
+        info.lastFinishedJobTimestampMs = tinfo.getLast_finished_job_timestamp_ms();
+        return info;
+    }
+
+    public static WarehouseInfo fromWarehouse(Warehouse wh) {
+        return new WarehouseInfo(wh.getFullName(), wh.getId());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WarehouseInfo that = (WarehouseInfo) o;
+        return id == that.id && numUnfinishedQueryJobs == that.numUnfinishedQueryJobs &&
+                numUnfinishedLoadJobs == that.numUnfinishedLoadJobs &&
+                numUnfinishedBackupJobs == that.numUnfinishedBackupJobs &&
+                numUnfinishedRestoreJobs == that.numUnfinishedRestoreJobs &&
+                lastFinishedJobTimestampMs == that.lastFinishedJobTimestampMs &&
+                Objects.equals(warehouse, that.warehouse);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(warehouse, id, numUnfinishedQueryJobs, numUnfinishedLoadJobs, numUnfinishedBackupJobs,
+                numUnfinishedRestoreJobs, lastFinishedJobTimestampMs);
+    }
+
+    @Override
+    public String toString() {
+        return "WarehouseInfo{" +
+                "warehouse='" + warehouse + '\'' +
+                ", id=" + id +
+                ", numUnfinishedQueryJobs=" + numUnfinishedQueryJobs +
+                ", numUnfinishedLoadJobs=" + numUnfinishedLoadJobs +
+                ", numUnfinishedBackupJobs=" + numUnfinishedBackupJobs +
+                ", numUnfinishedRestoreJobs=" + numUnfinishedRestoreJobs +
+                ", lastFinishedJobTimestampMs=" + lastFinishedJobTimestampMs +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseInfosBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseInfosBuilder.java
@@ -1,0 +1,106 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.warehouse;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
+import com.starrocks.metric.WarehouseMetricMgr;
+import com.starrocks.server.GlobalStateMgr;
+
+import java.util.Map;
+
+public class WarehouseInfosBuilder {
+    private final Map<String, WarehouseInfo> warehouseToInfo = Maps.newHashMap();
+
+    public static WarehouseInfosBuilder makeBuilderFromMetricAndMgrs() {
+        WarehouseInfosBuilder builder = new WarehouseInfosBuilder();
+
+        GlobalStateMgr.getCurrentState().getWarehouseMgr()
+                .getWarehouseInfos()
+                .forEach(builder::withWarehouseInfo);
+
+        return builder
+                .withNumUnfinishedQueries(WarehouseMetricMgr.getUnfinishedQueries())
+                .withNumUnfinishedBackupJobs(WarehouseMetricMgr.getUnfinishedBackupJobs())
+                .withNumUnfinishedRestoreJobs(WarehouseMetricMgr.getUnfinishedRestoreJobs())
+                .withLastFinishedJobTimestampMs(WarehouseMetricMgr.getLastFinishedJobTimestampMs())
+                .withLoadStatusInfo(GlobalStateMgr.getCurrentState().getLoadMgr().getWarehouseLoadInfo())
+                .withLoadStatusInfo(GlobalStateMgr.getCurrentState().getRoutineLoadMgr().getWarehouseLoadInfo())
+                .withLoadStatusInfo(GlobalStateMgr.getCurrentState().getStreamLoadMgr().getWarehouseLoadInfo());
+    }
+
+    @VisibleForTesting
+    WarehouseInfosBuilder() {
+    }
+
+    public Map<String, WarehouseInfo> build() {
+        return warehouseToInfo;
+    }
+
+    public WarehouseInfosBuilder withNumUnfinishedQueries(Map<String, Long> warehouseToDelta) {
+        return withUpdater(warehouseToDelta, WarehouseInfo::increaseNumUnfinishedQueryJobs);
+    }
+
+    public WarehouseInfosBuilder withNumUnfinishedBackupJobs(Map<String, Long> warehouseToDelta) {
+        return withUpdater(warehouseToDelta, WarehouseInfo::increaseNumUnfinishedBackupJobs);
+    }
+
+    public WarehouseInfosBuilder withNumUnfinishedRestoreJobs(Map<String, Long> warehouseToDelta) {
+        return withUpdater(warehouseToDelta, WarehouseInfo::increaseNumUnfinishedRestoreJobs);
+    }
+
+    public WarehouseInfosBuilder withLastFinishedJobTimestampMs(Map<String, Long> warehouseToTimestampMs) {
+        return withUpdater(warehouseToTimestampMs, WarehouseInfo::updateLastFinishedJobTimeMs);
+    }
+
+    public WarehouseInfosBuilder withLoadStatusInfo(Map<String, WarehouseLoadStatusInfo> warehouseToLoadInfo) {
+        warehouseToLoadInfo.forEach((warehouse, loadInfo) -> {
+            WarehouseInfo info = warehouseToInfo.computeIfAbsent(warehouse, WarehouseInfo::new);
+            info.increaseNumUnfinishedLoadJobs(loadInfo.getNumUnfinishedJobs());
+            info.updateLastFinishedJobTimeMs(loadInfo.getLastFinishedJobTimeMs());
+        });
+        return this;
+    }
+
+    public WarehouseInfosBuilder withWarehouseInfo(WarehouseInfo info) {
+        if (!warehouseToInfo.containsKey(info.getWarehouse())) {
+            warehouseToInfo.put(info.getWarehouse(), info);
+        } else {
+            WarehouseInfo destInfo = warehouseToInfo.get(info.getWarehouse());
+            destInfo.increaseNumUnfinishedQueryJobs(info.getNumUnfinishedQueryJobs());
+            destInfo.increaseNumUnfinishedLoadJobs(info.getNumUnfinishedLoadJobs());
+            destInfo.increaseNumUnfinishedBackupJobs(info.getNumUnfinishedBackupJobs());
+            destInfo.increaseNumUnfinishedRestoreJobs(info.getNumUnfinishedRestoreJobs());
+            destInfo.updateLastFinishedJobTimeMs(info.getLastFinishedJobTimestampMs());
+        }
+        return this;
+    }
+
+    @FunctionalInterface
+    interface BiConsumer<T1, T2> {
+        void accept(T1 t1, T2 t2);
+    }
+
+    private WarehouseInfosBuilder withUpdater(Map<String, Long> warehouseToValue,
+                                              BiConsumer<WarehouseInfo, Long> updater) {
+        warehouseToValue.forEach((warehouse, delta) -> {
+            WarehouseInfo info = warehouseToInfo.computeIfAbsent(warehouse, WarehouseInfo::new);
+            updater.accept(info, delta);
+        });
+
+        return this;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseLoadInfoBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseLoadInfoBuilder.java
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.warehouse;
+
+import com.google.common.collect.Maps;
+import com.starrocks.load.LoadJobWithWarehouse;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class WarehouseLoadInfoBuilder {
+    private final Map<String, Long> warehouseToRemovedJobLastFinishedTimeMs = Maps.newConcurrentMap();
+
+    public <T extends LoadJobWithWarehouse> Map<String, WarehouseLoadStatusInfo> buildFromJobs(Collection<T> jobs) {
+        Map<String, WarehouseLoadStatusInfo> warehouseToInfo = Maps.newHashMap();
+        for (T job : jobs) {
+            if (job.isInternalJob()) {
+                continue;
+            }
+
+            WarehouseLoadStatusInfo info =
+                    warehouseToInfo.computeIfAbsent(job.getCurrentWarehouse(), k -> new WarehouseLoadStatusInfo());
+            if (job.isFinal()) {
+                info.updateLastFinishedJobTimeMs(job.getFinishTimestampMs());
+            } else {
+                info.increaseUnfinishedJobs();
+            }
+        }
+
+        // Merge warehouseToRemovedTaskLastFinishedTimeMs to warehouseToInfo.
+        warehouseToRemovedJobLastFinishedTimeMs.forEach((warehouse, removedTaskLastFinishedTimeMs) -> {
+            if (warehouseToInfo.containsKey(warehouse)) {
+                WarehouseLoadStatusInfo info = warehouseToInfo.get(warehouse);
+                info.updateLastFinishedJobTimeMs(removedTaskLastFinishedTimeMs);
+            } else {
+                warehouseToInfo.put(warehouse, new WarehouseLoadStatusInfo(0L, removedTaskLastFinishedTimeMs));
+            }
+        });
+
+        return warehouseToInfo;
+    }
+
+    public void withRemovedJob(LoadJobWithWarehouse job) {
+        if (!job.isFinal() || job.isInternalJob()) {
+            return;
+        }
+        warehouseToRemovedJobLastFinishedTimeMs.compute(job.getCurrentWarehouse(), (k, lastFinishedTimeMs) -> {
+            if (lastFinishedTimeMs == null) {
+                return job.getFinishTimestampMs();
+            } else {
+                return Math.max(lastFinishedTimeMs, job.getFinishTimestampMs());
+            }
+        });
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseLoadStatusInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseLoadStatusInfo.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.warehouse;
+
+public class WarehouseLoadStatusInfo {
+    private long numUnfinishedJobs = 0L;
+    private long lastFinishedJobTimeMs = 0L;
+
+    public WarehouseLoadStatusInfo() {
+    }
+
+    public WarehouseLoadStatusInfo(long numUnfinishedJobs, long lastFinishedJobTimeMs) {
+        this.numUnfinishedJobs = numUnfinishedJobs;
+        this.lastFinishedJobTimeMs = lastFinishedJobTimeMs;
+    }
+
+    public void increaseUnfinishedJobs() {
+        numUnfinishedJobs++;
+    }
+
+    public void updateLastFinishedJobTimeMs(long finishedJobTimeMs) {
+        lastFinishedJobTimeMs = Math.max(lastFinishedJobTimeMs, finishedJobTimeMs);
+    }
+
+    public long getNumUnfinishedJobs() {
+        return numUnfinishedJobs;
+    }
+
+    public long getLastFinishedJobTimeMs() {
+        return lastFinishedJobTimeMs;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -108,10 +108,10 @@ public abstract class StarRocksHttpTestCase {
     private static long testReplicaId2 = 2001;
     private static long testReplicaId3 = 2002;
 
-    private static long testDbId = 100L;
-    private static long testTableId = 200L;
+    protected static final long TEST_DB_ID = 100L;
+    protected static final long TEST_TABLE_ID = 200L;
     private static long testPartitionId = 201L;
-    public static long testIndexId = testTableId; // the base indexid == tableid
+    public static long testIndexId = TEST_TABLE_ID; // the base indexid == tableid
     private static long tabletId = 400L;
 
     public static long testStartVersion = 12;
@@ -153,7 +153,8 @@ public abstract class StarRocksHttpTestCase {
         // index
         MaterializedIndex baseIndex = new MaterializedIndex(testIndexId, MaterializedIndex.IndexState.NORMAL);
         TabletMeta tabletMeta =
-                new TabletMeta(testDbId, testTableId, testPartitionId, testIndexId, testSchemaHash, TStorageMedium.HDD);
+                new TabletMeta(TEST_DB_ID, TEST_TABLE_ID, testPartitionId, testIndexId, testSchemaHash,
+                        TStorageMedium.HDD);
         baseIndex.addTablet(tablet, tabletMeta);
 
         tablet.addReplica(replica1);
@@ -171,7 +172,7 @@ public abstract class StarRocksHttpTestCase {
         partitionInfo.setDataProperty(testPartitionId, DataProperty.DEFAULT_DATA_PROPERTY);
         partitionInfo.setReplicationNum(testPartitionId, (short) 3);
         partitionInfo.setIsInMemory(testPartitionId, false);
-        OlapTable table = new OlapTable(testTableId, name, columns, KeysType.AGG_KEYS, partitionInfo,
+        OlapTable table = new OlapTable(TEST_TABLE_ID, name, columns, KeysType.AGG_KEYS, partitionInfo,
                 distributionInfo);
         table.addPartition(partition);
         table.setIndexMeta(testIndexId, "testIndex", columns, 0, testSchemaHash, (short) 1,
@@ -197,7 +198,7 @@ public abstract class StarRocksHttpTestCase {
         props.put(EsTable.KEY_INDEX, "test");
         props.put(EsTable.KEY_TYPE, "doc");
         try {
-            table = new EsTable(testTableId + 1, name, columns, props, partitionInfo);
+            table = new EsTable(TEST_TABLE_ID + 1, name, columns, props, partitionInfo);
         } catch (DdlException e) {
             e.printStackTrace();
         }
@@ -209,7 +210,7 @@ public abstract class StarRocksHttpTestCase {
             GlobalStateMgr globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
             Auth auth = new Auth();
             //EasyMock.expect(globalStateMgr.getAuth()).andReturn(starrocksAuth).anyTimes();
-            Database db = new Database(testDbId, "testDb");
+            Database db = new Database(TEST_DB_ID, "testDb");
             OlapTable table = newTable(TABLE_NAME);
             db.registerTableUnlocked(table);
             OlapTable table1 = newTable(TABLE_NAME + 1);
@@ -276,7 +277,7 @@ public abstract class StarRocksHttpTestCase {
             GlobalStateMgr globalStateMgr = Deencapsulation.newInstance(GlobalStateMgr.class);
             Auth auth = new Auth();
             //EasyMock.expect(globalStateMgr.getAuth()).andReturn(starrocksAuth).anyTimes();
-            Database db = new Database(testDbId, "testDb");
+            Database db = new Database(TEST_DB_ID, "testDb");
             OlapTable table = newTable(TABLE_NAME);
             db.registerTableUnlocked(table);
             OlapTable table1 = newTable(TABLE_NAME + 1);
@@ -415,6 +416,11 @@ public abstract class StarRocksHttpTestCase {
             @Mock
             TabletInvertedIndex getCurrentInvertedIndex() {
                 return tabletInvertedIndex;
+            }
+
+            @Mock
+            public EditLog getEditLog() {
+                return new EditLog(null);
             }
         };
         assignBackends();

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -120,6 +120,7 @@ public abstract class StarRocksHttpTestCase {
     public static int HTTP_PORT;
 
     protected static String URI;
+    protected static String BASE_URL;
 
     protected String rootAuth = Credentials.basic("root", "");
 
@@ -366,7 +367,8 @@ public abstract class StarRocksHttpTestCase {
             socket = new ServerSocket(0);
             socket.setReuseAddress(true);
             HTTP_PORT = socket.getLocalPort();
-            URI = "http://localhost:" + HTTP_PORT + "/api/" + DB_NAME + "/" + TABLE_NAME;
+            BASE_URL = "http://localhost:" + HTTP_PORT;
+            URI = BASE_URL + "/api/" + DB_NAME + "/" + TABLE_NAME;
         } catch (Exception e) {
             throw new IllegalStateException("Could not find a free TCP/IP port to start HTTP Server on");
         } finally {

--- a/fe/fe-core/src/test/java/com/starrocks/http/WarehouseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/WarehouseActionTest.java
@@ -1,0 +1,569 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.CatalogIdGenerator;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.ClientPool;
+import com.starrocks.common.Config;
+import com.starrocks.common.GenericPool;
+import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.Pair;
+import com.starrocks.common.UserException;
+import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.http.rest.ActionStatus;
+import com.starrocks.http.rest.RestSuccessBaseResult;
+import com.starrocks.http.rest.WarehouseAction;
+import com.starrocks.load.EtlJobType;
+import com.starrocks.load.loadv2.BrokerLoadJob;
+import com.starrocks.load.loadv2.JobState;
+import com.starrocks.load.loadv2.LoadJob;
+import com.starrocks.load.loadv2.LoadMgr;
+import com.starrocks.load.loadv2.SparkLoadJob;
+import com.starrocks.load.routineload.KafkaRoutineLoadJob;
+import com.starrocks.load.routineload.RoutineLoadJob;
+import com.starrocks.load.routineload.RoutineLoadMgr;
+import com.starrocks.load.streamload.StreamLoadMgr;
+import com.starrocks.load.streamload.StreamLoadTask;
+import com.starrocks.metric.WarehouseMetricMgr;
+import com.starrocks.persist.EditLog;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.statistic.StatisticUtils;
+import com.starrocks.system.Frontend;
+import com.starrocks.thrift.FrontendService;
+import com.starrocks.thrift.TGetWarehousesRequest;
+import com.starrocks.thrift.TGetWarehousesResponse;
+import com.starrocks.thrift.TLoadJobType;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.utframe.MockGenericPool;
+import com.starrocks.warehouse.LocalWarehouse;
+import com.starrocks.warehouse.Warehouse;
+import com.starrocks.warehouse.WarehouseInfo;
+import com.starrocks.warehouse.WarehouseInfosBuilder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import mockit.Mock;
+import mockit.MockUp;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.apache.thrift.TException;
+import org.apache.thrift.TServiceClient;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.sparkproject.guava.collect.ImmutableMap;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WarehouseActionTest extends StarRocksHttpTestCase {
+    private static final AtomicLong NEXT_INDEX = new AtomicLong(0L);
+    private LoadMgr loadMgr;
+    private RoutineLoadMgr routineLoadMgr;
+    private StreamLoadMgr streamLoadMgr;
+
+    private GenericPool<FrontendService.Client> prevFrontendClientPool;
+
+    @Before
+    public void before() {
+        GlobalStateMgr.getCurrentState().initDefaultWarehouse();
+        mockLoadMgr();
+
+        // Mock CatalogIdGenerator::getNextId, which is used when creating a new load job and assigned a job id.
+        new MockUp<CatalogIdGenerator>() {
+            @Mock
+            public synchronized long getNextId() {
+                return NEXT_INDEX.getAndIncrement();
+            }
+        };
+
+        // Mock logCreateXxxLoadJob to make we able to add LoadJobs to the load managers.
+        new MockUp<EditLog>() {
+            @Mock
+            public void logCreateLoadJob(com.starrocks.load.loadv2.LoadJob loadJob) {
+                // Do nothing.
+            }
+
+            @Mock
+            public void logCreateRoutineLoadJob(RoutineLoadJob routineLoadJob) {
+                // Do nothing.
+            }
+        };
+
+        prevFrontendClientPool = ClientPool.frontendPool;
+        ClientPool.frontendPool = new MockGenericPool("mock-pool") {
+            @Override
+            public TServiceClient borrowObject(TNetworkAddress address) throws Exception {
+                return new FrontendService.Client(null);
+            }
+        };
+    }
+
+    @After
+    public void after() {
+        ClientPool.frontendPool = prevFrontendClientPool;
+    }
+
+    @Test
+    public void testGetWarehousesEmpty() throws IOException {
+        Map<String, WarehouseInfo> infos = fetchWarehouseInfos();
+        assertThat(infos.values()).containsOnlyOnce(new WarehouseInfo(WarehouseManager.DEFAULT_WAREHOUSE_NAME, 0L));
+    }
+
+    @Test
+    public void testGetWarehousesWithException() throws IOException {
+        new MockUp<WarehouseInfosBuilder>() {
+            @Mock
+            public WarehouseInfosBuilder makeBuilderFromMetricAndMgrs() {
+                throw new RuntimeException("mock-runtime-exception");
+            }
+        };
+
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url(BASE_URL + WarehouseAction.URI)
+                .build();
+
+        try (Response response = networkClient.newCall(request).execute()) {
+            Assert.assertFalse(response.isSuccessful());
+            Assert.assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(), response.code());
+
+            Assert.assertNotNull(response.body());
+            RestSuccessBaseResult<WarehouseAction.Result> res =
+                    RestSuccessBaseResult.fromJson(response.body().charStream(), WarehouseAction.Result.class);
+            Assert.assertEquals(ActionStatus.FAILED, res.status);
+            assertThat(res.msg).contains("mock-runtime-exception");
+        }
+    }
+
+    @Test
+    public void testGetWarehouses() throws IOException, UserException, InterruptedException {
+        List<Warehouse> whs = ImmutableList.of(
+                new LocalWarehouse(WarehouseManager.DEFAULT_WAREHOUSE_ID, WarehouseManager.DEFAULT_WAREHOUSE_NAME),
+                new LocalWarehouse(1, "wh-1"));
+
+        Map<Warehouse, JobExecutingInfo> whToJobInfo = ImmutableMap.of(
+                whs.get(0), new JobExecutingInfo(
+                        new JobInfo(10L, 20L, 30L, 40L, 50L, 60L, 70L, 80L),
+                        new JobInfo(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L)
+                ),
+                whs.get(1), new JobExecutingInfo(
+                        new JobInfo(11L, 21L, 31L, 41L, 51L, 61L, 71L, 81L),
+                        new JobInfo(2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L)
+                )
+        );
+
+        long startTimestampMs = System.currentTimeMillis();
+        Map<String, WarehouseInfo> expectedWhToWhInfo = prepareWarehouseJobExecutingInfo(whToJobInfo);
+        long afterTimestampMs = System.currentTimeMillis();
+
+        // Add statistics insert jobs.
+        Thread.sleep(10L); // Make the finished timestamps of statistic jobs are different from the above jobs.
+        addInsertLoadJobs(whs.get(0).getFullName(), 13, false, true);
+        addInsertLoadJobs(whs.get(1).getFullName(), 12, true, true);
+
+        // ------------------------------------------------------------------------------------
+        // Case 1. The warehouse#1 is not in the warehouse manager.
+        // ------------------------------------------------------------------------------------
+        Map<String, WarehouseInfo> whToWhInfo = fetchWarehouseInfos();
+        Assert.assertEquals(2, whToWhInfo.size());
+
+        // Check the finished timestamp, it occurs in prepareWarehouseJobExecutingInfo,
+        // which should be between [startTimestampMs, afterTimestampMs].
+        whToWhInfo.forEach((wh, whInfo) -> {
+            assertThat(whInfo.getLastFinishedJobTimestampMs())
+                    .isGreaterThanOrEqualTo(startTimestampMs)
+                    .isLessThanOrEqualTo(afterTimestampMs);
+            // Record the timestamp to expected.
+            expectedWhToWhInfo.get(wh).updateLastFinishedJobTimeMs(whInfo.getLastFinishedJobTimestampMs());
+        });
+        // The warehouse#1 hasn't been in the warehouse manager, so WarehouseInfo.id is ABSENT_ID.
+        assertThat(whToWhInfo.get(whs.get(1).getFullName()).getId()).isEqualTo(WarehouseInfo.ABSENT_ID);
+        // Set id of warehouse#1 to ABSENT_ID temporarily, to compare the whole info below.
+        expectedWhToWhInfo.get(whs.get(1).getFullName()).setId(WarehouseInfo.ABSENT_ID);
+        assertThat(whToWhInfo).containsExactlyInAnyOrderEntriesOf(expectedWhToWhInfo);
+        // Reset id of warehouse#1.
+        expectedWhToWhInfo.get(whs.get(1).getFullName()).setId(1);
+
+        // ------------------------------------------------------------------------------------
+        // Case 2. All the warehouses are in the warehouse manager.
+        // ------------------------------------------------------------------------------------
+        mockWarehouses(whs);
+        whToWhInfo = fetchWarehouseInfos();
+        assertThat(whToWhInfo).containsExactlyInAnyOrderEntriesOf(expectedWhToWhInfo);
+
+        // ------------------------------------------------------------------------------------
+        // Case 3. After removing the expired finished jobs from load managers,
+        // the last finished timestamp should not be different.
+        // ------------------------------------------------------------------------------------
+        int prevLabelKeepMaxSecond = Config.label_keep_max_second;
+        int prevLabelKeepMaxNum = Config.label_keep_max_num;
+        try {
+            Config.label_keep_max_second = 1;
+            Config.label_keep_max_num = 0;
+            Thread.sleep(Config.label_keep_max_second); // Make the jobs expired.
+
+            loadMgr.removeOldLoadJob();
+            routineLoadMgr.cleanOldRoutineLoadJobs();
+            streamLoadMgr.cleanOldStreamLoadTasks(true);
+            streamLoadMgr.cleanSyncStreamLoadTasks();
+
+            whToWhInfo = fetchWarehouseInfos();
+            assertThat(whToWhInfo).containsExactlyInAnyOrderEntriesOf(expectedWhToWhInfo);
+
+        } finally {
+            Config.label_keep_max_num = prevLabelKeepMaxNum;
+            Config.label_keep_max_second = prevLabelKeepMaxSecond;
+        }
+    }
+
+    @Test
+    public void testGetWarehousesWithMultipleFEs() throws IOException {
+        List<Frontend> frontends = ImmutableList.of(
+                new Frontend(FrontendNodeType.FOLLOWER, "FE-1", "127.0.0.1", 9010),
+                new Frontend(FrontendNodeType.FOLLOWER, "FE-2", "127.0.0.2", 9010),
+                new Frontend(FrontendNodeType.FOLLOWER, "FE-3", "127.0.0.3", 9010),
+                new Frontend(FrontendNodeType.FOLLOWER, "FE-4", "127.0.0.4", 9010),
+                new Frontend(FrontendNodeType.FOLLOWER, "FE-5", "127.0.0.5", 9010),
+                new Frontend(FrontendNodeType.FOLLOWER, "FE-6", "127.0.0.6", 9010),
+                new Frontend(FrontendNodeType.FOLLOWER, "FE-7", "127.0.0.7", 9010),
+                new Frontend(FrontendNodeType.FOLLOWER, "FE-8", "127.0.0.8", 9010)
+        );
+
+        List<List<WarehouseInfo>> whInfosPerFE = ImmutableList.of(
+                // FE-2
+                ImmutableList.of(
+                        new WarehouseInfo(WarehouseManager.DEFAULT_WAREHOUSE_NAME,
+                                WarehouseManager.DEFAULT_WAREHOUSE_ID, 1L, 2L, 3L, 4L, 5L),
+                        new WarehouseInfo("wh-1", 1, 6, 7, 8, 9, 4L)
+                ),
+                // FE-3
+                ImmutableList.of(
+                        new WarehouseInfo(WarehouseManager.DEFAULT_WAREHOUSE_NAME,
+                                WarehouseManager.DEFAULT_WAREHOUSE_ID, 10L, 12L, 13L, 14L, 15L),
+                        new WarehouseInfo("wh-2", 2, 16, 17, 18, 19, 14L)
+                )
+        );
+        Map<String, WarehouseInfo> expectedWhToInfos = Maps.newHashMap();
+        whInfosPerFE.stream().flatMap(Collection::stream).forEach(newInfo ->
+                expectedWhToInfos.compute(newInfo.getWarehouse(), (wh, prevInfo) -> {
+                    WarehouseInfo info = prevInfo;
+                    if (prevInfo == null) {
+                        info = new WarehouseInfo(newInfo.getWarehouse(), newInfo.getId());
+                    }
+                    info.increaseNumUnfinishedQueryJobs(newInfo.getNumUnfinishedQueryJobs());
+                    info.increaseNumUnfinishedLoadJobs(newInfo.getNumUnfinishedLoadJobs());
+                    info.increaseNumUnfinishedBackupJobs(newInfo.getNumUnfinishedBackupJobs());
+                    info.increaseNumUnfinishedRestoreJobs(newInfo.getNumUnfinishedRestoreJobs());
+                    info.updateLastFinishedJobTimeMs(newInfo.getLastFinishedJobTimestampMs());
+
+                    return info;
+                }));
+
+        new MockUp<NodeMgr>() {
+            @Mock
+            public List<Frontend> getAllFrontends() {
+                return frontends;
+            }
+
+            @Mock
+            public Pair<String, Integer> getSelfNode() {
+                return new Pair<>("127.0.0.1", 9010);
+            }
+        };
+
+        AtomicInteger getTimes = new AtomicInteger(0);
+        new MockUp<FrontendService.Client>() {
+            @Mock
+            public TGetWarehousesResponse getWarehouses(TGetWarehousesRequest request) throws TException {
+                int times = getTimes.getAndIncrement();
+                if (times < whInfosPerFE.size()) {
+                    TGetWarehousesResponse res = new TGetWarehousesResponse();
+                    res.setStatus(new TStatus(TStatusCode.OK));
+                    res.setWarehouse_infos(
+                            whInfosPerFE.get(times).stream().map(WarehouseInfo::toThrift).collect(Collectors.toList()));
+                    return res;
+                } else if (times < whInfosPerFE.size() + 1) { // Internal Error.
+                    TGetWarehousesResponse res = new TGetWarehousesResponse();
+                    res.setStatus(new TStatus(TStatusCode.INTERNAL_ERROR));
+                    return res;
+                } else if (times < whInfosPerFE.size() + 2) { // OK without warehouse_infos.
+                    TGetWarehousesResponse res = new TGetWarehousesResponse();
+                    res.setStatus(new TStatus(TStatusCode.OK));
+                    return res;
+                } else { // Throw exception.
+                    throw new TException("mock exception");
+                }
+            }
+        };
+
+        Map<String, WarehouseInfo> infos = fetchWarehouseInfos();
+        assertThat(infos).containsExactlyInAnyOrderEntriesOf(expectedWhToInfos);
+    }
+
+    private void mockWarehouses(List<Warehouse> warehouses) {
+        new MockUp<WarehouseManager>() {
+            @Mock
+            Collection<Warehouse> getWarehouses() {
+                return warehouses;
+            }
+        };
+    }
+
+    /**
+     * Reset all the load managers to clear information of jobs.
+     */
+    private void mockLoadMgr() {
+        loadMgr = new LoadMgr(null);
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public LoadMgr getLoadMgr() {
+                return loadMgr;
+            }
+        };
+
+        routineLoadMgr = new RoutineLoadMgr();
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public RoutineLoadMgr getRoutineLoadMgr() {
+                return routineLoadMgr;
+            }
+        };
+
+        streamLoadMgr = new StreamLoadMgr();
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public StreamLoadMgr getStreamLoadMgr() {
+                return streamLoadMgr;
+            }
+        };
+    }
+
+    private static class JobInfo {
+        private final long numQueryJobs;
+        private final long numBackupJobs;
+        private final long numRestoreJobs;
+
+        private final long numBrokerLoadJobs;
+        private final long numInsertLoadJobs;
+        private final long numSparkLoadJobs;
+        private final long numRoutineLoadJobs;
+        private final long numStreamLoadJobs;
+
+        public JobInfo(long numQueryJobs, long numBackupJobs, long numRestoreJobs, long numBrokerLoadJobs,
+                       long numInsertLoadJobs, long numSparkLoadJobs, long numRoutineLoadJobs, long numStreamLoadJobs) {
+            this.numQueryJobs = numQueryJobs;
+            this.numBackupJobs = numBackupJobs;
+            this.numRestoreJobs = numRestoreJobs;
+            this.numBrokerLoadJobs = numBrokerLoadJobs;
+            this.numInsertLoadJobs = numInsertLoadJobs;
+            this.numSparkLoadJobs = numSparkLoadJobs;
+            this.numRoutineLoadJobs = numRoutineLoadJobs;
+            this.numStreamLoadJobs = numStreamLoadJobs;
+        }
+
+        private long getNumLoadJobsSupportWh() {
+            return numBrokerLoadJobs + numInsertLoadJobs;
+        }
+
+        private long getNumLoadJobsNonSupportWh() {
+            return numSparkLoadJobs + numRoutineLoadJobs + numStreamLoadJobs;
+        }
+    }
+
+    private static class JobExecutingInfo {
+        private final JobInfo unfinishedInfo;
+        private final JobInfo finishedInfo;
+
+        public JobExecutingInfo(JobInfo unfinishedInfo, JobInfo finishedInfo) {
+            this.unfinishedInfo = unfinishedInfo;
+            this.finishedInfo = finishedInfo;
+        }
+    }
+
+    private Map<String, WarehouseInfo> prepareWarehouseJobExecutingInfo(Map<Warehouse, JobExecutingInfo> whToInfo)
+            throws UserException {
+        Map<String, WarehouseInfo> whToWhInfo = whToInfo.keySet().stream().collect(Collectors.toMap(
+                Warehouse::getFullName,
+                WarehouseInfo::fromWarehouse
+        ));
+        WarehouseInfo defaultWhInfo = whToWhInfo.get(WarehouseManager.DEFAULT_WAREHOUSE_NAME);
+
+        for (Map.Entry<Warehouse, JobExecutingInfo> whAndJobInfo : whToInfo.entrySet()) {
+            Warehouse wh = whAndJobInfo.getKey();
+            JobExecutingInfo jobInfo = whAndJobInfo.getValue();
+
+            WarehouseInfo whInfo = whToWhInfo.get(wh.getFullName());
+
+            prepareJobInfo(whInfo, defaultWhInfo, wh, jobInfo.finishedInfo, true);
+            prepareJobInfo(whInfo, defaultWhInfo, wh, jobInfo.unfinishedInfo, false);
+        }
+
+        return whToWhInfo;
+    }
+
+    private void prepareJobInfo(WarehouseInfo whInfo, WarehouseInfo defaultWhInfo, Warehouse wh, JobInfo jobInfo,
+                                boolean isFinished)
+            throws UserException {
+        long deltaFactor = isFinished ? -1L : 1L;
+
+        // Add job info to whInfo.
+        whInfo.increaseNumUnfinishedQueryJobs(jobInfo.numQueryJobs * deltaFactor);
+        whInfo.increaseNumUnfinishedBackupJobs(jobInfo.numBackupJobs * deltaFactor);
+        whInfo.increaseNumUnfinishedRestoreJobs(jobInfo.numRestoreJobs * deltaFactor);
+        if (!isFinished) {
+            whInfo.increaseNumUnfinishedLoadJobs(jobInfo.getNumLoadJobsSupportWh());
+            defaultWhInfo.increaseNumUnfinishedLoadJobs(jobInfo.getNumLoadJobsNonSupportWh());
+        }
+
+        // Add job info to metric and manager.
+        WarehouseMetricMgr.increaseUnfinishedQueries(wh.getFullName(), jobInfo.numQueryJobs * deltaFactor);
+        WarehouseMetricMgr.increaseUnfinishedBackupJobs(wh.getFullName(), jobInfo.numBackupJobs * deltaFactor);
+        WarehouseMetricMgr.increaseUnfinishedRestoreJobs(wh.getFullName(), jobInfo.numRestoreJobs * deltaFactor);
+        addLoadJobs(wh.getFullName(), jobInfo.numBrokerLoadJobs, isFinished, this::genBrokerLoadJob);
+        addLoadJobs(wh.getFullName(), jobInfo.numSparkLoadJobs, isFinished, this::genSparkLoadJob);
+        addInsertLoadJobs(wh.getFullName(), jobInfo.numInsertLoadJobs, isFinished, false);
+        addRoutineJobs(wh.getFullName(), jobInfo.numRoutineLoadJobs, isFinished);
+        addStreamJobs(wh.getFullName(), jobInfo.numStreamLoadJobs, isFinished);
+    }
+
+    private BrokerLoadJob genBrokerLoadJob(String wh) throws MetaNotFoundException {
+        ConnectContext context = StatisticUtils.buildConnectContext();
+        context.setCurrentWarehouse(wh);
+        return new BrokerLoadJob(TEST_DB_ID, "broker-load-" + NEXT_INDEX.getAndIncrement(), null, null, context);
+    }
+
+    private SparkLoadJob genSparkLoadJob(String wh) throws MetaNotFoundException {
+        return new SparkLoadJob(TEST_DB_ID, "spark-load-" + NEXT_INDEX.getAndIncrement(), null, null);
+    }
+
+    private RoutineLoadJob genRoutineLoadJob(String wh) {
+        return new KafkaRoutineLoadJob(NEXT_INDEX.getAndIncrement(), "routine-load-" + NEXT_INDEX.getAndIncrement(),
+                TEST_DB_ID, TEST_TABLE_ID, "brokerList", "topic");
+    }
+
+    private StreamLoadTask genStreamLoadJob(String wh) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(TEST_DB_ID);
+        Table table = db.getTable(TEST_TABLE_ID);
+        return new StreamLoadTask(NEXT_INDEX.getAndIncrement(),
+                db,
+                (OlapTable) table,
+                "stream-load-" + NEXT_INDEX.getAndIncrement(),
+                0L, System.currentTimeMillis(),
+                false);
+    }
+
+    @FunctionalInterface
+    interface FunctionWithException<T, R, E extends Exception> {
+        R apply(T t) throws E;
+    }
+
+    private void addLoadJobs(String wh, long numJobs, boolean isFinished,
+                             FunctionWithException<String, LoadJob, MetaNotFoundException> jobSupplier)
+            throws MetaNotFoundException {
+        for (int i = 0; i < numJobs; i++) {
+            LoadJob job = jobSupplier.apply(wh);
+            if (isFinished) {
+                job.updateState(JobState.FINISHED);
+            }
+            loadMgr.replayCreateLoadJob(job);
+        }
+    }
+
+    private void addInsertLoadJobs(String wh, long numJobs, boolean isFinished, boolean isStatisticsJob)
+            throws UserException {
+
+        for (int i = 0; i < numJobs; i++) {
+            long jobId = loadMgr.registerLoadJob(
+                    "insert-load-" + NEXT_INDEX.getAndIncrement(),
+                    DB_NAME,
+                    TEST_TABLE_ID,
+                    EtlJobType.INSERT,
+                    System.currentTimeMillis(),
+                    0L,
+                    TLoadJobType.INSERT_QUERY,
+                    0L,
+                    wh,
+                    isStatisticsJob);
+            if (isFinished) {
+                loadMgr.getLoadJob(jobId).updateState(JobState.FINISHED);
+            }
+        }
+    }
+
+    private void addRoutineJobs(String wh, long numJobs, boolean isFinished)
+            throws UserException {
+        for (int i = 0; i < numJobs; i++) {
+            RoutineLoadJob job = genRoutineLoadJob(wh);
+            if (isFinished) {
+                job.updateState(RoutineLoadJob.JobState.STOPPED, null, true);
+            }
+            routineLoadMgr.addRoutineLoadJob(job, DB_NAME);
+        }
+    }
+
+    private void addStreamJobs(String wh, long numJobs, boolean isFinished)
+            throws UserException {
+        for (int i = 0; i < numJobs; i++) {
+            StreamLoadTask job = genStreamLoadJob(wh);
+            if (isFinished) {
+                job.cancelAfterRestart();
+            }
+            streamLoadMgr.addLoadTask(job);
+        }
+    }
+
+    private Map<String, WarehouseInfo> fetchWarehouseInfos() throws IOException {
+
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url(BASE_URL + WarehouseAction.URI)
+                .build();
+
+        try (Response response = networkClient.newCall(request).execute()) {
+            Assert.assertTrue(response.isSuccessful());
+
+            Assert.assertNotNull(response.body());
+            RestSuccessBaseResult<WarehouseAction.Result> res =
+                    RestSuccessBaseResult.fromJson(response.body().charStream(), WarehouseAction.Result.class);
+            Assert.assertEquals(ActionStatus.OK, res.status);
+
+            return res.getResult().getWarehouses().stream()
+                    .collect(Collectors.toMap(
+                            WarehouseInfo::getWarehouse,
+                            Function.identity()
+                    ));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/WarehouseActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/WarehouseActionTest.java
@@ -235,8 +235,7 @@ public class WarehouseActionTest extends StarRocksHttpTestCase {
 
             loadMgr.removeOldLoadJob();
             routineLoadMgr.cleanOldRoutineLoadJobs();
-            streamLoadMgr.cleanOldStreamLoadTasks(true);
-            streamLoadMgr.cleanSyncStreamLoadTasks();
+            streamLoadMgr.cleanOldStreamLoadTasks();
 
             whToWhInfo = fetchWarehouseInfos();
             assertThat(whToWhInfo).containsExactlyInAnyOrderEntriesOf(expectedWhToWhInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadManagerTest.java
@@ -56,6 +56,7 @@ import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.ColumnSeparator;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.PauseRoutineLoadStmt;
@@ -670,6 +671,9 @@ public class RoutineLoadManagerTest {
                 routineLoadJob.getName();
                 minTimes = 0;
                 result = "";
+                routineLoadJob.getCurrentWarehouse();
+                minTimes = 0;
+                result = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
                 globalStateMgr.getEditLog();
                 minTimes = 0;
                 result = editLog;
@@ -704,6 +708,9 @@ public class RoutineLoadManagerTest {
                 routineLoadJob.getDbId();
                 minTimes = 0;
                 result = 1L;
+                routineLoadJob.getCurrentWarehouse();
+                minTimes = 0;
+                result = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
                 operation.getId();
                 minTimes = 0;
                 result = 1L;

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1204,6 +1204,24 @@ struct TUpdateResourceUsageResponse {
     1: optional Status.TStatus status
 }
 
+struct TGetWarehousesRequest {
+}
+
+struct TWarehouseInfo {
+    1: optional string warehouse
+    2: optional i64 id
+    3: optional i64 num_unfinished_query_jobs
+    4: optional i64 num_unfinished_load_jobs
+    5: optional i64 num_unfinished_backup_jobs
+    6: optional i64 num_unfinished_restore_jobs
+    7: optional i64 last_finished_job_timestamp_ms
+}
+
+struct TGetWarehousesResponse {
+    1: optional Status.TStatus status
+    2: optional list<TWarehouseInfo> warehouse_infos;
+}
+
 struct TTableInfo {
     1: optional string table_catalog
     2: optional string table_schema
@@ -1345,6 +1363,8 @@ service FrontendService {
     TCreatePartitionResult createPartition(1: TCreatePartitionRequest request)
 
     TUpdateResourceUsageResponse updateResourceUsage(1: TUpdateResourceUsageRequest request)
+
+    TGetWarehousesResponse getWarehouses(1: TGetWarehousesRequest request)
     
     // For Materialized View
     MVMaintenance.TMVReportEpochResponse mvReport(1: MVMaintenance.TMVMaintenanceTasks request)


### PR DESCRIPTION
This is cherry-picked from #27567.

- URI: `API /api/v2/warehouses`
- Method: `GET`

- Code: 200
- Body:
```json
{
    "status": "OK",
    "msg": "Success",
    "result": {
        "warehouses": [
          {
            "warehouse": "default",
            "num_unfinished_query_jobs": 1,
            "num_unfinished_load_jobs": 2,
            "num_unfinished_backup_jobs": 3,
            "num_unfinished_restore_jobs": 4,
            "last_finished_job_timestamp_ms": 1689652900112
          },
          {
            "warehouse": "test_warehouse",
            "num_unfinished_query_jobs": 1,
            "num_unfinished_load_jobs": 2,
            "num_unfinished_backup_jobs": 3,
            "num_unfinished_restore_jobs": 4,
            "last_finished_job_timestamp_ms": 1689652900112
          },
        ]
    }
}
```

- Code: not 200/201/202/203
- Response:
```json
{
    "status": "Failed",
    "msg": "<error-msg>"
}
```

Note that only the jobs which is submitted by users themself are recorded in the above metrics.

The number of unfinished query, backup, and restore jobs and last finished timestamp are recorded by the metric counter. When the job is starting, the counter++; when the job is finished, the counter -- and record the finished timestamp.

The number of unfinished load jobs computes according to `idToJobs` in `LoadMgr`, `RoutineLoadMgr`, and `StreamLoadMgr`.

The HTTP handler `WarehouseAction` fetches the information from all the other FEs via the RPC `getWarehouses`, and will ignore all the failed RPC response.

- The backup, restore, spark load, routine load, stream load job don't support switch the current warehouse, which means their warehouse is always `default_warehouse`.
- All the query and load jobs using `_statistic_`, which is the internal statistic table, are considered as not user-queries.

---------

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
