### PR TITLE
[BugFix] Fix memory leak bug caused by label cleaner (#28311)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/GetStreamLoadState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/GetStreamLoadState.java
@@ -81,9 +81,9 @@ public class GetStreamLoadState extends RestBaseAction {
             throw new DdlException("unknown database, database=" + dbName);
         }
 
-        String state = GlobalStateMgr.getCurrentGlobalTransactionMgr().getLabelState(db.getId(), label).toString();
+        String status = GlobalStateMgr.getCurrentGlobalTransactionMgr().getLabelStatus(db.getId(), label).toString();
 
-        sendResult(request, response, new Result(state));
+        sendResult(request, response, new Result(status));
     }
 
     private static class Result extends RestBaseResult {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -157,7 +157,7 @@ public class TransactionLoadAction extends RestBaseAction {
             if (db == null) {
                 throw new UserException("database " + dbName + " not exists");
             }
-            TransactionStatus txnStatus = GlobalStateMgr.getCurrentGlobalTransactionMgr().getLabelState(db.getId(),
+            TransactionStatus txnStatus = GlobalStateMgr.getCurrentGlobalTransactionMgr().getLabelStatus(db.getId(),
                     label);
             Long txnID = GlobalStateMgr.getCurrentGlobalTransactionMgr().getLabelTxnID(db.getId(), label);
             if (txnStatus == TransactionStatus.PREPARED) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -67,6 +67,7 @@ import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.thrift.TLoadJobType;
 import com.starrocks.thrift.TReportExecStatusParams;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -209,10 +210,12 @@ public class LoadMgr implements Writable {
             throws UserException {
         LoadJob loadJob = getLoadJob(jobId);
         if (loadJob.isTxnDone() && !Strings.isNullOrEmpty(failMsg)) {
-            throw new LoadException("LoadJob " + jobId + " state " + loadJob.getState().name() + ", can not be cancal");
+            throw new LoadException("LoadJob " + jobId + " state " + loadJob.getState().name()
+                    + ", can not be cancelled");
         }
         if (loadJob.isCompleted()) {
-            throw new LoadException("LoadJob " + jobId + " state " + loadJob.getState().name() + ", can not be cancal/publish");
+            throw new LoadException("LoadJob " + jobId + " state " + loadJob.getState().name() +
+                    ", can not be cancelled/publish");
         }
         switch (jobType) {
             case INSERT:
@@ -387,8 +390,8 @@ public class LoadMgr implements Writable {
         return (currentTimeMs - job.getFinishTimestamp()) / 1000 > Config.label_keep_max_second;
     }
 
-    public void cleanResidualJob() {
-        // clean residual insert job
+    public void cancelResidualJob() {
+        // cancel residual insert job
         readLock();
         List<LoadJob> insertJobs;
         try {
@@ -400,13 +403,13 @@ public class LoadMgr implements Writable {
         }
 
         insertJobs.forEach(job -> {
-            TransactionStatus st = GlobalStateMgr.getCurrentGlobalTransactionMgr().getLabelState(
+            TransactionState state = GlobalStateMgr.getCurrentGlobalTransactionMgr().getLabelTransactionState(
                     job.getDbId(), job.getLabel());
-            if (st == TransactionStatus.UNKNOWN) {
+            if (state != null && state.getTransactionStatus() == TransactionStatus.UNKNOWN) {
                 try {
                     recordFinishedOrCacnelledLoadJob(
                             job.getId(), EtlJobType.INSERT, "Cancelled since transaction status unknown", "");
-                    LOG.info("abort job: {} since transaction status unknown", job.getLabel());
+                    LOG.warn("abort job: {}-{} since transaction status unknown", job.getLabel(), job.getId());
                 } catch (UserException e) {
                     LOG.warn("failed to abort job: {}", job.getLabel(), e);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1978,7 +1978,7 @@ public class GlobalStateMgr {
                 globalTransactionMgr.abortTimeoutTxns();
 
                 try {
-                    loadManager.cancelResidualJob();
+                    loadMgr.cancelResidualJob();
                 } catch (Throwable t) {
                     LOG.warn("load manager cancel residual job failed", t);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1976,6 +1976,12 @@ public class GlobalStateMgr {
             @Override
             protected void runAfterCatalogReady() {
                 globalTransactionMgr.abortTimeoutTxns();
+
+                try {
+                    loadManager.cancelResidualJob();
+                } catch (Throwable t) {
+                    LOG.warn("load manager cancel residual job failed", t);
+                }
             }
         };
     }
@@ -3828,12 +3834,6 @@ public class GlobalStateMgr {
             loadMgr.removeOldLoadJob();
         } catch (Throwable t) {
             LOG.warn("load manager remove old load jobs failed", t);
-        }
-
-        try {
-            loadMgr.cleanResidualJob();
-        } catch (Throwable t) {
-            LOG.warn("load manager clean residual job failed", t);
         }
 
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -736,6 +736,21 @@ public class DatabaseTransactionMgr {
         }
     }
 
+    public TransactionState getLabelTransactionState(String label) {
+        readLock();
+        try {
+            Set<Long> existingTxnIds = unprotectedGetTxnIdsByLabel(label);
+            if (existingTxnIds == null || existingTxnIds.isEmpty()) {
+                return null;
+            }
+            // find the latest txn (which id is largest)
+            long maxTxnId = existingTxnIds.stream().max(Comparator.comparingLong(Long::valueOf)).orElse(Long.MIN_VALUE);
+            return unprotectedGetTransactionState(maxTxnId);
+        } finally {
+            readUnlock();
+        }
+    }
+
     public Long getLabelTxnID(String label) {
         readLock();
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -318,7 +318,7 @@ public class GlobalTransactionMgr implements Writable {
         }
     }
 
-    public TransactionStatus getLabelState(long dbId, String label) {
+    public TransactionStatus getLabelStatus(long dbId, String label) {
         try {
             DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
             return dbTransactionMgr.getLabelState(label);
@@ -326,7 +326,6 @@ public class GlobalTransactionMgr implements Writable {
             LOG.warn("Get transaction status by label " + label + " failed", e);
             return TransactionStatus.UNKNOWN;
         }
-
     }
 
     public Long getLabelTxnID(long dbId, String label) {
@@ -336,6 +335,16 @@ public class GlobalTransactionMgr implements Writable {
         } catch (AnalysisException e) {
             LOG.warn("Get transaction status by label " + label + " failed", e);
             return (long) -1;
+        }
+    }
+
+    public TransactionState getLabelTransactionState(long dbId, String label) {
+        try {
+            DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
+            return dbTransactionMgr.getLabelTransactionState(label);
+        } catch (AnalysisException e) {
+            LOG.warn("Get transaction state by label " + label + " failed", e);
+            return null;
         }
     }
 


### PR DESCRIPTION
Fixes #27975

`loadMgr.cancelResidualJob()` will cancel the UNKNOWN state insert load jobs, and write editLog for every changed job. It should be executed only on leader node, because non-leader node cannot write editLog and the thread will be blocked forever once non-leader node calls `submitLog` (This is unreasonable, it will be changed by another PR). To fix this bug move the cancelResidualJob into txn cleaner thread, which is executed only on leader node.

Besides, the `cancelResidualJob` is based on `getLabelStatus`, but if there is no txn related to that label (If the target table is system table, there will be no txn related to the label), `getLabelStatus` will return `UNKNOWN` too, which will cause the job cancelled by mistake. So I added a new function `getLabelTransactionState`, and only when the txn exists and its status is `UNKNOWN`, the job can be cancelled.

backport #28311