### PR TITLE
[Feature] Disable PrimaryKeyUpdateTableRule for performance regression

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningCTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningCTETest.java
@@ -93,7 +93,7 @@ public class TablePruningCTETest extends TablePruningTestBase {
         return createTableSql.replaceAll(pat.pattern(), "CREATE TABLE `$10`");
     }
 
-    @Test
+    // @Test
     public void testUpdate() {
         String sql = "WITH cte0 as (\n" +
                 "WITH cte1 as (\n" +
@@ -132,31 +132,31 @@ public class TablePruningCTETest extends TablePruningTestBase {
         checkHashJoinCountWithOnlyRBO(sql, 1);
     }
 
-    @Test
+    // @Test
     public void testUpdateCTEFullInlined() {
         String q = getSqlList("sql/tpch_pk_tables/", "q1").get(0);
         checkHashJoinCountWithOnlyRBO(q, 3);
     }
 
-    @Test
+    // @Test
     public void testUpdateCTENotFullInlined() {
         String q = getSqlList("sql/tpch_pk_tables/", "q2").get(0);
         checkHashJoinCountWithOnlyRBO(q, 3);
     }
 
-    @Test
+    // @Test
     public void testUpdateCTEInnerJoin() {
         String q = getSqlList("sql/tpch_pk_tables/", "q3").get(0);
         checkHashJoinCountWithOnlyRBO(q, 3);
     }
 
-    @Test
+    // @Test
     public void testUpdateAggregationPreventPruning() {
         String q = getSqlList("sql/tpch_pk_tables/", "q4").get(0);
         checkHashJoinCountWithOnlyRBO(q, 5);
     }
 
-    @Test
+    // @Test
     public void testUpdateWithPredicates() {
         String q = getSqlList("sql/tpch_pk_tables/", "q5").get(0);
         String plan = checkHashJoinCountWithOnlyRBO(q, 3);
@@ -170,7 +170,7 @@ public class TablePruningCTETest extends TablePruningTestBase {
                 "[l_orderkey, BIGINT, false] <= 1000"));
     }
 
-    @Test
+    // @Test
     public void testUpdateContainsRightJoin() {
         String q = getSqlList("sql/tpch_pk_tables/", "q6").get(0);
         checkHashJoinCountWithOnlyRBO(q, 3);


### PR DESCRIPTION
Bucket shuffle join interpolation in PK table's update query can adjust layout of the data ingested by OlapTableSink and eliminate race introduced by multiple concurrent write operations on the same tablets, pruning this bucket shuffle join make update statement performance regression, so we can turn on this rule after we put an bucket-shuffle exchange in front of OlapTableSink in future, at present we turn off this rule.

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
