### PR TITLE
[BugFix] Fix the bug of RuntimeState use_after_free

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -792,12 +792,13 @@ void PInternalServiceImplBase<T>::_get_file_schema(google::protobuf::RpcControll
         return;
     }
 
+    RuntimeState state{};
+    RuntimeProfile profile{"dummy_profile", false};
+    ScannerCounter counter{};
     std::unique_ptr<FileScanner> p_scanner;
+
     auto tp = scan_range.ranges[0].format_type;
     {
-        RuntimeState state{};
-        RuntimeProfile profile{"dummy_profile", false};
-        ScannerCounter counter{};
         switch (tp) {
         case TFileFormatType::FORMAT_PARQUET:
             p_scanner = std::make_unique<ParquetScanner>(&state, &profile, scan_range, &counter, true);


### PR DESCRIPTION
Fixes [#3000](https://github.com/StarRocks/StarRocksTest/issues/3000)

```
==2390==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7f3c65102a14 at pc 0x00000a0c5def bp 0x7f3c65101c40 sp 0x7f3c65101c38
READ of size 4 at 0x7f3c65102a14 thread T197 (load_rpc)
    #0 0xa0c5dee in starrocks::RuntimeState::chunk_size() const /root/starrocks/be/src/runtime/runtime_state.h:123
    #1 0xd0a9cdb in starrocks::ORCScanner::open() /root/starrocks/be/src/exec/orc_scanner.cpp:84
    #2 0x12b6dcff in starrocks::PInternalServiceImplBase<doris::PBackendService>::_get_file_schema(google::protobuf::RpcController*, starrocks::PGetFileSchemaRequest const*, starrocks::PGetFileSchemaResult*, google::protobuf::Closure*) /root/starrocks/be/src/service/internal_service.cpp:818
    #3 0x12b7a02f in starrocks::PInternalServiceImplBase<doris::PBackendService>::get_file_schema(google::protobuf::RpcController*, starrocks::PGetFileSchemaRequest const*, starrocks::PGetFileSchemaResult*, google::protobuf::Closure*)::{lambda()#1}::operator()() const /root/starrocks/be/src/service/internal_service.cpp:757
    #4 0x12b89b89 in void std::__invoke_impl<void, starrocks::PInternalServiceImplBase<doris::PBackendService>::get_file_schema(google::protobuf::RpcController*, starrocks::PGetFileSchemaRequest const*, starrocks::PGetFileSchemaResult*, google::protobuf::Closure*)::{lambda()#1}&>(std::__invoke_other, starrocks::PInternalServiceImplBase<doris::PBackendService>::get_file_schema(google::protobuf::RpcController*, starrocks::PGetFileSchemaRequest const*, starrocks::PGetFileSchemaResult*, google::protobuf::Closure*)::{lambda()#1}&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:60
    #5 0x12b87158 in std::enable_if<is_invocable_r_v<void, starrocks::PInternalServiceImplBase<doris::PBackendService>::get_file_schema(google::protobuf::RpcController*, starrocks::PGetFileSchemaRequest const*, starrocks::PGetFileSchemaResult*, google::protobuf::Closure*)::{lambda()#1}&>, std::enable_if>::type std::__invoke_r<void, starrocks::PInternalServiceImplBase<doris::PBackendService>::get_file_schema(google::protobuf::RpcController*, starrocks::PGetFileSchemaRequest const*, starrocks::PGetFileSchemaResult*, google::protobuf::Closure*)::{lambda()#1}&>(void&&, (starrocks::PInternalServiceImplBase<doris::PBackendService>::get_file_schema(google::protobuf::RpcController*, starrocks::PGetFileSchemaRequest const*, starrocks::PGetFileSchemaResult*, google::protobuf::Closure*)::{lambda()#1}&)...) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:110
    #6 0x12b83377 in std::_Function_handler<void (), starrocks::PInternalServiceImplBase<doris::PBackendService>::get_file_schema(google::protobuf::RpcController*, starrocks::PGetFileSchemaRequest const*, starrocks::PGetFileSchemaResult*, google::protobuf::Closure*)::{lambda()#1}>::_M_invoke(std::_Any_data const&) /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:291
    #7 0x99f88bd in std::function<void ()>::operator()() const /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
    #8 0xa436e73 in starrocks::FunctionRunnable::run() (/home/disk1/sr/be/lib/starrocks_be+0xa436e73)
    #9 0xa4339c8 in starrocks::ThreadPool::dispatch_thread() /root/starrocks/be/src/util/threadpool.cpp:553
    #10 0xa450765 in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:73
    #11 0xa450250 in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:95
    #12 0xa44f199 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /opt/gcc/usr/include/c++/10.3.0/functional:416
    #13 0xa44e107 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /opt/gcc/usr/include/c++/10.3.0/functional:499
    #14 0xa44bc61 in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) (/home/disk1/sr/be/lib/starrocks_be+0xa44bc61)
    #15 0xa4485cf in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:110
    #16 0xa4448ba in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:291
    #17 0x99f88bd in std::function<void ()>::operator()() const /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
    #18 0xa41b326 in starrocks::Thread::supervise_thread(void*) /root/starrocks/be/src/util/thread.cpp:364
    #19 0x7f3cc51b5ea4 in start_thread (/lib64/libpthread.so.0+0x7ea4)
    #20 0x7f3cc47d0b0c in clone (/lib64/libc.so.6+0xfeb0c)
```


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
