### PR TITLE
[Enhancement] Fix wrong dcheck of array_intersect

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -1342,7 +1342,7 @@ inline static void nestloop_intersect(uint8_t* hits, const Column* base, size_t 
 }
 
 StatusOr<ColumnPtr> ArrayFunctions::array_intersect_any_type(FunctionContext* ctx, const Columns& columns) {
-    DCHECK_LE(2, columns.size());
+    DCHECK_LE(1, columns.size());
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
     size_t rows = columns[0]->size();


### PR DESCRIPTION
Fixes [#3015 ](https://github.com/StarRocks/StarRocksTest/issues/3015)

array_interscet support one or more arrays as param

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
