### PR TITLE
[BugFix] Release lock early in the drop tablet

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -360,8 +360,69 @@ TabletSharedPtr TabletManager::_create_tablet_meta_and_dir_unlocked(const TCreat
 }
 
 Status TabletManager::drop_tablet(TTabletId tablet_id, TabletDropFlag flag) {
-    std::unique_lock wlock(_get_tablets_shard_lock(tablet_id));
-    return _drop_tablet_unlocked(tablet_id, flag);
+    TabletSharedPtr dropped_tablet = nullptr;
+    {
+        std::unique_lock wlock(_get_tablets_shard_lock(tablet_id));
+        StarRocksMetrics::instance()->drop_tablet_requests_total.increment(1);
+
+        if (flag != kDeleteFiles && flag != kMoveFilesToTrash && flag != kKeepMetaAndFiles) {
+            return Status::InvalidArgument(fmt::format("invalid TabletDropFlag {}", (int)flag));
+        }
+
+        TabletMap& tablet_map = _get_tablet_map(tablet_id);
+        auto it = tablet_map.find(tablet_id);
+        if (it == tablet_map.end()) {
+            LOG(WARNING) << "Fail to drop nonexistent tablet " << tablet_id;
+            return Status::NotFound(strings::Substitute("tablet $0 not fount", tablet_id));
+        }
+
+        LOG(INFO) << "Start to drop tablet " << tablet_id;
+        dropped_tablet = it->second;
+        tablet_map.erase(it);
+        _remove_tablet_from_partition(*dropped_tablet);
+    }
+    if (config::enable_event_based_compaction_framework) {
+        dropped_tablet->stop_compaction();
+        StorageEngine::instance()->compaction_manager()->remove_candidate(dropped_tablet->tablet_id());
+    }
+
+    DroppedTabletInfo drop_info{.tablet = dropped_tablet, .flag = flag};
+
+    if (flag == kDeleteFiles) {
+        {
+            // NOTE: Other threads may save the tablet meta back to storage again after we
+            // have deleted it here, and the tablet will reappear after restarted.
+            // To prevent this, set the tablet state to `SHUTDOWN` first before removing tablet
+            // meta from storage, and assuming that no thread will change the tablet state back
+            // to 'RUNNING' from 'SHUTDOWN'.
+            std::unique_lock l(dropped_tablet->get_header_lock());
+            dropped_tablet->set_tablet_state(TABLET_SHUTDOWN);
+        }
+
+        // Remove tablet meta from storage, crash the program if failed.
+        if (auto st = _remove_tablet_meta(dropped_tablet); !st.ok()) {
+            LOG(FATAL) << "Fail to remove tablet meta: " << st;
+        }
+
+        // Remove the tablet directory in background to avoid holding the lock of tablet map shard for long.
+        std::unique_lock l(_shutdown_tablets_lock);
+        _shutdown_tablets.emplace(tablet_id, std::move(drop_info));
+    } else if (flag == kMoveFilesToTrash) {
+        {
+            // See comments above
+            std::unique_lock l(dropped_tablet->get_header_lock());
+            dropped_tablet->set_tablet_state(TABLET_SHUTDOWN);
+            dropped_tablet->save_meta();
+        }
+
+        std::unique_lock l(_shutdown_tablets_lock);
+        _shutdown_tablets.emplace(tablet_id, std::move(drop_info));
+    } else {
+        DCHECK_EQ(kKeepMetaAndFiles, flag);
+    }
+    dropped_tablet->deregister_tablet_from_dir();
+    LOG(INFO) << "Succeed to drop tablet " << tablet_id;
+    return Status::OK();
 }
 
 Status TabletManager::drop_tablets_on_error_root_path(const std::vector<TabletInfo>& tablet_info_vec) {


### PR DESCRIPTION
Drop tablet and release the lock quickly. The drop table will capture the tablets_shard lock.
But there are running apply tasks on the tablet. So the tablets_shard lock will be stuck on the apply thread.
The following thread are also stuck when try to get tablets_shard lock.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
