### PR TITLE
[Enhancement] Restrict mem size of one chunk

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -595,6 +595,9 @@ CONF_Bool(ignore_rowset_stale_unconsistent_delete, "false");
 // The chunk size for vector query engine
 CONF_Int32(vector_chunk_size, "4096");
 
+// Mem limit for single chunk
+CONF_Int64(chunk_mem_size, "33554432");
+
 // Valid range: [0-1000].
 // `0` will disable late materialization.
 // `1000` will enable late materialization always.


### PR DESCRIPTION
Fixes #issue

In the current exchange framework, a `Chunk` will be cached until 4096 lines before being sent. The actual memory size used is: number of BEs * Dop. For the large data type such as `Bitmap`, 1 row will be relatively large and will take up a lot of memory.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
