### PR TITLE
[Feature] support regex_extact_all

### DIFF
--- a/be/src/exprs/string_functions.h
+++ b/be/src/exprs/string_functions.h
@@ -314,6 +314,14 @@ public:
     DEFINE_VECTORIZED_FN(regexp_extract);
 
     /**
+     * return all match sub-string
+     * @param: [string_value, pattern_value]
+     * @paramType: [BinaryColumn, BinaryColumn]
+     * @return: Array<BinaryColumn>
+     */
+    DEFINE_VECTORIZED_FN(regexp_extract_all);
+
+    /**
      * @param: [string_value, pattern_value, replace_value]
      * @paramType: [BinaryColumn, BinaryColumn, BinaryColumn]
      * @return: BinaryColumn

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -660,6 +660,7 @@
       + [like](./sql-reference/sql-functions/like_predicate-functions/like.md)
       + [regexp](./sql-reference/sql-functions/like_predicate-functions/regexp.md)
       + [regexp_extract](./sql-reference/sql-functions/string-functions/regexp_extract.md)
+      + [regexp_extract_all](./sql-reference/sql-functions/like_predicate-functions/regexp_extract_all.md)
       + [regexp_replace](./sql-reference/sql-functions/string-functions/regexp_replace.md)
     + Percentile Functions
       + [percentile_approx_raw](./sql-reference/sql-functions/percentile-functions/percentile_approx_raw.md)

--- a/docs/sql-reference/sql-functions/like_predicate-functions/regexp_extract_all.md
+++ b/docs/sql-reference/sql-functions/like_predicate-functions/regexp_extract_all.md
@@ -1,0 +1,33 @@
+# regexp_extract
+
+## Description
+
+This function return all matching substrings in the target value which matches the regular expression pattern. It extracts the item in pos that matches the pattern. The pattern must completely match some parts of str so that the function can return parts needed to be matched in the pattern. If no matches are found, it will return an empty string.
+
+## Syntax
+
+```Haskell
+ARRAY<VARCHAR> regexp_extract_all(VARCHAR str, VARCHAR pattern, int pos)
+```
+
+## Examples
+
+```Plain Text
+MySQL > SELECT regexp_extract_all('AbCdE', '([[:lower:]]+)C([[:lower:]]+)', 1);
++-------------------------------------------------------------------+
+| regexp_extract_all('AbCdE', '([[:lower:]]+)C([[:lower:]]+)', 1)   |
++-------------------------------------------------------------------+
+| ['b']                                                             |
++-------------------------------------------------------------------+
+
+MySQL > SELECT regexp_extract_all('AbCdExCeF', '([[:lower:]]+)C([[:lower:]]+)', 2);
++---------------------------------------------------------------------+
+| regexp_extract_all('AbCdExCeF', '([[:lower:]]+)C([[:lower:]]+)', 2) |
++---------------------------------------------------------------------+
+| ['d','e']                                                           |
++---------------------------------------------------------------------+
+```
+
+## keyword
+
+REGEXP_EXTRACT_ALL,REGEXP,EXTRACT

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -297,6 +297,8 @@ vectorized_functions = [
 
     [30320, 'regexp_extract', 'VARCHAR', ['VARCHAR', 'VARCHAR', 'BIGINT'], 'StringFunctions::regexp_extract',
      'StringFunctions::regexp_extract_prepare', 'StringFunctions::regexp_close'],
+    [30321, 'regexp_extract_all', 'ARRAY_VARCHAR', ['VARCHAR', 'VARCHAR', 'BIGINT'], 'StringFunctions::regexp_extract_all',
+     'StringFunctions::regexp_extract_prepare', 'StringFunctions::regexp_close'],
     [30330, 'regexp_replace', 'VARCHAR', ['VARCHAR', 'VARCHAR', 'VARCHAR'], 'StringFunctions::regexp_replace',
      'StringFunctions::regexp_replace_prepare', 'StringFunctions::regexp_close'],
     # @Deprecated: 'replace_old' will be deleted in the future version, keep it just for compatible


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/19815

And fix `longest match`
before:
```
MySQL td> select regexp_extract("aEbECEdE", "(.*?E)", 1);
+-----------------------------------------+
| regexp_extract('aEbECEdE', '(.*?E)', 1) |
+-----------------------------------------+
| aEbECEdE                                |
+-----------------------------------------+
```

after:
```
MySQL td> select regexp_extract("aEbECEdE", "(.*?E)", 1);
+-----------------------------------------+
| regexp_extract('aEbECEdE', '(.*?E)', 1) |
+-----------------------------------------+
| aE                                      |
+-----------------------------------------+
```

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
