### PR TITLE
[BugFix] Check block cache switch before shutdown the cache instance.

### DIFF
--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -312,7 +312,9 @@ int main(int argc, char** argv) {
     }
 
 #ifdef WITH_BLOCK_CACHE
-    starrocks::BlockCache::instance()->shutdown();
+    if (starrocks::config::block_cache_enable) {
+        starrocks::BlockCache::instance()->shutdown();
+    }
 #endif
 
     daemon->stop();


### PR DESCRIPTION
Without checking block cache switch, shutdown procedure will cause some error. It does not affect too much because it is only occur when BE process stop.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
