### PR TITLE
[Enhancement] support limited memory stream aggregate

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -980,7 +980,9 @@ CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache={
 
 // limit local exchange buffer's memory size per driver
 CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB
-CONF_mInt64(wait_apply_time, "6000");                                // 6s
+// only used for test. default: 128M
+CONF_mInt64(streaming_agg_limited_memory_size, "134217728");
+CONF_mInt64(wait_apply_time, "6000"); // 6s
 
 // Max size of a binlog file. The default is 512MB.
 CONF_Int64(binlog_file_max_size, "536870912");

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -23,6 +23,9 @@ namespace starrocks::pipeline {
 Status AggregateDistinctStreamingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), _unique_metrics.get()));
+    if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::LIMITED_MEM) {
+        _limited_mem_state.limited_memory_size = config::streaming_agg_limited_memory_size;
+    }
     return _aggregator->open(state);
 }
 
@@ -54,7 +57,10 @@ StatusOr<ChunkPtr> AggregateDistinctStreamingSinkOperator::pull_chunk(RuntimeSta
 }
 
 void AggregateDistinctStreamingSinkOperator::set_execute_mode(int performance_level) {
-    _aggregator->streaming_preaggregation_mode() = TStreamingPreaggregationMode::FORCE_STREAMING;
+    if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::AUTO) {
+        _aggregator->streaming_preaggregation_mode() = TStreamingPreaggregationMode::LIMITED_MEM;
+    }
+    _limited_mem_state.limited_memory_size = _aggregator->hash_map_memory_usage();
 }
 
 Status AggregateDistinctStreamingSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
@@ -69,6 +75,8 @@ Status AggregateDistinctStreamingSinkOperator::push_chunk(RuntimeState* state, c
         return _push_chunk_by_force_streaming(chunk);
     } else if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_PREAGGREGATION) {
         return _push_chunk_by_force_preaggregation(chunk->num_rows());
+    } else if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::LIMITED_MEM) {
+        return _push_chunk_by_limited_memory(chunk, chunk_size);
     } else {
         return _push_chunk_by_auto(chunk, chunk->num_rows());
     }
@@ -91,6 +99,18 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_force_preaggregati
 
     TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_set());
 
