### PR TITLE
[Refactor] Change olap_table_query_rewrite_consistency to query_rewrite_consistency as materialized view's property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -30,7 +30,6 @@ import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
-import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TableName;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.common.AnalysisException;
@@ -536,8 +535,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         this.refreshScheme = refreshScheme;
     }
 
-    public Set<String> getUpdatedPartitionNamesOfTable(Table base) {
-        return getUpdatedPartitionNamesOfTable(base, false);
+    public Set<String> getBaseTableUpdatedPartitionNames(Table base) {
+        return getBaseTableUpdatedPartitionNames(base, false);
     }
 
     public int getMaxMVRewriteStaleness() {
@@ -548,7 +547,13 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         this.maxMVRewriteStaleness = maxMVRewriteStaleness;
     }
 
-    public static SlotRef getPartitionSlotRef(MaterializedView materializedView) {
+    /**
+     * @param materializedView : materialized view to check
+     * @return                 : return the column slot ref which materialized view's partition column comes from.
+     *
+     * NOTE: Only support one column for Materialized View's partition column for now.
+     */
+    public static SlotRef getRefBaseTablePartitionSlotRef(MaterializedView materializedView) {
         List<SlotRef> slotRefs = Lists.newArrayList();
         Expr partitionExpr = materializedView.getFirstPartitionRefTableExpr();
         partitionExpr.collect(SlotRef.class, slotRefs);
@@ -577,6 +582,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         for (String partitionName : baseTable.getPartitionNames()) {
             if (!mvBaseTableVisibleVersionMap.containsKey(partitionName)) {
                 Partition partition = baseTable.getPartition(partitionName);
+                // TODO: use `mvBaseTableVisibleVersionMap` to check whether base table has been refreshed or not instead of
+                //  checking its version, remove this later.
                 if (partition.getVisibleVersion() != 1) {
                     result.add(partitionName);
                 }
@@ -707,7 +714,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 .stream().map(BasePartitionInfo::fromExternalTable).collect(Collectors.toList());
     }
 
-    public Set<String> getUpdatedPartitionNamesOfExternalTable(Table baseTable) {
+    private Set<String> getUpdatedPartitionNamesOfExternalTable(Table baseTable) {
         if (!baseTable.isHiveTable()) {
             // Only support hive table now
             return null;
@@ -753,33 +760,42 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return result;
     }
 
-    public Set<String> getUpdatedPartitionNamesOfTable(Table base, boolean withMv) {
-        if (base.isView()) {
+    /**
+     * Return base tables' updated partition names, if `withMv` is true check base tables recursively when the base
+     * table is materialized view too.
+     *
+     * @param baseTable : materialized view's base table to be checked
+     * @param withMv    : whether to check the base table recursively when it is also a mv.
+     * @return
+     */
+    public Set<String> getBaseTableUpdatedPartitionNames(Table baseTable, boolean withMv) {
+        if (baseTable.isView()) {
             return Sets.newHashSet();
-        } else if (base.isNativeTableOrMaterializedView()) {
+        } else if (baseTable.isNativeTableOrMaterializedView()) {
             Set<String> result = Sets.newHashSet();
-            OlapTable baseTable = (OlapTable) base;
-            result.addAll(getUpdatedPartitionNamesOfOlapTable(baseTable));
+            OlapTable olapBaseTable = (OlapTable) baseTable;
+            result.addAll(getUpdatedPartitionNamesOfOlapTable(olapBaseTable));
+
             if (withMv && baseTable.isMaterializedView()) {
-                Set<String> partitionNames = ((MaterializedView) baseTable).getPartitionNamesToRefreshForMv();
+                Set<String> partitionNames = ((MaterializedView) baseTable).getMVToRefreshPartitionNames();
                 result.addAll(partitionNames);
             }
             return result;
         } else {
-            Set<String> updatePartitionNames = getUpdatedPartitionNamesOfExternalTable(base);
-            Pair<Table, Column> partitionTableAndColumn = getPartitionTableAndColumn();
+            Set<String> updatePartitionNames = getUpdatedPartitionNamesOfExternalTable(baseTable);
+            Pair<Table, Column> partitionTableAndColumn = getBaseTableAndPartitionColumn();
             if (partitionTableAndColumn == null) {
                 return updatePartitionNames;
             }
-            if (!base.getTableIdentifier().equals(partitionTableAndColumn.first.getTableIdentifier())) {
+            if (!baseTable.getTableIdentifier().equals(partitionTableAndColumn.first.getTableIdentifier())) {
                 return updatePartitionNames;
             }
             try {
                 boolean isListPartition = partitionInfo instanceof ListPartitionInfo;
-                return PartitionUtil.getMVPartitionName(base, partitionTableAndColumn.second,
+                return PartitionUtil.getMVPartitionName(baseTable, partitionTableAndColumn.second,
                         Lists.newArrayList(updatePartitionNames), isListPartition);
             } catch (AnalysisException e) {
-                LOG.warn("Mv {}'s base table {} get partition name fail", name, base.name, e);
+                LOG.warn("Mv {}'s base table {} get partition name fail", name, baseTable.name, e);
                 return null;
             }
         }
@@ -1193,162 +1209,179 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return table.isHiveTable();
     }
 
-    public Set<String> getPartitionNamesToRefreshForMv() {
+    /**
+     * Once the materialized view's base tables have updated, we need to check correspond materialized views' partitions
+     * to be refreshed.
+     *
+     * @return : Collect all need refreshed partitions of materialized view.
+     */
+    public Set<String> getMVToRefreshPartitionNames() {
+        // Skip check for sync materialized view.
         if (refreshScheme.isSync()) {
             return Sets.newHashSet();
         }
 
-        PartitionInfo partitionInfo = getPartitionInfo();
-        TableProperty.QueryRewriteConsistencyMode externalTableRewriteMode = getForceExternalTableQueryRewrite();
-        TableProperty.QueryRewriteConsistencyMode olapTableRewriteMode = tableProperty.getOlapTableQueryRewrite();
+        // check mv's query rewrite consistency mode property
+        TableProperty.QueryRewriteConsistencyMode mvConsistencyRewriteMode = tableProperty.getOlapTableQueryRewrite();
+        switch (mvConsistencyRewriteMode) {
+            case DISABLE:
+                return getPartitionNames();
+            case LOOSE:
+                return Sets.newHashSet();
+            case CHECKED:
+            default:
+                break;
+        }
+
         if (partitionInfo instanceof SinglePartitionInfo) {
-            // for non-partitioned materialized view
-            for (BaseTableInfo tableInfo : baseTableInfos) {
-                Table table = tableInfo.getTable();
-
-                if (table.isView()) {
-                    // freshness of view should be ignored
-                    continue;
-                }
-                // we can not judge whether mv based on external table is update-to-date,
-                // because we do not know that any changes in external table.
-                if (!table.isNativeTableOrMaterializedView()) {
-                    switch (externalTableRewriteMode) {
-                        case DISABLE:
-                            return getPartitionNames();
-                        case LOOSE: {
-                            return Sets.newHashSet();
-                        }
-                        case CHECKED:
-                            if (!supportPartialPartitionQueryRewriteForExternalTable(table)) {
-                                continue;
-                            }
-                            break;
-                        default:
-                            Preconditions.checkState(false, "unknown force_external_table_rewrite");
-                    }
-                }
-                if (table.isNativeTableOrMaterializedView()) {
-                    switch (olapTableRewriteMode) {
-                        case DISABLE:
-                            return getPartitionNames();
-                        case LOOSE:
-                            return Sets.newHashSet();
-                        case CHECKED:
-                        default:
-                            break;
-                    }
-                }
-
-                // Check the partition consistency
-                Set<String> partitionNames = getUpdatedPartitionNamesOfTable(table, true);
-                if (CollectionUtils.isNotEmpty(partitionNames)) {
-                    return getPartitionNames();
-                }
-            }
+            return getNonPartitionedMVRefreshPartitions();
         } else if (partitionInfo instanceof ExpressionRangePartitionInfo) {
             // partitions to refresh
             // 1. dropped partitions
             // 2. newly added partitions
             // 3. partitions loaded with new data
-            return getPartitionNamesToRefreshForPartitionedMv();
+            return getPartitionedMVRefreshPartitions();
         } else {
             throw UnsupportedException.unsupportedException("unsupported partition info type:"
                     + partitionInfo.getClass().getName());
         }
+    }
+
+    /**
+     * For non-partitioned materialized view, once its base table have updated, we need refresh the
+     * materialized view's totally.
+     * @return : non-partitioned materialized view's all need updated partition names.
+     */
+    private Set<String> getNonPartitionedMVRefreshPartitions() {
+        Preconditions.checkState(partitionInfo instanceof SinglePartitionInfo);
+        for (BaseTableInfo tableInfo : baseTableInfos) {
+            Table table = tableInfo.getTable();
+            // skip check freshness of view
+            if (table.isView()) {
+                continue;
+            }
+
+            // skip check external table if the external does not support rewrite.
+            if (!table.isNativeTableOrMaterializedView()) {
+                if (!supportPartialPartitionQueryRewriteForExternalTable(table)) {
+                    return Sets.newHashSet();
+                }
+                if (tableProperty.getForceExternalTableQueryRewrite() == TableProperty.QueryRewriteConsistencyMode.DISABLE) {
+                    return getPartitionNames();
+                }
+            }
+
+            // once mv's base table has updated, refresh the materialized view totally.
+            Set<String> partitionNames = getBaseTableUpdatedPartitionNames(table, true);
+            if (CollectionUtils.isNotEmpty(partitionNames)) {
+                return getPartitionNames();
+            }
+        }
         return Sets.newHashSet();
     }
 
-    private Set<String> getPartitionNamesToRefreshForPartitionedMv() {
+    /**
+     * Materialized Views' base tables have two kinds: ref base table and non-ref base table.
+     *   - If non ref base tables updated, need refresh all mv partitions.
+     *   - If ref base table updated, need refresh the ref base table's updated partitions.
+     *
+     * eg:
+     *    create mater
+     *    CREATE MATERIALIZED VIEW mv1
+     *    PARTITION BY k1
+     *    DISTRIBUTED BY HASH(k1) BUCKETS 10
+     *    AS
+     *      SELECT k1, v1 as k2, v2 as k3
+     *          from t1 join t2
+     *          on t1.k1 and t2.kk1;
+     *
+     * - t1 is mv1's ref base table because mv1's partition column k1 is deduced from t1
+     * - t2 is mv1's non ref base table because mv1's partition column k1 is not associated with t2.
+     *
+     * @return : partitioned materialized view's all need updated partition names.
+     */
+    private Set<String> getPartitionedMVRefreshPartitions() {
+        Preconditions.checkState(partitionInfo instanceof ExpressionRangePartitionInfo);
+        // If non-partition-by table has changed, should refresh all mv partitions
         Expr partitionExpr = getPartitionRefTableExprs().get(0);
-        Pair<Table, Column> partitionInfo = getPartitionTableAndColumn();
-        // if non-partition-by table has changed, should refresh all mv partitions
+        Pair<Table, Column> partitionInfo = getBaseTableAndPartitionColumn();
         if (partitionInfo == null) {
             setInactiveAndReason("partition configuration changed");
             LOG.warn("mark mv:{} inactive for get partition info failed", name);
             throw new RuntimeException(String.format("getting partition info failed for mv: %s", name));
         }
-        Table partitionTable = partitionInfo.first;
-        TableProperty.QueryRewriteConsistencyMode externalTableRewriteMode = getForceExternalTableQueryRewrite();
-        TableProperty.QueryRewriteConsistencyMode olapTableRewriteMode = tableProperty.getOlapTableQueryRewrite();
-        for (BaseTableInfo tableInfo : baseTableInfos) {
-            Table table = tableInfo.getTable();
-            if (table.isView()) {
-                continue;
-            }
-            if (!table.isNativeTableOrMaterializedView()) {
-                switch (externalTableRewriteMode) {
-                    case DISABLE:
-                        return getPartitionNames();
-                    case LOOSE:
-                        return Sets.newHashSet();
-                    case CHECKED: {
-                        if (!supportPartialPartitionQueryRewriteForExternalTable(table)) {
-                            return Sets.newHashSet();
-                        }
-                        break;
-                    }
-                    default:
-                        Preconditions.checkState(false, "unknown force_external_table_query_rewrite");
-                }
-            }
-            if (table.isNativeTableOrMaterializedView()) {
-                switch (olapTableRewriteMode) {
-                    case DISABLE:
-                        return getPartitionNames();
-                    case LOOSE:
-                        return Sets.newHashSet();
-                    case CHECKED:
-                    default:
-                        break;
-                }
-            }
 
-            if (table.getTableIdentifier().equals(partitionTable.getTableIdentifier())) {
+        Table refBaseTable = partitionInfo.first;
+        Column refBasePartitionCol = partitionInfo.second;
+        for (BaseTableInfo tableInfo : baseTableInfos) {
+            Table baseTable = tableInfo.getTable();
+            // skip view
+            if (baseTable.isView()) {
                 continue;
             }
-            Set<String> partitionNames = getUpdatedPartitionNamesOfTable(table, true);
+            // skip external table that is not supported for query rewrite, return all partition ?
+            // skip check external table if the external does not support rewrite.
+            if (!baseTable.isNativeTableOrMaterializedView()) {
+                if (!supportPartialPartitionQueryRewriteForExternalTable(baseTable)) {
+                    return Sets.newHashSet();
+                }
+                if (tableProperty.getForceExternalTableQueryRewrite() == TableProperty.QueryRewriteConsistencyMode.DISABLE) {
+                    return getPartitionNames();
+                }
+            }
+            if (baseTable.getTableIdentifier().equals(refBaseTable.getTableIdentifier())) {
+                continue;
+            }
+            // If the non ref table has already changed, need refresh all materialized views' partitions.
+            Set<String> partitionNames = getBaseTableUpdatedPartitionNames(baseTable, true);
             if (CollectionUtils.isNotEmpty(partitionNames)) {
                 return getPartitionNames();
             }
         }
-        // check partition-by table
+
+        // Step1: collect updated partitions by partition name to range name:
+        // - deleted partitions.
+        // - added partitions.
         Set<String> needRefreshMvPartitionNames = Sets.newHashSet();
-        Map<String, Range<PartitionKey>> basePartitionMap;
+        Map<String, Range<PartitionKey>> basePartitionNameToRangeMap;
         try {
-            basePartitionMap = PartitionUtil.getPartitionRange(partitionTable,
-                    partitionInfo.second);
+            basePartitionNameToRangeMap = PartitionUtil.getTablePartitionKeyRange(refBaseTable, refBasePartitionCol);
         } catch (UserException e) {
             LOG.warn("Materialized view compute partition difference with base table failed.", e);
             return getPartitionNames();
         }
-        Map<String, Range<PartitionKey>> mvPartitionMap = getRangePartitionMap();
-        RangePartitionDiff rangePartitionDiff = getPartitionDiff(partitionExpr, partitionInfo.second,
-                basePartitionMap, mvPartitionMap);
+
+        Map<String, Range<PartitionKey>> mvPartitionNameToRangeMap = getRangePartitionMap();
+        // step1.1: collect ref base table's partition range diff.
+        RangePartitionDiff rangePartitionDiff = SyncPartitionUtils.getRangePartitionDiff(partitionExpr, refBasePartitionCol,
+                basePartitionNameToRangeMap, mvPartitionNameToRangeMap);
+
+        // refresh ref base table's deleted partitions
         needRefreshMvPartitionNames.addAll(rangePartitionDiff.getDeletes().keySet());
+        // remove ref base table's deleted partitions from `mvPartitionMap`
         for (String deleted : rangePartitionDiff.getDeletes().keySet()) {
-            mvPartitionMap.remove(deleted);
+            mvPartitionNameToRangeMap.remove(deleted);
         }
+
+        // step1.2: refresh ref base table's new added partitions
         needRefreshMvPartitionNames.addAll(rangePartitionDiff.getAdds().keySet());
-        mvPartitionMap.putAll(rangePartitionDiff.getAdds());
+        mvPartitionNameToRangeMap.putAll(rangePartitionDiff.getAdds());
 
         Map<String, Set<String>> baseToMvNameRef = SyncPartitionUtils
-                .generatePartitionRefMap(basePartitionMap, mvPartitionMap);
+                .getIntersectedPartitions(basePartitionNameToRangeMap, mvPartitionNameToRangeMap);
         Map<String, Set<String>> mvToBaseNameRef = SyncPartitionUtils
-                .generatePartitionRefMap(mvPartitionMap, basePartitionMap);
+                .getIntersectedPartitions(mvPartitionNameToRangeMap, basePartitionNameToRangeMap);
 
-        Set<String> baseChangedPartitionNames = getUpdatedPartitionNamesOfTable(partitionTable, true);
+        // step2: check ref base table's updated partition names by checking its ref tables recursively.
+        Set<String> baseChangedPartitionNames = getBaseTableUpdatedPartitionNames(refBaseTable, true);
         if (baseChangedPartitionNames == null) {
             return mvToBaseNameRef.keySet();
         }
+
         if (partitionExpr instanceof SlotRef) {
-            for (String basePartitionName : baseChangedPartitionNames) {
-                needRefreshMvPartitionNames.addAll(baseToMvNameRef.get(basePartitionName));
-            }
+            baseChangedPartitionNames.stream().forEach(x -> needRefreshMvPartitionNames.addAll(baseToMvNameRef.get(x)));
         } else if (partitionExpr instanceof FunctionCallExpr) {
-            for (String baseChangedPartitionName : baseChangedPartitionNames) {
-                needRefreshMvPartitionNames.addAll(baseToMvNameRef.get(baseChangedPartitionName));
-            }
+            baseChangedPartitionNames.stream().forEach(x -> needRefreshMvPartitionNames.addAll(baseToMvNameRef.get(x)));
             // because the relation of partitions between materialized view and base partition table is n : m,
             // should calculate the candidate partitions recursively.
             SyncPartitionUtils.calcPotentialRefreshPartition(needRefreshMvPartitionNames, baseChangedPartitionNames,
@@ -1357,22 +1390,15 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return needRefreshMvPartitionNames;
     }
 
-    private RangePartitionDiff getPartitionDiff(Expr partitionExpr, Column partitionColumn,
-                                                Map<String, Range<PartitionKey>> basePartitionMap,
-                                                Map<String, Range<PartitionKey>> mvPartitionMap) {
-        if (partitionExpr instanceof SlotRef) {
-            return SyncPartitionUtils.calcSyncSameRangePartition(basePartitionMap, mvPartitionMap);
-        } else if (partitionExpr instanceof FunctionCallExpr) {
-            FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr;
-            String granularity = ((StringLiteral) functionCallExpr.getChild(0)).getValue().toLowerCase();
-            return SyncPartitionUtils.calcSyncRollupPartition(basePartitionMap, mvPartitionMap,
-                    granularity, partitionColumn.getPrimitiveType());
-        } else {
-            throw UnsupportedException.unsupportedException("unsupported partition expr:" + partitionExpr);
-        }
-    }
-
-    public Pair<Table, Column> getPartitionTableAndColumn() {
+    /**
+     * Materialized View's partition column can only refer one base table's partition column, get the referred
+     * base table and its partition column.
+     *
+     * TODO: support multi-column partitions later.
+     *
+     * @return : The materialized view's referred base table and its partition column.
+     */
+    public Pair<Table, Column> getBaseTableAndPartitionColumn() {
         if (!(partitionInfo instanceof ExpressionRangePartitionInfo || partitionInfo instanceof ListPartitionInfo)) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -785,7 +785,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             result.addAll(getUpdatedPartitionNamesOfOlapTable(olapBaseTable));
 
             if (withMv && baseTable.isMaterializedView()) {
-                Set<String> partitionNames = ((MaterializedView) baseTable).getMVToRefreshPartitionNames();
+                Set<String> partitionNames = ((MaterializedView) baseTable).getPartitionNamesToRefreshForMv();
                 result.addAll(partitionNames);
             }
             return result;
@@ -1223,14 +1223,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      *
      * @return : Collect all need refreshed partitions of materialized view.
      */
-    public Set<String> getMVToRefreshPartitionNames() {
+    public Set<String> getPartitionNamesToRefreshForMv() {
         // Skip check for sync materialized view.
         if (refreshScheme.isSync()) {
             return Sets.newHashSet();
         }
 
         // check mv's query rewrite consistency mode property
-        TableProperty.QueryRewriteConsistencyMode mvConsistencyRewriteMode = tableProperty.getOlapTableQueryRewrite();
+        TableProperty.QueryRewriteConsistencyMode mvConsistencyRewriteMode = tableProperty.getQueryRewriteConsistencyMode();
         switch (mvConsistencyRewriteMode) {
             case DISABLE:
                 return getPartitionNames();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -880,8 +880,12 @@ public class OlapTable extends Table {
         }
     }
 
-    // partition Name -> Range
+
+    /**
+     * @return  : table's partition name to range partition key mapping.
+     */
     public Map<String, Range<PartitionKey>> getRangePartitionMap() {
+        Preconditions.checkState(partitionInfo instanceof RangePartitionInfo);
         RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
         Map<String, Range<PartitionKey>> rangePartitionMap = Maps.newHashMap();
         for (Map.Entry<Long, Partition> partitionEntry : idToPartition.entrySet()) {
@@ -896,7 +900,11 @@ public class OlapTable extends Table {
         return rangePartitionMap;
     }
 
+    /**
+     * @return : table's partition name to list partition names.
+     */
     public Map<String, List<List<String>>> getListPartitionMap() {
+        Preconditions.checkState(partitionInfo instanceof ListPartitionInfo);
         ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
         Map<String, List<List<String>>> listPartitionMap = Maps.newHashMap();
         for (Map.Entry<Long, Partition> partitionEntry : idToPartition.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -91,7 +91,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         LOOSE,      // 1: enable query rewrite, and skip the partition version check
         CHECKED;    // 2: enable query rewrite, and rewrite only if mv partition version is consistent with table meta
 
-        public static QueryRewriteConsistencyMode defaultForOlapTable() {
+        public static QueryRewriteConsistencyMode defaultQueryRewriteConsistencyMode() {
             return CHECKED;
         }
 
@@ -139,7 +139,8 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     // This property only applies to materialized views,
     // Specify the query rewrite behaviour for external table
-    private QueryRewriteConsistencyMode olapTableQueryRewrite = QueryRewriteConsistencyMode.defaultForOlapTable();
+    private QueryRewriteConsistencyMode queryRewriteConsistencyMode =
+            QueryRewriteConsistencyMode.defaultQueryRewriteConsistencyMode();
 
     private boolean isInMemory = false;
 
@@ -371,6 +372,17 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public static QueryRewriteConsistencyMode analyzeQueryRewriteMode(String value) throws AnalysisException {
+        QueryRewriteConsistencyMode res = EnumUtils.getEnumIgnoreCase(QueryRewriteConsistencyMode.class, value);
+        if (res == null) {
+            String allValues = EnumUtils.getEnumList(QueryRewriteConsistencyMode.class)
+                    .stream().map(Enum::name).collect(Collectors.joining(","));
+            throw new AnalysisException(
+                    PropertyAnalyzer.PROPERTIES_QUERY_REWRITE_CONSISTENCY + " could only be " + allValues + " but got " + value);
+        }
+        return res;
+    }
+
+    public static QueryRewriteConsistencyMode analyzeExternalTableQueryRewrite(String value) throws AnalysisException {
         if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
             // old version use the boolean value
             boolean boolValue = Boolean.parseBoolean(value);
@@ -381,7 +393,8 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 String allValues = EnumUtils.getEnumList(QueryRewriteConsistencyMode.class)
                         .stream().map(Enum::name).collect(Collectors.joining(","));
                 throw new AnalysisException(
-                        "force_external_table_query_rewrite could only be " + allValues + " but got " + value);
+                        PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE + " could only be " + allValues + " but " +
+                                "got " + value);
             }
             return res;
         }
@@ -393,19 +406,19 @@ public class TableProperty implements Writable, GsonPostProcessable {
         forceExternalTableQueryRewrite = QueryRewriteConsistencyMode.defaultForExternalTable();
         if (value != null) {
             try {
-                forceExternalTableQueryRewrite = analyzeQueryRewriteMode(value);
+                forceExternalTableQueryRewrite = analyzeExternalTableQueryRewrite(value);
             } catch (AnalysisException e) {
                 LOG.error("analyze {} failed", PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE, e);
             }
         }
 
-        olapTableQueryRewrite = QueryRewriteConsistencyMode.defaultForOlapTable();
-        value = properties.get(PropertyAnalyzer.PROPERTIES_OLAP_TABLE_QUERY_REWRITE);
+        queryRewriteConsistencyMode = QueryRewriteConsistencyMode.defaultQueryRewriteConsistencyMode();
+        value = properties.get(PropertyAnalyzer.PROPERTIES_QUERY_REWRITE_CONSISTENCY);
         if (value != null) {
             try {
-                olapTableQueryRewrite = analyzeQueryRewriteMode(value);
+                queryRewriteConsistencyMode = analyzeQueryRewriteMode(value);
             } catch (AnalysisException e) {
-                LOG.error("analyze {} failed", PropertyAnalyzer.PROPERTIES_OLAP_TABLE_QUERY_REWRITE, e);
+                LOG.error("analyze {} failed", PropertyAnalyzer.PROPERTIES_QUERY_REWRITE_CONSISTENCY, e);
             }
         }
 
@@ -558,12 +571,12 @@ public class TableProperty implements Writable, GsonPostProcessable {
         this.forceExternalTableQueryRewrite = externalTableQueryRewrite;
     }
 
-    public void setOlapTableQueryRewrite(QueryRewriteConsistencyMode mode) {
-        this.olapTableQueryRewrite = mode;
+    public void setQueryRewriteConsistencyMode(QueryRewriteConsistencyMode mode) {
+        this.queryRewriteConsistencyMode = mode;
     }
 
-    public QueryRewriteConsistencyMode getOlapTableQueryRewrite() {
-        return this.olapTableQueryRewrite;
+    public QueryRewriteConsistencyMode getQueryRewriteConsistencyMode() {
+        return this.queryRewriteConsistencyMode;
     }
 
     public boolean isInMemory() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -150,7 +150,7 @@ public class PropertyAnalyzer {
     public static final String PROPERTIES_PARTITION_REFRESH_NUMBER = "partition_refresh_number";
     public static final String PROPERTIES_EXCLUDED_TRIGGER_TABLES = "excluded_trigger_tables";
     public static final String PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE = "force_external_table_query_rewrite";
-    public static final String PROPERTIES_OLAP_TABLE_QUERY_REWRITE = "olap_table_query_rewrite_consistency";
+    public static final String PROPERTIES_QUERY_REWRITE_CONSISTENCY = "query_rewrite_consistency";
     public static final String PROPERTIES_RESOURCE_GROUP = "resource_group";
 
     public static final String PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX = "session.";

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -23,10 +23,14 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.BoolLiteral;
 import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.MaxLiteral;
 import com.starrocks.analysis.NullLiteral;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DeltaLakePartitionKey;
 import com.starrocks.catalog.HiveMetaStoreTable;
@@ -47,6 +51,9 @@ import com.starrocks.common.UserException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.DmlException;
+import com.starrocks.sql.common.RangePartitionDiff;
+import com.starrocks.sql.common.SyncPartitionUtils;
+import com.starrocks.sql.common.UnsupportedException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.iceberg.PartitionField;
@@ -501,5 +508,20 @@ public class PartitionUtil {
         thread.setName(threadName);
         thread.setDaemon(true);
         thread.start();
+    }
+
+    public static RangePartitionDiff getPartitionDiff(Expr partitionExpr, Column partitionColumn,
+                                                      Map<String, Range<PartitionKey>> basePartitionMap,
+                                                      Map<String, Range<PartitionKey>> mvPartitionMap) {
+        if (partitionExpr instanceof SlotRef) {
+            return SyncPartitionUtils.calcSyncSameRangePartition(basePartitionMap, mvPartitionMap);
+        } else if (partitionExpr instanceof FunctionCallExpr) {
+            FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr;
+            String granularity = ((StringLiteral) functionCallExpr.getChild(0)).getValue().toLowerCase();
+            return SyncPartitionUtils.calcSyncRollupPartition(basePartitionMap, mvPartitionMap,
+                    granularity, partitionColumn.getPrimitiveType());
+        } else {
+            throw UnsupportedException.unsupportedException("unsupported partition expr:" + partitionExpr);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -496,7 +496,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
     private Pair<Table, Column> getPartitionTableAndColumn(
             Map<Long, Pair<BaseTableInfo, Table>> tables) {
-        SlotRef slotRef = MaterializedView.getPartitionSlotRef(materializedView);
+        SlotRef slotRef = MaterializedView.getRefBaseTablePartitionSlotRef(materializedView);
         for (Pair<BaseTableInfo, Table> tableInfo : tables.values()) {
             BaseTableInfo baseTableInfo = tableInfo.first;
             Table table = tableInfo.second;
@@ -859,7 +859,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                                             TableRelation tableRelation, PartitionInfo mvPartitionInfo)
             throws AnalysisException {
 
-        SlotRef partitionSlot = MaterializedView.getPartitionSlotRef(materializedView);
+        SlotRef partitionSlot = MaterializedView.getRefBaseTablePartitionSlotRef(materializedView);
         List<String> columnOutputNames = queryStatement.getQueryRelation().getColumnOutputNames();
         List<Expr> outputExpressions = queryStatement.getQueryRelation().getOutputExpression();
         Expr outputPartitionSlot = null;

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2943,19 +2943,19 @@ public class LocalMetastore implements ConnectorMetadata {
             // force external query rewrite
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)) {
                 String propertyValue = properties.get(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE);
-                TableProperty.QueryRewriteConsistencyMode value = TableProperty.analyzeQueryRewriteMode(propertyValue);
+                TableProperty.QueryRewriteConsistencyMode value = TableProperty.analyzeExternalTableQueryRewrite(propertyValue);
                 properties.remove(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE);
                 materializedView.getTableProperty().getProperties().
                         put(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE, String.valueOf(value));
                 materializedView.getTableProperty().setForceExternalTableQueryRewrite(value);
             }
-            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_OLAP_TABLE_QUERY_REWRITE)) {
-                String propertyValue = properties.get(PropertyAnalyzer.PROPERTIES_OLAP_TABLE_QUERY_REWRITE);
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_QUERY_REWRITE_CONSISTENCY)) {
+                String propertyValue = properties.get(PropertyAnalyzer.PROPERTIES_QUERY_REWRITE_CONSISTENCY);
                 TableProperty.QueryRewriteConsistencyMode value = TableProperty.analyzeQueryRewriteMode(propertyValue);
-                properties.remove(PropertyAnalyzer.PROPERTIES_OLAP_TABLE_QUERY_REWRITE);
+                properties.remove(PropertyAnalyzer.PROPERTIES_QUERY_REWRITE_CONSISTENCY);
                 materializedView.getTableProperty().getProperties().
-                        put(PropertyAnalyzer.PROPERTIES_OLAP_TABLE_QUERY_REWRITE, String.valueOf(value));
-                materializedView.getTableProperty().setOlapTableQueryRewrite(value);
+                        put(PropertyAnalyzer.PROPERTIES_QUERY_REWRITE_CONSISTENCY, String.valueOf(value));
+                materializedView.getTableProperty().setQueryRewriteConsistencyMode(value);
             }
             // unique keys
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -239,7 +239,7 @@ public class MvRewritePreprocessor {
             return;
         }
 
-        Set<String> partitionNamesToRefresh = mv.getMVToRefreshPartitionNames();
+        Set<String> partitionNamesToRefresh = mv.getPartitionNamesToRefreshForMv();
         PartitionInfo partitionInfo = mv.getPartitionInfo();
         if (partitionInfo instanceof SinglePartitionInfo) {
             if (!partitionNamesToRefresh.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -183,7 +183,7 @@ public class MvRewritePreprocessor {
                     .collect(Collectors.toSet());
         }
         if (relatedMvs.isEmpty()) {
-            logMVPrepare(connectContext, "No Related MVs for the query plan");
+            logMVPrepare(connectContext, "There are no related mvs for the query plan");
             return;
         }
 
@@ -197,7 +197,7 @@ public class MvRewritePreprocessor {
             }
         }
         if (relatedMvs.isEmpty()) {
-            logMVPrepare(connectContext, "No Related MVs after process");
+            logMVPrepare(connectContext, "There are no related mvs after process");
             return;
         }
         // all base table related mvs
@@ -206,12 +206,12 @@ public class MvRewritePreprocessor {
         List<String> candidateMvNames = context.getCandidateMvs().stream()
                 .map(materializationContext -> materializationContext.getMv().getName()).collect(Collectors.toList());
 
-        logMVPrepare(connectContext, "RelatedMVs: %s, CandidateMVs: %s", relatedMvNames, candidateMvNames);
+        logMVPrepare(connectContext, "RelatedMVs: {}, CandidateMVs: {}", relatedMvNames, candidateMvNames);
     }
 
     private void preprocessMv(MaterializedView mv, Set<Table> queryTables, Set<ColumnRefOperator> originQueryColumns) {
         if (!mv.isActive()) {
-            logMVPrepare(connectContext, mv, "MV is not active: %s", mv.getName());
+            logMVPrepare(connectContext, mv, "MV is not active: {}", mv.getName());
             return;
         }
 
@@ -234,12 +234,12 @@ public class MvRewritePreprocessor {
             mv.setPlanContext(mvRewriteContextCache);
         }
         if (!mvRewriteContextCache.isValidMvPlan()) {
-            logMVPrepare(connectContext, mv, "MV plan is not valid: %s, plan:\n %s",
+            logMVPrepare(connectContext, mv, "MV plan is not valid: {}, plan:\n {}",
                     mv.getName(), mvRewriteContextCache.getLogicalPlan().explain());
             return;
         }
 
-        Set<String> partitionNamesToRefresh = mv.getPartitionNamesToRefreshForMv();
+        Set<String> partitionNamesToRefresh = mv.getMVToRefreshPartitionNames();
         PartitionInfo partitionInfo = mv.getPartitionInfo();
         if (partitionInfo instanceof SinglePartitionInfo) {
             if (!partitionNamesToRefresh.isEmpty()) {
@@ -248,7 +248,7 @@ public class MvRewritePreprocessor {
                     String versionInfo = Joiner.on(",").join(mv.getBaseTableLatestPartitionInfo(base.getTable()));
                     sb.append(String.format("base table %s version: %s; ", base, versionInfo));
                 }
-                LOG.info("[MV PREPARE] MV {} is outdated, stale partitions {}, detailed version info: {}",
+                logMVPrepare(connectContext, mv, "MV {} is outdated, stale partitions {}, detailed version info: {}",
                         mv.getName(), partitionNamesToRefresh, sb.toString());
                 return;
             }
@@ -261,7 +261,7 @@ public class MvRewritePreprocessor {
                 String versionInfo = Joiner.on(",").join(mv.getBaseTableLatestPartitionInfo(base.getTable()));
                 sb.append(String.format("base table %s version: %s; ", base, versionInfo));
             }
-            LOG.info("[MV PREPARE] MV {} is outdated and all its partitions need to be " +
+            logMVPrepare(connectContext, mv, "MV {} is outdated and all its partitions need to be " +
                     "refreshed: {}, detailed info: {}", mv.getName(), partitionNamesToRefresh, sb.toString());
             return;
         }
@@ -273,8 +273,8 @@ public class MvRewritePreprocessor {
             // when should calculate the latest partition range predicates for partition-by base table
             mvPartialPartitionPredicates = getMvPartialPartitionPredicates(mv, mvPlan, partitionNamesToRefresh);
             if (mvPartialPartitionPredicates == null) {
-                logMVPrepare(connectContext, mv, "Partitioned MV %s is outdated which contains some partitions " +
-                        "to be refreshed:%s", mv.getName(), partitionNamesToRefresh);
+                logMVPrepare(connectContext, mv, "Partitioned MV {} is outdated which contains some partitions " +
+                        "to be refreshed: {}", mv.getName(), partitionNamesToRefresh);
                 return;
             }
         }
@@ -314,7 +314,7 @@ public class MvRewritePreprocessor {
         }
         materializationContext.setOutputMapping(outputMapping);
         context.addCandidateMvs(materializationContext);
-        logMVPrepare(connectContext, mv, "Prepare MV %s success", mv.getName());
+        logMVPrepare(connectContext, mv, "Prepare MV {} success", mv.getName());
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -248,7 +248,7 @@ public class Optimizer {
                     preprocessor.prepareSyncMvCandidatesForPlan();
                 }
             }
-            OptimizerTraceUtil.logMVPrepare(connectContext, "There are %d candidate MVs after prepare phase",
+            OptimizerTraceUtil.logMVPrepare(connectContext, "There are {} candidate MVs after prepare phase",
                     context.getCandidateMvs().size());
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -98,6 +98,8 @@ import com.starrocks.sql.optimizer.rule.Rule;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -144,13 +146,15 @@ public class OptimizerTraceUtil {
     public static void logMVPrepare(ConnectContext ctx, MaterializedView mv,
                                     String format, Object... object) {
         if (ctx.getSessionVariable().isEnableMVOptimizerTraceLog()) {
-            LOG.info("[MV TRACE] [PREPARE {}] {}", ctx.getQueryId(), String.format(format, object));
+            LOG.info("[MV TRACE] [PREPARE {}] {}", ctx.getQueryId(),
+                    MessageFormatter.arrayFormat(format, object).getMessage());
         }
         // Only record trace when mv is not null.
         if (mv != null) {
             PlannerProfile.LogTracer tracer = PlannerProfile.getLogTracer(mv.getName());
             if (tracer != null) {
-                tracer.log(String.format(format, object));
+                FormattingTuple ft = MessageFormatter.arrayFormat(format, object);
+                tracer.log(ft.getMessage());
             }
         }
     }
@@ -163,14 +167,15 @@ public class OptimizerTraceUtil {
                     mvContext.getOptimizerContext().getTraceInfo().getQueryId(),
                     mvRewriteContext.getRule().type().name(),
                     mvContext.getMv().getName(),
-                    String.format(format, object));
+                    MessageFormatter.arrayFormat(format, object).getMessage());
         }
 
         // Trace log if needed.
         PlannerProfile.LogTracer tracer = PlannerProfile.getLogTracer(mvContext.getMv().getName());
         if (tracer != null) {
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, object);
             tracer.log(String.format("[%s] %s",   mvRewriteContext.getRule().type().name(),
-                    String.format(format, object)));
+                    ft.getMessage()));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -136,7 +136,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                     queryAggOp.getAggregations().values().stream().anyMatch(callOp -> callOp.isDistinct());
             if (mvHasDistinctAggFunc && queryHasDistinctAggFunc) {
                 logMVRewrite(mvRewriteContext, "Rollup aggregate cannot contain distinct aggregate functions," +
-                        "mv:%s, query:%s", mvAggOp.getAggregations().values(), queryAggOp.getAggregations().values());
+                        "mv:{}, query:{}", mvAggOp.getAggregations().values(), queryAggOp.getAggregations().values());
                 return null;
             }
         }
@@ -185,7 +185,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                         queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
                         originalColumnSet, aggregateFunctionRewriter);
             if (rewritten == null) {
-                logMVRewrite(mvRewriteContext, "Rewrite aggregate group-by/agg expr failed: %s", scalarOp.toString());
+                logMVRewrite(mvRewriteContext, "Rewrite aggregate group-by/agg expr failed: {}", scalarOp.toString());
                 return null;
             }
             newQueryProjection.put(entry.getKey(), rewritten);
@@ -203,7 +203,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                         queryExprToMvExprRewriter, rewriteContext.getOutputMapping(),
                         originalColumnSet, aggregateFunctionRewriter);
                 if (rewritten == null) {
-                    logMVRewrite(mvRewriteContext, "Rewrite aggregate with having expr failed: %s", scalarOp.toString());
+                    logMVRewrite(mvRewriteContext, "Rewrite aggregate with having expr failed: {}", scalarOp.toString());
                     return null;
                 }
                 queryColumnRefToScalarMap.put(entry.getKey(), rewritten);
@@ -213,7 +213,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             ScalarOperator rewrittenPred = rewriter.rewrite(aggPredicate);
             if (rewrittenPred == null) {
                 logMVRewrite(mvRewriteContext, "Rewrite aggregate wth having failed, " +
-                        "cannot compensate aggregate having predicates: %s", queryAggregationOperator.getPredicate().toString());
+                        "cannot compensate aggregate having predicates: {}", queryAggregationOperator.getPredicate().toString());
                 return null;
             }
             LogicalScanOperator scanOperator = mvOptExpr.getOp().cast();
@@ -559,12 +559,12 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         for (ScalarOperator key : groupKeys) {
             ScalarOperator newGroupByKey = equationRewriter.replaceExprWithTarget(key);
             if (key.isVariable() && key == newGroupByKey) {
-                logMVRewrite(mvRewriteContext, "Rewrite group by key %s failed", key.toString());
+                logMVRewrite(mvRewriteContext, "Rewrite group by key {} failed", key.toString());
                 return null;
             }
             if (newGroupByKey == null || !isAllExprReplaced(newGroupByKey, queryColumnSet)) {
                 // it means there is some column that can not be rewritten by outputs of mv
-                logMVRewrite(mvRewriteContext, "Rewrite group by key %s failed: partially rewrite", key.toString());
+                logMVRewrite(mvRewriteContext, "Rewrite group by key {} failed: partially rewrite", key.toString());
                 return null;
             }
             newGroupByKeys.add(newGroupByKey);
@@ -588,19 +588,19 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             ScalarOperator targetColumn = equationRewriter.replaceExprWithTarget(aggCall);
             if (targetColumn == null || !isAllExprReplaced(targetColumn, queryColumnSet)) {
                 // it means there is some column that can not be rewritten by outputs of mv
-                logMVRewrite(mvRewriteContext, "Rewrite aggregate %s failed: partially rewrite", aggCall.toString());
+                logMVRewrite(mvRewriteContext, "Rewrite aggregate {} failed: partially rewrite", aggCall.toString());
                 return null;
             }
             // TODO: Support non column-ref agg function.
             if (!(targetColumn instanceof ColumnRefOperator)) {
-                logMVRewrite(mvRewriteContext, "Rewrite aggregate %s failed: only column-ref is supported after rewrite",
+                logMVRewrite(mvRewriteContext, "Rewrite aggregate {} failed: only column-ref is supported after rewrite",
                         aggCall.toString());
                 return null;
             }
             // Aggregate must be CallOperator
             CallOperator newAggregate = getRollupAggregate(aggCall, (ColumnRefOperator) targetColumn);
             if (newAggregate == null) {
-                logMVRewrite(mvRewriteContext, "Rewrite aggregate %s failed: cannot get rollup aggregate",
+                logMVRewrite(mvRewriteContext, "Rewrite aggregate {} failed: cannot get rollup aggregate",
                         aggCall.toString());
                 return null;
             }
@@ -621,14 +621,14 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             CallOperator aggCall = entry.getValue();
             ColumnRefOperator targetColumn = mapping.get(entry.getKey());
             if (targetColumn == null) {
-                logMVRewrite(mvRewriteContext, "Rewrite aggregate %s for union failed: target column is null",
+                logMVRewrite(mvRewriteContext, "Rewrite aggregate {} for union failed: target column is null",
                         aggCall.toString());
                 return null;
             }
             // Aggregate must be CallOperator
             CallOperator newAggregate = getRollupAggregate(aggCall, targetColumn);
             if (newAggregate == null) {
-                logMVRewrite(mvRewriteContext, "Rewrite aggregate %s failed: cannot get rollup aggregate",
+                logMVRewrite(mvRewriteContext, "Rewrite aggregate {} failed: cannot get rollup aggregate",
                         aggCall.toString());
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -214,7 +214,7 @@ public class MaterializedViewRewriter {
         LogicalOperator queryOp = (LogicalOperator) queryExpr.getOp();
         LogicalOperator mvOp = (LogicalOperator) mvExpr.getOp();
         if (!queryOp.getOpType().equals(mvOp.getOpType())) {
-            logMVRewrite(mvRewriteContext, "join type is different %s != %s", queryOp.getOpType(), mvOp.getOpType());
+            logMVRewrite(mvRewriteContext, "join type is different {} != {}", queryOp.getOpType(), mvOp.getOpType());
             return false;
         }
         if (queryOp instanceof LogicalJoinOperator) {
@@ -234,7 +234,7 @@ public class MaterializedViewRewriter {
             // For non-inner/cross join, we must ensure all on-predicates are not compensated, otherwise there may
             // be some correctness bugs.
             if (!ScalarOperator.isEquivalent(queryJoin.getOnPredicate(), (mvJoin.getOnPredicate()))) {
-                logMVRewrite(mvRewriteContext, "join predicate is different %s != %s", queryJoin.getOnPredicate(),
+                logMVRewrite(mvRewriteContext, "join predicate is different {} != {}", queryJoin.getOnPredicate(),
                         mvJoin.getOnPredicate());
                 return false;
             }
@@ -249,7 +249,7 @@ public class MaterializedViewRewriter {
             }
 
             if (!JOIN_COMPATIBLE_MAP.get(mvJoinType).contains(queryJoinType)) {
-                logMVRewrite(mvRewriteContext, "join type is not compatible %s not contains %s", mvJoinType,
+                logMVRewrite(mvRewriteContext, "join type is not compatible {} not contains {}", mvJoinType,
                         queryJoinType);
                 return false;
             }
@@ -263,7 +263,7 @@ public class MaterializedViewRewriter {
             boolean isSupported = isSupportedPredicate(queryOnPredicate,
                     materializationContext.getQueryRefFactory(), tableToJoinColumns, joinColumnPairs);
             if (!isSupported) {
-                logMVRewrite(mvRewriteContext, "join predicate is not supported %s", queryOnPredicate);
+                logMVRewrite(mvRewriteContext, "join predicate is not supported {}", queryOnPredicate);
                 return false;
             }
             // use join columns from query
@@ -280,7 +280,7 @@ public class MaterializedViewRewriter {
             boolean isCompatible = isJoinCompatible(usedColumnsToTable, queryJoinType, mvJoinType,
                     leftColumns, rightColumns, joinColumnPairs, joinColumnRefs, compensatedEquivalenceColumns);
             if (!isCompatible) {
-                logMVRewrite(mvRewriteContext, "join columns not compatible %s != %s", leftColumns, rightColumns);
+                logMVRewrite(mvRewriteContext, "join columns not compatible {} != {}", leftColumns, rightColumns);
                 return false;
             }
             JoinDeriveContext joinDeriveContext =
@@ -696,7 +696,7 @@ public class MaterializedViewRewriter {
         // used to prune partition and buckets after mv rewrite
         ScalarOperator mvPrunePredicate = collectMvPrunePredicate(materializationContext);
 
-        logMVRewrite(mvRewriteContext, "Construct %d relation id mappings from query to mv", relationIdMappings.size());
+        logMVRewrite(mvRewriteContext, "Construct {} relation id mappings from query to mv", relationIdMappings.size());
         for (BiMap<Integer, Integer> relationIdMapping : relationIdMappings) {
             mvRewriteContext.setMvPruneConjunct(mvPrunePredicate);
             rewriteContext.setQueryToMvRelationIdMapping(relationIdMapping);
@@ -1156,7 +1156,7 @@ public class MaterializedViewRewriter {
             newEqualPredicates = rewriteMVCompensationExpression(rewriteContext, rewriter,
                     mvColumnRefToScalarOp, equalPredicates, true);
             if (newEqualPredicates == null) {
-                logMVRewrite(mvRewriteContext, "Rewrite equal predicates compensation failed: %s", equalPredicates);
+                logMVRewrite(mvRewriteContext, "Rewrite equal predicates compensation failed: {}", equalPredicates);
                 return null;
             }
         }
@@ -1166,7 +1166,7 @@ public class MaterializedViewRewriter {
             newOtherPredicates = rewriteMVCompensationExpression(rewriteContext, rewriter,
                     mvColumnRefToScalarOp, otherPredicates, false);
             if (newOtherPredicates == null) {
-                logMVRewrite(mvRewriteContext, "Rewrite other predicates compensation failed: %s", otherPredicates);
+                logMVRewrite(mvRewriteContext, "Rewrite other predicates compensation failed: {}", otherPredicates);
                 return null;
             }
         }
@@ -1174,7 +1174,7 @@ public class MaterializedViewRewriter {
         ScalarOperator compensationPredicate = MvUtils.canonizePredicate(Utils.compoundAnd(newEqualPredicates,
                 newOtherPredicates));
         if (compensationPredicate == null) {
-            logMVRewrite(mvRewriteContext, "Canonize compensate predicates failed: %s , %s",
+            logMVRewrite(mvRewriteContext, "Canonize compensate predicates failed: {} , {}",
                     equalPredicates, otherPredicates);
             return null;
         }
@@ -1400,7 +1400,7 @@ public class MaterializedViewRewriter {
                     rewriteContext.getQueryExpression(), rewriteContext.getQueryRefFactory(), rewrittenFailedPredicates);
             if (rewrittenPair == null) {
                 logMVRewrite(mvRewriteContext, "Rewrite union failed: cannot rewrite compensations other predicates" +
-                        " from view to query, rewrittenFailedPredicates:%s", rewrittenFailedPredicates);
+                        " from view to query, rewrittenFailedPredicates:{}", rewrittenFailedPredicates);
                 return null;
             }
             mvCompensationPredicates = Utils.compoundAnd(mvCompensationPredicates, rewrittenPair.first);
@@ -1408,7 +1408,7 @@ public class MaterializedViewRewriter {
         }
         if (mvCompensationPredicates == null) {
             logMVRewrite(mvRewriteContext, "Rewrite union failed: cannot rewrite compensations from view to query, " +
-                    "mvEqualPreds:%s, mvOtherPreds:%s", (mvEqualPreds == null), (mvOtherPreds == null));
+                    "mvEqualPreds:{}, mvOtherPreds:{}", (mvEqualPreds == null), (mvOtherPreds == null));
             return null;
         }
 
@@ -1985,13 +1985,13 @@ public class MaterializedViewRewriter {
         for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : swappedQueryColumnMap.entrySet()) {
             ScalarOperator rewritten = equationRewriter.replaceExprWithTarget(entry.getValue());
             if (rewritten == null) {
-                logMVRewrite(mvRewriteContext, "Rewrite projection failed: cannot rewrite expr %s",
+                logMVRewrite(mvRewriteContext, "Rewrite projection failed: cannot rewrite expr {}",
                         entry.getValue().toString());
                 return null;
             }
             if (!isAllExprReplaced(rewritten, new ColumnRefSet(rewriteContext.getQueryColumnSet()))) {
                 // it means there is some column that can not be rewritten by outputs of mv
-                logMVRewrite(mvRewriteContext, "Rewrite projection failed: cannot totally rewrite expr %s",
+                logMVRewrite(mvRewriteContext, "Rewrite projection failed: cannot totally rewrite expr {}",
                         entry.getValue().toString());
                 return null;
             }
@@ -2260,7 +2260,7 @@ public class MaterializedViewRewriter {
                 getCompensationPredicate(srcPr, targetPr, columnRewriter, true, isQueryToMV);
         if (compensationPr == null) {
             logMVRewrite(mvRewriteContext, "Rewrite query failed: get range compensation predicates failed," +
-                    "srcPr:%s, targetPr:%s", MvUtils.toString(srcPr), MvUtils.toString(targetPr));
+                    "srcPr:{}, targetPr:{}", MvUtils.toString(srcPr), MvUtils.toString(targetPr));
             return null;
         }
 
@@ -2282,7 +2282,7 @@ public class MaterializedViewRewriter {
                 getCompensationPredicate(srcPu, targetPu, columnRewriter, false, isQueryToMV);
         if (compensationPu == null) {
             logMVRewrite(mvRewriteContext, "Rewrite query failed: get residual compensation predicates failed," +
-                    "srcPr:%s, targetPr:%s", MvUtils.toString(srcPu), MvUtils.toString(targetPu));
+                    "srcPr:{}, targetPr:{}", MvUtils.toString(srcPu), MvUtils.toString(targetPu));
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -803,7 +803,7 @@ public class MvUtils {
     public static ScalarOperator getMvPartialPartitionPredicates(MaterializedView mv,
                                                                  OptExpression mvPlan,
                                                                  Set<String> mvPartitionNamesToRefresh) {
-        Pair<Table, Column> partitionTableAndColumns = mv.getPartitionTableAndColumn();
+        Pair<Table, Column> partitionTableAndColumns = mv.getBaseTableAndPartitionColumn();
         if (partitionTableAndColumns == null) {
             return null;
         }
@@ -839,7 +839,7 @@ public class MvUtils {
                                                                              Column partitionColumn,
                                                                              MaterializedView mv,
                                                                              Set<String> mvPartitionNamesToRefresh) {
-        Set<String> modifiedPartitionNames = mv.getUpdatedPartitionNamesOfTable(partitionByTable);
+        Set<String> modifiedPartitionNames = mv.getBaseTableUpdatedPartitionNames(partitionByTable);
         List<Range<PartitionKey>> baseTableRanges = getLatestPartitionRange(partitionByTable, partitionColumn,
                 modifiedPartitionNames);
         List<Range<PartitionKey>> mvRanges = getLatestPartitionRangeForNativeTable(mv, mvPartitionNamesToRefresh);
@@ -873,7 +873,7 @@ public class MvUtils {
         } else {
             Map<String, Range<PartitionKey>> partitionMap;
             try {
-                partitionMap = PartitionUtil.getPartitionRange(table, partitionColumn);
+                partitionMap = PartitionUtil.getTablePartitionKeyRange(table, partitionColumn);
             } catch (UserException e) {
                 LOG.warn("Materialized view Optimizer compute partition range failed.", e);
                 return Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -839,7 +839,7 @@ public class MvUtils {
                                                                              Column partitionColumn,
                                                                              MaterializedView mv,
                                                                              Set<String> mvPartitionNamesToRefresh) {
-        Set<String> modifiedPartitionNames = mv.getBaseTableUpdatedPartitionNames(partitionByTable);
+        Set<String> modifiedPartitionNames = mv.getUpdatedPartitionNamesOfTable(partitionByTable);
         List<Range<PartitionKey>> baseTableRanges = getLatestPartitionRange(partitionByTable, partitionColumn,
                 modifiedPartitionNames);
         List<Range<PartitionKey>> mvRanges = getLatestPartitionRangeForNativeTable(mv, mvPartitionNamesToRefresh);
@@ -873,7 +873,7 @@ public class MvUtils {
         } else {
             Map<String, Range<PartitionKey>> partitionMap;
             try {
-                partitionMap = PartitionUtil.getTablePartitionKeyRange(table, partitionColumn);
+                partitionMap = PartitionUtil.getPartitionRange(table, partitionColumn);
             } catch (UserException e) {
                 LOG.warn("Materialized view Optimizer compute partition range failed.", e);
                 return Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -67,7 +67,7 @@ public class OptExpressionDuplicator {
         this.columnRefFactory = materializationContext.getQueryRefFactory();
         this.columnMapping = Maps.newHashMap();
         this.rewriter = new ReplaceColumnRefRewriter(columnMapping);
-        Pair<Table, Column> partitionInfo = materializationContext.getMv().getPartitionTableAndColumn();
+        Pair<Table, Column> partitionInfo = materializationContext.getMv().getBaseTableAndPartitionColumn();
         this.partitionByTable = partitionInfo == null ? null : partitionInfo.first;
         this.partitionColumn = partitionInfo == null ? null : partitionInfo.second;
         this.partialPartitionRewrite = !materializationContext.getMvPartitionNamesToRefresh().isEmpty();

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -168,20 +168,20 @@ public class RefreshMaterializedViewTest {
         cluster.runSql("test", "insert into tbl_with_mv values(\"2022-02-20\", 1, 10)");
         refreshMaterializedView("test", "mv_to_refresh");
         MaterializedView mv1 = getMv("test", "mv_to_refresh");
-        Set<String> partitionsToRefresh1 = mv1.getMVToRefreshPartitionNames();
+        Set<String> partitionsToRefresh1 = mv1.getPartitionNamesToRefreshForMv();
         Assert.assertTrue(partitionsToRefresh1.isEmpty());
         refreshMaterializedView("test", "mv2_to_refresh");
         MaterializedView mv2 = getMv("test", "mv2_to_refresh");
-        Set<String> partitionsToRefresh2 = mv2.getMVToRefreshPartitionNames();
+        Set<String> partitionsToRefresh2 = mv2.getPartitionNamesToRefreshForMv();
         Assert.assertTrue(partitionsToRefresh2.isEmpty());
         cluster.runSql("test", "insert into tbl_with_mv partition(p2) values(\"2022-02-20\", 2, 10)");
         OlapTable table = (OlapTable) getTable("test", "tbl_with_mv");
         Partition p1 = table.getPartition("p1");
         Partition p2 = table.getPartition("p2");
         if (p2.getVisibleVersion() == 3) {
-            partitionsToRefresh1 = mv1.getMVToRefreshPartitionNames();
+            partitionsToRefresh1 = mv1.getPartitionNamesToRefreshForMv();
             Assert.assertEquals(Sets.newHashSet("mv_to_refresh"), partitionsToRefresh1);
-            partitionsToRefresh2 = mv2.getMVToRefreshPartitionNames();
+            partitionsToRefresh2 = mv2.getPartitionNamesToRefreshForMv();
             Assert.assertTrue(partitionsToRefresh2.contains("p2"));
         } else {
             // publish version is async, so version update may be late
@@ -235,7 +235,7 @@ public class RefreshMaterializedViewTest {
         cluster.runSql("test", "insert into tbl_staleness1 values(\"2022-02-20\", 1, 10)");
         {
             MaterializedView mv1 = getMv("test", "mv_with_mv_rewrite_staleness");
-            Set<String> partitionsToRefresh = mv1.getMVToRefreshPartitionNames();
+            Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv();
             Assert.assertTrue(partitionsToRefresh.isEmpty());
 
         }
@@ -243,14 +243,14 @@ public class RefreshMaterializedViewTest {
         {
             refreshMaterializedView("test", "mv_with_mv_rewrite_staleness");
             MaterializedView mv2 = getMv("test", "mv_with_mv_rewrite_staleness");
-            Set<String> partitionsToRefresh = mv2.getMVToRefreshPartitionNames();
+            Set<String> partitionsToRefresh = mv2.getPartitionNamesToRefreshForMv();
             Assert.assertTrue(partitionsToRefresh.isEmpty());
         }
         // no refresh partitions if there is new data & no refresh but is set `mv_rewrite_staleness`.
         {
             cluster.runSql("test", "insert into tbl_staleness1 values(\"2022-02-22\", 1, 10)");
             MaterializedView mv1 = getMv("test", "mv_with_mv_rewrite_staleness");
-            Set<String> partitionsToRefresh = mv1.getMVToRefreshPartitionNames();
+            Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv();
             Assert.assertTrue(partitionsToRefresh.isEmpty());
         }
         starRocksAssert.dropTable("tbl_staleness1");
@@ -322,7 +322,7 @@ public class RefreshMaterializedViewTest {
             Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
             Assert.assertTrue(mv1.isStalenessSatisfied());
 
-            Set<String> partitionsToRefresh = mv1.getMVToRefreshPartitionNames();
+            Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv();
             Assert.assertTrue(partitionsToRefresh.isEmpty());
         }
         starRocksAssert.dropTable("tbl_staleness2");
@@ -420,7 +420,7 @@ public class RefreshMaterializedViewTest {
                 Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
                 Assert.assertTrue(mv1.isStalenessSatisfied());
 
-                Set<String> partitionsToRefresh = mv1.getMVToRefreshPartitionNames();
+                Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv();
                 Assert.assertTrue(partitionsToRefresh.isEmpty());
             }
             {
@@ -441,7 +441,7 @@ public class RefreshMaterializedViewTest {
                 Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
                 Assert.assertTrue(mv2.isStalenessSatisfied());
 
-                Set<String> partitionsToRefresh = mv2.getMVToRefreshPartitionNames();
+                Set<String> partitionsToRefresh = mv2.getPartitionNamesToRefreshForMv();
                 Assert.assertTrue(partitionsToRefresh.isEmpty());
             }
         }
@@ -466,7 +466,7 @@ public class RefreshMaterializedViewTest {
                 Assert.assertFalse(mv1.isStalenessSatisfied());
                 Assert.assertFalse(mv2.maxBaseTableRefreshTimestamp().isPresent());
 
-                Set<String> partitionsToRefresh = mv2.getMVToRefreshPartitionNames();
+                Set<String> partitionsToRefresh = mv2.getPartitionNamesToRefreshForMv();
                 Assert.assertFalse(partitionsToRefresh.isEmpty());
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -168,20 +168,20 @@ public class RefreshMaterializedViewTest {
         cluster.runSql("test", "insert into tbl_with_mv values(\"2022-02-20\", 1, 10)");
         refreshMaterializedView("test", "mv_to_refresh");
         MaterializedView mv1 = getMv("test", "mv_to_refresh");
-        Set<String> partitionsToRefresh1 = mv1.getPartitionNamesToRefreshForMv();
+        Set<String> partitionsToRefresh1 = mv1.getMVToRefreshPartitionNames();
         Assert.assertTrue(partitionsToRefresh1.isEmpty());
         refreshMaterializedView("test", "mv2_to_refresh");
         MaterializedView mv2 = getMv("test", "mv2_to_refresh");
-        Set<String> partitionsToRefresh2 = mv2.getPartitionNamesToRefreshForMv();
+        Set<String> partitionsToRefresh2 = mv2.getMVToRefreshPartitionNames();
         Assert.assertTrue(partitionsToRefresh2.isEmpty());
         cluster.runSql("test", "insert into tbl_with_mv partition(p2) values(\"2022-02-20\", 2, 10)");
         OlapTable table = (OlapTable) getTable("test", "tbl_with_mv");
         Partition p1 = table.getPartition("p1");
         Partition p2 = table.getPartition("p2");
         if (p2.getVisibleVersion() == 3) {
-            partitionsToRefresh1 = mv1.getPartitionNamesToRefreshForMv();
+            partitionsToRefresh1 = mv1.getMVToRefreshPartitionNames();
             Assert.assertEquals(Sets.newHashSet("mv_to_refresh"), partitionsToRefresh1);
-            partitionsToRefresh2 = mv2.getPartitionNamesToRefreshForMv();
+            partitionsToRefresh2 = mv2.getMVToRefreshPartitionNames();
             Assert.assertTrue(partitionsToRefresh2.contains("p2"));
         } else {
             // publish version is async, so version update may be late
@@ -235,7 +235,7 @@ public class RefreshMaterializedViewTest {
         cluster.runSql("test", "insert into tbl_staleness1 values(\"2022-02-20\", 1, 10)");
         {
             MaterializedView mv1 = getMv("test", "mv_with_mv_rewrite_staleness");
-            Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv();
+            Set<String> partitionsToRefresh = mv1.getMVToRefreshPartitionNames();
             Assert.assertTrue(partitionsToRefresh.isEmpty());
 
         }
@@ -243,14 +243,14 @@ public class RefreshMaterializedViewTest {
         {
             refreshMaterializedView("test", "mv_with_mv_rewrite_staleness");
             MaterializedView mv2 = getMv("test", "mv_with_mv_rewrite_staleness");
-            Set<String> partitionsToRefresh = mv2.getPartitionNamesToRefreshForMv();
+            Set<String> partitionsToRefresh = mv2.getMVToRefreshPartitionNames();
             Assert.assertTrue(partitionsToRefresh.isEmpty());
         }
         // no refresh partitions if there is new data & no refresh but is set `mv_rewrite_staleness`.
         {
             cluster.runSql("test", "insert into tbl_staleness1 values(\"2022-02-22\", 1, 10)");
             MaterializedView mv1 = getMv("test", "mv_with_mv_rewrite_staleness");
-            Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv();
+            Set<String> partitionsToRefresh = mv1.getMVToRefreshPartitionNames();
             Assert.assertTrue(partitionsToRefresh.isEmpty());
         }
         starRocksAssert.dropTable("tbl_staleness1");
@@ -322,7 +322,7 @@ public class RefreshMaterializedViewTest {
             Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
             Assert.assertTrue(mv1.isStalenessSatisfied());
 
-            Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv();
+            Set<String> partitionsToRefresh = mv1.getMVToRefreshPartitionNames();
             Assert.assertTrue(partitionsToRefresh.isEmpty());
         }
         starRocksAssert.dropTable("tbl_staleness2");
@@ -420,7 +420,7 @@ public class RefreshMaterializedViewTest {
                 Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
                 Assert.assertTrue(mv1.isStalenessSatisfied());
 
-                Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv();
+                Set<String> partitionsToRefresh = mv1.getMVToRefreshPartitionNames();
                 Assert.assertTrue(partitionsToRefresh.isEmpty());
             }
             {
@@ -441,7 +441,7 @@ public class RefreshMaterializedViewTest {
                 Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
                 Assert.assertTrue(mv2.isStalenessSatisfied());
 
-                Set<String> partitionsToRefresh = mv2.getPartitionNamesToRefreshForMv();
+                Set<String> partitionsToRefresh = mv2.getMVToRefreshPartitionNames();
                 Assert.assertTrue(partitionsToRefresh.isEmpty());
             }
         }
@@ -466,7 +466,7 @@ public class RefreshMaterializedViewTest {
                 Assert.assertFalse(mv1.isStalenessSatisfied());
                 Assert.assertFalse(mv2.maxBaseTableRefreshTimestamp().isPresent());
 
-                Set<String> partitionsToRefresh = mv2.getPartitionNamesToRefreshForMv();
+                Set<String> partitionsToRefresh = mv2.getMVToRefreshPartitionNames();
                 Assert.assertFalse(partitionsToRefresh.isEmpty());
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -27,7 +27,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
-import com.starrocks.statistic.StatsConstants;
+import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
@@ -43,8 +43,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static com.starrocks.utframe.UtFrameUtils.CREATE_STATISTICS_TABLE_STMT;
 
 public class MaterializedViewTestBase extends PlanTestBase {
     private static final Logger LOG = LogManager.getLogger(MaterializedViewTestBase.class);
@@ -72,7 +70,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
 
         new MockUp<MaterializedView>() {
             @Mock
-            Set<String> getPartitionNamesToRefreshForMv() {
+            Set<String> getMVToRefreshPartitionNames() {
                 return Sets.newHashSet();
             }
         };
@@ -92,9 +90,8 @@ public class MaterializedViewTestBase extends PlanTestBase {
         };
 
         if (!starRocksAssert.databaseExist("_statistics_")) {
-            starRocksAssert.withDatabaseWithoutAnalyze(StatsConstants.STATISTICS_DB_NAME)
-                    .useDatabase(StatsConstants.STATISTICS_DB_NAME);
-            starRocksAssert.withTable(CREATE_STATISTICS_TABLE_STMT);
+            StatisticsMetaManager m = new StatisticsMetaManager();
+            m.createStatisticsTablesForTest();
         }
 
         starRocksAssert.withDatabase(MATERIALIZED_DB_NAME)

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -70,7 +70,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
 
         new MockUp<MaterializedView>() {
             @Mock
-            Set<String> getMVToRefreshPartitionNames() {
+            Set<String> getPartitionNamesToRefreshForMv() {
                 return Sets.newHashSet();
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTest.java
@@ -268,7 +268,7 @@ public class OptimizerTest {
             Assert.assertEquals("mv_4", materializationContext.getMv().getName());
 
             MaterializedView mv = getMv("test", "mv_4");
-            Pair<Table, Column> partitionTableAndColumn = mv.getPartitionTableAndColumn();
+            Pair<Table, Column> partitionTableAndColumn = mv.getBaseTableAndPartitionColumn();
             Assert.assertEquals("tbl_with_mv", partitionTableAndColumn.first.getName());
 
             ScalarOperator scalarOperator  = materializationContext.getMvPartialPartitionPredicate();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -215,7 +215,7 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
             Assert.assertTrue((mvMaxBaseTableRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
             Assert.assertTrue(mv1.isStalenessSatisfied());
 
-            Set<String> partitionsToRefresh = mv1.getMVToRefreshPartitionNames();
+            Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv();
             Assert.assertTrue(partitionsToRefresh.isEmpty());
         }
         starRocksAssert.dropMaterializedView("hive_staleness_1");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -205,7 +205,6 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
 
         // no refresh partitions if mv_rewrite_staleness is set.
         {
-
             MaterializedView mv1 = getMv("test", "hive_staleness_1");
             Assert.assertTrue(mv1.maxBaseTableRefreshTimestamp().isPresent());
 
@@ -216,7 +215,7 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
             Assert.assertTrue((mvMaxBaseTableRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
             Assert.assertTrue(mv1.isStalenessSatisfied());
 
-            Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv();
+            Set<String> partitionsToRefresh = mv1.getMVToRefreshPartitionNames();
             Assert.assertTrue(partitionsToRefresh.isEmpty());
         }
         starRocksAssert.dropMaterializedView("hive_staleness_1");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -550,7 +550,7 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
     }
 
     @Test
-    public void testHivePartitionQueryRewrite() throws Exception {
+    public void testHivePartitionQueryRewrite1() throws Exception {
         starRocksAssert.getCtx().getSessionVariable().setEnableMaterializedViewUnionRewrite(true);
         String mvName = "hive_query_rewrite";
 
@@ -562,7 +562,7 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
                         "REFRESH MANUAL\n" +
                         "PROPERTIES (\n" +
                         "\"replication_num\" = \"1\",\n" +
-                        "'olap_table_query_rewrite_consistency' = 'checked', " +
+                        "'query_rewrite_consistency' = 'checked', " +
                         "\"force_external_table_query_rewrite\" = \"disable\"\n" +
                         ")\n" +
                         "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
@@ -620,5 +620,108 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
                 "where l_shipdate >= '1998-01-04'";
         PlanTestBase.assertContains(getFragmentPlan(query), mvName);
         dropMv("test", mvName);
+    }
+
+    @Test
+    public void testHivePartitionQueryRewrite2() throws Exception {
+        starRocksAssert.getCtx().getSessionVariable().setEnableMaterializedViewUnionRewrite(true);
+        String mvName = "hive_query_rewrite";
+
+        {
+            // default
+            createAndRefreshMv("test", mvName,
+                    "CREATE MATERIALIZED VIEW `hive_query_rewrite`\n" +
+                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                            "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                            "REFRESH MANUAL\n" +
+                            "PROPERTIES (\n" +
+                            "\"replication_num\" = \"1\"\n" +
+                            ")\n" +
+                            "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  " +
+                            "FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
+
+            MaterializedView ttlMv = getMv("test", mvName);
+            GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler().runOnceForTest();
+            Assert.assertEquals(1, ttlMv.getPartitions().size());
+
+            String query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                    "where l_shipdate >= '1998-01-04'";
+            PlanTestBase.assertNotContains(getFragmentPlan(query), mvName);
+            dropMv("test", mvName);
+        }
+
+        {
+            // Disable
+            createAndRefreshMv("test", mvName,
+                    "CREATE MATERIALIZED VIEW `hive_query_rewrite`\n" +
+                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                            "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                            "REFRESH MANUAL\n" +
+                            "PROPERTIES (\n" +
+                            "\"replication_num\" = \"1\",\n" +
+                            "'query_rewrite_consistency' = 'disable' " +
+                            ")\n" +
+                            "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  " +
+                            "FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
+
+            MaterializedView ttlMv = getMv("test", mvName);
+            GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler().runOnceForTest();
+            Assert.assertEquals(1, ttlMv.getPartitions().size());
+
+            String query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                    "where l_shipdate >= '1998-01-04'";
+            PlanTestBase.assertNotContains(getFragmentPlan(query), mvName);
+            dropMv("test", mvName);
+        }
+
+        {
+            // Checked
+            createMv("test", mvName,
+                    "CREATE MATERIALIZED VIEW `hive_query_rewrite`\n" +
+                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                            "DISTRIBUTED BY HASH(`l_shipdate`) BUCKETS 10\n" +
+                            "REFRESH DEFERRED MANUAL\n" +
+                            "PROPERTIES (\n" +
+                            "\"replication_num\" = \"1\",\n" +
+                            "\"query_rewrite_consistency\" = \"checked\"\n" +
+                            ")\n" +
+                            "AS SELECT `l_shipdate`, sum(`l_orderkey`)  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                            "GROUP BY l_shipdate");
+
+            String query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                    "where l_shipdate >= '1998-01-04'";
+            PlanTestBase.assertNotContains(getFragmentPlan(query), mvName);
+            // refresh mv
+            refreshMaterializedView("test", mvName);
+            query =
+                    "SELECT `l_shipdate`, sum(`l_orderkey`)  FROM `hive0`.`partitioned_db`.`lineitem_par` GROUP BY l_shipdate";
+            PlanTestBase.assertNotContains(getFragmentPlan(query), mvName);
+            dropMv("test", mvName);
+
+        }
+        {
+            // Loose
+            createAndRefreshMv("test", mvName,
+                    "CREATE MATERIALIZED VIEW `hive_query_rewrite`\n" +
+                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                            "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                            "REFRESH DEFERRED MANUAL\n" +
+                            "PROPERTIES (\n" +
+                            "\"replication_num\" = \"1\",\n" +
+                            "\"query_rewrite_consistency\" = \"loose\"\n" +
+                            ")\n" +
+                            "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  " +
+                            "FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
+
+            String query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                    "where l_shipdate >= '1998-01-04'";
+            PlanTestBase.assertContains(getFragmentPlan(query), mvName);
+            // refresh mv
+            refreshMaterializedView("test", mvName);
+            query = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
+                    "where l_shipdate >= '1998-01-04'";
+            PlanTestBase.assertContains(getFragmentPlan(query), mvName);
+            dropMv("test", mvName);
+        }
     }
 }

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q7.sql
@@ -41,9 +41,9 @@ order by
 [result]
 TOP-N (order by [[42: n_name ASC NULLS FIRST, 46: n_name ASC NULLS FIRST, 49: year ASC NULLS FIRST]])
     TOP-N (order by [[42: n_name ASC NULLS FIRST, 46: n_name ASC NULLS FIRST, 49: year ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{370: sum=sum(370: sum)}] group by [[68: n_name1, 69: n_name2, 70: l_shipyear]] having [null]
-            EXCHANGE SHUFFLE[68, 69, 70]
-                AGGREGATE ([LOCAL] aggregate [{370: sum=sum(71: sum_saleprice)}] group by [[68: n_name1, 69: n_name2, 70: l_shipyear]] having [null]
-                    SCAN (mv[lineitem_mv_agg_mv2] columns[67: l_shipdate, 68: n_name1, 69: n_name2, 70: l_shipyear, 71: sum_saleprice] predicate[68: n_name1 = CANADA AND 69: n_name2 = IRAN OR 68: n_name1 = IRAN AND 69: n_name2 = CANADA AND 67: l_shipdate <= 1996-12-31 AND 67: l_shipdate >= 1995-01-01])
+        AGGREGATE ([GLOBAL] aggregate [{370: sum=sum(370: sum)}] group by [[105: n_name1, 106: n_name2, 107: l_shipyear]] having [null]
+            EXCHANGE SHUFFLE[105, 106, 107]
+                AGGREGATE ([LOCAL] aggregate [{370: sum=sum(108: sum_saleprice)}] group by [[105: n_name1, 106: n_name2, 107: l_shipyear]] having [null]
+                    SCAN (mv[lineitem_mv_agg_mv2] columns[104: l_shipdate, 105: n_name1, 106: n_name2, 107: l_shipyear, 108: sum_saleprice] predicate[104: l_shipdate >= 1995-01-01 AND 104: l_shipdate <= 1996-12-31 AND 105: n_name1 = CANADA AND 106: n_name2 = IRAN OR 105: n_name1 = IRAN AND 106: n_name2 = CANADA])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q7.sql
@@ -41,9 +41,9 @@ order by
 [result]
 TOP-N (order by [[42: n_name ASC NULLS FIRST, 46: n_name ASC NULLS FIRST, 49: year ASC NULLS FIRST]])
     TOP-N (order by [[42: n_name ASC NULLS FIRST, 46: n_name ASC NULLS FIRST, 49: year ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{368: sum=sum(368: sum)}] group by [[66: n_name1, 67: n_name2, 68: l_shipyear]] having [null]
-            EXCHANGE SHUFFLE[66, 67, 68]
-                AGGREGATE ([LOCAL] aggregate [{368: sum=sum(69: sum_saleprice)}] group by [[66: n_name1, 67: n_name2, 68: l_shipyear]] having [null]
-                    SCAN (mv[lineitem_mv_agg_mv2] columns[65: l_shipdate, 66: n_name1, 67: n_name2, 68: l_shipyear, 69: sum_saleprice] predicate[65: l_shipdate >= 1995-01-01 AND 65: l_shipdate <= 1996-12-31 AND 66: n_name1 = CANADA AND 67: n_name2 = IRAN OR 66: n_name1 = IRAN AND 67: n_name2 = CANADA])
+        AGGREGATE ([GLOBAL] aggregate [{362: sum=sum(362: sum)}] group by [[135: n_name1, 136: n_name2, 137: l_shipyear]] having [null]
+            EXCHANGE SHUFFLE[135, 136, 137]
+                AGGREGATE ([LOCAL] aggregate [{362: sum=sum(138: sum_saleprice)}] group by [[135: n_name1, 136: n_name2, 137: l_shipyear]] having [null]
+                    SCAN (mv[lineitem_mv_agg_mv2] columns[134: l_shipdate, 135: n_name1, 136: n_name2, 137: l_shipyear, 138: sum_saleprice] predicate[135: n_name1 = CANADA AND 136: n_name2 = IRAN OR 135: n_name1 = IRAN AND 136: n_name2 = CANADA AND 134: l_shipdate <= 1996-12-31 AND 134: l_shipdate >= 1995-01-01])
 [end]
 


### PR DESCRIPTION
- Change olap_table_query_rewrite_consistency to query_rewrite_consistency to make it a property as MV.`query_rewrite_consistency` can be :
     - disable: this mv cannot be used for rewrite
     - checked: this mv can only be used for rewrite only this mv is satisfied for its staleness
     - loose: this mv will be always used for rewrite.
- To be compatible with old property `force_external_table_query_rewrite`, `force_external_table_query_rewrite` is still kept but will be Deprecated later.  
- Refactor getMVToRefreshPartitionNames into two methods: getNonPartitionedMVRefreshPartitions  and getPartitionedMVRefreshPartitions
- Change logPrepare/logRewrite into log format .、

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4