### PR TITLE
[BugFix] fix backport of 20741

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -338,8 +338,9 @@ public class HiveMetaClient {
                                                          IMetaStoreClient.NotificationFilter filter)
             throws MetastoreNotificationFetchException {
         try {
+            Class<?>[] argClasses = {long.class, int.class, IMetaStoreClient.NotificationFilter.class};
             return callRPC("getNextNotification", "Failed to get next notification based on last event id: " + lastEventId,
-                    lastEventId, maxEvents, filter);
+                    argClasses, lastEventId, maxEvents, filter);
         } catch (Exception e) {
             throw new MetastoreNotificationFetchException(e.getMessage());
         }


### PR DESCRIPTION
Fixes #issue

when this PR https://github.com/StarRocks/starrocks/pull/20741 backport to 3.0 and 2.5, a line is lost
- 3.0 https://github.com/StarRocks/starrocks/pull/21054/files
- 2.5 https://github.com/StarRocks/starrocks/pull/21056/files

```
Class<?>[] argClasses = {long.class, int.class, IMetaStoreClient.NotificationFilter.class};
return callRPC("getNextNotification", "Failed to get next notification based on last event id: " + lastEventId,
        argClasses, lastEventId, maxEvents, filter);
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
