### PR TITLE
[BugFix] Choose the valid timestamp bits to compose the data cache key.

### DIFF
--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -170,7 +170,7 @@ TEST_F(CacheInputStreamTest, test_file_overwrite) {
     gen_test_data(data, data_size, block_size);
 
     std::shared_ptr<io::SeekableInputStream> stream(new MockSeekableInputStream(data, data_size));
-    io::CacheInputStream cache_stream(stream, "test_file3", data_size, 1000000);
+    io::CacheInputStream cache_stream(stream, "test_file3", data_size, 1000);
     cache_stream.set_enable_populate_cache(true);
     auto& stats = cache_stream.stats();
 
@@ -192,7 +192,7 @@ TEST_F(CacheInputStreamTest, test_file_overwrite) {
     ASSERT_EQ(stats.read_cache_count, block_count);
 
     // With different modification time, the old cache cannot be used
-    io::CacheInputStream cache_stream2(stream, "test_file3", data_size, 2000000);
+    io::CacheInputStream cache_stream2(stream, "test_file3", data_size, 2000);
     cache_stream2.set_enable_populate_cache(true);
     auto& stats2 = cache_stream2.stats();
     for (int i = 0; i < block_count; ++i) {


### PR DESCRIPTION
Usually the last modification timestamp has 41 bits. Before, we only use the high 32 bits of timestamp, which only contains 9 valid bits. And many valid bits are ignored. So it can't reflect the file modification in a timely manner.

In this PR, we only ignore the lowest 9 bits, and store the other 32 bits to represent the second timestamp.

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
