### PR TITLE
[Refactor] refactor sql tester cases of query external file

### DIFF
--- a/test/sql/test_external_file/R/test_orc_count_star_opt
+++ b/test/sql/test_external_file/R/test_orc_count_star_opt
@@ -1,47 +1,32 @@
 -- name: testORCCountStarOpt
-shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_count_star_opt/array_data_only >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/array_data_only >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
 
 -- !result
-shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_count_star_opt/map_data_only >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/map_data_only >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
 
 -- !result
-shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_count_star_opt/struct_data_only >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/struct_data_only >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
 
 -- !result
-shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_count_star_opt/array_data_only >/dev/null || echo "exit 0" >/dev/null
--- result:
-0
-
--- !result
-shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_count_star_opt/map_data_only >/dev/null || echo "exit 0" >/dev/null
--- result:
-0
-
--- !result
-shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_count_star_opt/struct_data_only >/dev/null || echo "exit 0" >/dev/null
--- result:
-0
-
--- !result
-shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/array_data_only.orc oss://${oss_bucket}/test_orc_count_star_opt/array_data_only/array_data_only.orc | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/array_data_only.orc oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/array_data_only/array_data_only.orc | grep -Pv "(average|elapsed)"
 -- result:
 0
 
 Succeed: Total num: 1, size: 304. OK num: 1(upload 1 files).
 -- !result
-shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/map_data_only.orc oss://${oss_bucket}/test_orc_count_star_opt/map_data_only/map_data_only.orc | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/map_data_only.orc oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/map_data_only/map_data_only.orc | grep -Pv "(average|elapsed)"
 -- result:
 0
 
 Succeed: Total num: 1, size: 409. OK num: 1(upload 1 files).
 -- !result
-shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/struct_data_only.orc oss://${oss_bucket}/test_orc_count_star_opt/struct_data_only/struct_data_only.orc | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/struct_data_only.orc oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/struct_data_only/struct_data_only.orc | grep -Pv "(average|elapsed)"
 -- result:
 0
 
@@ -54,7 +39,7 @@ CREATE EXTERNAL TABLE array_data_only
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_orc_count_star_opt/array_data_only/", 
+    "path" = "oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/array_data_only/", 
     "format" = "orc"
 );
 -- result:
@@ -80,7 +65,7 @@ CREATE EXTERNAL TABLE map_data_only
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_orc_count_star_opt/map_data_only/", 
+    "path" = "oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/map_data_only/", 
     "format" = "orc"
 );
 -- result:
@@ -101,7 +86,7 @@ CREATE EXTERNAL TABLE struct_data_only
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_orc_count_star_opt/struct_data_only/", 
+    "path" = "oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/struct_data_only/", 
     "format" = "orc"
 );
 -- result:
@@ -112,4 +97,9 @@ set enable_count_star_optimization = true;
 select count(*) from struct_data_only;
 -- result:
 63
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
 -- !result

--- a/test/sql/test_external_file/R/test_parquet_bool_decoder
+++ b/test/sql/test_external_file/R/test_parquet_bool_decoder
@@ -1,10 +1,10 @@
 -- name: testParquetBoolDecoder
-shell: ossutil64 mkdir oss://${oss_bucket}/test_external_file/parquet_bool_decoder >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_bool_decoder/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
 
 -- !result
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/bool_decoder.parquet oss://${oss_bucket}/test_external_file/parquet_bool_decoder/bool_decoder.parquet | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/bool_decoder.parquet oss://${oss_bucket}/test_parquet_bool_decoder/${uuid0}/bool_decoder.parquet | grep -Pv "(average|elapsed)"
 -- result:
 0
 
@@ -17,7 +17,7 @@ CREATE EXTERNAL TABLE parquet_bool_decoder
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_external_file/parquet_bool_decoder/", 
+    "path" = "oss://${oss_bucket}/test_parquet_bool_decoder/${uuid0}/", 
     "format" = "parquet"
 );
 -- result:
@@ -27,4 +27,9 @@ select count(*),c_enabled from parquet_bool_decoder group by c_enabled order by 
 29967	None
 9948	0
 10085	1
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_bool_decoder/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
 -- !result

--- a/test/sql/test_external_file/R/test_parquet_count_star_opt
+++ b/test/sql/test_external_file/R/test_parquet_count_star_opt
@@ -1,47 +1,32 @@
 -- name: testParquetCountStarOpt
-shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_count_star_opt/array_data_only >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/array_data_only >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
 
 -- !result
-shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_count_star_opt/map_data_only >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/map_data_only >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
 
 -- !result
-shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_count_star_opt/struct_data_only >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/struct_data_only >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
 
 -- !result
-shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_count_star_opt/array_data_only >/dev/null || echo "exit 0" >/dev/null
--- result:
-0
-
--- !result
-shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_count_star_opt/map_data_only >/dev/null || echo "exit 0" >/dev/null
--- result:
-0
-
--- !result
-shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_count_star_opt/struct_data_only >/dev/null || echo "exit 0" >/dev/null
--- result:
-0
-
--- !result
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/array_data_only.parquet oss://${oss_bucket}/test_parquet_count_star_opt/array_data_only/array_data_only.parquet | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/array_data_only.parquet oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/array_data_only/array_data_only.parquet | grep -Pv "(average|elapsed)"
 -- result:
 0
 
 Succeed: Total num: 1, size: 1,959. OK num: 1(upload 1 files).
 -- !result
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/map_data_only.parquet oss://${oss_bucket}/test_parquet_count_star_opt/map_data_only/map_data_only.parquet | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/map_data_only.parquet oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/map_data_only/map_data_only.parquet | grep -Pv "(average|elapsed)"
 -- result:
 0
 
 Succeed: Total num: 1, size: 3,192. OK num: 1(upload 1 files).
 -- !result
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/struct_data_only.parquet oss://${oss_bucket}/test_parquet_count_star_opt/struct_data_only/struct_data_only.parquet | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/struct_data_only.parquet oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/struct_data_only/struct_data_only.parquet | grep -Pv "(average|elapsed)"
 -- result:
 0
 
@@ -54,7 +39,7 @@ CREATE EXTERNAL TABLE array_data_only
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_parquet_count_star_opt/array_data_only/", 
+    "path" = "oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/array_data_only/", 
     "format" = "parquet"
 );
 -- result:
@@ -80,7 +65,7 @@ CREATE EXTERNAL TABLE map_data_only
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_parquet_count_star_opt/map_data_only/", 
+    "path" = "oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/map_data_only/", 
     "format" = "parquet"
 );
 -- result:
@@ -101,7 +86,7 @@ CREATE EXTERNAL TABLE struct_data_only
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_parquet_count_star_opt/struct_data_only/", 
+    "path" = "oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/struct_data_only/", 
     "format" = "parquet"
 );
 -- result:
@@ -112,4 +97,9 @@ set enable_count_star_optimization = true;
 select count(*) from struct_data_only;
 -- result:
 73
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
 -- !result

--- a/test/sql/test_external_file/R/test_parquet_dict_null_predicate
+++ b/test/sql/test_external_file/R/test_parquet_dict_null_predicate
@@ -1,10 +1,10 @@
 -- name: testExternalParquetDictNullPredicate
-shell: ossutil64 mkdir oss://${oss_bucket}/test_external_file/dict_with_null_value >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_dict_with_null_value/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
 
 -- !result
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/dict_with_null_value.parquet oss://${oss_bucket}/test_external_file/dict_with_null_value/dict_with_null_value.parquet | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/dict_with_null_value.parquet oss://${oss_bucket}/test_parquet_dict_with_null_value/${uuid0}/dict_with_null_value.parquet | grep -Pv "(average|elapsed)"
 -- result:
 0
 
@@ -24,7 +24,7 @@ CREATE EXTERNAL TABLE tpch_customer_null
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_external_file/dict_with_null_value/",
+    "path" = "oss://${oss_bucket}/test_parquet_dict_with_null_value/${uuid0}/",
     "format" = "parquet"
 );
 -- result:
@@ -48,4 +48,9 @@ select count(*) from tpch_customer_null where c_mktsegment is null;
 select count(*) from tpch_customer_null where c_mktsegment is not null;
 -- result:
 24
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_dict_with_null_value/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
 -- !result

--- a/test/sql/test_external_file/R/test_parquet_optional_column_levels
+++ b/test/sql/test_external_file/R/test_parquet_optional_column_levels
@@ -1,10 +1,10 @@
 -- name: testParquetOptionalColumnLevels
-shell: ossutil64 mkdir oss://${oss_bucket}/test_external_file/optional_column_levels >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_optional_column_levels/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
 
 -- !result
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/optional_column_levels.parq oss://${oss_bucket}/test_external_file/optional_column_levels/optional_column_levels.parq | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/optional_column_levels.parq oss://${oss_bucket}/test_parquet_optional_column_levels/${uuid0}/optional_column_levels.parq | grep -Pv "(average|elapsed)"
 -- result:
 0
 
