### PR TITLE
[Enhancement] Reject write edit log on follower node

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.persist;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.alter.AlterJobV2;
 import com.starrocks.alter.BatchAlterJobPersistInfo;
@@ -1112,6 +1113,8 @@ public class EditLog {
      * submit log in queue and return immediately
      */
     private Future<Boolean> submitLog(short op, Writable writable, long maxWaitIntervalMs) {
+        Preconditions.checkState(GlobalStateMgr.getCurrentState().isLeader(),
+                "Current node is not leader, submit log is not allowed");
         DataOutputBuffer buffer = new DataOutputBuffer(OUTPUT_BUFFER_INIT_SIZE);
 
         // 1. serialized

--- a/fe/fe-core/src/test/java/com/starrocks/persist/EditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/EditLogTest.java
@@ -22,6 +22,8 @@ import com.starrocks.journal.JournalTask;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.system.Frontend;
+import mockit.Expectations;
+import mockit.Mocked;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
@@ -38,7 +40,19 @@ public class EditLogTest {
     public static final Logger LOG = LogManager.getLogger(EditLogTest.class);
 
     @Test
-    public void testtNormal() throws Exception {
+    public void testtNormal(@Mocked GlobalStateMgr globalStateMgr) throws Exception {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+
+                globalStateMgr.isLeader();
+                result = true;
+                minTimes = 0;
+            }
+        };
+
         BlockingQueue<JournalTask> logQueue = new ArrayBlockingQueue<>(100);
         short threadNum = 20;
         List<Thread> allThreads = new ArrayList<>();
@@ -79,7 +93,18 @@ public class EditLogTest {
     }
 
     @Test
-    public void testInterrupt() throws Exception {
+    public void testInterrupt(@Mocked GlobalStateMgr globalStateMgr) throws Exception {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                minTimes = 0;
+
+                globalStateMgr.isLeader();
+                result = true;
+                minTimes = 0;
+            }
+        };
         // block if more than one task is put
         BlockingQueue<JournalTask> journalQueue = new ArrayBlockingQueue<>(1);
         Thread t1 = new Thread(new Runnable() {

--- a/fe/fe-core/src/test/java/com/starrocks/persist/EditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/EditLogTest.java
@@ -22,8 +22,6 @@ import com.starrocks.journal.JournalTask;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.system.Frontend;
-import mockit.Expectations;
-import mockit.Mocked;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
@@ -46,7 +44,7 @@ public class EditLogTest {
     }
 
     @Test
-    public void testtNormal(@Mocked GlobalStateMgr globalStateMgr) throws Exception {
+    public void testtNormal() throws Exception {
         BlockingQueue<JournalTask> logQueue = new ArrayBlockingQueue<>(100);
         short threadNum = 20;
         List<Thread> allThreads = new ArrayList<>();
@@ -87,7 +85,7 @@ public class EditLogTest {
     }
 
     @Test
-    public void testInterrupt(@Mocked GlobalStateMgr globalStateMgr) throws Exception {
+    public void testInterrupt() throws Exception {
         // block if more than one task is put
         BlockingQueue<JournalTask> journalQueue = new ArrayBlockingQueue<>(1);
         Thread t1 = new Thread(new Runnable() {

--- a/fe/fe-core/src/test/java/com/starrocks/persist/EditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/EditLogTest.java
@@ -27,6 +27,7 @@ import mockit.Mocked;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
@@ -39,20 +40,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public class EditLogTest {
     public static final Logger LOG = LogManager.getLogger(EditLogTest.class);
 
+    @Before
+    public void setUp() {
+        GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.LEADER);
+    }
+
     @Test
     public void testtNormal(@Mocked GlobalStateMgr globalStateMgr) throws Exception {
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                result = globalStateMgr;
-                minTimes = 0;
-
-                globalStateMgr.isLeader();
-                result = true;
-                minTimes = 0;
-            }
-        };
-
         BlockingQueue<JournalTask> logQueue = new ArrayBlockingQueue<>(100);
         short threadNum = 20;
         List<Thread> allThreads = new ArrayList<>();
@@ -94,17 +88,6 @@ public class EditLogTest {
 
     @Test
     public void testInterrupt(@Mocked GlobalStateMgr globalStateMgr) throws Exception {
-        new Expectations() {
-            {
-                GlobalStateMgr.getCurrentState();
-                result = globalStateMgr;
-                minTimes = 0;
-
-                globalStateMgr.isLeader();
-                result = true;
-                minTimes = 0;
-            }
-        };
         // block if more than one task is put
         BlockingQueue<JournalTask> journalQueue = new ArrayBlockingQueue<>(1);
         Thread t1 = new Thread(new Runnable() {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -56,6 +56,7 @@ import com.starrocks.common.io.DataOutputBuffer;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.LogUtil;
 import com.starrocks.connector.hive.ReplayMetadataMgr;
+import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.journal.JournalEntity;
 import com.starrocks.journal.JournalTask;
 import com.starrocks.meta.MetaContext;
@@ -882,6 +883,7 @@ public class UtFrameUtils {
         protected static synchronized void setUp() {
             assert (fakeJournalWriter == null);
             GlobalStateMgr.getCurrentState().setEditLog(new EditLog(masterJournalQueue));
+            GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.LEADER);
 
             // simulate the process of master journal synchronizing to the follower
             fakeJournalWriter = new Thread(new Runnable() {


### PR DESCRIPTION
Currently, if follower node writes edit log, its thread will hang endless, which will cause unpredictable behavior, like #27975. 

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
