### PR TITLE
[Refactor] Log the task number in the task queue

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -393,8 +393,10 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
     for (auto* task : all_tasks) {                                                                                 \
         auto pool = get_thread_pool(t_task_type);                                                                  \
         auto signature = task->signature;                                                                          \
-        if (register_task_info(task_type, signature)) {                                                            \
-            LOG(INFO) << "Submit task success. type=" << t_task_type << ", signature=" << signature;               \
+        std::pair<bool, size_t> register_pair = register_task_info(task_type, signature);                          \
+        if (register_pair.first) {                                                                                 \
+            LOG(INFO) << "Submit task success. type=" << t_task_type << ", signature=" << signature                \
+                      << ", task_count_in_queue=" << register_pair.second;                                         \
             ret_st = pool->submit_func(                                                                            \
                     std::bind(do_func, std::make_shared<AGENT_REQ>(*task, task->request, time(nullptr)), env));    \
         } else {                                                                                                   \

--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -144,7 +144,9 @@ static void unify_finish_agent_task(TStatusCode::type status_code, const std::ve
     finish_task_request.__set_task_status(task_status);
 
     finish_task(finish_task_request);
-    remove_task_info(task_type, signature);
+    size_t task_queue_size = remove_task_info(task_type, signature);
+    LOG(INFO) << "Remove task success. type=" << task_type << ", signature=" << signature
+              << ", task_count_in_queue=" << task_queue_size;
 }
 
 void run_drop_tablet_task(const std::shared_ptr<DropTabletAgentTaskRequest>& agent_task_req, ExecEnv* exec_env) {

--- a/be/src/agent/task_signatures_manager.h
+++ b/be/src/agent/task_signatures_manager.h
@@ -21,9 +21,9 @@
 
 namespace starrocks {
 
-bool register_task_info(TTaskType::type task_type, int64_t signature);
+std::pair<bool, size_t> register_task_info(TTaskType::type task_type, int64_t signature);
 std::vector<uint8_t> batch_register_task_info(const std::vector<const TAgentTaskRequest*>& tasks);
-void remove_task_info(TTaskType::type task_type, int64_t signature);
+size_t remove_task_info(TTaskType::type task_type, int64_t signature);
 std::map<TTaskType::type, std::set<int64_t>> count_all_tasks();
 
 } // namespace starrocks

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -173,7 +173,8 @@ void TaskWorkerPool<AgentTaskRequest>::submit_task(const TAgentTaskRequest& task
     std::string type_str;
     EnumToString(TTaskType, task_type, type_str);
 
-    if (register_task_info(task_type, signature)) {
+    std::pair<bool, size_t> register_pair = register_task_info(task_type, signature);
+    if (register_pair.first) {
         // Set the receiving time of task so that we can determine whether it is timed out later
         auto new_task = _convert_task(task, time(nullptr));
         size_t task_count = _push_task(std::move(new_task));


### PR DESCRIPTION
The new framework doesn't output the queue size in the create table. Add it into the log to better trace the table creation pressure.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
