### PR TITLE
[Feature] Support to_tera_date/to_tera_timestamp

### DIFF
--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -339,6 +339,28 @@ public:
     DEFINE_VECTORIZED_FN(to_date);
 
     /**
+     * date to_tera_date(varchar, varchar)
+     * @param context
+     * @param columns [VARCHAR] Columns that hold timestamps, [VARCHAR] Columns that hold constant date foramt.
+     * @return  DateColumn  Date that corresponds to the timestamp.
+     */
+
+    DEFINE_VECTORIZED_FN(to_tera_date);
+    static Status to_tera_date_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+    static Status to_tera_date_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+
+    /**
+     * datetime to_tera_timestamp(varchar, varchar)
+     * @param context
+     * @param columns [VARCHAR] Columns that hold timestamps, [VARCHAR] Columns that hold constant date foramt.
+     * @return  DateColumn  Date that corresponds to the timestamp.
+     */
+
+    DEFINE_VECTORIZED_FN(to_tera_timestamp);
+    static Status to_tera_timestamp_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+    static Status to_tera_timestamp_close(FunctionContext* context, FunctionContext::FunctionStateScope scope);
+
+    /**
      * Calculate days from the first timestamp to the second timestamp. Only the date part of the timestamps are used in calculation.
      * @param context
      * @param columns [TimestampColumn] Columns that holds two groups timestamps for calculation.

--- a/be/src/runtime/datetime_value.cpp
+++ b/be/src/runtime/datetime_value.cpp
@@ -1892,4 +1892,270 @@ std::size_t hash_value(DateTimeValue const& value) {
     return HashUtil::hash(&value, sizeof(DateTimeValue), 0);
 }
 
+// NOTE: This is only a subset of teradata date format and is compatible with Presto.
+// see: https://github.com/trinodb/docs.trino.io/blob/master/318/_sources/functions/teradata.rst.txt
+// see: https://docs.teradata.com/r/SQL-Data-Types-and-Literals/July-2021/Data-Type-Conversion-Functions/TO_DATE/Argument-Types-and-Rules/format_arg-Format-Elements
+// - / , . ; :	Punctuation characters are ignored
+// dd	Day of month (1-31)
+// hh	Hour of day (1-12)
+// hh24	Hour of the day (0-23)
+// mi	Minute (0-59)
+// mm	Month (01-12)
+// ss	Second (0-59)
+// yyyy	4-digit year
+// yy	2-digit year
+enum TeradataFormatChar : char {
+    T1 = '-',   // Punctuation characters are ignored
+    T2 = '/',   // Punctuation characters are ignored
+    T3 = ',',   // Punctuation characters are ignored
+    T4 = '.',   // Punctuation characters are ignored
+    T5 = ';',   // Punctuation characters are ignored
+    T6 = ':',   // Punctuation characters are ignored
+    T7 = ' ',   // Punctuation characters are ignored
+    T8 = '\r',  // Punctuation characters are ignored
+    T9 = '\n',  // Punctuation characters are ignored
+    T10 = '\t', // Punctuation characters are ignored
+    D = 'd',    // Day of month (1-31)
+    H = 'h',    // Hour of day (1-12), , // Hour of the day (0-23)
+    M = 'm',    // Minute (0-59)
+    I = 'i',    // Month (01-12)
+    S = 's',    // Second (0-59)
+    Y = 'y',    // 2-digit year
+    A = 'a',    // am
+    P = 'p',    // pm
+    UNRECOGNIZED
+};
+
+bool TeradataFormat::prepare(std::string_view format) {
+    const char* ptr = format.data();
+    const char* end = format.data() + format.length();
+    while (ptr < end) {
+        const char* next_ch_ptr = ptr;
+        uint32_t repeat_count = 0;
+        for (char ch = *ptr; ch == *next_ch_ptr && next_ch_ptr < end; ++next_ch_ptr) {
+            ++repeat_count;
+        }
+
+        switch (*ptr) {
+        case TeradataFormatChar::T1:
+        case TeradataFormatChar::T2:
+        case TeradataFormatChar::T3:
+        case TeradataFormatChar::T4:
+        case TeradataFormatChar::T5:
+        case TeradataFormatChar::T6:
+        case TeradataFormatChar::T7:
+        case TeradataFormatChar::T8:
+        case TeradataFormatChar::T9:
+        case TeradataFormatChar::T10: {
+            //  - / , . ; :	Punctuation characters are ignored
+            auto ignored_char = *ptr;
+            _token_parsers.emplace_back([&, repeat_count, ignored_char]() {
+                if (*val != ignored_char) {
+                    return false;
+                }
+                val++;
+                return true;
+            });
+            break;
+        }
+        case TeradataFormatChar::D: {
+            // dd
+            if (repeat_count != 2) {
+                return false;
+            }
+            _token_parsers.emplace_back([&, repeat_count]() {
+                int64_t int_value = 0;
+                const char* tmp = val + std::min<int>(2, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                _day = int_value;
+                val = tmp;
+                return true;
+            });
+            break;
+        }
+        case TeradataFormatChar::H: {
+            if (repeat_count != 2) {
+                return false;
+            }
+
+            if (next_ch_ptr != end && *next_ch_ptr == '2') {
+                // hh24
+                ptr += 2;
+                ++next_ch_ptr;
+                if (next_ch_ptr == end || *next_ch_ptr != '4') {
+                    return false;
+                }
+                ++next_ch_ptr;
+            }
+            _token_parsers.emplace_back([&, repeat_count]() {
+                int64_t int_value = 0;
+                const char* tmp = val + std::min<int>(2, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                _hour = int_value;
+                val = tmp;
+                return true;
+            });
+            break;
+        }
+        case TeradataFormatChar::A: {
+            // am
+            if (repeat_count != 1) {
+                return false;
+            }
+            if (next_ch_ptr == end || *next_ch_ptr != 'm') {
+                return false;
+            }
+            next_ch_ptr++;
+            ptr++;
+            _token_parsers.emplace_back([&]() {
+                if (*val != 'a') {
+                    return false;
+                }
+                val++;
+                if (*val != 'm') {
+                    return false;
+                }
+                val++;
+                return true;
+            });
+            break;
+        }
+        case TeradataFormatChar::P: {
+            // pm
+            if (repeat_count != 1) {
+                return false;
+            }
+            if (next_ch_ptr == end || *next_ch_ptr != 'm') {
+                return false;
+            }
+            next_ch_ptr++;
+            ptr++;
+            _token_parsers.emplace_back([&]() {
+                if (*val != 'p') {
+                    return false;
+                }
+                val++;
+                if (*val != 'm') {
+                    return false;
+                }
+                val++;
+                _hour += 12;
+                return true;
+            });
+            break;
+        }
+        case TeradataFormatChar::M: {
+            if (repeat_count == 2) {
+                // mm
+                _token_parsers.emplace_back([&, repeat_count]() {
+                    int64_t int_value = 0;
+                    const char* tmp = val + std::min<int>(2, val_end - val);
+                    if (!str_to_int64(val, &tmp, &int_value)) {
+                        return false;
+                    }
+                    _month = int_value;
+                    val = tmp;
+                    return true;
+                });
+            } else if (repeat_count == 1) {
+                if (next_ch_ptr == end || *next_ch_ptr != TeradataFormatChar::I) {
+                    return false;
+                }
+                next_ch_ptr++;
+                ptr++;
+
+                // mi
+                _token_parsers.emplace_back([&, repeat_count]() {
+                    int64_t int_value = 0;
+                    const char* tmp = val + std::min<int>(2, val_end - val);
+                    ;
+                    if (!str_to_int64(val, &tmp, &int_value)) {
+                        return false;
+                    }
+                    _minute = int_value;
+                    val = tmp;
+                    return true;
+                });
+            } else {
+                return false;
+            }
+            break;
+        }
+        case TeradataFormatChar::S: {
+            if (repeat_count != 2) {
+                return false;
+            }
+            // ss
+            _token_parsers.emplace_back([&, repeat_count]() {
+                int64_t int_value = 0;
+                const char* tmp = val + std::min<int>(2, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                _second = int_value;
+                val = tmp;
+                return true;
+            });
+            break;
+        }
+        case TeradataFormatChar::Y: {
+            // yy
+            if (repeat_count == 2) {
+                _token_parsers.emplace_back([&, repeat_count]() {
+                    int64_t int_value = 0;
+                    const char* tmp = val + std::min<int>(2, val_end - val);
+                    ;
+                    if (!str_to_int64(val, &tmp, &int_value)) {
+                        return false;
+                    }
+                    int_value += int_value >= 70 ? 1900 : 2000;
+                    _year = int_value;
+                    val = tmp;
+                    return true;
+                });
+            } else if (repeat_count == 4) {
+                // yyyy
+                _token_parsers.emplace_back([&, repeat_count]() {
+                    int64_t int_value = 0;
+                    const char* tmp = val + std::min<int>(4, val_end - val);
+                    ;
+                    if (!str_to_int64(val, &tmp, &int_value)) {
+                        return false;
+                    }
+                    _year = int_value;
+                    val = tmp;
+                    return true;
+                });
+            } else {
+                return false;
+            }
+            break;
+        }
+        default: {
+            return false;
+        }
+        }
+        ptr += repeat_count;
+    }
+
+    return true;
+}
+
+bool TeradataFormat::parse(std::string_view str, DateTimeValue* output) {
+    val = str.data();
+    val_end = str.data() + str.length();
+
+    for (auto& p : _token_parsers) {
+        if (!p()) {
+            return false;
+        }
+    }
+    *output = DateTimeValue(type(), year(), month(), day(), hour(), minute(), second(), microsecond());
+    return true;
+}
+
 } // namespace starrocks

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -242,6 +242,7 @@ public:
 
     static uint8_t calc_weekday(uint64_t daynr, bool);
 
+    TimeType type() const { return (TimeType)_type; }
     int year() const { return _year; }
     int month() const { return _month; }
     int day() const { return _day; }
@@ -398,7 +399,7 @@ public:
 
     void set_type(int type);
 
-private:
+protected:
     // Used to make sure sizeof DateTimeValue
     friend class UnusedClass;
 
@@ -506,6 +507,25 @@ std::size_t operator-(const DateTimeValue& v1, const DateTimeValue& v2);
 std::ostream& operator<<(std::ostream& os, const DateTimeValue& value);
 
 std::size_t hash_value(DateTimeValue const& value);
+
+class TeradataFormat final : public DateTimeValue {
+public:
+    TeradataFormat() {
+        _month = 1;
+        _day = 1;
+    }
+    ~TeradataFormat() = default;
+
+    bool prepare(std::string_view format);
+    bool parse(std::string_view str, DateTimeValue* output);
+
+private:
+    // Token parsers
+    std::vector<std::function<bool()>> _token_parsers;
+    // Cursor
+    const char* val = nullptr;
+    const char* val_end = nullptr;
+};
 
 } // namespace starrocks
 

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -421,6 +421,133 @@ TEST_F(TimeFunctionsTest, toDateTest) {
     ASSERT_TRUE(date == dates->get_data()[0]);
 }
 
+using TestTeradataForamtParam = std::tuple<std::string, std::string, std::string>;
+
+class ToTeraDateTestFixture : public ::testing::TestWithParam<TestTeradataForamtParam> {};
+
+TEST_P(ToTeraDateTestFixture, to_tera_date) {
+    auto& [datetime_str, format_str, expect_str] = GetParam();
+
+    TQueryGlobals globals;
+    globals.__set_now_string("2019-08-06 01:38:57");
+    globals.__set_timestamp_ms(1565080737805);
+    globals.__set_time_zone("America/Los_Angeles");
+    auto state = std::make_shared<RuntimeState>(globals);
+    auto utils = std::make_shared<FunctionUtils>(state.get());
+
+    Columns columns;
+    auto data = BinaryColumn::create();
+    data->append(datetime_str);
+    auto format_data = BinaryColumn::create();
+    format_data->append(format_str);
+    auto format = ConstColumn::create(format_data, 1);
+
+    columns.emplace_back(data);
+    columns.emplace_back(format);
+
+    utils->get_fn_ctx()->set_constant_columns(columns);
+
+    // prepare
+    ASSERT_TRUE(TimeFunctions::to_tera_date_prepare(utils->get_fn_ctx(),
+                                                    FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
+
+    // execute
+    ColumnPtr result = TimeFunctions::to_tera_date(utils->get_fn_ctx(), columns).value();
+    ASSERT_TRUE(result->is_date());
+    ASSERT_FALSE(result->is_nullable());
+
+    auto dates = ColumnHelper::cast_to<TYPE_DATE>(result);
+    std::cout << " real   : " << dates->get_data()[0].to_string() << std::endl;
+    std::cout << " expect : " << expect_str << std::endl;
+    std::cout << std::endl;
+    ASSERT_TRUE(expect_str == dates->get_data()[0].to_string());
+
+    // close
+    ASSERT_TRUE(
+            TimeFunctions::to_tera_date_close(utils->get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                    .ok());
+}
+
+INSTANTIATE_TEST_SUITE_P(ToDateV2Test, ToDateV2TestFixture,
+                         ::testing::Values(
+                                 // clang-format: off
+                                 TestTeradataForamtParam("1994-09-09", "yyyy-mm-dd", "1994-09-09"),
+                                 TestTeradataForamtParam("04-08-1988", "mm-dd-yyyy", "1988-04-08"),
+                                 TestTeradataForamtParam("04.1988,08", "mm.yyyy,dd", "1988-04-08"),
+                                 TestTeradataForamtParam("1994", "yyyy", "1994-01-01"),
+                                 TestTeradataForamtParam(";198804:08", ";yyyymm:dd", "1988-04-08")
+                                 // clang-format: on
+                                 ));
+
+using TestToTimestampParam = std::tuple<std::string, std::string, std::string>;
+
+class ToTimestampTestFixture : public ::testing::TestWithParam<TestToTimestampParam> {};
+
+TEST_P(ToTimestampTestFixture, to_tera_timestamp) {
+    auto& [datetime_str, format_str, expect_str] = GetParam();
+
+    TQueryGlobals globals;
+    globals.__set_now_string("2019-08-06 01:38:57");
+    globals.__set_timestamp_ms(1565080737805);
+    globals.__set_time_zone("America/Los_Angeles");
+    auto state = std::make_shared<RuntimeState>(globals);
+    auto utils = std::make_shared<FunctionUtils>(state.get());
+
+    Columns columns;
+    auto data = BinaryColumn::create();
+    data->append(datetime_str);
+    auto format_data = BinaryColumn::create();
+    format_data->append(format_str);
+    auto format = ConstColumn::create(format_data, 1);
+
+    columns.emplace_back(data);
+    columns.emplace_back(format);
+
+    utils->get_fn_ctx()->set_constant_columns(columns);
+
+    // prepare
+    ASSERT_TRUE(TimeFunctions::to_tera_timestamp_prepare(utils->get_fn_ctx(),
+                                                         FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
+
+    // execute
+    ColumnPtr result = TimeFunctions::to_tera_timestamp(utils->get_fn_ctx(), columns).value();
+    ASSERT_TRUE(result->is_timestamp());
+    ASSERT_FALSE(result->is_nullable());
+
+    auto dates = ColumnHelper::cast_to<TYPE_DATETIME>(result);
+    std::cout << " real   : " << dates->get_data()[0].to_string() << std::endl;
+    std::cout << " expect : " << expect_str << std::endl;
+    std::cout << std::endl;
+    ASSERT_TRUE(expect_str == dates->get_data()[0].to_string());
+
+    // close
+    ASSERT_TRUE(TimeFunctions::to_tera_timestamp_close(utils->get_fn_ctx(),
+                                                       FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+        ToTimestampTest, ToTimestampTestFixture,
+        ::testing::Values(
+                // clang-format: off
+                TestTeradataForamtParam("1994-09-09", "yyyy-mm-dd", "1994-09-09 00:00:00"),
+                TestTeradataForamtParam("04-08-1988", "mm-dd-yyyy", "1988-04-08 00:00:00"),
+                TestTeradataForamtParam("04.1988,08", "mm.yyyy,dd", "1988-04-08 00:00:00"),
+                TestTeradataForamtParam(";198804:08", ";yyyymm:dd", "1988-04-08 00:00:00"),
+                TestTeradataForamtParam("1988/04/08 2", "yyyy/mm/dd hh", "1988-04-08 02:00:00"),
+                TestTeradataForamtParam("1988/04/08 14", "yyyy/mm/dd hh24", "1988-04-08 14:00:00"),
+                TestTeradataForamtParam("1988/04/08 14:15", "yyyy/mm/dd hh24:mi", "1988-04-08 14:15:00"),
+                TestTeradataForamtParam("1988/04/08 14:15:16", "yyyy/mm/dd hh24:mi:ss", "1988-04-08 14:15:16"),
+                TestTeradataForamtParam("1988/04/08 2:3:4", "yyyy/mm/dd hh24:mi:ss", "1988-04-08 02:03:04"),
+                TestTeradataForamtParam("1988/04/08 2 am:3:4", "yyyy/mm/dd hh am:mi:ss", "1988-04-08 02:03:04"),
+                TestTeradataForamtParam("1988/04/08 2 pm:3:4", "yyyy/mm/dd hh pm:mi:ss", "1988-04-08 14:03:04"),
+                TestTeradataForamtParam("1988/04/08 02:03:04", "yyyy/mm/dd hh24:mi:ss", "1988-04-08 02:03:04")
+
+                // clang-format: on
+                ));
+
 TEST_F(TimeFunctionsTest, dateAndDaysDiffTest) {
     auto tc1 = TimestampColumn::create();
     auto tc2 = TimestampColumn::create();

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -469,7 +469,7 @@ TEST_P(ToTeraDateTestFixture, to_tera_date) {
                     .ok());
 }
 
-INSTANTIATE_TEST_SUITE_P(ToDateV2Test, ToDateV2TestFixture,
+INSTANTIATE_TEST_SUITE_P(ToDateV2Test, ToTeraDateTestFixture,
                          ::testing::Values(
                                  // clang-format: off
                                  TestTeradataForamtParam("1994-09-09", "yyyy-mm-dd", "1994-09-09"),

--- a/docs/sql-reference/sql-functions/date-time-functions/to_tera_date.md
+++ b/docs/sql-reference/sql-functions/date-time-functions/to_tera_date.md
@@ -1,0 +1,53 @@
+# to_date
+
+## Description
+
+ Converts a VARCHAR value into a date from an input format.
+
+## Syntax
+
+```Haskell
+
+Converts a VARCHAR value into a date from an input format.
+
+DATE to_tera_date(VARCHAR str, VARCHAR format)
+```
+
+## Parameters
+
+Converts a VARCHAR value into a date from an input format.
+
+- `str`: the time expression you want to convert. It must be of the VARCHAR type.
+- `format`: the DateTime format as below:
+
+```
+[ \r \n \t - / , . ;] :	Punctuation characters are ignored
+dd	                  : Day of month (1-31)
+hh	                  : Hour of day (1-12)
+hh24                  : Hour of the day (0-23)
+mi                    : Minute (0-59)
+mm                    : Month (01-12)
+ss                    : Second (0-59)
+yyyy                  : 4-digit year
+yy                    : 2-digit year
+am                    : Meridian indicator
+pm                    : Meridian indicator
+```
+
+## Examples
+
+```Plain Text
+Converts a VARCHAR value into a date from an input format.
+
+mysql> select to_date("1988/04/08","yyyy/mm/dd");
++-------------------------------------+
+| to_date('1988/04/08', 'yyyy/mm/dd') |
++-------------------------------------+
+| 1988-04-08                          |
++-------------------------------------+
+
+```
+
+## keyword
+
+TO_TERA_DATE

--- a/docs/sql-reference/sql-functions/date-time-functions/to_tera_timestamp.md
+++ b/docs/sql-reference/sql-functions/date-time-functions/to_tera_timestamp.md
@@ -1,0 +1,45 @@
+# to_tera_timestamp
+
+## Description
+
+ Converts a VARCHAR value into a DATETIME from an input format.
+
+## Syntax
+
+```Haskell
+
+DATETIME to_tera_timestamp(VARCHAR str, VARCHAR format)
+```
+
+## Parameters
+- `str`: the time expression you want to convert. It must be of the VARCHAR type.
+- `format`: the DateTime format as below:
+
+```
+[ \r \n \t - / , . ;] :	Punctuation characters are ignored
+dd	                  : Day of month (1-31)
+hh	                  : Hour of day (1-12)
+hh24                  : Hour of the day (0-23)
+mi                    : Minute (0-59)
+mm                    : Month (01-12)
+ss                    : Second (0-59)
+yyyy                  : 4-digit year
+yy                    : 2-digit year
+am                    : Meridian indicator
+pm                    : Meridian indicator
+```
+
+## Examples
+
+```Plain Text
+mysql> select to_tera_timestamp("1988/04/08 2:3:4","yyyy/mm/dd hh24:mi:ss");
++-----------------------------------------------------------+
+| to_tera_timestamp('1988/04/08 2:3:4', 'yyyy/mm/dd hh24:mi:ss') |
++-----------------------------------------------------------+
+| 1988-04-08 02:03:04                                       |
++-----------------------------------------------------------+
+```
+
+## keyword
+
+to_tera_timestamp

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -351,6 +351,8 @@ vectorized_functions = [
     [50041, 'dayofweek_iso', 'INT', ['DATETIME'], 'TimeFunctions::day_of_week_iso'],
     [50050, 'to_date', 'DATE', ['DATETIME'], 'TimeFunctions::to_date'],
     [50051, 'date', 'DATE', ['DATETIME'], 'TimeFunctions::to_date'],
+    [50052, 'to_tera_date', 'DATE', ['VARCHAR', 'VARCHAR'], 'TimeFunctions::to_tera_date', "TimeFunctions::to_tera_date_prepare", "TimeFunctions::to_tera_date_close"],
+    [50053, 'to_tera_timestamp', 'DATETIME', ['VARCHAR', 'VARCHAR'], 'TimeFunctions::to_tera_timestamp', "TimeFunctions::to_tera_timestamp_prepare", "TimeFunctions::to_tera_timestamp_close"],
 
     [50057, 'day', 'TINYINT', ['DATE'], 'TimeFunctions::dayV3'],
     [50058, 'day', 'TINYINT', ['DATETIME'], 'TimeFunctions::dayV2'],

--- a/test/sql/test_time_fn/R/test_to_date
+++ b/test/sql/test_time_fn/R/test_to_date
@@ -1,5 +1,5 @@
 -- name: test_to_tera_date
-select to_tera_date(NULL);
+select to_tera_date(NULL, NULL);
 -- result:
 None
 -- !result
@@ -7,7 +7,7 @@ select to_tera_date(NULL, "yyyy");
 -- result:
 None
 -- !result
-select to_tera_date("2020-02-02 00:00:00");
+select to_tera_date("2020-02-02 00:00:00", "yyyy-mm-dd");
 -- result:
 2020-02-02
 -- !result

--- a/test/sql/test_time_fn/R/test_to_date
+++ b/test/sql/test_time_fn/R/test_to_date
@@ -1,0 +1,137 @@
+-- name: test_to_tera_date
+select to_tera_date(NULL);
+-- result:
+None
+-- !result
+select to_tera_date(NULL, "yyyy");
+-- result:
+None
+-- !result
+select to_tera_date("2020-02-02 00:00:00");
+-- result:
+2020-02-02
+-- !result
+select to_tera_date("1988","yyyy");
+-- result:
+1988-01-01
+-- !result
+select to_tera_date("1988/04/08","yyyy/mm/dd");
+-- result:
+1988-04-08
+-- !result
+select to_tera_date("1988/04/08","yyyy/mm/dd");
+-- result:
+1988-04-08
+-- !result
+select to_tera_date("04-08-1988","mm-dd-yyyy");
+-- result:
+1988-04-08
+-- !result
+select to_tera_date("04.1988,08","mm.yyyy,dd");
+-- result:
+1988-04-08
+-- !result
+select to_tera_date(";198804:08",";yyyymm:dd");
+-- result:
+1988-04-08
+-- !result
+select to_tera_timestamp(NULL, "yyyy/mm/dd");
+-- result:
+None
+-- !result
+select to_tera_timestamp("1988/04/08","yyyy/mm/dd");
+-- result:
+1988-04-08 00:00:00
+-- !result
+select to_tera_timestamp("04-08-1988","mm-dd-yyyy");
+-- result:
+1988-04-08 00:00:00
+-- !result
+select to_tera_timestamp("04.1988,08","mm.yyyy,dd");
+-- result:
+1988-04-08 00:00:00
+-- !result
+select to_tera_timestamp(";198804:08",";yyyymm:dd");
+-- result:
+1988-04-08 00:00:00
+-- !result
+select to_tera_timestamp("1988/04/08 2","yyyy/mm/dd hh");
+-- result:
+1988-04-08 02:00:00
+-- !result
+select to_tera_timestamp("1988/04/08 14","yyyy/mm/dd hh24");
+-- result:
+1988-04-08 14:00:00
+-- !result
+select to_tera_timestamp("1988/04/08 14:15","yyyy/mm/dd hh24:mi");
+-- result:
+1988-04-08 14:15:00
+-- !result
+select to_tera_timestamp("1988/04/08 14:15:16","yyyy/mm/dd hh24:mi:ss");
+-- result:
+1988-04-08 14:15:16
+-- !result
+select to_tera_timestamp("1988/04/08 2:3:4","yyyy/mm/dd hh24:mi:ss");
+-- result:
+1988-04-08 02:03:04
+-- !result
+select to_tera_timestamp("1988/04/08 02:03:04","yyyy/mm/dd hh24:mi:ss");
+-- result:
+1988-04-08 02:03:04
+-- !result
+select to_tera_timestamp("1988/04/08 02 am:3:4","yyyy/mm/dd hh am:mi:ss");
+-- result:
+1988-04-08 02:03:04
+-- !result
+select to_tera_timestamp("1988/04/08 02 pm:3:4","yyyy/mm/dd hh pm:mi:ss");
+-- result:
+1988-04-08 14:03:04
+-- !result
+select to_tera_date(";198804:08",";YYYYmm:dd");
+-- result:
+[REGEX].*'The format parameter ;YYYYmm:dd is invalid .*'
+-- !result
+select to_tera_date("1988/04/08","yy/mm/dd");
+-- result:
+None
+-- !result
+select to_tera_date("1988/04/08","xyz/mm/dd");
+-- result:
+[REGEX].*'The format parameter xyz/mm/dd is invalid .*'
+-- !result
+select to_tera_timestamp("1988/04/0800 02 pm:3:4","yyyy/mm/dd hh am:mi:ss");
+-- result:
+None
+-- !result
+select to_tera_timestamp("1988/04/08 02 pm:3:4","yyyy/mm/dd hh am:mi:ss");
+-- result:
+None
+-- !result
+CREATE TABLE IF NOT EXISTS `to_tera_date_test` (
+  `d1` DATE,
+  `d2` VARCHAR(1024)
+)
+DISTRIBUTED BY HASH(`d1`)
+PROPERTIES(
+  "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `to_tera_date_test`(d1, d2)
+VALUES ('2023-04-01', NULL),
+       ('2023-04-02', '2023-04-02 20:13:14'),
+       ('2023-04-03', '2023-04-03 20:13:14');
+-- result:
+-- !result
+select to_tera_date(d2, 'yyyy-mm-dd hh24:mi:ss') from to_tera_date_test order by d1;
+-- result:
+None
+2023-04-02
+2023-04-03
+-- !result
+select to_tera_timestamp(d2, 'yyyy-mm-dd hh24:mi:ss') from to_tera_date_test order by d1;
+-- result:
+None
+2023-04-02 20:13:14
+2023-04-03 20:13:14
+-- !result

--- a/test/sql/test_time_fn/T/test_to_date
+++ b/test/sql/test_time_fn/T/test_to_date
@@ -1,7 +1,7 @@
 -- name: test_to_tera_date
-select to_tera_date(NULL);
+select to_tera_date(NULL, NULL);
 select to_tera_date(NULL, "yyyy");
-select to_tera_date("2020-02-02 00:00:00");
+select to_tera_date("2020-02-02 00:00:00", "yyyy-mm-dd");
 select to_tera_date("1988","yyyy");
 select to_tera_date("1988/04/08","yyyy/mm/dd");
 select to_tera_date("1988/04/08","yyyy/mm/dd");

--- a/test/sql/test_time_fn/T/test_to_date
+++ b/test/sql/test_time_fn/T/test_to_date
@@ -1,0 +1,50 @@
+-- name: test_to_tera_date
+select to_tera_date(NULL);
+select to_tera_date(NULL, "yyyy");
+select to_tera_date("2020-02-02 00:00:00");
+select to_tera_date("1988","yyyy");
+select to_tera_date("1988/04/08","yyyy/mm/dd");
+select to_tera_date("1988/04/08","yyyy/mm/dd");
+select to_tera_date("04-08-1988","mm-dd-yyyy");
+select to_tera_date("04.1988,08","mm.yyyy,dd");
+select to_tera_date(";198804:08",";yyyymm:dd");
+
+select to_tera_timestamp(NULL, "yyyy/mm/dd");
+select to_tera_timestamp("1988/04/08","yyyy/mm/dd");
+select to_tera_timestamp("04-08-1988","mm-dd-yyyy");
+select to_tera_timestamp("04.1988,08","mm.yyyy,dd");
+select to_tera_timestamp(";198804:08",";yyyymm:dd");
+
+select to_tera_timestamp("1988/04/08 2","yyyy/mm/dd hh");
+select to_tera_timestamp("1988/04/08 14","yyyy/mm/dd hh24");
+select to_tera_timestamp("1988/04/08 14:15","yyyy/mm/dd hh24:mi");
+select to_tera_timestamp("1988/04/08 14:15:16","yyyy/mm/dd hh24:mi:ss");
+
+select to_tera_timestamp("1988/04/08 2:3:4","yyyy/mm/dd hh24:mi:ss");
+select to_tera_timestamp("1988/04/08 02:03:04","yyyy/mm/dd hh24:mi:ss");
+select to_tera_timestamp("1988/04/08 02 am:3:4","yyyy/mm/dd hh am:mi:ss");
+select to_tera_timestamp("1988/04/08 02 pm:3:4","yyyy/mm/dd hh pm:mi:ss");
+
+-- test_to_tera_date_bad_case
+select to_tera_date(";198804:08",";YYYYmm:dd");
+select to_tera_date("1988/04/08","yy/mm/dd");
+select to_tera_date("1988/04/08","xyz/mm/dd");
+select to_tera_timestamp("1988/04/0800 02 pm:3:4","yyyy/mm/dd hh am:mi:ss");
+select to_tera_timestamp("1988/04/08 02 pm:3:4","yyyy/mm/dd hh am:mi:ss");
+
+-- test_to_tera_date_from_table
+CREATE TABLE IF NOT EXISTS `to_tera_date_test` (
+  `d1` DATE,
+  `d2` VARCHAR(1024)
+)
+DISTRIBUTED BY HASH(`d1`)
+PROPERTIES(
+  "replication_num" = "1"
+);
+
+INSERT INTO `to_tera_date_test`(d1, d2)
+VALUES ('2023-04-01', NULL),
+       ('2023-04-02', '2023-04-02 20:13:14'),
+       ('2023-04-03', '2023-04-03 20:13:14');
+select to_tera_date(d2, 'yyyy-mm-dd hh24:mi:ss') from to_tera_date_test order by d1;
+select to_tera_timestamp(d2, 'yyyy-mm-dd hh24:mi:ss') from to_tera_date_test order by d1;


### PR DESCRIPTION
Fixes #issue

Support `to_tera_date `/`to_tera_timestamp` function to be compatible with trino : https://trino.io/docs/current/functions/list-by-topic.html?highlight=teradata#teradata

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4