### PR TITLE
[BugFix] Ensure column refs in project not refer the same input column reference

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -596,11 +596,8 @@ public class Optimizer {
                 rootTaskContext);
         result = new ExtractAggregateColumn().rewrite(result, rootTaskContext);
         result = new PruneSubfieldsForComplexType().rewrite(result, rootTaskContext);
+        result = new CloneDuplicateColRefRule().rewrite(result, rootTaskContext);
 
-        SessionVariable sessionVariable = rootTaskContext.getOptimizerContext().getSessionVariable();
-        if (sessionVariable.isEnableCboTablePrune() || sessionVariable.isEnableRboTablePrune()) {
-            result = new CloneDuplicateColRefRule().rewrite(result, rootTaskContext);
-        }
         result.setPlanCount(planCount);
         return result;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -525,9 +525,9 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 " where t0.v1 = 1" +
                 " group by v1, test_all_type.t1d";
         String plan1 = getFragmentPlan(query1);
-        PlanTestBase.assertContains(plan1, "1:Project\n" +
+        PlanTestBase.assertContains(plan1, "  1:Project\n" +
                 "  |  <slot 1> : 16: v1\n" +
-                "  |  <slot 7> : 16: v1\n" +
+                "  |  <slot 7> : clone(16: v1)\n" +
                 "  |  <slot 14> : 18: total_sum\n" +
                 "  |  <slot 15> : 19: total_num\n" +
                 "  |  \n" +
@@ -545,7 +545,7 @@ public class MvRewriteTest extends MvRewriteTestBase {
         String plan2 = getFragmentPlan(query2);
         PlanTestBase.assertContains(plan2, "1:Project\n" +
                 "  |  <slot 1> : 16: v1\n" +
-                "  |  <slot 7> : 16: v1\n" +
+                "  |  <slot 7> : clone(16: v1)\n" +
                 "  |  <slot 14> : 18: total_sum\n" +
                 "  |  <slot 15> : 19: total_num\n" +
                 "  |  \n" +
@@ -561,7 +561,7 @@ public class MvRewriteTest extends MvRewriteTestBase {
         String plan3 = getFragmentPlan(query3);
         PlanTestBase.assertContains(plan3, "1:Project\n" +
                 "  |  <slot 1> : 16: v1\n" +
-                "  |  <slot 7> : 16: v1\n" +
+                "  |  <slot 7> : clone(16: v1)\n" +
                 "  |  <slot 14> : 18: total_sum\n" +
                 "  |  <slot 15> : 19: total_num\n" +
                 "  |  \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -494,7 +494,7 @@ public class AggregateTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  2:Project\n" +
                 "  |  <slot 13> : 13: bitmap_union_count\n" +
-                "  |  <slot 14> : 13: bitmap_union_count\n" +
+                "  |  <slot 14> : clone(13: bitmap_union_count)\n" +
                 "  |  \n" +
                 "  1:AGGREGATE (update finalize)\n" +
                 "  |  output: bitmap_union_count(5: b1)");
@@ -1753,13 +1753,13 @@ public class AggregateTest extends PlanTestBase {
 
         sql = "select sum(t1c + 1), sum(t1c + 1 + 2), sum(t1d + 1 + 3) from test_all_type";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+        assertContains(plan, "2:AGGREGATE (update finalize)\n" +
                 "  |  output: sum(11: expr), sum(18: add + 2), sum(4: t1d + 1 + 3)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
                 "  1:Project\n" +
                 "  |  <slot 4> : 4: t1d\n" +
-                "  |  <slot 11> : 18: add\n" +
+                "  |  <slot 11> : clone(18: add)\n" +
                 "  |  <slot 18> : 18: add\n" +
                 "  |  common expressions:\n" +
                 "  |  <slot 17> : CAST(3: t1c AS BIGINT)\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConstantExpressionTest.java
@@ -361,9 +361,9 @@ public class ConstantExpressionTest extends PlanTestBase {
 
             sql = "SELECT percentile_approx(2.25, 0), percentile_approx(2.25, 0.)";
             plan = getFragmentPlan(sql);
-            assertContains(plan, "  2:Project\n" +
+            assertContains(plan, "2:Project\n" +
                     "  |  <slot 2> : 2: percentile_approx\n" +
-                    "  |  <slot 3> : 2: percentile_approx\n" +
+                    "  |  <slot 3> : clone(2: percentile_approx)\n" +
                     "  |  \n" +
                     "  1:AGGREGATE (update finalize)\n" +
                     "  |  output: percentile_approx(2.25, 0.0)\n" +
@@ -372,11 +372,11 @@ public class ConstantExpressionTest extends PlanTestBase {
             sql = "SELECT COUNT(CASE WHEN 1 THEN 1 END), COUNT(CASE WHEN TRUE THEN 1 END), " +
                     "COUNT(CASE WHEN 1.0 THEN 1 END), COUNT(CASE WHEN CAST(1 AS LARGEINT) THEN 1 END)";
             plan = getFragmentPlan(sql);
-            assertContains(plan, "  2:Project\n" +
+            assertContains(plan, "2:Project\n" +
                     "  |  <slot 2> : 2: count\n" +
-                    "  |  <slot 3> : 2: count\n" +
-                    "  |  <slot 4> : 2: count\n" +
-                    "  |  <slot 5> : 2: count\n" +
+                    "  |  <slot 3> : clone(2: count)\n" +
+                    "  |  <slot 4> : clone(2: count)\n" +
+                    "  |  <slot 5> : clone(2: count)\n" +
                     "  |  \n" +
                     "  1:AGGREGATE (update finalize)\n" +
                     "  |  output: count(1)\n" +

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
@@ -53,7 +53,7 @@ OutPut Exchange Id: 08
 6:Project
 |  output columns:
 |  21 <-> [21: p_type, VARCHAR, true]
-|  27 <-> [37: multiply, DECIMAL128(33,4), true]
+|  27 <-> clone([37: multiply, DECIMAL128(33,4), true])
 |  37 <-> [37: multiply, DECIMAL128(33,4), true]
 |  common expressions:
 |  33 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))

--- a/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/tpch-histogram-cost/q14.sql
@@ -44,7 +44,7 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 07
 
 6:AGGREGATE (update serialize)
-|  aggregate: sum[(if[(22: P_TYPE LIKE 'PROMO%', [34: multiply, DOUBLE, false], 0.0); args: BOOLEAN,DOUBLE,DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true], sum[([29: expr, DOUBLE, false]); args: DOUBLE; result: DOUBLE; args nullable: false; result nullable: true]
+|  aggregate: sum[(if[(22: P_TYPE LIKE 'PROMO%', [34: multiply, DOUBLE, false], 0.0); args: BOOLEAN,DOUBLE,DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true], sum[([29: expr, DOUBLE, true]); args: DOUBLE; result: DOUBLE; args nullable: true; result nullable: true]
 |  cardinality: 1
 |  column statistics:
 |  * sum-->[-Infinity, Infinity, 0.0, 8.0, 1.0] ESTIMATE
@@ -53,7 +53,7 @@ OutPut Exchange Id: 07
 5:Project
 |  output columns:
 |  22 <-> [22: P_TYPE, VARCHAR, false]
-|  29 <-> [34: multiply, DOUBLE, false]
+|  29 <-> clone([34: multiply, DOUBLE, false])
 |  34 <-> [34: multiply, DOUBLE, false]
 |  common expressions:
 |  33 <-> 1.0 - [7: L_DISCOUNT, DOUBLE, false]

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q14.sql
@@ -42,7 +42,7 @@ UNPARTITIONED
 |
 5:Project
 |  <slot 22> : 22: P_TYPE
-|  <slot 29> : 34: multiply
+|  <slot 29> : clone(34: multiply)
 |  <slot 34> : 34: multiply
 |  common expressions:
 |  <slot 33> : 1.0 - 7: L_DISCOUNT


### PR DESCRIPTION
As ` {Cbo,Rbo}TablePruneRule`, plan after mv rewrite should also ensure column refs in project not refer the same input column reference.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