@@ -14,11 +14,11 @@ CREATE EXTERNAL TABLE opt_col_levels
 (
     c0 int,
     c_struct struct<c1 int>
-) 
+)
 ENGINE=file
-PROPERTIES 
+PROPERTIES
 (
-    "path" = "oss://${oss_bucket}/test_external_file/optional_column_levels/optional_column_levels.parq",
+    "path" = "oss://${oss_bucket}/test_parquet_optional_column_levels/${uuid0}/optional_column_levels.parq",
     "format" = "parquet"
 );
 -- result:
@@ -30,4 +30,9 @@ select * from opt_col_levels where c0 = 403350;
 select * from opt_col_levels where c0 = 403376;
 -- result:
 403376	{"c1":403376}
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_optional_column_levels/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
 -- !result

--- a/test/sql/test_external_file/R/test_query_external_file
+++ b/test/sql/test_external_file/R/test_query_external_file
@@ -1,10 +1,10 @@
 -- name: testQueryExternalFile
-shell: ossutil64 mkdir oss://${oss_bucket}/test_external_file/dict_two_page >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_query_external_file/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
 
 -- !result
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/dict_two_page.parquet oss://${oss_bucket}/test_external_file/dict_two_page/dict_two_page.parquet | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/dict_two_page.parquet oss://${oss_bucket}/test_query_external_file/${uuid0}/dict_two_page.parquet | grep -Pv "(average|elapsed)"
 -- result:
 0
 
@@ -22,7 +22,7 @@ CREATE EXTERNAL TABLE dict_two_page
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_external_file/dict_two_page/", 
+    "path" = "oss://${oss_bucket}/test_query_external_file/${uuid0}/", 
     "format" = "parquet"
 );
 -- result:
@@ -80,4 +80,9 @@ select count(distinct seq) from dict_two_page;
 select count(*), min(f00), max(f00) from dict_two_page group by seq having seq = 99;
 -- result:
 2	vwxyzabcdefghijklmno	vwxyzabcdefghijklmno
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_query_external_file/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
 -- !result

--- a/test/sql/test_external_file/T/test_orc_count_star_opt
+++ b/test/sql/test_external_file/T/test_orc_count_star_opt
@@ -1,16 +1,12 @@
 -- name: testORCCountStarOpt
 
-shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_count_star_opt/array_data_only >/dev/null || echo "exit 0" >/dev/null
-shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_count_star_opt/map_data_only >/dev/null || echo "exit 0" >/dev/null
-shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_count_star_opt/struct_data_only >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/array_data_only >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/map_data_only >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/struct_data_only >/dev/null || echo "exit 0" >/dev/null
 
-shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_count_star_opt/array_data_only >/dev/null || echo "exit 0" >/dev/null
-shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_count_star_opt/map_data_only >/dev/null || echo "exit 0" >/dev/null
-shell: ossutil64 mkdir oss://${oss_bucket}/test_orc_count_star_opt/struct_data_only >/dev/null || echo "exit 0" >/dev/null
-
-shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/array_data_only.orc oss://${oss_bucket}/test_orc_count_star_opt/array_data_only/array_data_only.orc | grep -Pv "(average|elapsed)"
-shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/map_data_only.orc oss://${oss_bucket}/test_orc_count_star_opt/map_data_only/map_data_only.orc | grep -Pv "(average|elapsed)"
-shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/struct_data_only.orc oss://${oss_bucket}/test_orc_count_star_opt/struct_data_only/struct_data_only.orc | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/array_data_only.orc oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/array_data_only/array_data_only.orc | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/map_data_only.orc oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/map_data_only/map_data_only.orc | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/orc_scanner/struct_data_only.orc oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/struct_data_only/struct_data_only.orc | grep -Pv "(average|elapsed)"
 
 CREATE EXTERNAL TABLE array_data_only
 (
@@ -19,7 +15,7 @@ CREATE EXTERNAL TABLE array_data_only
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_orc_count_star_opt/array_data_only/", 
+    "path" = "oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/array_data_only/", 
     "format" = "orc"
 );
 
@@ -36,7 +32,7 @@ CREATE EXTERNAL TABLE map_data_only
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_orc_count_star_opt/map_data_only/", 
+    "path" = "oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/map_data_only/", 
     "format" = "orc"
 );
 set enable_count_star_optimization = true;
