### PR TITLE
[Feature] support star mgr worker info sync with fe be/cn info (backport #27647)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -47,7 +47,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
-import com.starrocks.lake.ShardDeleter;
+import com.starrocks.lake.StarMgrMetaSyncer;
 import com.starrocks.lake.Utils;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.gson.GsonUtils;
@@ -498,7 +498,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
             unusedShards.addAll(shards);
         }
         // TODO: what if unusedShards deletion is partially successful?
-        ShardDeleter.dropTabletAndDeleteShard(unusedShards, GlobalStateMgr.getCurrentStarOSAgent());
+        StarMgrMetaSyncer.dropTabletAndDeleteShard(unusedShards, GlobalStateMgr.getCurrentStarOSAgent());
 
         if (span != null) {
             span.end();

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2006,10 +2006,10 @@ public class Config extends ConfigBase {
     public static long shard_group_clean_threshold_sec = 3600L;
 
     /**
-     * ShardDeleter run interval in seconds
+     * fe sync with star mgr meta interval in seconds
      */
     @ConfField
-    public static long shard_deleter_run_interval_sec = 600L;
+    public static long star_mgr_meta_sync_interval_sec = 600L;
 
     // ***********************************************************
     // * BEGIN: Cloud native meta server related configurations

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -18,6 +18,7 @@ package com.starrocks.lake;
 import autovalue.shaded.com.google.common.common.collect.Lists;
 import autovalue.shaded.com.google.common.common.collect.Sets;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableCollection;
 import com.staros.proto.ShardGroupInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
@@ -33,6 +34,7 @@ import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,11 +45,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class ShardDeleter extends FrontendDaemon {
-    private static final Logger LOG = LogManager.getLogger(ShardDeleter.class);
+public class StarMgrMetaSyncer extends FrontendDaemon {
+    private static final Logger LOG = LogManager.getLogger(StarMgrMetaSyncer.class);
 
-    public ShardDeleter() {
-        super("ShardDeleter", Config.shard_deleter_run_interval_sec * 1000L);
+    public StarMgrMetaSyncer() {
+        super("StarMgrMetaSyncer", Config.star_mgr_meta_sync_interval_sec * 1000L);
     }
 
     private List<Long> getAllPartitionShardGroupId() {
@@ -188,8 +190,46 @@ public class ShardDeleter extends FrontendDaemon {
         }
     }
 
+    // get snapshot of star mgr workers and fe backend/compute node,
+    // if worker not found in backend/compute node, remove it from star mgr
+    public int deleteUnusedWorker() {
+        int cnt = 0;
+        try {
+            List<String> workerAddresses = GlobalStateMgr.getCurrentStarOSAgent().listDefaultWorkerGroupIpPort();
+
+            // filter backend
+            List<Backend> backends = GlobalStateMgr.getCurrentSystemInfo().getBackends();
+            for (Backend backend : backends) {
+                if (backend.getStarletPort() != 0) {
+                    String workerAddr = backend.getHost() + ":" + backend.getStarletPort();
+                    workerAddresses.remove(workerAddr);
+                }
+            }
+
+            // filter compute node
+            ImmutableCollection<ComputeNode> computeNodes =
+                    GlobalStateMgr.getCurrentSystemInfo().getComputeNodes(false /* needAlive */);
+            for (ComputeNode computeNode : computeNodes) {
+                if (computeNode.getStarletPort() != 0) {
+                    String workerAddr = computeNode.getHost() + ":" + computeNode.getStarletPort();
+                    workerAddresses.remove(workerAddr);
+                }
+            }
+
+            for (String unusedWorkerAddress : workerAddresses) {
+                GlobalStateMgr.getCurrentStarOSAgent().removeWorker(unusedWorkerAddress);
+                LOG.info("unused worker {} removed from star mgr", unusedWorkerAddress);
+                cnt++;
+            }
+        } catch (Exception e) {
+            LOG.warn("fail to delete unused worker, {}", e);
+        }
+        return cnt;
+    }
+
     @Override
     protected void runAfterCatalogReady() {
         deleteUnusedShardAndShardGroup();
+        deleteUnusedWorker();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -686,4 +686,21 @@ public class StarOSAgent {
             throw new UserException("Failed to get workers by group id. error: " + e.getMessage());
         }
     }
+
+    public List<String> listDefaultWorkerGroupIpPort() throws UserException {
+        List<String> addresses = new ArrayList<>();
+        prepare();
+        try {
+            List<WorkerGroupDetailInfo> workerGroupDetailInfos = client.
+                    listWorkerGroup(serviceId, Collections.singletonList(DEFAULT_WORKER_GROUP_ID), true);
+            Preconditions.checkState(1 == workerGroupDetailInfos.size());
+            WorkerGroupDetailInfo workerGroupInfo = workerGroupDetailInfos.get(0);
+            for (WorkerInfo workerInfo : workerGroupInfo.getWorkersInfoList()) {
+                addresses.add(workerInfo.getIpPort());
+            }
+            return addresses;
+        } catch (StarClientException e) {
+            throw new UserException("Fail to get workers by default group id, error: " + e.getMessage());
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -157,8 +157,8 @@ import com.starrocks.journal.JournalInconsistentException;
 import com.starrocks.journal.JournalTask;
 import com.starrocks.journal.JournalWriter;
 import com.starrocks.journal.bdbje.Timestamp;
-import com.starrocks.lake.ShardDeleter;
 import com.starrocks.lake.ShardManager;
+import com.starrocks.lake.StarMgrMetaSyncer;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.lake.vacuum.AutovacuumDaemon;
@@ -499,7 +499,7 @@ public class GlobalStateMgr {
 
     private StarOSAgent starOSAgent;
 
-    private ShardDeleter shardDeleter;
+    private StarMgrMetaSyncer starMgrMetaSyncer;
 
     private MetadataMgr metadataMgr;
     private CatalogMgr catalogMgr;
@@ -743,7 +743,7 @@ public class GlobalStateMgr {
         this.shardManager = new ShardManager();
         this.compactionMgr = new CompactionMgr();
         this.configRefreshDaemon = new ConfigRefreshDaemon();
-        this.shardDeleter = new ShardDeleter();
+        this.starMgrMetaSyncer = new StarMgrMetaSyncer();
 
         this.binlogManager = new BinlogManager();
 
@@ -1354,7 +1354,7 @@ public class GlobalStateMgr {
         taskRunStateSynchronizer.start();
 
         if (RunMode.allowCreateLakeTable()) {
-            shardDeleter.start();
+            starMgrMetaSyncer.start();
             autovacuumDaemon.start();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -87,7 +87,7 @@ public class ComputeNode implements IComputable, Writable {
 
     // port of starlet on BE
     @SerializedName("starletPort")
-    private volatile int starletPort;
+    private volatile int starletPort = 0;
 
     @SerializedName("lastWriteFail")
     private volatile boolean lastWriteFail = false;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -43,7 +43,7 @@ import com.starrocks.common.MarkedCountDownLatch;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
-import com.starrocks.lake.ShardDeleter;
+import com.starrocks.lake.StarMgrMetaSyncer;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.Utils;
 import com.starrocks.persist.EditLog;
@@ -827,7 +827,7 @@ public class LakeTableSchemaChangeJobTest {
             }
         };
 
-        new MockUp<ShardDeleter>() {
+        new MockUp<StarMgrMetaSyncer>() {
             @Mock
             public void dropTabletAndDeleteShard(List<Long> shardIds, StarOSAgent starOSAgent) {
                 // nothing to do

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarOSAgentTest.java
@@ -654,4 +654,23 @@ public class StarOSAgentTest {
                 "Failed to get file store, error: INVALID_ARGUMENT:mocked exception",
                 () -> starosAgent.getFileStore("test-fskey"));
     }
+
+    @Test
+    public void testListDefaultWorkerGroupIpPort() throws StarClientException, DdlException, UserException {
+        new MockUp<StarClient>() {
+            @Mock
+            public List<WorkerGroupDetailInfo> listWorkerGroup(String serviceId, List<Long> groupIds, boolean include) {
+                long workerId0 = 10000L;
+                WorkerInfo worker0 = newWorkerInfo(workerId0, "127.0.0.1:8090", 9050, 9060, 8040, 8060);
+                long workerId1 = 10001L;
+                WorkerInfo worker1 = newWorkerInfo(workerId1, "127.0.0.2:8091", 9051, 9061, 8041, 8061);
+                WorkerGroupDetailInfo group = WorkerGroupDetailInfo.newBuilder().addWorkersInfo(worker0)
+                        .addWorkersInfo(worker1).build();
+                return Lists.newArrayList(group);
+            }
+        };
+        List<String> addresses = starosAgent.listDefaultWorkerGroupIpPort();
+        Assert.assertEquals("127.0.0.1:8090", addresses.get(0));
+        Assert.assertEquals("127.0.0.2:8091", addresses.get(1));
+    }
 }


### PR DESCRIPTION
1. change ShardDeleter to StarMgrMetaSyncer
2. change shard_deleter_run_interval_sec to star_mgr_meta_sync_interval_sec
3. support worker diff

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
