### PR TITLE
[Feature] support `\N` as null element in array

### DIFF
--- a/be/src/formats/csv/nullable_converter.cpp
+++ b/be/src/formats/csv/nullable_converter.cpp
@@ -81,7 +81,7 @@ bool NullableConverter::read_quoted_string(Column* column, Slice s, const Option
     auto* nullable = down_cast<NullableColumn*>(column);
     auto* data = nullable->data_column().get();
 
-    if (s == "null") {
+    if (s == "null" || s == "\\N") {
         return nullable->append_nulls(1);
     } else if (_base_converter->read_quoted_string(data, s, options)) {
         nullable->null_column()->append(0);

--- a/be/src/gutil/bits.h
+++ b/be/src/gutil/bits.h
@@ -161,8 +161,6 @@ inline int Bits::FindLSBSetNonZero64(uint64 n) {
 }
 #elif defined(_MSC_VER)
 #include "gutil/bits-internal-windows.h"
-#else
-#include "gutil/bits-internal-unknown.h"
 #endif
 
 inline int Bits::CountOnesInByte(unsigned char n) {

--- a/be/test/formats/csv/nullable_converter_test.cpp
+++ b/be/test/formats/csv/nullable_converter_test.cpp
@@ -52,11 +52,13 @@ TEST_F(NullableConverterTest, test_read_quoted_string) {
     EXPECT_TRUE(conv->read_quoted_string(col.get(), "1", Converter::Options()));
     EXPECT_TRUE(conv->read_quoted_string(col.get(), "-1", Converter::Options()));
     EXPECT_TRUE(conv->read_quoted_string(col.get(), "null", Converter::Options()));
+    EXPECT_TRUE(conv->read_quoted_string(col.get(), "\N", Converter::Options()));
 
     EXPECT_EQ(3, col->size());
     EXPECT_EQ(1, col->get(0).get_int32());
     EXPECT_EQ(-1, col->get(1).get_int32());
     EXPECT_TRUE(col->get(2).is_null());
+    EXPECT_TRUE(col->get(3).is_null());
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
Fixes #issue
```
create table tbl_array (col_int int not null, col_array array<int>)  distributed by hash(col_int) properties("replication_num"="1");
```
We could use `\N` to represent NULL value in stream load.
```
curl --location-trusted -u root:  -H "format: csv" -H "column_separator:\t" -H "strict_mode: true" -d '1\t\N' -XPUT http://127.0.0.1:18040/api/db0/tbl_array/_stream_load -v


+---------+-----------+
| col_int | col_array |
+---------+-----------+
|       1 | NULL      |
+---------+-----------+

```
This PR adds the support using `\N` to represent NULL element in array.
```
curl --location-trusted -u root:  -H "format: csv" -H "column_separator:\t" -H "strict_mode: true" -d '1\t[1,2,\N]' -XPUT http://127.0.0.1:18040/api/db0/tbl_array/_stream_load -v

+---------+-----------+
| col_int | col_array |
+---------+-----------+
|       1 | [1,2,null]|
+---------+-----------+
```

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