@@ -54,10 +50,12 @@ CREATE EXTERNAL TABLE struct_data_only
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_orc_count_star_opt/struct_data_only/", 
+    "path" = "oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/struct_data_only/", 
     "format" = "orc"
 );
 set enable_count_star_optimization = true;
 select count(*) from struct_data_only;
 -- set enable_count_star_optimization = false;
 -- select count(*) from struct_data_only;
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_orc_count_star_opt/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_external_file/T/test_parquet_bool_decoder
+++ b/test/sql/test_external_file/T/test_parquet_bool_decoder
@@ -1,7 +1,7 @@
 -- name: testParquetBoolDecoder
 
-shell: ossutil64 mkdir oss://${oss_bucket}/test_external_file/parquet_bool_decoder >/dev/null || echo "exit 0" >/dev/null
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/bool_decoder.parquet oss://${oss_bucket}/test_external_file/parquet_bool_decoder/bool_decoder.parquet | grep -Pv "(average|elapsed)"
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_bool_decoder/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/bool_decoder.parquet oss://${oss_bucket}/test_parquet_bool_decoder/${uuid0}/bool_decoder.parquet | grep -Pv "(average|elapsed)"
 
 CREATE EXTERNAL TABLE parquet_bool_decoder
 (
@@ -10,8 +10,10 @@ CREATE EXTERNAL TABLE parquet_bool_decoder
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_external_file/parquet_bool_decoder/", 
+    "path" = "oss://${oss_bucket}/test_parquet_bool_decoder/${uuid0}/", 
     "format" = "parquet"
 );
 
 select count(*),c_enabled from parquet_bool_decoder group by c_enabled order by c_enabled;
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_bool_decoder/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_external_file/T/test_parquet_count_star_opt
+++ b/test/sql/test_external_file/T/test_parquet_count_star_opt
@@ -1,16 +1,12 @@
 -- name: testParquetCountStarOpt
 
-shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_count_star_opt/array_data_only >/dev/null || echo "exit 0" >/dev/null
-shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_count_star_opt/map_data_only >/dev/null || echo "exit 0" >/dev/null
-shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_count_star_opt/struct_data_only >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/array_data_only >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/map_data_only >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/struct_data_only >/dev/null || echo "exit 0" >/dev/null
 
-shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_count_star_opt/array_data_only >/dev/null || echo "exit 0" >/dev/null
-shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_count_star_opt/map_data_only >/dev/null || echo "exit 0" >/dev/null
-shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_count_star_opt/struct_data_only >/dev/null || echo "exit 0" >/dev/null
-
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/array_data_only.parquet oss://${oss_bucket}/test_parquet_count_star_opt/array_data_only/array_data_only.parquet | grep -Pv "(average|elapsed)"
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/map_data_only.parquet oss://${oss_bucket}/test_parquet_count_star_opt/map_data_only/map_data_only.parquet | grep -Pv "(average|elapsed)"
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/struct_data_only.parquet oss://${oss_bucket}/test_parquet_count_star_opt/struct_data_only/struct_data_only.parquet | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/array_data_only.parquet oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/array_data_only/array_data_only.parquet | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/map_data_only.parquet oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/map_data_only/map_data_only.parquet | grep -Pv "(average|elapsed)"
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/struct_data_only.parquet oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/struct_data_only/struct_data_only.parquet | grep -Pv "(average|elapsed)"
 
 CREATE EXTERNAL TABLE array_data_only
 (
@@ -19,7 +15,7 @@ CREATE EXTERNAL TABLE array_data_only
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_parquet_count_star_opt/array_data_only/", 
+    "path" = "oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/array_data_only/", 
     "format" = "parquet"
 );
 
@@ -36,7 +32,7 @@ CREATE EXTERNAL TABLE map_data_only
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_parquet_count_star_opt/map_data_only/", 
+    "path" = "oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/map_data_only/", 
     "format" = "parquet"
 );
 set enable_count_star_optimization = true;
@@ -54,10 +50,12 @@ CREATE EXTERNAL TABLE struct_data_only
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_parquet_count_star_opt/struct_data_only/", 
+    "path" = "oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/struct_data_only/", 
     "format" = "parquet"
 );
 set enable_count_star_optimization = true;
 select count(*) from struct_data_only;
 -- set enable_count_star_optimization = false;
 -- select count(*) from struct_data_only;
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_count_star_opt/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_external_file/T/test_parquet_dict_null_predicate
+++ b/test/sql/test_external_file/T/test_parquet_dict_null_predicate
@@ -1,7 +1,7 @@
 -- name: testExternalParquetDictNullPredicate
 
