### PR TITLE
[BugFix] fix jni scanner init failed and crashed

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -428,10 +428,10 @@ HdfsScanner* HiveDataSource::_create_paimon_jni_scanner(FSOptions& options) {
     jni_scanner_params["split_info"] = _scan_range.paimon_split_info;
     jni_scanner_params["predicate_info"] = _scan_range.paimon_predicate_info;
 
+    string option_info = "";
     if (options.cloud_configuration != nullptr && options.cloud_configuration->cloud_type == TCloudType::AWS) {
         const AWSCloudConfiguration aws_cloud_configuration =
                 CloudConfigurationFactory::create_aws(*options.cloud_configuration);
-        string option_info = "";
         AWSCloudCredential aws_cloud_credential = aws_cloud_configuration.aws_cloud_credential;
         if (!aws_cloud_credential.endpoint.empty()) {
             option_info += "s3.endpoint=" + aws_cloud_credential.endpoint + ",";
@@ -446,8 +446,8 @@ HdfsScanner* HiveDataSource::_create_paimon_jni_scanner(FSOptions& options) {
         option_info += "s3.connection.ssl.enabled=" + enable_ssl + ",";
         string enable_path_style_access = aws_cloud_configuration.enable_path_style_access ? "true" : "false";
         option_info += "s3.path.style.access=" + enable_path_style_access;
-        jni_scanner_params["option_info"] = option_info;
     }
+    jni_scanner_params["option_info"] = option_info;
 
     std::string scanner_factory_class = "com/starrocks/paimon/reader/PaimonSplitScannerFactory";
     HdfsScanner* scanner = _pool.add(new JniScanner(scanner_factory_class, jni_scanner_params));

--- a/be/src/exec/jni_scanner.cpp
+++ b/be/src/exec/jni_scanner.cpp
@@ -58,6 +58,7 @@ Status JniScanner::do_open(RuntimeState* state) {
 void JniScanner::do_update_counter(HdfsScanProfile* profile) {}
 
 void JniScanner::do_close(RuntimeState* runtime_state) noexcept {
+    if (_jni_scanner_obj == nullptr) return;
     JNIEnv* _jni_env = JVMFunctionHelper::getInstance().getEnv();
     _jni_env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_close);
     _check_jni_exception(_jni_env, "Failed to close the off-heap table scanner.");
@@ -124,7 +125,6 @@ Status JniScanner::_init_jni_table_scanner(JNIEnv* _jni_env, RuntimeState* runti
     int fetch_size = runtime_state->chunk_size();
     _jni_scanner_obj = _jni_env->NewObject(_jni_scanner_cls, scanner_constructor, fetch_size, hashmap_object);
     _jni_env->DeleteLocalRef(hashmap_object);
-
     DCHECK(_jni_scanner_obj != nullptr);
     RETURN_IF_ERROR(_check_jni_exception(_jni_env, "Failed to initialize a scanner instance."));
 


### PR DESCRIPTION
Fixes #issue

This PR is to fix:
- make sure `option_info` is always in `jni_scanner_params`
- fix `do_close` when `jni_scanner_obj` is not created (when `do_init` fails)

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
