### PR TITLE
[BugFix] Fix check extra_columns at deserializing

### DIFF
--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -245,13 +245,13 @@ StatusOr<Chunk> ProtobufChunkDeserializer::deserialize(std::string_view buff, in
     }
 
     for (int i = 0; i < columns.size(); ++i) {
-        size_t col_size = columns[i]->size();
-        if (col_size != rows) {
+        size_t col_num_rows = columns[i]->size();
+        if (col_num_rows != rows) {
             SlotId slot_id = get_slot_id_by_index(_meta.slot_id_to_index, i);
             return Status::Corruption(
                     fmt::format("Internal error. Detail: deserialize chunk data failed. column slot id: {}, column row "
                                 "count: {}, expected row count: {}. There is probably a bug here.",
-                                slot_id, col_size, rows));
+                                slot_id, col_num_rows, rows));
         }
     }
 
@@ -269,13 +269,13 @@ StatusOr<Chunk> ProtobufChunkDeserializer::deserialize(std::string_view buff, in
             cur = ColumnArraySerde::deserialize(cur, column.get());
         }
         for (int i = 0; i < extra_columns.size(); ++i) {
-            size_t col_size = extra_columns[i]->size();
-            if (col_size != rows) {
+            size_t col_num_rows = extra_columns[i]->size();
+            if (col_num_rows != rows) {
                 return Status::Corruption(
                         fmt::format("Internal error. Detail: deserialize chunk data failed. extra column index: {}, "
                                     "column row count: {}, expected "
                                     "row count: {}. There is probably a bug here.",
-                                    i, col_size, rows));
+                                    i, col_num_rows, rows));
             }
         }
         chunk_extra_data = std::make_shared<ChunkExtraColumnsData>(_meta.extra_data_metas, std::move(extra_columns));

--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -268,8 +268,8 @@ StatusOr<Chunk> ProtobufChunkDeserializer::deserialize(std::string_view buff, in
         for (auto& column : extra_columns) {
             cur = ColumnArraySerde::deserialize(cur, column.get());
         }
-        for (int i = 0; i < columns.size(); ++i) {
-            size_t col_size = columns[i]->size();
+        for (int i = 0; i < extra_columns.size(); ++i) {
+            size_t col_size = extra_columns[i]->size();
             if (col_size != rows) {
                 return Status::Corruption(
                         fmt::format("Internal error. Detail: deserialize chunk data failed. extra column index: {}, "


### PR DESCRIPTION
Introduced by #27969. When modifying the error message, accidentally change `extra_columns` to `columns`.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
