### PR TITLE
[Enhancement] Unbind with memtracker before main thread exit

### DIFF
--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -265,6 +265,9 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     exec_env->destroy();
     delete storage_engine;
 
+    // Unbind with MemTracker
+    tls_mem_tracker = nullptr;
+
     global_env->stop();
     LOG(INFO) << "BE exit step " << exit_step++ << ": global env stop successfully";
 


### PR DESCRIPTION
Fixes #issue

```
main RELEASE (build 75f1bcd)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
*** Aborted at 1690449364 (unix time) try "date -d @1690449364" if you are using GNU date ***
PC: @          0x2a2c796 starrocks::CurrentThread::MemCacheManager::commit()
*** SIGSEGV (@0x0) received by PID 2372 (TID 0x7fa2b0c43600) from PID 0; stack trace: ***
    @          0x6eb7372 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fa2af069630 (unknown)
    @          0x2a2c796 starrocks::CurrentThread::MemCacheManager::commit()
    @          0x2b5e528 free
    @     0x7fa2aecc5d10 __run_exit_handlers
    @     0x7fa2aecc5d37 __GI_exit
    @     0x7fa2aecae55c __libc_start_main
    @          0x28b715f (unknown)
    @                0x0 (unknown)
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
