### PR TITLE
[Enhancement] make thrift rpc use strict mode

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -486,6 +486,10 @@ CONF_mBool(sync_tablet_meta, "false");
 // Default thrift rpc timeout ms.
 CONF_mInt32(thrift_rpc_timeout_ms, "5000");
 
+CONF_Bool(thrift_rpc_strict_mode, "true");
+// rpc max string body size. 0 means unlimited
+CONF_Int32(thrift_rpc_max_body_size, "0");
+
 // txn commit rpc timeout
 CONF_mInt32(txn_commit_rpc_timeout_ms, "20000");
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -249,9 +249,7 @@ public:
 
     // using template to simplify client cache management
     template <typename T>
-    ClientCache<T>* get_client_cache() {
-        return nullptr;
-    }
+    ClientCache<T>* get_client_cache();
 
     PriorityThreadPool* thread_pool() { return _thread_pool; }
     workgroup::ScanExecutor* scan_executor() { return _scan_executor; }

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -57,6 +57,7 @@ static void send_rpc_runtime_filter(doris::PBackendService_Stub* stub, RuntimeFi
                                     int timeout_ms, const PTransmitRuntimeFilterParams& request) {
     if (rpc_closure->seq != 0) {
         brpc::Join(rpc_closure->cntl.call_id());
+        WARN_IF_RPC_ERROR(rpc_closure->cntl);
     }
     rpc_closure->ref();
     rpc_closure->cntl.Reset();
@@ -717,6 +718,7 @@ void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_relay(PTransmitRunti
             {request.query_id(), request.filter_id(), first_dest.address.hostname, "DELIVER_BROADCAST_RF_RELAY"});
     send_rpc_runtime_filter(stub, rpc_closure, timeout_ms, request);
     brpc::Join(rpc_closure->cntl.call_id());
+    WARN_IF_RPC_ERROR(rpc_closure->cntl);
     rpc_closure->unref();
 }
 
@@ -753,6 +755,7 @@ void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_passthrough(
 
         for (auto& rpc_closure : rpc_closures) {
             brpc::Join(rpc_closure->cntl.call_id());
+            WARN_IF_RPC_ERROR(rpc_closure->cntl);
             rpc_closure->unref();
             delete rpc_closure;
         }

--- a/be/src/util/ref_count_closure.h
+++ b/be/src/util/ref_count_closure.h
@@ -53,4 +53,9 @@ private:
     std::atomic<int> _refs;
 };
 
+#define WARN_IF_RPC_ERROR(cntl)                                                                                   \
+    if (cntl.Failed()) {                                                                                          \
+        LOG(WARNING) << "brpc failed, error=" << berror(cntl.ErrorCode()) << ", error_text=" << cntl.ErrorText(); \
+    }
+
 } // namespace starrocks

--- a/be/src/util/thrift_server.cpp
+++ b/be/src/util/thrift_server.cpp
@@ -50,6 +50,7 @@
 #include <thread>
 #include <utility>
 
+#include "common/config.h"
 #include "util/thread.h"
 
 namespace starrocks {
@@ -303,11 +304,13 @@ ThriftServer::ThriftServer(const std::string& name, std::shared_ptr<apache::thri
 
 Status ThriftServer::start() {
     DCHECK(!_started);
-    std::shared_ptr<apache::thrift::protocol::TProtocolFactory> protocol_factory(
-            new apache::thrift::protocol::TBinaryProtocolFactory());
+    auto protocol_factory = std::make_shared<apache::thrift::protocol::TBinaryProtocolFactory>();
+    protocol_factory->setStrict(config::thrift_rpc_strict_mode, true);
+    protocol_factory->setStringSizeLimit(config::thrift_rpc_max_body_size);
+
+    auto thread_factory = std::make_shared<apache::thrift::concurrency::ThreadFactory>();
+
     std::shared_ptr<apache::thrift::concurrency::ThreadManager> thread_mgr;
-    std::shared_ptr<apache::thrift::concurrency::ThreadFactory> thread_factory(
-            new apache::thrift::concurrency::ThreadFactory());
     std::shared_ptr<apache::thrift::transport::TServerTransport> fe_server_transport;
     std::shared_ptr<apache::thrift::transport::TTransportFactory> transport_factory;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -634,6 +634,13 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int thrift_rpc_retry_times = 3;
 
+    @ConfField
+    public static boolean thrift_rpc_strict_mode = true;
+
+    // thrift rpc max body limit size. -1 means unlimited
+    @ConfField
+    public static int thrift_rpc_max_body_size = -1;
+
     // May be necessary to modify the following BRPC configurations in high concurrency scenarios.
 
     // The size of BRPC connection pool. It will limit the concurrency of sending requests, because

--- a/fe/fe-core/src/main/java/com/starrocks/common/ThriftServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ThriftServer.java
@@ -54,9 +54,11 @@ public class ThriftServer {
                 .clientTimeout(Config.thrift_client_timeout_ms)
                 .backlog(Config.thrift_backlog_num);
 
+        TBinaryProtocol.Factory factory =
+                new TBinaryProtocol.Factory(Config.thrift_rpc_strict_mode, true, Config.thrift_rpc_max_body_size, -1);
         SRTThreadPoolServer.Args serverArgs =
                 new SRTThreadPoolServer.Args(new TServerSocket(socketTransportArgs)).protocolFactory(
-                        new TBinaryProtocol.Factory()).processor(processor);
+                        factory).processor(processor);
         ThreadPoolExecutor threadPoolExecutor = ThreadPoolManager
                 .newDaemonFixedThreadPool(Config.thrift_server_max_worker_threads,
                         Config.thrift_server_queue_size,


### PR DESCRIPTION
Fix the problem eg:
```
W0726 14:07:03.697324 16174 mem_hook.cpp:247] large memory alloc: 1347571780 b
ytes, stack:
    @          0x31a4d83  malloc
    @          0x8191535  operator new()
    @          0x27b6d7e  std::__cxx11::basic_string<>::_M_mutate()
    @          0x30af6b7  apache::thrift::protocol::TBinaryProtocolT<>::readStringBody<>()
    @          0x30af84c  apache::thrift::protocol::TVirtualProtocol<>::readMessageBegin_virt()
    @          0x3318599  apache::thrift::TDispatchProcessor::process()
    @          0x5f0a058  apache::thrift::server::TConnectedClient::run()
    @          0x5f02554  apache::thrift::server::TThreadedServer::TConnectedClientRunner::run()
    @          0x5f04d5d  apache::thrift::concurrency::Thread::threadMain()
    @          0x5eea4c6  std::thread::_State_impl<>::_M_run()
    @          0x820a430  execute_native_thread_routine
    @     0x7f77e8ebeea5  start_thread
    @     0x7f77e84d9b0d  __clone
    @              (nil)  (unknown)
```

mini reproduce case:
```
echo -e "\x50\x52\x50\x43" |nc $BE $BE_PORT
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
