### PR TITLE
[BugFix] Fix follower fe CpuCores not synchronized

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -436,10 +436,6 @@ public class ComputeNode implements IComputable, Writable {
         return cpuCores;
     }
 
-    public void setCpuCores(int cpuCores) {
-        this.cpuCores = cpuCores;
-    }
-
     /**
      * handle Compute node's heartbeat response.
      * return true if any port changed, or alive state is changed.

--- a/fe/fe-core/src/main/java/com/starrocks/system/FrontendHbResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/FrontendHbResponse.java
@@ -34,7 +34,6 @@
 
 package com.starrocks.system;
 
-import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -43,7 +42,6 @@ import com.starrocks.common.util.TimeUtils;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Map;
 
 /**
  * Frontend heartbeat response contains Frontend's query port, rpc port and current replayed journal id.
@@ -64,20 +62,8 @@ public class FrontendHbResponse extends HeartbeatResponse implements Writable {
     @SerializedName(value = "feVersion")
     private String feVersion;
 
-    // Synchronize cpu cores of backends when synchronizing master info to other Frontends.
-    // It is non-empty, only when replaying a 'mocked' master Frontend heartbeat response to other Frontends.
-    @SerializedName(value = "backendId2cpuCores")
-    private Map<Long, Integer> backendId2cpuCores = Maps.newHashMap();
-
     public FrontendHbResponse() {
         super(HeartbeatResponse.Type.FRONTEND);
-    }
-
-    public FrontendHbResponse(String name, int queryPort, int rpcPort,
-                              long replayedJournalId, long hbTime, long feStartTime, String feVersion,
-                              Map<Long, Integer> backendId2cpuCores) {
-        this(name, queryPort, rpcPort, replayedJournalId, hbTime, feStartTime, feVersion);
-        this.backendId2cpuCores = backendId2cpuCores;
     }
 
     public FrontendHbResponse(String name, int queryPort, int rpcPort,
@@ -122,10 +108,6 @@ public class FrontendHbResponse extends HeartbeatResponse implements Writable {
 
     public String getFeVersion() {
         return feVersion;
-    }
-
-    public Map<Long, Integer> getBackendId2cpuCores() {
-        return backendId2cpuCores;
     }
 
     public static FrontendHbResponse read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -1082,6 +1082,14 @@ public class SystemInfoService implements GsonPostProcessable {
             idToReportVersion.put(beId, new AtomicLong(0));
         }
         idToReportVersionRef = ImmutableMap.copyOf(idToReportVersion);
+
+        // update BackendCoreStat
+        for (ComputeNode node : idToBackendRef.values()) {
+            BackendCoreStat.setNumOfHardwareCoresOfBe(node.getId(), node.getCpuCores());
+        }
+        for (ComputeNode node : idToComputeNodeRef.values()) {
+            BackendCoreStat.setNumOfHardwareCoresOfBe(node.getId(), node.getCpuCores());
+        }
     }
 }
 


### PR DESCRIPTION
Currently, cpuCores in ComputeNode(Backend) is already serialized in image file, when follower restarts, cpuCores is normal and BackendCoreStat updates will not be triggered.

1. update BackendCoreStat when replay image file.
2. the cpuCores update of ComputeNode is also supported.
3. the old way is no longer needed.

Fixes #28470

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
