### PR TITLE
[BugFix] Revert invalid date partition prune (backport #27780)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -101,14 +101,11 @@ public class ColumnFilterConverter {
             return;
         }
 
-        // rewrite invalid date cast expr to NullLiteral
-        ScalarOperator rewritePredicate = rewriteInvalidDateCast(predicate);
-
-        if (rewritePredicate.getChildren().stream().skip(1).anyMatch(d -> !OperatorType.CONSTANT.equals(d.getOpType()))) {
+        if (predicate.getChildren().stream().skip(1).anyMatch(d -> !OperatorType.CONSTANT.equals(d.getOpType()))) {
             return;
         }
 
-        rewritePredicate.accept(COLUMN_FILTER_VISITOR, result);
+        predicate.accept(COLUMN_FILTER_VISITOR, result);
     }
 
     private static boolean checkColumnRefCanPartition(ScalarOperator right, Table table) {
@@ -193,31 +190,6 @@ public class ColumnFilterConverter {
                 (Objects.equals(exprTimeArg, callTimeArg) ||
                         (TIME_MAP.containsKey(exprTimeArg) && TIME_MAP.containsKey(callTimeArg) &&
                                 TIME_MAP.get(exprTimeArg) > TIME_MAP.get(callTimeArg)));
-    }
-
-    // only rewrite cast invalid date value to null like cast('abc' as date)
-    private static ScalarOperator rewriteInvalidDateCast(ScalarOperator scalarOperator) {
-        ScalarOperator copy = scalarOperator.clone();
-        List<ScalarOperator> children = copy.getChildren();
-
-        for (int i = 1; i < children.size(); i++) {
-            ScalarOperator child = children.get(i);
-            if (child instanceof CastOperator) {
-                CastOperator cast = (CastOperator) child;
-                Type toType = cast.getType();
-                if (cast.getChildren().size() == 1
-                        && cast.getChildren().get(0).isConstantRef()
-                        && toType.isDateType()) {
-                    ConstantOperator value = (ConstantOperator) cast.getChildren().get(0);
-                    try {
-                        value.castTo(toType);
-                    } catch (Exception e) {
-                        children.set(i, ConstantOperator.createNull(toType));
-                    }
-                }
-            }
-        }
-        return copy;
     }
 
     private static class ColumnFilterVisitor

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -15,12 +15,9 @@
 
 package com.starrocks.sql.plan;
 
-import com.clearspring.analytics.util.Lists;
 import com.starrocks.common.FeConstants;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
@@ -132,46 +129,6 @@ public class PartitionPruneTest extends PlanTestBase {
                 "     PREDICATES: (2: d2 > '1000-01-01') OR (2: d2 IN (NULL, NULL)), 2: d2 > '1000-01-01'\n" +
                 "     partitions=4/4\n" +
                 "     rollup: ptest"));
