### PR TITLE
Revert "[Enhancement] Distributing `TabletShards` to multiple compaction threads (#11747)"

### DIFF
--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -625,8 +625,7 @@ size_t StorageEngine::_compaction_check_one_round() {
     return tablets_num_checked;
 }
 
-Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir,
-                                                     std::pair<int32_t, int32_t> tablet_shards_range) {
+Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir) {
     scoped_refptr<Trace> trace(new Trace);
     MonotonicStopWatch watch;
     watch.start();
@@ -637,8 +636,8 @@ Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir,
     });
     ADOPT_TRACE(trace.get());
     TRACE("start to perform cumulative compaction");
-    TabletSharedPtr best_tablet = _tablet_manager->find_best_tablet_to_compaction(CompactionType::CUMULATIVE_COMPACTION,
-                                                                                  data_dir, tablet_shards_range);
+    TabletSharedPtr best_tablet =
+            _tablet_manager->find_best_tablet_to_compaction(CompactionType::CUMULATIVE_COMPACTION, data_dir);
     if (best_tablet == nullptr) {
         return Status::NotFound("there are no suitable tablets");
     }
@@ -667,7 +666,7 @@ Status StorageEngine::_perform_cumulative_compaction(DataDir* data_dir,
     return Status::OK();
 }
 
-Status StorageEngine::_perform_base_compaction(DataDir* data_dir, std::pair<int32_t, int32_t> tablet_shards_range) {
+Status StorageEngine::_perform_base_compaction(DataDir* data_dir) {
     scoped_refptr<Trace> trace(new Trace);
     MonotonicStopWatch watch;
     watch.start();
@@ -678,8 +677,8 @@ Status StorageEngine::_perform_base_compaction(DataDir* data_dir, std::pair<int3
     });
     ADOPT_TRACE(trace.get());
     TRACE("start to perform base compaction");
-    TabletSharedPtr best_tablet = _tablet_manager->find_best_tablet_to_compaction(CompactionType::BASE_COMPACTION,
-                                                                                  data_dir, tablet_shards_range);
+    TabletSharedPtr best_tablet =
+            _tablet_manager->find_best_tablet_to_compaction(CompactionType::BASE_COMPACTION, data_dir);
     if (best_tablet == nullptr) {
         return Status::NotFound("there are no suitable tablets");
     }

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -218,10 +218,10 @@ private:
     // unused rowset monitor thread
     void* _unused_rowset_monitor_thread_callback(void* arg);
 
-    void* _base_compaction_thread_callback(void* arg, DataDir* data_dir,
-                                           std::pair<int32_t, int32_t> tablet_shards_range);
-    void* _cumulative_compaction_thread_callback(void* arg, DataDir* data_dir,
-                                                 const std::pair<int32_t, int32_t>& tablet_shards_range);
+    // base compaction thread process function
+    void* _base_compaction_thread_callback(void* arg, DataDir* data_dir);
+    // cumulative process function
+    void* _cumulative_compaction_thread_callback(void* arg, DataDir* data_dir);
     // update compaction function
     void* _update_compaction_thread_callback(void* arg, DataDir* data_dir);
 
@@ -242,8 +242,8 @@ private:
     void* _tablet_checkpoint_callback(void* arg);
 
     void _start_clean_fd_cache();
-    Status _perform_cumulative_compaction(DataDir* data_dir, std::pair<int32_t, int32_t> tablet_shards_range);
-    Status _perform_base_compaction(DataDir* data_dir, std::pair<int32_t, int32_t> tablet_shards_range);
+    Status _perform_cumulative_compaction(DataDir* data_dir);
+    Status _perform_base_compaction(DataDir* data_dir);
     Status _perform_update_compaction(DataDir* data_dir);
     Status _start_trash_sweep(double* usage);
     void _start_disk_stat_monitor();

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -591,16 +591,15 @@ bool TabletManager::get_next_batch_tablets(size_t batch_size, std::vector<Tablet
     }
 }
 
-TabletSharedPtr TabletManager::find_best_tablet_to_compaction(CompactionType compaction_type, DataDir* data_dir,
-                                                              std::pair<int32_t, int32_t> tablet_shards_range) {
+TabletSharedPtr TabletManager::find_best_tablet_to_compaction(CompactionType compaction_type, DataDir* data_dir) {
     int64_t now_ms = UnixMillis();
     const std::string& compaction_type_str = compaction_type == CompactionType::BASE_COMPACTION ? "base" : "cumulative";
     // only do compaction if compaction #rowset > 1
     uint32_t highest_score = 1;
     TabletSharedPtr best_tablet;
-    for (int32_t i = tablet_shards_range.first; i < tablet_shards_range.second; i++) {
-        std::shared_lock rlock(_tablets_shards[i].lock);
-        for (auto [tablet_id, tablet_ptr] : _tablets_shards[i].tablet_map) {
+    for (const auto& tablets_shard : _tablets_shards) {
+        std::shared_lock rlock(tablets_shard.lock);
+        for (auto [tablet_id, tablet_ptr] : tablets_shard.tablet_map) {
             if (tablet_ptr->keys_type() == PRIMARY_KEYS) {
                 continue;
             }

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -75,8 +75,7 @@ public:
 
     Status drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec);
 
-    TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type, DataDir* data_dir,
-                                                   std::pair<int32_t, int32_t> tablet_shards_range);
+    TabletSharedPtr find_best_tablet_to_compaction(CompactionType compaction_type, DataDir* data_dir);
 
     TabletSharedPtr find_best_tablet_to_do_update_compaction(DataDir* data_dir);
 


### PR DESCRIPTION
This reverts commit 359185d73762d402a71e897b94eae7138073e54e.

Fixes #issue

When there is a large tablet compaction, even if there are multiple compaction threads, it is still possible to get stuck in the compaction of other small tablets, resulting in TooManyVersion
