### PR TITLE
[Enhancement] Fix StructColumn::byte_size memory estimation error

### DIFF
--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -205,7 +205,7 @@ public:
     size_t byte_size(size_t from, size_t size) const override {
         materialized_nullable();
         DCHECK_LE(from + size, this->size()) << "Range error";
-        return _data_column->byte_size(from, size) + _null_column->Column::byte_size(from, size);
+        return _data_column->byte_size(from, size) + _null_column->byte_size(from, size);
     }
 
     size_t byte_size(size_t idx) const override {

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -61,7 +61,7 @@ size_t ArrayColumn::byte_size(size_t from, size_t size) const {
     DCHECK_LE(from + size, this->size()) << "Range error";
     return _elements->byte_size(_offsets->get_data()[from],
                                 _offsets->get_data()[from + size] - _offsets->get_data()[from]) +
-           _offsets->Column::byte_size(from, size);
+           _offsets->byte_size(from, size);
 }
 
 size_t ArrayColumn::byte_size(size_t idx) const {

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -116,13 +116,7 @@ public:
 
     // Size of column data in memory (may be approximate). Zero, if could not be determined.
     virtual size_t byte_size() const = 0;
-    virtual size_t byte_size(size_t from, size_t size) const {
-        DCHECK_LE(from + size, this->size()) << "Range error";
-        if (empty()) {
-            return 0;
-        }
-        return byte_size() * size / this->size();
-    }
+    virtual size_t byte_size(size_t from, size_t size) const = 0;
 
     // The byte size for serialize, for varchar, we need to add the len byte size
     virtual size_t byte_size(size_t idx) const = 0;

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -94,6 +94,11 @@ public:
 
     size_t byte_size(size_t idx __attribute__((unused))) const override { return sizeof(ValueType); }
 
+    size_t byte_size(size_t from, size_t size) const override {
+        DCHECK_LE(from + size, this->size()) << "Range error";
+        return sizeof(ValueType) * size;
+    }
+
     void reserve(size_t n) override { _data.reserve(n); }
 
     void resize(size_t n) override { _data.resize(n); }

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -50,8 +50,6 @@ public:
     uint32_t serialize(size_t idx, uint8_t* pos) override;
     void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
                          uint32_t max_one_row_size) override;
-
-private:
 };
 
 } // namespace starrocks

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -72,7 +72,7 @@ size_t MapColumn::byte_size(size_t from, size_t size) const {
                             _offsets->get_data()[from + size] - _offsets->get_data()[from]) +
            _values->byte_size(_offsets->get_data()[from],
                               _offsets->get_data()[from + size] - _offsets->get_data()[from]) +
