### PR TITLE
[Enhancement] set a timeout for collecting statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1562,6 +1562,12 @@ public class Config extends ConfigBase {
     public static boolean enable_statistic_collect_on_first_load = true;
 
     /**
+     * max await time for collect statistic for loading
+     */
+    @ConfField(mutable = true)
+    public static long semi_sync_collect_statistic_await_seconds = 30;
+
+    /**
      * The start time of day when auto-updates are enabled
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -62,6 +62,8 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static com.starrocks.sql.optimizer.Utils.getLongFromDateTime;
 
@@ -166,10 +168,13 @@ public class StatisticUtils {
         }
 
         if (sync) {
+            long await = Config.semi_sync_collect_statistic_await_seconds;
             try {
-                future.get();
+                future.get(await, TimeUnit.SECONDS);
             } catch (InterruptedException | ExecutionException e) {
                 LOG.error("failed to execute statistic collect job", e);
+            } catch (TimeoutException e) {
+                LOG.warn("await collect statistic failed after {} seconds", await);
             }
         }
     }


### PR DESCRIPTION
Fixes #issue

Set a timeout for collecting statistics, in case the `Coordinator::join` never return, and blocking this thread.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
