### PR TITLE
[BugFix] Be crash when delete cols file for unused rowset (#28579)

### DIFF
--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -69,6 +69,7 @@ Rowset::Rowset(const TabletSchema* schema, std::string rowset_path, RowsetMetaSh
           _rowset_path(std::move(rowset_path)),
           _rowset_meta(std::move(rowset_meta)),
           _refs_by_reader(0) {
+    _keys_type = _schema->keys_type();
     MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->rowset_metadata_mem_tracker(), _mem_usage());
 }
 
@@ -310,7 +311,7 @@ Status Rowset::_remove_delta_column_group_files(const std::shared_ptr<FileSystem
         // 1. remove dcg files
         for (int i = 0; i < num_segments(); i++) {
             DeltaColumnGroupList list;
-            if (_schema->keys_type() == PRIMARY_KEYS) {
+            if (_keys_type == PRIMARY_KEYS) {
                 RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(kvstore, _rowset_meta->tablet_id(),
                                                                            _rowset_meta->get_rowset_seg_id() + i, 0,
                                                                            INT64_MAX, &list));
@@ -332,7 +333,7 @@ Status Rowset::_remove_delta_column_group_files(const std::shared_ptr<FileSystem
             }
         }
         // 2. remove dcg from rocksdb
-        if (_schema->keys_type() == PRIMARY_KEYS) {
+        if (_keys_type == PRIMARY_KEYS) {
             RETURN_IF_ERROR(TabletMetaManager::delete_delta_column_group(
                     kvstore, _rowset_meta->tablet_id(), _rowset_meta->get_rowset_seg_id(), num_segments()));
         } else {
@@ -381,7 +382,7 @@ Status Rowset::_link_delta_column_group_files(KVStore* kvstore, const std::strin
         for (int i = 0; i < num_segments(); i++) {
             DeltaColumnGroupList list;
 
-            if (_schema->keys_type() == PRIMARY_KEYS) {
+            if (_keys_type == PRIMARY_KEYS) {
                 RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(
                         kvstore, _rowset_meta->tablet_id(), _rowset_meta->get_rowset_seg_id() + i, 0, version, &list));
             } else {
@@ -468,7 +469,7 @@ Status Rowset::_copy_delta_column_group_files(KVStore* kvstore, const std::strin
         for (int i = 0; i < num_segments(); i++) {
             DeltaColumnGroupList list;
 
-            if (_schema->keys_type() == PRIMARY_KEYS) {
+            if (_keys_type == PRIMARY_KEYS) {
                 RETURN_IF_ERROR(TabletMetaManager::scan_delta_column_group(
                         kvstore, _rowset_meta->tablet_id(), _rowset_meta->get_rowset_seg_id() + i, 0, version, &list));
             } else {

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -383,6 +383,8 @@ private:
     Status _copy_delta_column_group_files(KVStore* kvstore, const std::string& dir, int64_t version);
 
     std::vector<SegmentSharedPtr> _segments;
+
+    KeysType _keys_type;
 };
 
 class RowsetReleaseGuard {


### PR DESCRIPTION
Problem:
Be crash when delete cols file for unused rowset. Because the _schema for the rowset maybe freed before use it and cause the crash.

Solution:
Save the key type in another variable.

Fixes #28579

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
