### PR TITLE
[BugFix] Rewritten aggregate projection should not refer other column references in  the same projection mapping

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -696,10 +696,11 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         aggregationOperator.getGroupingKeys().forEach(c -> defaultProjection.put(c, c));
         // Make a new logical agg with new projections.
         LogicalAggregationOperator newAggOp = LogicalAggregationOperator.builder()
-                        .setType(AggType.GLOBAL)
-                        .setGroupingKeys(aggregationOperator.getGroupingKeys())
-                        .setAggregations(newColumnRefToAggFuncMap)
-                        .build();
+                .withOperator(aggregationOperator)
+                .setType(AggType.GLOBAL)
+                .setGroupingKeys(aggregationOperator.getGroupingKeys())
+                .setAggregations(newColumnRefToAggFuncMap)
+                .build();
 
         // Copy original projection mappings.
         if (aggregationOperator.getProjection() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -695,9 +695,11 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         // Copy group by keys as projection
         aggregationOperator.getGroupingKeys().forEach(c -> defaultProjection.put(c, c));
         // Make a new logical agg with new projections.
-        LogicalAggregationOperator newAggOp =
-                new LogicalAggregationOperator(AggType.GLOBAL, aggregationOperator.getGroupingKeys(),
-                        newColumnRefToAggFuncMap);
+        LogicalAggregationOperator newAggOp = LogicalAggregationOperator.builder()
+                        .setType(AggType.GLOBAL)
+                        .setGroupingKeys(aggregationOperator.getGroupingKeys())
+                        .setAggregations(newColumnRefToAggFuncMap)
+                        .build();
 
         // Copy original projection mappings.
         if (aggregationOperator.getProjection() != null) {

--- a/test/sql/test_materialized_view/R/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_rewrite
@@ -1,183 +1,3 @@
--- name: test_all_join_type_rewrite
-CREATE TABLE emps (
-    empid INT NOT NULL,
-    deptno INT NOT NULL,
-    locationid INT NOT NULL,
-    commission INT NOT NULL,
-    name VARCHAR(20) NOT NULL,
-    salary DECIMAL(18, 2)
-) ENGINE=OLAP
-DUPLICATE KEY(`empid`)
-DISTRIBUTED BY HASH(`empid`) BUCKETS 12
-PROPERTIES (
-    "replication_num" = "1"
-);
--- result:
--- !result
-CREATE TABLE depts(
-    deptno INT NOT NULL,
-    name VARCHAR(20)
-) ENGINE=OLAP
-DUPLICATE KEY(`deptno`)
-DISTRIBUTED BY HASH(`deptno`) BUCKETS 12
-PROPERTIES (
-    "replication_num" = "1"
-);
--- result:
--- !result
-CREATE TABLE dependents(
-    empid INT NOT NULL,
-    name VARCHAR(20)
-) ENGINE=OLAP
-DUPLICATE KEY(`empid`)
-DISTRIBUTED BY HASH(`empid`) BUCKETS 12
-PROPERTIES (
-    "replication_num" = "1"
-);
--- result:
--- !result
-insert into emps values(1, 1, 1, 10, "emp_name1", 1000);
--- result:
--- !result
-insert into emps values(2, 1, 1, 10, "emp_name1", 1000);
--- result:
--- !result
-insert into emps values(3, 1, 1, 10, "emp_name1", 1000);
--- result:
--- !result
-insert into depts values(1, "dept_name1");
--- result:
--- !result
-insert into depts values(2, "dept_name2");
--- result:
--- !result
-insert into dependents values(1, "dependents_name1");
--- result:
--- !result
-insert into dependents values(2, "dependents_name2");
--- result:
--- !result
-insert into dependents values(3, "dependents_name3");
--- result:
--- !result
-create materialized view mv_right_outer
-distributed by hash(`empid`) buckets 10
-refresh manual
-as
-select empid, depts.deptno
-from emps right outer join depts using (deptno);
--- result:
--- !result
-refresh materialized view mv_right_outer with sync mode;
-explain logical select empid, depts.deptno
-from emps right outer join depts using (deptno);
-select empid, depts.deptno
-from emps right outer join depts using (deptno) order by empid;
--- result:
-None	2
-1	1
-2	1
-3	1
--- !result
-drop materialized view mv_right_outer;
--- result:
--- !result
-create materialized view mv_full_outer
-distributed by hash(`empid`) buckets 10
-refresh manual
-as
-select empid, depts.deptno 
-from emps full outer join depts using (deptno);
--- result:
--- !result
-refresh materialized view mv_full_outer with sync mode;
-explain logical select empid, depts.deptno 
-from emps full outer join depts using (deptno);
-select empid, depts.deptno 
-from emps full outer join depts using (deptno) order by empid;
--- result:
-None	2
-1	1
-2	1
-3	1
--- !result
-drop materialized view mv_full_outer;
--- result:
--- !result
-create materialized view mv_left_semi
-distributed by hash(`empid`) buckets 10
-refresh manual
-as
-select empid 
-from emps left semi join depts using (deptno);
--- result:
--- !result
-refresh materialized view mv_left_semi with sync mode;
-explain logical select empid 
-from emps left semi join depts using (deptno);
-select empid 
-from emps left semi join depts using (deptno) order by empid;
--- result:
-1
-2
-3
--- !result
-drop materialized view mv_left_semi;
--- result:
--- !result
-create materialized view mv_left_anti
-distributed by hash(`empid`) buckets 10
-refresh manual
-as
-select empid 
-from emps left anti join depts using (deptno);
--- result:
--- !result
-refresh materialized view mv_left_anti with sync mode;
-explain logical select empid 
-from emps left anti join depts using (deptno);
-select empid 
-from emps left anti join depts using (deptno) order by empid;
--- result:
--- !result
-drop materialized view mv_left_anti;
--- result:
--- !result
-create materialized view mv_right_semi
-distributed by hash(`deptno`) buckets 10
-refresh manual
-as
-select deptno 
-from emps right semi join depts using (deptno);
--- result:
--- !result
-refresh materialized view mv_right_semi with sync mode;
-explain select deptno 
-from emps right semi join depts using (deptno);
-select deptno 
-from emps right semi join depts using (deptno) order by deptno;
--- result:
-1
--- !result
-drop materialized view mv_right_semi;
--- result:
--- !result
-create materialized view mv_right_anti
-distributed by hash(`deptno`) buckets 10
-refresh manual
-as
-select deptno 
-from emps right anti join depts using (deptno);
--- result:
--- !result
-refresh materialized view mv_right_anti with sync mode;
-explain select depts.deptno
-from emps right anti join depts using (deptno);
-select depts.deptno 
-from emps right anti join depts using (deptno);
--- result:
-2
--- !result
 -- name: test_materialized_view_rewrite
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
 -- result:
@@ -458,9 +278,15 @@ select user_id, percentile_approx(tag_id, 0) x from user_tags group by user_id o
 -- !result
 select user_id, round(percentile_approx(tag_id, 0)) x from user_tags group by user_id order by user_id;
 -- result:
-1	0
-2	0
-3	0
+1	1
+2	5
+3	6
+-- !result
+select user_id, time, round(percentile_approx(tag_id, 0)) from user_tags group by user_id, time order by user_id;
+-- result:
+1	2023-04-13	1
+2	2023-04-13	5
+3	2023-04-13	6
 -- !result
 drop materialized view user_tags_percential_mv2;
 -- result:
@@ -577,4 +403,184 @@ select user_id, sum(tag_id) as total from user_tags  group by user_id having sum
 1	15
 2	5
 3	6
+-- !result
+-- name: test_all_join_type_rewrite
+CREATE TABLE emps (
+    empid INT NOT NULL,
+    deptno INT NOT NULL,
+    locationid INT NOT NULL,
+    commission INT NOT NULL,
+    name VARCHAR(20) NOT NULL,
+    salary DECIMAL(18, 2)
+) ENGINE=OLAP
+DUPLICATE KEY(`empid`)
+DISTRIBUTED BY HASH(`empid`) BUCKETS 12
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE depts(
+    deptno INT NOT NULL,
+    name VARCHAR(20)
+) ENGINE=OLAP
+DUPLICATE KEY(`deptno`)
+DISTRIBUTED BY HASH(`deptno`) BUCKETS 12
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE dependents(
+    empid INT NOT NULL,
+    name VARCHAR(20)
+) ENGINE=OLAP
+DUPLICATE KEY(`empid`)
+DISTRIBUTED BY HASH(`empid`) BUCKETS 12
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into emps values(1, 1, 1, 10, "emp_name1", 1000);
+-- result:
+-- !result
+insert into emps values(2, 1, 1, 10, "emp_name1", 1000);
+-- result:
+-- !result
+insert into emps values(3, 1, 1, 10, "emp_name1", 1000);
+-- result:
+-- !result
+insert into depts values(1, "dept_name1");
+-- result:
+-- !result
+insert into depts values(2, "dept_name2");
+-- result:
+-- !result
+insert into dependents values(1, "dependents_name1");
+-- result:
+-- !result
+insert into dependents values(2, "dependents_name2");
+-- result:
+-- !result
+insert into dependents values(3, "dependents_name3");
+-- result:
+-- !result
+create materialized view mv_right_outer
+distributed by hash(`empid`) buckets 10
+refresh manual
+as
+select empid, depts.deptno
+from emps right outer join depts using (deptno);
+-- result:
+-- !result
+refresh materialized view mv_right_outer with sync mode;
+explain logical select empid, depts.deptno
+from emps right outer join depts using (deptno);
+select empid, depts.deptno
+from emps right outer join depts using (deptno) order by empid;
+-- result:
+None	2
+1	1
+2	1
+3	1
+-- !result
+drop materialized view mv_right_outer;
+-- result:
+-- !result
+create materialized view mv_full_outer
+distributed by hash(`empid`) buckets 10
+refresh manual
+as
+select empid, depts.deptno 
+from emps full outer join depts using (deptno);
+-- result:
+-- !result
+refresh materialized view mv_full_outer with sync mode;
+explain logical select empid, depts.deptno 
+from emps full outer join depts using (deptno);
+select empid, depts.deptno 
+from emps full outer join depts using (deptno) order by empid;
+-- result:
+None	2
+1	1
+2	1
+3	1
+-- !result
+drop materialized view mv_full_outer;
+-- result:
+-- !result
+create materialized view mv_left_semi
+distributed by hash(`empid`) buckets 10
+refresh manual
+as
+select empid 
+from emps left semi join depts using (deptno);
+-- result:
+-- !result
+refresh materialized view mv_left_semi with sync mode;
+explain logical select empid 
+from emps left semi join depts using (deptno);
+select empid 
+from emps left semi join depts using (deptno) order by empid;
+-- result:
+1
+2
+3
+-- !result
+drop materialized view mv_left_semi;
+-- result:
+-- !result
+create materialized view mv_left_anti
+distributed by hash(`empid`) buckets 10
+refresh manual
+as
+select empid 
+from emps left anti join depts using (deptno);
+-- result:
+-- !result
+refresh materialized view mv_left_anti with sync mode;
+explain logical select empid 
+from emps left anti join depts using (deptno);
+select empid 
+from emps left anti join depts using (deptno) order by empid;
+-- result:
+-- !result
+drop materialized view mv_left_anti;
+-- result:
+-- !result
+create materialized view mv_right_semi
+distributed by hash(`deptno`) buckets 10
+refresh manual
+as
+select deptno 
+from emps right semi join depts using (deptno);
+-- result:
+-- !result
+refresh materialized view mv_right_semi with sync mode;
+explain select deptno 
+from emps right semi join depts using (deptno);
+select deptno 
+from emps right semi join depts using (deptno) order by deptno;
+-- result:
+1
+-- !result
+drop materialized view mv_right_semi;
+-- result:
+-- !result
+create materialized view mv_right_anti
+distributed by hash(`deptno`) buckets 10
+refresh manual
+as
+select deptno 
+from emps right anti join depts using (deptno);
+-- result:
+-- !result
+refresh materialized view mv_right_anti with sync mode;
+explain select depts.deptno
+from emps right anti join depts using (deptno);
+select depts.deptno 
+from emps right anti join depts using (deptno);
+-- result:
+2
 -- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_rewrite
@@ -79,6 +79,7 @@ select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id o
 select user_id, percentile_approx(tag_id, 1) x from user_tags group by user_id order by user_id;
 select user_id, percentile_approx(tag_id, 0) x from user_tags group by user_id order by user_id;
 select user_id, round(percentile_approx(tag_id, 0)) x from user_tags group by user_id order by user_id;
+select user_id, time, round(percentile_approx(tag_id, 0)) from user_tags group by user_id, time order by user_id;
 drop materialized view user_tags_percential_mv2;
 
 -- TEST BITMAP : UNOION


### PR DESCRIPTION
Fixes #issue

It's not safe for column ref to refer other column refs in the same projection mapping.

```
mysql> explain select user_id, round(percentile_approx(tag_id, 0)) x from user_tags group by user_id order by user_id;
+------------------------------------------------------------------------------+
| Explain String                                                               |
+------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                              |
|  OUTPUT EXPRS:2: user_id | 6: round                                          |
|   PARTITION: UNPARTITIONED                                                   |
|                                                                              |
|   RESULT SINK                                                                |
|                                                                              |
|   4:MERGING-EXCHANGE                                                         |
|                                                                              |
| PLAN FRAGMENT 1                                                              |
|  OUTPUT EXPRS:                                                               |
|   PARTITION: RANDOM                                                          |
|                                                                              |
|   STREAM DATA SINK                                                           |
|     EXCHANGE ID: 04                                                          |
|     UNPARTITIONED                                                            |
|                                                                              |
|   3:SORT                                                                     |
|   |  order by: <slot 2> 2: user_id ASC                                       |
|   |  offset: 0                                                               |
|   |                                                                          |
|   2:Project                                                                  |
|   |  <slot 2> : 9: user_id                                                   |
|   |  <slot 5> : percentile_approx_raw(13: percentile_union, 0.0)             |
|   |  <slot 6> : round(5: percentile_approx)                                  |
|   |                                                                          |
|   1:AGGREGATE (update finalize)                                              |
|   |  output: percentile_union(11: percentile_union(percentile_hash(tag_id))) |
|   |  group by: 9: user_id                                                    |
|   |                                                                          |
|   0:OlapScanNode                                                             |
|      TABLE: user_tags_percential_mv2                                         |
|      PREAGGREGATION: ON                                                      |
|      partitions=1/1                                                          |
|      rollup: user_tags_percential_mv2                                        |
|      tabletRatio=3/3                                                         |
|      tabletList=15079,15081,15083                                            |
|      cardinality=1                                                           |
|      avgRowSize=1048580.0                                                    |
+------------------------------------------------------------------------------+
38 rows in set (0.01 sec)
```

After this PR:
```
mysql> explain select user_id, round(percentile_approx(tag_id, 0)) x from user_tags group by user_id order by user_id;
+-----------------------------------------------------------------------------+
| Explain String                                                              |
+-----------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                             |
|  OUTPUT EXPRS:2: user_id | 6: round                                         |
|   PARTITION: UNPARTITIONED                                                  |
|                                                                             |
|   RESULT SINK                                                               |
|                                                                             |
|   4:MERGING-EXCHANGE                                                        |
|                                                                             |
| PLAN FRAGMENT 1                                                             |
|  OUTPUT EXPRS:                                                              |
|   PARTITION: RANDOM                                                         |
|                                                                             |
|   STREAM DATA SINK                                                          |
|     EXCHANGE ID: 04                                                         |
|     UNPARTITIONED                                                           |
|                                                                             |
|   3:SORT                                                                    |
|   |  order by: <slot 2> 2: user_id ASC                                      |
|   |  offset: 0                                                              |
|   |                                                                         |
|   2:Project                                                                 |
|   |  <slot 2> : 7: user_id                                                  |
|   |  <slot 6> : round(percentile_approx_raw(11: percentile_union, 0.0))     |
|   |                                                                         |
|   1:AGGREGATE (update finalize)                                             |
|   |  output: percentile_union(9: percentile_union(percentile_hash(tag_id))) |
|   |  group by: 7: user_id                                                   |
|   |                                                                         |
|   0:OlapScanNode                                                            |
|      TABLE: user_tags_percential_mv2                                        |
|      PREAGGREGATION: ON                                                     |
|      partitions=1/1                                                         |
|      rollup: user_tags_percential_mv2                                       |
|      tabletRatio=3/3                                                        |
|      tabletList=29715,29717,29719                                           |
|      cardinality=3                                                          |
|      avgRowSize=1048580.0                                                   |
+-----------------------------------------------------------------------------+
37 rows in set (0.01 sec)
```
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
