### PR TITLE
[cherry-pick][branch-3.1][Enhancement] Use consistent hash as hdfs backend selector default strategy (#27985)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ConsistentHashRing.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ConsistentHashRing.java
@@ -62,6 +62,10 @@ public class ConsistentHashRing<K, N> implements HashRing<K, N> {
         }
     }
 
+    public int getVirtualNumber() {
+        return virtualNumber;
+    }
+
     @Override
     public String policy() {
         return "ConsistentHash";

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -88,6 +88,10 @@ public abstract class ScanNode extends PlanNode {
         return canUseMinMaxCountOpt;
     }
 
+    public String getTableName() {
+        return desc.getTable().getName();
+    }
+
     /**
      * cast expr to SlotDescriptor type
      */

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.qe;
 
+import autovalue.shaded.com.google.common.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableCollection;
@@ -36,6 +37,7 @@ import com.starrocks.planner.HudiScanNode;
 import com.starrocks.planner.IcebergScanNode;
 import com.starrocks.planner.PaimonScanNode;
 import com.starrocks.planner.ScanNode;
+import com.starrocks.sql.PlannerProfile;
 import com.starrocks.sql.plan.HDFSScanNodePredicates;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.THdfsScanRange;
@@ -71,6 +73,8 @@ public class HDFSBackendSelector implements BackendSelector {
     public static final Logger LOG = LogManager.getLogger(HDFSBackendSelector.class);
     // be -> assigned scans
     Map<ComputeNode, Long> assignedScansPerComputeNode = Maps.newHashMap();
+    // be -> re-balance bytes
+    Map<ComputeNode, Long> reBalanceBytesPerComputeNode = Maps.newHashMap();
     // be host -> bes
     Multimap<String, ComputeNode> hostToBackends = HashMultimap.create();
     private final ScanNode scanNode;
@@ -84,8 +88,7 @@ public class HDFSBackendSelector implements BackendSelector {
     private boolean shuffleScanRange;
     private final int kCandidateNumber = 3;
     private final int kMaxImbalanceRatio = 3;
-    private final int kMaxNodeSizeUseRendezvousHashRing = 64;
-    private final int kConsistenHashRingVirtualNumber = 32;
+    public static final int CONSISTENT_HASH_RING_VIRTUAL_NUMBER = 32;
 
     class HdfsScanRangeHasher {
         String basePath;
@@ -158,7 +161,7 @@ public class HDFSBackendSelector implements BackendSelector {
         this.shuffleScanRange = shuffleScanRange;
     }
 
-    private ComputeNode selectLeastScanBytesComputeNode(Collection<ComputeNode> backends, long maxImbalanceBytes) {
+    private ComputeNode selectLeastScanBytesComputeNode(List<ComputeNode> backends, long maxImbalanceBytes) {
         if (backends == null || backends.isEmpty()) {
             return null;
         }
@@ -201,15 +204,20 @@ public class HDFSBackendSelector implements BackendSelector {
         }
     }
 
-    private HashRing makeHashRing() {
+    @VisibleForTesting
+    public HashRing makeHashRing() {
         Set<ComputeNode> nodes = assignedScansPerComputeNode.keySet();
         HashRing hashRing = null;
-        if (nodes.size() > kMaxNodeSizeUseRendezvousHashRing) {
-            hashRing = new ConsistentHashRing(Hashing.murmur3_128(), new TScanRangeLocationsFunnel(),
-                    new ComputeNodeFunnel(), nodes, kConsistenHashRingVirtualNumber);
-        } else {
+        String hashAlgorithm = ConnectContext.get() != null ? ConnectContext.get().getSessionVariable().
+                getHdfsBackendSelectorHashAlgorithm() : "consistent";
+        int virtualNodeNum = ConnectContext.get() != null ? ConnectContext.get().getSessionVariable().
+                getConsistentHashVirtualNodeNum() : CONSISTENT_HASH_RING_VIRTUAL_NUMBER;
+        if (hashAlgorithm.equalsIgnoreCase("rendezvous")) {
             hashRing = new RendezvousHashRing(Hashing.murmur3_128(), new TScanRangeLocationsFunnel(),
                     new ComputeNodeFunnel(), nodes);
+        } else {
+            hashRing = new ConsistentHashRing(Hashing.murmur3_128(), new TScanRangeLocationsFunnel(),
+                    new ComputeNodeFunnel(), nodes, virtualNodeNum);
         }
         return hashRing;
     }
@@ -237,6 +245,7 @@ public class HDFSBackendSelector implements BackendSelector {
                 continue;
             }
             assignedScansPerComputeNode.put(computeNode, 0L);
+            reBalanceBytesPerComputeNode.put(computeNode, 0L);
             hostToBackends.put(computeNode.getHost(), computeNode);
         }
         if (hostToBackends.isEmpty()) {
@@ -249,7 +258,7 @@ public class HDFSBackendSelector implements BackendSelector {
         if (forceScheduleLocal) {
             for (int i = 0; i < locations.size(); ++i) {
                 TScanRangeLocations scanRangeLocations = locations.get(i);
-                Collection<ComputeNode> backends = new ArrayList<>();
+                List<ComputeNode> backends = new ArrayList<>();
                 // select all backends that are co-located with this scan range.
                 for (final TScanRangeLocation location : scanRangeLocations.getLocations()) {
                     Collection<ComputeNode> servers = hostToBackends.get(location.getServer().getHostname());
@@ -262,7 +271,7 @@ public class HDFSBackendSelector implements BackendSelector {
                 if (node == null) {
                     remoteScanRangeLocations.add(scanRangeLocations);
                 } else {
-                    recordScanRangeAssignment(node, scanRangeLocations);
+                    recordScanRangeAssignment(node, backends, scanRangeLocations);
                 }
             }
         } else {
@@ -285,11 +294,14 @@ public class HDFSBackendSelector implements BackendSelector {
             if (node == null) {
                 throw new RuntimeException("Failed to find backend to execute");
             }
-            recordScanRangeAssignment(node, scanRangeLocations);
+            recordScanRangeAssignment(node, backends, scanRangeLocations);
         }
+
+        recordScanRangeStatistic();
     }
 
-    private void recordScanRangeAssignment(ComputeNode node, TScanRangeLocations scanRangeLocations) {
+    private void recordScanRangeAssignment(ComputeNode node, List<ComputeNode> backends,
+                                           TScanRangeLocations scanRangeLocations) {
         TNetworkAddress address = new TNetworkAddress(node.getHost(), node.getBePort());
         usedBackendIDs.add(node.getId());
         addressToBackendId.put(address, node.getId());
@@ -297,6 +309,11 @@ public class HDFSBackendSelector implements BackendSelector {
         // update statistic
         long addedScans = scanRangeLocations.scan_range.hdfs_scan_range.length;
         assignedScansPerComputeNode.put(node, assignedScansPerComputeNode.get(node) + addedScans);
+        // the fist item in backends will be assigned if there is no re-balance, we compute re-balance bytes
+        // if the worker is not the first item in backends.
+        if (node != backends.get(0)) {
+            reBalanceBytesPerComputeNode.put(node, reBalanceBytesPerComputeNode.get(node) + addedScans);
+        }
 
         // add in assignment
         Map<Integer, List<TScanRangeParams>> scanRanges =
@@ -307,5 +324,20 @@ public class HDFSBackendSelector implements BackendSelector {
         TScanRangeParams scanRangeParams = new TScanRangeParams();
         scanRangeParams.scan_range = scanRangeLocations.scan_range;
         scanRangeParamsList.add(scanRangeParams);
+    }
+
+    private void recordScanRangeStatistic() {
+        // record scan range size for each backend
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<ComputeNode, Long> entry : assignedScansPerComputeNode.entrySet()) {
+            sb.append(entry.getKey().getAddress().hostname).append(":").append(entry.getValue()).append(",");
+        }
+        PlannerProfile.addCustomProperties(scanNode.getTableName() + " scan_range_bytes", sb.toString());
+        // record re-balance bytes for each backend
+        sb = new StringBuilder();
+        for (Map.Entry<ComputeNode, Long> entry : reBalanceBytesPerComputeNode.entrySet()) {
+            sb.append(entry.getKey().getAddress().hostname).append(":").append(entry.getValue()).append(",");
+        }
+        PlannerProfile.addCustomProperties(scanNode.getTableName() + " rebalance_bytes", sb.toString());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -451,6 +451,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_COUNT_STAR_OPTIMIZATION = "enable_count_star_optimization";
 
+    public static final String HDFS_BACKEND_SELECTOR_HASH_ALGORITHM = "hdfs_backend_selector_hash_algorithm";
+
+    public static final String CONSISTENT_HASH_VIRTUAL_NUMBER = "consistent_hash_virtual_number";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -990,6 +994,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = PARTIAL_UPDATE_MODE)
     private String partialUpdateMode = "auto";
 
+    @VariableMgr.VarAttr(name = HDFS_BACKEND_SELECTOR_HASH_ALGORITHM, flag = VariableMgr.INVISIBLE)
+    private String hdfsBackendSelectorHashAlgorithm = "consistent";
+
+    @VariableMgr.VarAttr(name = CONSISTENT_HASH_VIRTUAL_NUMBER, flag = VariableMgr.INVISIBLE)
+    private int consistentHashVirtualNodeNum = 32;
+
     public void setPartialUpdateMode(String mode) {
         this.partialUpdateMode = mode;
     }
@@ -1414,6 +1424,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getMaxParallelScanInstanceNum() {
         return maxParallelScanInstanceNum;
+    }
+
+    public String getHdfsBackendSelectorHashAlgorithm() {
+        return hdfsBackendSelectorHashAlgorithm;
+    }
+
+    public void setHdfsBackendSelectorHashAlgorithm(String hdfsBackendSelectorHashAlgorithm) {
+        this.hdfsBackendSelectorHashAlgorithm = hdfsBackendSelectorHashAlgorithm;
+    }
+
+    public int getConsistentHashVirtualNodeNum() {
+        return consistentHashVirtualNodeNum;
+    }
+
+    public void setConsistentHashVirtualNodeNum(int consistentHashVirtualNodeNum) {
+        this.consistentHashVirtualNodeNum = consistentHashVirtualNodeNum;
     }
 
     // when pipeline engine is enabled

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -182,6 +182,10 @@ public class ComputeNode implements IComputable, Writable {
         return brpcPort;
     }
 
+    public TNetworkAddress getAddress() {
+        return new TNetworkAddress(host, bePort);
+    }
+
     public TNetworkAddress getBrpcAddress() {
         return new TNetworkAddress(host, brpcPort);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
@@ -16,7 +16,10 @@ package com.starrocks.qe;
 
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.HiveTable;
+import com.starrocks.common.util.ConsistentHashRing;
+import com.starrocks.common.util.HashRing;
 import com.starrocks.planner.HdfsScanNode;
+import com.starrocks.sql.PlannerProfile;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.THdfsScanRange;
 import com.starrocks.thrift.TNetworkAddress;
@@ -25,6 +28,8 @@ import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TScanRangeParams;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
@@ -41,6 +46,8 @@ public class HDFSBackendSelectorTest {
     private HdfsScanNode hdfsScanNode;
     @Mocked
     private HiveTable hiveTable;
+    @Mocked
+    private ConnectContext context;
     final int scanNodeId = 0;
     final int computeNodePort = 9030;
     final String hostFormat = "Host%02d";
@@ -96,12 +103,28 @@ public class HDFSBackendSelectorTest {
 
     @Test
     public void testHdfsScanNodeHashRing() throws Exception {
+        new MockUp<PlannerProfile>() {
+            @Mock
+            public void addCustomProperties(String name, String value) {
+            }
+        };
+        SessionVariable sessionVariable = new SessionVariable();
         new Expectations() {
             {
                 hdfsScanNode.getId();
                 result = scanNodeId;
+
+                hdfsScanNode.getTableName();
+                result = "hive_tbl";
+
                 hiveTable.getTableLocation();
                 result = "hdfs://dfs00/dataset/";
+
+                ConnectContext.get();
+                result = context;
+
+                context.getSessionVariable();
+                result = sessionVariable;
             }
         };
 
@@ -127,6 +150,49 @@ public class HDFSBackendSelectorTest {
             System.out.printf("%s -> %d bytes\n", entry.getKey(), entry.getValue());
             Assert.assertTrue(Math.abs(entry.getValue() - avg) < variance);
         }
+    }
+
+    @Test
+    public void testHashRingAlgorithm() {
+        SessionVariable sessionVariable = new SessionVariable();
+        new Expectations() {
+            {
+                ConnectContext.get();
+                result = context;
+
+                context.getSessionVariable();
+                result = sessionVariable;
+            }
+        };
+
+        int scanRangeNumber = 100;
+        int scanRangeSize = 10000;
+        int hostNumber = 3;
+        List<TScanRangeLocations> locations = createScanRanges(scanRangeNumber, scanRangeSize);
+        FragmentScanRangeAssignment assignment = new FragmentScanRangeAssignment();
+        Map<TNetworkAddress, Long> addressToBackendId = new HashMap<>();
+        Set<Long> usedBackendIDs = new HashSet<>();
+        List<ComputeNode> computeNodes = createComputeNodes(hostNumber);
+
+        HDFSBackendSelector selector =
+                new HDFSBackendSelector(hdfsScanNode, locations, assignment, addressToBackendId, usedBackendIDs,
+                        ImmutableList.copyOf(computeNodes), false, false, false);
+        HashRing hashRing = selector.makeHashRing();
+        Assert.assertTrue(hashRing.policy().equals("ConsistentHash"));
+        ConsistentHashRing consistentHashRing = (ConsistentHashRing) hashRing;
+        Assert.assertTrue(consistentHashRing.getVirtualNumber() ==
+                HDFSBackendSelector.CONSISTENT_HASH_RING_VIRTUAL_NUMBER);
+
+        sessionVariable.setHdfsBackendSelectorHashAlgorithm("rendezvous");
+        hashRing = selector.makeHashRing();
+        Assert.assertTrue(hashRing.policy().equals("RendezvousHash"));
+
+        sessionVariable.setHdfsBackendSelectorHashAlgorithm("consistent");
+        sessionVariable.setConsistentHashVirtualNodeNum(64);
+        hashRing = selector.makeHashRing();
+        Assert.assertTrue(hashRing.policy().equals("ConsistentHash"));
+        consistentHashRing = (ConsistentHashRing) hashRing;
+        Assert.assertTrue(consistentHashRing.getVirtualNumber() == 64);
     }
 
     @Test


### PR DESCRIPTION
Use consistent hash as hdfs backend selector default strategy, do not depend on be be num which may cause lots of cache miss when scale out/in

add profile for scan node about scan bytes/ rebalance bytes

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
