### PR TITLE
[BugFix] remove useless symbol link 

### DIFF
--- a/fe/doris_local.md
+++ b/fe/doris_local.md
@@ -1,1 +1,0 @@
-../../notes/doris_local.md


### PR DESCRIPTION
Fixes #issue

The symbol link introduced by this PR https://github.com/StarRocks/starrocks/pull/21131, seems useless. I would suggest to remove it.


## What type of PR is this:
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [X] 2.5
  - [ ] 2.4
