### PR TITLE
[BugFix] Fix break in asan

### DIFF
--- a/be/src/storage/aggregate_iterator.cpp
+++ b/be/src/storage/aggregate_iterator.cpp
@@ -46,9 +46,6 @@ public:
         for (size_t i = 0; i < _schema.num_key_fields(); i++) {
             CHECK(_schema.field(i)->is_key());
         }
-        for (size_t i = 0; i + 1 < _schema.num_key_fields(); i++) {
-            CHECK_LT(_schema.field(i)->id(), _schema.field(i + 1)->id());
-        }
 #endif
     }
 

--- a/be/src/storage/chunk_aggregator.cpp
+++ b/be/src/storage/chunk_aggregator.cpp
@@ -35,9 +35,6 @@ ChunkAggregator::ChunkAggregator(const starrocks::Schema* schema, uint32_t reser
     for (size_t i = 0; i < _schema->num_key_fields(); i++) {
         CHECK(_schema->field(i)->is_key());
     }
-    for (size_t i = 0; i + 1 < _schema->num_key_fields(); i++) {
-        CHECK_LT(_schema->field(i)->id(), _schema->field(i + 1)->id());
-    }
 #endif
     _key_fields = _schema->num_key_fields();
     _num_fields = _schema->num_fields();


### PR DESCRIPTION
Fixes #3001

After https://github.com/StarRocks/starrocks/pull/24750/files , `_selected_column_indexes`'s meaning has changed.
Before `selected_column_indexs` will keep the visit order by base table's schema, however after this pr for more common usage, `selected_column_indexs` will keep query's visit order.

```
const std::vector<ColumnId>& get_selected_column_indexes() const { return _selected_column_indexes; }
```

Old: selected_column_indexs
```
    auto selected_column_indexs = chunk_changer->get_mutable_selected_column_indexes();
    int32_t index = 0;
    for (const auto& iter : base_to_new) {
        ColumnMapping* column_mapping = chunk_changer->get_mutable_column_mapping(iter.second);
        // new tablet column index -> base reader column index
        column_mapping->ref_base_reader_column_index = index++;
        // selected column index from base tablet for base reader
        selected_column_indexs->emplace_back(iter.first);
    }
```

New: _selected_column_indexes
```
Status ChunkChanger::prepare() {
    int32_t index = 0;
    for (int i = 0; i < _schema_mapping.size(); ++i) {
        ColumnMapping* column_mapping = get_mutable_column_mapping(i);
        if (column_mapping == nullptr) {
            return Status::InternalError("referenced column was missing: " + i);
        }
        int32_t ref_column = column_mapping->ref_column;
        if (ref_column < 0) {
            continue;
        }
        if (_slot_id_to_index_map.find(ref_column) == _slot_id_to_index_map.end()) {
            _slot_id_to_index_map.emplace(ref_column, index++);
            _selected_column_indexes.emplace_back(ref_column);
        }
    }
    return Status::OK();
}

```
## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
