### PR TITLE
[Enhancement] Implement bthread support for future/promise/packaged_task

### DIFF
--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -99,6 +99,7 @@ set(UTIL_FILES
   random.cc
   stack_trace_mutex.cpp
   failpoint/fail_point.cpp
+  bthreads/future.h
 )
 
 add_library(Util STATIC

--- a/be/src/util/bthreads/future.h
+++ b/be/src/util/bthreads/future.h
@@ -1,0 +1,1105 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// <future> -*- C++ -*-
+//
+// Copyright (C) 2009-2021 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+// original source location refer to:
+//  https://github.com/gcc-mirror/gcc/blob/master/libstdc%2B%2B-v3/include/std/future
+
+#pragma once
+
+#include <bthread/butex.h>
+#include <butil/thread_local.h>
+
+#include <condition_variable>
+#include <exception>
+#include <functional>
+#include <future>
+#include <mutex>
+
+#include "util/time.h"
+
+namespace starrocks::bthreads {
+
+// Forward declarations.
+template <typename _Res>
+class future;
+
+template <typename _Res>
+class shared_future;
+
+template <typename _Signature>
+class packaged_task;
+
+template <typename _Res>
+class promise;
+
+/// Base class and enclosing scope.
+struct __future_base {
+    /// Base class for results.
+    struct _Result_base {
+        std::exception_ptr _M_error;
+
+        _Result_base(const _Result_base&) = delete;
+        _Result_base& operator=(const _Result_base&) = delete;
+
+        // _M_destroy() allows derived classes to control deallocation
+        virtual void _M_destroy() = 0;
+
+        struct _Deleter {
+            void operator()(_Result_base* __fr) const { __fr->_M_destroy(); }
+        };
+
+    protected:
+        _Result_base() noexcept = default;
+        virtual ~_Result_base() = default;
+    };
+
+    /// A unique_ptr for result objects.
+    template <typename _Res>
+    using _Ptr = std::unique_ptr<_Res, _Result_base::_Deleter>;
+
+    /// A result object that has storage for an object of type _Res.
+    template <typename _Res>
+    struct _Result : _Result_base {
+    private:
+        typename std::aligned_storage<sizeof(_Res), alignof(_Res)>::type _M_storage;
+        bool _M_initialized;
+
+    public:
+        typedef _Res result_type;
+
+        _Result() noexcept : _M_initialized() {}
+
+        ~_Result() override {
+            if (_M_initialized) _M_value().~_Res();
+        }
+
+        // Return lvalue, future will add const or rvalue-reference
+        _Res& _M_value() noexcept { return *static_cast<_Res*>(static_cast<void*>(&_M_storage)); }
+
+        void _M_set(const _Res& __res) {
+            ::new (static_cast<void*>(&_M_storage)) _Res(__res);
+            _M_initialized = true;
+        }
+
+        void _M_set(_Res&& __res) {
+            ::new (static_cast<void*>(&_M_storage)) _Res(std::move(__res));
+            _M_initialized = true;
+        }
+
+    private:
+        void _M_destroy() { delete this; }
+    };
+
+    // Keep it simple for std::allocator.
+    template <typename _Res, typename _Tp>
+    static _Ptr<_Result<_Res>> _S_allocate_result(const std::allocator<_Tp>& __a) {
+        return _Ptr<_Result<_Res>>(new _Result<_Res>);
+    }
+
+    // Base class for various types of shared state created by an
+    // asynchronous provider (such as a std::promise) and shared with one
+    // or more associated futures.
+    class _State_baseV2 {
+        typedef _Ptr<_Result_base> _Ptr_type;
+
+        enum _Status : unsigned { __not_ready, __ready };
+
+        _Ptr_type _M_result;
+        butil::atomic<int>* _M_status;
+        std::atomic_flag _M_retrieved{};
+        std::once_flag _M_once;
+
+    public:
+        _State_baseV2() noexcept : _M_result(), _M_status(nullptr), _M_once() {
+            _M_status = bthread::butex_create_checked<butil::atomic<int>>();
+            _M_status->store(_Status::__not_ready, butil::memory_order_release);
+        }
+        _State_baseV2(const _State_baseV2&) = delete;
+        _State_baseV2& operator=(const _State_baseV2&) = delete;
+        virtual ~_State_baseV2() { bthread::butex_destroy(_M_status); };
+
+        _Result_base& wait() {
+            // Run any deferred function or join any asynchronous thread:
+            _M_complete_async();
+            // Acquire MO makes sure this synchronizes with the thread that made
+            // the future ready.
+            while (_M_status->load(butil::memory_order_acquire) != _Status::__ready) {
+                bthread::butex_wait(_M_status, _Status::__not_ready, nullptr);
+            }
+            return *_M_result;
+        }
+
+        template <typename _Rep, typename _Period>
+        std::future_status wait_for(const std::chrono::duration<_Rep, _Period>& __rel) {
+            // First, check if the future has been made ready.  Use acquire MO
+            // to synchronize with the thread that made it ready.
+            if (_M_status->load(butil::memory_order_acquire) == _Status::__ready) return std::future_status::ready;
+
+            if (_M_is_deferred_future()) return std::future_status::deferred;
+
+            // Don't wait unless the relative time is greater than zero.
+            if (__rel > __rel.zero()) {
+                using __dur = typename std::chrono::steady_clock::duration;
+                return wait_until(std::chrono::steady_clock::now() + std::chrono::ceil<__dur>(__rel));
+            }
+            return std::future_status::timeout;
+        }
+
+        template <typename _Clock, typename _Duration>
+        std::future_status wait_until(const std::chrono::time_point<_Clock, _Duration>& __abs) {
+            static_assert(std::chrono::is_clock_v<_Clock>);
+            // First, check if the future has been made ready.  Use acquire MO
+            // to synchronize with the thread that made it ready.
+            if (_M_status->load(butil::memory_order_acquire) == _Status::__ready) return std::future_status::ready;
+
+            if (_M_is_deferred_future()) return std::future_status::deferred;
+
+            timespec ts = TimespecFromTimePoint(__abs);
+            do {
+                if (bthread::butex_wait(_M_status, _Status::__not_ready, &ts) < 0 && errno == ETIMEDOUT)
+                    return std::future_status::timeout;
+            } while (_M_status->load(butil::memory_order_acquire) != _Status::__ready);
+            _M_complete_async();
+            return std::future_status::ready;
+        }
+
+        // Provide a result to the shared state and make it ready.
+        // Calls at most once: _M_result = __res();
+        void _M_set_result(std::function<_Ptr_type()> __res, bool __ignore_failure = false) {
+            bool __did_set = false;
+            // all calls to this function are serialized,
+            // side-effects of invoking __res only happen once
+            call_once(_M_once, &_State_baseV2::_M_do_set, this, std::addressof(__res), std::addressof(__did_set));
+            if (__did_set) {
+                // Use release MO to synchronize with observers of the ready state.
+                _M_status->store(_Status::__ready, butil::memory_order_release);
+                bthread::butex_wake_all(_M_status);
+            } else if (!__ignore_failure)
+                throw std::future_error(std::future_errc::promise_already_satisfied);
+        }
+
+        // Provide a result to the shared state but delay making it ready
+        // until the calling thread exits.
+        // Calls at most once: _M_result = __res();
+        void _M_set_delayed_result(std::function<_Ptr_type()> __res, std::weak_ptr<_State_baseV2> __self) {
+            bool __did_set = false;
+            std::unique_ptr<_Make_ready> __mr{new _Make_ready};
+            // all calls to this function are serialized,
+            // side-effects of invoking __res only happen once
+            call_once(_M_once, &_State_baseV2::_M_do_set, this, std::addressof(__res), std::addressof(__did_set));
+            if (!__did_set) throw std::future_error(std::future_errc::promise_already_satisfied);
+            __mr->_M_shared_state = std::move(__self);
+            CHECK_EQ(0, butil::thread_atexit(&_Make_ready::_S_run, __mr.release()));
+        }
+
+        // Abandon this shared state.
+        void _M_break_promise(_Ptr_type __res) {
+            if (static_cast<bool>(__res)) {
+                __res->_M_error = std::make_exception_ptr(std::future_error(std::future_errc::broken_promise));
+                // This function is only called when the last asynchronous result
+                // provider is abandoning this shared state, so noone can be
+                // trying to make the shared state ready at the same time, and
+                // we can access _M_result directly instead of through call_once.
+                _M_result.swap(__res);
+                // Use release MO to synchronize with observers of the ready state.
+                _M_status->store(_Status::__ready, butil::memory_order_release);
+                bthread::butex_wake_all(_M_status);
+            }
+        }
+
+        // Called when this object is first passed to a future.
+        void _M_set_retrieved_flag() {
+            if (_M_retrieved.test_and_set()) throw std::future_error(std::future_errc::future_already_retrieved);
+        }
+
+        template <typename _Res, typename _Arg>
+        struct _Setter;
+
+        // set lvalues
+        template <typename _Res, typename _Arg>
+        struct _Setter<_Res, _Arg&> {
+            // check this is only used by promise<R>::set_value(const R&)
+            // or promise<R&>::set_value(R&)
+            static_assert(std::is_same<_Res, _Arg&>::value                  // promise<R&>
+                                  || std::is_same<const _Res, _Arg>::value, // promise<R>
+                          "Invalid specialisation");
+
+            // Used by std::promise to copy construct the result.
+            typename promise<_Res>::_Ptr_type operator()() const {
+                _M_promise->_M_storage->_M_set(*_M_arg);
+                return std::move(_M_promise->_M_storage);
+            }
+            promise<_Res>* _M_promise;
+            _Arg* _M_arg;
+        };
+
+        // set rvalues
+        template <typename _Res>
+        struct _Setter<_Res, _Res&&> {
+            // Used by std::promise to move construct the result.
+            typename promise<_Res>::_Ptr_type operator()() const {
+                _M_promise->_M_storage->_M_set(std::move(*_M_arg));
+                return std::move(_M_promise->_M_storage);
+            }
+            promise<_Res>* _M_promise;
+            _Res* _M_arg;
+        };
+
+        // set void
+        template <typename _Res>
+        struct _Setter<_Res, void> {
+            static_assert(std::is_void<_Res>::value, "Only used for promise<void>");
+
+            typename promise<_Res>::_Ptr_type operator()() const { return std::move(_M_promise->_M_storage); }
+
+            promise<_Res>* _M_promise;
+        };
+
+        struct __exception_ptr_tag {};
+
+        // set exceptions
+        template <typename _Res>
+        struct _Setter<_Res, __exception_ptr_tag> {
+            // Used by std::promise to store an exception as the result.
+            typename promise<_Res>::_Ptr_type operator()() const {
+                _M_promise->_M_storage->_M_error = *_M_ex;
+                return std::move(_M_promise->_M_storage);
+            }
+
+            promise<_Res>* _M_promise;
+            std::exception_ptr* _M_ex;
+        };
+
+        template <typename _Res, typename _Arg>
+        __attribute__((__always_inline__)) static _Setter<_Res, _Arg&&> __setter(promise<_Res>* __prom,
+                                                                                 _Arg&& __arg) noexcept {
+            return _Setter<_Res, _Arg&&>{__prom, std::addressof(__arg)};
+        }
+
+        template <typename _Res>
+        __attribute__((__always_inline__)) static _Setter<_Res, __exception_ptr_tag> __setter(
+                std::exception_ptr& __ex, promise<_Res>* __prom) noexcept {
+            return _Setter<_Res, __exception_ptr_tag>{__prom, &__ex};
+        }
+
+        template <typename _Res>
+        __attribute__((__always_inline__)) static _Setter<_Res, void> __setter(promise<_Res>* __prom) noexcept {
+            return _Setter<_Res, void>{__prom};
+        }
+
+        template <typename _Tp>
+        static void _S_check(const std::shared_ptr<_Tp>& __p) {
+            if (!static_cast<bool>(__p)) throw std::future_error(std::future_errc::no_state);
+        }
+
+    private:
+        // The function invoked with std::call_once(_M_once, ...).
+        void _M_do_set(std::function<_Ptr_type()>* __f, bool* __did_set) {
+            _Ptr_type __res = (*__f)();
+            // Notify the caller that we did try to set; if we do not throw an
+            // exception, the caller will be aware that it did set (e.g., see
+            // _M_set_result).
+            *__did_set = true;
+            _M_result.swap(__res); // nothrow
+        }
+
+        // Wait for completion of async function.
+        virtual void _M_complete_async() {}
+
+        // Return true if state corresponds to a deferred function.
+        virtual bool _M_is_deferred_future() const { return false; }
+
+        struct _Make_ready {
+            std::weak_ptr<_State_baseV2> _M_shared_state;
+
+            static void _S_run(void* arg) {
+                _Make_ready* _make_ready = reinterpret_cast<_Make_ready*>(arg);
+                std::shared_ptr<_State_baseV2> state = _make_ready->_M_shared_state.lock();
+                if (static_cast<bool>(state)) {
+                    // Use release MO to synchronize with observers of the ready state.
+                    state->_M_status->store(_Status::__ready, butil::memory_order_release);
+                    bthread::butex_wake_all(state->_M_status);
+                }
+                delete _make_ready;
+            }
+        };
+    };
+
+    using _State_base = _State_baseV2;
+
+    template <typename _Signature>
+    class _Task_state_base;
+
+    template <typename _Fn, typename _Alloc, typename _Signature>
+    class _Task_state;
+
+    template <typename _Res_ptr, typename _Fn, typename _Res = typename _Res_ptr::element_type::result_type>
+    struct _Task_setter;
+
+    template <typename _Res_ptr, typename _BoundFn>
+    static _Task_setter<_Res_ptr, _BoundFn> _S_task_setter(_Res_ptr& __ptr, _BoundFn& __call) {
+        return {std::addressof(__ptr), std::addressof(__call)};
+    }
+};
+
+/// Partial specialization for reference types.
+template <typename _Res>
+struct __future_base::_Result<_Res&> : __future_base::_Result_base {
+    typedef _Res& result_type;
+
+    _Result() noexcept : _M_value_ptr() {}
+
+    void _M_set(_Res& __res) noexcept { _M_value_ptr = std::addressof(__res); }
+
+    _Res& _M_get() noexcept { return *_M_value_ptr; }
+
+private:
+    _Res* _M_value_ptr;
+
+    void _M_destroy() override { delete this; }
+};
+
+/// Explicit specialization for void.
+template <>
+struct __future_base::_Result<void> : __future_base::_Result_base {
+    typedef void result_type;
+
+private:
+    void _M_destroy() override { delete this; }
+};
+
+/// Common implementation for future and shared_future.
+template <typename _Res>
+class __basic_future : public __future_base {
+protected:
+    typedef std::shared_ptr<_State_base> __state_type;
+    typedef __future_base::_Result<_Res>& __result_type;
+
+private:
+    __state_type _M_state;
+
+public:
+    // Disable copying.
+    __basic_future(const __basic_future&) = delete;
+    __basic_future& operator=(const __basic_future&) = delete;
+
+    bool valid() const noexcept { return static_cast<bool>(_M_state); }
+
+    void wait() const {
+        _State_base::_S_check(_M_state);
+        _M_state->wait();
+    }
+
+    template <typename _Rep, typename _Period>
+    std::future_status wait_for(const std::chrono::duration<_Rep, _Period>& __rel) const {
+        _State_base::_S_check(_M_state);
+        return _M_state->wait_for(__rel);
+    }
+
+    template <typename _Clock, typename _Duration>
+    std::future_status wait_until(const std::chrono::time_point<_Clock, _Duration>& __abs) const {
+        _State_base::_S_check(_M_state);
+        return _M_state->wait_until(__abs);
+    }
+
+protected:
+    /// Wait for the state to be ready and rethrow any stored exception
+    __result_type _M_get_result() const {
+        _State_base::_S_check(_M_state);
+        _Result_base& __res = _M_state->wait();
+        if (!(__res._M_error == nullptr)) rethrow_exception(__res._M_error);
+        return static_cast<__result_type>(__res);
+    }
+
+    void _M_swap(__basic_future& __that) noexcept { _M_state.swap(__that._M_state); }
+
+    // Construction of a future by promise::get_future()
+    explicit __basic_future(const __state_type& __state) : _M_state(__state) {
+        _State_base::_S_check(_M_state);
+        _M_state->_M_set_retrieved_flag();
+    }
+
+    // Copy construction from a shared_future
+    explicit __basic_future(const shared_future<_Res>&) noexcept;
+
+    // Move construction from a shared_future
+    explicit __basic_future(shared_future<_Res>&&) noexcept;
+
+    // Move construction from a future
+    explicit __basic_future(future<_Res>&&) noexcept;
+
+    constexpr __basic_future() noexcept : _M_state() {}
+
+    struct _Reset {
+        explicit _Reset(__basic_future& __fut) noexcept : _M_fut(__fut) {}
+        ~_Reset() { _M_fut._M_state.reset(); }
+        __basic_future& _M_fut;
+    };
+};
+
+/// Primary template for future.
+template <typename _Res>
+class future : public __basic_future<_Res> {
+    // _GLIBCXX_RESOLVE_LIB_DEFECTS
+    // 3458. Is shared_future intended to work with arrays or function types?
+    static_assert(!std::is_array_v<_Res>, "result type must not be an array");
+    static_assert(!std::is_function_v<_Res>, "result type must not be a function");
+    static_assert(std::is_destructible_v<_Res>, "result type must be destructible");
+
+    friend class promise<_Res>;
+    template <typename>
+    friend class packaged_task;
+
+    typedef __basic_future<_Res> _Base_type;
+    typedef typename _Base_type::__state_type __state_type;
+
+    explicit future(const __state_type& __state) : _Base_type(__state) {}
+
+public:
+    constexpr future() noexcept : _Base_type() {}
+
+    /// Move constructor
+    future(future&& __uf) noexcept : _Base_type(std::move(__uf)) {}
+
+    // Disable copying
+    future(const future&) = delete;
+    future& operator=(const future&) = delete;
+
+    future& operator=(future&& __fut) noexcept {
+        future(std::move(__fut))._M_swap(*this);
+        return *this;
+    }
+
+    /// Retrieving the value
+    _Res get() {
+        typename _Base_type::_Reset __reset(*this);
+        return std::move(this->_M_get_result()._M_value());
+    }
+
+    shared_future<_Res> share() noexcept;
+};
+
+/// Partial specialization for future<R&>
+template <typename _Res>
+class future<_Res&> : public __basic_future<_Res&> {
+    friend class promise<_Res&>;
+    template <typename>
+    friend class packaged_task;
+
+    typedef __basic_future<_Res&> _Base_type;
+    typedef typename _Base_type::__state_type __state_type;
+
+    explicit future(const __state_type& __state) : _Base_type(__state) {}
+
+public:
+    constexpr future() noexcept : _Base_type() {}
+
+    /// Move constructor
+    future(future&& __uf) noexcept : _Base_type(std::move(__uf)) {}
+
+    // Disable copying
+    future(const future&) = delete;
+    future& operator=(const future&) = delete;
+
+    future& operator=(future&& __fut) noexcept {
+        future(std::move(__fut))._M_swap(*this);
+        return *this;
+    }
+
+    /// Retrieving the value
+    _Res& get() {
+        typename _Base_type::_Reset __reset(*this);
+        return this->_M_get_result()._M_get();
+    }
+
+    shared_future<_Res&> share() noexcept;
+};
+
+/// Explicit specialization for future<void>
+template <>
+class future<void> : public __basic_future<void> {
+    friend class promise<void>;
+    template <typename>
+    friend class packaged_task;
+
+    typedef __basic_future<void> _Base_type;
+    typedef typename _Base_type::__state_type __state_type;
+
+    explicit future(const __state_type& __state) : _Base_type(__state) {}
+
+public:
+    constexpr future() noexcept : _Base_type() {}
+
+    /// Move constructor
+    future(future&& __uf) noexcept : _Base_type(std::move(__uf)) {}
+
+    // Disable copying
+    future(const future&) = delete;
+    future& operator=(const future&) = delete;
+
+    future& operator=(future&& __fut) noexcept {
+        future(std::move(__fut))._M_swap(*this);
+        return *this;
+    }
+
+    /// Retrieving the value
+    void get() {
+        typename _Base_type::_Reset __reset(*this);
+        this->_M_get_result();
+    }
+
+    shared_future<void> share() noexcept;
+};
+
+/// Primary template for shared_future.
+template <typename _Res>
+class shared_future : public __basic_future<_Res> {
+    // _GLIBCXX_RESOLVE_LIB_DEFECTS
+    // 3458. Is shared_future intended to work with arrays or function types?
+    static_assert(!std::is_array_v<_Res>, "result type must not be an array");
+    static_assert(!std::is_function_v<_Res>, "result type must not be a function");
+    static_assert(std::is_destructible_v<_Res>, "result type must be destructible");
+
+    typedef __basic_future<_Res> _Base_type;
+
+public:
+    constexpr shared_future() noexcept : _Base_type() {}
+
+    /// Copy constructor
+    shared_future(const shared_future& __sf) noexcept : _Base_type(__sf) {}
+
+    /// Construct from a future rvalue
+    shared_future(future<_Res>&& __uf) noexcept : _Base_type(std::move(__uf)) {}
+
+    /// Construct from a shared_future rvalue
+    shared_future(shared_future&& __sf) noexcept : _Base_type(std::move(__sf)) {}
+
+    shared_future& operator=(const shared_future& __sf) noexcept {
+        shared_future(__sf)._M_swap(*this);
+        return *this;
+    }
+
+    shared_future& operator=(shared_future&& __sf) noexcept {
+        shared_future(std::move(__sf))._M_swap(*this);
+        return *this;
+    }
+
+    /// Retrieving the value
+    const _Res& get() const { return this->_M_get_result()._M_value(); }
+};
+
+/// Partial specialization for shared_future<R&>
+template <typename _Res>
+class shared_future<_Res&> : public __basic_future<_Res&> {
+    typedef __basic_future<_Res&> _Base_type;
+
+public:
+    constexpr shared_future() noexcept : _Base_type() {}
+
+    /// Copy constructor
+    shared_future(const shared_future& __sf) : _Base_type(__sf) {}
+
+    /// Construct from a future rvalue
+    shared_future(future<_Res&>&& __uf) noexcept : _Base_type(std::move(__uf)) {}
+
+    /// Construct from a shared_future rvalue
+    shared_future(shared_future&& __sf) noexcept : _Base_type(std::move(__sf)) {}
+
+    shared_future& operator=(const shared_future& __sf) {
+        shared_future(__sf)._M_swap(*this);
+        return *this;
+    }
+
+    shared_future& operator=(shared_future&& __sf) noexcept {
+        shared_future(std::move(__sf))._M_swap(*this);
+        return *this;
+    }
+
+    /// Retrieving the value
+    _Res& get() const { return this->_M_get_result()._M_get(); }
+};
+
+/// Explicit specialization for shared_future<void>
+template <>
+class shared_future<void> : public __basic_future<void> {
+    typedef __basic_future<void> _Base_type;
+
+public:
+    constexpr shared_future() noexcept : _Base_type() {}
+
+    /// Copy constructor
+    shared_future(const shared_future& __sf) : _Base_type(__sf) {}
+
+    /// Construct from a future rvalue
+    shared_future(future<void>&& __uf) noexcept : _Base_type(std::move(__uf)) {}
+
+    /// Construct from a shared_future rvalue
+    shared_future(shared_future&& __sf) noexcept : _Base_type(std::move(__sf)) {}
+
+    shared_future& operator=(const shared_future& __sf) {
+        shared_future(__sf)._M_swap(*this);
+        return *this;
+    }
+
+    shared_future& operator=(shared_future&& __sf) noexcept {
+        shared_future(std::move(__sf))._M_swap(*this);
+        return *this;
+    }
+
+    // Retrieving the value
+    void get() const { this->_M_get_result(); }
+};
+
+// Now we can define the protected __basic_future constructors.
+template <typename _Res>
+inline __basic_future<_Res>::__basic_future(const shared_future<_Res>& __sf) noexcept : _M_state(__sf._M_state) {}
+
+template <typename _Res>
+inline __basic_future<_Res>::__basic_future(shared_future<_Res>&& __sf) noexcept : _M_state(std::move(__sf._M_state)) {}
+
+template <typename _Res>
+inline __basic_future<_Res>::__basic_future(future<_Res>&& __uf) noexcept : _M_state(std::move(__uf._M_state)) {}
+
+// _GLIBCXX_RESOLVE_LIB_DEFECTS
+// 2556. Wide contract for future::share()
+template <typename _Res>
+inline shared_future<_Res> future<_Res>::share() noexcept {
+    return shared_future<_Res>(std::move(*this));
+}
+
+template <typename _Res>
+inline shared_future<_Res&> future<_Res&>::share() noexcept {
+    return shared_future<_Res&>(std::move(*this));
+}
+
+inline shared_future<void> future<void>::share() noexcept {
+    return shared_future<void>(std::move(*this));
+}
+
+/// Primary template for promise
+template <typename _Res>
+class promise {
+    // _GLIBCXX_RESOLVE_LIB_DEFECTS
+    // 3466: Specify the requirements for promise/future/[...] consistently
+    static_assert(!std::is_array_v<_Res>, "result type must not be an array");
+    static_assert(!std::is_function_v<_Res>, "result type must not be a function");
+    static_assert(std::is_destructible_v<_Res>, "result type must be destructible");
+
+    typedef __future_base::_State_base _State;
+    typedef __future_base::_Result<_Res> _Res_type;
+    typedef __future_base::_Ptr<_Res_type> _Ptr_type;
+    template <typename, typename>
+    friend struct _State::_Setter;
+    friend _State;
+
+    std::shared_ptr<_State> _M_future;
+    _Ptr_type _M_storage;
+
+public:
+    promise() : _M_future(std::make_shared<_State>()), _M_storage(new _Res_type()) {}
+
+    promise(promise&& __rhs) noexcept
+            : _M_future(std::move(__rhs._M_future)), _M_storage(std::move(__rhs._M_storage)) {}
+
+    promise(const promise&) = delete;
+
+    ~promise() {
+        if (static_cast<bool>(_M_future) && !_M_future.unique()) _M_future->_M_break_promise(std::move(_M_storage));
+    }
+
+    // Assignment
+    promise& operator=(promise&& __rhs) noexcept {
+        promise(std::move(__rhs)).swap(*this);
+        return *this;
+    }
+
+    promise& operator=(const promise&) = delete;
+
+    void swap(promise& __rhs) noexcept {
+        _M_future.swap(__rhs._M_future);
+        _M_storage.swap(__rhs._M_storage);
+    }
+
+    // Retrieving the result
+    future<_Res> get_future() { return future<_Res>(_M_future); }
+
+    // Setting the result
+    void set_value(const _Res& __r) { _M_state()._M_set_result(_State::__setter(this, __r)); }
+
+    void set_value(_Res&& __r) { _M_state()._M_set_result(_State::__setter(this, std::move(__r))); }
+
+    void set_exception(std::exception_ptr __p) { _M_state()._M_set_result(_State::__setter(__p, this)); }
+
+    void set_value_at_pthread_exit(const _Res& __r) {
+        _M_state()._M_set_delayed_result(_State::__setter(this, __r), _M_future);
+    }
+
+    void set_value_at_pthread_exit(_Res&& __r) {
+        _M_state()._M_set_delayed_result(_State::__setter(this, std::move(__r)), _M_future);
+    }
+
+    void set_exception_at_pthread_exit(std::exception_ptr __p) {
+        _M_state()._M_set_delayed_result(_State::__setter(__p, this), _M_future);
+    }
+
+private:
+    _State& _M_state() {
+        __future_base::_State_base::_S_check(_M_future);
+        return *_M_future;
+    }
+};
+
+template <typename _Res>
+inline void swap(promise<_Res>& __x, promise<_Res>& __y) noexcept {
+    __x.swap(__y);
+}
+
+/// Partial specialization for promise<R&>
+template <typename _Res>
+class promise<_Res&> {
+    typedef __future_base::_State_base _State;
+    typedef __future_base::_Result<_Res&> _Res_type;
+    typedef __future_base::_Ptr<_Res_type> _Ptr_type;
+    template <typename, typename>
+    friend struct _State::_Setter;
+    friend _State;
+
+    std::shared_ptr<_State> _M_future;
+    _Ptr_type _M_storage;
+
+public:
+    promise() : _M_future(std::make_shared<_State>()), _M_storage(new _Res_type()) {}
+
+    promise(promise&& __rhs) noexcept
+            : _M_future(std::move(__rhs._M_future)), _M_storage(std::move(__rhs._M_storage)) {}
+
+    promise(const promise&) = delete;
+
+    ~promise() {
+        if (static_cast<bool>(_M_future) && !_M_future.unique()) _M_future->_M_break_promise(std::move(_M_storage));
+    }
+
+    // Assignment
+    promise& operator=(promise&& __rhs) noexcept {
+        promise(std::move(__rhs)).swap(*this);
+        return *this;
+    }
+
+    promise& operator=(const promise&) = delete;
+
+    void swap(promise& __rhs) noexcept {
+        _M_future.swap(__rhs._M_future);
+        _M_storage.swap(__rhs._M_storage);
+    }
+
+    // Retrieving the result
+    future<_Res&> get_future() { return future<_Res&>(_M_future); }
+
+    // Setting the result
+    void set_value(_Res& __r) { _M_state()._M_set_result(_State::__setter(this, __r)); }
+
+    void set_exception(std::exception_ptr __p) { _M_state()._M_set_result(_State::__setter(__p, this)); }
+
+    void set_value_at_pthread_exit(_Res& __r) {
+        _M_state()._M_set_delayed_result(_State::__setter(this, __r), _M_future);
+    }
+
+    void set_exception_at_pthread_exit(std::exception_ptr __p) {
+        _M_state()._M_set_delayed_result(_State::__setter(__p, this), _M_future);
+    }
+
+private:
+    _State& _M_state() {
+        __future_base::_State_base::_S_check(_M_future);
+        return *_M_future;
+    }
+};
+
+/// Explicit specialization for promise<void>
+template <>
+class promise<void> {
+    typedef __future_base::_State_base _State;
+    typedef __future_base::_Result<void> _Res_type;
+    typedef __future_base::_Ptr<_Res_type> _Ptr_type;
+    template <typename, typename>
+    friend struct _State::_Setter;
+    friend _State;
+
+    std::shared_ptr<_State> _M_future;
+    _Ptr_type _M_storage;
+
+public:
+    promise() : _M_future(std::make_shared<_State>()), _M_storage(new _Res_type()) {}
+
+    promise(promise&& __rhs) noexcept
+            : _M_future(std::move(__rhs._M_future)), _M_storage(std::move(__rhs._M_storage)) {}
+
+    promise(const promise&) = delete;
+
+    ~promise() {
+        if (static_cast<bool>(_M_future) && !_M_future.unique()) _M_future->_M_break_promise(std::move(_M_storage));
+    }
+
+    // Assignment
+    promise& operator=(promise&& __rhs) noexcept {
+        promise(std::move(__rhs)).swap(*this);
+        return *this;
+    }
+
+    promise& operator=(const promise&) = delete;
+
+    void swap(promise& __rhs) noexcept {
+        _M_future.swap(__rhs._M_future);
+        _M_storage.swap(__rhs._M_storage);
+    }
+
+    // Retrieving the result
+    future<void> get_future() { return future<void>(_M_future); }
+
+    // Setting the result
+    void set_value() { _M_state()._M_set_result(_State::__setter(this)); }
+
+    void set_exception(std::exception_ptr __p) { _M_state()._M_set_result(_State::__setter(__p, this)); }
+
+    void set_value_at_pthread_exit() { _M_state()._M_set_delayed_result(_State::__setter(this), _M_future); }
+
+    void set_exception_at_pthread_exit(std::exception_ptr __p) {
+        _M_state()._M_set_delayed_result(_State::__setter(__p, this), _M_future);
+    }
+
+private:
+    _State& _M_state() {
+        __future_base::_State_base::_S_check(_M_future);
+        return *_M_future;
+    }
+};
+
+template <typename _Ptr_type, typename _Fn, typename _Res>
+struct __future_base::_Task_setter {
+    // Invoke the function and provide the result to the caller.
+    _Ptr_type operator()() const {
+        try {
+            (*_M_result)->_M_set((*_M_fn)());
+        } catch (...) {
+            (*_M_result)->_M_error = std::current_exception();
+        }
+        return std::move(*_M_result);
+    }
+    _Ptr_type* _M_result;
+    _Fn* _M_fn;
+};
+
+template <typename _Ptr_type, typename _Fn>
+struct __future_base::_Task_setter<_Ptr_type, _Fn, void> {
+    _Ptr_type operator()() const {
+        try {
+            (*_M_fn)();
+        } catch (...) {
+            (*_M_result)->_M_error = std::current_exception();
+        }
+        return std::move(*_M_result);
+    }
+    _Ptr_type* _M_result;
+    _Fn* _M_fn;
+};
+
+// Holds storage for a packaged_task's result.
+template <typename _Res, typename... _Args>
+struct __future_base::_Task_state_base<_Res(_Args...)> : __future_base::_State_base {
+    typedef _Res _Res_type;
+
+    template <typename _Alloc>
+    _Task_state_base(const _Alloc& __a) : _M_result(_S_allocate_result<_Res>(__a)) {}
+
+    // Invoke the stored task and make the state ready.
+    virtual void _M_run(_Args&&... __args) = 0;
+
+    // Invoke the stored task and make the state ready at thread exit.
+    virtual void _M_run_delayed(_Args&&... __args, std::weak_ptr<_State_base>) = 0;
+
+    virtual std::shared_ptr<_Task_state_base> _M_reset() = 0;
+
+    typedef __future_base::_Ptr<_Result<_Res>> _Ptr_type;
+    _Ptr_type _M_result;
+};
+
+// Holds a packaged_task's stored task.
+template <typename _Fn, typename _Alloc, typename _Res, typename... _Args>
+struct __future_base::_Task_state<_Fn, _Alloc, _Res(_Args...)> final : __future_base::_Task_state_base<_Res(_Args...)> {
+    template <typename _Fn2>
+    _Task_state(_Fn2&& __fn, const _Alloc& __a)
+            : _Task_state_base<_Res(_Args...)>(__a), _M_impl(std::forward<_Fn2>(__fn), __a) {}
+
+private:
+    virtual void _M_run(_Args&&... __args) {
+        auto __boundfn = [&]() -> _Res { return std::__invoke_r<_Res>(_M_impl._M_fn, std::forward<_Args>(__args)...); };
+        this->_M_set_result(_S_task_setter(this->_M_result, __boundfn));
+    }
+
+    virtual void _M_run_delayed(_Args&&... __args, std::weak_ptr<_State_base> __self) {
+        auto __boundfn = [&]() -> _Res { return std::__invoke_r<_Res>(_M_impl._M_fn, std::forward<_Args>(__args)...); };
+        this->_M_set_delayed_result(_S_task_setter(this->_M_result, __boundfn), std::move(__self));
+    }
+
+    virtual std::shared_ptr<_Task_state_base<_Res(_Args...)>> _M_reset();
+
+    struct _Impl : _Alloc {
+        template <typename _Fn2>
+        _Impl(_Fn2&& __fn, const _Alloc& __a) : _Alloc(__a), _M_fn(std::forward<_Fn2>(__fn)) {}
+        _Fn _M_fn;
+    } _M_impl;
+};
+
+template <typename _Signature, typename _Fn, typename _Alloc = std::allocator<int>>
+static std::shared_ptr<__future_base::_Task_state_base<_Signature>> __my_create_task_state(
+        _Fn&& __fn, const _Alloc& __a = _Alloc()) {
+    typedef typename std::decay<_Fn>::type _Fn2;
+    typedef __future_base::_Task_state<_Fn2, _Alloc, _Signature> _State;
+    return std::allocate_shared<_State>(__a, std::forward<_Fn>(__fn), __a);
+}
+
+template <typename _Fn, typename _Alloc, typename _Res, typename... _Args>
+std::shared_ptr<__future_base::_Task_state_base<_Res(_Args...)>>
+__future_base::_Task_state<_Fn, _Alloc, _Res(_Args...)>::_M_reset() {
+    return __my_create_task_state<_Res(_Args...)>(std::move(_M_impl._M_fn), static_cast<_Alloc&>(_M_impl));
+}
+
+/// packaged_task
+template <typename _Res, typename... _ArgTypes>
+class packaged_task<_Res(_ArgTypes...)> {
+    typedef __future_base::_Task_state_base<_Res(_ArgTypes...)> _State_type;
+    std::shared_ptr<_State_type> _M_state;
+
+    // _GLIBCXX_RESOLVE_LIB_DEFECTS
+    // 3039. Unnecessary decay in thread and packaged_task
+    template <typename _Fn, typename _Fn2 = std::remove_cvref_t<_Fn>>
+    using __not_same = typename std::enable_if<!std::is_same<packaged_task, _Fn2>::value>::type;
+
+public:
+    // Construction and destruction
+    packaged_task() noexcept {}
+
+    template <typename _Fn, typename = __not_same<_Fn>>
+    explicit packaged_task(_Fn&& __fn)
+            : _M_state(__my_create_task_state<_Res(_ArgTypes...)>(std::forward<_Fn>(__fn))) {}
+
+    ~packaged_task() {
+        if (static_cast<bool>(_M_state) && !_M_state.unique())
+            _M_state->_M_break_promise(std::move(_M_state->_M_result));
+    }
+
+    // No copy
+    packaged_task(const packaged_task&) = delete;
+    packaged_task& operator=(const packaged_task&) = delete;
+
+    // Move support
+    packaged_task(packaged_task&& __other) noexcept { this->swap(__other); }
+
+    packaged_task& operator=(packaged_task&& __other) noexcept {
+        packaged_task(std::move(__other)).swap(*this);
+        return *this;
+    }
+
+    void swap(packaged_task& __other) noexcept { _M_state.swap(__other._M_state); }
+
+    bool valid() const noexcept { return static_cast<bool>(_M_state); }
+
+    // Result retrieval
+    future<_Res> get_future() { return future<_Res>(_M_state); }
+
+    // Execution
+    void operator()(_ArgTypes... __args) {
+        __future_base::_State_base::_S_check(_M_state);
+        _M_state->_M_run(std::forward<_ArgTypes>(__args)...);
+    }
+
+    void make_ready_at_pthread_exit(_ArgTypes... __args) {
+        __future_base::_State_base::_S_check(_M_state);
+        _M_state->_M_run_delayed(std::forward<_ArgTypes>(__args)..., _M_state);
+    }
+
+    void reset() {
+        __future_base::_State_base::_S_check(_M_state);
+        packaged_task __tmp;
+        __tmp._M_state = _M_state;
+        _M_state = _M_state->_M_reset();
+    }
+};
+
+template <typename>
+struct __function_guide_helper {};
+
+template <typename _Res, typename _Tp, bool _Nx, typename... _Args>
+struct __function_guide_helper<_Res (_Tp::*)(_Args...) noexcept(_Nx)> {
+    using type = _Res(_Args...);
+};
+
+template <typename _Res, typename _Tp, bool _Nx, typename... _Args>
+struct __function_guide_helper<_Res (_Tp::*)(_Args...)& noexcept(_Nx)> {
+    using type = _Res(_Args...);
+};
+
+template <typename _Res, typename _Tp, bool _Nx, typename... _Args>
+struct __function_guide_helper<_Res (_Tp::*)(_Args...) const noexcept(_Nx)> {
+    using type = _Res(_Args...);
+};
+
+template <typename _Res, typename _Tp, bool _Nx, typename... _Args>
+struct __function_guide_helper<_Res (_Tp::*)(_Args...) const& noexcept(_Nx)> {
+    using type = _Res(_Args...);
+};
+
+//template<typename _Res, typename... _ArgTypes>
+//function(_Res(*)(_ArgTypes...)) -> function<_Res(_ArgTypes...)>;
+//
+//template<typename _Functor, typename _Signature = typename
+//                             __function_guide_helper<decltype(&_Functor::operator())>::type>
+//function(_Functor) -> function<_Signature>;
+
+template <typename _Res, typename... _ArgTypes>
+packaged_task(_Res (*)(_ArgTypes...)) -> packaged_task<_Res(_ArgTypes...)>;
+
+template <typename _Fun, typename _Signature = typename __function_guide_helper<decltype(&_Fun::operator())>::type>
+packaged_task(_Fun) -> packaged_task<_Signature>;
+
+/// swap
+template <typename _Res, typename... _ArgTypes>
+inline void swap(packaged_task<_Res(_ArgTypes...)>& __x, packaged_task<_Res(_ArgTypes...)>& __y) noexcept {
+    __x.swap(__y);
+}
+} // namespace starrocks::bthreads

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -330,7 +330,11 @@ set(EXEC_FILES
         ./util/block_compression_test.cpp
         ./util/blocking_queue_test.cpp
         ./util/brpc_stub_cache_test.cpp
+        ./util/bthreads/future_test.cpp
+        ./util/bthreads/packaged_task_test.cpp
+        ./util/bthreads/promise_test.cpp
         ./util/bthreads/shared_mutex_test.cpp
+        ./util/bthreads/shared_future_test.cpp
         ./util/c_string_test.cpp
         ./util/cidr_test.cpp
         ./util/coding_test.cpp

--- a/be/test/util/bthreads/future_test.cpp
+++ b/be/test/util/bthreads/future_test.cpp
@@ -1,0 +1,414 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (C) 2010-2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+//
+// original source location refer to:
+//  https://github.com/gcc-mirror/gcc/tree/master/libstdc%2B%2B-v3/testsuite/30_threads/future
+
+#include "util/bthreads/future.h"
+
+#include <bthread/bthread.h>
+#include <gtest/gtest.h>
+
+namespace starrocks::bthreads {
+namespace {
+class ClassType {
+private:
+    int x;
+};
+
+class AbstractClass {
+public:
+    virtual ~AbstractClass() = default;
+    virtual void foo() = 0;
+};
+
+future<int> get() {
+    return promise<int>().get_future();
+}
+
+} // namespace
+
+TEST(FutureTest, test_default_ctor) {
+    future<int> p1;
+    EXPECT_FALSE(p1.valid());
+    future<int&> p2;
+    EXPECT_FALSE(p2.valid());
+    future<void> p3;
+    EXPECT_FALSE(p3.valid());
+    future<ClassType> p4;
+    EXPECT_FALSE(p4.valid());
+    future<AbstractClass&> p5;
+    EXPECT_FALSE(p5.valid());
+}
+
+TEST(FutureTest, test_move) {
+    promise<int> p1;
+    future<int> f1(p1.get_future());
+    future<int> f2(std::move(f1));
+    EXPECT_TRUE(f2.valid());
+    EXPECT_FALSE(f1.valid());
+}
+
+TEST(FutureTest, test_move_assign) {
+    future<int> p1;
+    future<int> p2 = get();
+    p1 = std::move(p2);
+    EXPECT_TRUE(p1.valid());
+    EXPECT_FALSE(p2.valid());
+}
+
+TEST(FutureTest, test_exception_no_state01) {
+    bthreads::promise<int> p;
+    bthreads::future<int> f = p.get_future();
+    p.set_value(10);
+    EXPECT_EQ(10, f.get());
+    EXPECT_THROW(
+            {
+                try {
+                    f.get();
+                    EXPECT_FALSE(true) << "unreachable";
+                } catch (const std::future_error& e) {
+                    EXPECT_EQ(std::future_errc::no_state, e.code());
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(FutureTest, test_exception_no_state02) {
+    bthreads::promise<int&> p;
+    bthreads::future<int&> f = p.get_future();
+    int i = 1;
+    p.set_value(i);
+    EXPECT_EQ(&i, &f.get());
+    EXPECT_THROW(
+            {
+                try {
+                    f.get();
+                    EXPECT_FALSE(true) << "unreachable";
+                } catch (const std::future_error& e) {
+                    EXPECT_EQ(std::future_errc::no_state, e.code());
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(FutureTest, test_exception_no_state03) {
+    bthreads::promise<void> p;
+    bthreads::future<void> f = p.get_future();
+    p.set_value();
+    f.get();
+    EXPECT_THROW(
+            {
+                try {
+                    f.get();
+                    EXPECT_FALSE(true) << "unreachable";
+                } catch (const std::future_error& e) {
+                    EXPECT_EQ(std::future_errc::no_state, e.code());
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+static int value = 99;
+
+TEST(FutureTest, test_get01) {
+    promise<int> p1;
+    future<int> f1(p1.get_future());
+
+    p1.set_value(value);
+    EXPECT_EQ(value, f1.get());
+    EXPECT_FALSE(f1.valid());
+}
+
+TEST(FutureTest, test_get02) {
+    promise<int&> p1;
+    future<int&> f1(p1.get_future());
+
+    p1.set_value(value);
+    EXPECT_EQ(&f1.get(), &value);
+    EXPECT_FALSE(f1.valid());
+}
+
+TEST(FutureTest, test_get03) {
+    promise<void> p1;
+    future<void> f1(p1.get_future());
+
+    p1.set_value();
+    f1.get();
+    EXPECT_FALSE(f1.valid());
+}
+
+TEST(FutureTest, test_get04) {
+    promise<int> p1;
+    future<int> f1(p1.get_future());
+
+    p1.set_exception(std::make_exception_ptr(value));
+    try {
+        (void)f1.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_EQ(e, value);
+    }
+    EXPECT_FALSE(f1.valid());
+}
+
+TEST(FutureTest, test_get05) {
+    promise<int&> p1;
+    future<int&> f1(p1.get_future());
+
+    p1.set_exception(std::make_exception_ptr(value));
+    try {
+        (void)f1.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_EQ(e, value);
+    }
+    EXPECT_FALSE(f1.valid());
+}
+
+TEST(FutureTest, test_get06) {
+    promise<void> p1;
+    future<void> f1(p1.get_future());
+
+    p1.set_exception(std::make_exception_ptr(value));
+    try {
+        f1.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_EQ(value, e);
+    }
+    EXPECT_FALSE(f1.valid());
+}
+
+static int iterations = 200;
+
+template <typename Duration>
+static double print(const char* desc, Duration dur) {
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(dur).count();
+    double d = double(ns) / iterations;
+    std::cout << desc << ": " << ns << "ns for " << iterations << " calls, avg " << d << "ns per call\n";
+    return d;
+}
+
+TEST(FutureTest, test_poll) {
+    promise<int> p;
+    future<int> f = p.get_future();
+
+start_over:
+    auto start = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < iterations; i++) f.wait_for(std::chrono::seconds(0));
+    auto stop = std::chrono::high_resolution_clock::now();
+
+    /* We've run too few iterations for the clock resolution.
+     Attempt to calibrate it.  */
+    if (start == stop) {
+        /* After set_value, wait_for is faster, so use that for the
+	 calibration to avoid zero at low clock resultions.  */
+        promise<int> pc;
+        future<int> fc = pc.get_future();
+        pc.set_value(1);
+
+        /* Loop until the clock advances, so that start is right after a
+	 time increment.  */
+        do
+            start = std::chrono::high_resolution_clock::now();
+        while (start == stop);
+        int i = 0;
+        /* Now until the clock advances again, so that stop is right
+	 after another time increment.  */
+        do {
+            fc.wait_for(std::chrono::seconds(0));
+            stop = std::chrono::high_resolution_clock::now();
+            i++;
+        } while (start == stop);
+        /* Go for some 10 cycles, but if we're already past that and
+	 still get into the calibration loop, double the iteration
+	 count and try again.  */
+        if (iterations < i * 10)
+            iterations = i * 10;
+        else
+            iterations *= 2;
+        goto start_over;
+    }
+
+    double wait_for_0 = print("wait_for(0s)", stop - start);
+
+    start = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < iterations; i++) f.wait_until(std::chrono::system_clock::time_point::min());
+    stop = std::chrono::high_resolution_clock::now();
+    double wait_until_sys_min __attribute__((unused)) = print("wait_until(system_clock minimum)", stop - start);
+
+    start = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < iterations; i++) f.wait_until(std::chrono::steady_clock::time_point::min());
+    stop = std::chrono::high_resolution_clock::now();
+    double wait_until_steady_min __attribute__((unused)) = print("wait_until(steady_clock minimum)", stop - start);
+
+    start = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < iterations; i++) f.wait_until(std::chrono::system_clock::time_point());
+    stop = std::chrono::high_resolution_clock::now();
+    double wait_until_sys_epoch __attribute__((unused)) = print("wait_until(system_clock epoch)", stop - start);
+
+    start = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < iterations; i++) f.wait_until(std::chrono::steady_clock::time_point());
+    stop = std::chrono::high_resolution_clock::now();
+    double wait_until_steady_epoch __attribute__((unused)) = print("wait_until(steady_clock epoch", stop - start);
+
+    p.set_value(1);
+
+    start = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < iterations; i++) f.wait_for(std::chrono::seconds(0));
+    stop = std::chrono::high_resolution_clock::now();
+    double ready = print("wait_for when ready", stop - start);
+
+    // Polling before ready with wait_for(0s) should be almost as fast as
+    // after the result is ready.
+    EXPECT_TRUE(wait_for_0 < (ready * 30));
+
+    // Polling before ready using wait_until(min) should not be terribly slow.
+    EXPECT_TRUE(wait_until_sys_min < (ready * 100));
+    EXPECT_TRUE(wait_until_steady_min < (ready * 100));
+}
+
+TEST(FutureTest, test_share01) {
+    promise<int> p1;
+    future<int> f1(p1.get_future());
+    shared_future<int> f2 = f1.share();
+
+    p1.set_value(value);
+    EXPECT_TRUE(f2.get() == value);
+}
+
+TEST(FutureTest, test_share02) {
+    promise<int&> p1;
+    future<int&> f1(p1.get_future());
+    shared_future<int&> f2 = f1.share();
+
+    p1.set_value(value);
+    EXPECT_TRUE(&f2.get() == &value);
+}
+
+TEST(FutureTest, test_share03) {
+    promise<void> p1;
+    future<void> f1(p1.get_future());
+    shared_future<void> f2 = f1.share();
+
+    p1.set_value();
+    f2.get();
+}
+
+TEST(FutureTest, test_valid) {
+    future<int> f0;
+    EXPECT_TRUE(!f0.valid());
+
+    promise<int> p1;
+    future<int> f1(p1.get_future());
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_value(1);
+
+    EXPECT_TRUE(f1.valid());
+
+    f1 = std::move(f0);
+
+    EXPECT_TRUE(!f1.valid());
+    EXPECT_TRUE(!f0.valid());
+}
+
+static void fut_wait(future<void>& f) {
+    f.wait();
+}
+
+static void* fut_wait2(void* arg) {
+    auto f = static_cast<future<void>*>(arg);
+    f->wait();
+    return nullptr;
+}
+
+TEST(FutureTest, test_wait01) {
+    promise<void> p1;
+    future<void> f1(p1.get_future());
+
+    std::thread t1(fut_wait, std::ref(f1));
+
+    p1.set_value();
+    t1.join();
+}
+
+TEST(FutureTest, test_wait02) {
+    promise<void> p1;
+    future<void> f1(p1.get_future());
+
+    bthread_t t1;
+    ASSERT_EQ(0, bthread_start_background(&t1, nullptr, fut_wait2, &f1));
+
+    p1.set_value();
+    bthread_join(t1, nullptr);
+}
+
+TEST(FutureTest, test_wait_for01) {
+    promise<int> p1;
+    future<int> f1(p1.get_future());
+
+    std::chrono::milliseconds delay(100);
+
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::timeout);
+
+    p1.set_value(1);
+
+    auto before = std::chrono::system_clock::now();
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::ready);
+    EXPECT_TRUE(std::chrono::system_clock::now() < (before + delay));
+}
+
+static std::chrono::system_clock::time_point make_time(int i) {
+    return std::chrono::system_clock::now() + std::chrono::milliseconds(i);
+}
+
+TEST(FutureTest, test_wait_until01) {
+    promise<int> p1;
+    future<int> f1(p1.get_future());
+
+    auto when = make_time(10);
+    EXPECT_TRUE(f1.wait_until(when) == std::future_status::timeout);
+    EXPECT_TRUE(std::chrono::system_clock::now() >= when);
+
+    p1.set_value(1);
+
+    when = make_time(100);
+    EXPECT_TRUE(f1.wait_until(when) == std::future_status::ready);
+    EXPECT_TRUE(std::chrono::system_clock::now() < when);
+}
+
+} // namespace starrocks::bthreads

--- a/be/test/util/bthreads/packaged_task_test.cpp
+++ b/be/test/util/bthreads/packaged_task_test.cpp
@@ -1,0 +1,461 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (C) 2010-2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+//
+// original source location refer to:
+//  https://github.com/gcc-mirror/gcc/tree/master/libstdc%2B%2B-v3/testsuite/30_threads/packaged_task
+
+#include <bthread/bthread.h>
+#include <gtest/gtest.h>
+
+#include "util/bthreads/future.h"
+
+namespace starrocks::bthreads {
+namespace {
+class ClassType {
+private:
+    int x;
+};
+
+class AbstractClass {
+public:
+    virtual ~AbstractClass() = default;
+    virtual void rotate(int) = 0;
+};
+
+int f1() {
+    return 0;
+}
+int& f2() {
+    static int i;
+    return i;
+}
+void f3() {}
+ClassType f4() {
+    return ClassType();
+}
+
+struct Derived : AbstractClass {
+    void rotate(int) {}
+    Derived& operator()(int i) {
+        rotate(i);
+        return *this;
+    }
+} f5;
+
+template <typename F>
+future<typename std::result_of<F()>::type> spawn_task(F f) {
+    typedef typename std::result_of<F()>::type result_type;
+    packaged_task<result_type()> task(std::move(f));
+    future<result_type> res(task.get_future());
+    std::thread(std::move(task)).detach();
+    return res;
+}
+
+int get_res() {
+    return 42;
+}
+
+struct S {
+    S() = default;
+    S(S&&) = default;
+    void operator()() {}
+};
+
+packaged_task<void()> pt{S{}};
+
+template <typename T, typename U>
+struct require_same;
+template <typename T>
+struct require_same<T, T> {
+    using type = void;
+};
+
+template <typename T, typename U>
+typename require_same<T, U>::type check_type(U&) {}
+
+void f0v() {}
+void f0vn() noexcept {}
+int f0i() {
+    return 0;
+}
+int f0in() noexcept {
+    return 3;
+}
+long f1l(int&) {
+    return 2;
+}
+long f1ln(double*) noexcept {
+    return 1;
+}
+struct X {
+    int operator()(const short&, void*) { return 0; }
+};
+
+struct Y {
+    void operator()(int) const& noexcept {}
+};
+} // namespace
+
+TEST(PackagedTaskTest, test01) {
+    packaged_task<int()> p1;
+    EXPECT_TRUE(!p1.valid());
+    packaged_task<int&()> p2;
+    EXPECT_TRUE(!p2.valid());
+    packaged_task<void()> p3;
+    EXPECT_TRUE(!p3.valid());
+    packaged_task<ClassType()> p4;
+    EXPECT_TRUE(!p4.valid());
+    packaged_task<AbstractClass&(int)> p5;
+    EXPECT_TRUE(!p5.valid());
+}
+
+TEST(PackagedTaskTest, test02) {
+    packaged_task<int()> p1(f1);
+    EXPECT_TRUE(p1.valid());
+    packaged_task<int&()> p2(f2);
+    EXPECT_TRUE(p2.valid());
+    packaged_task<void()> p3(f3);
+    EXPECT_TRUE(p3.valid());
+    packaged_task<ClassType()> p4(f4);
+    EXPECT_TRUE(p4.valid());
+    packaged_task<AbstractClass&(int)> p5(f5);
+    EXPECT_TRUE(p5.valid());
+}
+
+TEST(PackagedTaskTest, test03) {
+    auto f = spawn_task(get_res);
+    EXPECT_TRUE(f.get() == get_res());
+}
+
+void test_deduction01() {
+    packaged_task task1{f0v};
+    check_type<packaged_task<void()>>(task1);
+
+    packaged_task task2{f0vn};
+    check_type<packaged_task<void()>>(task2);
+
+    packaged_task task3{f0i};
+    check_type<packaged_task<int()>>(task3);
+
+    packaged_task task4{f0in};
+    check_type<packaged_task<int()>>(task4);
+
+    packaged_task task5{f1l};
+    check_type<packaged_task<long(int&)>>(task5);
+
+    packaged_task task6{f1ln};
+    check_type<packaged_task<long(double*)>>(task6);
+
+    packaged_task task5a{std::move(task5)};
+    check_type<packaged_task<long(int&)>>(task5a);
+
+    packaged_task task6a{std::move(task6)};
+    check_type<packaged_task<long(double*)>>(task6a);
+}
+
+void test_deduction02() {
+    X x;
+    packaged_task task1{x};
+    check_type<packaged_task<int(const short&, void*)>>(task1);
+
+    Y y;
+    packaged_task task2{y};
+    check_type<packaged_task<void(int)>>(task2);
+
+    packaged_task task3{[&x](float) -> X& { return x; }};
+    check_type<packaged_task<X&(float)>>(task3);
+}
+
+TEST(PackagedTaskTest, test_move) {
+    // move
+    packaged_task<int()> p1(f1);
+    packaged_task<int()> p2(std::move(p1));
+    EXPECT_TRUE(!p1.valid());
+    EXPECT_TRUE(p2.valid());
+}
+
+TEST(PackagedTaskTest, test_move_assign) {
+    // move assign
+    packaged_task<int()> p1;
+    packaged_task<int()> p2(f1);
+    p1 = std::move(p2);
+    EXPECT_TRUE(p1.valid());
+    EXPECT_TRUE(!p2.valid());
+}
+
+namespace test_at_pthread_exit {
+bool executed = false;
+
+int execute(int i) {
+    executed = true;
+    return i + 1;
+}
+
+future<int> f1;
+
+bool ready(future<int>& f) {
+    return f.wait_for(std::chrono::milliseconds(1)) == std::future_status::ready;
+}
+
+void foo01() {
+    packaged_task<int(int)> p1(execute);
+    f1 = p1.get_future();
+
+    p1.make_ready_at_pthread_exit(1);
+
+    EXPECT_TRUE(executed);
+    EXPECT_TRUE(p1.valid());
+    EXPECT_TRUE(!ready(f1));
+}
+
+TEST(PackagedTaskTest, test_at_pthread_exit) {
+    std::thread t{foo01};
+    t.join();
+    EXPECT_TRUE(ready(f1));
+    EXPECT_TRUE(f1.get() == 2);
+}
+} // namespace test_at_pthread_exit
+
+namespace test_get_future {
+int& inc(int& i) {
+    return ++i;
+}
+
+TEST(PackagedTaskTest, test_get_future01) {
+    packaged_task<int&(int&)> p1(inc);
+    future<int&> f1 = p1.get_future();
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.valid());
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::timeout);
+
+    int i1 = 0;
+
+    p1(i1);
+
+    int& i2 = f1.get();
+
+    EXPECT_TRUE(&i1 == &i2);
+    EXPECT_TRUE(i1 == 1);
+}
+TEST(PackagedTaskTest, test_get_future02) {
+    packaged_task<int&(int&)> p1(inc);
+    p1.get_future();
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.get_future();
+                    EXPECT_TRUE(false);
+                } catch (const std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::future_already_retrieved);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+} // namespace test_get_future
+
+namespace test_invoke {
+
+int zero() {
+    return 0;
+}
+
+TEST(PackagedTaskTest, test_invoke01) {
+    packaged_task<int()> p1(zero);
+    future<int> f1 = p1.get_future();
+
+    p1();
+
+    EXPECT_TRUE(p1.valid());
+    EXPECT_TRUE(f1.get() == 0);
+}
+bool odd(unsigned i) {
+    return i % 2;
+}
+
+TEST(PackagedTaskTest, test_invoke02) {
+    packaged_task<bool(unsigned)> p1(odd);
+
+    p1(5);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1(4);
+                } catch (const std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+int& inc(int& i) {
+    ++i;
+    return i;
+}
+
+TEST(PackagedTaskTest, test_invoke03) {
+    packaged_task<void(int&)> p1(inc);
+
+    int i1 = 0;
+    p1(i1);
+
+    EXPECT_TRUE(i1 == 1);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1(i1);
+                } catch (const std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    EXPECT_TRUE(i1 == 1);
+}
+
+void thrower() {
+    throw 0;
+}
+
+TEST(PackagedTaskTest, test_invoke04) {
+    bool test = false;
+
+    packaged_task<void()> p1(thrower);
+    future<void> f1 = p1.get_future();
+
+    p1();
+
+    try {
+        f1.get();
+    } catch (int) {
+        test = true;
+    }
+    EXPECT_TRUE(test);
+}
+void noop() {}
+void waiter(shared_future<void> f) {
+    f.wait();
+}
+
+TEST(PackagedTaskTest, test_invoke05) {
+    packaged_task<void()> p1(noop);
+    shared_future<void> f1(p1.get_future());
+    std::thread t1(waiter, f1);
+
+    p1();
+
+    t1.join();
+}
+} // namespace test_invoke
+
+namespace test_reset {
+
+int zero() {
+    return 0;
+}
+
+TEST(PackagedTaskTest, test_reset01) {
+    packaged_task<int()> p1(zero);
+    future<int> f1 = p1.get_future();
+
+    p1.reset();
+    EXPECT_TRUE(p1.valid());
+
+    future<int> f2 = p1.get_future();
+
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::broken_promise);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+int iota() {
+    static int i = 0;
+    return i++;
+}
+
+TEST(PackagedTaskTest, test_reset02) {
+    packaged_task<int()> p1(iota);
+    future<int> f1 = p1.get_future();
+
+    p1();
+    p1.reset();
+
+    EXPECT_TRUE(p1.valid());
+    EXPECT_TRUE(f1.get() == 0);
+
+    future<int> f2 = p1.get_future();
+    p1();
+    EXPECT_TRUE(f2.get() == 1);
+}
+} // namespace test_reset
+
+namespace test_swap {
+int zero() {
+    return 0;
+}
+
+TEST(PackagedTaskTest, test_swap) {
+    packaged_task<int()> p1(zero);
+    packaged_task<int()> p2;
+    EXPECT_TRUE(p1.valid());
+    EXPECT_TRUE(!p2.valid());
+    p1.swap(p2);
+    EXPECT_TRUE(!p1.valid());
+    EXPECT_TRUE(p2.valid());
+}
+} // namespace test_swap
+
+namespace test_valid {
+int zero() {
+    return 0;
+}
+
+TEST(PackagedTaskTest, test_valid) {
+    packaged_task<int()> p1;
+    EXPECT_TRUE(!p1.valid());
+
+    packaged_task<int()> p2(zero);
+    EXPECT_TRUE(p2.valid());
+}
+} // namespace test_valid
+
+} // namespace starrocks::bthreads

--- a/be/test/util/bthreads/promise_test.cpp
+++ b/be/test/util/bthreads/promise_test.cpp
@@ -1,0 +1,982 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (C) 2010-2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+//
+// original source location refer to:
+//  https://github.com/gcc-mirror/gcc/tree/master/libstdc%2B%2B-v3/testsuite/30_threads/promise
+
+#include <bthread/bthread.h>
+#include <gtest/gtest.h>
+
+#include "util/bthreads/future.h"
+
+namespace starrocks::bthreads {
+namespace {
+class ClassType {
+private:
+    int x;
+};
+
+class AbstractClass {
+public:
+    virtual ~AbstractClass() = default;
+    virtual void foo() = 0;
+};
+} // namespace
+
+TEST(PromiseTest, test_default_ctor01) {
+    promise<int> p1;
+    promise<int&> p2;
+    promise<void> p3;
+    promise<ClassType> p4;
+    promise<AbstractClass&> p5;
+}
+
+TEST(PromiseTest, test_move_ctor) {
+    promise<int> p1;
+    p1.set_value(3);
+    promise<int> p2(std::move(p1));
+    EXPECT_TRUE(p2.get_future().get() == 3);
+    EXPECT_THROW(
+            {
+                try {
+                    p1.get_future();
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(PromiseTest, test_move_assign) {
+    promise<int> p1;
+    p1.set_value(3);
+    promise<int> p2;
+    p2 = std::move(p1);
+    EXPECT_TRUE(p2.get_future().get() == 3);
+    EXPECT_THROW(
+            {
+                try {
+                    p1.get_future();
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+namespace {
+static int copies;
+static int copies_cmp;
+struct Obj {
+    Obj() = default;
+    Obj(const Obj&) { ++copies; }
+};
+static future<Obj> g_f1;
+
+} // namespace
+
+static bool ready(future<Obj>& f) {
+    return f.wait_for(std::chrono::milliseconds(1)) == std::future_status::ready;
+}
+
+static void test_at_pthread_exit01_func() {
+    promise<Obj> p1;
+    g_f1 = p1.get_future();
+
+    p1.set_value_at_pthread_exit({});
+
+    copies_cmp = copies;
+
+    EXPECT_TRUE(!ready(g_f1));
+}
+
+TEST(PromiseTest, test_at_pthread_exit) {
+    std::thread t{test_at_pthread_exit01_func};
+    t.join();
+    EXPECT_TRUE(ready(g_f1));
+    EXPECT_TRUE(copies == copies_cmp);
+}
+
+TEST(PromiseTest, test_at_pthread_exit02) {
+    promise<int> p1;
+    p1.set_value(1);
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value_at_pthread_exit(2);
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception_at_pthread_exit(std::make_exception_ptr(3));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    promise<int> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value_at_pthread_exit(2);
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception_at_pthread_exit(std::make_exception_ptr(3));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(PromiseTest, test_at_pthread_exit03) {
+    promise<int&> p1;
+    int i = 1;
+    p1.set_value(i);
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value_at_pthread_exit(i);
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception_at_pthread_exit(std::make_exception_ptr(3));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    promise<int&> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    int i = 0;
+                    p1.set_value_at_pthread_exit(i);
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception_at_pthread_exit(std::make_exception_ptr(3));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(PromiseTest, test_at_pthread_exit04) {
+    promise<void> p1;
+    p1.set_value();
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value_at_pthread_exit();
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception_at_pthread_exit(std::make_exception_ptr(3));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    promise<void> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value_at_pthread_exit();
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception_at_pthread_exit(std::make_exception_ptr(3));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(PromiseTest, test_get_future01) {
+    promise<int&> p1;
+    future<int&> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    int i1 = 0;
+
+    p1.set_value(i1);
+
+    int& i2 = f1.get();
+
+    EXPECT_TRUE(&i1 == &i2);
+}
+
+TEST(PromiseTest, test_get_future02) {
+    promise<int&> p1;
+    p1.get_future();
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.get_future();
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::future_already_retrieved);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(PromiseTest, test_exception01) {
+    promise<int> p1;
+    future<int> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_exception(std::make_exception_ptr(0));
+
+    EXPECT_THROW({ f1.get(); }, int);
+    EXPECT_TRUE(!f1.valid());
+}
+
+TEST(PromiseTest, test_exception02) {
+    promise<int&> p1;
+    future<int&> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_exception(std::make_exception_ptr(0));
+
+    EXPECT_THROW({ f1.get(); }, int);
+    EXPECT_TRUE(!f1.valid());
+}
+
+TEST(PromiseTest, test_exception03) {
+    promise<void> p1;
+    future<void> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_exception(std::make_exception_ptr(0));
+
+    EXPECT_THROW({ f1.get(); }, int);
+    EXPECT_TRUE(!f1.valid());
+}
+
+TEST(PromiseTest, test_exception04) {
+    promise<int> p1;
+    future<int> f1 = p1.get_future();
+
+    p1.set_exception(std::make_exception_ptr(0));
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(1));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                    EXPECT_TRUE(false);
+                } catch (int i) {
+                    EXPECT_TRUE(i == 0);
+                    throw;
+                }
+            },
+            int);
+}
+
+TEST(PromiseTest, test_exception05) {
+    promise<int> p1;
+    future<int> f1 = p1.get_future();
+
+    p1.set_value(2);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(0));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(PromiseTest, test_exception06) {
+    promise<int&> p1;
+    future<int&> f1 = p1.get_future();
+
+    p1.set_exception(std::make_exception_ptr(0));
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(1));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                    EXPECT_TRUE(false);
+                } catch (int i) {
+                    EXPECT_TRUE(i == 0);
+                    throw;
+                }
+            },
+            int);
+}
+
+TEST(PromiseTest, test_exception07) {
+    promise<int&> p1;
+    future<int&> f1 = p1.get_future();
+
+    int i = 2;
+    p1.set_value(i);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(0));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(PromiseTest, test_exception08) {
+    promise<void> p1;
+    future<void> f1 = p1.get_future();
+
+    p1.set_exception(std::make_exception_ptr(0));
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(1));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                    EXPECT_TRUE(false);
+                } catch (int i) {
+                    EXPECT_TRUE(i == 0);
+                    throw;
+                }
+            },
+            int);
+}
+
+TEST(PromiseTest, test_exception09) {
+    promise<void> p1;
+    future<void> f1 = p1.get_future();
+
+    p1.set_value();
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(0));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+// Check for no_state error condition (PR libstdc++/80316)
+
+TEST(PromiseTest, test_exception10) {
+    promise<int> p1;
+    promise<int> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(1));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(PromiseTest, test_exception11) {
+    promise<int&> p1;
+    promise<int&> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(1));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(PromiseTest, test_exception12) {
+    promise<void> p1;
+    promise<void> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(1));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(PromiseTest, test_set_value01) {
+    promise<int> p1;
+    future<int> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_value(0);
+
+    int&& i1 = f1.get();
+
+    EXPECT_TRUE(i1 == 0);
+}
+
+namespace {
+// This class is designed to test libstdc++'s template-based rvalue
+// reference support. It should fail at compile-time if there is an
+// attempt to copy it.
+struct rvalstruct {
+    int val;
+    bool valid;
+
+    rvalstruct() : val(0), valid(true) {}
+
+    rvalstruct(int inval) : val(inval), valid(true) {}
+
+    rvalstruct& operator=(int newval) {
+        val = newval;
+        valid = true;
+        return *this;
+    }
+
+    rvalstruct(const rvalstruct&) = delete;
+
+    rvalstruct(rvalstruct&& in) {
+        CHECK(in.valid == true);
+        val = in.val;
+        in.valid = false;
+        valid = true;
+    }
+
+    rvalstruct& operator=(const rvalstruct&) = delete;
+
+    rvalstruct& operator=(rvalstruct&& in) {
+        CHECK(this != &in);
+        CHECK(in.valid == true);
+        val = in.val;
+        in.valid = false;
+        valid = true;
+        return *this;
+    }
+};
+} // namespace
+
+TEST(PromiseTest, test_set_value02) {
+    promise<rvalstruct> p1;
+    future<rvalstruct> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_value(rvalstruct(1));
+
+    rvalstruct r1(f1.get());
+
+    EXPECT_TRUE(!f1.valid());
+    EXPECT_TRUE(r1.val == 1);
+}
+
+TEST(PromiseTest, test_set_value03) {
+    promise<int&> p1;
+    future<int&> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    int i1 = 0;
+    p1.set_value(i1);
+    int& i2 = f1.get();
+
+    EXPECT_TRUE(!f1.valid());
+    EXPECT_TRUE(&i1 == &i2);
+}
+
+TEST(PromiseTest, test_set_value04) {
+    promise<void> p1;
+    future<void> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_value();
+    f1.get();
+
+    EXPECT_TRUE(!f1.valid());
+}
+
+TEST(PromiseTest, test_set_value05) {
+    promise<int> p1;
+    future<int> f1 = p1.get_future();
+
+    p1.set_value(1);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value(2);
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::ready);
+    EXPECT_TRUE(f1.get() == 1);
+}
+
+TEST(PromiseTest, test_set_value06) {
+    promise<int> p1;
+    future<int> f1 = p1.get_future();
+
+    p1.set_value(3);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(4));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::ready);
+    EXPECT_TRUE(f1.get() == 3);
+}
+
+TEST(PromiseTest, test_set_value07) {
+    promise<int> p1;
+    future<int> f1 = p1.get_future();
+
+    p1.set_exception(std::make_exception_ptr(4));
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value(3);
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::ready);
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                    EXPECT_TRUE(false);
+                } catch (int e) {
+                    EXPECT_TRUE(e == 4);
+                    throw;
+                }
+            },
+            int);
+}
+
+TEST(PromiseTest, test_set_value08) {
+    promise<int&> p1;
+    future<int&> f1 = p1.get_future();
+
+    int i = 1;
+    p1.set_value(i);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value(i);
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::ready);
+    EXPECT_TRUE(f1.get() == 1);
+}
+
+TEST(PromiseTest, test_set_value09) {
+    promise<int&> p1;
+    future<int&> f1 = p1.get_future();
+
+    int i = 3;
+    p1.set_value(i);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(4));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::ready);
+    EXPECT_TRUE(f1.get() == 3);
+}
+
+TEST(PromiseTest, test_set_value10) {
+    promise<int&> p1;
+    future<int&> f1 = p1.get_future();
+
+    p1.set_exception(std::make_exception_ptr(4));
+
+    EXPECT_THROW(
+            {
+                try {
+                    int i = 3;
+                    p1.set_value(i);
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::ready);
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                    EXPECT_TRUE(false);
+                } catch (int e) {
+                    EXPECT_TRUE(e == 4);
+                    throw;
+                }
+            },
+            int);
+}
+
+TEST(PromiseTest, test_set_value11) {
+    promise<void> p1;
+    future<void> f1 = p1.get_future();
+
+    p1.set_value();
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value();
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::ready);
+    f1.get();
+}
+
+TEST(PromiseTest, test_set_value12) {
+    promise<void> p1;
+    future<void> f1 = p1.get_future();
+
+    p1.set_value();
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(4));
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::ready);
+    f1.get();
+}
+
+TEST(PromiseTest, test_set_value13) {
+    promise<void> p1;
+    future<void> f1 = p1.get_future();
+
+    p1.set_exception(std::make_exception_ptr(4));
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value();
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::promise_already_satisfied);
+                    throw;
+                }
+            },
+            std::future_error);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::ready);
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                    EXPECT_TRUE(false);
+                } catch (int e) {
+                    EXPECT_TRUE(e == 4);
+                    throw;
+                }
+            },
+            int);
+}
+
+// Check for no_state error condition (PR libstdc++/80316)
+
+TEST(PromiseTest, test_set_value14) {
+    promise<int> p1;
+    promise<int> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value(1);
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(PromiseTest, test_set_value15) {
+    promise<int&> p1;
+    promise<int&> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    int i = 0;
+                    p1.set_value(i);
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(PromiseTest, test_set_value16) {
+    promise<void> p1;
+    promise<void> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value();
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+namespace {
+struct tester {
+    tester(int);
+    tester(const tester&);
+    tester() = delete;
+    tester& operator=(const tester&);
+};
+
+promise<tester> pglobal;
+future<tester> fglobal = pglobal.get_future();
+
+auto delay = std::chrono::milliseconds(1);
+
+tester::tester(int) {
+    EXPECT_TRUE(fglobal.wait_for(delay) == std::future_status::timeout);
+}
+
+tester::tester(const tester&) {
+    // if this copy happens while a mutex is locked next line could deadlock:
+    EXPECT_TRUE(fglobal.wait_for(delay) == std::future_status::timeout);
+}
+} // namespace
+
+TEST(PromiseTest, test_set_value17) {
+    pglobal.set_value(tester(1));
+
+    EXPECT_TRUE(fglobal.wait_for(delay) == std::future_status::ready);
+}
+
+TEST(PromiseTest, test_swap) {
+    promise<int> p1;
+    promise<int> p2;
+    p1.set_value(1);
+    p1.swap(p2);
+    auto delay = std::chrono::milliseconds(1);
+    EXPECT_TRUE(p1.get_future().wait_for(delay) == std::future_status::timeout);
+    EXPECT_TRUE(p2.get_future().wait_for(delay) == std::future_status::ready);
+}
+
+} // namespace starrocks::bthreads

--- a/be/test/util/bthreads/shared_future_test.cpp
+++ b/be/test/util/bthreads/shared_future_test.cpp
@@ -1,0 +1,326 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright (C) 2010-2023 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License along
+// with this library; see the file COPYING3.  If not see
+// <http://www.gnu.org/licenses/>.
+//
+// original source location refer to:
+//  https://github.com/gcc-mirror/gcc/tree/master/libstdc%2B%2B-v3/testsuite/30_threads/shared_future
+
+#include <bthread/bthread.h>
+#include <gtest/gtest.h>
+
+#include "util/bthreads/future.h"
+
+namespace starrocks::bthreads {
+
+namespace {
+class ClassType {
+private:
+    int x;
+};
+
+class AbstractClass {
+public:
+    virtual ~AbstractClass() = default;
+    virtual void foo() = 0;
+};
+shared_future<int> get() {
+    return promise<int>().get_future();
+}
+} // namespace
+
+TEST(SharedFutureTest, test_default_ctor) {
+    bool __attribute__((unused)) test = true;
+
+    shared_future<int> p1;
+    EXPECT_TRUE(!p1.valid());
+    shared_future<int&> p2;
+    EXPECT_TRUE(!p2.valid());
+    shared_future<void> p3;
+    EXPECT_TRUE(!p3.valid());
+    shared_future<ClassType> p4;
+    EXPECT_TRUE(!p4.valid());
+    shared_future<AbstractClass&> p5;
+    EXPECT_TRUE(!p5.valid());
+}
+
+TEST(SharedFutureTest, test_move_ctor) {
+    promise<int> p1;
+    shared_future<int> f1(p1.get_future());
+    shared_future<int> f2(std::move(f1));
+}
+
+TEST(SharedFutureTest, test_move_assign) {
+    shared_future<int> p1;
+    shared_future<int> p2 = get();
+    p1 = std::move(p2);
+    EXPECT_TRUE(p1.valid());
+    EXPECT_TRUE(!p2.valid());
+}
+
+TEST(SharedFutureTest, test_exception_01) {
+    shared_future<int> f;
+    EXPECT_THROW(
+            {
+                try {
+                    f.get();
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(SharedFutureTest, test_exception02) {
+    shared_future<int&> f;
+    EXPECT_THROW(
+            {
+                try {
+                    f.get();
+                    EXPECT_TRUE(false);
+                } catch (std::future_error& e) {
+                    EXPECT_TRUE(e.code() == std::future_errc::no_state);
+                    throw;
+                }
+            },
+            std::future_error);
+}
+
+TEST(SharedFutureTest, test_exception03) {
+    shared_future<void> f;
+    try {
+        f.get();
+        EXPECT_TRUE(false);
+    } catch (std::future_error& e) {
+        EXPECT_TRUE(e.code() == std::future_errc::no_state);
+    }
+}
+
+static int value = 99;
+
+TEST(SharedFutureTest, test_get01) {
+    promise<int> p1;
+    const shared_future<int> f1(p1.get_future());
+    shared_future<int> f2(f1);
+
+    p1.set_value(value);
+    EXPECT_TRUE(f1.get() == value);
+    EXPECT_TRUE(f2.get() == value);
+}
+
+TEST(SharedFutureTest, test_get02) {
+    promise<int&> p1;
+    const shared_future<int&> f1(p1.get_future());
+    shared_future<int&> f2(f1);
+
+    p1.set_value(value);
+    EXPECT_TRUE(&f1.get() == &value);
+    EXPECT_TRUE(&f2.get() == &value);
+}
+
+TEST(SharedFutureTest, test_get03) {
+    promise<void> p1;
+    const shared_future<void> f1(p1.get_future());
+    shared_future<void> f2(f1);
+
+    p1.set_value();
+    f1.get();
+    f2.get();
+}
+
+TEST(SharedFutureTest, test_get04) {
+    promise<int> p1;
+    shared_future<int> f1(p1.get_future());
+    shared_future<int> f2(f1);
+
+    p1.set_exception(std::make_exception_ptr(value));
+    try {
+        (void)f1.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_TRUE(e == value);
+    }
+    try {
+        (void)f2.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_TRUE(e == value);
+    }
+}
+
+TEST(SharedFutureTest, test_get05) {
+    promise<int&> p1;
+    shared_future<int&> f1(p1.get_future());
+    shared_future<int&> f2(f1);
+
+    p1.set_exception(std::make_exception_ptr(value));
+    try {
+        (void)f1.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_TRUE(e == value);
+    }
+    try {
+        (void)f2.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_TRUE(e == value);
+    }
+}
+
+TEST(SharedFutureTest, test_get06) {
+    promise<void> p1;
+    shared_future<void> f1(p1.get_future());
+    shared_future<void> f2(f1);
+
+    p1.set_exception(std::make_exception_ptr(value));
+    try {
+        f1.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_TRUE(e == value);
+    }
+    try {
+        f2.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_TRUE(e == value);
+    }
+}
+
+TEST(SharedFutureTest, test_valid01) {
+    shared_future<int> f0;
+
+    EXPECT_TRUE(!f0.valid());
+
+    promise<int> p1;
+    shared_future<int> f1(p1.get_future());
+    shared_future<int> f2(f1);
+
+    EXPECT_TRUE(f1.valid());
+    EXPECT_TRUE(f2.valid());
+
+    p1.set_value(1);
+
+    EXPECT_TRUE(f1.valid());
+    EXPECT_TRUE(f2.valid());
+
+    f1 = std::move(f0);
+
+    EXPECT_TRUE(!f0.valid());
+    EXPECT_TRUE(!f1.valid());
+    EXPECT_TRUE(f2.valid());
+}
+
+static void fut_wait(shared_future<void> f) {
+    f.wait();
+}
+
+static void* fut_wait02(void* arg) {
+    auto f = static_cast<shared_future<void>*>(arg);
+    f->wait();
+    return nullptr;
+}
+
+TEST(SharedFutureTest, test_wait01) {
+    promise<void> p1;
+    shared_future<void> f1(p1.get_future());
+
+    std::thread t1(fut_wait, f1);
+    std::thread t2(fut_wait, f1);
+    std::thread t3(fut_wait, f1);
+
+    p1.set_value();
+    t1.join();
+    t2.join();
+    t3.join();
+}
+
+TEST(SharedFutureTest, test_wait02) {
+    promise<void> p1;
+    shared_future<void> f1(p1.get_future());
+
+    bthread_t t1, t2, t3;
+    EXPECT_EQ(0, bthread_start_background(&t1, nullptr, fut_wait02, &f1));
+    EXPECT_EQ(0, bthread_start_background(&t2, nullptr, fut_wait02, &f1));
+    EXPECT_EQ(0, bthread_start_background(&t3, nullptr, fut_wait02, &f1));
+
+    p1.set_value();
+
+    bthread_join(t1, nullptr);
+    bthread_join(t2, nullptr);
+    bthread_join(t3, nullptr);
+}
+
+TEST(SharedFutureTest, test_wait_for01) {
+    promise<int> p1;
+    shared_future<int> f1(p1.get_future());
+    shared_future<int> f2(f1);
+
+    std::chrono::milliseconds delay(100);
+
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::timeout);
+    EXPECT_TRUE(f2.wait_for(delay) == std::future_status::timeout);
+
+    p1.set_value(1);
+
+    auto before = std::chrono::system_clock::now();
+    EXPECT_TRUE(f1.wait_for(delay) == std::future_status::ready);
+    EXPECT_TRUE(f2.wait_for(delay) == std::future_status::ready);
+    EXPECT_TRUE(std::chrono::system_clock::now() < (before + 2 * delay));
+}
+
+static std::chrono::system_clock::time_point make_time(int i) {
+    return std::chrono::system_clock::now() + std::chrono::milliseconds(i);
+}
+
+TEST(SharedFutureTest, test_wait_until01) {
+    promise<int> p1;
+    shared_future<int> f1(p1.get_future());
+    shared_future<int> f2(f1);
+
+    auto when = make_time(10);
+    EXPECT_TRUE(f1.wait_until(make_time(10)) == std::future_status::timeout);
+    EXPECT_TRUE(std::chrono::system_clock::now() >= when);
+
+    when = make_time(10);
+    EXPECT_TRUE(f2.wait_until(make_time(10)) == std::future_status::timeout);
+    EXPECT_TRUE(std::chrono::system_clock::now() >= when);
+
+    p1.set_value(1);
+
+    when = make_time(100);
+    EXPECT_TRUE(f1.wait_until(when) == std::future_status::ready);
+    EXPECT_TRUE(f2.wait_until(when) == std::future_status::ready);
+    EXPECT_TRUE(std::chrono::system_clock::now() < when);
+}
+
+} // namespace starrocks::bthreads


### PR DESCRIPTION
This patch implemented  bthreads::{future, promise, packaged_task}, based on the source code of libstd++.

The key changes are:
bthreads::future::get() will now suspend the current bthread instead of blocking the pthread when the result is not ready yet.
Waiting on a bthreads::future automatically resumes the bthread when the result is available.
This allows non-blocking waiting on asynchronous results in a bthread by leveraging bthread suspensions.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
