### PR TITLE
[Enhancement] Expose error code when the query cancelled by BE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Status.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Status.java
@@ -37,6 +37,7 @@ package com.starrocks.common;
 import com.starrocks.proto.StatusPB;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Optional;
 
@@ -134,53 +135,20 @@ public class Status {
         this.errorMsg = msg;
     }
 
-    public void rewriteErrorMsg() {
-        if (ok()) {
-            return;
-        }
-
-        switch (errorCode) {
-            case CANCELLED: {
-                this.errorMsg = "Cancelled";
-                break;
-            }
-            case ANALYSIS_ERROR: {
-                this.errorMsg = "Analysis_error";
-                break;
-            }
-            case NOT_IMPLEMENTED_ERROR: {
-                this.errorMsg = "Not_implemented_error";
-                break;
-            }
-            case RUNTIME_ERROR: {
-                this.errorMsg = "Runtime_error";
-                break;
-            }
-            case MEM_LIMIT_EXCEEDED: {
-                this.errorMsg = "Mem_limit_error";
-                break;
-            }
-            case INTERNAL_ERROR: {
-                this.errorMsg = "Internal_error";
-                break;
-            }
-            case THRIFT_RPC_ERROR: {
-                this.errorMsg = "Thrift_rpc_error";
-                break;
-            }
-            case TIMEOUT: {
-                this.errorMsg = "Timeout";
-                break;
-            }
-            default: {
-                this.errorMsg = "Unknown_error";
-                break;
-            }
-        }
-    }
-
     public String getErrorCodeString() {
         return Optional.ofNullable(getErrorCode()).map(Enum::toString).orElse("UNKNOWN");
+    }
+
+    /**
+     * Return the detail error message combined {@link #errorCode} and {@link #errorMsg}.
+     */
+    public String getDetailErrorMsg() {
+        StringBuilder builder = new StringBuilder(getErrorCodeString());
+        if (!StringUtils.isEmpty(errorMsg)) {
+            builder.append(". Detail: ").append(errorMsg);
+        }
+
+        return builder.toString();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -35,7 +35,6 @@
 package com.starrocks.qe;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -1371,18 +1370,14 @@ public class DefaultCoordinator extends Coordinator {
         }
 
         if (!copyStatus.ok()) {
-            if (Strings.isNullOrEmpty(copyStatus.getErrorMsg())) {
-                copyStatus.rewriteErrorMsg();
-            }
-
             if (copyStatus.isRemoteFileNotFound()) {
                 throw new RemoteFileNotFoundException(copyStatus.getErrorMsg());
             }
 
             if (copyStatus.isRpcError()) {
-                throw new RpcException("unknown", copyStatus.getErrorMsg());
+                throw new RpcException("unknown", copyStatus.getDetailErrorMsg());
             } else {
-                String errMsg = copyStatus.getErrorMsg();
+                String errMsg = copyStatus.getDetailErrorMsg();
                 LOG.warn("query failed: {}", errMsg);
 
                 // hide host info
@@ -1390,6 +1385,7 @@ public class DefaultCoordinator extends Coordinator {
                 if (hostIndex != -1) {
                     errMsg = errMsg.substring(0, hostIndex);
                 }
+
                 throw new UserException(errMsg);
             }
         }


### PR DESCRIPTION
When a fragment in BE report an error status, we only display the error message to clients.
Maybe we could expose the error code in the meanwhile, to make use known the error type, such as internal error or some other reasons.

```
# before:
deserialize chunk data failed. column slot id: 10, column row count: 1, expected row count: 2

# after:
INTERNAL_ERROR. Detail: deserialize chunk data failed. column slot id: 10, column row count: 1, expected row count: 2
```


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
