### PR TITLE
[Refactor] Some minor changes involving graceful exit

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -43,12 +43,11 @@ GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_
                                     [this]() { return _blocked_driver_poller->blocked_driver_queue_len(); });
 }
 
-GlobalDriverExecutor::~GlobalDriverExecutor() {
-    close();
-}
+GlobalDriverExecutor::~GlobalDriverExecutor() = default;
 
 void GlobalDriverExecutor::close() {
     _driver_queue->close();
+    _thread_pool->shutdown();
 }
 
 void GlobalDriverExecutor::initialize(int num_threads) {

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -43,11 +43,12 @@ GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_
                                     [this]() { return _blocked_driver_poller->blocked_driver_queue_len(); });
 }
 
-GlobalDriverExecutor::~GlobalDriverExecutor() = default;
+GlobalDriverExecutor::~GlobalDriverExecutor() {
+    close();
+}
 
 void GlobalDriverExecutor::close() {
     _driver_queue->close();
-    _thread_pool->shutdown();
 }
 
 void GlobalDriverExecutor::initialize(int num_threads) {

--- a/be/src/fs/fs_s3.h
+++ b/be/src/fs/fs_s3.h
@@ -19,5 +19,6 @@
 namespace starrocks {
 
 std::unique_ptr<FileSystem> new_fs_s3(const FSOptions& options);
+void close_s3_clients();
 
 } // namespace starrocks

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -539,7 +539,9 @@ void ExecEnv::stop() {
         _load_rpc_pool->shutdown();
     }
 
+#ifndef BE_TEST
     close_s3_clients();
+#endif
 }
 
 void ExecEnv::destroy() {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -49,6 +49,7 @@
 #include "exec/spill/dir_manager.h"
 #include "exec/workgroup/scan_executor.h"
 #include "exec/workgroup/work_group.h"
+#include "fs/fs_s3.h"
 #include "gen_cpp/BackendService.h"
 #include "gen_cpp/TFileBrokerService.h"
 #include "gutil/strings/join.h"
@@ -526,6 +527,10 @@ void ExecEnv::stop() {
         _wg_driver_executor->close();
     }
 
+    if (_agent_server) {
+        _agent_server->stop();
+    }
+
     if (_automatic_partition_pool) {
         _automatic_partition_pool->shutdown();
     }
@@ -533,6 +538,8 @@ void ExecEnv::stop() {
     if (_load_rpc_pool) {
         _load_rpc_pool->shutdown();
     }
+
+    close_s3_clients();
 }
 
 void ExecEnv::destroy() {
@@ -545,14 +552,14 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_stream_context_mgr);
     SAFE_DELETE(_routine_load_task_executor);
     SAFE_DELETE(_stream_load_executor);
-    SAFE_DELETE(_brpc_stub_cache);
+    SAFE_DELETE(_fragment_mgr);
     SAFE_DELETE(_load_stream_mgr);
     SAFE_DELETE(_load_channel_mgr);
     SAFE_DELETE(_broker_mgr);
     SAFE_DELETE(_bfd_parser);
     SAFE_DELETE(_load_path_mgr);
     SAFE_DELETE(_wg_driver_executor);
-    SAFE_DELETE(_fragment_mgr);
+    SAFE_DELETE(_brpc_stub_cache);
     SAFE_DELETE(_udf_call_pool);
     SAFE_DELETE(_pipeline_prepare_pool);
     SAFE_DELETE(_pipeline_sink_io_pool);

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -369,8 +369,6 @@ int main(int argc, char** argv) {
     heartbeat_thrift_server->stop();
     heartbeat_thrift_server->join();
 
-    exec_env->agent_server()->stop();
-
     exec_env->stop();
     engine->stop();
     delete engine;

--- a/be/src/util/thrift_server.cpp
+++ b/be/src/util/thrift_server.cpp
@@ -134,7 +134,7 @@ Status ThriftServer::ThriftServerEventProcessor::start_and_wait_for_server() {
 
     // _started == true only if preServe was called. May be false if there was an exception
     // after preServe that was caught by Supervise, causing it to reset the error condition.
-    if (_thrift_server->_started == false) {
+    if (!_thrift_server->_started) {
         std::stringstream ss;
         ss << "ThriftServer '" << _thrift_server->_name << "' (on port: " << _thrift_server->_port
            << ") did not start correctly ";
@@ -398,7 +398,6 @@ void ThriftServer::stop() {
 
 void ThriftServer::join() {
     DCHECK(_server_thread != nullptr);
-    DCHECK(_started);
     _server_thread->join();
 }
 


### PR DESCRIPTION
Fixes #27417 

graceful exit step 7:

1. Add interface to clean s3 clients
2. Move AgentServer::stop() to ExecEnv::stop()
3. Destruct _fragment_mgr before _brpc_stub_cache, otherwise it maybe stuck.
4. Remove unused DCHECK for ThriftServer, because it already set to false in ThriftServer::ThriftServerEventProcessor::supervise() 


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
