### PR TITLE
[BugFix] Different column types in different chunks 

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -164,7 +164,9 @@ public:
     }
 
     // Update column according to whether the dest column and source column are nullable or not.
-    static ColumnPtr update_column_nullable(bool dst_nullable, const ColumnPtr& src_column, int num_rows) {
+    // when force is set true, the column would be converted as required, ignoring the actual type of column.
+    static ColumnPtr update_column_nullable(bool dst_nullable, const ColumnPtr& src_column, int num_rows,
+                                            bool force = false) {
         if (src_column->is_nullable()) {
             if (dst_nullable) {
                 // 1. Src column and dest column are both nullable.
@@ -172,7 +174,7 @@ public:
             } else {
                 // 2. src column is nullable, and dest column is non-nullable.
                 auto* nullable_column = as_raw_column<NullableColumn>(src_column);
-                DCHECK(!nullable_column->has_null());
+                DCHECK(force || !nullable_column->has_null());
                 return nullable_column->data_column();
             }
         } else {

--- a/be/src/connector/file_connector.h
+++ b/be/src/connector/file_connector.h
@@ -91,5 +91,7 @@ private:
     void _init_counter();
 
     void _update_counter();
+
+    void _validate_nullable(ChunkPtr chunk);
 };
 } // namespace starrocks::connector


### PR DESCRIPTION
Fixes #issue
The column type like datetime is cast from varchar in the file scanner.
cast_from_string_to_datetime_fn would build a column as nullable when there're nulls in the column, while it would build a column as non-nullable when there's no null in the column. So, the column types of different chunks may be different.
The exchange node gets the chunk schema according to the first chunk it receives and then parses the chunk according to the schema. In this way, the exchange node cannot handle the variable column type.
This PR corrects the columns returned by the cast_from_string_to_datetime_fn according to the actual schema.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
