### PR TITLE
[Enhancement] still use cte rewrite  when count distinct with limit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -261,6 +261,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_CTE_REUSE_RATE = "cbo_cte_reuse_rate";
     public static final String CBO_CTE_MAX_LIMIT = "cbo_cte_max_limit";
     public static final String CBO_CTE_REUSE_RATE_V2 = "cbo_cte_reuse_rate_v2";
+    public static final String PREFER_CTE_REUSE_REWRITE = "prefer_cte_reuse_rewrite";
     public static final String ENABLE_SQL_DIGEST = "enable_sql_digest";
     public static final String CBO_MAX_REORDER_NODE = "cbo_max_reorder_node";
     public static final String CBO_PRUNE_SHUFFLE_COLUMN_RATE = "cbo_prune_shuffle_column_rate";
@@ -670,6 +671,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_CTE_MAX_LIMIT, flag = VariableMgr.INVISIBLE)
     private int cboCTEMaxLimit = 10;
+
+    @VarAttr(name = PREFER_CTE_REUSE_REWRITE, flag = VariableMgr.INVISIBLE)
+    private boolean preferCTEReuseRewrite = false;
 
     @VarAttr(name = CBO_PRUNE_SUBFIELD, flag = VariableMgr.INVISIBLE)
     private boolean cboPruneSubfield = true;
@@ -1913,6 +1917,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setCboCteReuse(boolean cboCteReuse) {
         this.cboCteReuse = cboCteReuse;
+    }
+
+    public boolean isPreferCTEReuseRewrite() {
+        return preferCTEReuseRewrite;
     }
 
     public void setSingleNodeExecPlan(boolean singleNodeExecPlan) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -261,7 +261,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_CTE_REUSE_RATE = "cbo_cte_reuse_rate";
     public static final String CBO_CTE_MAX_LIMIT = "cbo_cte_max_limit";
     public static final String CBO_CTE_REUSE_RATE_V2 = "cbo_cte_reuse_rate_v2";
-    public static final String PREFER_CTE_REUSE_REWRITE = "prefer_cte_reuse_rewrite";
+    public static final String PREFER_CTE_REWRITE = "prefer_cte_rewrite";
     public static final String ENABLE_SQL_DIGEST = "enable_sql_digest";
     public static final String CBO_MAX_REORDER_NODE = "cbo_max_reorder_node";
     public static final String CBO_PRUNE_SHUFFLE_COLUMN_RATE = "cbo_prune_shuffle_column_rate";
@@ -672,8 +672,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_CTE_MAX_LIMIT, flag = VariableMgr.INVISIBLE)
     private int cboCTEMaxLimit = 10;
 
-    @VarAttr(name = PREFER_CTE_REUSE_REWRITE, flag = VariableMgr.INVISIBLE)
-    private boolean preferCTEReuseRewrite = false;
+    @VarAttr(name = PREFER_CTE_REWRITE, flag = VariableMgr.INVISIBLE)
+    private boolean preferCTERewrite = false;
 
     @VarAttr(name = CBO_PRUNE_SUBFIELD, flag = VariableMgr.INVISIBLE)
     private boolean cboPruneSubfield = true;
@@ -1919,8 +1919,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.cboCteReuse = cboCteReuse;
     }
 
-    public boolean isPreferCTEReuseRewrite() {
-        return preferCTEReuseRewrite;
+    public boolean isPreferCTERewrite() {
+        return preferCTERewrite;
     }
 
     public void setSingleNodeExecPlan(boolean singleNodeExecPlan) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
@@ -151,7 +151,7 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
             return true;
         }
 
-        if (agg.hasLimit() && !ConnectContext.get().getSessionVariable().isPreferCTEReuseRewrite()) {
+        if (agg.hasLimit() && !ConnectContext.get().getSessionVariable().isPreferCTERewrite()) {
             return false;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteMultiDistinctByCTERule.java
@@ -23,6 +23,7 @@ import com.starrocks.analysis.JoinOperator;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ScalarType;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.optimizer.ExpressionContext;
@@ -150,7 +151,7 @@ public class RewriteMultiDistinctByCTERule extends TransformationRule {
             return true;
         }
 
-        if (agg.hasLimit()) {
+        if (agg.hasLimit() && !ConnectContext.get().getSessionVariable().isPreferCTEReuseRewrite()) {
             return false;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2393,4 +2393,35 @@ public class AggregateTest extends PlanTestBase {
                         "  8:EXCHANGE");
 
     }
+
+    @Test
+    public void testCountDistinctWithLimit() throws Exception {
+        String sql = "select count(distinct v1), count(distinct v2) from t0 limit 10";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "1:AGGREGATE (update finalize)\n" +
+                "  |  output: multi_distinct_count(1: v1), multi_distinct_count(2: v2)");
+
+        sql = "select count(distinct v1), count(distinct v2) from t0 group by v3 limit 10";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "1:AGGREGATE (update finalize)\n" +
+                "  |  output: multi_distinct_count(1: v1), multi_distinct_count(2: v2)\n" +
+                "  |  group by: 3: v3");
+
+        sql = "select /*+ SET_VAR (prefer_cte_reuse_rewrite = true) */ count(distinct v1), count(distinct v2) from t0 " +
+                "limit 10";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, " 18:NESTLOOP JOIN\n" +
+                "  |  join op: CROSS JOIN\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  limit: 10");
+
+        sql = "select /*+ SET_VAR (prefer_cte_reuse_rewrite = true) */ count(distinct v1), count(distinct v2) from t0 " +
+                "group by v3 limit 10";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "13:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 7: v3 <=> 9: v3\n" +
+                "  |  limit: 10");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2407,7 +2407,7 @@ public class AggregateTest extends PlanTestBase {
                 "  |  output: multi_distinct_count(1: v1), multi_distinct_count(2: v2)\n" +
                 "  |  group by: 3: v3");
 
-        sql = "select /*+ SET_VAR (prefer_cte_reuse_rewrite = true) */ count(distinct v1), count(distinct v2) from t0 " +
+        sql = "select /*+ SET_VAR (prefer_cte_rewrite = true) */ count(distinct v1), count(distinct v2) from t0 " +
                 "limit 10";
         plan = getFragmentPlan(sql);
         assertContains(plan, " 18:NESTLOOP JOIN\n" +
@@ -2415,7 +2415,7 @@ public class AggregateTest extends PlanTestBase {
                 "  |  colocate: false, reason: \n" +
                 "  |  limit: 10");
 
-        sql = "select /*+ SET_VAR (prefer_cte_reuse_rewrite = true) */ count(distinct v1), count(distinct v2) from t0 " +
+        sql = "select /*+ SET_VAR (prefer_cte_rewrite = true) */ count(distinct v1), count(distinct v2) from t0 " +
                 "group by v3 limit 10";
         plan = getFragmentPlan(sql);
         assertContains(plan, "13:HASH JOIN\n" +


### PR DESCRIPTION
Fixes #issue
support use cte rewrite  when count distinct with limit, we add a session variable prefer_cte_reuse_rewrite, when it set to true, will use cte reuse to rewrite multi count distinct even with limit.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
