### PR TITLE
[Enhancement] support mandatory split distinct group by clause into 4 stage agg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -75,6 +75,10 @@ public class SplitAggregateRule extends TransformationRule {
 
     private static final int TWO_STAGE = 2;
 
+    private static final int THREE_STAGE = 3;
+
+    private static final int FOUR_STAGE = 4;
+
     public static SplitAggregateRule getInstance() {
         return INSTANCE;
     }
@@ -178,6 +182,10 @@ public class SplitAggregateRule extends TransformationRule {
 
 
     private boolean isThreeStageMoreEfficient(OptExpression input, List<ColumnRefOperator> groupKeys) {
+        if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == FOUR_STAGE) {
+            return false;
+        }
+
         Statistics inputStatistics = input.getGroupExpression().inputAt(0).getStatistics();
         Collection<ColumnStatistic> inputsColumnStatistics = inputStatistics.getColumnStatistics().values();
         if (inputsColumnStatistics.stream().anyMatch(ColumnStatistic::isUnknown)) {


### PR DESCRIPTION
Fixes #issue
When setting `new_planner_agg_stage = 4`,  we split distinct group by clause into 4 stage agg no matter what.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
