### PR TITLE
[BugFix] Support set tablet state in script engine to fix tablet in NOT_READAY state in tablet meta caused by #21223

### DIFF
--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -77,6 +77,10 @@ static int tablet_tablet_state(Tablet& tablet) {
     return static_cast<int>(tablet.tablet_state());
 }
 
+static std::string tablet_set_tablet_state(Tablet& tablet, int state) {
+    return tablet.set_tablet_state(static_cast<TabletState>(state)).to_string();
+}
+
 static const TabletSchema& tablet_tablet_schema(Tablet& tablet) {
     return tablet.tablet_schema();
 }
@@ -361,6 +365,7 @@ public:
             cls.funcExt<tablet_data_dir>("data_dir");
             cls.funcExt<tablet_keys_type_int>("keys_type_as_int");
             cls.funcExt<tablet_tablet_state>("tablet_state_as_int");
+            cls.funcExt<tablet_set_tablet_state>("set_tablet_state_as_int");
             REG_METHOD(Tablet, tablet_footprint);
             REG_METHOD(Tablet, num_rows);
             REG_METHOD(Tablet, version_count);


### PR DESCRIPTION
Fixes #28735

Because of #21223, lots of tablets may already in NOT_READY state and cannot do compaction.
Although #21224 fixes this bug, early versions without the fix may already persist the bad state, which need to be updated. This PR addes a method to set tablet states in script engine, so providing a way for developer/SA to use scripts to fix error tablets. Example:

```
admin execute on 10004 '
for (info in StorageEngine.get_tablet_infos(-1, -1)) {
    if (info.state == 0) {
        var t = StorageEngine.get_tablet(info.tablet_id)
        if (t != null) {
            t.set_tablet_state_as_int(0)
            t.save_meta()
            System.print("fix table %(info.table_id) tablet %(info.tablet_id)")
        }
    }
}
';

```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