-shell: ossutil64 mkdir oss://${oss_bucket}/test_external_file/dict_with_null_value >/dev/null || echo "exit 0" >/dev/null
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/dict_with_null_value.parquet oss://${oss_bucket}/test_external_file/dict_with_null_value/dict_with_null_value.parquet | grep -Pv "(average|elapsed)"
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_dict_with_null_value/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/dict_with_null_value.parquet oss://${oss_bucket}/test_parquet_dict_with_null_value/${uuid0}/dict_with_null_value.parquet | grep -Pv "(average|elapsed)"
 
 -- MySQL [tpch_100g_zhangyan_parquet_lz4]> select c_mktsegment from customer_with_nulls3;
 -- +--------------+
@@ -53,7 +53,7 @@ CREATE EXTERNAL TABLE tpch_customer_null
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_external_file/dict_with_null_value/",
+    "path" = "oss://${oss_bucket}/test_parquet_dict_with_null_value/${uuid0}/",
     "format" = "parquet"
 );
 
@@ -68,3 +68,5 @@ select count(*) from tpch_customer_null where coalesce(c_mktsegment, 'BUILDING')
 select count(*) from tpch_customer_null where c_mktsegment is null;
 
 select count(*) from tpch_customer_null where c_mktsegment is not null;
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_dict_with_null_value/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_external_file/T/test_parquet_optional_column_levels
+++ b/test/sql/test_external_file/T/test_parquet_optional_column_levels
@@ -1,7 +1,7 @@
 -- name: testParquetOptionalColumnLevels
 
-shell: ossutil64 mkdir oss://${oss_bucket}/test_external_file/optional_column_levels >/dev/null || echo "exit 0" >/dev/null
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/optional_column_levels.parq oss://${oss_bucket}/test_external_file/optional_column_levels/optional_column_levels.parq | grep -Pv "(average|elapsed)"
+shell: ossutil64 mkdir oss://${oss_bucket}/test_parquet_optional_column_levels/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/optional_column_levels.parq oss://${oss_bucket}/test_parquet_optional_column_levels/${uuid0}/optional_column_levels.parq | grep -Pv "(average|elapsed)"
 
 CREATE EXTERNAL TABLE opt_col_levels
 (
@@ -11,9 +11,11 @@ CREATE EXTERNAL TABLE opt_col_levels
 ENGINE=file
 PROPERTIES
 (
-    "path" = "oss://${oss_bucket}/test_external_file/optional_column_levels/optional_column_levels.parq",
+    "path" = "oss://${oss_bucket}/test_parquet_optional_column_levels/${uuid0}/optional_column_levels.parq",
     "format" = "parquet"
 );
 
 select * from opt_col_levels where c0 = 403350;
 select * from opt_col_levels where c0 = 403376;
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_optional_column_levels/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_external_file/T/test_query_external_file
+++ b/test/sql/test_external_file/T/test_query_external_file
@@ -1,7 +1,7 @@
 -- name: testQueryExternalFile
 
-shell: ossutil64 mkdir oss://${oss_bucket}/test_external_file/dict_two_page >/dev/null || echo "exit 0" >/dev/null
-shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/dict_two_page.parquet oss://${oss_bucket}/test_external_file/dict_two_page/dict_two_page.parquet | grep -Pv "(average|elapsed)"
+shell: ossutil64 mkdir oss://${oss_bucket}/test_query_external_file/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+shell: ossutil64 cp --force ../be/test/exec/test_data/parquet_scanner/dict_two_page.parquet oss://${oss_bucket}/test_query_external_file/${uuid0}/dict_two_page.parquet | grep -Pv "(average|elapsed)"
 
 CREATE EXTERNAL TABLE dict_two_page
 (
@@ -15,7 +15,7 @@ CREATE EXTERNAL TABLE dict_two_page
 ENGINE=file
 PROPERTIES 
 (
-    "path" = "oss://${oss_bucket}/test_external_file/dict_two_page/", 
+    "path" = "oss://${oss_bucket}/test_query_external_file/${uuid0}/", 
     "format" = "parquet"
 );
 
@@ -47,4 +47,6 @@ select min(seq), max(seq) from dict_two_page where f00 >= 'a';
 select count(distinct seq) from dict_two_page;
 
 select count(*), min(f00), max(f00) from dict_two_page group by seq having seq = 99;
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_query_external_file/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 


### PR DESCRIPTION
Fixes #issue

Some sql-tester cases are unstable. Probably because many test cases are running simultaneouly, then maybe some staments are executing at the same time：
- `ossutil64 rm -rf oss://${oss_bucket}/test_orc_count_star_opt/array_data_only`
- sql-query

So maybe sometimes, there will be error like 'file not found'.

To fix this case, it's better to generate unique environment for each run of test cases.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
