### PR TITLE
[Feature] Support storage_cooldown_ttl for table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2216,6 +2216,16 @@ public class OlapTable extends Table {
         tableProperty.buildDataCachePartitionDuration();
     }
 
+
+    public void setStorageCoolDownTTL(PeriodDuration duration) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL,
+                TimeUtils.toHumanReadableString(duration));
+        tableProperty.buildStorageCoolDownTTL();
+    }
+
     public boolean hasForbitGlobalDict() {
         if (tableProperty == null) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2216,7 +2216,6 @@ public class OlapTable extends Table {
         tableProperty.buildDataCachePartitionDuration();
     }
 
-
     public void setStorageCoolDownTTL(PeriodDuration duration) {
         if (tableProperty == null) {
             tableProperty = new TableProperty(new HashMap<>());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -160,6 +160,8 @@ public class TableProperty implements Writable, GsonPostProcessable {
      */
     private String storageVolume;
 
+    private PeriodDuration storageCoolDownTTL;
+
     // This property only applies to materialized views
     private String resourceGroup = null;
 
@@ -503,6 +505,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildStorageCoolDownTTL() {
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL)) {
+            storageCoolDownTTL = TimeUtils.parseHumanReadablePeriodOrDuration(
+                    properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL));
+        }
+        return this;
+    }
+
     public void modifyTableProperties(Map<String, String> modifyProperties) {
         properties.putAll(modifyProperties);
     }
@@ -663,6 +673,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return dataCachePartitionDuration;
     }
 
+    public PeriodDuration getStorageCoolDownTTL() {
+        return storageCoolDownTTL;
+    }
+
     public void clearBinlogAvailableVersion() {
         binlogAvailabeVersions.clear();
         for (Iterator<Map.Entry<String, String>> it = properties.entrySet().iterator(); it.hasNext(); ) {
@@ -688,6 +702,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildReplicationNum();
         buildInMemory();
         buildStorageVolume();
+        buildStorageCoolDownTTL();
         buildEnablePersistentIndex();
         buildPersistentIndexType();
         buildCompressionType();

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -225,7 +225,7 @@ public class PropertyAnalyzer {
 
         if (hasCooldownTime && hasCoolDownTTL) {
             throw new AnalysisException("Invalid data property. "
-                    + coolDownTimeKey + " and " + coolDownTTLKey + "conflict. you can only use one of them. ");
+                    + coolDownTimeKey + " and " + coolDownTTLKey + " conflict. you can only use one of them. ");
         }
 
         properties.remove(mediumKey);
@@ -240,10 +240,8 @@ public class PropertyAnalyzer {
                 throw new AnalysisException("Can not assign cooldown timestamp to HDD storage medium");
             }
             long currentTimeMs = System.currentTimeMillis();
-            if (storageMedium == TStorageMedium.SSD) {
-                if (coolDownTimeStamp <= currentTimeMs) {
-                    throw new AnalysisException("Cooldown time should later than now");
-                }
+            if (coolDownTimeStamp <= currentTimeMs) {
+                throw new AnalysisException("Cooldown time should be later than now");
             }
 
         } else if (hasCoolDownTTL) {
@@ -251,7 +249,7 @@ public class PropertyAnalyzer {
                 throw new AnalysisException("Invalid data property. storage medium property is not found");
             }
             if (storageMedium == TStorageMedium.HDD) {
-                throw new AnalysisException("Can not assign cooldown ttl to HDD storage medium");
+                throw new AnalysisException("Can not assign cooldown ttl to table with HDD storage medium");
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2727,6 +2727,15 @@ public class GlobalStateMgr {
                     sb.append(properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM)).append("\"");
                 }
 
+                String storageCoolDownTTL =
+                        olapTable.getTableProperty().getProperties().get(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL);
+                if (storageCoolDownTTL != null) {
+                    sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR)
+                            .append(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL)
+                            .append("\" = \"")
+                            .append(storageCoolDownTTL).append("\"");
+                }
+
                 // partition live number
                 if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER)) {
                     sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_PARTITION_LIVE_NUMBER)

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -970,6 +970,12 @@ public class LocalMetastore implements ConnectorMetadata {
                 cloneProperties.putAll(sourceProperties);
             }
 
