### PR TITLE
[Enhancement] support coalesce block cache read to reduce cache read overhead.

### DIFF
--- a/be/src/block_cache/CMakeLists.txt
+++ b/be/src/block_cache/CMakeLists.txt
@@ -24,6 +24,7 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/block_cache")
 
 set(CACHE_FILES
   block_cache.cpp
+  io_buffer.cpp
 )
 
 if (${WITH_CACHELIB} STREQUAL "ON")

--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -83,32 +83,47 @@ Status BlockCache::init(const CacheOptions& options) {
     return _kv_cache->init(options);
 }
 
-Status BlockCache::write_cache(const CacheKey& cache_key, off_t offset, size_t size, const char* buffer,
-                               size_t ttl_seconds, bool overwrite) {
+Status BlockCache::write_cache(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer, size_t ttl_seconds,
+                               bool overwrite) {
     if (offset % _block_size != 0) {
         LOG(WARNING) << "write block key: " << cache_key << " with invalid args, offset: " << offset;
         return Status::InvalidArgument(strings::Substitute("offset must be aligned by block size $0", _block_size));
     }
-    if (!buffer) {
+    if (buffer.empty()) {
+        return Status::OK();
+    }
+    size_t index = offset / _block_size;
+    std::string block_key = fmt::format("{}/{}", cache_key, index);
+    return _kv_cache->write_cache(block_key, buffer, ttl_seconds, overwrite);
+}
+
+static void empty_deleter(void*) {}
+
+Status BlockCache::write_cache(const CacheKey& cache_key, off_t offset, size_t size, const char* data,
+                               size_t ttl_seconds, bool overwrite) {
+    if (!data) {
         return Status::InvalidArgument("invalid data buffer");
     }
+
+    IOBuffer buffer;
+    buffer.append_user_data((void*)data, size, empty_deleter);
+    return write_cache(cache_key, offset, buffer, ttl_seconds, overwrite);
+}
+
+Status BlockCache::read_cache(const CacheKey& cache_key, off_t offset, size_t size, IOBuffer* buffer) {
     if (size == 0) {
         return Status::OK();
     }
-
     size_t index = offset / _block_size;
     std::string block_key = fmt::format("{}/{}", cache_key, index);
-    return _kv_cache->write_cache(block_key, buffer, size, ttl_seconds, overwrite);
+    return _kv_cache->read_cache(block_key, offset - index * _block_size, size, buffer);
 }
 
-StatusOr<size_t> BlockCache::read_cache(const CacheKey& cache_key, off_t offset, size_t size, char* buffer) {
-    // when buffer == nullptr, it can check if cached.
-    if (size == 0) {
-        return 0;
-    }
-    size_t index = offset / _block_size;
-    std::string block_key = fmt::format("{}/{}", cache_key, index);
-    return _kv_cache->read_cache(block_key, buffer, offset - index * _block_size, size);
+StatusOr<size_t> BlockCache::read_cache(const CacheKey& cache_key, off_t offset, size_t size, char* data) {
+    IOBuffer buffer;
+    RETURN_IF_ERROR(read_cache(cache_key, offset, size, &buffer));
+    buffer.copy_to(data);
+    return buffer.size();
 }
 
 Status BlockCache::remove_cache(const CacheKey& cache_key, off_t offset, size_t size) {

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -30,16 +30,17 @@ public:
     Status init(const CacheOptions& options);
 
     // Write data to cache, the offset must be aligned by block size
-    Status write_cache(const CacheKey& cache_key, off_t offset, size_t size, const char* buffer, size_t ttl_seconds = 0,
+    Status write_cache(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer, size_t ttl_seconds = 0,
+                       bool overwrite = true);
+
+    Status write_cache(const CacheKey& cache_key, off_t offset, size_t size, const char* data, size_t ttl_seconds = 0,
                        bool overwrite = true);
 
     // Read data from cache, it returns the data size if successful; otherwise the error status
     // will be returned. The offset and size must be aligned by block size.
-    StatusOr<size_t> read_cache(const CacheKey& cache_key, off_t offset, size_t size, char* buffer);
+    Status read_cache(const CacheKey& cache_key, off_t offset, size_t size, IOBuffer* buffer);
 
-    // NOTICE: This function is not safe now, as the returned buffer may be evicted before visited
-    // by users. We need to implement it more safe by cachelib item handle.
-    Status read_cache_zero_copy(const CacheKey& cache_key, off_t offset, size_t size, const char** buf);
+    StatusOr<size_t> read_cache(const CacheKey& cache_key, off_t offset, size_t size, char* data);
 
     // Remove data from cache. The offset and size must be aligned by block size
     Status remove_cache(const CacheKey& cache_key, off_t offset, size_t size);

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -55,24 +55,23 @@ Status CacheLibWrapper::init(const CacheOptions& options) {
     return Status::OK();
 }
 
-Status CacheLibWrapper::write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds,
+Status CacheLibWrapper::write_cache(const std::string& key, const IOBuffer& buffer, size_t ttl_seconds,
                                     bool overwrite) {
     //  Simulate the behavior of skipping if exists
     if (!overwrite && _cache->find(key)) {
         return Status::AlreadyExist("the cache item already exists");
     }
     // TODO: check size for chain item
-    auto handle = _cache->allocate(_default_pool, key, size);
+    auto handle = _cache->allocate(_default_pool, key, buffer.size());
     if (!handle) {
         return Status::InternalError("allocate cachelib item failed");
     }
-    // std::memcpy(handle->getMemory(), value, size);
-    strings::memcpy_inlined(handle->getMemory(), value, size);
+    buffer.copy_to(handle->getMemory());
     _cache->insertOrReplace(handle);
     return Status::OK();
 }
 
-StatusOr<size_t> CacheLibWrapper::read_cache(const std::string& key, char* value, size_t off, size_t size) {
+Status CacheLibWrapper::read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer) {
     // TODO:
     // 1. check chain item
     // 2. replace with async methods
@@ -80,17 +79,12 @@ StatusOr<size_t> CacheLibWrapper::read_cache(const std::string& key, char* value
     if (!handle) {
         return Status::NotFound("not found cachelib item");
     }
-    // to check if cached.
-    if (value == nullptr) {
-        return 0;
-    }
     DCHECK((off + size) <= handle->getSize());
     // std::memcpy(value, (char*)handle->getMemory() + off, size);
-    strings::memcpy_inlined(value, (char*)handle->getMemory() + off, size);
-
-    if (handle->hasChainedItem()) {
-    }
-    return size;
+    void* data = malloc(size);
+    strings::memcpy_inlined(data, (char*)handle->getMemory() + off, size);
+    buffer->append_user_data(data, size, nullptr);
+    return Status::OK();
 }
 
 Status CacheLibWrapper::remove_cache(const std::string& key) {

--- a/be/src/block_cache/cachelib_wrapper.h
+++ b/be/src/block_cache/cachelib_wrapper.h
@@ -44,10 +44,9 @@ public:
 
     Status init(const CacheOptions& options) override;
 
-    Status write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds,
-                       bool overwrite) override;
+    Status write_cache(const std::string& key, const IOBuffer& buffer, size_t ttl_seconds, bool overwrite) override;
 
-    StatusOr<size_t> read_cache(const std::string& key, char* value, size_t off, size_t size) override;
+    Status read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer) override;
 
     Status remove_cache(const std::string& key) override;
 

--- a/be/src/block_cache/io_buffer.cpp
+++ b/be/src/block_cache/io_buffer.cpp
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "block_cache/io_buffer.h"
+
+#include "gutil/strings/fastmem.h"
+
+namespace starrocks {
+
+size_t IOBuffer::copy_to(void* data, ssize_t size, size_t pos) const {
+    size_t bytes_to_copy = size > 0 ? size : _buf.size();
+    size_t bytes_copied = 0;
+    size_t skip = pos;
+    for (size_t i = 0; i < _buf.backing_block_num(); ++i) {
+        auto sp = _buf.backing_block(i);
+        if (!sp.empty()) {
+            if (sp.size() <= skip) {
+                skip -= sp.size();
+                continue;
+            }
+            size_t to_cp = std::min(sp.size(), bytes_to_copy - bytes_copied);
+            strings::memcpy_inlined((char*)data + bytes_copied, sp.data() + skip, to_cp);
+            bytes_copied += to_cp;
+            if (bytes_copied >= size) {
+                break;
+            }
+        }
+    }
+    return bytes_copied;
+}
+
+} // namespace starrocks

--- a/be/src/block_cache/io_buffer.h
+++ b/be/src/block_cache/io_buffer.h
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <butil/iobuf.h>
+
+namespace starrocks {
+
+class IOBuffer {
+public:
+    using IOBuf = butil::IOBuf;
+
+    IOBuffer() = default;
+    explicit IOBuffer(const IOBuffer& iobuf) { _buf = iobuf._buf; }
+    explicit IOBuffer(const IOBuf& buf) { _buf = buf; }
+    ~IOBuffer() = default;
+
+    void append(const IOBuffer& other) { _buf.append(other._buf); }
+
+    int append_user_data(void* data, size_t size, void (*deleter)(void*)) {
+        return _buf.append_user_data(data, size, deleter);
+    }
+
+    size_t copy_to(void* data, ssize_t size = -1, size_t pos = 0) const;
+
+    size_t size() const { return _buf.size(); }
+
+    bool empty() const { return _buf.empty(); }
+
+    IOBuf& raw_buf() { return _buf; }
+
+    const IOBuf& const_raw_buf() const { return _buf; }
+
+private:
+    butil::IOBuf _buf;
+};
+
+} // namespace starrocks

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "block_cache/cache_options.h"
+#include "block_cache/io_buffer.h"
 #include "common/status.h"
 
 namespace starrocks {
@@ -27,12 +28,11 @@ public:
     virtual Status init(const CacheOptions& options) = 0;
 
     // Write data to cache
-    virtual Status write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds,
-                               bool overwrite) = 0;
+    virtual Status write_cache(const std::string& key, const IOBuffer& buffer, size_t ttl_seconds, bool overwrite) = 0;
 
     // Read data from cache, it returns the data size if successful; otherwise the error status
     // will be returned.
-    virtual StatusOr<size_t> read_cache(const std::string& key, char* value, size_t off, size_t size) = 0;
+    virtual Status read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer) = 0;
 
     // Remove data from cache. The offset must be aligned by block size
     virtual Status remove_cache(const std::string& key) = 0;

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -23,19 +23,6 @@
 
 namespace starrocks {
 
-void copy_iobuf(const butil::IOBuf& buf, char* value) {
-    off_t off = 0;
-    for (size_t i = 0; i < buf.backing_block_num(); ++i) {
-        auto sp = buf.backing_block(i);
-        if (!sp.empty()) {
-            strings::memcpy_inlined(value + off, (void*)sp.data(), sp.size());
-            off += sp.size();
-        }
-    }
-}
-
-static void empty_deleter(void* buf) {}
-
 Status StarCacheWrapper::init(const CacheOptions& options) {
     starcache::CacheOptions opt;
     opt.mem_quota_bytes = options.mem_space_size;
@@ -50,27 +37,16 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
     return to_status(_cache->init(opt));
 }
 
-Status StarCacheWrapper::write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds,
+Status StarCacheWrapper::write_cache(const std::string& key, const IOBuffer& buffer, size_t ttl_seconds,
                                      bool overwrite) {
-    butil::IOBuf buf;
-    // Don't free the buffer passed by users
-    buf.append_user_data((void*)value, size, empty_deleter);
-
     starcache::WriteOptions options;
     options.ttl_seconds = ttl_seconds;
     options.overwrite = overwrite;
-    return to_status(_cache->set(key, buf, &options));
+    return to_status(_cache->set(key, buffer.const_raw_buf(), &options));
 }
 
-StatusOr<size_t> StarCacheWrapper::read_cache(const std::string& key, char* value, size_t off, size_t size) {
-    butil::IOBuf buf;
-    RETURN_IF_ERROR(to_status(_cache->read(key, off, size, &buf)));
-    // to check if cached.
-    if (value == nullptr) {
-        return 0;
-    }
-    copy_iobuf(buf, value);
-    return buf.size();
+Status StarCacheWrapper::read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer) {
+    return to_status(_cache->read(key, off, size, &buffer->raw_buf()));
 }
 
 Status StarCacheWrapper::remove_cache(const std::string& key) {

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -27,10 +27,9 @@ public:
 
     Status init(const CacheOptions& options) override;
 
-    Status write_cache(const std::string& key, const char* value, size_t size, size_t ttl_seconds,
-                       bool overwrite) override;
+    Status write_cache(const std::string& key, const IOBuffer& buffer, size_t ttl_seconds, bool overwrite) override;
 
-    StatusOr<size_t> read_cache(const std::string& key, char* value, size_t off, size_t size) override;
+    Status read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer) override;
 
     Status remove_cache(const std::string& key) override;
 

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -307,6 +307,10 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
                 ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheWriteFailCounter", TUnit::UNIT, prefix);
         _profile.block_cache_write_fail_bytes =
                 ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheWriteFailBytes", TUnit::BYTES, prefix);
+        _profile.block_cache_read_block_buffer_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheReadBlockBufferCounter", TUnit::UNIT, prefix);
+        _profile.block_cache_read_block_buffer_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheReadBlockBufferBytes", TUnit::BYTES, prefix);
     }
 
     {

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -234,8 +234,8 @@ Status HdfsScanner::open_random_access_file() {
 
         // input_stream = CacheInputStream(input_stream)
         if (_scanner_params.use_block_cache) {
-            _cache_input_stream = std::make_shared<io::CacheInputStream>(input_stream, filename, file_size,
-                                                                         _scanner_params.modification_time);
+            _cache_input_stream = std::make_shared<io::CacheInputStream>(_shared_buffered_input_stream, filename,
+                                                                         file_size, _scanner_params.modification_time);
             _cache_input_stream->set_enable_populate_cache(_scanner_params.enable_populate_block_cache);
             _shared_buffered_input_stream->set_align_size(_cache_input_stream->get_align_size());
             input_stream = _cache_input_stream;
@@ -302,6 +302,8 @@ void HdfsScanner::update_counter() {
         COUNTER_UPDATE(profile->block_cache_write_timer, stats.write_cache_ns);
         COUNTER_UPDATE(profile->block_cache_write_fail_counter, stats.write_cache_fail_count);
         COUNTER_UPDATE(profile->block_cache_write_fail_bytes, stats.write_cache_fail_bytes);
+        COUNTER_UPDATE(profile->block_cache_read_block_buffer_counter, stats.read_block_buffer_count);
+        COUNTER_UPDATE(profile->block_cache_read_block_buffer_bytes, stats.read_block_buffer_bytes);
     }
     if (_shared_buffered_input_stream) {
         COUNTER_UPDATE(profile->shared_buffered_shared_io_count, _shared_buffered_input_stream->shared_io_count());

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -95,6 +95,8 @@ struct HdfsScanProfile {
     RuntimeProfile::Counter* block_cache_write_timer = nullptr;
     RuntimeProfile::Counter* block_cache_write_fail_counter = nullptr;
     RuntimeProfile::Counter* block_cache_write_fail_bytes = nullptr;
+    RuntimeProfile::Counter* block_cache_read_block_buffer_counter = nullptr;
+    RuntimeProfile::Counter* block_cache_read_block_buffer_bytes = nullptr;
 
     RuntimeProfile::Counter* shared_buffered_shared_io_count = nullptr;
     RuntimeProfile::Counter* shared_buffered_shared_io_bytes = nullptr;

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -26,15 +26,21 @@
 
 namespace starrocks::io {
 
-CacheInputStream::CacheInputStream(const std::shared_ptr<SeekableInputStream>& stream, const std::string& filename,
-                                   size_t size, int64_t modification_time)
+// We use the `SharedBufferedInputStream` in `CacheInputStream` directly, because the we depend some functions of
+// `SharedBufferedInputStream`.
+// In fact, although the parameter is `SeekableInputStream` before, we only use `CacheInputStream` when using
+// `SharedBufferedInputStream`. Also, if we don't set the io range for `SharedBufferedInputStream`, it will
+// act as the old `DefaultInputStream`.
+CacheInputStream::CacheInputStream(const std::shared_ptr<SharedBufferedInputStream>& stream,
+                                   const std::string& filename, size_t size, int64_t modification_time)
         : SeekableInputStreamWrapper(stream.get(), kDontTakeOwnership),
           _filename(filename),
-          _stream(stream),
+          _sb_stream(stream),
           _offset(0),
           _size(size) {
     // _cache_key = _filename;
     // use hash(filename) as cache key.
+    _block_size = BlockCache::instance()->block_size();
     _cache_key.resize(12);
     char* data = _cache_key.data();
     uint64_t hash_value = HashUtil::hash64(filename.data(), filename.size(), 0);
@@ -50,7 +56,124 @@ CacheInputStream::CacheInputStream(const std::shared_ptr<SeekableInputStream>& s
         int32_t file_size = _size;
         memcpy(data + 8, &file_size, sizeof(file_size));
     }
-    _buffer.reserve(BlockCache::instance()->block_size());
+    _buffer.reserve(_block_size);
+}
+
+Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bool can_zero_copy) {
+    DCHECK(size <= _block_size);
+    int64_t block_id = offset / _block_size;
+
+    // check block map
+    auto iter = _block_map.find(block_id);
+    if (iter != _block_map.end()) {
+        auto& block = iter->second;
+        block.buffer.copy_to(out, size, offset - block.offset);
+        _stats.read_block_buffer_bytes += size;
+        _stats.read_block_buffer_count += 1;
+        return Status::OK();
+    }
+
+    // check shared buffer
+    int64_t block_offset = block_id * _block_size;
+    int64_t load_size = std::min(_block_size, _size - block_offset);
+    int64_t shift = offset - block_offset;
+
+    SharedBufferedInputStream::SharedBuffer* sb = nullptr;
+    auto ret = _sb_stream->find_shared_buffer(offset, size);
+    if (ret.ok()) {
+        sb = ret.value();
+        if (sb->buffer.capacity() > 0) {
+            strings::memcpy_inlined(out, sb->buffer.data() + offset - sb->offset, size);
+            _populate_cache_from_zero_copy_buffer((const char*)sb->buffer.data() + block_offset - sb->offset,
+                                                  block_offset, load_size);
+            return Status::OK();
+        }
+    }
+
+    // read cache
+    BlockCache* cache = BlockCache::instance();
+    Status res;
+    {
+        SCOPED_RAW_TIMER(&_stats.read_cache_ns);
+        BlockBuffer block;
+        res = cache->read_cache(_cache_key, block_offset, load_size, &block.buffer);
+        if (res.ok()) {
+            block.buffer.copy_to(out, size, shift);
+            block.offset = block_offset;
+            _block_map[block_id] = block;
+            _stats.read_cache_count += 1;
+            _stats.read_cache_bytes += load_size;
+            return Status::OK();
+        }
+    }
+    if (!res.is_not_found()) return res;
+    DCHECK(res.is_not_found());
+
+    // read remote
+    char* src = nullptr;
+    if (sb) {
+        // Duplicate the block ranges to avoid saving the same data both in cache and shared buffer.
+        _deduplicate_shared_buffer(sb);
+        const uint8_t* buffer = nullptr;
+        RETURN_IF_ERROR(_sb_stream->get_bytes(&buffer, block_offset, load_size));
+        strings::memcpy_inlined(out, buffer + shift, size);
+        src = (char*)buffer;
+    } else {
+        if (!can_zero_copy || (shift != 0)) {
+            can_zero_copy = false;
+            src = _buffer.data();
+        } else {
+            src = out;
+        }
+
+        // if not found, read from stream and write back to cache.
+        RETURN_IF_ERROR(_sb_stream->read_at_fully(block_offset, src, load_size));
+        if (!can_zero_copy) {
+            strings::memcpy_inlined(out, src + shift, size);
+        }
+    }
+
+    if (_enable_populate_cache) {
+        SCOPED_RAW_TIMER(&_stats.write_cache_ns);
+        Status r = cache->write_cache(_cache_key, block_offset, load_size, src);
+        if (r.ok()) {
+            _stats.write_cache_count += 1;
+            _stats.write_cache_bytes += load_size;
+        } else {
+            _stats.write_cache_fail_count += 1;
+            _stats.write_cache_fail_bytes += load_size;
+            LOG(WARNING) << "write block cache failed, errmsg: " << r.get_error_msg();
+            // Failed to write cache, but we can keep processing query.
+        }
+    }
+    return Status::OK();
+}
+
+void CacheInputStream::_deduplicate_shared_buffer(SharedBufferedInputStream::SharedBuffer* sb) {
+    int64_t end_offset = sb->offset + sb->size;
+    int64_t start_block_id = sb->offset / _block_size;
+    int64_t end_block_id = (end_offset - 1) / _block_size;
+    while (start_block_id < end_block_id) {
+        if (_block_map.find(start_block_id) == _block_map.end()) {
+            break;
+        }
+        ++start_block_id;
+    }
+    while (start_block_id < end_block_id) {
+        if (_block_map.find(end_block_id) == _block_map.end()) {
+            break;
+        }
+        --end_block_id;
+    }
+    // It is impossible that all block exists in block_map because we check block map before
+    // reading remote storage.
+    for (int64_t i = start_block_id; i <= end_block_id; ++i) {
+        _block_map.erase(i);
+    }
+
+    sb->offset = std::max(start_block_id * _block_size, sb->offset);
+    int64_t end = std::min((end_block_id + 1) * _block_size, end_offset);
+    sb->size = end - sb->offset;
 }
 
 Status CacheInputStream::read_at_fully(int64_t offset, void* out, int64_t count) {
@@ -59,76 +182,22 @@ Status CacheInputStream::read_at_fully(int64_t offset, void* out, int64_t count)
     if (count < 0) {
         return Status::EndOfFile("");
     }
-    const int64_t BLOCK_SIZE = cache->block_size();
+    const int64_t _block_size = cache->block_size();
     char* p = static_cast<char*>(out);
     char* pe = p + count;
 
-    auto read_one_block = [&](size_t offset, size_t size) {
-        StatusOr<size_t> res;
-
-        DCHECK(size <= BLOCK_SIZE);
-        {
-            SCOPED_RAW_TIMER(&_stats.read_cache_ns);
-            res = cache->read_cache(_cache_key, offset, size, p);
-            if (res.ok()) {
-                _stats.read_cache_count += 1;
-                _stats.read_cache_bytes += size;
-                p += size;
-                return Status::OK();
-            }
-        }
-        if (!res.status().is_not_found()) return res.status();
-        DCHECK(res.status().is_not_found());
-
-        int64_t block_id = offset / BLOCK_SIZE;
-        int64_t block_offset = block_id * BLOCK_SIZE;
-        int64_t shift = offset - block_offset;
-
-        char* src = nullptr;
-        bool can_zero_copy = false;
-        if ((p + BLOCK_SIZE <= pe) && (shift == 0)) {
-            can_zero_copy = true;
-            src = p;
-        } else {
-            src = _buffer.data();
-        }
-
-        // if not found, read from stream and write back to cache.
-        int64_t load_size = std::min(BLOCK_SIZE, _size - block_offset);
-        RETURN_IF_ERROR(_stream->read_at_fully(block_offset, src, load_size));
-
-        if (_enable_populate_cache) {
-            SCOPED_RAW_TIMER(&_stats.write_cache_ns);
-            Status r = cache->write_cache(_cache_key, block_offset, load_size, src);
-            if (r.ok()) {
-                _stats.write_cache_count += 1;
-                _stats.write_cache_bytes += load_size;
-            } else {
-                _stats.write_cache_fail_count += 1;
-                _stats.write_cache_fail_bytes += load_size;
-                LOG(WARNING) << "write block cache failed, errmsg: " << r.get_error_msg();
-                // Failed to write cache, but we can keep processing query.
-            }
-        }
-
-        if (!can_zero_copy) {
-            // memcpy(p, src + shift, size);
-            strings::memcpy_inlined(p, src + shift, size);
-        }
-        p += size;
-        return Status::OK();
-    };
-
     int64_t end_offset = offset + count;
-    int64_t start_block_id = offset / BLOCK_SIZE;
-    int64_t end_block_id = (end_offset - 1) / BLOCK_SIZE;
+    int64_t start_block_id = offset / _block_size;
+    int64_t end_block_id = (end_offset - 1) / _block_size;
+    bool can_zero_copy = p + _block_size < pe;
     for (int64_t i = start_block_id; i <= end_block_id; i++) {
-        size_t off = std::max(offset, i * BLOCK_SIZE);
-        size_t end = std::min((i + 1) * BLOCK_SIZE, end_offset);
+        size_t off = std::max(offset, i * _block_size);
+        size_t end = std::min((i + 1) * _block_size, end_offset);
         size_t size = end - off;
-        Status st = read_one_block(off, size);
+        Status st = _read_block(off, size, p, can_zero_copy);
         if (!st.ok()) return st;
         offset += size;
+        p += size;
     }
     DCHECK(p == pe);
     return Status::OK();
@@ -143,7 +212,7 @@ StatusOr<int64_t> CacheInputStream::read(void* data, int64_t count) {
 Status CacheInputStream::seek(int64_t offset) {
     if (offset < 0 || offset >= _size) return Status::InvalidArgument(fmt::format("Invalid offset {}", offset));
     _offset = offset;
-    _stream->seek(offset);
+    _sb_stream->seek(offset);
     return Status::OK();
 }
 
@@ -156,14 +225,13 @@ StatusOr<int64_t> CacheInputStream::get_size() {
 }
 
 int64_t CacheInputStream::get_align_size() const {
-    BlockCache* cache = BlockCache::instance();
-    return cache->block_size();
+    return _block_size;
 }
 
 StatusOr<std::string_view> CacheInputStream::peek(int64_t count) {
     // if app level uses zero copy read, it does bypass the cache layer.
     // so here we have to fill cache manually.
-    ASSIGN_OR_RETURN(auto s, _stream->peek(count));
+    ASSIGN_OR_RETURN(auto s, _sb_stream->peek(count));
     if (_enable_populate_cache) {
         _populate_cache_from_zero_copy_buffer(s.data(), _offset, count);
     }
@@ -172,9 +240,8 @@ StatusOr<std::string_view> CacheInputStream::peek(int64_t count) {
 
 void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int64_t offset, int64_t count) {
     BlockCache* cache = BlockCache::instance();
-    const int64_t BLOCK_SIZE = cache->block_size();
-    int64_t begin = offset / BLOCK_SIZE * BLOCK_SIZE;
-    int64_t end = std::min((offset + count + BLOCK_SIZE - 1) / BLOCK_SIZE * BLOCK_SIZE, _size);
+    int64_t begin = offset / _block_size * _block_size;
+    int64_t end = std::min((offset + count + _block_size - 1) / _block_size * _block_size, _size);
     p -= (offset - begin);
     auto f = [&](const char* buf, size_t offset, size_t size) {
         SCOPED_RAW_TIMER(&_stats.write_cache_ns);
@@ -190,7 +257,7 @@ void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int6
     };
 
     while (begin < end) {
-        size_t size = std::min(BLOCK_SIZE, end - begin);
+        size_t size = std::min(_block_size, end - begin);
         f(p, begin, size);
         begin += size;
         p += size;

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -17,7 +17,8 @@
 #include <memory>
 #include <string>
 
-#include "io/seekable_input_stream.h"
+#include "block_cache/io_buffer.h"
+#include "io/shared_buffered_input_stream.h"
 
 namespace starrocks::io {
 
@@ -32,9 +33,11 @@ public:
         int64_t write_cache_bytes = 0;
         int64_t write_cache_fail_count = 0;
         int64_t write_cache_fail_bytes = 0;
+        int64_t read_block_buffer_bytes = 0;
+        int64_t read_block_buffer_count = 0;
     };
 
-    explicit CacheInputStream(const std::shared_ptr<SeekableInputStream>& stream, const std::string& filename,
+    explicit CacheInputStream(const std::shared_ptr<SharedBufferedInputStream>& stream, const std::string& filename,
                               size_t size, int64_t modification_time);
 
     ~CacheInputStream() override = default;
@@ -59,20 +62,29 @@ public:
 
     Status skip(int64_t count) override {
         _offset += count;
-        return _stream->skip(count);
+        return _sb_stream->skip(count);
     }
 
 private:
+    struct BlockBuffer {
+        int64_t offset;
+        IOBuffer buffer;
+    };
+
+    Status _read_block(int64_t offset, int64_t size, char* out, bool single_read);
     void _populate_cache_from_zero_copy_buffer(const char* p, int64_t offset, int64_t count);
+    void _deduplicate_shared_buffer(SharedBufferedInputStream::SharedBuffer* sb);
 
     std::string _cache_key;
     std::string _filename;
-    std::shared_ptr<SeekableInputStream> _stream;
+    std::shared_ptr<SharedBufferedInputStream> _sb_stream;
     int64_t _offset;
     std::string _buffer;
     Stats _stats;
     int64_t _size;
     bool _enable_populate_cache = false;
+    int64_t _block_size = 0;
+    std::unordered_map<int64_t, BlockBuffer> _block_map;
 };
 
 } // namespace starrocks::io

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -182,8 +182,8 @@ Status SharedBufferedInputStream::set_io_ranges(const std::vector<IORange>& rang
     }
 }
 
-StatusOr<SharedBufferedInputStream::SharedBuffer*> SharedBufferedInputStream::_find_shared_buffer(size_t offset,
-                                                                                                  size_t count) {
+StatusOr<SharedBufferedInputStream::SharedBuffer*> SharedBufferedInputStream::find_shared_buffer(size_t offset,
+                                                                                                 size_t count) {
     auto iter = _map.upper_bound(offset);
     if (iter == _map.end()) {
         return Status::RuntimeError("failed to find shared buffer based on offset");
@@ -195,8 +195,8 @@ StatusOr<SharedBufferedInputStream::SharedBuffer*> SharedBufferedInputStream::_f
     return &sb;
 }
 
-Status SharedBufferedInputStream::_get_bytes(const uint8_t** buffer, size_t offset, size_t nbytes) {
-    ASSIGN_OR_RETURN(auto ret, _find_shared_buffer(offset, nbytes));
+Status SharedBufferedInputStream::get_bytes(const uint8_t** buffer, size_t offset, size_t nbytes) {
+    ASSIGN_OR_RETURN(auto ret, find_shared_buffer(offset, nbytes));
     SharedBuffer& sb = *ret;
     if (sb.buffer.capacity() == 0) {
         SCOPED_RAW_TIMER(&_shared_io_timer);
@@ -222,7 +222,7 @@ void SharedBufferedInputStream::release_to_offset(int64_t offset) {
 }
 
 Status SharedBufferedInputStream::read_at_fully(int64_t offset, void* out, int64_t count) {
-    auto st = _find_shared_buffer(offset, count);
+    auto st = find_shared_buffer(offset, count);
     if (!st.ok()) {
         SCOPED_RAW_TIMER(&_direct_io_timer);
         _direct_io_count += 1;
@@ -231,7 +231,7 @@ Status SharedBufferedInputStream::read_at_fully(int64_t offset, void* out, int64
         return Status::OK();
     }
     const uint8_t* buffer = nullptr;
-    RETURN_IF_ERROR(_get_bytes(&buffer, offset, count));
+    RETURN_IF_ERROR(get_bytes(&buffer, offset, count));
     strings::memcpy_inlined(out, buffer, count);
     return Status::OK();
 }
@@ -248,10 +248,10 @@ StatusOr<int64_t> SharedBufferedInputStream::read(void* data, int64_t count) {
 }
 
 StatusOr<std::string_view> SharedBufferedInputStream::peek(int64_t count) {
-    ASSIGN_OR_RETURN(auto ret, _find_shared_buffer(_offset, count));
+    ASSIGN_OR_RETURN(auto ret, find_shared_buffer(_offset, count));
     if (ret->buffer.capacity() == 0) return Status::NotSupported("peek shared buffer empty");
     const uint8_t* buf = nullptr;
-    RETURN_IF_ERROR(_get_bytes(&buf, _offset, count));
+    RETURN_IF_ERROR(get_bytes(&buf, _offset, count));
     return std::string_view((const char*)buf, count);
 }
 

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -36,6 +36,17 @@ public:
         int64_t max_dist_size = 1 * MB;
         int64_t max_buffer_size = 8 * MB;
     };
+    struct SharedBuffer {
+        // request range
+        int64_t raw_offset;
+        int64_t raw_size;
+        // request range after alignment
+        int64_t offset;
+        int64_t size;
+        int64_t ref_count;
+        std::vector<uint8_t> buffer;
+        void align(int64_t align_size, int64_t file_size);
+    };
 
     SharedBufferedInputStream(std::shared_ptr<SeekableInputStream> stream, std::string filename, size_t file_size);
     ~SharedBufferedInputStream() override = default;
@@ -52,6 +63,9 @@ public:
         _offset += count;
         return _stream->skip(count);
     }
+
+    Status get_bytes(const uint8_t** buffer, size_t offset, size_t nbytes);
+    StatusOr<SharedBuffer*> find_shared_buffer(size_t offset, size_t count);
 
     StatusOr<std::unique_ptr<NumericStatistics>> get_numeric_statistics() override {
         return _stream->get_numeric_statistics();
@@ -75,25 +89,11 @@ public:
     StatusOr<std::string_view> peek(int64_t count) override;
 
 private:
-    struct SharedBuffer {
-    public:
-        // request range
-        int64_t raw_offset;
-        int64_t raw_size;
-        // request range after alignment
-        int64_t offset;
-        int64_t size;
-        int64_t ref_count;
-        std::vector<uint8_t> buffer;
-        void align(int64_t align_size, int64_t file_size);
-    };
-
     void _update_estimated_mem_usage();
     Status _get_bytes(const uint8_t** buffer, size_t offset, size_t nbytes);
     Status _sort_and_check_overlap(std::vector<IORange>& ranges);
     void _merge_small_ranges(const std::vector<IORange>& ranges);
     Status _set_io_ranges_separately(const std::vector<IORange>& ranges);
-    StatusOr<SharedBuffer*> _find_shared_buffer(size_t offset, size_t count);
     const std::shared_ptr<SeekableInputStream> _stream;
     const std::string _filename;
     std::map<int64_t, SharedBuffer> _map;

--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -170,7 +170,7 @@ TEST_F(CacheInputStreamTest, test_file_overwrite) {
     gen_test_data(data, data_size, block_size);
 
     std::shared_ptr<io::SeekableInputStream> stream(new MockSeekableInputStream(data, data_size));
-    io::CacheInputStream cache_stream(stream, "test_file3", data_size, 1000000);
+    io::CacheInputStream cache_stream(stream, "test_file3", data_size, 1000);
     cache_stream.set_enable_populate_cache(true);
     auto& stats = cache_stream.stats();
 
@@ -192,7 +192,7 @@ TEST_F(CacheInputStreamTest, test_file_overwrite) {
     ASSERT_EQ(stats.read_cache_count, block_count);
 
     // With different modification time, the old cache cannot be used
-    io::CacheInputStream cache_stream2(stream, "test_file3", data_size, 2000000);
+    io::CacheInputStream cache_stream2(stream, "test_file3", data_size, 2000);
     cache_stream2.set_enable_populate_cache(true);
     auto& stats2 = cache_stream2.stats();
     for (int i = 0; i < block_count; ++i) {
@@ -201,6 +201,36 @@ TEST_F(CacheInputStreamTest, test_file_overwrite) {
         ASSERT_TRUE(check_data_content(buffer, block_size, 'a' + i));
     }
     ASSERT_EQ(stats2.read_cache_count, 0);
+}
+
+TEST_F(CacheInputStreamTest, test_read_from_io_buffer) {
+    const int64_t block_count = 1;
+
+    int64_t data_size = block_size * block_count;
+    char data[data_size + 1];
+    gen_test_data(data, data_size, block_size);
+
+    std::shared_ptr<io::SeekableInputStream> stream(new MockSeekableInputStream(data, data_size));
+    io::CacheInputStream cache_stream(stream, "test_file3", data_size, 1000);
+    cache_stream.set_enable_populate_cache(true);
+    auto& stats = cache_stream.stats();
+
+    // read from backend, cache the data
+    char buffer[block_size];
+    read_stream_data(&cache_stream, 0, block_size, buffer);
+    ASSERT_TRUE(check_data_content(buffer, block_size, 'a'));
+    ASSERT_EQ(stats.read_cache_count, 0);
+    ASSERT_EQ(stats.write_cache_count, 1);
+
+    // read the first 1024 bytes from cache, actually it will read the whole block from cache
+    // and save it to block buffer.
+    read_stream_data(&cache_stream, 0, 1024, buffer);
+    ASSERT_TRUE(check_data_content(buffer, block_size, 'a'));
+    ASSERT_EQ(stats.read_cache_count, 1);
+
+    read_stream_data(&cache_stream, 1024, 1024, buffer);
+    ASSERT_TRUE(check_data_content(buffer, block_size, 'a'));
+    ASSERT_EQ(stats.read_block_buffer_count, 1);
 }
 
 } // namespace starrocks::io


### PR DESCRIPTION
After moving the coalesce read below block cache, we need more cache operates for reading same data, which will bring some overhead like cache lookup, access update, etc. So, we also  coalesce block cache read and cache the data in io buffer map. 
To reduce the repeated cache both in io buffer map and shared buffer, we also need to duplicate the overlapped range.

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
