### PR TITLE
[BugFix] Fix cannot query the system table be_bvars

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeBvarsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeBvarsSystemTable.java
@@ -31,7 +31,7 @@ public class BeBvarsSystemTable {
                 builder()
                         .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT), false)
                         .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN), false)
-                        .column("DESC", ScalarType.createVarchar(NAME_CHAR_LEN), false)
+                        .column("VALUE", ScalarType.createVarchar(NAME_CHAR_LEN), false)
                         .build(), TSchemaTableType.SCH_BE_BVARS);
     }
 }


### PR DESCRIPTION
The column name in BeBvarsSystemTable was changed from "DESC" to "VALUE". The previous name was a reserved keyword that cannot be queried.

Fixes #28246 

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
