### PR TITLE
[Feature] create and drop hive database in the hive catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
@@ -41,7 +41,9 @@ public class DeltaLakeMetadataFactory {
 
     public DeltaLakeMetadata create() {
         HiveMetastoreOperations hiveMetastoreOperations = new HiveMetastoreOperations(
-                createQueryLevelInstance(metastore, perQueryMetastoreMaxNum), metastore instanceof CachingHiveMetastore);
+                createQueryLevelInstance(metastore, perQueryMetastoreMaxNum),
+                metastore instanceof CachingHiveMetastore,
+                hdfsEnvironment.getConfiguration());
 
         return new DeltaLakeMetadata(hdfsEnvironment.getConfiguration(), catalogName, hiveMetastoreOperations);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -180,6 +180,24 @@ public class CachingHiveMetastore implements IHiveMetastore {
         return metastore.getAllDatabaseNames();
     }
 
+    @Override
+    public void createDb(String dbName, Map<String, String> properties) {
+        try {
+            metastore.createDb(dbName, properties);
+        } finally {
+            invalidateDatabase(dbName);
+        }
+    }
+
+    @Override
+    public void dropDb(String dbName, boolean deleteData) {
+        try {
+            metastore.dropDb(dbName, deleteData);
+        } finally {
+            invalidateDatabase(dbName);
+        }
+    }
+
     public List<String> getAllTableNames(String dbName) {
         return get(tableNamesCache, dbName);
     }
@@ -504,6 +522,11 @@ public class CachingHiveMetastore implements IHiveMetastore {
         partitionCache.invalidateAll();
         tableStatsCache.invalidateAll();
         partitionStatsCache.invalidateAll();
+    }
+
+    public synchronized void invalidateDatabase(String dbName) {
+        databaseCache.invalidate(dbName);
+        databaseNamesCache.invalidateAll();
     }
 
     public synchronized void invalidateTable(String dbName, String tableName) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
@@ -49,7 +49,7 @@ public class HiveConnector implements Connector {
         this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
         this.internalMgr = new HiveConnectorInternalMgr(catalogName, properties, hdfsEnvironment);
-        this.metadataFactory = createMetadataFactory();
+        this.metadataFactory = createMetadataFactory(hdfsEnvironment);
         validate();
         onCreate();
     }
@@ -72,7 +72,7 @@ public class HiveConnector implements Connector {
         return metadataFactory.create();
     }
 
-    private HiveMetadataFactory createMetadataFactory() {
+    private HiveMetadataFactory createMetadataFactory(HdfsEnvironment hdfsEnvironment) {
         IHiveMetastore metastore = internalMgr.createHiveMetastore();
         RemoteFileIO remoteFileIO = internalMgr.createRemoteFileIO();
 
@@ -84,7 +84,8 @@ public class HiveConnector implements Connector {
                 internalMgr.getRemoteFileConf(),
                 internalMgr.getPullRemoteFileExecutor(),
                 internalMgr.isSearchRecursive(),
-                internalMgr.enableHmsEventsIncrementalSync()
+                internalMgr.enableHmsEventsIncrementalSync(),
+                hdfsEnvironment.getConfiguration()
         );
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -178,6 +178,20 @@ public class HiveMetaClient {
         }
     }
 
+    public void createDatabase(Database database) {
+        Class<?>[] argClasses = {Database.class};
+
+        try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.createDatabase")) {
+            callRPC("createDatabase", "Failed to create database " + database.getName(), argClasses, database);
+        }
+    }
+
+    public void dropDatabase(String dbName, boolean deleteData) {
+        try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.dropDatabase")) {
+            callRPC("dropDatabase", "Failed to drop database " + dbName, dbName, deleteData, false, false);
+        }
+    }
+
     public List<String> getAllTableNames(String dbName) {
         try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("HMS.getAllTables")) {
             return callRPC("getAllTables", "Failed to get all table names on database: " + dbName, dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
@@ -19,6 +19,7 @@ import com.starrocks.connector.CachingRemoteFileConf;
 import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.RemoteFileIO;
 import com.starrocks.connector.RemoteFileOperations;
+import org.apache.hadoop.conf.Configuration;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -34,6 +35,7 @@ public class HiveMetadataFactory {
     private final ExecutorService pullRemoteFileExecutor;
     private final boolean isRecursive;
     private final boolean enableHmsEventsIncrementalSync;
+    private final Configuration configuration;
 
     public HiveMetadataFactory(String catalogName,
                                IHiveMetastore metastore,
@@ -42,7 +44,8 @@ public class HiveMetadataFactory {
                                CachingRemoteFileConf fileConf,
                                ExecutorService pullRemoteFileExecutor,
                                boolean isRecursive,
-                               boolean enableHmsEventsIncrementalSync) {
+                               boolean enableHmsEventsIncrementalSync,
+                               Configuration configuration) {
         this.catalogName = catalogName;
         this.metastore = metastore;
         this.remoteFileIO = remoteFileIO;
@@ -51,11 +54,14 @@ public class HiveMetadataFactory {
         this.pullRemoteFileExecutor = pullRemoteFileExecutor;
         this.isRecursive = isRecursive;
         this.enableHmsEventsIncrementalSync = enableHmsEventsIncrementalSync;
+        this.configuration = configuration;
     }
 
     public HiveMetadata create() {
         HiveMetastoreOperations hiveMetastoreOperations = new HiveMetastoreOperations(
-                createQueryLevelInstance(metastore, perQueryMetastoreMaxNum), metastore instanceof CachingHiveMetastore);
+                createQueryLevelInstance(metastore, perQueryMetastoreMaxNum),
+                metastore instanceof CachingHiveMetastore,
+                configuration);
         RemoteFileOperations remoteFileOperations = new RemoteFileOperations(
                 CachingRemoteFileIO.createQueryLevelInstance(remoteFileIO, perQueryCacheRemotePathMaxNum),
                 pullRemoteFileExecutor,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveMetaStoreTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.connector.ConnectorTableId;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.events.MetastoreNotificationFetchException;
@@ -41,6 +42,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.starrocks.connector.hive.HiveMetastoreApiConverter.toHiveCommonStats;
 import static com.starrocks.connector.hive.HiveMetastoreApiConverter.validateHiveTableType;
+import static com.starrocks.connector.hive.HiveMetastoreOperations.LOCATION_PROPERTY;
 
 public class HiveMetastore implements IHiveMetastore {
 
@@ -58,6 +60,20 @@ public class HiveMetastore implements IHiveMetastore {
         return client.getAllDatabaseNames();
     }
 
+    @Override
+    public void createDb(String dbName, Map<String, String> properties) {
+        String location = properties.getOrDefault(LOCATION_PROPERTY, "");
+        long dbId = ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt();
+        Database database = new Database(dbId, dbName, location);
+        client.createDatabase(HiveMetastoreApiConverter.toMetastoreApiDatabase(database));
+    }
+
+    @Override
+    public void dropDb(String dbName, boolean deleteData) {
+        client.dropDatabase(dbName, deleteData);
+    }
+
+    @Override
     public List<String> getAllTableNames(String dbName) {
         return client.getAllTableNames(dbName);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -93,7 +93,8 @@ public class HiveMetastoreApiConverter {
         if (database == null || database.getName() == null) {
             throw new StarRocksConnectorException("Hive database [%s] doesn't exist");
         }
-        return new Database(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), database.getName());
+        return new Database(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), database.getName(),
+                database.getLocationUri());
     }
 
     public static org.apache.hadoop.hive.metastore.api.Database toMetastoreApiDatabase(Database database) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
@@ -28,9 +28,14 @@ public interface IHiveMetastore {
 
     List<String> getAllDatabaseNames();
 
-    List<String> getAllTableNames(String dbName);
+    void createDb(String dbName, Map<String, String> properties);
+
+    void dropDb(String dbName, boolean deleteData);
 
     Database getDb(String dbName);
+
+
+    List<String> getAllTableNames(String dbName);
 
     Table getTable(String dbName, String tableName);
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnector.java
@@ -48,7 +48,7 @@ public class HudiConnector implements Connector {
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
         this.catalogName = context.getCatalogName();
         this.internalMgr = new HudiConnectorInternalMgr(catalogName, properties, hdfsEnvironment);
-        this.metadataFactory = createMetadataFactory();
+        this.metadataFactory = createMetadataFactory(hdfsEnvironment);
         validate();
         onCreate();
     }
@@ -71,7 +71,7 @@ public class HudiConnector implements Connector {
         return metadataFactory.create();
     }
 
-    private HudiMetadataFactory createMetadataFactory() {
+    private HudiMetadataFactory createMetadataFactory(HdfsEnvironment hdfsEnvironment) {
         IHiveMetastore metastore = internalMgr.createHiveMetastore();
         RemoteFileIO remoteFileIO = internalMgr.createRemoteFileIO();
         return new HudiMetadataFactory(
@@ -81,7 +81,8 @@ public class HudiConnector implements Connector {
                 internalMgr.getHiveMetastoreConf(),
                 internalMgr.getRemoteFileConf(),
                 internalMgr.getPullRemoteFileExecutor(),
-                internalMgr.isSearchRecursive()
+                internalMgr.isSearchRecursive(),
+                hdfsEnvironment.getConfiguration()
         );
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadataFactory.java
@@ -25,6 +25,7 @@ import com.starrocks.connector.hive.CachingHiveMetastoreConf;
 import com.starrocks.connector.hive.HiveMetastoreOperations;
 import com.starrocks.connector.hive.HiveStatisticsProvider;
 import com.starrocks.connector.hive.IHiveMetastore;
+import org.apache.hadoop.conf.Configuration;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -39,6 +40,7 @@ public class HudiMetadataFactory {
     private final long perQueryCacheRemotePathMaxNum;
     private final ExecutorService pullRemoteFileExecutor;
     private final boolean isRecursive;
+    private final Configuration hadoopConf;
 
     public HudiMetadataFactory(String catalogName,
                                IHiveMetastore metastore,
@@ -46,7 +48,8 @@ public class HudiMetadataFactory {
                                CachingHiveMetastoreConf hmsConf,
                                CachingRemoteFileConf fileConf,
                                ExecutorService pullRemoteFileExecutor,
-                               boolean isRecursive) {
+                               boolean isRecursive,
+                               Configuration hadoopConf) {
         this.catalogName = catalogName;
         this.metastore = metastore;
         this.remoteFileIO = remoteFileIO;
@@ -54,11 +57,14 @@ public class HudiMetadataFactory {
         this.perQueryCacheRemotePathMaxNum = fileConf.getPerQueryCacheMaxSize();
         this.pullRemoteFileExecutor = pullRemoteFileExecutor;
         this.isRecursive = isRecursive;
+        this.hadoopConf = hadoopConf;
     }
 
     public HudiMetadata create() {
         HiveMetastoreOperations hiveMetastoreOperations = new HiveMetastoreOperations(
-                createQueryLevelInstance(metastore, perQueryMetastoreMaxNum), metastore instanceof CachingHiveMetastore);
+                createQueryLevelInstance(metastore, perQueryMetastoreMaxNum),
+                metastore instanceof CachingHiveMetastore,
+                hadoopConf);
         RemoteFileOperations remoteFileOperations = new RemoteFileOperations(
                 CachingRemoteFileIO.createQueryLevelInstance(remoteFileIO, perQueryCacheRemotePathMaxNum),
                 pullRemoteFileExecutor,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -26,6 +26,7 @@ import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.RemoteFileBlockDesc;
@@ -290,5 +291,9 @@ public class HiveMetadataTest {
         ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
                 "Database d1 not empty",
                 () -> hiveMetadata.dropDb("d1", true));
+
+        ExceptionChecker.expectThrowsWithMsg(MetaNotFoundException.class,
+                "Failed to access database empty_db",
+                () -> hiveMetadata.dropDb("empty_db", true));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -22,7 +22,9 @@ import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.FeConstants;
 import com.starrocks.connector.CachingRemoteFileIO;
 import com.starrocks.connector.PartitionUtil;
@@ -85,7 +87,7 @@ public class HiveMetadataTest {
         metastore = new HiveMetastore(client, "hive_catalog");
         cachingHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
                 metastore, executorForHmsRefresh, 100, 10, 1000, false);
-        hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true);
+        hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true, new Configuration());
 
         hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
         FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
@@ -259,5 +261,34 @@ public class HiveMetadataTest {
         Assert.assertEquals(0.03, dataColumnStats.getNullsFraction(), 0.001);
         Assert.assertEquals(4, dataColumnStats.getAverageRowSize(), 0.001);
         Assert.assertEquals(5, dataColumnStats.getDistinctValuesCount(), 0.001);
+    }
+
+    @Test
+    public void createDbTest() throws AlreadyExistsException {
+        ExceptionChecker.expectThrowsWithMsg(AlreadyExistsException.class,
+                "Database Already Exists",
+                () -> hiveMetadata.createDb("db1", new HashMap<>()));
+
+        Map<String, String> conf = new HashMap<>();
+        conf.put("location", "abs://xxx/zzz");
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Invalid location URI: abs://xxx/zzz",
+                () -> hiveMetadata.createDb("db3", conf));
+
+        conf.clear();
+        conf.put("not_support_prop", "xxx");
+        ExceptionChecker.expectThrowsWithMsg(IllegalArgumentException.class,
+                "Unrecognized property: not_support_prop",
+                () -> hiveMetadata.createDb("db3", conf));
+
+        conf.clear();
+        hiveMetadata.createDb("db4", conf);
+    }
+
+    @Test
+    public void dropDbTest() {
+        ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
+                "Database d1 not empty",
+                () -> hiveMetadata.dropDb("d1", true));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -194,7 +194,11 @@ public class HiveMetastoreTest {
         }
 
         public List<String> getAllTableNames(String dbName) {
-            return Lists.newArrayList("table1", "table2");
+            if (dbName.equals("empty_db")) {
+                return Lists.newArrayList();
+            } else {
+                return Lists.newArrayList("table1", "table2");
+            }
         }
 
         public org.apache.hadoop.hive.metastore.api.Database getDb(String dbName) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -185,6 +185,14 @@ public class HiveMetastoreTest {
             return Lists.newArrayList("db1", "db2");
         }
 
+        public void createDatabase(org.apache.hadoop.hive.metastore.api.Database database) {
+
+        }
+
+        public void dropDatabase(String dbName, boolean deleteData) {
+
+        }
+
         public List<String> getAllTableNames(String dbName) {
             return Lists.newArrayList("table1", "table2");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
@@ -80,7 +80,7 @@ public class HiveStatisticsProviderTest {
         metastore = new HiveMetastore(client, "hive_catalog");
         cachingHiveMetastore = new CachingHiveMetastore(
                 metastore, executorForHmsRefresh, 100, 10, 1000, false);
-        hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true);
+        hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true, new Configuration());
 
         hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
         FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -830,7 +830,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         HiveMetastore metastore = new HiveMetastore(metaClient, MOCKED_HIVE_CATALOG_NAME);
         CachingHiveMetastore cachingHiveMetastore = createCatalogLevelInstance(
                 metastore, Executors.newSingleThreadExecutor(), 0, 0, 0, false);
-        HiveMetastoreOperations hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, false);
+        HiveMetastoreOperations hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, false, new Configuration());
         RemoteFileIO remoteFileIO = new HiveRemoteFileIO(new Configuration());
         CachingRemoteFileIO cacheIO = CachingRemoteFileIO.createCatalogLevelInstance(remoteFileIO,
                 Executors.newSingleThreadExecutor(), 0, 0, 0);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -68,7 +68,7 @@ public class HudiMetadataTest {
         metastore = new HiveMetastore(client, "hive_catalog");
         cachingHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
                 metastore, executorForHmsRefresh, 100, 10, 1000, false);
-        hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true);
+        hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true, new Configuration());
 
         hudiRemoteFileIO = new HudiRemoteFileIO(new Configuration());
         cachingRemoteFileIO = CachingRemoteFileIO.createCatalogLevelInstance(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDropDbTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDropDbTest.java
@@ -40,7 +40,7 @@ public class AnalyzeDropDbTest {
                 "\"hive.metastore.uris\"=\"thrift://hms:9083\", \"iceberg.catalog.type\"=\"hive\")";
         starRocksAssert.withCatalog(createIcebergCatalogStmt);
 
-        createIcebergCatalogStmt = "create external catalog hive_catalog properties (\"type\"=\"hive\", " +
+        createIcebergCatalogStmt = "create external catalog hudi_catalog properties (\"type\"=\"hudi\", " +
                 "\"hive.metastore.uris\"=\"thrift://hms:9083\")";
         starRocksAssert.withCatalog(createIcebergCatalogStmt);
     }
@@ -56,10 +56,11 @@ public class AnalyzeDropDbTest {
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof AnalysisException);
-            Assert.assertTrue(e.getMessage().contains("Getting analyzing error. Detail message: Unknown catalog"));
+            Assert.assertTrue(e.getMessage().contains("Getting analyzing error." +
+                    " Detail message: Unknown catalog 'not_exist_catalog'."));
         }
 
-        String stmt = "DROP DATABASE hive_catalog.iceberg_db";
+        String stmt = "DROP DATABASE hudi_catalog.iceberg_db";
         DropDbStmt dropDbStmt =
                 (DropDbStmt) UtFrameUtils.parseStmtWithNewParser(stmt, connectContext);
 


### PR DESCRIPTION
Fixes #issue
Support create and drop hive database.
- create database hive_db; // under hive catalog
- create database hive_catalog.hive_db properties ("location"="s3://bucket/hive_db")
- drop database ut1; // only empty database can be dropped. The db location dir will be deleted only if there is no directory or file under the db location


## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
