### PR TITLE
[Enhancement] Optimize the mem alloc and disk size for zonemap

### DIFF
--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -328,7 +328,7 @@ Status ScalarColumnWriter::init() {
     }
     if (_opts.need_zone_map) {
         _has_index_builder = true;
-        _zone_map_index_builder = ZoneMapIndexWriter::create(type_info(), length());
+        _zone_map_index_builder = ZoneMapIndexWriter::create(type_info());
     }
     if (_opts.need_bitmap_index) {
         _has_index_builder = true;

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -182,9 +182,11 @@ ZoneMapIndexWriterImpl<type>::ZoneMapIndexWriterImpl(TypeInfo* type_info) : _typ
 template <LogicalType type>
 void ZoneMapIndexWriterImpl<type>::add_values(const void* values, size_t count) {
     if (count > 0) {
+        _page_zone_map.has_not_null = true;
+        const auto* vals = reinterpret_cast<const CppType*>(values);
+        auto [pmin, pmax] = std::minmax_element(vals, vals + count);
+
         if (_page_zone_map.has_not_null) {
-            const auto* vals = reinterpret_cast<const CppType*>(values);
-            auto [pmin, pmax] = std::minmax_element(vals, vals + count);
             if (unaligned_load<CppType>(pmin) < _page_zone_map.min_value.value) {
                 _page_zone_map.min_value.resize_container_for_fit(_type_info, pmin);
                 _type_info->direct_copy(&_page_zone_map.min_value.value, pmin);
@@ -194,10 +196,6 @@ void ZoneMapIndexWriterImpl<type>::add_values(const void* values, size_t count) 
                 _type_info->direct_copy(&_page_zone_map.max_value.value, pmax);
             }
         } else {
-            _page_zone_map.has_not_null = true;
-            const auto* vals = reinterpret_cast<const CppType*>(values);
-            auto [pmin, pmax] = std::minmax_element(vals, vals + count);
-
             _page_zone_map.min_value.resize_container_for_fit(_type_info, pmin);
             _type_info->direct_copy(&_page_zone_map.min_value.value, pmin);
 

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -67,17 +67,17 @@ template <LogicalType type>
 struct ZoneMapDatum final : public ZoneMapDatumBase<type> {};
 
 template <>
-struct ZoneMapDatum<TYPE_DECIMAL32> : public ZoneMapDatumBase<TYPE_DECIMAL32> {
+struct ZoneMapDatum<TYPE_DECIMAL32> final : public ZoneMapDatumBase<TYPE_DECIMAL32> {
     std::string to_zone_map_string(TypeInfo* type_info) const { return get_decimal_zone_map_string(type_info, &value); }
 };
 
 template <>
-struct ZoneMapDatum<TYPE_DECIMAL64> : public ZoneMapDatumBase<TYPE_DECIMAL64> {
+struct ZoneMapDatum<TYPE_DECIMAL64> final : public ZoneMapDatumBase<TYPE_DECIMAL64> {
     std::string to_zone_map_string(TypeInfo* type_info) const { return get_decimal_zone_map_string(type_info, &value); }
 };
 
 template <>
-struct ZoneMapDatum<TYPE_DECIMAL128> : public ZoneMapDatumBase<TYPE_DECIMAL128> {
+struct ZoneMapDatum<TYPE_DECIMAL128> final : public ZoneMapDatumBase<TYPE_DECIMAL128> {
     std::string to_zone_map_string(TypeInfo* type_info) const { return get_decimal_zone_map_string(type_info, &value); }
 };
 
@@ -104,7 +104,7 @@ struct ZoneMapDatum<TYPE_CHAR> : public ZoneMapDatumBase<TYPE_CHAR> {
 };
 
 template <>
-struct ZoneMapDatum<TYPE_VARCHAR> : public ZoneMapDatum<TYPE_CHAR> {};
+struct ZoneMapDatum<TYPE_VARCHAR> final : public ZoneMapDatum<TYPE_CHAR> {};
 
 template <LogicalType type>
 struct ZoneMap {

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -182,7 +182,6 @@ ZoneMapIndexWriterImpl<type>::ZoneMapIndexWriterImpl(TypeInfo* type_info) : _typ
 template <LogicalType type>
 void ZoneMapIndexWriterImpl<type>::add_values(const void* values, size_t count) {
     if (count > 0) {
-        _page_zone_map.has_not_null = true;
         const auto* vals = reinterpret_cast<const CppType*>(values);
         auto [pmin, pmax] = std::minmax_element(vals, vals + count);
 
@@ -202,6 +201,7 @@ void ZoneMapIndexWriterImpl<type>::add_values(const void* values, size_t count) 
             _page_zone_map.max_value.resize_container_for_fit(_type_info, pmax);
             _type_info->direct_copy(&_page_zone_map.max_value.value, pmax);
         }
+        _page_zone_map.has_not_null = true;
     }
 }
 

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -68,22 +68,28 @@ struct ZoneMapDatum final : public ZoneMapDatumBase<type> {};
 
 template <>
 struct ZoneMapDatum<TYPE_DECIMAL32> final : public ZoneMapDatumBase<TYPE_DECIMAL32> {
-    std::string to_zone_map_string(TypeInfo* type_info) const { return get_decimal_zone_map_string(type_info, &value); }
+    std::string to_zone_map_string(TypeInfo* type_info) const override {
+        return get_decimal_zone_map_string(type_info, &value);
+    }
 };
 
 template <>
 struct ZoneMapDatum<TYPE_DECIMAL64> final : public ZoneMapDatumBase<TYPE_DECIMAL64> {
-    std::string to_zone_map_string(TypeInfo* type_info) const { return get_decimal_zone_map_string(type_info, &value); }
+    std::string to_zone_map_string(TypeInfo* type_info) const override {
+        return get_decimal_zone_map_string(type_info, &value);
+    }
 };
 
 template <>
 struct ZoneMapDatum<TYPE_DECIMAL128> final : public ZoneMapDatumBase<TYPE_DECIMAL128> {
-    std::string to_zone_map_string(TypeInfo* type_info) const { return get_decimal_zone_map_string(type_info, &value); }
+    std::string to_zone_map_string(TypeInfo* type_info) const override {
+        return get_decimal_zone_map_string(type_info, &value);
+    }
 };
 
 template <>
 struct ZoneMapDatum<TYPE_CHAR> : public ZoneMapDatumBase<TYPE_CHAR> {
-    void resize_container_for_fit(TypeInfo* type_info, const void* v) {
+    void resize_container_for_fit(TypeInfo* type_info, const void* v) override {
         static const int INIT_SIZE = 64;
         const Slice* slice = reinterpret_cast<const Slice*>(v);
         if (slice->size > _length) {
@@ -94,7 +100,7 @@ struct ZoneMapDatum<TYPE_CHAR> : public ZoneMapDatumBase<TYPE_CHAR> {
         }
     }
 
-    void reset(TypeInfo* type_info) {
+    void reset(TypeInfo* type_info) override {
         value.data = _value_container.data();
         value.size = 0;
     }

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -62,7 +62,7 @@ struct ZoneMapDatumBase {
 };
 
 template <LogicalType type>
-struct ZoneMapDatum : public ZoneMapDatumBase<type> {};
+struct ZoneMapDatum final : public ZoneMapDatumBase<type> {};
 
 template <>
 struct ZoneMapDatum<TYPE_DECIMAL32> : public ZoneMapDatumBase<TYPE_DECIMAL32> {
@@ -289,7 +289,7 @@ StatusOr<bool> ZoneMapIndexReader::load(const IndexReadOptions& opts, const Zone
         Status st = _do_load(opts, meta);
         if (st.ok()) {
             MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->column_zonemap_index_mem_tracker(),
-                                     _mem_usage() - sizeof(ZoneMapIndexReader));
+                                     _mem_usage() - sizeof(ZoneMapIndexReader))
         } else {
             _reset();
         }

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -56,6 +56,8 @@ struct ZoneMapDatumBase {
     using CppType = typename TypeTraits<type>::CppType;
     CppType value;
 
+    virtual ~ZoneMapDatumBase() = default;
+
     virtual void reset(TypeInfo* type_info) { type_info->set_to_min(&value); }
     virtual void resize_container_for_fit(TypeInfo* type_info, const void* v) {}
     virtual std::string to_zone_map_string(TypeInfo* type_info) const { return type_info->to_string(&value); }

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -56,10 +56,9 @@ struct ZoneMapDatumBase {
     using CppType = typename TypeTraits<type>::CppType;
     CppType value;
 
-    void init([[maybe_unused]] TypeInfo* type_info, [[maybe_unused]] int length) {}
-    void set_to_max(TypeInfo* type_info) { type_info->set_to_max(&value); }
-    void set_to_min(TypeInfo* type_info) { type_info->set_to_min(&value); }
-    std::string to_zone_map_string(TypeInfo* type_info) const { return type_info->to_string(&value); }
+    virtual void reset(TypeInfo* type_info) { type_info->set_to_min(&value); }
+    virtual void resize_container_for_fit(TypeInfo* type_info, const void* v) {}
+    virtual std::string to_zone_map_string(TypeInfo* type_info) const { return type_info->to_string(&value); }
 };
 
 template <LogicalType type>
@@ -82,18 +81,23 @@ struct ZoneMapDatum<TYPE_DECIMAL128> : public ZoneMapDatumBase<TYPE_DECIMAL128> 
 
 template <>
 struct ZoneMapDatum<TYPE_CHAR> : public ZoneMapDatumBase<TYPE_CHAR> {
-    void init([[maybe_unused]] TypeInfo* type_info_, int length) {
-        _length = length;
-        raw::make_room(&_value_container, length);
-        value.data = (char*)_value_container.c_str();
-        value.size = length;
+    void resize_container_for_fit(TypeInfo* type_info, const void* v) {
+        static const int INIT_SIZE = 64;
+        const Slice* slice = reinterpret_cast<const Slice*>(v);
+        if (slice->size > _length) {
+            _length = std::max<int>(BitUtil::next_power_of_two(slice->size), INIT_SIZE);
+            raw::stl_string_resize_uninitialized(&_value_container, _length);
+            value.data = _value_container.data();
+            value.size = 0;
+        }
     }
-    void set_to_max([[maybe_unused]] TypeInfo* type_info) {
-        value.size = _length;
-        memset(value.data, 0xFF, value.size);
+
+    void reset(TypeInfo* type_info) {
+        value.data = _value_container.data();
+        value.size = 0;
     }
-    void set_to_min([[maybe_unused]] TypeInfo* type_info) { value.size = 0; }
-    int _length;
+
+    int _length = 0;
     std::string _value_container;
 };
 
@@ -102,9 +106,7 @@ struct ZoneMapDatum<TYPE_VARCHAR> : public ZoneMapDatum<TYPE_CHAR> {};
 
 template <LogicalType type>
 struct ZoneMap {
-    // min value of zone
     ZoneMapDatum<type> min_value;
-    // max value of zone
     ZoneMapDatum<type> max_value;
 
     // if both has_null and has_not_null is false, means no rows.
@@ -131,7 +133,7 @@ class ZoneMapIndexWriterImpl final : public ZoneMapIndexWriter {
 public:
     // TypeInfo is used for all kinds of types. It is used to change the content of datum of the max/min value.
     // length is only used for CHAR/VARCHAR, and used to allocate enough memory for min/max value.
-    explicit ZoneMapIndexWriterImpl(TypeInfo* type_info, int length);
+    explicit ZoneMapIndexWriterImpl(TypeInfo* type_info);
 
     void add_values(const void* values, size_t count) override;
 
@@ -147,8 +149,8 @@ public:
 private:
     void _reset_zone_map(ZoneMap<type>* zone_map) {
         // we should allocate max varchar length and set to max for min value
-        zone_map->min_value.set_to_max(_type_info);
-        zone_map->max_value.set_to_min(_type_info);
+        zone_map->min_value.reset(_type_info);
+        zone_map->max_value.reset(_type_info);
         zone_map->has_null = false;
         zone_map->has_not_null = false;
     }
@@ -164,25 +166,34 @@ private:
 };
 
 template <LogicalType type>
-ZoneMapIndexWriterImpl<type>::ZoneMapIndexWriterImpl(TypeInfo* type_info, int length) : _type_info(type_info) {
-    _page_zone_map.min_value.init(_type_info, length);
-    _page_zone_map.max_value.init(_type_info, length);
+ZoneMapIndexWriterImpl<type>::ZoneMapIndexWriterImpl(TypeInfo* type_info) : _type_info(type_info) {
     _reset_zone_map(&_page_zone_map);
-    _segment_zone_map.min_value.init(_type_info, length);
-    _segment_zone_map.max_value.init(_type_info, length);
     _reset_zone_map(&_segment_zone_map);
 }
 
 template <LogicalType type>
 void ZoneMapIndexWriterImpl<type>::add_values(const void* values, size_t count) {
     if (count > 0) {
-        _page_zone_map.has_not_null = true;
-        const auto* vals = reinterpret_cast<const CppType*>(values);
-        auto [pmin, pmax] = std::minmax_element(vals, vals + count);
-        if (unaligned_load<CppType>(pmin) < _page_zone_map.min_value.value) {
+        if (_page_zone_map.has_not_null) {
+            const auto* vals = reinterpret_cast<const CppType*>(values);
+            auto [pmin, pmax] = std::minmax_element(vals, vals + count);
+            if (unaligned_load<CppType>(pmin) < _page_zone_map.min_value.value) {
+                _page_zone_map.min_value.resize_container_for_fit(_type_info, pmin);
+                _type_info->direct_copy(&_page_zone_map.min_value.value, pmin);
+            }
+            if (unaligned_load<CppType>(pmax) > _page_zone_map.max_value.value) {
+                _page_zone_map.max_value.resize_container_for_fit(_type_info, pmax);
+                _type_info->direct_copy(&_page_zone_map.max_value.value, pmax);
+            }
+        } else {
+            _page_zone_map.has_not_null = true;
+            const auto* vals = reinterpret_cast<const CppType*>(values);
+            auto [pmin, pmax] = std::minmax_element(vals, vals + count);
+
+            _page_zone_map.min_value.resize_container_for_fit(_type_info, pmin);
             _type_info->direct_copy(&_page_zone_map.min_value.value, pmin);
-        }
-        if (unaligned_load<CppType>(pmax) > _page_zone_map.max_value.value) {
+
+            _page_zone_map.max_value.resize_container_for_fit(_type_info, pmax);
             _type_info->direct_copy(&_page_zone_map.max_value.value, pmax);
         }
     }
@@ -191,17 +202,28 @@ void ZoneMapIndexWriterImpl<type>::add_values(const void* values, size_t count) 
 template <LogicalType type>
 Status ZoneMapIndexWriterImpl<type>::flush() {
     // Update segment zone map.
-    if (_page_zone_map.min_value.value < _segment_zone_map.min_value.value) {
-        _type_info->direct_copy(&_segment_zone_map.min_value.value, &_page_zone_map.min_value.value);
+    if (_page_zone_map.has_not_null) {
+        if (_segment_zone_map.has_not_null) {
+            if (_page_zone_map.min_value.value < _segment_zone_map.min_value.value) {
+                _segment_zone_map.min_value.resize_container_for_fit(_type_info, &_page_zone_map.min_value.value);
+                _type_info->direct_copy(&_segment_zone_map.min_value.value, &_page_zone_map.min_value.value);
+            }
+            if (_page_zone_map.max_value.value > _segment_zone_map.max_value.value) {
+                _segment_zone_map.max_value.resize_container_for_fit(_type_info, &_page_zone_map.max_value.value);
+                _type_info->direct_copy(&_segment_zone_map.max_value.value, &_page_zone_map.max_value.value);
+            }
+        } else {
+            _segment_zone_map.min_value.resize_container_for_fit(_type_info, &_page_zone_map.min_value.value);
+            _type_info->direct_copy(&_segment_zone_map.min_value.value, &_page_zone_map.min_value.value);
+
+            _segment_zone_map.max_value.resize_container_for_fit(_type_info, &_page_zone_map.max_value.value);
+            _type_info->direct_copy(&_segment_zone_map.max_value.value, &_page_zone_map.max_value.value);
+        }
+        _segment_zone_map.has_not_null = true;
     }
-    if (_page_zone_map.max_value.value > _segment_zone_map.max_value.value) {
-        _type_info->direct_copy(&_segment_zone_map.max_value.value, &_page_zone_map.max_value.value);
-    }
+
     if (_page_zone_map.has_null) {
         _segment_zone_map.has_null = true;
-    }
-    if (_page_zone_map.has_not_null) {
-        _segment_zone_map.has_not_null = true;
     }
 
     ZoneMapPB zone_map_pb;
@@ -220,13 +242,13 @@ Status ZoneMapIndexWriterImpl<type>::flush() {
 
 struct ZoneMapIndexWriterBuilder {
     template <LogicalType ftype>
-    std::unique_ptr<ZoneMapIndexWriter> operator()(TypeInfo* type_info, int length) {
-        return std::make_unique<ZoneMapIndexWriterImpl<ftype>>(type_info, length);
+    std::unique_ptr<ZoneMapIndexWriter> operator()(TypeInfo* type_info) {
+        return std::make_unique<ZoneMapIndexWriterImpl<ftype>>(type_info);
     }
 };
 
-std::unique_ptr<ZoneMapIndexWriter> ZoneMapIndexWriter::create(TypeInfo* type_info, int length) {
-    return field_type_dispatch_zonemap_index(type_info->type(), ZoneMapIndexWriterBuilder(), type_info, length);
+std::unique_ptr<ZoneMapIndexWriter> ZoneMapIndexWriter::create(TypeInfo* type_info) {
+    return field_type_dispatch_zonemap_index(type_info->type(), ZoneMapIndexWriterBuilder(), type_info);
 }
 
 template <LogicalType type>

--- a/be/src/storage/rowset/zone_map_index.h
+++ b/be/src/storage/rowset/zone_map_index.h
@@ -58,7 +58,7 @@ class WritableFile;
 // reader can prune an entire segment without reading pages.
 class ZoneMapIndexWriter {
 public:
-    static std::unique_ptr<ZoneMapIndexWriter> create(TypeInfo* type_info, int length);
+    static std::unique_ptr<ZoneMapIndexWriter> create(TypeInfo* type_info);
 
     virtual ~ZoneMapIndexWriter() = default;
 

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -52,17 +52,16 @@ protected:
 
     void SetUp() override {
         _mem_tracker = std::make_unique<MemTracker>();
-        StoragePageCache::create_global_cache(_mem_tracker.get(), 1000000000);
         _fs = std::make_shared<MemoryFileSystem>();
         ASSERT_TRUE(_fs->create_dir(kTestDir).ok());
     }
 
-    void TearDown() override { StoragePageCache::release_global_cache(); }
+    void TearDown() override {}
 
-    void test_string(const std::string& testname, TypeInfoPtr type_info, int length) {
+    void test_string(const std::string& testname, TypeInfoPtr type_info) {
         std::string filename = kTestDir + "/" + testname;
 
-        std::unique_ptr<ZoneMapIndexWriter> builder = ZoneMapIndexWriter::create(type_info.get());
+        auto builder = ZoneMapIndexWriter::create(type_info.get());
         std::vector<std::string> values1 = {"aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff"};
         for (auto& value : values1) {
             Slice slice(value);
@@ -83,7 +82,7 @@ protected:
         // write out zone map index
         ColumnIndexMetaPB index_meta;
         {
-            ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(filename));
+            ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(filename))
             ASSERT_TRUE(builder->finish(wfile.get(), &index_meta).ok());
             ASSERT_EQ(ZONE_MAP_INDEX, index_meta.type());
             ASSERT_OK(wfile->close());
@@ -92,13 +91,13 @@ protected:
         IndexReadOptions opts;
         ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(filename))
         opts.read_file = rfile.get();
-        opts.use_page_cache = true;
+        opts.use_page_cache = false;
         opts.kept_in_memory = false;
         opts.skip_fill_data_cache = false;
         OlapReaderStatistics stats;
         opts.stats = &stats;
         ZoneMapIndexReader column_zone_map;
-        ASSIGN_OR_ABORT(auto r, column_zone_map.load(opts, index_meta.zone_map_index()));
+        ASSIGN_OR_ABORT(auto r, column_zone_map.load(opts, index_meta.zone_map_index()))
         ASSERT_TRUE(r);
         ASSERT_EQ(3, column_zone_map.num_pages());
         const std::vector<ZoneMapPB>& zone_maps = column_zone_map.page_zone_maps();
@@ -117,9 +116,201 @@ protected:
         ASSERT_EQ(false, zone_maps[2].has_not_null());
     }
 
+    void write_file(ZoneMapIndexWriter& builder, ColumnIndexMetaPB& meta, std::string filename);
+    void load_zone_map(ZoneMapIndexReader& reader, ColumnIndexMetaPB& meta, std::string filename);
+    void check_result(const ZoneMapPB& zone_map, bool has_min, bool has_max, const std::string& min,
+                      const std::string& max, bool has_null, bool has_not_null);
+
     std::shared_ptr<MemoryFileSystem> _fs = nullptr;
     std::unique_ptr<MemTracker> _mem_tracker = nullptr;
 };
+
+void ColumnZoneMapTest::check_result(const ZoneMapPB& zone_map, bool has_min, bool has_max, const std::string& min,
+                                     const std::string& max, bool has_null, bool has_not_null) {
+    ASSERT_EQ(has_min, zone_map.has_min());
+    ASSERT_EQ(has_max, zone_map.has_max());
+    ASSERT_EQ(min, zone_map.min());
+    ASSERT_EQ(max, zone_map.max());
+    ASSERT_EQ(has_null, zone_map.has_null());
+    ASSERT_EQ(has_not_null, zone_map.has_not_null());
+}
+
+void ColumnZoneMapTest::write_file(ZoneMapIndexWriter& builder, ColumnIndexMetaPB& meta, std::string filename) {
+    ASSIGN_OR_ABORT(auto file, _fs->new_writable_file(filename))
+    ASSERT_TRUE(builder.finish(file.get(), &meta).ok());
+    ASSERT_EQ(ZONE_MAP_INDEX, meta.type());
+    ASSERT_OK(file->close());
+}
+
+void ColumnZoneMapTest::load_zone_map(ZoneMapIndexReader& reader, ColumnIndexMetaPB& meta, std::string filename) {
+    IndexReadOptions opts;
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(filename))
+    opts.read_file = rfile.get();
+    opts.use_page_cache = false;
+    opts.kept_in_memory = false;
+    opts.skip_fill_data_cache = false;
+    OlapReaderStatistics stats;
+    opts.stats = &stats;
+    ASSERT_TRUE(reader.load(opts, meta.zone_map_index()).value());
+    if (!meta.zone_map_index().segment_zone_map().has_not_null()) {
+        delete meta.mutable_zone_map_index()->mutable_segment_zone_map()->release_min();
+        delete meta.mutable_zone_map_index()->mutable_segment_zone_map()->release_max();
+    }
+}
+
+TEST_F(ColumnZoneMapTest, PartialNullPage1) {
+    std::string filename = kTestDir + "/PartialNullPage1";
+
+    TabletColumn int_column = create_int_key(0);
+    TypeInfoPtr type_info = get_type_info(int_column);
+
+    auto writer = ZoneMapIndexWriter::create(type_info.get());
+
+    // add two page
+    writer->add_nulls(10);
+    writer->flush();
+
+    std::vector<int> values = {1, 2, 3, 4, 5};
+    writer->add_values(values.data(), 5);
+    writer->flush();
+
+    // write
+    ColumnIndexMetaPB index_meta;
+    write_file(*writer, index_meta, filename);
+
+    // read
+    ZoneMapIndexReader reader;
+    load_zone_map(reader, index_meta, filename);
+
+    // page zone map
+    ASSERT_EQ(2, reader.num_pages());
+    const auto& zone_maps = reader.page_zone_maps();
+    ASSERT_EQ(2, zone_maps.size());
+
+    check_result(zone_maps[0], false, false, "", "", true, false);
+    check_result(zone_maps[1], true, true, "1", "5", false, true);
+
+    // segment zonemap
+    const auto& segment_zonemap = index_meta.zone_map_index().segment_zone_map();
+    check_result(segment_zonemap, true, true, "1", "5", true, true);
+}
+
+TEST_F(ColumnZoneMapTest, PartialNullPage2) {
+    std::string filename = kTestDir + "/PartialNullPage2";
+
+    TabletColumn int_column = create_int_key(0);
+    TypeInfoPtr type_info = get_type_info(int_column);
+
+    auto writer = ZoneMapIndexWriter::create(type_info.get());
+
+    // add two page
+    std::vector<int> values = {1, 2, 3, 4, 5};
+    writer->add_values(values.data(), 5);
+    writer->flush();
+
+    writer->add_nulls(10);
+    writer->flush();
+
+    // write
+    ColumnIndexMetaPB index_meta;
+    write_file(*writer, index_meta, filename);
+
+    // read
+    ZoneMapIndexReader reader;
+    load_zone_map(reader, index_meta, filename);
+
+    // page zone map
+    ASSERT_EQ(2, reader.num_pages());
+    const auto& zone_maps = reader.page_zone_maps();
+    ASSERT_EQ(2, zone_maps.size());
+
+    check_result(zone_maps[0], true, true, "1", "5", false, true);
+    check_result(zone_maps[1], false, false, "", "", true, false);
+
+    // segment zonemap
+    const auto& segment_zonemap = index_meta.zone_map_index().segment_zone_map();
+    check_result(segment_zonemap, true, true, "1", "5", true, true);
+}
+
+TEST_F(ColumnZoneMapTest, StringResize) {
+    std::string filename = kTestDir + "/StringResize";
+
+    TabletColumn varchar_column = create_varchar_key(0);
+    TypeInfoPtr type_info = get_type_info(varchar_column);
+
+    auto writer = ZoneMapIndexWriter::create(type_info.get());
+
+    // add two page
+    std::string str1 = std::string("01234");
+    std::string str2 = std::string("0123456789");
+    std::string str3;
+    std::string str4;
+    for (size_t i = 0; i < 10; i++) {
+        str3.append(str2);
+    }
+    for (size_t i = 0; i < 20; i++) {
+        str4.append(str2);
+    }
+    std::vector<Slice> values1 = {{str1.data(), str1.size()}, {str2.data(), str2.size()}};
+    writer->add_values(values1.data(), 2);
+    writer->flush();
+
+    std::vector<Slice> values2 = {{str3.data(), str3.size()}, {str4.data(), str4.size()}};
+    writer->add_values(values2.data(), 2);
+    writer->flush();
+
+    // write
+    ColumnIndexMetaPB index_meta;
+    write_file(*writer, index_meta, filename);
+
+    // read
+    ZoneMapIndexReader reader;
+    load_zone_map(reader, index_meta, filename);
+
+    // page zone map
+    ASSERT_EQ(2, reader.num_pages());
+    const auto& zone_maps = reader.page_zone_maps();
+    ASSERT_EQ(2, zone_maps.size());
+
+    check_result(zone_maps[0], true, true, str1, str2, false, true);
+    check_result(zone_maps[1], true, true, str3, str4, false, true);
+
+    // segment zonemap
+    const auto& segment_zonemap = index_meta.zone_map_index().segment_zone_map();
+    check_result(segment_zonemap, true, true, str1, str4, false, true);
+}
+
+TEST_F(ColumnZoneMapTest, AllNullPage) {
+    std::string filename = kTestDir + "/AllNullPage";
+
+    TabletColumn int_column = create_int_key(0);
+    TypeInfoPtr type_info = get_type_info(int_column);
+
+    auto writer = ZoneMapIndexWriter::create(type_info.get());
+
+    // add one page
+    writer->add_nulls(10);
+    writer->flush();
+
+    // write
+    ColumnIndexMetaPB index_meta;
+    write_file(*writer, index_meta, filename);
+
+    // read
+    ZoneMapIndexReader reader;
+    load_zone_map(reader, index_meta, filename);
+
+    // page zone map
+    ASSERT_EQ(1, reader.num_pages());
+    const auto& zone_maps = reader.page_zone_maps();
+    ASSERT_EQ(1, zone_maps.size());
+
+    check_result(zone_maps[0], false, false, "", "", true, false);
+
+    // segment zonemap
+    const auto& segment_zonemap = index_meta.zone_map_index().segment_zone_map();
+    check_result(segment_zonemap, false, false, "", "", true, false);
+}
 
 // Test for int
 TEST_F(ColumnZoneMapTest, NormalTestIntPage) {
@@ -144,54 +335,32 @@ TEST_F(ColumnZoneMapTest, NormalTestIntPage) {
     builder->flush();
     // write out zone map index
     ColumnIndexMetaPB index_meta;
-    {
-        ASSIGN_OR_ABORT(auto file, _fs->new_writable_file(filename));
-        ASSERT_TRUE(builder->finish(file.get(), &index_meta).ok());
-        ASSERT_EQ(ZONE_MAP_INDEX, index_meta.type());
-        ASSERT_OK(file->close());
-    }
+    write_file(*builder, index_meta, filename);
 
-    IndexReadOptions opts;
-    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(filename))
-    opts.read_file = rfile.get();
-    opts.use_page_cache = true;
-    opts.kept_in_memory = false;
-    opts.skip_fill_data_cache = false;
-    OlapReaderStatistics stats;
-    opts.stats = &stats;
     ZoneMapIndexReader column_zone_map;
-    ASSIGN_OR_ABORT(auto r, column_zone_map.load(opts, index_meta.zone_map_index()));
-    ASSERT_TRUE(r);
+    load_zone_map(column_zone_map, index_meta, filename);
+
     ASSERT_EQ(3, column_zone_map.num_pages());
     const std::vector<ZoneMapPB>& zone_maps = column_zone_map.page_zone_maps();
     ASSERT_EQ(3, zone_maps.size());
 
-    ASSERT_EQ(std::to_string(1), zone_maps[0].min());
-    ASSERT_EQ(std::to_string(22), zone_maps[0].max());
-    ASSERT_EQ(false, zone_maps[0].has_null());
-    ASSERT_EQ(true, zone_maps[0].has_not_null());
-
-    ASSERT_EQ(std::to_string(2), zone_maps[1].min());
-    ASSERT_EQ(std::to_string(31), zone_maps[1].max());
-    ASSERT_EQ(true, zone_maps[1].has_null());
-    ASSERT_EQ(true, zone_maps[1].has_not_null());
-
-    ASSERT_EQ(true, zone_maps[2].has_null());
-    ASSERT_EQ(false, zone_maps[2].has_not_null());
+    check_result(zone_maps[0], true, true, "1", "22", false, true);
+    check_result(zone_maps[1], true, true, "2", "31", true, true);
+    check_result(zone_maps[2], false, false, "", "", true, false);
 }
 
 // Test for string
 TEST_F(ColumnZoneMapTest, NormalTestVarcharPage) {
     TabletColumn varchar_column = create_varchar_key(0);
     TypeInfoPtr type_info = get_type_info(varchar_column);
-    test_string("NormalTestVarcharPage", type_info, 10);
+    test_string("NormalTestVarcharPage", type_info);
 }
 
 // Test for string
 TEST_F(ColumnZoneMapTest, NormalTestCharPage) {
     TabletColumn char_column = create_char_key(0);
     TypeInfoPtr type_info = get_type_info(char_column);
-    test_string("NormalTestCharPage", type_info, 10);
+    test_string("NormalTestCharPage", type_info);
 }
 
 } // namespace starrocks

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -62,7 +62,7 @@ protected:
     void test_string(const std::string& testname, TypeInfoPtr type_info, int length) {
         std::string filename = kTestDir + "/" + testname;
 
-        std::unique_ptr<ZoneMapIndexWriter> builder = ZoneMapIndexWriter::create(type_info.get(), length);
+        std::unique_ptr<ZoneMapIndexWriter> builder = ZoneMapIndexWriter::create(type_info.get());
         std::vector<std::string> values1 = {"aaaa", "bbbb", "cccc", "dddd", "eeee", "ffff"};
         for (auto& value : values1) {
             Slice slice(value);
@@ -128,7 +128,7 @@ TEST_F(ColumnZoneMapTest, NormalTestIntPage) {
     TabletColumn int_column = create_int_key(0);
     TypeInfoPtr type_info = get_type_info(int_column);
 
-    std::unique_ptr<ZoneMapIndexWriter> builder = ZoneMapIndexWriter::create(type_info.get(), 4);
+    std::unique_ptr<ZoneMapIndexWriter> builder = ZoneMapIndexWriter::create(type_info.get());
     std::vector<int> values1 = {1, 10, 11, 20, 21, 22};
     for (auto value : values1) {
         builder->add_values((const uint8_t*)&value, 1);


### PR DESCRIPTION
Fixes #issue

Currently implement: 

For varchar(65536), min_zone_map will alloc 64K mem first. If the value is all null, will write 64K size zonemap to segment file.

After the Optimization:

1. Allocate memory on demand for zonemap.
2. If the value is all null in page, no need to write 64K min zonemap to segment file 

Example:

```
CREATE TABLE `t2` (
  `c1` int(11) NULL COMMENT "",
  `c2` varchar(65533) NULL COMMENT "",
  `c3` int(11) NULL COMMENT ""
) ENGINE=OLAP 
DUPLICATE KEY(`c1`, `c2`)
DISTRIBUTED BY HASH(`c1`) BUCKETS 1 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"compression" = "LZ4"
);

insert into t2 select lo_orderkey, null, 1 from lineorder limit 10;
```

Before opt (Segment file size):  131K
After opt (Segment file size): 0.6K

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
