### PR TITLE
[Enhancement] optimize the re-balance strategy for backend scan range

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -85,18 +85,10 @@ public class RemoteScanRangeLocations {
         long length = blockDesc.getLength();
         long offset = blockDesc.getOffset();
         do {
-            if (remainingBytes <= splitSize) {
+            if (remainingBytes < 2 * splitSize) {
                 createScanRangeLocationsForSplit(partitionId, partition, fileDesc,
                         blockDesc, offset + length - remainingBytes,
                         remainingBytes);
-                remainingBytes = 0;
-            } else if (remainingBytes <= 2 * splitSize) {
-                long mid = (remainingBytes + 1) / 2;
-                createScanRangeLocationsForSplit(partitionId, partition, fileDesc,
-                        blockDesc, offset + length - remainingBytes, mid);
-                createScanRangeLocationsForSplit(partitionId, partition, fileDesc,
-                        blockDesc, offset + length - remainingBytes + mid,
-                        remainingBytes - mid);
                 remainingBytes = 0;
             } else {
                 createScanRangeLocationsForSplit(partitionId, partition, fileDesc,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -82,6 +82,8 @@ public class HDFSBackendSelector implements BackendSelector {
     private final boolean forceScheduleLocal;
     private final boolean shuffleScanRange;
     private final int kCandidateNumber = 3;
+    // After testing, this value can ensure that the scan range size assigned to each BE is as uniform as possible,
+    // and the largest scan data is not more than 1.1 times of the average value
     private final double kMaxImbalanceRatio = 1.1;
     public static final int CONSISTENT_HASH_RING_VIRTUAL_NUMBER = 32;
 


### PR DESCRIPTION
Fixes #issue
optimize the re-balance strategy for backend scan range
**before:**
tpch q1:
![img_v2_2c795289-f568-4f20-9306-d526dec37f6g](https://github.com/StarRocks/starrocks/assets/9495145/eeeac209-fd9f-49a6-8b18-2ff171affe44)

backend 1 re-balance bytes: 609M+
backend 2 re-balance bytes: 3.8G+
backend 3 re-balance bytes: 811M+

tpch q2:
![image](https://github.com/StarRocks/starrocks/assets/9495145/73e31b13-6bcb-47d2-88f6-c9c97f6fff63)

For partsupp
backend 1 re-balance bytes:  536M+
backend 2 re-balance bytes: 1.2G+
backend 3 re-balance bytes: 0

**now :**
tpch q1:
![img_v2_964962bb-3d29-4a8a-b579-b3bbe57ff43g](https://github.com/StarRocks/starrocks/assets/9495145/c3771648-256f-4684-9cf6-043538bb2b39)

backend 1 re-balance bytes: 0
backend 2 re-balance bytes : 1.0G+
backend 3 re-balance bytes: 134M


tpch q2:
![64c433c9-35e5-42fa-9d5b-c471d0a3f253](https://github.com/StarRocks/starrocks/assets/9495145/bc1b4734-db61-4703-91a8-77350b08dae7)

For partsupp
backend 1 re-balance bytes:  391M+
backend 2 re-balance bytes: 930M+
backend 3 re-balance bytes: 0


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
