### PR TITLE
[Refactor] Remove param `mempool` from TypeInfo::direct_copy

### DIFF
--- a/be/src/storage/decimal_type_info.cpp
+++ b/be/src/storage/decimal_type_info.cpp
@@ -163,25 +163,15 @@ public:
         *data = 1 - get_scale_factor<CppType>(_precision);
     }
 
-    size_t size() const override {
-        return _delegate->size();
-    }
+    size_t size() const override { return _delegate->size(); }
 
-    int precision() const override {
-        return _precision;
-    }
+    int precision() const override { return _precision; }
 
-    int scale() const override {
-        return _scale;
-    }
+    int scale() const override { return _scale; }
 
-    LogicalType type() const override {
-        return TYPE;
-    }
+    LogicalType type() const override { return TYPE; }
 
-    std::string to_zone_map_string(const void* src) {
-        return _delegate->to_string(src);
-    }
+    std::string to_zone_map_string(const void* src) { return _delegate->to_string(src); }
 
 protected:
     int _datum_cmp_impl(const Datum& left, const Datum& right) const override {

--- a/be/src/storage/decimal_type_info.cpp
+++ b/be/src/storage/decimal_type_info.cpp
@@ -44,9 +44,7 @@ public:
         return _delegate->deep_copy(dest, src, mem_pool);
     }
 
-    void direct_copy(void* dest, const void* src) const override {
-        _delegate->direct_copy(dest, src);
-    }
+    void direct_copy(void* dest, const void* src) const override { _delegate->direct_copy(dest, src); }
 
     template <typename From, typename To>
     static inline Status to_decimal(const From* src, To* dst, int src_precision, int src_scale, int dst_precision,
@@ -165,15 +163,25 @@ public:
         *data = 1 - get_scale_factor<CppType>(_precision);
     }
 
-    size_t size() const override { return _delegate->size(); }
+    size_t size() const override {
+        return _delegate->size();
+    }
 
-    int precision() const override { return _precision; }
+    int precision() const override {
+        return _precision;
+    }
 
-    int scale() const override { return _scale; }
+    int scale() const override {
+        return _scale;
+    }
 
-    LogicalType type() const override { return TYPE; }
+    LogicalType type() const override {
+        return TYPE;
+    }
 
-    std::string to_zone_map_string(const void* src) { return _delegate->to_string(src); }
+    std::string to_zone_map_string(const void* src) {
+        return _delegate->to_string(src);
+    }
 
 protected:
     int _datum_cmp_impl(const Datum& left, const Datum& right) const override {

--- a/be/src/storage/decimal_type_info.cpp
+++ b/be/src/storage/decimal_type_info.cpp
@@ -44,8 +44,8 @@ public:
         return _delegate->deep_copy(dest, src, mem_pool);
     }
 
-    void direct_copy(void* dest, const void* src, MemPool* mem_pool) const override {
-        _delegate->direct_copy(dest, src, mem_pool);
+    void direct_copy(void* dest, const void* src) const override {
+        _delegate->direct_copy(dest, src);
     }
 
     template <typename From, typename To>

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -180,10 +180,10 @@ void ZoneMapIndexWriterImpl<type>::add_values(const void* values, size_t count) 
         const auto* vals = reinterpret_cast<const CppType*>(values);
         auto [pmin, pmax] = std::minmax_element(vals, vals + count);
         if (unaligned_load<CppType>(pmin) < _page_zone_map.min_value.value) {
-            _type_info->direct_copy(&_page_zone_map.min_value.value, pmin, nullptr);
+            _type_info->direct_copy(&_page_zone_map.min_value.value, pmin);
         }
         if (unaligned_load<CppType>(pmax) > _page_zone_map.max_value.value) {
-            _type_info->direct_copy(&_page_zone_map.max_value.value, pmax, nullptr);
+            _type_info->direct_copy(&_page_zone_map.max_value.value, pmax);
         }
     }
 }
