### PR TITLE
[BugFix][Cherry-pick][branch-2.3] fix pk compaction bug (#13106)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1723,6 +1723,11 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
         // give 10s time gitter, so same table's compaction don't start at same time
         _last_compaction_time_ms = UnixMillis() + rand() % 10000;
     }
+    if (info->inputs.empty()) {
+        LOG(INFO) << "no candidate rowset to do update compaction, tablet:" << _tablet.tablet_id();
+        _compaction_running = false;
+        return Status::OK();
+    }
     std::sort(info->inputs.begin(), info->inputs.end());
     // else there are still many(>3) rowset's need's to be compacted,
     // do not reset _last_compaction_time_ms so we can continue doing compaction


### PR DESCRIPTION
If there are no eligible rowsets in the primary key table, we will do a meaningless compaction and may cause NPE in the following code.
```
void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info) {
...
    // info->inputs is empty, so be will crash when calling the following function
    uint32_t max_rowset_id = *std::max_element(info->inputs.begin(), info->inputs.end());
    Rowset* rowset = _get_rowset(max_rowset_id).get();
...
}
```
We should return success directly when we don't find eligible rowset to do compaction.
