### PR TITLE
[BugFix] Remove prune subfield check on unequals join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.optimizer.rule.tree.prunesubfield;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -233,7 +232,7 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
                 join.getOnPredicate().accept(collector, null);
                 for (ScalarOperator expr : collector.getComplexExpressions()) {
                     // the expression in on-predicate must was push down to children
-                    Preconditions.checkState(expr.isColumnRef());
+                    // Preconditions.checkState(expr.isColumnRef());
                     checkColumns.union(expr.getUsedColumns());
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -587,4 +587,16 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "  0:OlapScanNode");
         assertContains(plan, "ColumnAccessPath: [/st1/s1]");
     }
+
+    @Test
+    public void testNoEqualsJoin() throws Exception {
+        String sql = "select st2.s2, st4.ss3.s31 from t0" +
+                " left join " +
+                "sc0 x on x.st3.s1 + 1 >= t0.v1 + 2";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  5:NESTLOOP JOIN\n" +
+                "  |  join op: RIGHT OUTER JOIN\n" +
+                "  |  other join predicates: cast(6: st3.s1 as BIGINT) + 1 >= [1: v1, BIGINT, true] + 2");
+        assertContains(plan, "ColumnAccessPath: [/st2/s2, /st4/ss3/s31]");
+    }
 }


### PR DESCRIPTION
Fixes #issue

Remove a check of pruneSubfieldRule, the reason is unequals on-predicate doesn't push to children, will fix the question in other PR

like SQL:
```
MySQL test> explain select x.v1 from sc3 x join sc3 y on x.array[1] >= y.array[2]
(1064, 'Unknown error')
MySQL test>
```

the plan:
```
........
|   |  <slot 1> : 1: v1                           |
|   |                                             |
|   3:NESTLOOP JOIN                               |
|   |  join op: INNER JOIN                        |
|   |  colocate: false, reason:                   |
|   |  other join predicates: 2: a1[1] > 8: a1[2] |
|   |                                             |
|   |----2:EXCHANGE                               |
|   |                                             |
|   0:OlapScanNode
.......
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
