### PR TITLE
[WIP] [Enhancement] Remove unused dcheck for RleEncoder

### DIFF
--- a/be/src/storage/rowset/rle_page.h
+++ b/be/src/storage/rowset/rle_page.h
@@ -74,7 +74,6 @@ class RlePageBuilder final : public PageBuilder {
 public:
     explicit RlePageBuilder(const PageBuilderOptions& options)
             : _options(options),
-
               _rle_encoder(nullptr),
               _first_value(0),
               _last_value(0) {

--- a/be/src/storage/rowset/rle_page.h
+++ b/be/src/storage/rowset/rle_page.h
@@ -73,10 +73,7 @@ template <LogicalType Type>
 class RlePageBuilder final : public PageBuilder {
 public:
     explicit RlePageBuilder(const PageBuilderOptions& options)
-            : _options(options),
-              _rle_encoder(nullptr),
-              _first_value(0),
-              _last_value(0) {
+            : _options(options), _rle_encoder(nullptr), _first_value(0), _last_value(0) {
         _bit_width = (Type == TYPE_BOOLEAN) ? 1 : SIZE_OF_TYPE * 8;
         _rle_encoder = std::make_unique<RleEncoder<CppType>>(&_buf, _bit_width);
         reset();

--- a/be/src/util/rle_encoding.h
+++ b/be/src/util/rle_encoding.h
@@ -451,7 +451,7 @@ inline size_t RleDecoder<T>::GetBatch(T* vals, size_t batch_num) {
 // it decides whether they should be encoded as a literal or repeated run.
 template <typename T>
 inline void RleEncoder<T>::Put(T value, size_t run_length) {
-    DCHECK(bit_width_ == 64 || value < (1LL << bit_width_));
+    DCHECK(value < (1LL << bit_width_));
 
     // TODO(perf): remove the loop and use the repeat_count_
     for (; run_length > 0; run_length--) {


### PR DESCRIPTION
Fixes [#3012](https://github.com/StarRocks/StarRocksTest/issues/3012)

if type == boolean, _bit_withd is 1 not 64

```
    explicit RlePageBuilder(const PageBuilderOptions& options)
            : _options(options),
              _rle_encoder(nullptr),
              _first_value(0),
              _last_value(0) {
        _bit_width = (Type == TYPE_BOOLEAN) ? 1 : SIZE_OF_TYPE * 8;
        _rle_encoder = std::make_unique<RleEncoder<CppType>>(&_buf, _bit_width);
        reset();
    }
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
