### PR TITLE
[BugFix] Disable local passthrough for global merger

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -735,7 +735,8 @@ std::shared_ptr<ExchangeSinkOperatorFactory> _create_exchange_sink_operator(Pipe
     auto exchange_sink = std::make_shared<ExchangeSinkOperatorFactory>(
             context->next_operator_id(), stream_sink.dest_node_id, sink_buffer, sender->get_partition_type(),
             sender->destinations(), is_pipeline_level_shuffle, dest_dop, sender->sender_id(),
-            sender->get_dest_node_id(), sender->get_partition_exprs(), sender->get_enable_exchange_pass_through(),
+            sender->get_dest_node_id(), sender->get_partition_exprs(),
+            !is_dest_merge && sender->get_enable_exchange_pass_through(),
             sender->get_enable_exchange_perf() && !context->has_aggregation, fragment_ctx, sender->output_columns());
     return exchange_sink;
 }

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -637,7 +637,8 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
     if (keep_order) {
         DCHECK(!request.has_is_pipeline_level_shuffle() && !request.is_pipeline_level_shuffle());
     }
-    bool use_pass_through = request.use_pass_through();
+    const bool use_pass_through = request.use_pass_through();
+    DCHECK(!(keep_order && use_pass_through));
     DCHECK(request.chunks_size() > 0 || use_pass_through);
     if (_is_cancelled || _num_remaining_senders <= 0) {
         return Status::OK();
@@ -652,33 +653,18 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
     // there is no chance to handle deserialize error, so the lazy deserialization is not supported now,
     // we can change related interface's defination to do this later.
     ChunkList chunks;
-    if (!(keep_order && use_pass_through)) {
-        ASSIGN_OR_RETURN(chunks, use_pass_through
-                                         ? get_chunks_from_pass_through(request.sender_id(), total_chunk_bytes)
-                                         : (keep_order ? get_chunks_from_request<true>(request, total_chunk_bytes)
-                                                       : get_chunks_from_request<false>(request, total_chunk_bytes)));
-        COUNTER_UPDATE(use_pass_through ? _recvr->_bytes_pass_through_counter : _recvr->_bytes_received_counter,
-                       total_chunk_bytes);
-    }
+    ASSIGN_OR_RETURN(chunks, use_pass_through
+                                     ? get_chunks_from_pass_through(request.sender_id(), total_chunk_bytes)
+                                     : (keep_order ? get_chunks_from_request<true>(request, total_chunk_bytes)
+                                                   : get_chunks_from_request<false>(request, total_chunk_bytes)));
+    COUNTER_UPDATE(use_pass_through ? _recvr->_bytes_pass_through_counter : _recvr->_bytes_received_counter,
+                   total_chunk_bytes);
 
     if (_is_cancelled) {
         return Status::OK();
     }
 
-    // Things have been a little weird while pass_through is enabled
-    // Consider such a situation:
-    //      time1: ChunkA is added to pass_through context, now context has only ChunkA. And related RequestA(sequence=1) is sent.
-    //      time2: ChunkB is added to pass_through context, now context has ChunkA and ChunkB. And related RequestB(sequence=2) is sent.
-    //      time3: RequestB is received, and all the chunks(ChunkA and ChunkB) have been fetched, and they are considered belonging to RequestB.
-    //      time4: ChunkC is added to pass_through context, now context has only ChunkC. And related RequestC(sequence=3) is sent.
-    //      tiem5: RequestA is received, and all the chunks(ChunkC) have been fetched, and they are considered belonging to RequestA.
-    //      time6: RequestC is received, nothing can be fetched.
-    // And here comes the funny thing, RequestA received the ChunkC, and RequestB received the ChunkA and ChunkB, so with the help of the
-    // keep_order mechanism, which is not compatible with local pass through, the output order will be ChunkC, ChunkA, ChunkB,
-    // but the expected order is ChunkA, ChunkB, ChunkC.
-    //
-    // So the solution is simple, if pass_through is enabled, simply treat it as un-ordered request, and the order will be kept naturally.
-    if (keep_order && !use_pass_through) {
+    if (keep_order) {
         const int32_t be_number = request.be_number();
         const int32_t sequence = request.sequence();
         ScopedTimer<MonotonicStopWatch> wait_timer(_recvr->_sender_wait_lock_timer);
@@ -734,14 +720,6 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
             ++max_processed_sequence;
         }
     } else {
-        // In order to keep the order of pass through chunks, we need to guarantee that
-        // the chunk which is taken out first from pass_throush_context must be enqueued first.
-        // So here we put these two steps under the same lock.
-        if (keep_order && use_pass_through) {
-            ASSIGN_OR_RETURN(chunks, get_chunks_from_pass_through(request.sender_id(), total_chunk_bytes))
-            COUNTER_UPDATE(_recvr->_bytes_pass_through_counter, total_chunk_bytes);
-        }
-
         if (_is_cancelled) {
             LOG(ERROR) << "Cancelled receiver cannot add_chunk!";
             return Status::OK();
@@ -770,11 +748,7 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
             int index = _is_pipeline_level_shuffle ? chunk.driver_sequence : 0;
             size_t chunk_bytes = chunk.chunk_bytes;
             auto* closure = chunk.closure;
-            if (keep_order && use_pass_through) {
-                _chunk_queues[index].enqueue(*_producer_token, std::move(chunk));
-            } else {
-                _chunk_queues[index].enqueue(std::move(chunk));
-            }
+            _chunk_queues[index].enqueue(std::move(chunk));
             _chunk_queue_states[index].blocked_closure_num += closure != nullptr;
             _total_chunks++;
             // Double check here for short circuit compatibility without introducing a critical section


### PR DESCRIPTION
There is a clear conflict between local paththrough optimization and global merger which requires the correct ordering of the data transmition.

On the one hand, `SinkBuffer` and `PipelineSenderQueue` together maintain a sliding window for the ordering of the data packets, which requires the first sent packet must be processed first.

On the other hand, the local passthrough may cause a silly syndrome where the first sent packet may potentially be processed later. which is clearly defined in the pr #20550

And to a conclusion, we must disable the local passthrough optimization when it comes to global merger.

## How to reproduce this problem

```sql
SELECT SUM(wv) FROM (
    SELECT max(fn_int) OVER (ORDER BY fn_int ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING) AS wv FROM t_large
) tmp
```

the table `t_large` has 100M rows. and this sql may be blocked forever at a relatively low ratio.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
