### PR TITLE
[BugFix] fix priority of partition refresh 

### DIFF
--- a/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
@@ -231,6 +231,15 @@ Status SchemaTaskRunsScanner::fill_chunk(ChunkPtr* chunk) {
             }
             break;
         }
+        case 13: {
+            // properties
+            {
+                ColumnPtr column = (*chunk)->get_column_by_slot_id(13);
+                const std::string* str = &task_run_info.properties;
+                Slice value(str->c_str(), str->length());
+                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
+            }
+        }
         default:
             break;
         }

--- a/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_task_runs_scanner.cpp
@@ -36,7 +36,8 @@ SchemaScanner::ColumnDesc SchemaTaskRunsScanner::_s_tbls_columns[] = {
         {"ERROR_CODE", TYPE_BIGINT, sizeof(StringValue), true},
         {"ERROR_MESSAGE", TYPE_VARCHAR, sizeof(StringValue), true},
         {"PROGRESS", TYPE_VARCHAR, sizeof(StringValue), true},
-        {"EXTRA_MESSAGE", TYPE_VARCHAR, sizeof(StringValue), true}};
+        {"EXTRA_MESSAGE", TYPE_VARCHAR, sizeof(StringValue), true},
+        {"PROPERTIES", TYPE_VARCHAR, sizeof(StringValue), true}};
 
 SchemaTaskRunsScanner::SchemaTaskRunsScanner()
         : SchemaScanner(_s_tbls_columns, sizeof(_s_tbls_columns) / sizeof(SchemaScanner::ColumnDesc)) {}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
