### PR TITLE
[BugFix] Hung on desctructor of librdkafka consumer

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -358,6 +358,7 @@ echo "Finished patching $GPERFTOOLS_SOURCE"
 cd $TP_SOURCE_DIR/$LIBRDKAFKA_SOURCE
 if [ ! -f $PATCHED_MARK ] && [ $LIBRDKAFKA_SOURCE = "librdkafka-2.0.2" ]; then
     patch -p0 < $TP_PATCH_DIR/librdkafka.patch
+    patch -p0 < $TP_PATCH_DIR/librdkafka-v2.0.2-broker-terminating.patch
     touch $PATCHED_MARK
 fi
 cd -

--- a/thirdparty/patches/librdkafka-v2.0.2-broker-terminating.patch
+++ b/thirdparty/patches/librdkafka-v2.0.2-broker-terminating.patch
@@ -1,0 +1,13 @@
+diff --git a/src/rdkafka_broker.c b/src/rdkafka_broker.c
+index a32d08d2..cf412440 100644
+--- a/src/rdkafka_broker.c
++++ b/src/rdkafka_broker.c
+@@ -4397,7 +4397,7 @@ static int rd_kafka_broker_thread_main(void *arg) {
+ 
+         rd_rkb_dbg(rkb, BROKER, "BRKMAIN", "Enter main broker thread");
+ 
+-        while (!rd_kafka_broker_terminating(rkb)) {
++        while (!rd_kafka_broker_terminating(rkb) && rd_kafka_terminating(rkb)) {
+                 int backoff;
+                 int r;
+                 rd_kafka_broker_state_t orig_state;


### PR DESCRIPTION
Fixes #issue
When the kafka broker break down, the rdkafka consumer may get stuck on desctructor.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
