### PR TITLE
[Feature] partial update by column support upsert (backport #28288)

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -201,8 +201,10 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
         request.set_partial_update_mode(PartialUpdateMode::ROW_MODE);
     } else if (_parent->_partial_update_mode == TPartialUpdateMode::type::AUTO_MODE) {
         request.set_partial_update_mode(PartialUpdateMode::AUTO_MODE);
-    } else if (_parent->_partial_update_mode == TPartialUpdateMode::type::COLUMN_MODE) {
-        request.set_partial_update_mode(PartialUpdateMode::COLUMN_MODE);
+    } else if (_parent->_partial_update_mode == TPartialUpdateMode::type::COLUMN_UPSERT_MODE) {
+        request.set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE);
+    } else if (_parent->_partial_update_mode == TPartialUpdateMode::type::COLUMN_UPDATE_MODE) {
+        request.set_partial_update_mode(PartialUpdateMode::COLUMN_UPDATE_MODE);
     }
     request.set_allocated_id(&_parent->_load_id);
     request.set_index_id(index_id);

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -539,7 +539,7 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
         } else if (http_req->header(HTTP_PARTIAL_UPDATE_MODE) == "auto") {
             request.__set_partial_update_mode(TPartialUpdateMode::type::AUTO_MODE);
         } else if (http_req->header(HTTP_PARTIAL_UPDATE_MODE) == "column") {
-            request.__set_partial_update_mode(TPartialUpdateMode::type::COLUMN_MODE);
+            request.__set_partial_update_mode(TPartialUpdateMode::type::COLUMN_UPSERT_MODE);
         }
     }
     if (!http_req->header(HTTP_TRANSMISSION_COMPRESSION_TYPE).empty()) {

--- a/be/src/storage/rowset/rowset_factory.cpp
+++ b/be/src/storage/rowset/rowset_factory.cpp
@@ -53,7 +53,8 @@ Status RowsetFactory::create_rowset(const TabletSchema* schema, const std::strin
 
 Status RowsetFactory::create_rowset_writer(const RowsetWriterContext& context, std::unique_ptr<RowsetWriter>* output) {
     if (context.writer_type == kHorizontal) {
-        if (context.partial_update_mode == PartialUpdateMode::COLUMN_MODE) {
+        if (context.partial_update_mode == PartialUpdateMode::COLUMN_UPSERT_MODE ||
+            context.partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
             // rowset writer for partial update in column mode
             *output = std::make_unique<HorizontalUpdateRowsetWriter>(context);
         } else {

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -90,6 +90,8 @@ public:
 
     int64_t num_rows() const { return _rowset_meta_pb->num_rows(); }
 
+    void set_num_rows(int64_t num_rows) { _rowset_meta_pb->set_num_rows(num_rows); }
+
     int64_t total_row_size() { return _rowset_meta_pb->total_row_size(); }
 
     void set_total_row_size(int64_t total_size) { _rowset_meta_pb->set_total_row_size(total_size); }
@@ -105,6 +107,8 @@ public:
     void set_data_disk_size(size_t data_size) { _rowset_meta_pb->set_data_disk_size(data_size); }
 
     size_t index_disk_size() const { return _rowset_meta_pb->index_disk_size(); }
+
+    void set_index_disk_size(int64_t index_disk_size) { _rowset_meta_pb->set_index_disk_size(index_disk_size); }
 
     bool has_delete_predicate() const { return _rowset_meta_pb->has_delete_predicate(); }
 
@@ -142,6 +146,10 @@ public:
 
     int64_t num_segments() const { return _rowset_meta_pb->num_segments(); }
 
+    void set_num_segments(int64_t num_segments) { _rowset_meta_pb->set_num_segments(num_segments); }
+
+    void set_empty(bool empty) { _rowset_meta_pb->set_empty(empty); }
+
     void to_rowset_pb(RowsetMetaPB* rs_meta_pb) const { *rs_meta_pb = *_rowset_meta_pb; }
 
     RowsetMetaPB to_rowset_pb() const {
@@ -164,6 +172,10 @@ public:
     bool is_remove_from_rowset_meta() const { return _is_removed_from_rowset_meta; }
 
     SegmentsOverlapPB segments_overlap() const { return _rowset_meta_pb->segments_overlap_pb(); }
+
+    void set_segments_overlap_pb(SegmentsOverlapPB overlap) {
+        return _rowset_meta_pb->set_segments_overlap_pb(overlap);
+    }
 
     // return true if segments in this rowset has overlapping data.
     // this is not same as `segments_overlap()` method.

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -22,6 +22,7 @@
 #include "storage/delta_column_group.h"
 #include "storage/primary_key_encoder.h"
 #include "storage/rowset/column_iterator.h"
+#include "storage/rowset/default_value_column_iterator.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_options.h"
 #include "storage/rowset/segment_options.h"
@@ -263,8 +264,8 @@ Status RowsetColumnUpdateState::_check_and_resolve_conflict(Tablet* tablet, uint
         return Status::InternalError(msg);
     }
 
-    LOG(INFO) << "latest_applied_version is " << latest_applied_version.to_string() << " read version is "
-              << _partial_update_states[segment_id].read_version.to_string();
+    VLOG(2) << "latest_applied_version is " << latest_applied_version.to_string() << " read version is "
+            << _partial_update_states[segment_id].read_version.to_string();
     if (latest_applied_version == _partial_update_states[segment_id].read_version) {
         // _read_version is equal to latest_applied_version which means there is no other rowset is applied.
         // skip resolve conflict
@@ -424,7 +425,164 @@ Status RowsetColumnUpdateState::_read_chunk_from_update(const RowidsToUpdateRowi
     return Status::OK();
 }
 
-Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, const PrimaryIndex& index) {
+// this function build segment writer for segment files
+StatusOr<std::unique_ptr<SegmentWriter>> RowsetColumnUpdateState::_prepare_segment_writer(
+        Rowset* rowset, const TabletSchema& tablet_schema, int segment_id) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(rowset->rowset_path()));
+    const std::string path = Rowset::segment_file_path(rowset->rowset_path(), rowset->rowset_id(), segment_id);
+    (void)fs->delete_file(path); // delete .dat if already exist
+    WritableFileOptions opts{.sync_on_close = true};
+    ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(opts, path));
+    SegmentWriterOptions writer_options;
+    auto segment_writer = std::make_unique<SegmentWriter>(std::move(wfile), segment_id, &tablet_schema, writer_options);
+    RETURN_IF_ERROR(segment_writer->init());
+    return std::move(segment_writer);
+}
+
+static std::pair<std::vector<uint32_t>, std::vector<uint32_t>> get_read_update_columns_ids(
+        const RowsetTxnMetaPB& txn_meta, const TabletSchema& tablet_schema) {
+    std::vector<uint32_t> update_column_ids(txn_meta.partial_update_column_ids().begin(),
+                                            txn_meta.partial_update_column_ids().end());
+    std::set<uint32_t> update_columns_set(update_column_ids.begin(), update_column_ids.end());
+
+    std::vector<uint32_t> read_column_ids;
+    for (uint32_t i = 0; i < tablet_schema.num_columns(); i++) {
+        if (update_columns_set.find(i) == update_columns_set.end()) {
+            read_column_ids.push_back(i);
+        }
+    }
+
+    return {read_column_ids, update_column_ids};
+}
+
+Status RowsetColumnUpdateState::_fill_default_columns(const TabletSchema& tablet_schema,
+                                                      const std::vector<uint32_t>& column_ids, const int64_t row_cnt,
+                                                      vector<std::shared_ptr<Column>>* columns) {
+    for (auto i = 0; i < column_ids.size(); ++i) {
+        const TabletColumn& tablet_column = tablet_schema.column(column_ids[i]);
+        if (tablet_column.has_default_value()) {
+            const TypeInfoPtr& type_info = get_type_info(tablet_column);
+            std::unique_ptr<DefaultValueColumnIterator> default_value_iter =
+                    std::make_unique<DefaultValueColumnIterator>(
+                            tablet_column.has_default_value(), tablet_column.default_value(),
+                            tablet_column.is_nullable(), type_info, tablet_column.length(), row_cnt);
+            ColumnIteratorOptions iter_opts;
+            RETURN_IF_ERROR(default_value_iter->init(iter_opts));
+            default_value_iter->fetch_values_by_rowid(nullptr, row_cnt, (*columns)[column_ids[i]].get());
+        } else {
+            (*columns)[column_ids[i]]->append_default(row_cnt);
+        }
+    }
+    return Status::OK();
+}
+
+Status RowsetColumnUpdateState::_update_primary_index(const TabletSchema& tablet_schema, Tablet* tablet,
+                                                      const EditVersion& edit_version, uint32_t rowset_id,
+                                                      std::map<int, ChunkUniquePtr>& segid_to_chunk,
+                                                      int64_t insert_row_cnt, PersistentIndexMetaPB& index_meta,
+                                                      vector<std::pair<uint32_t, DelVectorPtr>>& delvecs,
+                                                      PrimaryIndex& index) {
+    // 1. build pk column
+    vector<uint32_t> pk_column_ids;
+    for (size_t i = 0; i < tablet_schema.num_key_columns(); i++) {
+        pk_column_ids.push_back((uint32_t)i);
+    }
+    Schema pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_column_ids);
+
+    // 2. update pk index
+    PrimaryIndex::DeletesMap new_deletes;
+    RETURN_IF_ERROR(index.prepare(edit_version, insert_row_cnt));
+    for (const auto& each_chunk : segid_to_chunk) {
+        new_deletes[rowset_id + each_chunk.first] = {};
+        std::unique_ptr<Column> pk_column;
+        RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+        PrimaryKeyEncoder::encode(pkey_schema, *each_chunk.second, 0, each_chunk.second->num_rows(), pk_column.get());
+        RETURN_IF_ERROR(index.upsert(rowset_id + each_chunk.first, 0, *pk_column, &new_deletes));
+    }
+    RETURN_IF_ERROR(index.commit(&index_meta));
+    for (auto& new_delete : new_deletes) {
+        // record delvec
+        auto delvec = std::make_shared<DelVector>();
+        auto& del_ids = new_delete.second;
+        delvec->init(edit_version.major(), del_ids.data(), del_ids.size());
+        delvecs.emplace_back(new_delete.first, delvec);
+    }
+    return Status::OK();
+}
+
+Status RowsetColumnUpdateState::_update_rowset_meta(const RowsetSegmentStat& stat, Rowset* rowset) {
+    rowset->rowset_meta()->set_num_rows(stat.num_rows_written);
+    rowset->rowset_meta()->set_total_row_size(stat.total_row_size);
+    rowset->rowset_meta()->set_total_disk_size(stat.total_data_size);
+    rowset->rowset_meta()->set_data_disk_size(stat.total_data_size);
+    rowset->rowset_meta()->set_index_disk_size(stat.total_index_size);
+    rowset->rowset_meta()->set_empty(stat.num_rows_written == 0);
+    rowset->rowset_meta()->set_num_segments(stat.num_segment);
+    if (stat.num_segment <= 1) {
+        rowset->rowset_meta()->set_segments_overlap_pb(NONOVERLAPPING);
+    }
+    rowset->rowset_meta()->clear_txn_meta();
+    return Status::OK();
+}
+
+// handle new rows, generate segment files and update primary index
+Status RowsetColumnUpdateState::_insert_new_rows(const TabletSchema& tablet_schema, Tablet* tablet,
+                                                 const EditVersion& edit_version, Rowset* rowset, uint32_t rowset_id,
+                                                 PersistentIndexMetaPB& index_meta,
+                                                 vector<std::pair<uint32_t, DelVectorPtr>>& delvecs,
+                                                 PrimaryIndex& index) {
+    int segid = 0;
+    RowsetSegmentStat stat;
+    const auto& txn_meta = rowset->rowset_meta()->get_meta_pb().txn_meta();
+    auto schema = ChunkHelper::convert_schema(tablet_schema);
+    auto read_update_column_ids = get_read_update_columns_ids(txn_meta, tablet_schema);
+    std::map<int, ChunkUniquePtr> segid_to_chunk;
+    std::vector<ChunkIteratorPtr> update_iterators;
+    OlapReaderStatistics stats;
+    Schema partial_schema = ChunkHelper::convert_schema(tablet_schema, read_update_column_ids.second);
+    ASSIGN_OR_RETURN(update_iterators, rowset->get_update_file_iterators(partial_schema, &stats));
+    for (int upt_id = 0; upt_id < _partial_update_states.size(); upt_id++) {
+        if (_partial_update_states[upt_id].insert_rowids.size() > 0) {
+            // 1. generate segment file
+            auto chunk_ptr = ChunkHelper::new_chunk(schema, _partial_update_states[upt_id].insert_rowids.size());
+            ChunkPtr partial_chunk_ptr = ChunkHelper::new_chunk(partial_schema, 4096);
+            ASSIGN_OR_RETURN(auto writer, _prepare_segment_writer(rowset, tablet_schema, segid));
+            RETURN_IF_ERROR(read_chunk_from_update_file(update_iterators[upt_id], partial_chunk_ptr));
+            for (uint32_t column_id : read_update_column_ids.second) {
+                chunk_ptr->get_column_by_id(column_id)->append_selective(
+                        *partial_chunk_ptr->get_column_by_id(column_id), _partial_update_states[upt_id].insert_rowids);
+            }
+            // fill default columns
+            RETURN_IF_ERROR(_fill_default_columns(tablet_schema, read_update_column_ids.first, chunk_ptr->num_rows(),
+                                                  &chunk_ptr->columns()));
+            uint64_t segment_file_size = 0;
+            uint64_t index_size = 0;
+            uint64_t footer_position = 0;
+            RETURN_IF_ERROR(writer->append_chunk(*chunk_ptr));
+            RETURN_IF_ERROR(writer->finalize(&segment_file_size, &index_size, &footer_position));
+            // update statisic
+            stat.num_segment++;
+            stat.total_data_size += segment_file_size;
+            stat.total_index_size += index_size;
+            stat.num_rows_written += static_cast<int64_t>(chunk_ptr->num_rows());
+            stat.total_row_size += static_cast<int64_t>(chunk_ptr->bytes_usage());
+            segid_to_chunk[segid] = std::move(chunk_ptr);
+            segid++;
+        }
+    }
+    if (stat.num_segment > 0) {
+        // 2. update pk index
+        RETURN_IF_ERROR(_update_primary_index(tablet_schema, tablet, edit_version, rowset_id, segid_to_chunk,
+                                              stat.num_rows_written, index_meta, delvecs, index));
+        // 3. update meta, add segment to rowset
+        RETURN_IF_ERROR(_update_rowset_meta(stat, rowset));
+    }
+    return Status::OK();
+}
+
+Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_t rowset_id,
+                                         PersistentIndexMetaPB& index_meta,
+                                         vector<std::pair<uint32_t, DelVectorPtr>>& delvecs, PrimaryIndex& index) {
     if (_finalize_finished) return Status::OK();
     std::stringstream cost_str;
     MonotonicStopWatch watch;
@@ -481,9 +639,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, const P
     // 3. create update file's iterator
     OlapReaderStatistics stats;
     std::vector<ChunkIteratorPtr> update_file_iters;
-    if (!_enable_preload_column_mode_update_data) {
-        ASSIGN_OR_RETURN(update_file_iters, rowset->get_update_file_iterators(partial_schema, &stats));
-    }
+    ASSIGN_OR_RETURN(update_file_iters, rowset->get_update_file_iterators(partial_schema, &stats));
     cost_str << " [prepare upt column iter] " << watch.elapsed_time();
     watch.reset();
 
@@ -534,6 +690,14 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, const P
     }
     cost_str << " [generate delta column group] " << watch.elapsed_time();
     watch.reset();
+    // generate segment file for insert data
+    if (txn_meta.partial_update_mode() == PartialUpdateMode::COLUMN_UPSERT_MODE) {
+        // ignore insert missing rows if partial_update_mode == COLUMN_UPDATE_MODE
+        RETURN_IF_ERROR(_insert_new_rows(tschema, tablet, EditVersion(latest_applied_version.major() + 1, 0), rowset,
+                                         rowset_id, index_meta, delvecs, index));
+        cost_str << " [insert missing rows] " << watch.elapsed_time();
+        watch.reset();
+    }
     cost_str << strings::Substitute(
             " seek_source_segment(ms):$0 read_column_from_update(ms):$1 avg_merge_column_time(ms):$2 "
             "avg_finalize_dcg_time(ms):$3 ",

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -31,6 +31,14 @@ class Segment;
 class RandomAccessFile;
 class ColumnIterator;
 
+struct RowsetSegmentStat {
+    int64_t num_rows_written = 0;
+    int64_t total_row_size = 0;
+    int64_t total_data_size = 0;
+    int64_t total_index_size = 0;
+    int64_t num_segment = 0;
+};
+
 // This struct can serve as the unique identifier for a specific segment.
 // The unique identifier contructed by rowset_id + segment_id.
 // There are two kinds of rowset_id in our implementations:
@@ -51,16 +59,21 @@ struct ColumnPartialUpdateState {
     EditVersion read_version;
     // Maintains the mapping of source row to update segment's row
     std::map<uint64_t, uint32_t> rss_rowid_to_update_rowid;
+    // Maintains the rowids in update segment, which are need to be inserted
+    std::vector<uint32> insert_rowids;
 
     // build `rss_rowid_to_update_rowid` from `src_rss_rowids`
     void build_rss_rowid_to_update_rowid() {
         rss_rowid_to_update_rowid.clear();
-        for (uint32_t upt_id = 0; upt_id < src_rss_rowids.size(); upt_id++) {
-            uint64_t each_rss_rowid = src_rss_rowids[upt_id];
+        insert_rowids.clear();
+        for (uint32_t upt_row_id = 0; upt_row_id < src_rss_rowids.size(); upt_row_id++) {
+            uint64_t each_rss_rowid = src_rss_rowids[upt_row_id];
             // build rssid & rowid -> update file's rowid
             // each_rss_rowid == UINT64_MAX means that key not exist in pk index
             if (each_rss_rowid < UINT64_MAX) {
-                rss_rowid_to_update_rowid[each_rss_rowid] = upt_id;
+                rss_rowid_to_update_rowid[each_rss_rowid] = upt_row_id;
+            } else {
+                insert_rowids.push_back(upt_row_id);
             }
         }
     }
@@ -90,10 +103,14 @@ public:
 
     // Generate delta columns by partial update states and rowset,
     // And distribute partial update column data to different `.col` files
-    // |rowset| : the rowset that we want to handle it to generate delta column group
     // |tablet| : current tablet
+    // |rowset| : the rowset that we want to handle it to generate delta column group
+    // |rowset_id| : the new rowset's id
+    // |index_meta| : persistent index's meta
+    // |delvecs| : new generate delvecs
     // |index| : tablet's primary key index
-    Status finalize(Tablet* tablet, Rowset* rowset, const PrimaryIndex& index);
+    Status finalize(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, PersistentIndexMetaPB& index_meta,
+                    vector<std::pair<uint32_t, DelVectorPtr>>& delvecs, PrimaryIndex& index);
 
     const std::vector<ColumnUniquePtr>& upserts() const { return _upserts; }
 
@@ -147,6 +164,21 @@ private:
                                    Chunk* result_chunk);
 
     void _check_if_preload_column_mode_update_data(Rowset* rowset, MemTracker* update_mem_tracker);
+
+    StatusOr<std::unique_ptr<SegmentWriter>> _prepare_segment_writer(Rowset* rowset, const TabletSchema& tablet_schema,
+                                                                     int segment_id);
+
+    Status _fill_default_columns(const TabletSchema& tablet_schema, const std::vector<uint32_t>& column_ids,
+                                 const int64_t row_cnt, vector<std::shared_ptr<Column>>* columns);
+    Status _update_primary_index(const TabletSchema& tablet_schema, Tablet* tablet, const EditVersion& edit_version,
+                                 uint32_t rowset_id, std::map<int, ChunkUniquePtr>& segid_to_chunk,
+                                 int64_t insert_row_cnt, PersistentIndexMetaPB& index_meta,
+                                 vector<std::pair<uint32_t, DelVectorPtr>>& delvecs, PrimaryIndex& index);
+    Status _update_rowset_meta(const RowsetSegmentStat& stat, Rowset* rowset);
+
+    Status _insert_new_rows(const TabletSchema& tablet_schema, Tablet* tablet, const EditVersion& edit_version,
+                            Rowset* rowset, uint32_t rowset_id, PersistentIndexMetaPB& index_meta,
+                            vector<std::pair<uint32_t, DelVectorPtr>>& delvecs, PrimaryIndex& index);
 
 private:
     int64_t _tablet_id = 0;

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -510,8 +510,8 @@ Status RowsetUpdateState::_check_and_resolve_conflict(Tablet* tablet, Rowset* ro
 
     // _read_version is equal to latest_applied_version which means there is no other rowset is applied
     // the data of write_columns can be write to segment file directly
-    LOG(INFO) << "latest_applied_version is " << latest_applied_version.to_string() << " read version is "
-              << _partial_update_states[segment_id].read_version.to_string();
+    VLOG(2) << "latest_applied_version is " << latest_applied_version.to_string() << " read version is "
+            << _partial_update_states[segment_id].read_version.to_string();
     if (latest_applied_version == _partial_update_states[segment_id].read_version) {
         return Status::OK();
     }

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -165,6 +165,8 @@ public:
     // used in column mode partial update
     static Status apply_rowset_commit(DataDir* store, TTabletId tablet_id, int64_t logid, const EditVersion& version,
                                       const std::map<uint32_t, DeltaColumnGroupPtr>& delta_column_groups,
+                                      const vector<std::pair<uint32_t, DelVectorPtr>>& delvecs,
+                                      const PersistentIndexMetaPB& index_meta, bool enable_persistent_index,
                                       const starrocks::RowsetMetaPB* rowset_meta);
 
     // traverse all the op logs for a tablet

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -657,7 +657,9 @@ Status TabletUpdates::_rowset_commit_unlocked(int64_t version, const RowsetShare
         }
     }
     edit.add_deltas(rowsetid);
-    uint32_t rowsetid_add = std::max(1U, (uint32_t)rowset->num_segments());
+    // reserve id if .upt files exist, because we may transfer them to .dat files later.
+    uint32_t rowsetid_add =
+            std::max(std::max(1U, (uint32_t)rowset->num_update_files()), (uint32_t)rowset->num_segments());
     edit.set_rowsetid_add(rowsetid_add);
     // TODO: is rollback modification of rowset meta required if commit failed?
     rowset->make_commit(version, rowsetid);
@@ -871,6 +873,7 @@ void TabletUpdates::_apply_column_partial_update_commit(const EditVersionInfo& v
     auto scoped = trace::Scope(span);
 
     auto tablet_id = _tablet.tablet_id();
+    uint32_t rowset_id = version_info.deltas[0];
     auto& version = version_info.version;
     auto manager = StorageEngine::instance()->update_manager();
 
@@ -911,10 +914,20 @@ void TabletUpdates::_apply_column_partial_update_commit(const EditVersionInfo& v
             return;
         }
     }
+    bool enable_persistent_index = index.enable_persistent_index();
+    PersistentIndexMetaPB index_meta;
+    if (enable_persistent_index) {
+        st = TabletMetaManager::get_persistent_index_meta(_tablet.data_dir(), _tablet.tablet_id(), &index_meta);
+        if (!st.ok() && !st.is_not_found()) {
+            failure_handler("get persistent index meta failed", st);
+            return;
+        }
+    }
 
+    vector<std::pair<uint32_t, DelVectorPtr>> new_del_vecs;
     span->AddEvent("gen_delta_column_group");
     // 3. finalize and generate delta column group
-    st = state.finalize(&_tablet, rowset.get(), index);
+    st = state.finalize(&_tablet, rowset.get(), rowset_id, index_meta, new_del_vecs, index);
     if (!st.ok()) {
         failure_handler("finalize failed", st);
         return;
@@ -929,8 +942,8 @@ void TabletUpdates::_apply_column_partial_update_commit(const EditVersionInfo& v
         }
 
         st = TabletMetaManager::apply_rowset_commit(_tablet.data_dir(), tablet_id, _next_log_id, version,
-                                                    state.delta_column_groups(),
-                                                    &(rowset->rowset_meta()->get_meta_pb()));
+                                                    state.delta_column_groups(), new_del_vecs, index_meta,
+                                                    enable_persistent_index, &(rowset->rowset_meta()->get_meta_pb()));
 
         if (!st.ok()) {
             failure_handler("apply_rowset_commit failed", st);
@@ -945,19 +958,51 @@ void TabletUpdates::_apply_column_partial_update_commit(const EditVersionInfo& v
                 return;
             }
         }
+        size_t num_dels = 0;
+        // put delvec in cache
+        TabletSegmentId tsid;
+        tsid.tablet_id = tablet_id;
+        for (auto& delvec_pair : new_del_vecs) {
+            tsid.segment_id = delvec_pair.first;
+            manager->set_cached_del_vec(tsid, delvec_pair.second);
+            // try to set empty dcg cache, for improving latency when reading
+            manager->set_cached_empty_delta_column_group(_tablet.data_dir()->get_meta(), tsid);
+            num_dels += delvec_pair.second->cardinality();
+        }
+        if (rowset->num_segments() > 0) {
+            // update rowset stats if insert missing rows
+            auto rowset_stats = std::make_unique<RowsetStats>();
+            rowset_stats->num_segments = rowset->num_segments();
+            rowset_stats->num_rows = rowset->num_rows();
+            rowset_stats->num_dels = num_dels;
+            rowset_stats->byte_size = rowset->data_disk_size();
+            rowset_stats->row_size = rowset->total_row_size();
+            rowset_stats->partial_update_by_column = false;
+            _calc_compaction_score(rowset_stats.get());
+
+            std::lock_guard lg(_rowset_stats_lock);
+            _rowset_stats[rowset_id] = std::move(rowset_stats);
+        }
         // 5. apply memory
         _next_log_id++;
         _apply_version_idx++;
         _apply_version_changed.notify_all();
     }
 
+    st = index.on_commited();
+    if (!st.ok()) {
+        failure_handler("primary index on_commit failed", st);
+        return;
+    }
+
     // 6. clear state and index cache
     manager->update_column_state_cache().remove(state_entry);
-    if (index.enable_persistent_index() ^ _tablet.get_enable_persistent_index()) {
+    if (enable_persistent_index ^ _tablet.get_enable_persistent_index()) {
         manager->index_cache().remove(index_entry);
     } else {
         manager->index_cache().release(index_entry);
     }
+    _update_total_stats(version_info.rowsets, nullptr, nullptr);
 }
 
 void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -137,7 +137,8 @@ public:
     RowsetSharedPtr create_partial_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
                                           std::vector<int32_t>& column_indexes, std::function<int16_t(int64_t)> v1_func,
                                           std::function<int32_t(int64_t)> v2_func,
-                                          const std::shared_ptr<TabletSchema>& partial_schema, int segment_num) {
+                                          const std::shared_ptr<TabletSchema>& partial_schema, int segment_num,
+                                          PartialUpdateMode mode = PartialUpdateMode::COLUMN_UPDATE_MODE) {
         // create partial rowset
         RowsetWriterContext writer_context;
         RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
@@ -154,7 +155,7 @@ public:
         writer_context.version.first = 0;
         writer_context.version.second = 0;
         writer_context.segments_overlap = NONOVERLAPPING;
-        writer_context.partial_update_mode = PartialUpdateMode::COLUMN_MODE;
+        writer_context.partial_update_mode = mode;
         std::unique_ptr<RowsetWriter> writer;
         EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
         auto schema = ChunkHelper::convert_schema(*partial_schema.get());
@@ -737,6 +738,43 @@ TEST_F(RowsetColumnPartialUpdateTest, test_get_column_values) {
             ASSERT_EQ(columns[1]->get(i).get_int16(), (int16_t)(i % 100 + 3));
             ASSERT_EQ(columns[2]->get(i).get_int32(), (int32_t)(i % 1000 + 4));
         }
+    }
+}
+
+TEST_F(RowsetColumnPartialUpdateTest, test_upsert) {
+    const int N = 100;
+    auto tablet = create_tablet(rand(), rand());
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+    int64_t version = 1;
+    int64_t version_before_partial_update = 1;
+    prepare_tablet(this, tablet, version, version_before_partial_update, N);
+    auto v1_func = [](int64_t k1) { return (int16_t)(k1 % 100 + 3); };
+    auto v2_func = [](int64_t k1) { return (int32_t)(k1 % 1000 + 4); };
+
+    {
+        // upsert keys, because keys aren't exist, so they will be inserted.
+        std::vector<int64_t> keys(N);
+        for (int i = 0; i < N; i++) {
+            keys[i] = i + N;
+        }
+        std::vector<RowsetSharedPtr> rowsets;
+        rowsets.reserve(10);
+        std::vector<std::shared_ptr<TabletSchema>> partial_schemas;
+        // upsert v1 and v2 one by one
+        for (int i = 0; i < 10; i++) {
+            std::vector<int32_t> column_indexes = {0, (i % 2) + 1};
+            partial_schemas.push_back(TabletSchema::create(tablet->tablet_schema(), column_indexes));
+            rowsets.emplace_back(create_partial_rowset(tablet, keys, column_indexes, v1_func, v2_func,
+                                                       partial_schemas[i], 5, PartialUpdateMode::COLUMN_UPSERT_MODE));
+            ASSERT_EQ(rowsets[i]->num_update_files(), 5);
+            // preload rowset update state
+            ASSERT_OK(StorageEngine::instance()->update_manager()->on_rowset_finished(tablet.get(), rowsets[i].get()));
+        }
+        commit_rowsets(tablet, rowsets, version);
+        // check data
+        ASSERT_TRUE(check_tablet(tablet, version, 2 * N, [](int64_t k1, int64_t v1, int32_t v2) {
+            return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
+        }));
     }
 }
 

--- a/be/test/storage/rowset_column_update_state_test.cpp
+++ b/be/test/storage/rowset_column_update_state_test.cpp
@@ -139,7 +139,7 @@ public:
         writer_context.version.first = 0;
         writer_context.version.second = 0;
         writer_context.segments_overlap = NONOVERLAPPING;
-        writer_context.partial_update_mode = PartialUpdateMode::COLUMN_MODE;
+        writer_context.partial_update_mode = PartialUpdateMode::COLUMN_UPDATE_MODE;
         std::unique_ptr<RowsetWriter> writer;
         EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
         auto schema = ChunkHelper::convert_schema(*partial_schema.get());

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -276,7 +276,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 String mergeCondition = (brokerDesc == null) ? "" : brokerDesc.getMergeConditionStr();
                 TPartialUpdateMode mode = TPartialUpdateMode.UNKNOWN_MODE;
                 if (partialUpdateMode.equals("column")) {
-                    mode = TPartialUpdateMode.COLUMN_MODE;
+                    mode = TPartialUpdateMode.COLUMN_UPSERT_MODE;
                 } else if (partialUpdateMode.equals("auto")) {
                     mode = TPartialUpdateMode.AUTO_MODE;
                 } else if (partialUpdateMode.equals("row")) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -608,7 +608,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
     }
 
     public String getPartialUpdateMode() {
-        return jobProperties.get(LoadStmt.PARTIAL_UPDATE_MODE);
+        // RoutineLoad job only support row mode.
+        return "row";
     }
 
     public RoutineLoadProgress getProgress() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -322,7 +322,7 @@ public class StreamLoadInfo {
         }
         if (context.partialUpdateMode != null) {
             if (context.partialUpdateMode.equals("column")) {
-                partialUpdateMode = TPartialUpdateMode.COLUMN_MODE;
+                partialUpdateMode = TPartialUpdateMode.COLUMN_UPSERT_MODE;
             } else if (context.partialUpdateMode.equals("auto")) {
                 partialUpdateMode = TPartialUpdateMode.AUTO_MODE;
             } else if (context.partialUpdateMode.equals("row")) {
@@ -469,13 +469,7 @@ public class StreamLoadInfo {
         }
         stripOuterArray = routineLoadJob.isStripOuterArray();
         partialUpdate = routineLoadJob.isPartialUpdate();
-        if (routineLoadJob.getPartialUpdateMode().equals("column")) {
-            partialUpdateMode = TPartialUpdateMode.COLUMN_MODE;
-        } else if (routineLoadJob.getPartialUpdateMode().equals("auto")) {
-            partialUpdateMode = TPartialUpdateMode.AUTO_MODE;
-        } else if (routineLoadJob.getPartialUpdateMode().equals("row")) {
-            partialUpdateMode = TPartialUpdateMode.UNKNOWN_MODE;
-        }
+        partialUpdateMode = TPartialUpdateMode.ROW_MODE;
         if (routineLoadJob.getSessionVariables().containsKey(SessionVariable.EXEC_MEM_LIMIT)) {
             execMemLimit = Long.parseLong(routineLoadJob.getSessionVariables().get(SessionVariable.EXEC_MEM_LIMIT));
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -116,7 +116,7 @@ public class UpdatePlanner {
                                 olapTable.enableReplicatedStorage(), false, olapTable.supportedAutomaticPartition());
                 if (updateStmt.usePartialUpdate()) {
                     // using column mode partial update in UPDATE stmt
-                    ((OlapTableSink) dataSink).setPartialUpdateMode(TPartialUpdateMode.COLUMN_MODE);
+                    ((OlapTableSink) dataSink).setPartialUpdateMode(TPartialUpdateMode.COLUMN_UPDATE_MODE);
                 }
                 execPlan.getFragments().get(0).setSink(dataSink);
                 execPlan.getFragments().get(0).setLoadGlobalDicts(globalDicts);

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -553,6 +553,18 @@ public class BrokerLoadJobTest {
     }
 
     @Test
+    public void testLoadingTaskOnFinishedPartialUpdate(@Injectable BrokerPendingTaskAttachment attachment1,
+                                          @Injectable LoadTask loadTask1,
+                                          @Mocked GlobalStateMgr globalStateMgr,
+                                          @Injectable Database database) throws DdlException {
+        BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(LoadStmt.PARTIAL_UPDATE_MODE, "column");
+        brokerLoadJob.setJobProperties(properties);
+        brokerLoadJob.onTaskFinished(attachment1);
+    }
+
+    @Test
     public void testExecuteReplayOnAborted(@Injectable TransactionState txnState,
                                            @Injectable LoadJobFinalOperation attachment,
                                            @Injectable EtlStatus etlStatus) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -257,6 +257,12 @@ public class RoutineLoadJobTest {
     }
 
     @Test
+    public void testPartialUpdateMode(@Mocked GlobalStateMgr globalStateMgr) {
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+        Assert.assertEquals(routineLoadJob.getPartialUpdateMode(), "row");
+    }
+
+    @Test
     public void testUpdateTotalMoreThanBatch() {
         RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
         Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadPlannerTest.java
@@ -46,7 +46,10 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.UserException;
+import com.starrocks.load.routineload.KafkaRoutineLoadJob;
+import com.starrocks.load.routineload.RoutineLoadJob;
 import com.starrocks.load.streamload.StreamLoadInfo;
+import com.starrocks.load.streamload.StreamLoadParam;
 import com.starrocks.thrift.TFileFormatType;
 import com.starrocks.thrift.TFileType;
 import com.starrocks.thrift.TStreamLoadPutRequest;
@@ -59,6 +62,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 public class StreamLoadPlannerTest {
     @Injectable
@@ -156,6 +160,17 @@ public class StreamLoadPlannerTest {
         StreamLoadInfo streamLoadInfo = StreamLoadInfo.fromTStreamLoadPutRequest(request, db);
         StreamLoadPlanner planner = new StreamLoadPlanner(db, destTable, streamLoadInfo);
         planner.plan(streamLoadInfo.getId());
+    }
+
+    @Test
+    public void testPartialUpdateMode() throws UserException {
+        StreamLoadParam param = new StreamLoadParam();
+        param.partialUpdateMode = "column";
+        UUID uuid = UUID.randomUUID();
+        TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+        StreamLoadInfo streamLoadInfo2 = StreamLoadInfo.fromStreamLoadContext(loadId, 100, 100, param);
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+        StreamLoadInfo streamLoadInfo3 = StreamLoadInfo.fromRoutineLoadJob(routineLoadJob);
     }
 
     @Test

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -88,8 +88,9 @@ message FooterPointerPB {
 enum PartialUpdateMode {
     UNKNOWN_MODE = 0;
     ROW_MODE = 1;
-    COLUMN_MODE = 2;
+    COLUMN_UPSERT_MODE = 2;
     AUTO_MODE = 3;
+    COLUMN_UPDATE_MODE = 4;
 }
 message RowsetTxnMetaPB {
     repeated uint32 partial_update_column_ids = 1;
@@ -236,8 +237,8 @@ message TabletMetaOpPB {
     optional EditVersionPB apply = 3;
 }
 
-message TabletMetaLogPB { 
-    repeated TabletMetaOpPB ops = 1; 
+message TabletMetaLogPB {
+    repeated TabletMetaOpPB ops = 1;
 }
 
 message TabletUpdatesPB {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -514,8 +514,9 @@ struct TBinlogOffset {
 enum TPartialUpdateMode {
     UNKNOWN_MODE = 0;
     ROW_MODE = 1;
-    COLUMN_MODE = 2;
+    COLUMN_UPSERT_MODE = 2;
     AUTO_MODE = 3;
+    COLUMN_UPDATE_MODE = 4;
 }
 
 enum TRunMode {


### PR DESCRIPTION
Fixes #20436
Support upsert for the partial update by column, so we can use stream load/broker load with column mode. E.g:
```
curl --location-trusted -u root: \
    -H "label:label7" -H "column_separator:," \
    -H "partial_update:true" \
    -H "partial_update_mode:column" \
    -H "columns:id,name" \
    -T example4.csv -XPUT\
    http://<fe_host>:<fe_http_port>/api/test_db/table4/_stream_load
```

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
