### PR TITLE
[Refactor] Change the log level of varchar length exceed limit

### DIFF
--- a/be/src/formats/csv/string_converter.cpp
+++ b/be/src/formats/csv/string_converter.cpp
@@ -15,6 +15,7 @@
 #include "formats/csv/string_converter.h"
 
 #include "column/binary_column.h"
+#include "gutil/strings/substitute.h"
 #include "runtime/descriptors.h"
 #include "runtime/types.h"
 
@@ -59,7 +60,8 @@ bool StringConverter::read_string(Column* column, Slice s, const Options& option
     }
 
     if (UNLIKELY((s.size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && s.size > max_size))) {
-        LOG(WARNING) << "Column [" << column->get_name() << "]'s length exceed max varchar length.";
+        VLOG(3) << strings::Substitute("Column [$0]'s length exceed max varchar length. str_size($1), max_size($2)",
+                                       column->get_name(), s.size, max_size);
         return false;
     }
     down_cast<BinaryColumn*>(column)->append(s);
@@ -104,7 +106,10 @@ bool StringConverter::read_quoted_string(Column* column, Slice s, const Options&
     size_t ext_size = new_size - old_size;
     if (UNLIKELY((ext_size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && ext_size > max_size))) {
         bytes.resize(old_size);
-        LOG(WARNING) << "Column [" << column->get_name() << "]'s length exceed max varchar length.";
+        VLOG(3) << strings::Substitute(
+                "Column [$0]'s length exceed max varchar length. old_size($1), new_size($2), ext_size($3), "
+                "max_size($4)",
+                column->get_name(), old_size, new_size, ext_size, max_size);
         return false;
     }
     offsets.push_back(bytes.size());


### PR DESCRIPTION
Fixes #issue

Change log level to VLOG

Before change:

```
W0731 15:38:23.014871 100302 string_converter.cpp:62] Column [binary]'s length exceed max varchar length.
```

After change:

```
I0731 16:05:00.604197 84989 string_converter.cpp:63] Column [binary]'s length exceed max varchar length. str_size(9), max_size(5)
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