@@ -41,6 +41,7 @@ public class TaskRunsSystemTable {
                         .column("ERROR_MESSAGE", ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
                         .column("PROGRESS", ScalarType.createVarchar(64))
                         .column("EXTRA_MESSAGE", ScalarType.createVarchar(8192))
+                        .column("PROPERTIES", ScalarType.createVarcharType(512))
                         .build(), TSchemaTableType.SCH_TASK_RUNS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -316,9 +316,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
         newProperties.put(TaskRun.PARTITION_START, mvContext.getNextPartitionStart());
         newProperties.put(TaskRun.PARTITION_END, mvContext.getNextPartitionEnd());
-        ExecuteOption option = new ExecuteOption(mvContext.getPriority(), false, newProperties);
+        // Partition refreshing task run should have the HIGHEST priority, and be scheduled before other tasks
+        // Otherwise this round of partition refreshing would be staved and never got finished
+        ExecuteOption option = new ExecuteOption(Constants.TaskRunPriority.HIGHEST.value(), true, newProperties);
         taskManager.executeTask(taskName, option);
-        LOG.info("Submit a generate taskRun for task:{}, partitionStart:{}, partitionEnd:{}", mvId,
+        LOG.info("[MV] Generate a task to refresh next batches of partitions for MV {}-{}, start={}, end={}",
+                materializedView.getName(), materializedView.getId(),
                 mvContext.getNextPartitionStart(), mvContext.getNextPartitionEnd());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -647,33 +648,34 @@ public class TaskManager {
                 pTaskRunQueue.stream()
                         .filter(task -> task.getTask().getSource() == Constants.TaskSource.MV)
                         .map(TaskRun::getStatus)
-                        .filter(task -> task != null)
+                        .filter(Objects::nonNull)
                         .forEach(task -> mvNameRunStatusMap.putIfAbsent(task.getTaskName(), task));
             }
+            taskRunManager.getTaskRunHistory().getAllHistory()
+                    .forEach(task -> mvNameRunStatusMap.putIfAbsent(task.getTaskName(), task));
+            // use Map::put to make running task status overwrite the pending task
             taskRunManager.getRunningTaskRunMap().values().stream()
                     .filter(task -> task.getTask().getSource() == Constants.TaskSource.MV)
                     .map(TaskRun::getStatus)
-                    .filter(task -> task != null)
-                    .forEach(task -> mvNameRunStatusMap.putIfAbsent(task.getTaskName(), task));
-            taskRunManager.getTaskRunHistory().getAllHistory().stream()
-                    .forEach(task -> mvNameRunStatusMap.putIfAbsent(task.getTaskName(), task));
+                    .filter(Objects::nonNull)
+                    .forEach(task -> mvNameRunStatusMap.put(task.getTaskName(), task));
         } else {
             for (Queue<TaskRun> pTaskRunQueue : taskRunManager.getPendingTaskRunMap().values()) {
                 pTaskRunQueue.stream()
                         .filter(task -> task.getTask().getSource() == Constants.TaskSource.MV)
                         .map(TaskRun::getStatus)
-                        .filter(task -> task != null)
-                        .filter(u -> u != null && u.getDbName().equals(dbName))
+                        .filter(Objects::nonNull)
+                        .filter(u -> u.getDbName().equals(dbName))
                         .forEach(task -> mvNameRunStatusMap.putIfAbsent(task.getTaskName(), task));
             }
+            taskRunManager.getTaskRunHistory().getAllHistory().stream()
+                    .filter(u -> u.getDbName().equals(dbName))
+                    .forEach(task -> mvNameRunStatusMap.putIfAbsent(task.getTaskName(), task));
             taskRunManager.getRunningTaskRunMap().values().stream()
                     .filter(task -> task.getTask().getSource() == Constants.TaskSource.MV)
                     .map(TaskRun::getStatus)
                     .filter(u -> u != null && u.getDbName().equals(dbName))
-                    .forEach(task -> mvNameRunStatusMap.putIfAbsent(task.getTaskName(), task));
-            taskRunManager.getTaskRunHistory().getAllHistory().stream()
-                    .filter(u -> u.getDbName().equals(dbName))
-                    .forEach(task -> mvNameRunStatusMap.putIfAbsent(task.getTaskName(), task));
+                    .forEach(task -> mvNameRunStatusMap.put(task.getTaskName(), task));
         }
         return mvNameRunStatusMap;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -446,8 +446,9 @@ public class TaskManager {
             initialDelay = 0;
         }
         // this operation should only run in master
+        ExecuteOption option = new ExecuteOption(Constants.TaskRunPriority.LOWEST.value(), true, task.getProperties());
         ScheduledFuture<?> future = periodScheduler.scheduleAtFixedRate(() ->
-                        executeTask(task.getName()), initialDelay,
+                        executeTask(task.getName(), option), initialDelay,
                 TimeUtils.convertTimeUnitValueToSecond(schedule.getPeriod(), schedule.getTimeUnit()),
                 TimeUnit.SECONDS);
         periodFutureMap.put(task.getId(), future);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunBuilder.java
@@ -67,12 +67,8 @@ public class TaskRunBuilder {
             return task.getProperties();
         }
         Map<String, String> result = new HashMap<>();
-        for (Map.Entry<String, String> entry : task.getProperties().entrySet()) {
-            result.put(entry.getKey(), entry.getValue());
-        }
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            result.put(entry.getKey(), entry.getValue());
-        }
+        result.putAll(task.getProperties());
+        result.putAll(properties);
         return result;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -228,6 +228,22 @@ public class TaskRunManager {
         this.taskRunLock.unlock();
     }
 
+    public TaskRun getRunnableTaskRun(long taskId) {
+        TaskRun res = runningTaskRunMap.get(taskId);
+        if (res != null) {
+            return res;
+        }
+        PriorityBlockingQueue<TaskRun> queue = pendingTaskRunMap.get(taskId);
+        if (queue != null) {
+            for (TaskRun run : queue) {
+                if (run.getTaskId() == taskId) {
+                    return run;
+                }
+            }
+        }
+        return null;
+    }
+
     public Map<Long, PriorityBlockingQueue<TaskRun>> getPendingTaskRunMap() {
         return pendingTaskRunMap;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -80,6 +80,7 @@ public class TaskRunManager {
         TaskRunStatus status = taskRun.initStatus(queryId, System.currentTimeMillis());
         status.setPriority(option.getPriority());
         status.setMergeRedundant(option.isMergeRedundant());
+        status.setProperties(option.getTaskRunProperties());
         GlobalStateMgr.getCurrentState().getEditLog().logTaskRunCreateStatus(status);
         arrangeTaskRun(taskRun, option.isMergeRedundant());
         return new SubmitResult(queryId, SubmitResult.SubmitStatus.SUBMITTED, taskRun.getFuture());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -21,6 +21,7 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.scheduler.Constants;
+import org.apache.commons.collections.MapUtils;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -257,6 +258,13 @@ public class TaskRunStatus implements Writable {
 
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    public String getPropertiesJson() {
+        if (MapUtils.isEmpty(properties)) {
+            return null;
+        }
+        return GsonUtils.GSON.toJson(properties);
     }
 
     public void setProperties(Map<String, String> properties) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/TaskRunStatus.java
@@ -25,6 +25,7 @@ import com.starrocks.scheduler.Constants;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Map;
 
 public class TaskRunStatus implements Writable {
 
@@ -83,7 +84,11 @@ public class TaskRunStatus implements Writable {
     @SerializedName("mvExtraMessage")
     private MVTaskRunExtraMessage mvTaskRunExtraMessage = new MVTaskRunExtraMessage();
 
-    public TaskRunStatus() {}
+    @SerializedName("properties")
+    private Map<String, String> properties;
+
+    public TaskRunStatus() {
+    }
 
     public String getQueryId() {
         return queryId;
@@ -248,6 +253,14 @@ public class TaskRunStatus implements Writable {
         } else {
             // do nothing
         }
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
     }
 
     public static TaskRunStatus read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -671,6 +671,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             info.setExpire_time(status.getExpireTime() / 1000);
             info.setProgress(status.getProgress() + "%");
             info.setExtra_message(status.getExtraMessage());
+            info.setProperties(status.getPropertiesJson());
             tasksResult.add(info);
         }
         return result;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -35,30 +35,83 @@
 package com.starrocks.analysis;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.system.information.MaterializedViewsSystemTable;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.scheduler.Task;
+import com.starrocks.scheduler.TaskBuilder;
+import com.starrocks.scheduler.TaskManager;
+import com.starrocks.scheduler.TaskRun;
+import com.starrocks.scheduler.TaskRunBuilder;
+import com.starrocks.scheduler.TaskRunManager;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.DmlStmt;
+import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.ShowMaterializedViewsStmt;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.commons.collections.MapUtils;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.platform.commons.util.Preconditions;
 
+import java.util.HashMap;
 import java.util.List;
 
 public class ShowMaterializedViewTest {
-    private ConnectContext ctx;
 
-    @Before
-    public void setUp() {
+    private static ConnectContext ctx;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE test.tbl6\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p0 values [('2021-12-01'),('2022-01-01')),\n" +
+                        "    PARTITION p1 values [('2022-01-01'),('2022-02-01')),\n" +
+                        "    PARTITION p2 values [('2022-02-01'),('2022-03-01')),\n" +
+                        "    PARTITION p3 values [('2022-03-01'),('2022-04-01')),\n" +
+                        "    PARTITION p4 values [('2022-04-01'),('2022-05-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withMaterializedView("create materialized view test.mv_refresh_priority\n" +
+                        "partition by date_trunc('month',k1) \n" +
+                        "distributed by hash(k2) buckets 10\n" +
+                        "refresh deferred manual\n" +
+                        "properties('replication_num' = '1', 'partition_refresh_number'='1')\n" +
+                        "as select k1, k2 from tbl6;");
+
     }
 
     @Test
     public void testNormal() throws Exception {
-        ctx = UtFrameUtils.createDefaultCtx();
         ctx.setDatabase("testDb");
 
         ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("");
@@ -142,5 +195,72 @@ public class ShowMaterializedViewTest {
         ShowMaterializedViewsStmt stmt = new ShowMaterializedViewsStmt("");
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         Assert.fail("No exception throws");
+    }
+
+    private void setPartitionVersion(Partition partition, long version) {
+        partition.setVisibleVersion(version, System.currentTimeMillis());
+        MaterializedIndex baseIndex = partition.getBaseIndex();
+        List<Tablet> tablets = baseIndex.getTablets();
+        for (Tablet tablet : tablets) {
+            List<Replica> replicas = ((LocalTablet) tablet).getImmutableReplicas();
+            for (Replica replica : replicas) {
+                replica.updateVersionInfo(version, -1, version);
+            }
+        }
+    }
+
+    @Test
+    public void testTaskRun() throws Exception {
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+                if (stmt instanceof InsertStmt) {
+                    InsertStmt insertStmt = (InsertStmt) stmt;
+                    TableName tableName = insertStmt.getTableName();
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
+                    for (Partition partition : tbl.getPartitions()) {
+                        if (insertStmt.getTargetPartitionIds().contains(partition.getId())) {
+                            setPartitionVersion(partition, partition.getVisibleVersion() + 1);
+                        }
+                    }
+                }
+            }
+        };
+        String mvName = "mv_refresh_priority";
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+        TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+        TaskRunManager trm = tm.getTaskRunManager();
+
+        String insertSql = "insert into tbl6 partition(p1) values('2022-01-02',2,10);";
+        new StmtExecutor(ctx, insertSql).execute();
+        insertSql = "insert into tbl6 partition(p2) values('2022-02-02',2,10);";
+        new StmtExecutor(ctx, insertSql).execute();
+
+        // refresh materialized view
+        HashMap<String, String> taskRunProperties = new HashMap<>();
+        taskRunProperties.put(TaskRun.FORCE, Boolean.toString(true));
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+
+        // without db name
+        Assert.assertFalse(tm.showTaskRunStatus(null).isEmpty());
+        Assert.assertFalse(tm.showTasks(null).isEmpty());
+        Assert.assertFalse(tm.showMVLastRefreshTaskRunStatus(null).isEmpty());
+
+        // specific db
+        String dbName = "test";
+        Assert.assertFalse(tm.showTaskRunStatus(dbName).isEmpty());
+        Assert.assertFalse(tm.showTasks(dbName).isEmpty());
+        Assert.assertFalse(tm.showMVLastRefreshTaskRunStatus(dbName).isEmpty());
+
+        long taskId = tm.getTask(TaskBuilder.getMvTaskName(materializedView.getId())).getId();
+        Assert.assertNotNull(tm.getTaskRunManager().getRunnableTaskRun(taskId));
+        while (MapUtils.isNotEmpty(trm.getRunningTaskRunMap())) {
+            Thread.sleep(100);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -52,6 +52,7 @@ import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -142,6 +143,22 @@ public class PartitionBasedMvRefreshProcessorTest {
                         "    k3 bigint\n" +
                         ")\n" +
                         "PARTITION BY RANGE(dt)\n" +
+                        "(\n" +
+                        "    PARTITION p0 values [('2021-12-01'),('2022-01-01')),\n" +
+                        "    PARTITION p1 values [('2022-01-01'),('2022-02-01')),\n" +
+                        "    PARTITION p2 values [('2022-02-01'),('2022-03-01')),\n" +
+                        "    PARTITION p3 values [('2022-03-01'),('2022-04-01')),\n" +
+                        "    PARTITION p4 values [('2022-04-01'),('2022-05-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE test.tbl6\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
                         "(\n" +
                         "    PARTITION p0 values [('2021-12-01'),('2022-01-01')),\n" +
                         "    PARTITION p1 values [('2022-01-01'),('2022-02-01')),\n" +
@@ -524,6 +541,57 @@ public class PartitionBasedMvRefreshProcessorTest {
         Assert.assertEquals(2, materializedView.getPartition("p202202_202203").getVisibleVersion());
         Assert.assertEquals(2, materializedView.getPartition("p202203_202204").getVisibleVersion());
         Assert.assertEquals(2, materializedView.getPartition("p202204_202205").getVisibleVersion());
+    }
+
+    @Test
+    public void testRefreshPriority() throws Exception {
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+                if (stmt instanceof InsertStmt) {
+                    InsertStmt insertStmt = (InsertStmt) stmt;
+                    TableName tableName = insertStmt.getTableName();
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
+                    for (Partition partition : tbl.getPartitions()) {
+                        if (insertStmt.getTargetPartitionIds().contains(partition.getId())) {
+                            setPartitionVersion(partition, partition.getVisibleVersion() + 1);
+                        }
+                    }
+                }
+            }
+        };
+        String mvName = "mv_refresh_priority";
+        starRocksAssert.withMaterializedView("create materialized view test.mv_refresh_priority\n" +
+                "partition by date_trunc('month',k1) \n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "refresh deferred manual\n" +
+                "properties('replication_num' = '1', 'partition_refresh_number'='1')\n" +
+                "as select k1, k2 from tbl6;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+        TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+        TaskRunManager trm = tm.getTaskRunManager();
+
+        String insertSql = "insert into tbl6 partition(p1) values('2022-01-02',2,10);";
+        new StmtExecutor(connectContext, insertSql).execute();
+        insertSql = "insert into tbl6 partition(p2) values('2022-02-02',2,10);";
+        new StmtExecutor(connectContext, insertSql).execute();
+
+        HashMap<String, String> taskRunProperties = new HashMap<>();
+        taskRunProperties.put(TaskRun.FORCE, Boolean.toString(true));
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+
+        long taskId = tm.getTask(TaskBuilder.getMvTaskName(materializedView.getId())).getId();
+        TaskRun run = tm.getTaskRunManager().getRunnableTaskRun(taskId);
+        Assert.assertEquals(Constants.TaskRunPriority.HIGHEST.value(), run.getStatus().getPriority());
+
+        while (MapUtils.isNotEmpty(trm.getRunningTaskRunMap())) {
+            Thread.sleep(100);
+        }
     }
 
     public void testAutoRefreshPartitionLimitWithHiveTable() throws Exception {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -425,6 +425,7 @@ struct TTaskRunInfo {
     11: optional string progress
 
     12: optional string extra_message
+    13: optional string properties
 }
 
 struct TGetTaskRunInfoResult {


### PR DESCRIPTION
Fixes #28067


Case:
- Set the refresh interval very small, less than the actual duration of `PartitionRefresh` task
- So the periodical task will generate a lot of task runs, then get pended at the queue
- As a result, the MV will never get refreshed


Cause:
- The PartitionBasedMvRefresh will submit task to refresh other partitions, whose priority is same as periodical task
- So the refresh procedure will always execute the `MVRefresh` task, instead of the `PartitionRefresh` task. Which also mean, it will always refresh the first batch of partitions

Solution:
- Display task properties in `information_schema.task_runs`
- Make the `PartitionRefresh` task have higher priority than `MVRefresh` task
- Use mergeRedundant strategy when `TaskManager::registerScheduler`
- Display the running task status for `show materialized views`


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
