### PR TITLE
[BugFix] Fix does not supporting s3 path with spaces

### DIFF
--- a/be/src/common/s3_uri.cpp
+++ b/be/src/common/s3_uri.cpp
@@ -14,17 +14,17 @@
 
 #include "common/s3_uri.h"
 
+#include <aws/core/utils/StringUtils.h>
+#include <aws/crt/io/Uri.h>
 #include <fmt/format.h>
 #include <gutil/strings/util.h>
-#include <aws/crt/io/Uri.h>
-#include <aws/core/utils/StringUtils.h>
 
 #include <algorithm>
 
 namespace starrocks {
 
 bool S3URI::parse(const char* uri_str, const size_t size) {
-    Aws::Crt::Io::Uri uri(Aws::Crt::ByteCursor{size, (uint8_t*) uri_str});
+    Aws::Crt::Io::Uri uri(Aws::Crt::ByteCursor{size, (uint8_t*)uri_str});
     if (!uri) {
         return false;
     }

--- a/be/src/common/s3_uri.cpp
+++ b/be/src/common/s3_uri.cpp
@@ -14,29 +14,31 @@
 
 #include "common/s3_uri.h"
 
-#include <brpc/uri.h>
 #include <fmt/format.h>
 #include <gutil/strings/util.h>
+#include <aws/crt/io/Uri.h>
+#include <aws/core/utils/StringUtils.h>
 
 #include <algorithm>
 
 namespace starrocks {
 
-bool S3URI::parse(const char* uri_str) {
-    brpc::URI uri;
-    if (uri.SetHttpURL(uri_str) != 0) {
+bool S3URI::parse(const char* uri_str, const size_t size) {
+    Aws::Crt::Io::Uri uri(Aws::Crt::ByteCursor{size, (uint8_t*) uri_str});
+    if (!uri) {
         return false;
     }
 
-    _scheme = uri.scheme();
+    _scheme = Aws::Utils::StringUtils::FromByteCursor(uri.GetScheme());
     std::transform(_scheme.begin(), _scheme.end(), _scheme.begin(), ::tolower);
-    const std::string& host = uri.host();
+    const std::string& host = Aws::Utils::StringUtils::FromByteCursor(uri.GetHostName());
+    const std::string& aws_path = Aws::Utils::StringUtils::FromByteCursor(uri.GetPath());
     std::string_view path;
 
-    if (!uri.path().empty() && uri.path()[0] == '/') {
-        path = std::string_view(uri.path().data() + 1, uri.path().size() - 1);
+    if (!aws_path.empty() && aws_path[0] == '/') {
+        path = std::string_view(aws_path.data() + 1, aws_path.size() - 1);
     } else {
-        path = uri.path();
+        path = aws_path;
     }
 
     if (_scheme == "s3" || _scheme == "s3a" || _scheme == "s3n") {

--- a/be/src/common/s3_uri.h
+++ b/be/src/common/s3_uri.h
@@ -25,7 +25,7 @@ public:
 
     // Decompose |uri| and set into corresponding fields.
     // Returns true on success, false otherwise.
-    bool parse(const char* uri,  const size_t size);
+    bool parse(const char* uri, const size_t size);
     bool parse(const std::string& uri) { return parse(uri.c_str(), uri.size()); }
 
     const std::string& scheme() const { return _scheme; }

--- a/be/src/common/s3_uri.h
+++ b/be/src/common/s3_uri.h
@@ -25,8 +25,8 @@ public:
 
     // Decompose |uri| and set into corresponding fields.
     // Returns true on success, false otherwise.
-    bool parse(const char* uri);
-    bool parse(const std::string& uri) { return parse(uri.c_str()); }
+    bool parse(const char* uri,  const size_t size);
+    bool parse(const std::string& uri) { return parse(uri.c_str(), uri.size()); }
 
     const std::string& scheme() const { return _scheme; }
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -21,7 +21,7 @@ set(EXEC_FILES
         ./common/config_test.cpp
         ./common/status_test.cpp
         ./common/tracer_test.cpp
-        ./common/s3_uri_test.cpp
+        ./common/uri_test.cpp
         ./fs/fs_broker_test.cpp
         ./fs/fs_posix_test.cpp
         ./fs/fs_memory_test.cpp

--- a/be/test/common/uri_test.cpp
+++ b/be/test/common/uri_test.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "common/s3_uri.h"
-
 #include <gtest/gtest.h>
 
+#include "common/s3_uri.h"
 #include "testutil/parallel_test.h"
 
 namespace starrocks {

--- a/be/test/common/uri_test.cpp
+++ b/be/test/common/uri_test.cpp
@@ -20,7 +20,7 @@
 
 namespace starrocks {
 
-PARALLEL_TEST(S3URITest, virtual_host_url) {
+PARALLEL_TEST(URITest, virtual_host_url) {
     S3URI uri;
     ASSERT_TRUE(uri.parse("https://mybucket.s3.us-west-2.amazonaws.com/puppy.png"));
     EXPECT_EQ("https", uri.scheme());
@@ -30,7 +30,7 @@ PARALLEL_TEST(S3URITest, virtual_host_url) {
     EXPECT_EQ("s3.us-west-2.amazonaws.com", uri.endpoint());
 }
 
-PARALLEL_TEST(S3URITest, path_style_url) {
+PARALLEL_TEST(URITest, path_style_url) {
     S3URI uri;
     ASSERT_TRUE(uri.parse("https://s3.us-west-2.amazonaws.com/mybucket/puppy.jpg"));
     EXPECT_EQ("https", uri.scheme());
@@ -40,7 +40,7 @@ PARALLEL_TEST(S3URITest, path_style_url) {
     EXPECT_EQ("s3.us-west-2.amazonaws.com", uri.endpoint());
 }
 
-PARALLEL_TEST(S3URITest, s3_scheme) {
+PARALLEL_TEST(URITest, s3_scheme) {
     {
         S3URI uri;
         ASSERT_TRUE(uri.parse("s3://mybucket/puppy.jpg"));
@@ -79,7 +79,7 @@ PARALLEL_TEST(S3URITest, s3_scheme) {
     }
 }
 
-PARALLEL_TEST(S3URITest, virtual_host_non_s3_url) {
+PARALLEL_TEST(URITest, virtual_host_non_s3_url) {
     S3URI uri;
     ASSERT_TRUE(uri.parse("https://examplebucket.oss-cn-hangzhou.aliyuncs.com/exampledir/example.txt"));
     EXPECT_EQ("https", uri.scheme());
@@ -89,7 +89,7 @@ PARALLEL_TEST(S3URITest, virtual_host_non_s3_url) {
     EXPECT_EQ("oss-cn-hangzhou.aliyuncs.com", uri.endpoint());
 }
 
-PARALLEL_TEST(S3URITest, with_query_and_fragment) {
+PARALLEL_TEST(URITest, with_query_and_fragment) {
     S3URI uri;
     ASSERT_TRUE(uri.parse("https://examplebucket.oss-cn-hangzhou.aliyuncs.com/exampledir/example.txt?a=b#xyz"));
     EXPECT_EQ("https", uri.scheme());
@@ -99,17 +99,17 @@ PARALLEL_TEST(S3URITest, with_query_and_fragment) {
     EXPECT_EQ("oss-cn-hangzhou.aliyuncs.com", uri.endpoint());
 }
 
-PARALLEL_TEST(S3URITest, empty) {
+PARALLEL_TEST(URITest, empty) {
     S3URI uri;
     ASSERT_FALSE(uri.parse(""));
 }
 
-PARALLEL_TEST(S3URITest, missing_scheme) {
+PARALLEL_TEST(URITest, missing_scheme) {
     S3URI uri;
     ASSERT_FALSE(uri.parse("/bucket/puppy.jpg"));
 }
 
-PARALLEL_TEST(S3URITest, oss_bucket) {
+PARALLEL_TEST(URITest, oss_bucket) {
     S3URI uri;
     ASSERT_TRUE(uri.parse("oss://sr-test/dataset/smith/foo.parquet"));
     EXPECT_EQ("oss", uri.scheme());
@@ -117,6 +117,27 @@ PARALLEL_TEST(S3URITest, oss_bucket) {
     EXPECT_EQ("sr-test", uri.bucket());
     EXPECT_EQ("dataset/smith/foo.parquet", uri.key());
     EXPECT_EQ("", uri.endpoint());
+}
+
+TEST(URITest, s3_complex_path) {
+    {
+        S3URI uri;
+        ASSERT_TRUE(uri.parse("s3://smith-us-west-2/134f/hello/event_date=2023-07-24\\ 23%3A00%3A00/foo.parquet"));
+        EXPECT_EQ("s3", uri.scheme());
+        EXPECT_EQ("", uri.region());
+        EXPECT_EQ("smith-us-west-2", uri.bucket());
+        EXPECT_EQ("134f/hello/event_date=2023-07-24\\ 23%3A00%3A00/foo.parquet", uri.key());
+        EXPECT_EQ("", uri.endpoint());
+    }
+    {
+        S3URI uri;
+        ASSERT_TRUE(uri.parse("s3://smith-us-west-2/134f/hello/event_date=2023-07-24\\%2023%3A00%3A00/foo.parquet"));
+        EXPECT_EQ("s3", uri.scheme());
+        EXPECT_EQ("", uri.region());
+        EXPECT_EQ("smith-us-west-2", uri.bucket());
+        EXPECT_EQ("134f/hello/event_date=2023-07-24\\%2023%3A00%3A00/foo.parquet", uri.key());
+        EXPECT_EQ("", uri.endpoint());
+    }
 }
 
 } // namespace starrocks


### PR DESCRIPTION
1. Fix not supporting s3 path with spaces (BRPC's URI does not allow path contains spaces, so we change to use AWS CRT URI)
3. Rename the ut name, so that we can run it by default. otherwise, we have to run the below command `./run-be-ut.sh --with-aws`;

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