+    return Status::OK();
+}
+
+Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_limited_memory(const ChunkPtr& chunk,
+                                                                             const size_t chunk_size) {
+    bool ht_needs_expansion = _aggregator->hash_set_variant().need_expand(chunk_size);
+    if (ht_needs_expansion && _limited_mem_state.has_limited(*_aggregator)) {
+        RETURN_IF_ERROR(_push_chunk_by_force_streaming(chunk));
+        _aggregator->set_streaming_all_states(true);
+    } else {
+        RETURN_IF_ERROR(_push_chunk_by_auto(chunk, chunk_size));
+    }
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -21,6 +21,7 @@
 #include "exec/pipeline/operator.h"
 
 namespace starrocks::pipeline {
+// TODO: think about refactor
 class AggregateDistinctStreamingSinkOperator : public Operator {
 public:
     AggregateDistinctStreamingSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
@@ -33,7 +34,10 @@ public:
     ~AggregateDistinctStreamingSinkOperator() override = default;
 
     bool has_output() const override { return false; }
-    bool need_input() const override { return !is_finished(); }
+    bool need_input() const override {
+        return !is_finished() && !_aggregator->is_streaming_all_states() &&
+               _aggregator->chunk_buffer_size() < Aggregator::MAX_CHUNK_BUFFER_SIZE;
+    }
     bool is_finished() const override { return _is_finished || _aggregator->is_finished(); }
     Status set_finishing(RuntimeState* state) override;
 
@@ -57,6 +61,9 @@ private:
     // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::AUTO
     Status _push_chunk_by_auto(const ChunkPtr& chunk, const size_t chunk_size);
 
+    // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::LIMITED
+    Status _push_chunk_by_limited_memory(const ChunkPtr& chunk, const size_t chunk_size);
+
     // It is used to perform aggregation algorithms shared by
     // AggregateDistinctStreamingSourceOperator. It is
     // - prepared at SinkOperator::prepare(),
@@ -65,6 +72,7 @@ private:
     AggregatorPtr _aggregator = nullptr;
     // Whether prev operator has no output
     bool _is_finished = false;
+    LimitedMemAggState _limited_mem_state;
 };
 
 class AggregateDistinctStreamingSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
@@ -26,6 +26,10 @@ bool AggregateDistinctStreamingSourceOperator::has_output() const {
         return true;
     }
 
+    if (_aggregator->is_streaming_all_states()) {
+        return true;
+    }
+
     // There are two cases where chunk buffer is null,
     // it will apply local aggregate, so need to wait sink operator finish
     // case1：streaming mode is 'FORCE_PREAGGREGATION'
@@ -56,13 +60,13 @@ StatusOr<ChunkPtr> AggregateDistinctStreamingSourceOperator::pull_chunk(RuntimeS
     }
 
     ChunkPtr chunk = std::make_shared<Chunk>();
-    _output_chunk_from_hash_set(&chunk, state);
+    RETURN_IF_ERROR(_output_chunk_from_hash_set(&chunk, state));
     eval_runtime_bloom_filters(chunk.get());
     DCHECK_CHUNK(chunk);
     return std::move(chunk);
 }
 
-void AggregateDistinctStreamingSourceOperator::_output_chunk_from_hash_set(ChunkPtr* chunk, RuntimeState* state) {
+Status AggregateDistinctStreamingSourceOperator::_output_chunk_from_hash_set(ChunkPtr* chunk, RuntimeState* state) {
     if (!_aggregator->it_hash().has_value()) {
         _aggregator->hash_set_variant().visit(
                 [&](auto& hash_set_with_key) { _aggregator->it_hash() = hash_set_with_key->hash_set.begin(); });
@@ -70,6 +74,13 @@ void AggregateDistinctStreamingSourceOperator::_output_chunk_from_hash_set(Chunk
     }
 
     _aggregator->convert_hash_set_to_chunk(state->chunk_size(), chunk);
+
+    if (_aggregator->is_streaming_all_states() && _aggregator->is_ht_eos()) {
+        RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr));
+        _aggregator->set_streaming_all_states(false);
+    }
+
+    return Status::OK();
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.h
@@ -41,7 +41,7 @@ public:
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
 
 private:
-    void _output_chunk_from_hash_set(ChunkPtr* chunk, RuntimeState* state);
+    Status _output_chunk_from_hash_set(ChunkPtr* chunk, RuntimeState* state);
 
     // It is used to perform aggregation algorithms shared by
     // AggregateDistinctStreamingSinkOperator. It is

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.cpp
@@ -17,6 +17,7 @@
 #include <variant>
 
 #include "column/vectorized_fwd.h"
+#include "common/config.h"
 #include "exec/pipeline/pipeline_fwd.h"
 #include "runtime/current_thread.h"
 #include "simd/simd.h"
@@ -25,6 +26,9 @@ namespace starrocks::pipeline {
 Status AggregateStreamingSinkOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(Operator::prepare(state));
     RETURN_IF_ERROR(_aggregator->prepare(state, state->obj_pool(), _unique_metrics.get()));
+    if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::LIMITED_MEM) {
+        _limited_mem_state.limited_memory_size = config::streaming_agg_limited_memory_size;
+    }
     return _aggregator->open(state);
 }
 
@@ -56,7 +60,10 @@ StatusOr<ChunkPtr> AggregateStreamingSinkOperator::pull_chunk(RuntimeState* stat
 }
 
 void AggregateStreamingSinkOperator::set_execute_mode(int performance_level) {
-    _aggregator->streaming_preaggregation_mode() = TStreamingPreaggregationMode::FORCE_STREAMING;
+    if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::AUTO) {
+        _aggregator->streaming_preaggregation_mode() = TStreamingPreaggregationMode::LIMITED_MEM;
+    }
+    _limited_mem_state.limited_memory_size = _aggregator->hash_map_memory_usage();
 }
 
 Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
@@ -68,11 +75,12 @@ Status AggregateStreamingSinkOperator::push_chunk(RuntimeState* state, const Chu
     COUNTER_SET(_aggregator->input_row_count(), _aggregator->num_input_rows());
 
     RETURN_IF_ERROR(_aggregator->evaluate_groupby_exprs(chunk.get()));
-
     if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_STREAMING) {
         RETURN_IF_ERROR(_push_chunk_by_force_streaming(chunk));
     } else if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_PREAGGREGATION) {
         RETURN_IF_ERROR(_push_chunk_by_force_preaggregation(chunk, chunk->num_rows()));
+    } else if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::LIMITED_MEM) {
+        RETURN_IF_ERROR(_push_chunk_by_limited_memory(chunk, chunk_size));
     } else {
         RETURN_IF_ERROR(_push_chunk_by_auto(chunk, chunk->num_rows()));
     }
@@ -284,6 +292,17 @@ Status AggregateStreamingSinkOperator::_push_chunk_by_auto(const ChunkPtr& chunk
         }
         break;
     }
