### PR TITLE
[BugFix] Add SpinLock protect concurrency accesses to TicketChecker

### DIFF
--- a/be/src/exec/query_cache/ticket_checker.h
+++ b/be/src/exec/query_cache/ticket_checker.h
@@ -20,6 +20,8 @@
 #include <unordered_map>
 
 #include "gutil/macros.h"
+#include "util/spinlock.h"
+
 namespace starrocks::query_cache {
 
 // TicketChecker is used to count down EOS chunk of the SplitMorsels generated from the same
@@ -64,6 +66,7 @@ public:
 
 private:
     DISALLOW_COPY_AND_MOVE(TicketChecker);
+    SpinLock _lock;
     std::unordered_map<int64_t, Ticket> _tickets;
 };
 } // namespace starrocks::query_cache


### PR DESCRIPTION
TicketChecker's method should be protected by lock, it is a query-scoped object, so use spin_lock.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
