### PR TITLE
[Enhancement] Support os page cache in block cache.

### DIFF
--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -32,7 +32,8 @@ struct CacheOptions {
 
     // advanced
     size_t block_size;
-    bool checksum;
+    bool enable_checksum;
+    bool enable_direct_io;
     std::string engine;
     size_t max_concurrent_inserts;
     // The following options are only valid for cachelib engine currently

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -41,7 +41,7 @@ Status CacheLibWrapper::init(const CacheOptions& options) {
             nvmConfig.navyConfig.setRaidFiles(nvm_files, options.disk_spaces[0].size, false);
         }
         nvmConfig.navyConfig.blockCache().setRegionSize(16 * 1024 * 1024);
-        nvmConfig.navyConfig.blockCache().setDataChecksum(options.checksum);
+        nvmConfig.navyConfig.blockCache().setDataChecksum(options.enable_checksum);
         nvmConfig.navyConfig.setMaxParcelMemoryMB(options.max_parcel_memory_mb);
         nvmConfig.navyConfig.setMaxConcurrentInserts(options.max_concurrent_inserts);
         config.enableNvmCache(nvmConfig);

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -43,8 +43,9 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
         opt.disk_dir_spaces.push_back({.path = dir.path, .quota_bytes = dir.size});
     }
     opt.block_size = options.block_size;
-    opt.enable_disk_checksum = options.checksum;
+    opt.enable_disk_checksum = options.enable_checksum;
     opt.max_concurrent_writes = options.max_concurrent_inserts;
+    opt.enable_os_page_cache = !options.enable_direct_io;
 
     _cache = std::make_unique<starcache::StarCache>();
     return to_status(_cache->init(opt));

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -963,6 +963,7 @@ CONF_Int64(block_cache_lru_insertion_point, "1");
 // Set the default value empty to indicate whether it is manully configured by users.
 // If not, we need to adjust the default engine based on build switches like "WITH_CACHELIB" and "WITH_STARCACHE".
 CONF_String(block_cache_engine, "");
+CONF_Bool(block_cache_direct_io_enable, "false");
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -348,10 +348,11 @@ int main(int argc, char** argv) {
         }
         cache_options.meta_path = starrocks::config::block_cache_meta_path;
         cache_options.block_size = starrocks::config::block_cache_block_size;
-        cache_options.checksum = starrocks::config::block_cache_checksum_enable;
         cache_options.max_parcel_memory_mb = starrocks::config::block_cache_max_parcel_memory_mb;
         cache_options.max_concurrent_inserts = starrocks::config::block_cache_max_concurrent_inserts;
         cache_options.lru_insertion_point = starrocks::config::block_cache_lru_insertion_point;
+        cache_options.enable_checksum = starrocks::config::block_cache_checksum_enable;
+        cache_options.enable_direct_io = starrocks::config::block_cache_direct_io_enable;
         cache_options.engine = starrocks::config::block_cache_engine;
         EXIT_IF_ERROR(cache->init(cache_options));
     }

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -85,7 +85,7 @@ Status HdfsScannerTest::_init_block_cache(size_t mem_size, const std::string& en
     CacheOptions cache_options;
     cache_options.mem_space_size = mem_size;
     cache_options.block_size = starrocks::config::block_cache_block_size;
-    cache_options.checksum = starrocks::config::block_cache_checksum_enable;
+    cache_options.enable_checksum = starrocks::config::block_cache_checksum_enable;
     cache_options.engine = engine;
     return cache->init(cache_options);
 }


### PR DESCRIPTION
We add an option to control whether use os page cache in block cache. If it is false, read data in direct io mode.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