-           _offsets->Column::byte_size(from, size);
+           _offsets->byte_size(from, size);
 }
 
 size_t MapColumn::byte_size(size_t idx) const {

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -104,7 +104,7 @@ public:
 
     size_t byte_size(size_t from, size_t size) const override {
         DCHECK_LE(from + size, this->size()) << "Range error";
-        return _data_column->byte_size(from, size) + _null_column->Column::byte_size(from, size);
+        return _data_column->byte_size(from, size) + _null_column->byte_size(from, size);
     }
 
     size_t byte_size(size_t idx) const override { return _data_column->byte_size(idx) + sizeof(bool); }

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -54,6 +54,15 @@ size_t StructColumn::byte_size() const {
     return total_size;
 }
 
+size_t StructColumn::byte_size(size_t from, size_t size) const {
+    DCHECK_LE(from + size, this->size()) << "Range error";
+    size_t total_size = 0;
+    for (const auto& column : _fields) {
+        total_size += column->byte_size(from, size);
+    }
+    return total_size;
+}
+
 size_t StructColumn::byte_size(size_t idx) const {
     size_t total_size = 0;
     for (const auto& column : _fields) {

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -82,6 +82,8 @@ public:
 
     size_t byte_size(size_t idx) const override;
 
+    size_t byte_size(size_t from, size_t size) const override;
+
     void reserve(size_t n) override;
 
     void resize(size_t n) override;

--- a/be/test/column/struct_column_test.cpp
+++ b/be/test/column/struct_column_test.cpp
@@ -23,87 +23,46 @@
 
 namespace starrocks {
 
-TEST(StructColumnTest, test_create) {
+std::shared_ptr<StructColumn> create_test_column() {
     std::vector<std::string> field_name{"id", "name"};
     auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
     auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
     Columns fields{id, name};
     auto column = StructColumn::create(fields, field_name);
 
-    ASSERT_TRUE(column->is_struct());
-    ASSERT_FALSE(column->is_nullable());
-    ASSERT_EQ(0, column->size());
-
     DatumStruct struct1{uint64_t(1), Slice("smith")};
     DatumStruct struct2{uint64_t(2), Slice("cruise")};
     column->append_datum(struct1);
     column->append_datum(struct2);
 
-    ASSERT_EQ(column->size(), 2);
-    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
+    return column;
+}
 
-    ASSERT_EQ("{id:1,name:'smith'}, {id:2,name:'cruise'}", column->debug_string());
+TEST(StructColumnTest, test_create) {
+    auto col = create_test_column();
+
+    ASSERT_EQ(col->size(), 2);
+    ASSERT_EQ("{id:1,name:'smith'}", col->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", col->debug_item(1));
+
+    ASSERT_EQ("{id:1,name:'smith'}, {id:2,name:'cruise'}", col->debug_string());
 }
 
 TEST(StructColumnTest, test_update_if_overflow) {
-    {
-        std::vector<std::string> field_name{"id", "name"};
-        auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-        auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-        Columns fields{id, name};
-        auto column = StructColumn::create(fields, field_name);
+    auto col = create_test_column();
 
-        DatumStruct struct1{uint64_t(1), Slice("smith")};
-        DatumStruct struct2{uint64_t(2), Slice("cruise")};
-        column->append_datum(struct1);
-        column->append_datum(struct2);
-
-        // it does not upgrade because of not overflow
-        auto ret = column->upgrade_if_overflow();
-        ASSERT_TRUE(ret.ok());
-        ASSERT_TRUE(ret.value() == nullptr);
-    }
-
-    {
-        /*
-         * require too much of time, comment it.
-        auto field_name = BinaryColumn::create();
-        field_name->append_string("id");
-        field_name->append_string("name");
-        auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-        auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-        Columns fields{id, name};
-        auto column = StructColumn::create(fields, field_name);
-
-        size_t item_count = 1 << 30;
-        for (size_t i = 0; i < item_count; i++) {
-            column->append_datum(DatumStruct{i, Slice("smith")});
-        }
-
-        auto ret = column->upgrade_if_overflow();
-        ASSERT_TRUE(ret.ok());
-        ASSERT_TRUE(ret.value() == nullptr);
-        ASSERT_TRUE(column->has_large_column());
-         */
-    }
+    // it does not upgrade because of not overflow
+    auto ret = col->upgrade_if_overflow();
+    ASSERT_TRUE(ret.ok());
+    ASSERT_TRUE(ret.value() == nullptr);
 }
 
 TEST(StructColumnTest, test_column_downgrade) {
     {
-        std::vector<std::string> field_name{"id", "name"};
-        auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-        auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-        Columns fields{id, name};
-        auto column = StructColumn::create(fields, field_name);
+        auto col = create_test_column();
 
-        DatumStruct struct1{uint64_t(1), Slice("smith")};
-        DatumStruct struct2{uint64_t(2), Slice("cruise")};
-        column->append_datum(struct1);
-        column->append_datum(struct2);
-
-        ASSERT_FALSE(column->has_large_column());
-        auto ret = column->downgrade();
+        ASSERT_FALSE(col->has_large_column());
+        auto ret = col->downgrade();
         ASSERT_TRUE(ret.ok());
         ASSERT_TRUE(ret.value() == nullptr);
     }
@@ -234,44 +193,32 @@ TEST(StructColumnTest, equals) {
     ASSERT_TRUE(lhs->equals(3, *rhs, 3));
 }
 
+TEST(StructColumnTest, test_byte_size) {
+    auto col = create_test_column();
+
+    ASSERT_EQ(sizeof(uint64_t) * 2 + sizeof(BinaryColumn::Offset) * 3 + 11, col->byte_size());
+    ASSERT_EQ(sizeof(uint64_t) + sizeof(BinaryColumn::Offset) + 6, col->byte_size(1, 1));
+    ASSERT_EQ(sizeof(uint64_t) + sizeof(BinaryColumn::Offset) + 5, col->byte_size(0));
+}
+
 TEST(StructColumnTest, test_resize) {
-    std::vector<std::string> field_name{"id", "name"};
-    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    Columns fields{id, name};
-    auto column = StructColumn::create(fields, field_name);
+    auto col = create_test_column();
 
-    DatumStruct struct1{uint64_t(1), Slice("smith")};
-    DatumStruct struct2{uint64_t(2), Slice("cruise")};
-    column->append_datum(struct1);
-    column->append_datum(struct2);
+    ASSERT_EQ(2, col->size());
 
-    ASSERT_EQ(2, column->size());
+    col->resize(1);
 
-    column->resize(1);
-
-    ASSERT_EQ(1, column->size());
-    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
+    ASSERT_EQ(1, col->size());
+    ASSERT_EQ("{id:1,name:'smith'}", col->debug_item(0));
 }
 
 TEST(StructColumnTest, test_reset_column) {
-    std::vector<std::string> field_name{"id", "name"};
-    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    Columns fields{id, name};
-    auto column = StructColumn::create(fields, field_name);
+    auto col = create_test_column();
 
-    DatumStruct struct1{uint64_t(1), Slice("smith")};
-    DatumStruct struct2{uint64_t(2), Slice("cruise")};
-    column->append_datum(struct1);
-    column->append_datum(struct2);
+    col->reset_column();
 
-    ASSERT_EQ(2, column->size());
-
-    column->reset_column();
-
-    ASSERT_EQ(0, column->size());
-    for (const auto& subfield : column->fields()) {
+    ASSERT_EQ(0, col->size());
+    for (const auto& subfield : col->fields()) {
         ASSERT_EQ(0, subfield->size());
     }
 }
@@ -316,31 +263,15 @@ TEST(StructColumnTest, test_swap_column) {
 }
 
 TEST(StructColumnTest, test_copy_construtor) {
-    std::vector<std::string> field_name{"id", "name"};
-    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    auto column = StructColumn::create(Columns{id, name}, field_name);
+    auto col = create_test_column();
 
-    // delete reference
-    id = nullptr;
-    name = nullptr;
+    ASSERT_EQ(col->size(), 2);
+    ASSERT_EQ("{id:1,name:'smith'}", col->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", col->debug_item(1));
 
-    ASSERT_TRUE(column->is_struct());
-    ASSERT_FALSE(column->is_nullable());
-    ASSERT_EQ(0, column->size());
-
-    DatumStruct struct1{uint64_t(1), Slice("smith")};
-    DatumStruct struct2{uint64_t(2), Slice("cruise")};
-    column->append_datum(struct1);
-    column->append_datum(struct2);
-
-    ASSERT_EQ(column->size(), 2);
-    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
-
-    StructColumn copy(*column);
-    column->reset_column();
-    ASSERT_EQ(0, column->size());
+    StructColumn copy(*col);
+    col->reset_column();
+    ASSERT_EQ(0, col->size());
     ASSERT_EQ(2, copy.size());
     ASSERT_EQ("{id:1,name:'smith'}", copy.debug_item(0));
     ASSERT_EQ("{id:2,name:'cruise'}", copy.debug_item(1));
@@ -350,29 +281,13 @@ TEST(StructColumnTest, test_copy_construtor) {
 }
 
 TEST(StructColumnTest, test_move_construtor) {
-    std::vector<std::string> field_name{"id", "name"};
-    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    auto column = StructColumn::create(Columns{id, name}, field_name);
+    auto col = create_test_column();
 
-    // delete reference
-    id = nullptr;
-    name = nullptr;
+    ASSERT_EQ(col->size(), 2);
+    ASSERT_EQ("{id:1,name:'smith'}", col->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", col->debug_item(1));
 
-    ASSERT_TRUE(column->is_struct());
-    ASSERT_FALSE(column->is_nullable());
-    ASSERT_EQ(0, column->size());
-
-    DatumStruct struct1{uint64_t(1), Slice("smith")};
-    DatumStruct struct2{uint64_t(2), Slice("cruise")};
-    column->append_datum(struct1);
-    column->append_datum(struct2);
-
-    ASSERT_EQ(column->size(), 2);
-    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
-
-    StructColumn copy(std::move(*column));
+    StructColumn copy(std::move(*col));
     ASSERT_EQ(2, copy.size());
     ASSERT_EQ("{id:1,name:'smith'}", copy.debug_item(0));
     ASSERT_EQ("{id:2,name:'cruise'}", copy.debug_item(1));
@@ -382,30 +297,14 @@ TEST(StructColumnTest, test_move_construtor) {
 }
 
 TEST(StructColumnTest, test_clone) {
-    std::vector<std::string> field_name{"id", "name"};
-    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    auto column = StructColumn::create(Columns{id, name}, field_name);
+    auto col = create_test_column();
 
-    // delete reference
-    id = nullptr;
-    name = nullptr;
+    ASSERT_EQ(col->size(), 2);
+    ASSERT_EQ("{id:1,name:'smith'}", col->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", col->debug_item(1));
 
-    ASSERT_TRUE(column->is_struct());
-    ASSERT_FALSE(column->is_nullable());
-    ASSERT_EQ(0, column->size());
-
-    DatumStruct struct1{uint64_t(1), Slice("smith")};
-    DatumStruct struct2{uint64_t(2), Slice("cruise")};
-    column->append_datum(struct1);
-    column->append_datum(struct2);
-
-    ASSERT_EQ(column->size(), 2);
-    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
-
-    auto copy = column->clone();
-    column->reset_column();
+    auto copy = col->clone();
+    col->reset_column();
     ASSERT_EQ(2, copy->size());
     ASSERT_EQ("{id:1,name:'smith'}", copy->debug_item(0));
     ASSERT_EQ("{id:2,name:'cruise'}", copy->debug_item(1));
@@ -415,30 +314,14 @@ TEST(StructColumnTest, test_clone) {
 }
 
 TEST(StructColumnTest, test_clone_shared) {
-    std::vector<std::string> field_name{"id", "name"};
-    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    auto column = StructColumn::create(Columns{id, name}, field_name);
+    auto col = create_test_column();
 
-    // delete reference
-    id = nullptr;
-    name = nullptr;
+    ASSERT_EQ(col->size(), 2);
+    ASSERT_EQ("{id:1,name:'smith'}", col->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", col->debug_item(1));
 
-    ASSERT_TRUE(column->is_struct());
-    ASSERT_FALSE(column->is_nullable());
-    ASSERT_EQ(0, column->size());
-
-    DatumStruct struct1{uint64_t(1), Slice("smith")};
-    DatumStruct struct2{uint64_t(2), Slice("cruise")};
-    column->append_datum(struct1);
-    column->append_datum(struct2);
-
-    ASSERT_EQ(column->size(), 2);
-    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
-
-    auto copy = column->clone_shared();
-    column->reset_column();
+    auto copy = col->clone_shared();
+    col->reset_column();
     ASSERT_EQ(2, copy->size());
     ASSERT_EQ("{id:1,name:'smith'}", copy->debug_item(0));
     ASSERT_EQ("{id:2,name:'cruise'}", copy->debug_item(1));
@@ -448,30 +331,14 @@ TEST(StructColumnTest, test_clone_shared) {
 }
 
 TEST(StructColumnTest, test_clone_empty) {
-    std::vector<std::string> field_name{"id", "name"};
-    auto id = NullableColumn::create(UInt64Column::create(), NullColumn::create());
-    auto name = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
-    auto column = StructColumn::create(Columns{id, name}, field_name);
+    auto col = create_test_column();
 
-    // delete reference
-    id = nullptr;
-    name = nullptr;
+    ASSERT_EQ(2, col->size());
+    ASSERT_EQ("{id:1,name:'smith'}", col->debug_item(0));
+    ASSERT_EQ("{id:2,name:'cruise'}", col->debug_item(1));
 
-    ASSERT_TRUE(column->is_struct());
-    ASSERT_FALSE(column->is_nullable());
-    ASSERT_EQ(0, column->size());
-
-    DatumStruct struct1{uint64_t(1), Slice("smith")};
-    DatumStruct struct2{uint64_t(2), Slice("cruise")};
-    column->append_datum(struct1);
-    column->append_datum(struct2);
-
-    ASSERT_EQ(2, column->size());
-    ASSERT_EQ("{id:1,name:'smith'}", column->debug_item(0));
-    ASSERT_EQ("{id:2,name:'cruise'}", column->debug_item(1));
-
-    auto copy = column->clone_empty();
-    column->reset_column();
+    auto copy = col->clone_empty();
+    col->reset_column();
     ASSERT_EQ(0, copy->size());
 
     ASSERT_TRUE(down_cast<StructColumn*>(copy.get())->fields().at(0).unique());

--- a/be/test/column/struct_column_test.cpp
+++ b/be/test/column/struct_column_test.cpp
@@ -196,9 +196,9 @@ TEST(StructColumnTest, equals) {
 TEST(StructColumnTest, test_byte_size) {
     auto col = create_test_column();
 
-    ASSERT_EQ(sizeof(uint64_t) * 2 + sizeof(BinaryColumn::Offset) * 3 + 11, col->byte_size());
-    ASSERT_EQ(sizeof(uint64_t) + sizeof(BinaryColumn::Offset) + 6, col->byte_size(1, 1));
-    ASSERT_EQ(sizeof(uint64_t) + sizeof(BinaryColumn::Offset) + 5, col->byte_size(0));
+    ASSERT_EQ(sizeof(uint64_t) * 2 + sizeof(BinaryColumn::Offset) * 2 + 11 + 2, col->byte_size());
+    ASSERT_EQ(sizeof(uint64_t) + sizeof(BinaryColumn::Offset) + 6 + 2, col->byte_size(1, 1));
+    ASSERT_EQ(sizeof(uint64_t) + sizeof(BinaryColumn::Offset) + 5 + 2, col->byte_size(0));
 }
 
 TEST(StructColumnTest, test_resize) {

--- a/be/test/column/struct_column_test.cpp
+++ b/be/test/column/struct_column_test.cpp
@@ -196,7 +196,7 @@ TEST(StructColumnTest, equals) {
 TEST(StructColumnTest, test_byte_size) {
     auto col = create_test_column();
 
-    ASSERT_EQ(sizeof(uint64_t) * 2 + sizeof(BinaryColumn::Offset) * 2 + 11 + 2, col->byte_size());
+    ASSERT_EQ(sizeof(uint64_t) * 2 + sizeof(BinaryColumn::Offset) * 2 + 11 + 2 * 2, col->byte_size());
     ASSERT_EQ(sizeof(uint64_t) + sizeof(BinaryColumn::Offset) + 6 + 2, col->byte_size(1, 1));
     ASSERT_EQ(sizeof(uint64_t) + sizeof(BinaryColumn::Offset) + 5 + 2, col->byte_size(0));
 }


### PR DESCRIPTION
Fixes #issue

If there are variable length types such as strings in StructColumn, the old estimation method is not accurate.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
