### PR TITLE
[Enhancement] support struct column late materialized

### DIFF
--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -78,7 +78,12 @@ public:
 
     void reserve(size_t n) override {}
 
-    void resize(size_t n) override { _size = n; }
+    void resize(size_t n) override {
+        if (_size == 0) {
+            _data->resize(1);
+        }
+        _size = n;
+    }
 
     // This method resize the underlying data column,
     // Because when sometimes(agg functions), we want to handle const column as normal data column
@@ -128,9 +133,19 @@ public:
         }
     }
 
-    void append_default() override { _size++; }
+    void append_default() override {
+        if (_size == 0) {
+            _data->append_default(1);
+        }
+        _size++;
+    }
 
-    void append_default(size_t count) override { _size += count; }
+    void append_default(size_t count) override {
+        if (_size == 0) {
+            _data->append_default(1);
+        }
+        _size += count;
+    }
 
     void fill_default(const Filter& filter) override;
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -70,8 +70,9 @@ void NullableColumn::append_datum(const Datum& datum) {
 
 void NullableColumn::append(const Column& src, size_t offset, size_t count) {
     DCHECK_EQ(_null_column->size(), _data_column->size());
-
-    if (src.is_nullable()) {
+    if (src.only_null()) {
+        append_nulls(count);
+    } else if (src.is_nullable()) {
         const auto& c = down_cast<const NullableColumn&>(src);
 
         DCHECK_EQ(c._null_column->size(), c._data_column->size());
@@ -90,8 +91,9 @@ void NullableColumn::append(const Column& src, size_t offset, size_t count) {
 void NullableColumn::append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) {
     DCHECK_EQ(_null_column->size(), _data_column->size());
     size_t orig_size = _null_column->size();
-
-    if (src.is_nullable()) {
+    if (src.only_null()) {
+        append_nulls(size);
+    } else if (src.is_nullable()) {
         const auto& src_column = down_cast<const NullableColumn&>(src);
 
         DCHECK_EQ(src_column._null_column->size(), src_column._data_column->size());
@@ -110,8 +112,9 @@ void NullableColumn::append_selective(const Column& src, const uint32_t* indexes
 void NullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
     DCHECK_EQ(_null_column->size(), _data_column->size());
     size_t orig_size = _null_column->size();
-
-    if (src.is_nullable()) {
+    if (src.only_null()) {
+        append_nulls(size);
+    } else if (src.is_nullable()) {
         const auto& src_column = down_cast<const NullableColumn&>(src);
 
         DCHECK_EQ(src_column._null_column->size(), src_column._data_column->size());

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -605,9 +605,6 @@ CONF_Int32(late_materialization_ratio, "10");
 // `1000` will enable late materialization always select metric type.
 CONF_Int32(metric_late_materialization_ratio, "1000");
 
-// Whether to late materialization struct's subfield
-CONF_Bool(late_materialization_subfield, "true");
-
 // Max batched bytes for each transmit request. (256KB)
 CONF_Int64(max_transmit_batched_bytes, "262144");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -605,6 +605,9 @@ CONF_Int32(late_materialization_ratio, "10");
 // `1000` will enable late materialization always select metric type.
 CONF_Int32(metric_late_materialization_ratio, "1000");
 
+// Whether to late materialization struct's subfield
+CONF_Bool(late_materialization_subfield, "true");
+
 // Max batched bytes for each transmit request. (256KB)
 CONF_Int64(max_transmit_batched_bytes, "262144");
 

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(Storage STATIC
     rowset/default_value_column_iterator.cpp
     rowset/dictcode_column_iterator.cpp
     rowset/encoding_info.cpp
+    rowset/fill_subfield_iterator.cpp
     rowset/scalar_column_iterator.cpp
     rowset/index_page.cpp
     rowset/indexed_column_reader.cpp

--- a/be/src/storage/rowset/array_column_iterator.cpp
+++ b/be/src/storage/rowset/array_column_iterator.cpp
@@ -16,6 +16,7 @@
 
 #include "column/array_column.h"
 #include "column/column_access_path.h"
+#include "column/const_column.h"
 #include "column/nullable_column.h"
 #include "storage/rowset/scalar_column_iterator.h"
 
@@ -85,7 +86,12 @@ Status ArrayColumnIterator::next_batch(size_t* n, Column* dst) {
     if (_access_values) {
         RETURN_IF_ERROR(_element_iterator->next_batch(&num_to_read, array_column->elements_column().get()));
     } else {
-        array_column->elements_column()->append_default(num_to_read);
+        if (!array_column->elements_column()->is_constant()) {
+            array_column->elements_column()->append_default(1);
+            array_column->elements_column() = ConstColumn::create(array_column->elements_column(), num_to_read);
+        } else {
+            array_column->elements_column()->append_default(num_to_read);
+        }
     }
 
     return Status::OK();
@@ -158,7 +164,12 @@ Status ArrayColumnIterator::next_batch(const SparseRange<>& range, Column* dst) 
         DCHECK(element_read_range.empty() || (element_read_range.begin() == _element_iterator->get_current_ordinal()));
         RETURN_IF_ERROR(_element_iterator->next_batch(element_read_range, array_column->elements_column().get()));
     } else {
-        array_column->elements_column()->append_default(read_rows);
+        if (!array_column->elements_column()->is_constant()) {
+            array_column->elements_column()->append_default(1);
+            array_column->elements_column() = ConstColumn::create(array_column->elements_column(), read_rows);
+        } else {
+            array_column->elements_column()->append_default(read_rows);
+        }
     }
 
     return Status::OK();
@@ -195,17 +206,31 @@ Status ArrayColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t 
     }
 
     // 3. Read elements
-    for (size_t i = 0; i < size; ++i) {
-        RETURN_IF_ERROR(_array_size_iterator->seek_to_ordinal_and_calc_element_ordinal(rowids[i]));
-        size_t element_ordinal = _array_size_iterator->element_ordinal();
-        RETURN_IF_ERROR(_element_iterator->seek_to_ordinal(element_ordinal));
-        size_t size_to_read = array_size.get_data()[i];
-        if (_access_values) {
+    if (_access_values) {
+        for (size_t i = 0; i < size; ++i) {
+            RETURN_IF_ERROR(_array_size_iterator->seek_to_ordinal_and_calc_element_ordinal(rowids[i]));
+            size_t element_ordinal = _array_size_iterator->element_ordinal();
+            RETURN_IF_ERROR(_element_iterator->seek_to_ordinal(element_ordinal));
+            size_t size_to_read = array_size.get_data()[i];
             RETURN_IF_ERROR(_element_iterator->next_batch(&size_to_read, array_column->elements_column().get()));
-        } else {
-            array_column->elements_column()->append_default(size_to_read);
         }
+    } else {
+        if (!array_column->elements_column()->is_constant()) {
+            array_column->elements_column()->append_default(1);
+            array_column->elements_column() = ConstColumn::create(array_column->elements_column());
+        }
+
+        size_t size_to_read = 0;
+        for (size_t i = 0; i < size; ++i) {
+            RETURN_IF_ERROR(_array_size_iterator->seek_to_ordinal_and_calc_element_ordinal(rowids[i]));
+            size_t element_ordinal = _array_size_iterator->element_ordinal();
+            RETURN_IF_ERROR(_element_iterator->seek_to_ordinal(element_ordinal));
+            size_to_read += array_size.get_data()[i];
+        }
+
+        array_column->elements_column()->append_default(size_to_read);
     }
+
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -44,6 +44,7 @@ namespace starrocks {
 class CondColumn;
 
 class Column;
+class ColumnAccessPath;
 class ColumnPredicate;
 
 class ColumnReader;
@@ -171,6 +172,15 @@ public:
     }
 
     Status fetch_dict_codes_by_rowid(const Column& rowids, Column* values);
+
+    // for complex collection type (Array/Struct/Map)
+    virtual Status next_batch(size_t* n, Column* dst, ColumnAccessPath* path) { return next_batch(n, dst); }
+
+    virtual Status next_batch(const SparseRange<>& range, Column* dst, ColumnAccessPath* path) {
+        return next_batch(range, dst);
+    }
+
+    virtual Status fetch_subfield_by_rowid(const rowid_t* rowids, size_t size, Column* values) { return Status::OK(); }
 
 protected:
     ColumnIteratorOptions _opts;

--- a/be/src/storage/rowset/fill_subfield_iterator.cpp
+++ b/be/src/storage/rowset/fill_subfield_iterator.cpp
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset/fill_subfield_iterator.h"
+
+namespace starrocks {
+
+Status FillSubfieldIterator::next_batch(size_t* n, Column* dst) {
+    return _column_iter->next_batch(n, dst, _predicate_path);
+}
+
+Status FillSubfieldIterator::next_batch(const SparseRange<>& range, Column* dst) {
+    return _column_iter->next_batch(range, dst, _predicate_path);
+}
+
+Status FillSubfieldIterator::seek_to_first() {
+    return _column_iter->seek_to_first();
+}
+
+Status FillSubfieldIterator::seek_to_ordinal(ordinal_t ord) {
+    return _column_iter->seek_to_ordinal(ord);
+}
+
+ordinal_t FillSubfieldIterator::get_current_ordinal() const {
+    return _column_iter->get_current_ordinal();
+}
+
+Status FillSubfieldIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
+    return _column_iter->fetch_subfield_by_rowid(rowids, size, values);
+}
+
+} // namespace starrocks

--- a/be/src/storage/rowset/fill_subfield_iterator.h
+++ b/be/src/storage/rowset/fill_subfield_iterator.h
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "column/column_access_path.h"
+#include "storage/range.h"
+#include "storage/rowset/column_iterator.h"
+
+namespace starrocks {
+// FillSubfieldIterator is a wrapper/proxy on complex type(STRUCT) column iterator that will
+// transform the invoking of `next_batch(size_t*, Column*)`
+// For early materialize subfield
+class FillSubfieldIterator final : public ColumnIterator {
+public:
+    using Column = starrocks::Column;
+    using ColumnPredicate = starrocks::ColumnPredicate;
+    // does not take the ownership of |iter|.
+    FillSubfieldIterator(ColumnId cid, ColumnAccessPath* predicate_path, ColumnIterator* column_iter)
+            : _cid(cid), _predicate_path(predicate_path), _column_iter(column_iter) {}
+
+    ~FillSubfieldIterator() override = default;
+
+    ColumnId column_id() const { return _cid; }
+
+    Status next_batch(size_t* n, Column* dst) override;
+
+    Status next_batch(const SparseRange<>& range, Column* dst) override;
+
+    Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
+
+    Status seek_to_first() override;
+
+    Status seek_to_ordinal(ordinal_t ord);
+
+    ordinal_t get_current_ordinal() const override;
+
+    Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
+                                      const ColumnPredicate* del_predicate, SparseRange<>* row_ranges) override {
+        return Status::NotSupported("");
+    }
+
+private:
+    ColumnId _cid;
+    ColumnAccessPath* _predicate_path;
+    ColumnIterator* _column_iter;
+};
+
+} // namespace starrocks

--- a/be/src/storage/rowset/map_column_iterator.cpp
+++ b/be/src/storage/rowset/map_column_iterator.cpp
@@ -15,6 +15,7 @@
 #include "storage/rowset/map_column_iterator.h"
 
 #include "column/column_access_path.h"
+#include "column/const_column.h"
 #include "column/map_column.h"
 #include "column/nullable_column.h"
 #include "storage/rowset/scalar_column_iterator.h"
@@ -106,14 +107,23 @@ Status MapColumnIterator::next_batch(size_t* n, Column* dst) {
     if (_access_keys) {
         RETURN_IF_ERROR(_keys->next_batch(&num_to_read, map_column->keys_column().get()));
     } else {
-        // todo: unpack struct in scan, and don't need append default values
-        map_column->keys_column()->append_default(num_to_read);
+        if (!map_column->keys_column()->is_constant()) {
+            map_column->keys_column()->append_default(1);
+            map_column->keys_column() = ConstColumn::create(map_column->keys_column(), num_to_read);
+        } else {
+            map_column->keys_column()->append_default(num_to_read);
+        }
     }
 
     if (_access_values) {
         RETURN_IF_ERROR(_values->next_batch(&num_to_read, map_column->values_column().get()));
     } else {
-        map_column->values_column()->append_default(num_to_read);
+        if (!map_column->values_column()->is_constant()) {
+            map_column->values_column()->append_default(1);
+            map_column->values_column() = ConstColumn::create(map_column->values_column(), num_to_read);
+        } else {
+            map_column->values_column()->append_default(num_to_read);
+        }
     }
 
     return Status::OK();
@@ -186,13 +196,23 @@ Status MapColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
     if (_access_keys) {
         RETURN_IF_ERROR(_keys->next_batch(element_read_range, map_column->keys_column().get()));
     } else {
-        map_column->keys_column()->append_default(read_rows);
+        if (!map_column->keys_column()->is_constant()) {
+            map_column->keys_column()->append_default(1);
+            map_column->keys_column() = ConstColumn::create(map_column->keys_column(), read_rows);
+        } else {
+            map_column->keys_column()->append_default(read_rows);
+        }
     }
 
     if (_access_values) {
         RETURN_IF_ERROR(_values->next_batch(element_read_range, map_column->values_column().get()));
     } else {
-        map_column->values_column()->append_default(read_rows);
+        if (!map_column->values_column()->is_constant()) {
+            map_column->values_column()->append_default(1);
+            map_column->values_column() = ConstColumn::create(map_column->values_column(), read_rows);
+        } else {
+            map_column->values_column()->append_default(read_rows);
+        }
     }
 
     return Status::OK();
@@ -247,11 +267,21 @@ Status MapColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t si
     }
 
     if (!_access_keys) {
-        map_column->keys_column()->append_default(offset - start);
+        if (!map_column->keys_column()->is_constant()) {
+            map_column->keys_column()->append_default(1);
+            map_column->keys_column() = ConstColumn::create(map_column->keys_column(), offset - start);
+        } else {
+            map_column->keys_column()->append_default(offset - start);
+        }
     }
 
     if (!_access_values) {
-        map_column->values_column()->append_default(offset - start);
+        if (!map_column->values_column()->is_constant()) {
+            map_column->values_column()->append_default(1);
+            map_column->values_column() = ConstColumn::create(map_column->values_column(), offset - start);
+        } else {
+            map_column->values_column()->append_default(offset - start);
+        }
     }
 
     return Status::OK();

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1362,7 +1362,7 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
     }
 
     size_t build_read_index_size = ctx->_read_schema.num_fields();
-    if (late_materialization && (predicate_count < _schema.num_fields() || !_predicate_column_access_paths.empty())) {
+    if (late_materialization && (predicate_count < _schema.num_fields() || !ctx->_subfield_columns.empty())) {
         // ordinal column
         ColumnId cid = -1;
         if (predicate_count < _schema.num_fields()) {

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -609,10 +609,6 @@ Status SegmentIterator::_init_column_iterators(const Schema& schema) {
 }
 
 bool SegmentIterator::need_early_materialize_subfield(const FieldPtr& field) {
-    if (!config::late_materialization_subfield) {
-        return false;
-    }
-
     if (field->type()->type() != LogicalType::TYPE_STRUCT) {
         // @Todo: support json/map/array when support flat-column,
         // the performance improvement scenarios are too few now

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -48,6 +48,7 @@
 #include "storage/rowset/common.h"
 #include "storage/rowset/default_value_column_iterator.h"
 #include "storage/rowset/dictcode_column_iterator.h"
+#include "storage/rowset/fill_subfield_iterator.h"
 #include "storage/rowset/rowid_column_iterator.h"
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/rowset/segment.h"
@@ -154,6 +155,8 @@ private:
         Schema _dict_decode_schema;
         std::vector<bool> _is_dict_column;
         std::vector<ColumnIterator*> _column_iterators;
+        std::vector<ColumnId> _subfield_columns;
+        std::vector<ColumnIterator*> _subfield_iterators;
         ScanContext* _next{nullptr};
 
         // index the column which only be used for filter
@@ -260,6 +263,8 @@ private:
     //  This function will search and build the segment from delta column group,
     // and also return the columns's index in this segment if need.
     StatusOr<std::shared_ptr<Segment>> _get_dcg_segment(uint32_t ucid, int32_t* col_index);
+
+    bool need_early_materialize_subfield(const FieldPtr& field);
 
 private:
     using RawColumnIterators = std::vector<std::unique_ptr<ColumnIterator>>;
@@ -600,6 +605,19 @@ Status SegmentIterator::_init_column_iterators(const Schema& schema) {
         }
     }
     return Status::OK();
+}
+
+bool SegmentIterator::need_early_materialize_subfield(const FieldPtr& field) {
+    if (field->type()->type() != LogicalType::TYPE_STRUCT) {
+        // @Todo: support json/map/array when support flat-column,
+        // the performance improvement scenarios are too few now
+        return false;
+    }
+    auto cid = field->id();
+    if (_predicate_column_access_paths.find(cid) != _predicate_column_access_paths.end()) {
+        return true;
+    }
+    return false;
 }
 
 void SegmentIterator::_init_column_predicates() {
@@ -1265,6 +1283,7 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
 
     ctx->_read_schema.reserve(ctx_fields);
     ctx->_dict_decode_schema.reserve(ctx_fields);
+    ctx->_subfield_columns.reserve(ctx_fields);
     ctx->_is_dict_column.reserve(ctx_fields);
     ctx->_column_iterators.reserve(ctx_fields);
     ctx->_skip_dict_decode_indexes.reserve(ctx_fields);
@@ -1319,6 +1338,16 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
             } else {
                 ctx->_dict_decode_schema.append(f);
             }
+        } else if (late_materialization && need_early_materialize_subfield(f)) {
+            auto path = _predicate_column_access_paths[cid];
+            ColumnIterator* iter = new FillSubfieldIterator(cid, path, _column_iterators[cid].get());
+            _obj_pool.add(iter);
+            ctx->_read_schema.append(f);
+            ctx->_column_iterators.emplace_back(iter);
+            ctx->_is_dict_column.emplace_back(false);
+            ctx->_dict_decode_schema.append(f);
+            ctx->_subfield_columns.emplace_back(i);
+            ctx->_subfield_iterators.emplace_back(iter);
         } else {
             ctx->_read_schema.append(f);
             ctx->_column_iterators.emplace_back(_column_iterators[cid].get());
@@ -1328,9 +1357,13 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
     }
 
     size_t build_read_index_size = ctx->_read_schema.num_fields();
-    if (late_materialization && predicate_count < _schema.num_fields()) {
+    if (late_materialization && (predicate_count < _schema.num_fields() || !_predicate_column_access_paths.empty())) {
         // ordinal column
-        ColumnId cid = _schema.field(predicate_count)->id();
+        ColumnId cid = -1;
+        if (predicate_count < _schema.num_fields()) {
+            cid = _schema.field(predicate_count)->id();
+        }
+
         static_assert(std::is_same_v<rowid_t, TypeTraits<TYPE_UNSIGNED_INT>::CppType>);
         auto f = std::make_shared<Field>(cid, "ordinal", TYPE_UNSIGNED_INT, -1, -1, false);
         auto* iter = new RowIdColumnIterator();
@@ -1374,7 +1407,8 @@ Status SegmentIterator::_init_context() {
 
     RETURN_IF_ERROR(_init_global_dict_decoder());
 
-    if (_predicate_columns == 0 || _predicate_columns >= _schema.num_fields()) {
+    if (_predicate_columns == 0 ||
+        (_predicate_columns >= _schema.num_fields() && _predicate_column_access_paths.empty())) {
         // non or all field has predicate, disable late materialization.
         RETURN_IF_ERROR(_build_context<false>(&_context_list[0]));
     } else {
@@ -1514,19 +1548,32 @@ Status SegmentIterator::_finish_late_materialization(ScanContext* ctx) {
     ColumnPtr rowid_column = ctx->_dict_chunk->get_column_by_index(m - 1);
     const auto* ordinals = down_cast<FixedLengthColumn<rowid_t>*>(rowid_column.get());
 
-    const size_t n = _schema.num_fields();
-    const size_t start_pos = ctx->_read_index_map.size();
-    for (size_t i = m - 1, j = start_pos; i < n; i++, j++) {
-        const FieldPtr& f = _schema.field(i);
-        const ColumnId cid = f->id();
-        ColumnPtr& col = ctx->_final_chunk->get_column_by_index(j);
-        col->reserve(ordinals->size());
-        col->resize(0);
+    if (_predicate_columns < _schema.num_fields()) {
+        const size_t n = _schema.num_fields();
+        const size_t start_pos = ctx->_read_index_map.size();
+        for (size_t i = m - 1, j = start_pos; i < n; i++, j++) {
+            const FieldPtr& f = _schema.field(i);
+            const ColumnId cid = f->id();
+            ColumnPtr& col = ctx->_final_chunk->get_column_by_index(j);
+            col->reserve(ordinals->size());
+            col->resize(0);
 
-        RETURN_IF_ERROR(_column_decoders[cid].decode_values_by_rowid(*ordinals, col.get()));
-        DCHECK_EQ(ordinals->size(), col->size());
-        may_has_del_row |= (col->delete_state() != DEL_NOT_SATISFIED);
+            RETURN_IF_ERROR(_column_decoders[cid].decode_values_by_rowid(*ordinals, col.get()));
+            DCHECK_EQ(ordinals->size(), col->size());
+            may_has_del_row |= (col->delete_state() != DEL_NOT_SATISFIED);
+        }
     }
+
+    // fill subfield of early materialization columns
+    for (size_t i = 0; i < ctx->_subfield_columns.size(); i++) {
+        auto cid = ctx->_subfield_columns[i];
+        auto f = _schema.field(cid);
+        ColumnPtr& col = ctx->_final_chunk->get_column_by_index(cid);
+        // FillSubfieldIterator
+        RETURN_IF_ERROR(ctx->_subfield_iterators[i]->fetch_values_by_rowid(*ordinals, col.get()));
+        DCHECK_EQ(ordinals->size(), col->size());
+    }
+
     ctx->_final_chunk->set_delete_state(may_has_del_row ? DEL_PARTIAL_SATISFIED : DEL_NOT_SATISFIED);
     ctx->_final_chunk->check_or_die();
 

--- a/be/src/storage/rowset/struct_column_iterator.cpp
+++ b/be/src/storage/rowset/struct_column_iterator.cpp
@@ -15,6 +15,7 @@
 #include "storage/rowset/struct_column_iterator.h"
 
 #include "column/column_access_path.h"
+#include "column/const_column.h"
 #include "column/nullable_column.h"
 #include "column/struct_column.h"
 #include "storage/rowset/column_reader.h"
@@ -46,6 +47,12 @@ public:
                                       const ColumnPredicate* del_predicate, SparseRange<>* row_ranges) override;
 
     Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
+
+    Status next_batch(size_t* n, Column* dst, ColumnAccessPath* path) override;
+
+    Status next_batch(const SparseRange<>& range, Column* dst, ColumnAccessPath* path) override;
+
+    Status fetch_subfield_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
 
 private:
     ColumnReader* _reader;
@@ -109,21 +116,23 @@ Status StructColumnIterator::next_batch(size_t* n, Column* dst) {
         down_cast<NullableColumn*>(dst)->update_has_null();
     }
 
-    // Read all fields
-    // TODO(Alvin): _field_iters may have different order with struct_column
-    // FIXME:
-    auto fields = struct_column->fields();
+    size_t row_count = 0;
+    auto& fields = struct_column->fields_column();
     for (int i = 0; i < _field_iters.size(); ++i) {
         if (_access_flags[i]) {
             auto num_to_read = *n;
             RETURN_IF_ERROR(_field_iters[i]->next_batch(&num_to_read, fields[i].get()));
+            row_count = fields[i]->size();
         }
     }
 
-    // todo: unpack struct in scan, and don't need append default values
     for (int i = 0; i < _field_iters.size(); ++i) {
         if (!_access_flags[i]) {
-            fields[i]->append_default(*n);
+            if (!fields[i]->is_constant()) {
+                fields[i]->append_default(1);
+                fields[i] = ConstColumn::create(fields[i], 1);
+            }
+            fields[i]->resize(row_count);
         }
     }
 
@@ -148,7 +157,7 @@ Status StructColumnIterator::next_batch(const SparseRange<>& range, Column* dst)
     }
     // Read all fields
     size_t row_count = 0;
-    auto fields = struct_column->fields();
+    auto& fields = struct_column->fields_column();
     for (int i = 0; i < _field_iters.size(); ++i) {
         if (_access_flags[i]) {
             RETURN_IF_ERROR(_field_iters[i]->next_batch(range, fields[i].get()));
@@ -158,7 +167,11 @@ Status StructColumnIterator::next_batch(const SparseRange<>& range, Column* dst)
 
     for (int i = 0; i < _field_iters.size(); ++i) {
         if (!_access_flags[i]) {
-            fields[i]->append_default(row_count);
+            if (!fields[i]->is_constant()) {
+                fields[i]->append_default(1);
+                fields[i] = ConstColumn::create(fields[i], 1);
+            }
+            fields[i]->resize(row_count);
         }
     }
     return Status::OK();
@@ -179,16 +192,22 @@ Status StructColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t
     }
 
     // read all fields
-    auto fields = struct_column->fields();
+    auto& fields = struct_column->fields_column();
+    size_t row_count = 0;
     for (int i = 0; i < _field_iters.size(); ++i) {
         if (_access_flags[i]) {
             RETURN_IF_ERROR(_field_iters[i]->fetch_values_by_rowid(rowids, size, fields[i].get()));
+            row_count = fields[i]->size();
         }
     }
 
     for (int i = 0; i < _field_iters.size(); ++i) {
         if (!_access_flags[i]) {
-            fields[i]->append_default(size);
+            if (!fields[i]->is_constant()) {
+                fields[i]->append_default(1);
+                fields[i] = ConstColumn::create(fields[i], 1);
+            }
+            fields[i]->resize(row_count);
         }
     }
     return Status::OK();
@@ -218,6 +237,153 @@ Status StructColumnIterator::get_row_ranges_by_zone_map(const std::vector<const 
                                                         const ColumnPredicate* del_predicate,
                                                         SparseRange<>* row_ranges) {
     row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
+    return Status::OK();
+}
+
+Status StructColumnIterator::next_batch(size_t* n, Column* dst, ColumnAccessPath* path) {
+    if (path == nullptr || path->children().empty()) {
+        return next_batch(n, dst);
+    }
+
+    // 1. init predicate access path
+    std::vector<uint8_t> predicate_access_flags;
+    std::vector<ColumnAccessPath*> predicate_child_paths;
+    predicate_access_flags.resize(_field_iters.size(), 0);
+    predicate_child_paths.resize(_field_iters.size(), nullptr);
+    for (const auto& child : path->children()) {
+        predicate_access_flags[child->index()] = 1;
+        predicate_child_paths[child->index()] = child.get();
+    }
+
+    StructColumn* struct_column = nullptr;
+    NullColumn* null_column = nullptr;
+    if (dst->is_nullable()) {
+        auto* nullable_column = down_cast<NullableColumn*>(dst);
+        struct_column = down_cast<StructColumn*>(nullable_column->data_column().get());
+        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
+    } else {
+        struct_column = down_cast<StructColumn*>(dst);
+    }
+
+    // 2. Read null column
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->next_batch(n, null_column));
+        down_cast<NullableColumn*>(dst)->update_has_null();
+    }
+
+    // 3. Read fields
+    size_t row_count = 0;
+    auto& fields = struct_column->fields_column();
+    for (int i = 0; i < _field_iters.size(); ++i) {
+        if (predicate_access_flags[i]) {
+            auto num_to_read = *n;
+            RETURN_IF_ERROR(_field_iters[i]->next_batch(&num_to_read, fields[i].get(), predicate_child_paths[i]));
+            row_count = fields[i]->size();
+        }
+    }
+
+    for (int i = 0; i < _field_iters.size(); ++i) {
+        if (!predicate_access_flags[i]) {
+            if (!fields[i]->is_constant()) {
+                fields[i]->append_default(1);
+                fields[i] = ConstColumn::create(fields[i], 1);
+            }
+            fields[i]->resize(row_count);
+        }
+    }
+    return Status::OK();
+}
+
+Status StructColumnIterator::next_batch(const SparseRange<>& range, Column* dst, ColumnAccessPath* path) {
+    if (path == nullptr || path->children().empty()) {
+        return next_batch(range, dst);
+    }
+
+    std::vector<uint8_t> predicate_access_flags;
+    std::vector<ColumnAccessPath*> predicate_child_paths;
+    predicate_access_flags.resize(_field_iters.size(), 0);
+    predicate_child_paths.resize(_field_iters.size(), nullptr);
+    for (const auto& child : path->children()) {
+        predicate_access_flags[child->index()] = 1;
+        predicate_child_paths[child->index()] = child.get();
+    }
+
+    StructColumn* struct_column = nullptr;
+    NullColumn* null_column = nullptr;
+    if (dst->is_nullable()) {
+        auto* nullable_column = down_cast<NullableColumn*>(dst);
+
+        struct_column = down_cast<StructColumn*>(nullable_column->data_column().get());
+        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
+    } else {
+        struct_column = down_cast<StructColumn*>(dst);
+    }
+    // Read null column
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->next_batch(range, null_column));
+        down_cast<NullableColumn*>(dst)->update_has_null();
+    }
+    // Read all fields
+    size_t row_count = 0;
+    auto& fields = struct_column->fields_column();
+    for (int i = 0; i < _field_iters.size(); ++i) {
+        if (!predicate_access_flags[i]) {
+            continue;
+        }
+        RETURN_IF_ERROR(_field_iters[i]->next_batch(range, fields[i].get(), predicate_child_paths[i]));
+        row_count = fields[i]->size();
+    }
+
+    for (int i = 0; i < _field_iters.size(); ++i) {
+        if (!predicate_access_flags[i]) {
+            if (!fields[i]->is_constant()) {
+                fields[i]->append_default(1);
+                fields[i] = ConstColumn::create(fields[i], 1);
+            }
+            fields[i]->resize(row_count);
+        }
+    }
+    return Status::OK();
+}
+
+Status StructColumnIterator::fetch_subfield_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
+    StructColumn* struct_column = nullptr;
+    // 1. null column was readed
+    if (_null_iter != nullptr) {
+        auto* nullable_column = down_cast<NullableColumn*>(values);
+        struct_column = down_cast<StructColumn*>(nullable_column->data_column().get());
+    } else {
+        struct_column = down_cast<StructColumn*>(values);
+    }
+
+    // read all fields
+    auto& fields = struct_column->fields_column();
+    size_t row_count = 0;
+    for (int i = 0; i < _field_iters.size(); ++i) {
+        if (_access_flags[i]) {
+            if (fields[i]->is_constant()) {
+                // doesn't meterialized
+                fields[i] = down_cast<ConstColumn*>(fields[i].get())->data_column()->clone_empty();
+                RETURN_IF_ERROR(_field_iters[i]->fetch_values_by_rowid(rowids, size, fields[i].get()));
+            } else {
+                // handle nested struct
+                // structA -> structB -> e (meterialized)
+                //                    -> f (un-meterialized)
+                RETURN_IF_ERROR(_field_iters[i]->fetch_subfield_by_rowid(rowids, size, fields[i].get()));
+            }
+            row_count = fields[i]->size();
+        }
+    }
+
+    for (int i = 0; i < _field_iters.size(); ++i) {
+        if (!_access_flags[i]) {
+            if (!fields[i]->is_constant()) {
+                fields[i]->append_default(1);
+                fields[i] = ConstColumn::create(fields[i], 1);
+            }
+            fields[i]->resize(row_count);
+        }
+    }
     return Status::OK();
 }
 

--- a/be/test/storage/rowset/map_column_rw_test.cpp
+++ b/be/test/storage/rowset/map_column_rw_test.cpp
@@ -210,10 +210,13 @@ protected:
                 ASSERT_TRUE(st.ok());
                 ASSERT_EQ(src_column->size(), rows_read);
 
-                ASSERT_EQ("{NULL:NULL}", dst_column->debug_item(0));
+                ASSERT_TRUE(dst_column->keys_column()->only_null());
+                ASSERT_TRUE(dst_column->values_column()->only_null());
+                ASSERT_EQ("{CONST: NULL:CONST: NULL}", dst_column->debug_item(0));
                 ASSERT_EQ("{}", dst_column->debug_item(1));
-                ASSERT_EQ("{NULL:NULL,NULL:NULL}", dst_column->debug_item(2));
-                ASSERT_EQ("{NULL:NULL,NULL:NULL,NULL:NULL}", dst_column->debug_item(3));
+                ASSERT_EQ("{CONST: NULL:CONST: NULL,CONST: NULL:CONST: NULL}", dst_column->debug_item(2));
+                ASSERT_EQ("{CONST: NULL:CONST: NULL,CONST: NULL:CONST: NULL,CONST: NULL:CONST: NULL}",
+                          dst_column->debug_item(3));
             }
         }
 
@@ -248,10 +251,11 @@ protected:
                 ASSERT_TRUE(st.ok());
                 ASSERT_EQ(src_column->size(), rows_read);
 
-                ASSERT_EQ("{1:NULL}", dst_column->debug_item(0));
+                ASSERT_TRUE(dst_column->values_column()->only_null());
+                ASSERT_EQ("{1:CONST: NULL}", dst_column->debug_item(0));
                 ASSERT_EQ("{}", dst_column->debug_item(1));
-                ASSERT_EQ("{2:NULL,3:NULL}", dst_column->debug_item(2));
-                ASSERT_EQ("{4:NULL,5:NULL,6:NULL}", dst_column->debug_item(3));
+                ASSERT_EQ("{2:CONST: NULL,3:CONST: NULL}", dst_column->debug_item(2));
+                ASSERT_EQ("{4:CONST: NULL,5:CONST: NULL,6:CONST: NULL}", dst_column->debug_item(3));
             }
         }
     }

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -199,7 +199,7 @@ protected:
                 ASSERT_TRUE(st.ok());
                 ASSERT_EQ(src_column->size(), rows_read);
 
-                ASSERT_EQ("{f1:1,f2:''}", dst_column->debug_item(0));
+                ASSERT_EQ("{f1:1,f2:CONST: ''}", dst_column->debug_item(0));
             }
         }
 
@@ -238,7 +238,7 @@ protected:
                 ASSERT_TRUE(st.ok());
                 ASSERT_EQ(src_column->size(), rows_read);
 
-                ASSERT_EQ("{f1:0,f2:'Column2'}", dst_column->debug_item(0));
+                ASSERT_EQ("{f1:CONST: 0,f2:'Column2'}", dst_column->debug_item(0));
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -288,6 +288,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             "enable_rewrite_groupingsets_to_union_all";
 
     public static final String CBO_USE_DB_LOCK = "cbo_use_lock_db";
+    public static final String CBO_PREDICATE_SUBFIELD_PATH = "cbo_enable_predicate_subfield_path";
 
     // --------  New planner session variables end --------
 
@@ -1247,6 +1248,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     private int exprChildrenLimit = -1;
 
+    @VarAttr(name = CBO_PREDICATE_SUBFIELD_PATH, flag = VariableMgr.INVISIBLE)
+    private boolean cboPredicateSubfieldPath = true;
+
     public String getHiveTempStagingDir() {
         return hiveTempStagingDir;
     }
@@ -1254,6 +1258,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public SessionVariable setHiveTempStagingDir(String hiveTempStagingDir) {
         this.hiveTempStagingDir = hiveTempStagingDir;
         return this;
+    }
+
+    public boolean isCboPredicateSubfieldPath() {
+        return cboPredicateSubfieldPath;
     }
 
     public int getExprChildrenLimit() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -658,7 +658,11 @@ public class PlanFragmentBuilder {
         }
 
         // get all column access path, and mark paths which one is predicate used
-        private List<ColumnAccessPath> computeAllColumnAccessPath(PhysicalScanOperator scan) {
+        private List<ColumnAccessPath> computeAllColumnAccessPath(PhysicalScanOperator scan, ExecPlan context) {
+            if (!context.getConnectContext().getSessionVariable().isCboPredicateSubfieldPath()) {
+                return scan.getColumnAccessPaths();
+            }
+
             if (scan.getPredicate() == null) {
                 return scan.getColumnAccessPaths();
             }
@@ -761,7 +765,7 @@ public class PlanFragmentBuilder {
             }
 
             // set column access path
-            scanNode.setColumnAccessPaths(computeAllColumnAccessPath(node));
+            scanNode.setColumnAccessPaths(computeAllColumnAccessPath(node, context));
 
             // set predicate
             List<ScalarOperator> predicates = Utils.extractConjuncts(node.getPredicate());


### PR DESCRIPTION
Fixes #issue

support late materialized on struct column

* Remove append default value on ARRAY/MAP/STRUCT column
* Add fill_subfield_column to support late materialized subfield on struct column
* Only support prune nested struct type, like: `/structA/structB/structC`, can't prune the subfield of `structB`(`/structA/array/structB`), because the interface of `array/map` doesn't support now, `array/map` need flatten rows when fetch values by rowid, it's too complex

Doesn't support on map/array, because only few scenarios when use `MAP_SIZE/ARRAY_LENGTH = xx` as scan predicate 


| SSB | scalar column | struct column before PR | struct column after PR | 
| --- | ---| --- | --- |
| Q01 | 61 | 1098 | 526 |
| Q02 | 17 | 224 | 57 |
| Q03 | 50 | 359 | 269 |
| Q04 | 1330 | 8471 | 6529 |
| Q05 | 416 | 8154 | 6837 |
| Q06 | 175 | 5841 | 4883 |
| Q07 | 1327 | 8431 | 6527 |
| Q08 | 1052 | 6965 | 6199 |
| Q09 | 293 | 3738 | 3108 |
| Q10 | 23 | 78 | 66 |
| Q11 | 1707 | 10353 | 8623 |
| Q12 | 165 | 2287 | 1889 |
| Q13 | 100 | 1726 | 1475 |

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
