### PR TITLE
[BugFix] Txn watermark should be reset too after decommission state is reset

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -765,8 +765,9 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     public String getReplicaInfos() {
         StringBuilder sb = new StringBuilder();
         for (Replica replica : replicas) {
-            sb.append(String.format("%d:%d/%d/%d/%d,", replica.getBackendId(), replica.getVersion(),
-                    replica.getLastFailedVersion(), replica.getLastSuccessVersion(), replica.getMinReadableVersion()));
+            sb.append(String.format("%d:%d/%d/%d/%d:%s,", replica.getBackendId(), replica.getVersion(),
+                    replica.getLastFailedVersion(), replica.getLastSuccessVersion(), replica.getMinReadableVersion(),
+                    replica.getState()));
         }
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -755,6 +755,10 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 && decommissionedReplica.getState() == ReplicaState.DECOMMISSION
                 && decommissionedReplicaPreviousState != null) {
             decommissionedReplica.setState(decommissionedReplicaPreviousState);
+            decommissionedReplica.setWatermarkTxnId(-1);
+            LOG.debug("reset replica {} on backend {} with state from DECOMMISSION to {}, tablet: {}",
+                    decommissionedReplica.getId(), decommissionedReplica.getBackendId(),
+                    decommissionedReplica.getState(), tabletId);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -83,6 +83,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Queue;
@@ -768,6 +769,7 @@ public class TabletScheduler extends FrontendDaemon {
                         "table is in alter process, but tablet status is " + statusPair.first.name());
             }
 
+            TabletStatus oldStatus = tabletCtx.getTabletStatus();
             tabletCtx.setTabletStatus(statusPair.first);
             if (statusPair.first == TabletStatus.HEALTHY && tabletCtx.getType() == TabletSchedCtx.Type.REPAIR) {
                 throw new SchedException(Status.UNRECOVERABLE, "tablet is healthy");
@@ -789,7 +791,14 @@ public class TabletScheduler extends FrontendDaemon {
                     partition.getCommittedVersion(), partition.getVisibleTxnId());
             tabletCtx.setSchemaHash(tbl.getSchemaHashByIndexId(idx.getId()));
             tabletCtx.setStorageMedium(dataProperty.getStorageMedium());
-
+            if (!Objects.equals(oldStatus, statusPair.first)) {
+                LOG.info("change TabletSchedCtx status from {} to {}, partition visible version: {}," +
+                                " visibleTxnId: {}, tablet: {}, all version infos: {}",
+                        oldStatus, statusPair.first, tabletCtx.getVisibleVersion(),
+                        tabletCtx.getVisibleTxnId(),
+                        tabletCtx.getTabletId(),
+                        tabletCtx.getTablet().getReplicaInfos());
+            }
         } finally {
             db.readUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -193,16 +193,17 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
                             } else {
                                 Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(tabletBackend);
                                 failedReplicaInfoSB.append(
-                                        String.format("%d:{be:%d %s V:%d LFV:%d},", replica.getId(), tabletBackend,
-                                                backend == null ? "" : backend.getHost(), replica.getVersion(), lfv));
+                                        String.format("%d:{be:%d %s st:%s V:%d LFV:%d},", replica.getId(), tabletBackend,
+                                                backend == null ? "" : backend.getHost(),
+                                                replica.getState(), replica.getVersion(), lfv));
                             }
                             replica.setLastWriteFail(false);
                         } else {
                             Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(tabletBackend);
                             failedReplicaInfoSB.append(
-                                    String.format("%d:{be:%d %s V:%d LFV:%d},", replica.getId(), tabletBackend,
-                                            backend == null ? "" : backend.getHost(), replica.getVersion(),
-                                            replica.getLastFailedVersion()));
+                                    String.format("%d:{be:%d %s st:%s V:%d LFV:%d},", replica.getId(), tabletBackend,
+                                            backend == null ? "" : backend.getHost(),
+                                            replica.getState(), replica.getVersion(), replica.getLastFailedVersion()));
                             // not remove rollup task here, because the commit maybe failed
                             // remove rollup task when commit successfully
                             errorReplicaIds.add(replica.getId());


### PR DESCRIPTION
Fixes SSU-477

This may cause replica is deleted before on-the-fly loading txn finished
which may lead to commit failure.
And we also add some logs about the state of the replica for easy debug.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.3
