### PR TITLE
[Enhancement] Reduce consumption time when routine load txn timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -178,7 +178,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         tRoutineLoadTask.setParams(plan(routineLoadJob));
         // When the transaction times out, we reduce the consumption time to lower the BE load.
         if (msg.contains(DatabaseTransactionMgr.TXN_TIMEOUT_BY_MANAGER)) {
-            tRoutineLoadTask.setMax_interval_s(routineLoadJob.getTaskConsumeSecond()/2);
+            tRoutineLoadTask.setMax_interval_s(routineLoadJob.getTaskConsumeSecond() / 2);
         } else {
             tRoutineLoadTask.setMax_interval_s(routineLoadJob.getTaskConsumeSecond());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -52,7 +52,6 @@ import com.starrocks.thrift.TPlanFragment;
 import com.starrocks.thrift.TRoutineLoadTask;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.DatabaseTransactionMgr;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -104,6 +104,8 @@ public class DatabaseTransactionMgr {
 
     private static final Logger LOG = LogManager.getLogger(DatabaseTransactionMgr.class);
 
+    public static final String TXN_TIMEOUT_BY_MANAGER = "timeout by txn manager";
+
     private long dbId;
 
     // the lock is used to control the access to transaction states
@@ -1589,7 +1591,7 @@ public class DatabaseTransactionMgr {
         // abort timeout txns
         for (Long txnId : timeoutTxns) {
             try {
-                abortTransaction(txnId, "timeout by txn manager", null);
+                abortTransaction(txnId, TXN_TIMEOUT_BY_MANAGER, null);
                 LOG.info("transaction [" + txnId + "] is timeout, abort it by transaction manager");
             } catch (UserException e) {
                 // abort may be failed. it is acceptable. just print a log


### PR DESCRIPTION
When the concurrent load jobs for routine load are high, routine load task transactions are prone to timeouts, primarily due to increased BE load. To mitigate the BE load when routine load task transactions time out, this PR sets the consumption time to half of the normal consumption time.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
