### PR TITLE
[BugFix] fix a wrong DCHECK in SenderQueue

### DIFF
--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -589,7 +589,9 @@ Status DataStreamRecvr::PipelineSenderQueue::try_to_build_chunk_meta(const PTran
     std::lock_guard<Mutex> l(_lock);
     wait_timer.stop();
 
-    DCHECK(_chunk_meta.types.empty());
+    if (!_chunk_meta.types.empty()) {
+        return Status::OK();
+    }
 
     SCOPED_TIMER(_recvr->_deserialize_chunk_timer);
     auto& pchunk = request.chunks(0);

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -589,7 +589,7 @@ Status DataStreamRecvr::PipelineSenderQueue::try_to_build_chunk_meta(const PTran
     std::lock_guard<Mutex> l(_lock);
     wait_timer.stop();
 
-    if (!_chunk_meta.types.empty()) {
+    if (_is_chunk_meta_built) {
         return Status::OK();
     }
 


### PR DESCRIPTION
introduced by #28080
if many threads are competing for this lock, the first one which gets this lock will build chunk meta and the others will see !_chunk_meta.types.empty(), we should return instead of checking failed

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
