### PR TITLE
[Enhancement] libhdfs lazy open and read retry

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -781,6 +781,7 @@ CONF_Bool(hdfs_client_enable_hedged_read, "false");
 CONF_Int32(hdfs_client_hedged_read_threadpool_size, "128");
 // dfs.client.hedged.read.threshold.millis
 CONF_Int32(hdfs_client_hedged_read_threshold_millis, "2500");
+CONF_Int32(hdfs_client_io_read_retry, "0");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.
 // Once logging is enabled in your application, the SDK will generate log files in your current working directory

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -459,6 +459,8 @@ HdfsScanner* HiveDataSource::_create_paimon_jni_scanner(FSOptions& options) {
 }
 
 Status HiveDataSource::_init_scanner(RuntimeState* state) {
+    SCOPED_TIMER(_profile.open_file_timer);
+
     const auto& scan_range = _scan_range;
     std::string native_file_path = scan_range.full_path;
     if (_hive_table != nullptr && _hive_table->has_partition()) {
@@ -468,9 +470,6 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
                     "Plan inconsistency. scan_range.partition_id = {} not found in partition description map",
                     scan_range.partition_id));
         }
-
-        SCOPED_TIMER(_profile.open_file_timer);
-
         std::filesystem::path file_path(partition_desc->location());
         file_path /= scan_range.relative_path;
         native_file_path = file_path.native();

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -259,7 +259,7 @@ StatusOr<std::unique_ptr<io::NumericStatistics>> HdfsInputStream::get_numeric_st
 
         if (config::hdfs_client_enable_hedged_read) {
             struct hdfsHedgedReadMetrics* hdfs_hedged_read_statistics = nullptr;
-            r = hdfsGetHedgedReadMetrics(_fs, &hdfs_hedged_read_statistics);
+            r = hdfsGetHedgedReadMetrics(_handle->getFS(), &hdfs_hedged_read_statistics);
             if (r == 0) {
                 stats->append("TotalHedgedReadOps", hdfs_hedged_read_statistics->hedgedReadOps);
                 stats->append("TotalHedgedReadOpsInCurThread", hdfs_hedged_read_statistics->hedgedReadOpsInCurThread);


### PR DESCRIPTION
Fixes #issue

This PR is to:
1.  support lazily create FS and open file
2. support pread/read two modes(pread is perferred, however it's not supported in libhdfs3)
3. support read retry for busy hdfs cluster.
4. and also fixe bug  #29019

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