@@ -192,10 +192,10 @@ template <LogicalType type>
 Status ZoneMapIndexWriterImpl<type>::flush() {
     // Update segment zone map.
     if (_page_zone_map.min_value.value < _segment_zone_map.min_value.value) {
-        _type_info->direct_copy(&_segment_zone_map.min_value.value, &_page_zone_map.min_value.value, nullptr);
+        _type_info->direct_copy(&_segment_zone_map.min_value.value, &_page_zone_map.min_value.value);
     }
     if (_page_zone_map.max_value.value > _segment_zone_map.max_value.value) {
-        _type_info->direct_copy(&_segment_zone_map.max_value.value, &_page_zone_map.max_value.value, nullptr);
+        _type_info->direct_copy(&_segment_zone_map.max_value.value, &_page_zone_map.max_value.value);
     }
     if (_page_zone_map.has_null) {
         _segment_zone_map.has_null = true;

--- a/be/src/storage/types.cpp
+++ b/be/src/storage/types.cpp
@@ -109,9 +109,7 @@ public:
 
     void deep_copy(void* dest, const void* src, MemPool* mem_pool) const override { _deep_copy(dest, src, mem_pool); }
 
-    void direct_copy(void* dest, const void* src, MemPool* mem_pool) const override {
-        _direct_copy(dest, src, mem_pool);
-    }
+    void direct_copy(void* dest, const void* src) const override { _direct_copy(dest, src); }
 
     Status from_string(void* buf, const std::string& scan_key) const override { return _from_string(buf, scan_key); }
 
@@ -130,7 +128,7 @@ protected:
 private:
     void (*_shallow_copy)(void* dest, const void* src);
     void (*_deep_copy)(void* dest, const void* src, MemPool* mem_pool);
-    void (*_direct_copy)(void* dest, const void* src, MemPool* mem_pool);
+    void (*_direct_copy)(void* dest, const void* src);
 
     Status (*_from_string)(void* buf, const std::string& scan_key);
     std::string (*_to_string)(const void* src);
@@ -184,7 +182,7 @@ struct ScalarTypeInfoImplBase {
         unaligned_store<CppType>(dest, unaligned_load<CppType>(src));
     }
 
-    static void direct_copy(void* dest, const void* src, MemPool* mem_pool) {
+    static void direct_copy(void* dest, const void* src) {
         unaligned_store<CppType>(dest, unaligned_load<CppType>(src));
     }
 
@@ -529,7 +527,7 @@ struct ScalarTypeInfoImpl<TYPE_LARGEINT> : public ScalarTypeInfoImplBase<TYPE_LA
         unaligned_store<int128_t>(dest, unaligned_load<int128_t>(src));
     }
 
-    static void direct_copy(void* dest, const void* src, MemPool* mem_pool) {
+    static void direct_copy(void* dest, const void* src) {
         unaligned_store<int128_t>(dest, unaligned_load<int128_t>(src));
     }
     static void set_to_max(void* buf) { unaligned_store<int128_t>(buf, ~((int128_t)(1) << 127)); }
@@ -665,7 +663,7 @@ struct ScalarTypeInfoImpl<TYPE_DECIMALV2> : public ScalarTypeInfoImplBase<TYPE_D
         memcpy(dest, src, sizeof(CppType));
     }
 
-    static void direct_copy(void* dest, const void* src, MemPool* mem_pool) { memcpy(dest, src, sizeof(CppType)); }
+    static void direct_copy(void* dest, const void* src) { memcpy(dest, src, sizeof(CppType)); }
 
     static void set_to_max(void* buf) {
         CppType v;
@@ -934,7 +932,7 @@ struct ScalarTypeInfoImpl<TYPE_CHAR> : public ScalarTypeInfoImplBase<TYPE_CHAR> 
         unaligned_store<Slice>(dest, l_slice);
     }
 
-    static void direct_copy(void* dest, const void* src, MemPool* mem_pool) {
+    static void direct_copy(void* dest, const void* src) {
         auto l_slice = unaligned_load<Slice>(dest);
         auto r_slice = unaligned_load<Slice>(src);
         memory_copy(l_slice.data, r_slice.data, r_slice.size);

--- a/be/src/storage/types.h
+++ b/be/src/storage/types.h
@@ -63,9 +63,8 @@ public:
 
     virtual void deep_copy(void* dest, const void* src, MemPool* mem_pool) const = 0;
 
-    // The mem_pool is used to allocate memory for array type.
-    // The scalar type can copy the value directly
-    virtual void direct_copy(void* dest, const void* src, MemPool* mem_pool) const = 0;
+    // map/struct/array have not yet implemented this interface.
+    virtual void direct_copy(void* dest, const void* src) const = 0;
 
     virtual Status from_string(void* buf, const std::string& scan_key) const = 0;
 

--- a/be/src/types/array_type_info.cpp
+++ b/be/src/types/array_type_info.cpp
@@ -64,7 +64,7 @@ public:
         unaligned_store<Collection>(dest, dest_value);
     }
 
-    void direct_copy(void* dest, const void* src, MemPool* mem_pool) const override { deep_copy(dest, src, mem_pool); }
+    void direct_copy(void* dest, const void* src) const override { CHECK(false); }
 
     Status from_string(void* buf, const std::string& scan_key) const override {
         return Status::NotSupported("Not supported function");

--- a/be/src/types/map_type_info.cpp
+++ b/be/src/types/map_type_info.cpp
@@ -31,7 +31,7 @@ public:
 
     void deep_copy(void* dest, const void* src, MemPool* mem_pool) const override { CHECK(false); }
 
-    void direct_copy(void* dest, const void* src, MemPool* mem_pool) const override { CHECK(false); }
+    void direct_copy(void* dest, const void* src) const override { CHECK(false); }
 
     Status from_string(void* buf, const std::string& scan_key) const override {
         return Status::NotSupported("Not supported function");

--- a/be/src/types/struct_type_info.cpp
+++ b/be/src/types/struct_type_info.cpp
@@ -29,7 +29,7 @@ public:
 
     void deep_copy(void* dest, const void* src, MemPool* mem_pool) const override { CHECK(false); }
 
-    void direct_copy(void* dest, const void* src, MemPool* mem_pool) const override { CHECK(false); }
+    void direct_copy(void* dest, const void* src) const override { CHECK(false); }
 
     Status from_string(void* buf, const std::string& scan_key) const override {
         return Status::NotSupported("Not supported function");

--- a/be/test/storage/storage_types_test.cpp
+++ b/be/test/storage/storage_types_test.cpp
@@ -60,7 +60,7 @@ void common_test(typename TypeTraits<field_type>::CppType src_val) {
     }
     {
         typename TypeTraits<field_type>::CppType dst_val;
-        type->direct_copy((char*)&dst_val, (char*)&src_val, nullptr);
+        type->direct_copy((char*)&dst_val, (char*)&src_val);
     }
     // test min
     {
@@ -90,7 +90,7 @@ void test_char(Slice src_val) {
     {
         char buf[64];
         Slice dst_val(buf, sizeof(buf));
-        type->direct_copy((char*)&dst_val, (char*)&src_val, nullptr);
+        type->direct_copy((char*)&dst_val, (char*)&src_val);
     }
     // test min
     {


### PR DESCRIPTION
Fixes #issue

shallow_copy: shallow copy
deep_copy: alloc memory and deep copy
direct_copy: pre alloc memory and deep copy

map/struct/array no need to implemented this interface: direct_copy.

Currently, direct_copy only used for ZoneMap.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
