### PR TITLE
[BugFix] Fix the wrong query state of failed query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryState.java
@@ -84,10 +84,14 @@ public class QueryState {
 
     public void reset() {
         stateType = MysqlStateType.OK;
+        errorMessage = "";
         errorCode = null;
         infoMessage = null;
-        serverStatus = 0;
+        errType = ErrType.OTHER_ERR;
         isQuery = false;
+        affectedRows = 0;
+        warningRows = 0;
+        serverStatus = 0;
         isFinished = false;
     }
 


### PR DESCRIPTION
## How to reproduce

```sql
-- enable profile
set enable_profile=true;

-- set memory limit to a small value to generate OOM deliberately
SELECT /*+ SET_VAR(query_mem_limit='1')*/ COUNT(*) from lineitem;

-- run same query normally
SELECT COUNT(*) from lineitem;

-- run failed query again
SELECT /*+ SET_VAR(query_mem_limit='1')*/ COUNT(*) from lineitem;
```

You will see the state of the three query is: error, finished, running.

## Root cause

All the queries within a connection share the single instance of QueryState, and `QueryState::reset()` will be called every time when query is finished. And some of the fields are not reset.

and here's part of the cancel process listed down below, which shows that the queryState will not be set if the errorMessage is not empty, finally resulting to this problem.

```java
private void cancelInternal(PPlanFragmentCancelReason cancelReason) {
        if (StringUtils.isEmpty(connectContext.getState().getErrorMessage())) {
            connectContext.getState().setError(cancelReason.toString());
        }
        ...
    }
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