-    }
-
-    @Test
-    public void testInvalidDatePrune() throws Exception {
-        connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000);
-        List<String> sqls = Lists.newArrayList();
-
-        String plan = "";
-        sqls.add("select * from ptest where d2 in ('1998-01-32', 'abc', 'abc')");
-        sqls.add("select * from ptest where d2 <= '1998-01-32'");
-        for (String sql : sqls) {
-            plan = getFragmentPlan(sql);
-            assertContains(plan, "partitions=0/4");
-        }
-
-        sqls.clear();
-        sqls.add("select * from ptest where d2 in ('abc')");
-        sqls.add("select * from ptest where d2 in ('1998-01-32')");
-        sqls.add("select * from ptest where d2 = '1998-01-32'");
-        sqls.add("select * from ptest where d2 in ('1998-01-01', 'abc', '1998-13-01')");
-        for (String sql : sqls) {
-            plan = getFragmentPlan(sql);
-            assertContains(plan, "partitions=1/4");
-        }
-
-        sqls.clear();
-        sqls.add("select * from ptest where d2 in ('2020-06-01', 'abc', '1998-11-01')");
-        sqls.add("select * from ptest where d2 in ('2020-06-01', 'abc', '1998-11-01', '2001-01-33')");
-        for (String sql : sqls) {
-            plan = getFragmentPlan(sql);
-            assertContains(plan, "partitions=2/4");
-        }
-
-        sqls.clear();
-        sqls.add("select * from ptest where d2 in ('1998-01-32', cast(cast('2021-01-12' as SIGNED) as DATE))");
-        sqls.add("select * from ptest where d2 in ('1998-01-01', cast(cast('2021-01-12' as SIGNED) as DATE))");
-        for (String sql : sqls) {
-            plan = getFragmentPlan(sql);
-            assertContains(plan, "partitions=4/4");
-        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #issue

SR will delete invalid date partition when the predicate is invalid date on FE, but the date cast behavior is different with BE

REVERT: https://github.com/StarRocks/starrocks/pull/14820

```
MySQL td> explain select  CAST('1998-07-01 22' AS DATEtime)
+---------------------------------------------------+
| Explain String                                    |
+---------------------------------------------------+
| PLAN FRAGMENT 0                                   |
|  OUTPUT EXPRS:2: cast                             |
|   PARTITION: UNPARTITIONED                        |
|                                                   |
|   RESULT SINK                                     |
|                                                   |
|   1:Project                                       |
|   |  <slot 2> : CAST('1998-07-01 22' AS DATETIME) |
|   |                                               |
|   0:UNION                                         |
|      constant exprs:                              |
|          NULL                                     |
+---------------------------------------------------+
12 rows in set
Time: 0.009s
MySQL td>  select  CAST('1998-07-01 22' AS DATEtime)
+-----------------------------------+
| CAST('1998-07-01 22' AS DATETIME) |
+-----------------------------------+
| 1998-07-01 22:00:00               |
+-----------------------------------+
1 row in set
Time: 0.022s
MySQL td> explain select  CAST('1998-07-01 22' AS DATE)
+-----------------------------------------------+
| Explain String                                |
+-----------------------------------------------+
| PLAN FRAGMENT 0                               |
|  OUTPUT EXPRS:2: cast                         |
|   PARTITION: UNPARTITIONED                    |
|                                               |
|   RESULT SINK                                 |
|                                               |
|   1:Project                                   |
|   |  <slot 2> : CAST('1998-07-01 22' AS DATE) |
|   |                                           |
|   0:UNION                                     |
|      constant exprs:                          |
|          NULL                                 |
+-----------------------------------------------+
12 rows in set
Time: 0.015s
MySQL td>  select  CAST('1998-07-01 22' AS DATE)
+-------------------------------+
| CAST('1998-07-01 22' AS DATE) |
+-------------------------------+
| 1998-07-01                    |
+-------------------------------+
1 row in set
Time: 0.017s
MySQL td> show create table p0\G;
***************************[ 1. row ]***************************
Table        | p0
Create Table | CREATE TABLE `p0` (
  `v1` bigint(20) NULL COMMENT "",
  `d1` date NULL COMMENT "",
  `v2` bigint(20) NULL COMMENT "",
  `v3` bigint(20) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`v1`)
COMMENT "OLAP"
PARTITION BY RANGE(`d1`)
(PARTITION p6 VALUES [("1997-01-01"), ("1998-01-01")),
PARTITION p7 VALUES [("1998-01-01"), ("1999-01-01")))
DISTRIBUTED BY HASH(`v1`) BUCKETS 3
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "false",
"compression" = "LZ4"
);
1 row in set
Time: 0.002s
MySQL td>
MySQL td> explain select * from p0 where d1 <= ("1998-07-01 22")
+---------------------------------------------------------+
| Explain String                                          |
+---------------------------------------------------------+
| PLAN FRAGMENT 0                                         |
|  OUTPUT EXPRS:1: v1 | 2: d1 | 3: v2 | 4: v3             |
|   PARTITION: RANDOM                                     |
|                                                         |
|   RESULT SINK                                           |
|                                                         |
|   0:OlapScanNode                                        |
|      TABLE: p0                                          |
|      PREAGGREGATION: ON                                 |
|      PREDICATES: 2: d1 <= CAST('1998-07-01 22' AS DATE) |
|      partitions=0/2                                     |
|      rollup: p0                                         |
|      tabletRatio=0/0                                    |
|      tabletList=                                        |
|      cardinality=1                                      |
|      avgRowSize=4.0                                     |
+---------------------------------------------------------+
16 rows in set
Time: 0.012s
```

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
