### PR TITLE
[BugFix][CherryPick] fix outer join and anti join rewrite bug for 2.5 (#28028)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/EquivalenceClasses.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/EquivalenceClasses.java
@@ -25,7 +25,12 @@ public class EquivalenceClasses implements Cloneable {
         final EquivalenceClasses ec = new EquivalenceClasses();
         for (Map.Entry<ColumnRefOperator, Set<ColumnRefOperator>> entry :
                 this.columnToEquivalenceClass.entrySet()) {
-            ec.columnToEquivalenceClass.put(entry.getKey(), Sets.newLinkedHashSet(entry.getValue()));
+            if (!ec.columnToEquivalenceClass.containsKey(entry.getKey())) {
+                Set<ColumnRefOperator> columnEcs = Sets.newLinkedHashSet(entry.getValue());
+                for (ColumnRefOperator column : columnEcs) {
+                    ec.columnToEquivalenceClass.put(column, columnEcs);
+                }
+            }
         }
         ec.cacheColumnToEquivalenceClass = null;
         return ec;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -25,6 +25,9 @@ public abstract class ScalarOperator implements Cloneable {
     // from JoinNode.
     protected boolean isRedundant = false;
 
+    // whether the ScalarOperator is pushdown from equivalence derivation
+    protected boolean isPushdown = false;
+
     private List<String> hints = Collections.emptyList();
 
     public ScalarOperator(OperatorType opType, Type type) {
@@ -141,6 +144,7 @@ public abstract class ScalarOperator implements Cloneable {
             operator = (ScalarOperator) super.clone();
             operator.hints = Lists.newArrayList(hints);
             operator.isRedundant = this.isRedundant;
+            operator.isPushdown = this.isPushdown;
         } catch (CloneNotSupportedException ignored) {
         }
         return operator;
@@ -207,6 +211,14 @@ public abstract class ScalarOperator implements Cloneable {
 
     public void setRedundant(boolean redundant) {
         isRedundant = redundant;
+    }
+
+    public boolean isPushdown() {
+        return isPushdown;
+    }
+
+    public void setIsPushdown(boolean isPushdown) {
+        this.isPushdown = isPushdown;
     }
 
     // whether ScalarOperator are equals without id

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
@@ -391,6 +391,7 @@ public class JoinPredicatePushdown {
         if (join.getJoinType().isLeftSemiJoin()) {
             for (ScalarOperator p : derivedPredicates) {
                 if (rightOutputColumns.containsAll(p.getUsedColumns())) {
+                    p.setIsPushdown(true);
                     rightPushDown.add(p);
                 }
             }
@@ -398,12 +399,14 @@ public class JoinPredicatePushdown {
             for (ScalarOperator p : derivedPredicates) {
                 if (rightOutputColumns.containsAll(p.getUsedColumns()) &&
                         Utils.canEliminateNull(rightOutputColumnOps, p.clone())) {
+                    p.setIsPushdown(true);
                     rightPushDown.add(p);
                 }
             }
         } else if (join.getJoinType().isRightSemiJoin()) {
             for (ScalarOperator p : derivedPredicates) {
                 if (leftOutputColumns.containsAll(p.getUsedColumns())) {
+                    p.setIsPushdown(true);
                     leftPushDown.add(p);
                 }
             }
@@ -411,6 +414,7 @@ public class JoinPredicatePushdown {
             for (ScalarOperator p : derivedPredicates) {
                 if (leftOutputColumns.containsAll(p.getUsedColumns()) &&
                         Utils.canEliminateNull(leftOutputColumnOps, p.clone())) {
+                    p.setIsPushdown(true);
                     leftPushDown.add(p);
                 }
             }
@@ -444,12 +448,14 @@ public class JoinPredicatePushdown {
         } else if (join.getJoinType().isLeftOuterJoin()) {
             for (ScalarOperator p : derivedPredicates) {
                 if (rightOutputColumns.containsAll(p.getUsedColumns())) {
+                    p.setIsPushdown(true);
                     pushDown.add(p);
                 }
             }
         } else if (join.getJoinType().isRightOuterJoin()) {
             for (ScalarOperator p : derivedPredicates) {
                 if (leftOutputColumns.containsAll(p.getUsedColumns())) {
+                    p.setIsPushdown(true);
                     pushDown.add(p);
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/JoinDeriveContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/JoinDeriveContext.java
@@ -15,23 +15,28 @@
 package com.starrocks.sql.optimizer.rule.mv;
 
 import com.starrocks.analysis.JoinOperator;
+import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
 import java.util.List;
 
 public class JoinDeriveContext {
-    private JoinOperator queryJoinType;
-    private JoinOperator mvJoinType;
+    private final JoinOperator queryJoinType;
+    private final JoinOperator mvJoinType;
     // join columns for left and right join tables
-    private List<List<ColumnRefOperator>> joinColumns;
+    private final List<List<ColumnRefOperator>> joinColumns;
+
+    private final List<Pair<ColumnRefOperator, ColumnRefOperator>> compensatedEquivalenceColumns;
 
     public JoinDeriveContext(
             JoinOperator queryJoinType,
             JoinOperator mvJoinType,
-            List<List<ColumnRefOperator>> joinColumns) {
+            List<List<ColumnRefOperator>> joinColumns,
+            List<Pair<ColumnRefOperator, ColumnRefOperator>> compensatedEquivalenceColumns) {
         this.queryJoinType = queryJoinType;
         this.mvJoinType = mvJoinType;
         this.joinColumns = joinColumns;
+        this.compensatedEquivalenceColumns = compensatedEquivalenceColumns;
     }
 
     public JoinOperator getQueryJoinType() {
@@ -48,5 +53,9 @@ public class JoinDeriveContext {
 
     public List<ColumnRefOperator> getRightJoinColumns() {
         return joinColumns.get(1);
+    }
+
+    public List<Pair<ColumnRefOperator, ColumnRefOperator>> getCompensatedEquivalenceColumns() {
+        return compensatedEquivalenceColumns;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -185,7 +185,7 @@ public class MaterializedViewRewriter {
             // query: a left outer join b
             // mv: a inner join b inner join c
             for (TableScanDesc queryScanDesc : queryTableScanDescs) {
-                if (queryScanDesc.getParentJoinType() != null
+                if (queryScanDesc.getJoinOptExpression() != null
                         && !mvTableScanDescs.stream().anyMatch(scanDesc -> scanDesc.isMatch(queryScanDesc))) {
                     logMVRewrite(mvRewriteContext, "MV is not applicable in view delta mode: " +
                             "at least one same join type should be existed");
@@ -240,7 +240,12 @@ public class MaterializedViewRewriter {
             }
             if (queryJoinType.equals(mvJoinType)) {
                 // it means both joins' type and onPredicate are equal
-                return true;
+                // for outer join, we should check some extra conditions
+                boolean ret = checkJoinMatch(queryJoinType, queryExpr, mvExpr);
+                if (!ret) {
+                    logMVRewrite(mvRewriteContext, "join match check failed, joinType: %s", queryJoinType);
+                }
+                return ret;
             }
 
             if (!JOIN_COMPATIBLE_MAP.get(mvJoinType).contains(queryJoinType)) {
@@ -253,29 +258,33 @@ public class MaterializedViewRewriter {
             // should know the right table
             ScalarOperator queryOnPredicate = queryJoin.getOnPredicate();
             // relationId -> join on predicate used columns
-            Map<Integer, ColumnRefSet> joinColumns = Maps.newHashMap();
-            boolean isSupported =
-                    isSupportedPredicate(queryOnPredicate, materializationContext.getQueryRefFactory(), joinColumns);
+            Map<Integer, ColumnRefSet> tableToJoinColumns = Maps.newHashMap();
+            List<Pair<ColumnRefOperator, ColumnRefOperator>> joinColumnPairs = Lists.newArrayList();
+            boolean isSupported = isSupportedPredicate(queryOnPredicate,
+                    materializationContext.getQueryRefFactory(), tableToJoinColumns, joinColumnPairs);
             if (!isSupported) {
                 logMVRewrite(mvRewriteContext, "join predicate is not supported %s", queryOnPredicate);
                 return false;
             }
             // use join columns from query
             Map<ColumnRefSet, Table> usedColumnsToTable = Maps.newHashMap();
-            for (Map.Entry<Integer, ColumnRefSet> entry : joinColumns.entrySet()) {
+            for (Map.Entry<Integer, ColumnRefSet> entry : tableToJoinColumns.entrySet()) {
                 Table table = materializationContext.getQueryRefFactory().getTableForColumn(entry.getValue().getFirstId());
                 usedColumnsToTable.put(entry.getValue(), table);
             }
             ColumnRefSet leftColumns = queryExpr.inputAt(0).getOutputColumns();
             ColumnRefSet rightColumns = queryExpr.inputAt(1).getOutputColumns();
             List<List<ColumnRefOperator>> joinColumnRefs = Lists.newArrayList(Lists.newArrayList(), Lists.newArrayList());
-            boolean isCompatible =
-                    isJoinCompatible(usedColumnsToTable, queryJoinType, mvJoinType, leftColumns, rightColumns, joinColumnRefs);
+            // query based join columns pair
+            List<Pair<ColumnRefOperator, ColumnRefOperator>> compensatedEquivalenceColumns = Lists.newArrayList();
+            boolean isCompatible = isJoinCompatible(usedColumnsToTable, queryJoinType, mvJoinType,
+                    leftColumns, rightColumns, joinColumnPairs, joinColumnRefs, compensatedEquivalenceColumns);
             if (!isCompatible) {
                 logMVRewrite(mvRewriteContext, "join columns not compatible %s != %s", leftColumns, rightColumns);
                 return false;
             }
-            JoinDeriveContext joinDeriveContext = new JoinDeriveContext(queryJoinType, mvJoinType, joinColumnRefs);
+            JoinDeriveContext joinDeriveContext =
+                    new JoinDeriveContext(queryJoinType, mvJoinType, joinColumnRefs, compensatedEquivalenceColumns);
             mvRewriteContext.addJoinDeriveContext(joinDeriveContext);
             return true;
         } else if (queryOp instanceof LogicalScanOperator) {
@@ -291,12 +300,64 @@ public class MaterializedViewRewriter {
         }
     }
 
+    private boolean checkJoinMatch(JoinOperator joinOperator, OptExpression queryExpr, OptExpression mvExpr) {
+        if (joinOperator.isInnerJoin() || joinOperator.isCrossJoin() || joinOperator.isSemiJoin()) {
+            return true;
+        } else if (joinOperator.isLeftOuterJoin() || joinOperator.isLeftAntiJoin()) {
+            // for left outer/anti join, we should make sure the predicates of right child should be equivalent
+            return checkJoinChildPredicate(queryExpr, mvExpr, 1);
+        } else if (joinOperator.isRightOuterJoin() || joinOperator.isRightAntiJoin()) {
+            // for right outer/anti join, we should make sure the predicates of left child should be equivalent
+            return checkJoinChildPredicate(queryExpr, mvExpr, 0);
+        } else if (joinOperator.isFullOuterJoin()) {
+            // for full outer join, we should make sure the predicates of both children should be equivalent
+            return checkJoinChildPredicate(queryExpr, mvExpr, 0) && checkJoinChildPredicate(queryExpr, mvExpr, 1);
+        }
+        return false;
+    }
+
+    private boolean checkJoinChildPredicate(OptExpression queryExpr, OptExpression mvExpr, int index) {
+        Set<ScalarOperator> queryPredicates = Sets.newHashSet();
+        // extract all conjuncts
+        ScalarOperator normalizedQueryPredicate =
+                MvUtils.canonizePredicateForRewrite(Utils.compoundAnd(MvUtils.getAllPredicates(queryExpr.inputAt(index))));
+        queryPredicates.addAll(Utils.extractConjuncts(normalizedQueryPredicate));
+        queryPredicates =
+                queryPredicates.stream().filter(scalarOperator -> !scalarOperator.isPushdown()).collect(Collectors.toSet());
+        Set<ScalarOperator> mvPredicates = Sets.newHashSet();
+        // extract all conjuncts
+        ScalarOperator normalizedMvPredicate =
+                MvUtils.canonizePredicateForRewrite(Utils.compoundAnd(MvUtils.getAllPredicates(mvExpr.inputAt(index))));
+        mvPredicates.addAll(Utils.extractConjuncts(normalizedMvPredicate));
+        mvPredicates = mvPredicates.stream().filter(scalarOperator -> !scalarOperator.isPushdown()).collect(Collectors.toSet());
+        if (queryPredicates.isEmpty() && mvPredicates.isEmpty()) {
+            return true;
+        }
+        boolean isEqual = isAllPredicateEquivalent(queryPredicates, mvPredicates);
+        if (!isEqual) {
+            logMVRewrite(
+                    mvRewriteContext,
+                    "join child predicate not matched, queryPredicates: %s, mvPredicates: %s, index: %s",
+                    queryPredicates, mvPredicates, index);
+        }
+        return isEqual;
+    }
+
+    private boolean isAllPredicateEquivalent(
+            Collection<ScalarOperator> queryPredicates, final Collection<ScalarOperator> mvPredicates) {
+        return queryPredicates.size() == mvPredicates.size()
+                && queryPredicates.stream().allMatch(queryPredicate ->
+                mvPredicates.stream().anyMatch(mvPredicate -> mvPredicate.equivalent(queryPredicate)));
+    }
+
     private boolean isJoinCompatible(
             Map<ColumnRefSet, Table> usedColumnsToTable, JoinOperator queryJoinType,
             JoinOperator mvJoinType,
             ColumnRefSet leftColumns,
             ColumnRefSet rightColumns,
-            List<List<ColumnRefOperator>> joinColumnRefs) {
+            List<Pair<ColumnRefOperator, ColumnRefOperator>> joinColumnPairs,
+            List<List<ColumnRefOperator>> joinColumnRefs,
+            List<Pair<ColumnRefOperator, ColumnRefOperator>> compensatedEquivalenceColumns) {
         boolean isCompatible = true;
         if (mvJoinType.isInnerJoin() && queryJoinType.isLeftSemiJoin()) {
             // rewrite left semi join to inner join
@@ -337,6 +398,10 @@ public class MaterializedViewRewriter {
             List<ColumnRefOperator> rightJoinColumnRefs =
                     rightColumnRefSet.get().getColumnRefOperators(materializationContext.getQueryRefFactory());
             joinColumnRefs.set(1, rightJoinColumnRefs);
+            if (queryJoinType.isInnerJoin()) {
+                // for inner join, we should add the join columns into equivalence
+                compensatedEquivalenceColumns.addAll(joinColumnPairs);
+            }
         } else if (mvJoinType.isRightOuterJoin() && (queryJoinType.isInnerJoin() || queryJoinType.isRightAntiJoin())) {
             Optional<ColumnRefSet> leftColumnRefSet = usedColumnsToTable.keySet()
                     .stream().filter(columnSet -> leftColumns.containsAll(columnSet)).findFirst();
@@ -346,6 +411,10 @@ public class MaterializedViewRewriter {
             List<ColumnRefOperator> leftJoinColumnRefs =
                     leftColumnRefSet.get().getColumnRefOperators(materializationContext.getQueryRefFactory());
             joinColumnRefs.set(0, leftJoinColumnRefs);
+            if (queryJoinType.isInnerJoin()) {
+                // for inner join, we should add the join columns into equivalence
+                compensatedEquivalenceColumns.addAll(joinColumnPairs);
+            }
         } else if (mvJoinType.isFullOuterJoin() && queryJoinType.isLeftOuterJoin()) {
             Optional<ColumnRefSet> leftColumnRefSet = usedColumnsToTable.keySet()
                     .stream().filter(columnSet -> leftColumns.containsAll(columnSet)).findFirst();
@@ -403,6 +472,8 @@ public class MaterializedViewRewriter {
             List<ColumnRefOperator> rightJoinColumnRefs =
                     rightColumnRefSet.get().getColumnRefOperators(materializationContext.getQueryRefFactory());
             joinColumnRefs.set(1, rightJoinColumnRefs);
+            // for inner join, we should add the join columns into equivalence
+            compensatedEquivalenceColumns.addAll(joinColumnPairs);
         }
         return isCompatible;
     }
@@ -421,12 +492,17 @@ public class MaterializedViewRewriter {
     }
 
     private boolean isSupportedPredicate(
-            ScalarOperator onPredicate, ColumnRefFactory columnRefFactory, Map<Integer, ColumnRefSet> joinColumns) {
+            ScalarOperator onPredicate, ColumnRefFactory columnRefFactory, Map<Integer, ColumnRefSet> tableToJoinColumns,
+            List<Pair<ColumnRefOperator, ColumnRefOperator>> joinColumnPairs) {
         List<ScalarOperator> conjuncts = Utils.extractConjuncts(onPredicate);
         List<ScalarOperator> binaryPredicates = conjuncts.stream()
                 .filter(conjunct -> ScalarOperator.isColumnEqualBinaryPredicate(conjunct)).collect(Collectors.toList());
         if (binaryPredicates.isEmpty()) {
             return false;
+        }
+
+        for (ScalarOperator scalarOperator : binaryPredicates) {
+            joinColumnPairs.add(Pair.create(scalarOperator.getChild(0).cast(), scalarOperator.getChild(1).cast()));
         }
 
         ColumnRefSet usedColumns = Utils.compoundAnd(binaryPredicates).getUsedColumns();
@@ -436,10 +512,10 @@ public class MaterializedViewRewriter {
                 // not use the column from table scan, unsupported
                 return false;
             }
-            ColumnRefSet refColumns = joinColumns.computeIfAbsent(relationId, k -> new ColumnRefSet());
+            ColumnRefSet refColumns = tableToJoinColumns.computeIfAbsent(relationId, k -> new ColumnRefSet());
             refColumns.union(columnId);
         }
-        if (joinColumns.size() != 2) {
+        if (tableToJoinColumns.size() != 2) {
             // join predicate refs more than two tables, unsupported
             return false;
         }
@@ -460,6 +536,7 @@ public class MaterializedViewRewriter {
 
         // Check whether mv can be applicable for the query.
         if (!isMVApplicable(mvExpression, queryTables, mvTables, matchMode, queryExpression)) {
+            logMVRewrite(mvRewriteContext, "mv applicable check failed");
             return null;
         }
 
@@ -550,13 +627,11 @@ public class MaterializedViewRewriter {
             }
             mvDistinctScanDescs.add(mvExtraTableScanDescsSet);
 
-            final ScalarOperator mvEqualPredicate = mvPredicateSplit.getEqualPredicates();
-            EquivalenceClasses viewEquivalenceClasses = createEquivalenceClasses(mvEqualPredicate);
             final Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns = ArrayListMultimap.create();
             final Map<Table, Set<Integer>> compensationRelations = Maps.newHashMap();
             final Map<Integer, Integer> expectedExtraQueryToMVRelationIds = Maps.newHashMap();
-            if (!compensateViewDelta(viewEquivalenceClasses, mvTableScanDescs, mvExtraTableScanDescs,
-                    compensationJoinColumns, compensationRelations, expectedExtraQueryToMVRelationIds, 
+            if (!compensateViewDelta(mvTableScanDescs, mvExtraTableScanDescs,
+                    compensationJoinColumns, compensationRelations, expectedExtraQueryToMVRelationIds,
                     materializationContext)) {
                 logMVRewrite(mvRewriteContext, "Rewrite ViewDelta failed: cannot compensate query by using PK/FK constraints");
                 continue;
@@ -608,8 +683,8 @@ public class MaterializedViewRewriter {
                 .stream().flatMap(x -> x.values().stream())
                 .filter(columnRef -> !scanMvOutputColumns.contains(columnRef))
                 .collect(Collectors.toSet());
-        final EquivalenceClasses queryEc =
-                createEquivalenceClasses(mvRewriteContext.getQueryPredicateSplit().getEqualPredicates());
+        final EquivalenceClasses queryEc = createEquivalenceClasses(
+                mvRewriteContext.getQueryPredicateSplit().getEqualPredicates(), queryExpression, null);
         final RewriteContext rewriteContext = new RewriteContext(
                 queryExpression, mvRewriteContext.getQueryPredicateSplit(), queryEc,
                 queryRelationIdToColumns, materializationContext.getQueryRefFactory(),
@@ -642,7 +717,16 @@ public class MaterializedViewRewriter {
 
             // construct query based view EC
             final EquivalenceClasses queryBasedViewEqualPredicate =
-                    createQueryBasedEquivalenceClasses(columnRewriter, mvEqualPredicate);
+                    createEquivalenceClasses(mvEqualPredicate, mvExpression, columnRewriter);
+            if (queryBasedViewEqualPredicate == null) {
+                logMVRewrite(mvRewriteContext, "Rewrite complete failed: cannot construct query based equivalence classes");
+                return null;
+            }
+            for (JoinDeriveContext deriveContext : mvRewriteContext.getJoinDeriveContexts()) {
+                for (Pair<ColumnRefOperator, ColumnRefOperator> pair : deriveContext.getCompensatedEquivalenceColumns()) {
+                    queryBasedViewEqualPredicate.addEquivalence(pair.first, pair.second);
+                }
+            }
             rewriteContext.setQueryBasedViewEquivalenceClasses(queryBasedViewEqualPredicate);
 
             OptExpression rewrittenExpression = tryRewriteForRelationMapping(rewriteContext, compensationJoinColumns);
@@ -675,7 +759,6 @@ public class MaterializedViewRewriter {
     // compensationJoinColumns and compensation table into compensationRelations.
     // return false if it can not be rewritten.
     private boolean compensateViewDelta(
-            EquivalenceClasses viewEquivalenceClasses,
             List<TableScanDesc> mvTableScanDescs,
             List<TableScanDesc> mvExtraTableScanDescs,
             Multimap<ColumnRefOperator, ColumnRefOperator> compensationJoinColumns,
@@ -742,21 +825,26 @@ public class MaterializedViewRewriter {
 
                     Multimap<ColumnRefOperator, ColumnRefOperator> constraintCompensationJoinColumns = ArrayListMultimap.create();
                     if (!extraJoinCheck(mvParentTableScanDesc, mvTableScanDesc, columnPairs, childKeys, parentKeys,
-                            viewEquivalenceClasses, constraintCompensationJoinColumns, materializedView)) {
+                            constraintCompensationJoinColumns, materializedView)) {
                         continue;
                     }
 
                     // If `mvParentTableScanDesc` is not included in query's plan, add it
                     // to extraColumns.
+                    JoinOperator joinOperator = mvParentTableScanDesc.getJoinType();
                     if (mvExtraTableScanDescs.contains(mvParentTableScanDesc)) {
-                        compensationJoinColumns.putAll(constraintCompensationJoinColumns);
+                        if (joinOperator.isInnerJoin() || joinOperator.isCrossJoin() || joinOperator.isSemiJoin()) {
+                            compensationJoinColumns.putAll(constraintCompensationJoinColumns);
+                        }
                         List<ColumnRefOperator> parentTableCompensationColumns =
                                 constraintCompensationJoinColumns.keys().stream().collect(Collectors.toList());
                         extraTableColumns.computeIfAbsent(mvParentTableScanDesc, x -> Lists.newArrayList())
                                 .addAll(parentTableCompensationColumns);
                     }
                     if (mvExtraTableScanDescs.contains(mvTableScanDesc)) {
-                        compensationJoinColumns.putAll(constraintCompensationJoinColumns);
+                        if (joinOperator.isInnerJoin() || joinOperator.isCrossJoin() || joinOperator.isSemiJoin()) {
+                            compensationJoinColumns.putAll(constraintCompensationJoinColumns);
+                        }
                         List<ColumnRefOperator> childTableCompensationColumns =
                                 constraintCompensationJoinColumns.values().stream().collect(Collectors.toList());
                         extraTableColumns.computeIfAbsent(mvTableScanDesc, k -> Lists.newArrayList())
@@ -805,12 +893,14 @@ public class MaterializedViewRewriter {
     private boolean extraJoinCheck(
             TableScanDesc parentTableScanDesc, TableScanDesc tableScanDesc,
             List<Pair<String, String>> columnPairs, List<String> childKeys, List<String> parentKeys,
-            EquivalenceClasses viewEquivalenceClasses,
             Multimap<ColumnRefOperator, ColumnRefOperator> constraintCompensationJoinColumns,
             MaterializedView materializedView) {
         Table parentTable = parentTableScanDesc.getTable();
         Table childTable = tableScanDesc.getTable();
-        JoinOperator parentJoinType = parentTableScanDesc.getParentJoinType();
+        OptExpression joinOptExpr = parentTableScanDesc.getJoinOptExpression();
+        Preconditions.checkNotNull(joinOptExpr);
+        LogicalJoinOperator joinOperator = joinOptExpr.getOp().cast();
+        JoinOperator parentJoinType = joinOperator.getJoinType();
         if (parentJoinType.isInnerJoin()) {
             // to check:
             // 1. childKeys should be foreign key
@@ -843,20 +933,24 @@ public class MaterializedViewRewriter {
             if (childColumn == null || parentColumn == null) {
                 return false;
             }
-            if (viewEquivalenceClasses.getEquivalenceClass(childColumn) == null) {
-                return false;
-            }
-            if (viewEquivalenceClasses.getEquivalenceClass(parentColumn) == null) {
-                return false;
-            }
-            if (!viewEquivalenceClasses.getEquivalenceClass(childColumn).contains(parentColumn)
-                    || !viewEquivalenceClasses.getEquivalenceClass(parentColumn).contains(childColumn)) {
-                // there is no join between childTable and parentTable
+            if (!isJoinOnCondition(joinOptExpr, childColumn, parentColumn)) {
                 return false;
             }
             constraintCompensationJoinColumns.put(parentColumn, childColumn);
         }
         return true;
+    }
+
+    private boolean isJoinOnCondition(
+            OptExpression joinExpr,
+            ColumnRefOperator childColumn,
+            ColumnRefOperator parentColumn) {
+        LogicalJoinOperator joinOperator = joinExpr.getOp().cast();
+        List<ScalarOperator> onConjuncts = Utils.extractConjuncts(joinOperator.getOnPredicate());
+        List<ScalarOperator> binaryConjuncts =
+                onConjuncts.stream().filter(ScalarOperator::isColumnEqualBinaryPredicate).collect(Collectors.toList());
+        ColumnRefSet columns = new ColumnRefSet(Lists.newArrayList(childColumn, parentColumn));
+        return binaryConjuncts.stream().anyMatch(conjunct -> conjunct.getUsedColumns().containsAll(columns));
     }
 
     private boolean graphBasedCheck(MutableGraph<TableScanDesc> graph,
@@ -1712,6 +1806,44 @@ public class MaterializedViewRewriter {
 
         }
         return rewriter;
+    }
+
+    private EquivalenceClasses createEquivalenceClasses(
+            ScalarOperator equalPredicate, OptExpression expression, ColumnRewriter columnRewriter) {
+        List<ScalarOperator> outerJoinOnPredicate = MvUtils.collectOuterAntiJoinOnPredicate(expression);
+        final PredicateSplit outerJoinPredicateSplit = PredicateSplit.splitPredicate(Utils.compoundAnd(outerJoinOnPredicate));
+        return createEquivalenceClasses(equalPredicate, outerJoinPredicateSplit.getEqualPredicates(), columnRewriter);
+    }
+
+    // equalPredicates eg: t1.a = t2.b and t1.c = t2.d
+    private EquivalenceClasses createEquivalenceClasses(
+            ScalarOperator equalPredicates,
+            ScalarOperator outerJoinEqualPredicates,
+            ColumnRewriter columnRewriter) {
+        EquivalenceClasses ec = new EquivalenceClasses();
+        if (equalPredicates == null) {
+            return ec;
+        }
+        equalPredicates = MvUtils.canonizePredicateForRewrite(equalPredicates);
+        outerJoinEqualPredicates = MvUtils.canonizePredicateForRewrite(outerJoinEqualPredicates);
+        List<ScalarOperator> outerJoinConjuncts = Utils.extractConjuncts(outerJoinEqualPredicates);
+        for (ScalarOperator equalPredicate : Utils.extractConjuncts(equalPredicates)) {
+            if (outerJoinConjuncts.contains(equalPredicate)) {
+                // outer join on predicates can not be used to construct equivalence class
+                continue;
+            }
+            Preconditions.checkState(equalPredicate.getChild(0).isColumnRef());
+            ColumnRefOperator left = (ColumnRefOperator) equalPredicate.getChild(0);
+            Preconditions.checkState(equalPredicate.getChild(1).isColumnRef());
+            ColumnRefOperator right = (ColumnRefOperator) equalPredicate.getChild(1);
+            ColumnRefOperator leftTarget = columnRewriter == null ? left : columnRewriter.rewriteViewToQuery(left).cast();
+            ColumnRefOperator rightTarget = columnRewriter == null ? right : columnRewriter.rewriteViewToQuery(right).cast();
+            if (leftTarget == null || rightTarget == null) {
+                return null;
+            }
+            ec.addEquivalence(leftTarget, rightTarget);
+        }
+        return ec;
     }
 
     // equalPredicates eg: t1.a = t2.b and t1.c = t2.d

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -168,7 +168,7 @@ public class MvUtils {
                         Integer id = scanContext.getTableIdMap().computeIfAbsent(table, t -> 0);
                         LogicalJoinOperator joinOperator = optExpression.getOp().cast();
                         TableScanDesc tableScanDesc = new TableScanDesc(
-                                table, id, scanOperator, joinOperator.getJoinType(), i == 0);
+                                table, id, scanOperator, optExpression, i == 0);
                         context.getTableScanDescs().add(tableScanDesc);
                         scanContext.getTableIdMap().put(table, ++id);
                     } else {
@@ -412,8 +412,10 @@ public class MvUtils {
         return new ReplaceColumnRefRewriter(mvLineage, true);
     }
 
+    // pushdown predicates are excluded when calculating comppensation predicates,
+    // because they are derived from equivalence class, the original predicates have be considered
     private static void collectValidPredicates(List<ScalarOperator> conjuncts, List<ScalarOperator> predicates) {
-        conjuncts.stream().filter(x -> !x.isRedundant()).forEach(predicates::add);
+        conjuncts.stream().filter(x -> !x.isRedundant() && !x.isPushdown()).forEach(predicates::add);
     }
 
     private static void getAllPredicates(OptExpression root, List<ScalarOperator> predicates) {
@@ -860,5 +862,32 @@ public class MvUtils {
             return "";
         }
         return o.toString();
+    }
+
+    public static List<ScalarOperator> collectOnPredicate(OptExpression optExpression) {
+        List<ScalarOperator> onPredicates = Lists.newArrayList();
+        collectOnPredicate(optExpression, onPredicates, false);
+        return onPredicates;
+    }
+
+    public static List<ScalarOperator> collectOuterAntiJoinOnPredicate(OptExpression optExpression) {
+        List<ScalarOperator> onPredicates = Lists.newArrayList();
+        collectOnPredicate(optExpression, onPredicates, true);
+        return onPredicates;
+    }
+
+    public static void collectOnPredicate(
+            OptExpression optExpression, List<ScalarOperator> onPredicates, boolean onlyOuterAntiJoin) {
+        for (OptExpression child : optExpression.getInputs()) {
+            collectOnPredicate(child, onPredicates, onlyOuterAntiJoin);
+        }
+        if (optExpression.getOp() instanceof LogicalJoinOperator) {
+            LogicalJoinOperator joinOperator = optExpression.getOp().cast();
+            if (onlyOuterAntiJoin &&
+                    !(joinOperator.getJoinType().isOuterJoin() || joinOperator.getJoinType().isAntiJoin())) {
+                return;
+            }
+            onPredicates.addAll(Utils.extractConjuncts(joinOperator.getOnPredicate()));
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/TableScanDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/TableScanDesc.java
@@ -17,6 +17,8 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.catalog.Table;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 
 import java.util.Objects;
@@ -27,16 +29,16 @@ public class TableScanDesc {
     private final int index;
     private final LogicalScanOperator scanOperator;
     // join type of LogicalJoinOperator above scan operator
-    private final JoinOperator parentJoinType;
+    private final OptExpression joinOptExpression;
     private final boolean isLeft;
 
     public TableScanDesc(Table table, int index,
-                         LogicalScanOperator scanOperator, JoinOperator parentJoinType,
+                         LogicalScanOperator scanOperator, OptExpression joinOptExpression,
                          boolean isLeft) {
         this.table = table;
         this.index = index;
         this.scanOperator = scanOperator;
-        this.parentJoinType = parentJoinType;
+        this.joinOptExpression = joinOptExpression;
         this.isLeft = isLeft;
     }
 
@@ -48,8 +50,8 @@ public class TableScanDesc {
         return index;
     }
 
-    public JoinOperator getParentJoinType() {
-        return parentJoinType;
+    public OptExpression getJoinOptExpression() {
+        return joinOptExpression;
     }
 
     public String getName() {
@@ -58,6 +60,14 @@ public class TableScanDesc {
 
     public LogicalScanOperator getScanOperator() {
         return scanOperator;
+    }
+
+    public JoinOperator getJoinType() {
+        if (joinOptExpression == null) {
+            return null;
+        }
+        LogicalJoinOperator joinOperator = joinOptExpression.getOp().cast();
+        return joinOperator.getJoinType();
     }
 
     public boolean isMatch(TableScanDesc other) {
@@ -69,16 +79,24 @@ public class TableScanDesc {
         // for
         // query: a left join c
         // mv: a inner join b left join c
-        if (parentJoinType.isInnerJoin()) {
-            return other.parentJoinType.isInnerJoin() || (other.parentJoinType.isLeftOuterJoin() && other.isLeft);
+        JoinOperator joinOperator = getJoinType();
+        JoinOperator otherJoinOperator = other.getJoinType();
+        if (joinOperator == null && otherJoinOperator == null) {
+            return true;
+        } else if (joinOperator == null || otherJoinOperator == null) {
+            return false;
+        }
+        if (joinOperator.isInnerJoin()) {
+            return otherJoinOperator.isInnerJoin()
+                    || (otherJoinOperator.isLeftOuterJoin() && other.isLeft);
         }
 
         // for
         // query: a inner join c
         // mv: a left outer join b inner join c
-        if (parentJoinType.isLeftOuterJoin()) {
-            return (isLeft && other.parentJoinType.isInnerJoin())
-                    || (other.parentJoinType.isLeftOuterJoin() && isLeft == other.isLeft);
+        if (joinOperator.isLeftOuterJoin()) {
+            return (isLeft && otherJoinOperator.isInnerJoin())
+                    || (otherJoinOperator.isLeftOuterJoin() && isLeft == other.isLeft);
         }
 
         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -10,7 +10,6 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
-import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
@@ -86,7 +85,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             queryPredicate = MvUtils.canonizePredicate(Utils.compoundAnd(queryPredicate, queryPartitionPredicate));
         }
         final PredicateSplit queryPredicateSplit = PredicateSplit.splitPredicate(queryPredicate);
-        List<ScalarOperator> onPredicates = collectOnPredicate(queryExpression);
+        List<ScalarOperator> onPredicates = MvUtils.collectOnPredicate(queryExpression);
         onPredicates = onPredicates.stream().map(MvUtils::canonizePredicate).collect(Collectors.toList());
         List<Table> queryTables = MvUtils.getAllTables(queryExpression);
         for (MaterializationContext mvContext : mvCandidateContexts) {
@@ -108,23 +107,6 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         }
 
         return results;
-    }
-
-    private List<ScalarOperator> collectOnPredicate(OptExpression optExpression) {
-        List<ScalarOperator> onPredicates = Lists.newArrayList();
-        collectOnPredicate(optExpression, onPredicates);
-        return onPredicates;
-    }
-
-    private void collectOnPredicate(OptExpression optExpression, List<ScalarOperator> onPredicates) {
-        if (optExpression.getOp() instanceof LogicalJoinOperator) {
-            LogicalJoinOperator joinOperator = optExpression.getOp().cast();
-            onPredicates.addAll(Utils.extractConjuncts(joinOperator.getOnPredicate()));
-        } else {
-            for (OptExpression child : optExpression.getInputs()) {
-                collectOnPredicate(child, onPredicates);
-            }
-        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -519,6 +519,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     public void testLeftOuterJoinQueryComplete() {
         String mv = "select deptno as col1, empid as col2, emps.locationid as col3 from emps " +
                 " left join locations on emps.locationid = locations.locationid";
+
         testRewriteOK(mv, "select count(*) from " +
                 "emps  left join locations on emps.locationid = locations.locationid");
         testRewriteOK(mv, "select empid as col2, emps.locationid from " +
@@ -527,7 +528,8 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteOK(mv, "select count(*) from " +
                 "emps  left join locations on emps.locationid = locations.locationid " +
                 "where emps.deptno > 10");
-        testRewriteOK(mv, "select empid as col2, locations.locationid from " +
+
+        testRewriteOK(mv, "select empid as col2, emps.locationid from " +
                 "emps left join locations on emps.locationid = locations.locationid " +
                 "where emps.locationid > 10");
         // TODO: Query's left outer join will be converted to Inner Join.
@@ -556,7 +558,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteOK(mv, "select count(*) from " +
                 "emps  right join locations on emps.locationid = locations.locationid " +
                 "where emps.deptno > 10");
-        testRewriteOK(mv, "select empid as col2, locations.locationid from " +
+        testRewriteFail(mv, "select empid as col2, locations.locationid from " +
                 "emps  right join locations on emps.locationid = locations.locationid " +
                 "where locations.locationid > 10");
         testRewriteOK(mv, "select empid as col2, locations.locationid from " +
@@ -1702,48 +1704,49 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
 
     @Test
     public void testOuterJoinViewDelta() {
-        connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000000);
-        String mv = "SELECT" +
-                " `l`.`LO_ORDERKEY` as col1, `l`.`LO_ORDERDATE`, `l`.`LO_LINENUMBER`, `l`.`LO_CUSTKEY`, `l`.`LO_PARTKEY`," +
-                " `l`.`LO_SUPPKEY`, `l`.`LO_ORDERPRIORITY`, `l`.`LO_SHIPPRIORITY`, `l`.`LO_QUANTITY`," +
-                " `l`.`LO_EXTENDEDPRICE`, `l`.`LO_ORDTOTALPRICE`, `l`.`LO_DISCOUNT`, `l`.`LO_REVENUE`," +
-                " `l`.`LO_SUPPLYCOST`, `l`.`LO_TAX`, `l`.`LO_COMMITDATE`, `l`.`LO_SHIPMODE`," +
-                " `c`.`C_NAME`, `c`.`C_ADDRESS`, `c`.`C_CITY`, `c`.`C_NATION`, `c`.`C_REGION`, `c`.`C_PHONE`," +
-                " `c`.`C_MKTSEGMENT`, `s`.`S_NAME`, `s`.`S_ADDRESS`, `s`.`S_CITY`, `s`.`S_NATION`, `s`.`S_REGION`," +
-                " `s`.`S_PHONE`, `p`.`P_NAME`, `p`.`P_MFGR`, `p`.`P_CATEGORY`, `p`.`P_BRAND`, `p`.`P_COLOR`," +
-                " `p`.`P_TYPE`, `p`.`P_SIZE`, `p`.`P_CONTAINER`\n" +
-                "FROM `lineorder` AS `l` " +
-                " LEFT OUTER JOIN `customer` AS `c` ON `c`.`C_CUSTKEY` = `l`.`LO_CUSTKEY`" +
-                " LEFT OUTER JOIN `supplier` AS `s` ON `s`.`S_SUPPKEY` = `l`.`LO_SUPPKEY`" +
-                " LEFT OUTER JOIN `part` AS `p` ON `p`.`P_PARTKEY` = `l`.`LO_PARTKEY`;";
+        {
+            String mv = "SELECT" +
+                    " `l`.`LO_ORDERKEY` as col1, `l`.`LO_ORDERDATE`, `l`.`LO_LINENUMBER`, `l`.`LO_CUSTKEY`, `l`.`LO_PARTKEY`," +
+                    " `l`.`LO_SUPPKEY`, `l`.`LO_ORDERPRIORITY`, `l`.`LO_SHIPPRIORITY`, `l`.`LO_QUANTITY`," +
+                    " `l`.`LO_EXTENDEDPRICE`, `l`.`LO_ORDTOTALPRICE`, `l`.`LO_DISCOUNT`, `l`.`LO_REVENUE`," +
+                    " `l`.`LO_SUPPLYCOST`, `l`.`LO_TAX`, `l`.`LO_COMMITDATE`, `l`.`LO_SHIPMODE`," +
+                    " `c`.`C_NAME`, `c`.`C_ADDRESS`, `c`.`C_CITY`, `c`.`C_NATION`, `c`.`C_REGION`, `c`.`C_PHONE`," +
+                    " `c`.`C_MKTSEGMENT`, `s`.`S_NAME`, `s`.`S_ADDRESS`, `s`.`S_CITY`, `s`.`S_NATION`, `s`.`S_REGION`," +
+                    " `s`.`S_PHONE`, `p`.`P_NAME`, `p`.`P_MFGR`, `p`.`P_CATEGORY`, `p`.`P_BRAND`, `p`.`P_COLOR`," +
+                    " `p`.`P_TYPE`, `p`.`P_SIZE`, `p`.`P_CONTAINER`\n" +
+                    "FROM `lineorder` AS `l` " +
+                    " LEFT OUTER JOIN `customer` AS `c` ON `c`.`C_CUSTKEY` = `l`.`LO_CUSTKEY`" +
+                    " LEFT OUTER JOIN `supplier` AS `s` ON `s`.`S_SUPPKEY` = `l`.`LO_SUPPKEY`" +
+                    " LEFT OUTER JOIN `part` AS `p` ON `p`.`P_PARTKEY` = `l`.`LO_PARTKEY`;";
 
-        String query =
-                "SELECT `lineorder`.`lo_orderkey`, `lineorder`.`lo_orderdate`, `customer`.`c_custkey` AS `cd`\n" +
-                        "FROM `lineorder` LEFT OUTER JOIN `customer` ON `lineorder`.`lo_custkey` = `customer`.`c_custkey`\n" +
-                        "WHERE `lineorder`.`lo_orderkey` = 100;";
+            String query = "SELECT `lineorder`.`lo_orderkey`, `lineorder`.`lo_orderdate`, `lineorder`.`lo_custkey` AS `cd`\n" +
+                    "FROM `lineorder` LEFT OUTER JOIN `customer` ON `lineorder`.`lo_custkey` = `customer`.`c_custkey`\n" +
+                    "WHERE `lineorder`.`lo_orderkey` = 100;";
 
-        testRewriteOK(mv, query);
+            testRewriteOK(mv, query);
+        }
 
-        String mv2 = "SELECT" +
-                " `l`.`LO_ORDERKEY` as col1, `l`.`LO_ORDERDATE`, `l`.`LO_LINENUMBER`, `l`.`LO_CUSTKEY`, `l`.`LO_PARTKEY`," +
-                " `l`.`LO_SUPPKEY`, `l`.`LO_ORDERPRIORITY`, `l`.`LO_SHIPPRIORITY`, `l`.`LO_QUANTITY`," +
-                " `l`.`LO_EXTENDEDPRICE`, `l`.`LO_ORDTOTALPRICE`, `l`.`LO_DISCOUNT`, `l`.`LO_REVENUE`," +
-                " `l`.`LO_SUPPLYCOST`, `l`.`LO_TAX`, `l`.`LO_COMMITDATE`, `l`.`LO_SHIPMODE`," +
-                " `c`.`C_NAME`, `c`.`C_ADDRESS`, `c`.`C_CITY`, `c`.`C_NATION`, `c`.`C_REGION`, `c`.`C_PHONE`," +
-                " `c`.`C_MKTSEGMENT`, `s`.`S_NAME`, `s`.`S_ADDRESS`, `s`.`S_CITY`, `s`.`S_NATION`, `s`.`S_REGION`," +
-                " `s`.`S_PHONE`, `p`.`P_NAME`, `p`.`P_MFGR`, `p`.`P_CATEGORY`, `p`.`P_BRAND`, `p`.`P_COLOR`," +
-                " `p`.`P_TYPE`, `p`.`P_SIZE`, `p`.`P_CONTAINER`\n" +
-                "FROM `lineorder_null` AS `l` " +
-                " LEFT OUTER JOIN `customer` AS `c` ON `c`.`C_CUSTKEY` = `l`.`LO_CUSTKEY`" +
-                " LEFT OUTER JOIN `supplier` AS `s` ON `s`.`S_SUPPKEY` = `l`.`LO_SUPPKEY`" +
-                " LEFT OUTER JOIN `part` AS `p` ON `p`.`P_PARTKEY` = `l`.`LO_PARTKEY`;";
+        {
+            String mv2 = "SELECT" +
+                    " `l`.`LO_ORDERKEY` as col1, `l`.`LO_ORDERDATE`, `l`.`LO_LINENUMBER`, `l`.`LO_CUSTKEY`, `l`.`LO_PARTKEY`," +
+                    " `l`.`LO_SUPPKEY`, `l`.`LO_ORDERPRIORITY`, `l`.`LO_SHIPPRIORITY`, `l`.`LO_QUANTITY`," +
+                    " `l`.`LO_EXTENDEDPRICE`, `l`.`LO_ORDTOTALPRICE`, `l`.`LO_DISCOUNT`, `l`.`LO_REVENUE`," +
+                    " `l`.`LO_SUPPLYCOST`, `l`.`LO_TAX`, `l`.`LO_COMMITDATE`, `l`.`LO_SHIPMODE`," +
+                    " `c`.`C_NAME`, `c`.`C_ADDRESS`, `c`.`C_CITY`, `c`.`C_NATION`, `c`.`C_REGION`, `c`.`C_PHONE`," +
+                    " `c`.`C_MKTSEGMENT`, `s`.`S_NAME`, `s`.`S_ADDRESS`, `s`.`S_CITY`, `s`.`S_NATION`, `s`.`S_REGION`," +
+                    " `s`.`S_PHONE`, `p`.`P_NAME`, `p`.`P_MFGR`, `p`.`P_CATEGORY`, `p`.`P_BRAND`, `p`.`P_COLOR`," +
+                    " `p`.`P_TYPE`, `p`.`P_SIZE`, `p`.`P_CONTAINER`\n" +
+                    "FROM `lineorder_null` AS `l` " +
+                    " LEFT OUTER JOIN `customer` AS `c` ON `c`.`C_CUSTKEY` = `l`.`LO_CUSTKEY`" +
+                    " LEFT OUTER JOIN `supplier` AS `s` ON `s`.`S_SUPPKEY` = `l`.`LO_SUPPKEY`" +
+                    " LEFT OUTER JOIN `part` AS `p` ON `p`.`P_PARTKEY` = `l`.`LO_PARTKEY`;";
 
-        String query2 =
-                "SELECT `lineorder_null`.`lo_orderkey`, `lineorder_null`.`lo_orderdate`, `customer`.`c_custkey` AS `cd`\n" +
-                        "FROM `lineorder_null` LEFT OUTER JOIN `customer` ON `lineorder_null`.`lo_custkey` = `customer`.`c_custkey`\n" +
-                        "WHERE `lineorder_null`.`lo_orderkey` = 100;";
+            String query2 = "SELECT `lineorder_null`.`lo_orderkey`, `lineorder_null`.`lo_orderdate`, `lineorder_null`.`lo_custkey` AS `cd`\n" +
+                    "FROM `lineorder_null` LEFT OUTER JOIN `customer` ON `lineorder_null`.`lo_custkey` = `customer`.`c_custkey`\n" +
+                    "WHERE `lineorder_null`.`lo_orderkey` = 100;";
 
-        testRewriteOK(mv2, query2);
+            testRewriteOK(mv2, query2);
+        }
     }
 
     @Test
@@ -3123,7 +3126,8 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, c_name" +
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey";
-            String query = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, lo_custkey" +
+
+            String query =  "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue" +
                     " from lineorder left anti join customer" +
                     " on lo_custkey = c_custkey";
             MVRewriteChecker checker = testRewriteOK(mv, query);
@@ -3727,5 +3731,29 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "    WHERE t1.`fdate` >= 20230702 and t1.fdate <= 20230705\n" +
                 "    GROUP BY   `col1_name`;")
                 .match("test_mv1");
+    }
+
+    @Test
+    public void testJoinDerive() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE t5 (\n" +
+                "                k1 int,\n" +
+                "                k2 int not null\n" +
+                "            )\n" +
+                "            DUPLICATE KEY(k1) " +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\",\n" +
+                "    \"in_memory\" = \"false\"\n" +
+                ")\n");
+        starRocksAssert.withTable("CREATE TABLE t4 (\n" +
+                "                a int,\n" +
+                "                b int not null\n" +
+                "            )\n" +
+                "            DUPLICATE KEY(a) " +
+                "PROPERTIES (\n" +
+                "    \"replication_num\" = \"1\",\n" +
+                "    \"in_memory\" = \"false\"\n" +
+                ")\n");
+        testRewriteOK("select * from t5 full outer join t4 on k1=a",
+                "select * from t5 left outer join t4 on k1=a where k1=3;");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -3740,6 +3740,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "                k2 int not null\n" +
                 "            )\n" +
                 "            DUPLICATE KEY(k1) " +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 12\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
                 "    \"in_memory\" = \"false\"\n" +
@@ -3749,6 +3750,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 "                b int not null\n" +
                 "            )\n" +
                 "            DUPLICATE KEY(a) " +
+                "DISTRIBUTED BY HASH(`a`) BUCKETS 12\n" +
                 "PROPERTIES (\n" +
                 "    \"replication_num\" = \"1\",\n" +
                 "    \"in_memory\" = \"false\"\n" +

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q5.sql
@@ -29,6 +29,6 @@ TOP-N (order by [[49: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{49: sum=sum(49: sum)}] group by [[42: n_name]] having [null]
             EXCHANGE SHUFFLE[42]
                 AGGREGATE ([LOCAL] aggregate [{49: sum=sum(48: expr)}] group by [[42: n_name]] having [null]
-                    SCAN (mv[lineitem_mv] columns[70: c_nationkey, 85: o_orderdate, 96: s_nationkey, 98: l_saleprice, 104: n_name2, 107: r_name2] predicate[96: s_nationkey = 70: c_nationkey AND 85: o_orderdate >= 1995-01-01 AND 85: o_orderdate < 1996-01-01 AND 107: r_name2 = AFRICA])
+                    SCAN (mv[lineitem_mv] columns[75: c_nationkey, 90: o_orderdate, 101: s_nationkey, 103: l_saleprice, 109: n_name2, 112: r_name2] predicate[75: c_nationkey = 101: s_nationkey AND 90: o_orderdate >= 1995-01-01 AND 90: o_orderdate < 1996-01-01 AND 112: r_name2 = AFRICA])
 [end]
 

--- a/test/sql/test_materialized_view/R/test_mv_join_derivabllity_rewrite
+++ b/test/sql/test_materialized_view/R/test_mv_join_derivabllity_rewrite
@@ -618,3 +618,50 @@ order by lo_orderkey, lo_linenumber;
 10002	2	10	2500	2	name_2
 10003	1	30	3000	3	name_3
 10003	1	30	3600	3	name_3
+
+
+-- name: test_outer_join_rewrite
+
+CREATE TABLE t1 (
+                k1 int,
+                k2 int not null
+            )
+            DUPLICATE KEY(k1);
+CREATE TABLE t2 (
+                a int,
+                b int not null
+            )
+            DUPLICATE KEY(a);
+INSERT INTO t1 VALUES (1,1),(3,2),(null,1);
+INSERT INTO t2 VALUES (1,1),(2,2),(null,1);
+CREATE MATERIALIZED VIEW mv1 REFRESH MANUAL AS select * from t1 full outer join t2 on k1=a;
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+select * from t1 left outer join t2 on k1=a where k1=3;
+-- result:
+3	2	NULL	NULL
+
+select * from t1 right outer join t2 on k1=a where b=2;
+-- result:
+NULL	NULL	2	2
+
+-- name: test_anti_join_rewrite
+
+CREATE TABLE t1 (
+                                    k1 int,
+                                    k2 int
+                                )
+                                DUPLICATE KEY(k1);
+CREATE TABLE t2 (
+                  a int,
+                  b int
+              )
+              DUPLICATE KEY(a);
+INSERT INTO t1 VALUES (1,1),(3,2),(1,null),(null,null);
+INSERT INTO t2 VALUES (1,1),(2,2),(null,1),(null,null);
+CREATE MATERIALIZED VIEW mv1 REFRESH MANUAL AS select * from t1 right outer join t2 on k1=a;
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+select * from t1 right anti join t2 on k1=a order by 1,2;
+-- result:
+NULL	NULL
+NULL	1
+2	2

--- a/test/sql/test_materialized_view/T/test_mv_join_derivabllity_rewrite
+++ b/test/sql/test_materialized_view/T/test_mv_join_derivabllity_rewrite
@@ -431,3 +431,40 @@ select lo_orderkey, lo_linenumber, lo_quantity, lo_custkey, c_custkey, c_name
 from lineorder inner join customer
 on lo_custkey = c_custkey
 order by lo_orderkey, lo_linenumber;
+
+-- name: test_outer_join_rewrite
+
+CREATE TABLE t1 (
+                k1 int,
+                k2 int not null
+            )
+            DUPLICATE KEY(k1);
+CREATE TABLE t2 (
+                a int,
+                b int not null
+            )
+            DUPLICATE KEY(a);
+INSERT INTO t1 VALUES (1,1),(3,2),(null,1);
+INSERT INTO t2 VALUES (1,1),(2,2),(null,1);
+CREATE MATERIALIZED VIEW mv1 REFRESH MANUAL AS select * from t1 full outer join t2 on k1=a;
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+select * from t1 left outer join t2 on k1=a where k1=3;
+select * from t1 right outer join t2 on k1=a where b=2;
+
+-- name: test_anti_join_rewrite
+
+CREATE TABLE t1 (
+                                    k1 int,
+                                    k2 int
+                                )
+                                DUPLICATE KEY(k1);
+CREATE TABLE t2 (
+                  a int,
+                  b int
+              )
+              DUPLICATE KEY(a);
+INSERT INTO t1 VALUES (1,1),(3,2),(1,null),(null,null);
+INSERT INTO t2 VALUES (1,1),(2,2),(null,1),(null,null);
+CREATE MATERIALIZED VIEW mv1 REFRESH MANUAL AS select * from t1 right outer join t2 on k1=a;
+REFRESH MATERIALIZED VIEW mv1 with sync mode;
+select * from t1 right anti join t2 on k1=a order by 1,2;


### PR DESCRIPTION
Fixes #27163

The bug has the following causes:
1. The invalid use of equivalence in outer join and anti join, which leads to the invalid use of output columns. The join on predicate A.a = B.b for outer join and anti join can not be used to construct equivalence class.
2. the compatibility check should be more strict for outer and anti join, which should not consider the pushdown predicates derived from equivalence class. eg: the left outer join should make sure that the predicates of right child tree of query and mv should be equal. it means that the compensation predicates should not come from right child of left outer join.
3. when clone equivalence class, should use the same Set<ColumnRefOperator> for the columns in the same ec.

fixed by
1. constructing eq without column equal predicates in outer and anti join
2. add more strict compatibility check for outer and anti join, excluding pushdown ec derived predicates
3. fix equivalence class clone bug.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
