### PR TITLE
[BugFix] fix join probe metric is 0

### DIFF
--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -114,7 +114,7 @@ Status HashJoiner::prepare_builder(RuntimeState* state, RuntimeProfile* runtime_
     return Status::OK();
 }
 
-// prepare_builder is done before this
+// it is ok that prepare_builder is done whether before this or not
 Status HashJoiner::prepare_prober(RuntimeState* state, RuntimeProfile* runtime_profile) {
     if (_runtime_state == nullptr) {
         _runtime_state = state;

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -114,6 +114,7 @@ Status HashJoiner::prepare_builder(RuntimeState* state, RuntimeProfile* runtime_
     return Status::OK();
 }
 
+// prepare_builder is done before this
 Status HashJoiner::prepare_prober(RuntimeState* state, RuntimeProfile* runtime_profile) {
     if (_runtime_state == nullptr) {
         _runtime_state = state;
@@ -122,6 +123,15 @@ Status HashJoiner::prepare_prober(RuntimeState* state, RuntimeProfile* runtime_p
     runtime_profile->add_info_string("DistributionMode", to_string(_hash_join_node.distribution_mode));
     runtime_profile->add_info_string("JoinType", to_string(_join_type));
     _probe_metrics->prepare(runtime_profile);
+
+    auto& hash_table = _hash_join_builder->hash_table();
+    hash_table.set_probe_profile(probe_metrics().search_ht_timer, probe_metrics().output_probe_column_timer,
+                                 probe_metrics().output_tuple_column_timer, probe_metrics().output_build_column_timer);
+
+    _hash_table_param.search_ht_timer = probe_metrics().search_ht_timer;
+    _hash_table_param.output_build_column_timer = probe_metrics().output_build_column_timer;
+    _hash_table_param.output_probe_column_timer = probe_metrics().output_probe_column_timer;
+    _hash_table_param.output_tuple_column_timer = probe_metrics().output_tuple_column_timer;
 
     return Status::OK();
 }
@@ -134,10 +144,6 @@ void HashJoiner::_init_hash_table_param(HashTableParam* param) {
     param->row_desc = &_row_descriptor;
     param->build_row_desc = &_build_row_descriptor;
     param->probe_row_desc = &_probe_row_descriptor;
-    param->search_ht_timer = probe_metrics().search_ht_timer;
-    param->output_build_column_timer = probe_metrics().output_build_column_timer;
-    param->output_probe_column_timer = probe_metrics().output_probe_column_timer;
-    param->output_tuple_column_timer = probe_metrics().output_tuple_column_timer;
     param->output_slots = _output_slots;
     std::set<SlotId> predicate_slots;
     for (ExprContext* expr_context : _conjunct_ctxs) {
@@ -313,7 +319,7 @@ void HashJoiner::reference_hash_table(HashJoiner* src_join_builder) {
     _hash_table_param = src_join_builder->hash_table_param();
     hash_table = src_join_builder->_hash_join_builder->hash_table().clone_readable_table();
     hash_table.set_probe_profile(probe_metrics().search_ht_timer, probe_metrics().output_probe_column_timer,
-                                 probe_metrics().output_tuple_column_timer);
+                                 probe_metrics().output_tuple_column_timer, probe_metrics().output_build_column_timer);
 
     // _hash_table_build_rows is root truth, it used to by _short_circuit_break().
     _hash_table_build_rows = src_join_builder->_hash_table_build_rows;

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -127,8 +127,6 @@ struct JoinHashTableItems {
 
     std::unique_ptr<MemPool> build_pool = nullptr;
     std::vector<JoinKeyDesc> join_keys;
-
-    RuntimeProfile::Counter* output_build_column_timer = nullptr;
 };
 
 struct HashTableProbeState {
@@ -172,6 +170,7 @@ struct HashTableProbeState {
     RuntimeProfile::Counter* search_ht_timer = nullptr;
     RuntimeProfile::Counter* output_probe_column_timer = nullptr;
     RuntimeProfile::Counter* output_tuple_column_timer = nullptr;
+    RuntimeProfile::Counter* output_build_column_timer = nullptr;
 
     HashTableProbeState() = default;
     ~HashTableProbeState() = default;
@@ -516,7 +515,7 @@ private:
         }
     }
     void _build_output(ChunkPtr* chunk) {
-        SCOPED_TIMER(_table_items->output_build_column_timer);
+        SCOPED_TIMER(_probe_state->output_build_column_timer);
         bool to_nullable = _table_items->right_to_nullable;
         for (size_t i = 0; i < _table_items->build_column_count; i++) {
             HashTableSlotDescriptor hash_table_slot = _table_items->build_slots[i];
@@ -685,7 +684,8 @@ public:
     // and the different probe state from this.
     JoinHashTable clone_readable_table();
     void set_probe_profile(RuntimeProfile::Counter* search_ht_timer, RuntimeProfile::Counter* output_probe_column_timer,
-                           RuntimeProfile::Counter* output_tuple_column_timer);
+                           RuntimeProfile::Counter* output_tuple_column_timer,
+                           RuntimeProfile::Counter* output_build_column_timer);
 
     void create(const HashTableParam& param);
     void close();

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -750,7 +750,7 @@ private:
     bool _need_create_tuple_columns = true;
 
     std::shared_ptr<JoinHashTableItems> _table_items;
-    std::unique_ptr<HashTableProbeState> _probe_state;
+    std::unique_ptr<HashTableProbeState> _probe_state = std::make_unique<HashTableProbeState>();
 };
 } // namespace starrocks
 

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -436,7 +436,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
             }
         }
         {
-            SCOPED_TIMER(_table_items->output_build_column_timer);
+            SCOPED_TIMER(_probe_state->output_build_column_timer);
             _build_output(chunk);
         }
         {
@@ -457,7 +457,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
         }
         {
             // output default values for build-columns as placeholder.
-            SCOPED_TIMER(_table_items->output_build_column_timer);
+            SCOPED_TIMER(_probe_state->output_build_column_timer);
             if (!_table_items->with_other_conjunct) {
                 _build_default_output(chunk, _probe_state->count);
             } else {
@@ -476,7 +476,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
             _probe_output(probe_chunk, chunk);
         }
         {
-            SCOPED_TIMER(_table_items->output_build_column_timer);
+            SCOPED_TIMER(_probe_state->output_build_column_timer);
             _build_output(chunk);
         }
         {

--- a/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_probe_operator.cpp
@@ -95,6 +95,8 @@ Status HashJoinProbeOperator::set_finished(RuntimeState* state) {
 }
 
 Status HashJoinProbeOperator::_reference_builder_hash_table_once() {
+    // non-broadcast join directly return as _join_prober == _join_builder,
+    // but broadcast should refer to the shared join builder
     if (_join_prober == _join_builder) {
         return Status::OK();
     }

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -516,7 +516,6 @@ void JoinHashMapTest::prepare_table_items(JoinHashTableItems* table_items, uint3
     table_items->row_count = row_count;
     table_items->next.resize(row_count + 1);
     table_items->build_pool = std::make_unique<MemPool>();
-    table_items->output_build_column_timer = ADD_TIMER(_runtime_profile, "OutputBuildColumnTime");
 }
 
 void JoinHashMapTest::prepare_probe_state(HashTableProbeState* probe_state, uint32_t probe_row_count) {
@@ -1060,7 +1059,7 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFunc) {
     param.search_ht_timer = ADD_TIMER(_runtime_profile, "search_ht");
     param.output_build_column_timer = ADD_TIMER(_runtime_profile, "output_build_column");
     param.output_probe_column_timer = ADD_TIMER(_runtime_profile, "output_probe_column");
-    param.output_build_column_timer = ADD_TIMER(_runtime_profile, "output_tuple_column");
+    param.output_tuple_column_timer = ADD_TIMER(_runtime_profile, "output_tuple_column");
 
     JoinHashTable ht;
 
@@ -1120,7 +1119,7 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFuncNullable) {
     param.search_ht_timer = ADD_TIMER(_runtime_profile, "search_ht");
     param.output_build_column_timer = ADD_TIMER(_runtime_profile, "output_build_column");
     param.output_probe_column_timer = ADD_TIMER(_runtime_profile, "output_probe_column");
-    param.output_build_column_timer = ADD_TIMER(_runtime_profile, "output_tuple_column");
+    param.output_tuple_column_timer = ADD_TIMER(_runtime_profile, "output_tuple_column");
 
     JoinHashTable ht;
 


### PR DESCRIPTION
let probe metrics attach to probe_state in prepare_prober(). result
```
UniqueMetrics:
 - DistributionMode: LOCAL_HASH_BUCKET
 - JoinType: INNER_JOIN
 - OtherJoinConjunctEvaluateTime: 0ns
 - OutputBuildColumnTime: 723.293ms
 - __MAX_OF_OutputBuildColumnTime: 777.605ms
 - __MIN_OF_OutputBuildColumnTime: 662.359ms
 - OutputProbeColumnTime: 38.990ms
 - __MAX_OF_OutputProbeColumnTime: 48.890ms
 - __MIN_OF_OutputProbeColumnTime: 32.626ms
 - OutputTupleColumnTime: 383.335us
 - __MAX_OF_OutputTupleColumnTime: 407.101us
 - __MIN_OF_OutputTupleColumnTime: 368.21us
 - ProbeConjunctEvaluateTime: 14.255ms
 - __MAX_OF_ProbeConjunctEvaluateTime: 20.247ms
 - __MIN_OF_ProbeConjunctEvaluateTime: 11.531ms
 - SearchHashTableTime: 5s964ms
 - __MAX_OF_SearchHashTableTime: 6s295ms
 - __MIN_OF_SearchHashTableTime: 5s291ms
 - WhereConjunctEvaluateTime: 0ns
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