+            String storageCoolDownTTL = olapTable.getTableProperty()
+                    .getProperties().get(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL);
+            if (storageCoolDownTTL != null) {
+                cloneProperties.putIfAbsent(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL, storageCoolDownTTL);
+            }
+
             if (partitionDesc instanceof SingleRangePartitionDesc) {
                 RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
                 SingleRangePartitionDesc singleRangePartitionDesc = ((SingleRangePartitionDesc) partitionDesc);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -348,6 +348,17 @@ public class OlapTableFactory implements AbstractTableFactory {
                 }
             }
 
+            if (properties != null) {
+                try {
+                    PeriodDuration duration = PropertyAnalyzer.analyzeStorageCoolDownTTL(properties);
+                    if (duration != null) {
+                        table.setStorageCoolDownTTL(duration);
+                    }
+                } catch (AnalysisException e) {
+                    throw new DdlException(e.getMessage());
+                }
+            }
+
             if (partitionInfo.getType() == PartitionType.UNPARTITIONED) {
                 // if this is an unpartitioned table, we should analyze data property and replication num here.
                 // if this is a partitioned table, there properties are already analyzed in RangePartitionDesc analyze phase.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiItemListPartitionDesc.java
@@ -69,7 +69,7 @@ public class MultiItemListPartitionDesc extends SinglePartitionDesc {
 
         FeNameFormat.checkPartitionName(getPartitionName());
         analyzeValues(columnDefList.size());
-        analyzeProperties(tableProperties);
+        analyzeProperties(tableProperties, null);
         this.columnDefList = columnDefList;
 
         isAnalyzed = true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleItemListPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleItemListPartitionDesc.java
@@ -64,7 +64,7 @@ public class SingleItemListPartitionDesc extends SinglePartitionDesc {
         }
 
         FeNameFormat.checkPartitionName(this.getPartitionName());
-        analyzeProperties(tableProperties);
+        analyzeProperties(tableProperties, null);
 
         if (columnDefList.size() != 1) {
             throw new AnalysisException("Partition column size should be one when use single list partition ");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SinglePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SinglePartitionDesc.java
@@ -17,14 +17,22 @@ package com.starrocks.sql.ast;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.analysis.DateLiteral;
 import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTabletType;
+import org.threeten.extra.PeriodDuration;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 public abstract class SinglePartitionDesc extends PartitionDesc {
@@ -103,7 +111,8 @@ public abstract class SinglePartitionDesc extends PartitionDesc {
         return isAnalyzed;
     }
 
-    protected void analyzeProperties(Map<String, String> tableProperties) throws AnalysisException {
+    protected void analyzeProperties(Map<String, String> tableProperties,
+                                     PartitionKeyDesc partitionKeyDesc) throws AnalysisException {
         Map<String, String> partitionAndTableProperties = Maps.newHashMap();
         // The priority of the partition attribute is higher than that of the table
         if (tableProperties != null) {
@@ -117,6 +126,22 @@ public abstract class SinglePartitionDesc extends PartitionDesc {
         partitionDataProperty = PropertyAnalyzer.analyzeDataProperty(partitionAndTableProperties,
                 DataProperty.getInferredDefaultDataProperty(), false);
         Preconditions.checkNotNull(partitionDataProperty);
+
+        if (tableProperties != null && tableProperties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL)) {
+            String storageCoolDownTTL = tableProperties.get(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL);
+            PeriodDuration periodDuration = TimeUtils.parseHumanReadablePeriodOrDuration(storageCoolDownTTL);
+            if (partitionKeyDesc.isMax()) {
+                partitionDataProperty = new DataProperty(TStorageMedium.SSD, DataProperty.MAX_COOLDOWN_TIME_MS);
+            } else {
+                String stringUpperValue = partitionKeyDesc.getUpperValues().get(0).getStringValue();
+                DateTimeFormatter dateTimeFormatter = DateUtils.probeFormat(stringUpperValue);
+                LocalDateTime upperTime = DateUtils.parseStringWithDefaultHSM(stringUpperValue, dateTimeFormatter);
+                LocalDateTime updatedUpperTime = upperTime.plus(periodDuration);
+                DateLiteral dateLiteral = new DateLiteral(updatedUpperTime, Type.DATETIME);
+                long coolDownTimeStamp = dateLiteral.unixTimestamp(TimeUtils.getTimeZone());
+                partitionDataProperty = new DataProperty(TStorageMedium.SSD, coolDownTimeStamp);
+            }
+        }
 
         // analyze replication num
         replicationNum = PropertyAnalyzer

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SingleRangePartitionDesc.java
@@ -48,8 +48,12 @@ public class SingleRangePartitionDesc extends SinglePartitionDesc {
 
         FeNameFormat.checkPartitionName(getPartitionName());
         partitionKeyDesc.analyze(partColNum);
-        analyzeProperties(tableProperties);
 
+        if (partColNum == 1) {
+            analyzeProperties(tableProperties, partitionKeyDesc);
+        } else {
+            analyzeProperties(tableProperties, null);
+        }
         isAnalyzed = true;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StorageCoolDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StorageCoolDownTest.java
@@ -83,7 +83,7 @@ public class StorageCoolDownTest {
                 ));
 
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
-                "Can not assign cooldown ttl to HDD storage medium",
+                "e: Can not assign cooldown ttl to table with HDD storage medium",
                 () -> createTable(
                         "CREATE TABLE site_access_date_with_1_day_ttl_less_than(\n" +
                                 "event_day DATE,\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StorageCoolDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StorageCoolDownTest.java
@@ -1,0 +1,379 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.TimeUtils;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.DropTableStmt;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class StorageCoolDownTest {
+
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        Config.alter_scheduler_interval_millisecond = 100;
+        Config.dynamic_partition_enable = true;
+        Config.dynamic_partition_check_interval_seconds = 1;
+        Config.enable_strict_storage_medium_check = false;
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.addMockBackend(10002);
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test").useDatabase("test");
+    }
+
+    private static void createTable(String sql) throws Exception {
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+    }
+
+    @Test
+    public void testForbidCreateTable() throws Exception {
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "storage medium property is not found",
+                () -> createTable(
+                        "CREATE TABLE site_access_with_only_ttl(\n" +
+                                "event_day DATE,\n" +
+                                "site_id INT DEFAULT '10',\n" +
+                                "city_code VARCHAR(100),\n" +
+                                "user_name VARCHAR(32) DEFAULT '',\n" +
+                                "pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY RANGE(event_day)(\n" +
+                                "\tSTART (\"2021-05-01\") END (\"2021-05-04\") EVERY (INTERVAL 1 DAY)\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                                "PROPERTIES(\n" +
+                                "\t\"replication_num\" = \"1\",\n" +
+                                "    \"dynamic_partition.enable\" = \"false\",\n" +
+                                "    \"dynamic_partition.time_unit\" = \"DAY\",\n" +
+                                "    \"dynamic_partition.start\" = \"-3\",\n" +
+                                "    \"dynamic_partition.end\" = \"3\",\n" +
+                                "    \"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                                "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
+                                ");"
+                ));
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "Can not assign cooldown ttl to HDD storage medium",
+                () -> createTable(
+                        "CREATE TABLE site_access_date_with_1_day_ttl_less_than(\n" +
+                                "event_day DATE,\n" +
+                                "site_id INT DEFAULT '10',\n" +
+                                "city_code VARCHAR(100),\n" +
+                                "user_name VARCHAR(32) DEFAULT '',\n" +
+                                "pv BIGINT DEFAULT '0'\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                                "PARTITION BY RANGE(event_day)(\n" +
+                                "\tSTART (\"2021-05-01\") END (\"2021-05-04\") EVERY (INTERVAL 1 DAY)\n" +
+                                ")\n" +
+                                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                                "PROPERTIES(\n" +
+                                "\t\"replication_num\" = \"1\",\n" +
+                                "    \"dynamic_partition.enable\" = \"false\",\n" +
+                                "    \"dynamic_partition.time_unit\" = \"DAY\",\n" +
+                                "    \"dynamic_partition.start\" = \"-3\",\n" +
+                                "    \"dynamic_partition.end\" = \"3\",\n" +
+                                "    \"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                                "    \"storage_medium\" = \"HDD\",\n" +
+                                "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
+                                ");"
+                ));
+    }
+
+    @Test
+    public void testDateWithTTLLessThan() throws Exception {
+
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE site_access_datetime_with_1_day_ttl_less_than(\n" +
+                "event_day DATE,\n" +
+                "site_id INT DEFAULT '10',\n" +
+                "city_code VARCHAR(100),\n" +
+                "user_name VARCHAR(32) DEFAULT '',\n" +
+                "pv BIGINT DEFAULT '0'\n" +
+                ")\n" +
+                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                "PARTITION BY RANGE(event_day)(\n" +
+                "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
+                "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
+                "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
+                "PARTITION p20200324 VALUES LESS THAN (\"2020-03-25\")\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                "PROPERTIES(\n" +
+                "\t\"replication_num\" = \"1\",\n" +
+                "    \"dynamic_partition.enable\" = \"false\",\n" +
+                "    \"dynamic_partition.time_unit\" = \"DAY\",\n" +
+                "    \"dynamic_partition.start\" = \"-3\",\n" +
+                "    \"dynamic_partition.end\" = \"3\",\n" +
+                "    \"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                "    \"storage_medium\" = \"SSD\",\n" +
+                "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
+                ");";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
+                .getTable("site_access_datetime_with_1_day_ttl_less_than");
+
+        RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+        DataProperty p20200321 = partitionInfo.idToDataProperty.get(table.getPartition("p20200321").getId());
+        DataProperty p20200322 = partitionInfo.idToDataProperty.get(table.getPartition("p20200322").getId());
+        DataProperty p20200323 = partitionInfo.idToDataProperty.get(table.getPartition("p20200323").getId());
+        DataProperty p20200324 = partitionInfo.idToDataProperty.get(table.getPartition("p20200324").getId());
+
+        Assert.assertEquals("2020-03-23 00:00:00", TimeUtils.longToTimeString(p20200321.getCooldownTimeMs()));
+        Assert.assertEquals("2020-03-24 00:00:00", TimeUtils.longToTimeString(p20200322.getCooldownTimeMs()));
+        Assert.assertEquals("2020-03-25 00:00:00", TimeUtils.longToTimeString(p20200323.getCooldownTimeMs()));
+        Assert.assertEquals("2020-03-26 00:00:00", TimeUtils.longToTimeString(p20200324.getCooldownTimeMs()));
+
+
+        String dropSQL = "drop table site_access_datetime_with_1_day_ttl_less_than";
+        DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
+        GlobalStateMgr.getCurrentState().dropTable(dropTableStmt);
+
+    }
+
+    @Test
+    public void testDateWithTTLUpperLower() throws Exception {
+
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE `site_access_date_upper_lower_ttl` (\n" +
+                "  `event_day` date NULL COMMENT \"\",\n" +
+                "  `site_id` int(11) NULL DEFAULT \"10\" COMMENT \"\",\n" +
+                "  `city_code` varchar(100) NULL COMMENT \"\",\n" +
+                "  `user_name` varchar(32) NULL DEFAULT \"\" COMMENT \"\",\n" +
+                "  `pv` bigint(20) NULL DEFAULT \"0\" COMMENT \"\"\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`event_day`, `site_id`, `city_code`, `user_name`)\n" +
+                "PARTITION BY RANGE(`event_day`)\n" +
+                "(PARTITION p20230807 VALUES [(\"2023-08-07\"), (\"2023-08-08\")),\n" +
+                "PARTITION p20230808 VALUES [(\"2023-08-08\"), (\"2023-08-09\")),\n" +
+                "PARTITION p20230809 VALUES [(\"2023-08-09\"), (\"2023-08-10\")),\n" +
+                "PARTITION p20230810 VALUES [(\"2023-08-10\"), (\"2023-08-11\")))\n" +
+                "DISTRIBUTED BY HASH(`event_day`, `site_id`)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"dynamic_partition.enable\" = \"false\",\n" +
+                "\"dynamic_partition.time_unit\" = \"DAY\",\n" +
+                "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
+                "\"dynamic_partition.start\" = \"-3\",\n" +
+                "\"dynamic_partition.end\" = \"3\",\n" +
+                "\"dynamic_partition.prefix\" = \"p\",\n" +
+                "\"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"enable_persistent_index\" = \"false\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"storage_medium\" = \"SSD\",\n" +
+                "\"storage_cooldown_ttl\" = \"1 days\",\n" +
+                "\"compression\" = \"LZ4\"\n" +
+                ");;";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
+                .getTable("site_access_date_upper_lower_ttl");
+
+        RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+        DataProperty p20230807 = partitionInfo.idToDataProperty.get(table.getPartition("p20230807").getId());
+        DataProperty p20230808 = partitionInfo.idToDataProperty.get(table.getPartition("p20230808").getId());
+        DataProperty p20230809 = partitionInfo.idToDataProperty.get(table.getPartition("p20230809").getId());
+        DataProperty p20230810 = partitionInfo.idToDataProperty.get(table.getPartition("p20230810").getId());
+
+        Assert.assertEquals("2023-08-09 00:00:00", TimeUtils.longToTimeString(p20230807.getCooldownTimeMs()));
+        Assert.assertEquals("2023-08-10 00:00:00", TimeUtils.longToTimeString(p20230808.getCooldownTimeMs()));
+        Assert.assertEquals("2023-08-11 00:00:00", TimeUtils.longToTimeString(p20230809.getCooldownTimeMs()));
+        Assert.assertEquals("2023-08-12 00:00:00", TimeUtils.longToTimeString(p20230810.getCooldownTimeMs()));
+
+
+        String dropSQL = "drop table site_access_date_upper_lower_ttl";
+        DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
+        GlobalStateMgr.getCurrentState().dropTable(dropTableStmt);
+
+    }
+
+    @Test
+    public void testDateWithTTLStartEnd() throws Exception {
+
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE site_access_date_with_1_day_ttl_start_end(\n" +
+                "event_day DATE,\n" +
+                "site_id INT DEFAULT '10',\n" +
+                "city_code VARCHAR(100),\n" +
+                "user_name VARCHAR(32) DEFAULT '',\n" +
+                "pv BIGINT DEFAULT '0'\n" +
+                ")\n" +
+                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                "PARTITION BY RANGE(event_day)(\n" +
+                "\tSTART (\"2023-08-07\") END (\"2023-08-11\") EVERY (INTERVAL 1 DAY)\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                "PROPERTIES(\n" +
+                "\t\"replication_num\" = \"1\",\n" +
+                "    \"dynamic_partition.enable\" = \"false\",\n" +
+                "    \"dynamic_partition.time_unit\" = \"DAY\",\n" +
+                "    \"dynamic_partition.start\" = \"-3\",\n" +
+                "    \"dynamic_partition.end\" = \"3\",\n" +
+                "    \"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                "    \"storage_medium\" = \"SSD\",\n" +
+                "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
+                ");";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
+                .getTable("site_access_date_with_1_day_ttl_start_end");
+
+        RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+        DataProperty p20230807 = partitionInfo.idToDataProperty.get(table.getPartition("p20230807").getId());
+        DataProperty p20230808 = partitionInfo.idToDataProperty.get(table.getPartition("p20230808").getId());
+        DataProperty p20230809 = partitionInfo.idToDataProperty.get(table.getPartition("p20230809").getId());
+        DataProperty p20230810 = partitionInfo.idToDataProperty.get(table.getPartition("p20230810").getId());
+
+        Assert.assertEquals("2023-08-09 00:00:00", TimeUtils.longToTimeString(p20230807.getCooldownTimeMs()));
+        Assert.assertEquals("2023-08-10 00:00:00", TimeUtils.longToTimeString(p20230808.getCooldownTimeMs()));
+        Assert.assertEquals("2023-08-11 00:00:00", TimeUtils.longToTimeString(p20230809.getCooldownTimeMs()));
+        Assert.assertEquals("2023-08-12 00:00:00", TimeUtils.longToTimeString(p20230810.getCooldownTimeMs()));
+
+
+        String dropSQL = "drop table site_access_date_with_1_day_ttl_start_end";
+        DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
+        GlobalStateMgr.getCurrentState().dropTable(dropTableStmt);
+
+    }
+
+    @Test
+    public void testDateTimeWithTTLLessThan() throws Exception {
+
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE site_access_date_with_1_day_ttl_less_than(\n" +
+                "event_day DATETIME,\n" +
+                "site_id INT DEFAULT '10',\n" +
+                "city_code VARCHAR(100),\n" +
+                "user_name VARCHAR(32) DEFAULT '',\n" +
+                "pv BIGINT DEFAULT '0'\n" +
+                ")\n" +
+                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                "PARTITION BY RANGE(event_day)(\n" +
+                "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
+                "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
+                "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
+                "PARTITION p20200324 VALUES LESS THAN (\"2020-03-25\")\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                "PROPERTIES(\n" +
+                "\t\"replication_num\" = \"1\",\n" +
+                "    \"dynamic_partition.enable\" = \"false\",\n" +
+                "    \"dynamic_partition.time_unit\" = \"DAY\",\n" +
+                "    \"dynamic_partition.start\" = \"-3\",\n" +
+                "    \"dynamic_partition.end\" = \"3\",\n" +
+                "    \"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                "    \"storage_medium\" = \"SSD\",\n" +
+                "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
+                ");";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
+                .getTable("site_access_date_with_1_day_ttl_less_than");
+
+        RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+        DataProperty p20200321 = partitionInfo.idToDataProperty.get(table.getPartition("p20200321").getId());
+        DataProperty p20200322 = partitionInfo.idToDataProperty.get(table.getPartition("p20200322").getId());
+        DataProperty p20200323 = partitionInfo.idToDataProperty.get(table.getPartition("p20200323").getId());
+        DataProperty p20200324 = partitionInfo.idToDataProperty.get(table.getPartition("p20200324").getId());
+
+        Assert.assertEquals("2020-03-23 00:00:00", TimeUtils.longToTimeString(p20200321.getCooldownTimeMs()));
+        Assert.assertEquals("2020-03-24 00:00:00", TimeUtils.longToTimeString(p20200322.getCooldownTimeMs()));
+        Assert.assertEquals("2020-03-25 00:00:00", TimeUtils.longToTimeString(p20200323.getCooldownTimeMs()));
+        Assert.assertEquals("2020-03-26 00:00:00", TimeUtils.longToTimeString(p20200324.getCooldownTimeMs()));
+
+
+        String dropSQL = "drop table site_access_date_with_1_day_ttl_less_than";
+        DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
+        GlobalStateMgr.getCurrentState().dropTable(dropTableStmt);
+
+    }
+
+    @Test
+    public void testDateTimeWithMaxPartition() throws Exception {
+
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE site_access_with_max_partition (\n" +
+                "event_day DATE,\n" +
+                "site_id INT DEFAULT '10',\n" +
+                "city_code VARCHAR(100),\n" +
+                "user_name VARCHAR(32) DEFAULT '',\n" +
+                "pv BIGINT DEFAULT '0'\n" +
+                ")\n" +
+                "DUPLICATE KEY(event_day, site_id, city_code, user_name)\n" +
+                "PARTITION BY RANGE(event_day)(\n" +
+                "PARTITION p20200321 VALUES LESS THAN (\"2020-03-22\"),\n" +
+                "PARTITION p20200322 VALUES LESS THAN (\"2020-03-23\"),\n" +
+                "PARTITION p20200323 VALUES LESS THAN (\"2020-03-24\"),\n" +
+                "PARTITION p20200324 VALUES LESS THAN MAXVALUE\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(event_day, site_id)\n" +
+                "PROPERTIES(\n" +
+                "        \"replication_num\" = \"1\",\n" +
+                "    \"dynamic_partition.enable\" = \"false\",\n" +
+                "    \"dynamic_partition.time_unit\" = \"DAY\",\n" +
+                "    \"dynamic_partition.start\" = \"-3\",\n" +
+                "    \"dynamic_partition.end\" = \"3\",\n" +
+                "    \"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                "    \"storage_medium\" = \"SSD\",\n" +
+                "    \"storage_cooldown_ttl\" = \"1 day\"\n" +
+                ");";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getDb("test")
+                .getTable("site_access_with_max_partition");
+
+        RangePartitionInfo partitionInfo = (RangePartitionInfo) table.getPartitionInfo();
+        DataProperty p20200321 = partitionInfo.idToDataProperty.get(table.getPartition("p20200321").getId());
+        DataProperty p20200322 = partitionInfo.idToDataProperty.get(table.getPartition("p20200322").getId());
+        DataProperty p20200323 = partitionInfo.idToDataProperty.get(table.getPartition("p20200323").getId());
+        DataProperty p20200324 = partitionInfo.idToDataProperty.get(table.getPartition("p20200324").getId());
+
+        Assert.assertEquals("2020-03-23 00:00:00", TimeUtils.longToTimeString(p20200321.getCooldownTimeMs()));
+        Assert.assertEquals("2020-03-24 00:00:00", TimeUtils.longToTimeString(p20200322.getCooldownTimeMs()));
+        Assert.assertEquals("2020-03-25 00:00:00", TimeUtils.longToTimeString(p20200323.getCooldownTimeMs()));
+        Assert.assertEquals("9999-12-31 23:59:59", TimeUtils.longToTimeString(p20200324.getCooldownTimeMs()));
+
+
+        String dropSQL = "drop table site_access_with_max_partition";
+        DropTableStmt dropTableStmt = (DropTableStmt) UtFrameUtils.parseStmtWithNewParser(dropSQL, ctx);
+        GlobalStateMgr.getCurrentState().dropTable(dropTableStmt);
+
+    }
+}


### PR DESCRIPTION
At present, we can only set the global storage_cooldown_second or storage_cooldown_time on the table to control the cooling of the partition, but the user's demand is often to use the dynamic partition function, and then keep the latest n partitions on the SSD (n is different for different tables), currently Neither the global relative time nor the absolute time can meet this requirement.

```
CREATE TABLE site_access(
event_day DATE,
site_id INT DEFAULT '10',
city_code VARCHAR(100),
user_name VARCHAR(32) DEFAULT '',
pv BIGINT DEFAULT '0'
)
DUPLICATE KEY(event_day, site_id, city_code, user_name)
PARTITION BY RANGE(event_day)(
PARTITION p20200321 VALUES LESS THAN ("2020-03-22"),
PARTITION p20200322 VALUES LESS THAN ("2020-03-23"),
PARTITION p20200323 VALUES LESS THAN ("2020-03-24"),
PARTITION p20200324 VALUES LESS THAN MAXVALUE
)
DISTRIBUTED BY HASH(event_day, site_id)
PROPERTIES(
	"replication_num" = "1",
    "dynamic_partition.enable" = "false",
    "dynamic_partition.time_unit" = "DAY",
    "dynamic_partition.start" = "-3",
    "dynamic_partition.end" = "3",
    "dynamic_partition.history_partition_num" = "0",
    "storage_medium" = "SSD",
    "storage_cooldown_ttl" = "1 day"
);
```

```
+-------------+---------------+----------------+---------------------+--------------------+--------+--------------+----------------------------------------------------------------------------+--------------------+---------+----------------+---------------+---------------------+--------------------------+----------+------------+----------+
| PartitionId | PartitionName | VisibleVersion | VisibleVersionTime  | VisibleVersionHash | State  | PartitionKey | Range                                                                      | DistributionKey    | Buckets | ReplicationNum | StorageMedium | CooldownTime        | LastConsistencyCheckTime | DataSize | IsInMemory | RowCount |
+-------------+---------------+----------------+---------------------+--------------------+--------+--------------+----------------------------------------------------------------------------+--------------------+---------+----------------+---------------+---------------------+--------------------------+----------+------------+----------+
| 42058       | p20200321     | 1              | 2023-08-07 16:10:18 | 0                  | NORMAL | event_day    | [types: [DATE]; keys: [0000-01-01]; ..types: [DATE]; keys: [2020-03-22]; ) | event_day, site_id | 2       | 1              | SSD           | 2020-03-23 00:00:00 | NULL                     | 0B       | false      | 0        |
| 42059       | p20200322     | 1              | 2023-08-07 16:10:18 | 0                  | NORMAL | event_day    | [types: [DATE]; keys: [2020-03-22]; ..types: [DATE]; keys: [2020-03-23]; ) | event_day, site_id | 2       | 1              | SSD           | 2020-03-24 00:00:00 | NULL                     | 0B       | false      | 0        |
| 42060       | p20200323     | 1              | 2023-08-07 16:10:18 | 0                  | NORMAL | event_day    | [types: [DATE]; keys: [2020-03-23]; ..types: [DATE]; keys: [2020-03-24]; ) | event_day, site_id | 2       | 1              | SSD           | 2020-03-25 00:00:00 | NULL                     | 0B       | false      | 0        |
| 42061       | p20200324     | 1              | 2023-08-07 16:10:18 | 0                  | NORMAL | event_day    | [types: [DATE]; keys: [2020-03-24]; ..types: [DATE]; keys: [MAXVALUE]; )   | event_day, site_id | 2       | 1              | SSD           | 9999-12-31 23:59:59 | NULL                     | 0B       | false      | 0        |
+-------------+---------------+----------------+---------------------+--------------------+--------+--------------+----------------------------------------------------------------------------+--------------------+---------+----------------+---------------+---------------------+--------------------------+----------+------------+----------+
```

## What type of PR is this:
- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
