### PR TITLE
[BugFix] Support push down on-predicate subfield

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
@@ -90,6 +90,11 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
                                                            ColumnRefSet checkColumns) {
             LogicalOperator operator = optExpression.getOp().cast();
             ScalarOperator predicate = operator.getPredicate();
+            return pushDownExpression(predicate, context, checkColumns);
+        }
+
+        private Optional<ScalarOperator> pushDownExpression(ScalarOperator predicate, Context context,
+                                                            ColumnRefSet checkColumns) {
             if (predicate == null) {
                 return Optional.empty();
             }
@@ -112,7 +117,7 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
                 context.put(index, expr);
             }
 
-            // rewrite join predicate
+            // rewrite predicate
             if (needRewritePredicate) {
                 ExpressionReplacer replacer = new ExpressionReplacer(context.pushDownExprRefsIndex);
                 ScalarOperator newPredicate = predicate.accept(replacer, null);
@@ -227,22 +232,28 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
             ColumnRefSet checkColumns = new ColumnRefSet();
 
             // check on-predicate used columns
+            Optional<ScalarOperator> onPredicate = Optional.empty();
             if (join.getOnPredicate() != null) {
                 SubfieldExpressionCollector collector = new SubfieldExpressionCollector();
                 join.getOnPredicate().accept(collector, null);
                 for (ScalarOperator expr : collector.getComplexExpressions()) {
                     // the expression in on-predicate must was push down to children
-                    // Preconditions.checkState(expr.isColumnRef());
-                    checkColumns.union(expr.getUsedColumns());
+                    if (expr.isColumnRef()) {
+                        checkColumns.union(expr.getUsedColumns());
+                    }
                 }
+
+                onPredicate = pushDownExpression(join.getOnPredicate(), context, checkColumns);
             }
 
             // handle predicate
             Optional<ScalarOperator> predicate = pushDownPredicate(optExpression, context, checkColumns);
-            if (predicate.isPresent()) {
-                join = LogicalJoinOperator.builder().withOperator(join)
-                        .setOnPredicate(predicate.get())
-                        .build();
+            if (predicate.isPresent() || onPredicate.isPresent()) {
+                LogicalJoinOperator.Builder builder = LogicalJoinOperator.builder().withOperator(join);
+                predicate.ifPresent(builder::setPredicate);
+                onPredicate.ifPresent(builder::setOnPredicate);
+
+                join = builder.build();
                 optExpression = OptExpression.create(join, optExpression.getInputs());
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.plan;
 
 import com.starrocks.catalog.Database;
@@ -2761,7 +2760,7 @@ public class JoinTest extends PlanTestBase {
                 "  PARTITION: HASH_PARTITIONED: 2: v2\n" +
                 "\n" +
                 "  RESULT SINK");
-        
+
         try {
             connectContext.getSessionVariable().setPreferComputeNode(true);
             plan = getFragmentPlan(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -596,7 +596,20 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         String plan = getVerboseExplain(sql);
         assertContains(plan, "  5:NESTLOOP JOIN\n" +
                 "  |  join op: RIGHT OUTER JOIN\n" +
-                "  |  other join predicates: cast(6: st3.s1 as BIGINT) + 1 >= [1: v1, BIGINT, true] + 2");
-        assertContains(plan, "ColumnAccessPath: [/st2/s2, /st4/ss3/s31]");
+                "  |  other join predicates: cast([14: expr, INT, true] as BIGINT) + 1 >= [1: v1, BIGINT, true] + 2");
+        assertContains(plan, "ColumnAccessPath: [/st2/s2, /st3/s1, /st4/ss3/s31]");
+    }
+
+    @Test
+    public void testNoEqualsJoinHaving() throws Exception {
+        String sql = "select st2.s2, st4.ss3.s31 from t0" +
+                " left join " +
+                "sc0 x on x.st3.s1 + 1 >= t0.v1 + 2 where x.st1.s2 = 2";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  5:NESTLOOP JOIN\n" +
+                "  |  join op: RIGHT OUTER JOIN\n" +
+                "  |  other join predicates: cast([14: expr, INT, true] as BIGINT) + 1 >= [1: v1, BIGINT, true] + 2\n" +
+                "  |  other predicates: [15: expr, INT, true] = 2");
+        assertContains(plan, "ColumnAccessPath: [/st1/s2, /st2/s2, /st3/s1, /st4/ss3/s31]");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/pull/28273

The previous PR will prevent the subfield expression to pushed down by check the expression in the on-predicate, but it's will cause the subfield expression to be lost in some cases

This PR will push the subfield expression(in on-predicate) to the children of join, and fix set predicate error bug



## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
