### PR TITLE
[BugFix] fix hms version issue when creating iceberg table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -621,6 +621,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             // Using get_table() first, if user's Hive forbidden this request,
             // then fail over to use get_table_req() instead.
             return client.get_table(dbName, tableName);
+        } catch (NoSuchObjectException e) {
+            // NoSuchObjectException need to be thrown when creating iceberg table.
+            LOG.warn("Failed to get table {}.{}", dbName, tableName, e);
+            throw e;
         } catch (Exception e) {
             LOG.warn("Using get_table() failed, fail over to use get_table_req()", e);
             GetTableRequest req = new GetTableRequest(dbName, tableName);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreClientTest.java
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive;
+
+import com.starrocks.common.ExceptionChecker;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
+import org.apache.thrift.TException;
+import org.apache.thrift.transport.TSocket;
+import org.junit.Test;
+
+public class HiveMetastoreClientTest {
+    @Test
+    public void testGetTableError(@Mocked ThriftHiveMetastore.Iface client) throws TException {
+        new MockUp<TSocket>() {
+            @Mock
+            public boolean isOpen() {
+                return true;
+            }
+        };
+
+        new MockUp<ThriftHiveMetastore.Client>() {
+            @Mock
+            Table get_table(String dbName, String tblName) throws NoSuchObjectException {
+                throw new NoSuchObjectException("Table not found");
+            }
+        };
+
+        Configuration configuration = new HiveConf();
+        configuration.set("metastore.thrift.uris", "thrift://127.0.0.1:1234");
+        HiveMetaStoreClient metaStoreClient = new HiveMetaStoreClient(configuration);
+        ExceptionChecker.expectThrowsWithMsg(NoSuchObjectException.class,
+                "Table not found",
+                () -> metaStoreClient.getTable("db", "table"));
+    }
+}


### PR DESCRIPTION
Fixes #issue

We use low hms version api `get_table` instread of high version api `get_table_req` for compatibility with all hms versions.
In the pr https://github.com/StarRocks/starrocks/pull/19260 we use the `get_table_req` as failedCallback api. But iceberg api need to catch the NoSuchObjectException when creating iceberg table according to the https://github.com/apache/iceberg/blob/master/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L163C1-L163C1. If the user hms doens't support high level api `get_table_req`, NoSuchObjectException will be replaced by MethodNotSuppportException. So we need to catch the NoSuchObjectException alone and throw it.



## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