+    }
+    return Status::OK();
+}
+
+Status AggregateStreamingSinkOperator::_push_chunk_by_limited_memory(const ChunkPtr& chunk, const size_t chunk_size) {
+    bool ht_needs_expansion = _aggregator->hash_map_variant().need_expand(chunk_size);
+    if (ht_needs_expansion && _limited_mem_state.has_limited(*_aggregator)) {
+        RETURN_IF_ERROR(_push_chunk_by_force_streaming(chunk));
+        _aggregator->set_streaming_all_states(true);
+    } else {
+        RETURN_IF_ERROR(_push_chunk_by_auto(chunk, chunk_size));
     }
     return Status::OK();
 }

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -20,6 +20,7 @@
 #include "exec/pipeline/operator.h"
 
 namespace starrocks::pipeline {
+
 class AggregateStreamingSinkOperator : public Operator {
 public:
     AggregateStreamingSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
@@ -34,7 +35,8 @@ public:
 
     bool has_output() const override { return false; }
     bool need_input() const override {
-        return !is_finished() && _aggregator->chunk_buffer_size() < Aggregator::MAX_CHUNK_BUFFER_SIZE;
+        return !is_finished() && !_aggregator->is_streaming_all_states() &&
+               _aggregator->chunk_buffer_size() < Aggregator::MAX_CHUNK_BUFFER_SIZE;
     }
     bool is_finished() const override { return _is_finished || _aggregator->is_finished(); }
     Status set_finishing(RuntimeState* state) override;
@@ -60,6 +62,9 @@ private:
 
     Status _push_chunk_by_selective_preaggregation(const ChunkPtr& chunk, const size_t chunk_size, bool need_build);
 
+    // Invoked by push_chunk  if current mode is TStreamingPreaggregationMode::LIMITED
+    Status _push_chunk_by_limited_memory(const ChunkPtr& chunk, const size_t chunk_size);
+
     // It is used to perform aggregation algorithms shared by
     // AggregateStreamingSourceOperator. It is
     // - prepared at SinkOperator::prepare(),
@@ -70,6 +75,7 @@ private:
     bool _is_finished = false;
     AggrAutoState _auto_state{};
     AggrAutoContext _auto_context;
+    LimitedMemAggState _limited_mem_state;
 };
 
 class AggregateStreamingSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -28,6 +28,10 @@ bool AggregateStreamingSourceOperator::has_output() const {
         return true;
     }
 
+    if (_aggregator->is_streaming_all_states()) {
+        return true;
+    }
+
     // There are four cases where chunk buffer is empty
     // case1: streaming mode is 'FORCE_STREAMING'
     // case2: streaming mode is 'AUTO'
@@ -43,7 +47,7 @@ bool AggregateStreamingSourceOperator::has_output() const {
 }
 
 bool AggregateStreamingSourceOperator::is_finished() const {
-    return _aggregator->is_sink_complete() && _aggregator->is_chunk_buffer_empty() && _aggregator->is_ht_eos();
+    return _aggregator->is_sink_complete() && !has_output();
 }
 
 Status AggregateStreamingSourceOperator::set_finished(RuntimeState* state) {
@@ -79,6 +83,12 @@ Status AggregateStreamingSourceOperator::_output_chunk_from_hash_map(ChunkPtr* c
     }
 
     RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(state->chunk_size(), chunk));
+
+    if (_aggregator->is_streaming_all_states() && _aggregator->is_ht_eos()) {
+        RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr));
+        _aggregator->set_streaming_all_states(false);
+    }
+
     return Status::OK();
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -73,6 +73,7 @@ import java.util.stream.IntStream;
 
 import static com.starrocks.qe.SessionVariableConstants.FORCE_PREAGGREGATION;
 import static com.starrocks.qe.SessionVariableConstants.FORCE_STREAMING;
+import static com.starrocks.qe.SessionVariableConstants.LIMITED;
 
 public class AggregationNode extends PlanNode {
     private final AggregateInfo aggInfo;
@@ -248,6 +249,8 @@ public class AggregationNode extends PlanNode {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.FORCE_STREAMING);
         } else if (streamingPreaggregationMode.equalsIgnoreCase(FORCE_PREAGGREGATION)) {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.FORCE_PREAGGREGATION);
+        } else if (streamingPreaggregationMode.equalsIgnoreCase(LIMITED)) {
+            msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.LIMITED_MEM);
         } else {
             msg.agg_node.setStreaming_preaggregation_mode(TStreamingPreaggregationMode.AUTO);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -23,4 +23,6 @@ public class SessionVariableConstants {
     public static final String FORCE_STREAMING = "force_streaming";
 
     public static final String FORCE_PREAGGREGATION = "force_preaggregation";
+
+    public static final String LIMITED = "limited";
 }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -531,7 +531,8 @@ struct TEqJoinCondition {
 enum TStreamingPreaggregationMode {
   AUTO,
   FORCE_STREAMING,
-  FORCE_PREAGGREGATION
+  FORCE_PREAGGREGATION,
+  LIMITED_MEM
 }
 
 enum TJoinOp {


### PR DESCRIPTION

```
set new_planner_agg_stage=2;
set query_mem_limit=100*1024*1024*1024;
set pipeline_dop=4;
```

```
 select max(s_tax) from (select sum(lo_tax) s_tax from lineorder group by lo_orderkey) tb;
```


| mode                  | auto      | limited   |
| --------------------- | --------- | --------- |
| time                  | 14s49ms   | 9s254ms   |
| memory usage          | 20.48 GB  | 11.74 GB  |
| streaming output rows | 150000000 | 534009541 |


Compared to auto mode, for multi-stage high base group by can use less memory. Compared to force_streaming, it has a certain degree of aggregation, which can reduce the network overhead.
So we use it as an option in streaming spill mode. 


It also works in grouping set scenario. such as TPCDSQ67



## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
