### PR TITLE
[BugFix] Clear garbage file if clone primary key table failed

### DIFF
--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -985,13 +985,12 @@ Status EngineCloneTask::_finish_clone_primary(Tablet* tablet, const std::string&
         }
     }
 
-    //RETURN_IF_ERROR(tablet->updates()->load_snapshot(snapshot_meta));
     int64_t expired_stale_sweep_endtime = UnixSeconds() - config::tablet_rowset_stale_sweep_time_sec;
     tablet->updates()->remove_expired_versions(expired_stale_sweep_endtime);
     LOG(INFO) << "Loaded snapshot of tablet " << tablet->tablet_id() << ", removing directory " << clone_dir;
     st = fs::remove_all(clone_dir);
     LOG_IF(WARNING, !st.ok()) << "Fail to remove clone directory " << clone_dir << ": " << st;
-    return Status::OK();
+    return st;
 }
 
 } // namespace starrocks


### PR DESCRIPTION
If some error occurs in the last step of clone primary key table(tablet is in error state), we will return error directly without clear the garbage files. And we will retry clone because replica lost some version and the garbage files grows which cause disk usage grows.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
