### PR TITLE
[Enhancement] Encode file modification time to data cache key. (#27755)

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -334,6 +334,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.fs = _pool.add(fs.release());
     scanner_params.path = native_file_path;
     scanner_params.file_size = _scan_range.file_length;
+    scanner_params.modification_time = _scan_range.modification_time;
     scanner_params.tuple_desc = _tuple_desc;
     scanner_params.materialize_slots = _materialize_slots;
     scanner_params.materialize_index_in_chunk = _materialize_index_in_chunk;

--- a/be/src/exec/vectorized/hdfs_scanner.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner.cpp
@@ -218,7 +218,8 @@ Status HdfsScanner::open_random_access_file() {
 
         // input_stream = CacheInputStream(input_stream)
         if (_scanner_params.use_block_cache) {
-            _cache_input_stream = std::make_shared<io::CacheInputStream>(input_stream, filename, file_size);
+            _cache_input_stream = std::make_shared<io::CacheInputStream>(input_stream, filename, file_size,
+                                                                         _scanner_params.modification_time);
             _cache_input_stream->set_enable_populate_cache(_scanner_params.enable_populate_block_cache);
             _shared_buffered_input_stream->set_align_size(_cache_input_stream->get_align_size());
             input_stream = _cache_input_stream;

--- a/be/src/exec/vectorized/hdfs_scanner.h
+++ b/be/src/exec/vectorized/hdfs_scanner.h
@@ -109,6 +109,8 @@ struct HdfsScannerParams {
     // The file size. -1 means unknown.
     int64_t file_size = -1;
 
+    int64_t modification_time = 0;
+
     const TupleDescriptor* tuple_desc = nullptr;
 
     // columns read from file

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -13,7 +13,7 @@
 namespace starrocks::io {
 
 CacheInputStream::CacheInputStream(std::shared_ptr<SeekableInputStream> stream, const std::string& filename,
-                                   size_t size)
+                                   size_t size, int64_t modification_time)
         : SeekableInputStreamWrapper(stream.get(), kDontTakeOwnership),
           _filename(filename),
           _stream(stream),
@@ -22,12 +22,22 @@ CacheInputStream::CacheInputStream(std::shared_ptr<SeekableInputStream> stream, 
 #ifdef WITH_BLOCK_CACHE
     // _cache_key = _filename;
     // use hash(filename) as cache key.
-    _cache_key.resize(16);
+    _cache_key.resize(12);
     char* data = _cache_key.data();
     uint64_t hash_value = HashUtil::hash64(filename.data(), filename.size(), 0);
     memcpy(data, &hash_value, sizeof(hash_value));
-    int64_t file_size = _size;
-    memcpy(data + 8, &file_size, sizeof(file_size));
+    // The modification time is more appropriate to indicate the different file versions.
+    // While some data source, such as Hudi, have no modification time because their files
+    // cannot be overwritten. So, if the modification time is unsupported, we use file size instead.
+    // Usually the last modification timestamp has 41 bits, to reduce memory usage, we ignore the tail 9
+    // bytes and choose the high 32 bits to represent the second timestamp.
+    if (modification_time > 0) {
+        uint32_t mtime_s = (modification_time >> 9) & 0x00000000FFFFFFFF;
+        memcpy(data + 8, &mtime_s, sizeof(mtime_s));
+    } else {
+        uint32_t file_size = _size;
+        memcpy(data + 8, &file_size, sizeof(file_size));
+    }
     _buffer.reserve(BlockCache::instance()->block_size());
 #endif
 }

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -22,7 +22,8 @@ public:
         int64_t write_cache_fail_bytes = 0;
     };
 
-    explicit CacheInputStream(std::shared_ptr<SeekableInputStream> stream, const std::string& filename, size_t size);
+    explicit CacheInputStream(std::shared_ptr<SeekableInputStream> stream, const std::string& filename, size_t size,
+                              int64_t modification_time);
 
     ~CacheInputStream() override = default;
 

--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -90,7 +90,7 @@ TEST_F(CacheInputStreamTest, test_aligned_read) {
     gen_test_data(data, data_size, block_size);
 
     std::shared_ptr<io::SeekableInputStream> stream(new MockSeekableInputStream(data, data_size));
-    io::CacheInputStream cache_stream(stream, "test_file1", data_size);
+    io::CacheInputStream cache_stream(stream, "test_file1", data_size, 1000000);
     cache_stream.set_enable_populate_cache(true);
     auto& stats = cache_stream.stats();
 
@@ -120,7 +120,7 @@ TEST_F(CacheInputStreamTest, test_random_read) {
     gen_test_data(data, data_size, block_size);
 
     std::shared_ptr<io::SeekableInputStream> stream(new MockSeekableInputStream(data, data_size));
-    io::CacheInputStream cache_stream(stream, "test_file2", data_size);
+    io::CacheInputStream cache_stream(stream, "test_file2", data_size, 1000000);
     cache_stream.set_enable_populate_cache(true);
     auto& stats = cache_stream.stats();
 
@@ -146,6 +146,47 @@ TEST_F(CacheInputStreamTest, test_random_read) {
     ASSERT_TRUE(check_data_content(buffer + block_size - off_in_block, block_size, 'a' + 2));
 
     ASSERT_EQ(stats.read_cache_count, 2);
+}
+
+TEST_F(CacheInputStreamTest, test_file_overwrite) {
+    const int64_t block_count = 3;
+
+    int64_t data_size = block_size * block_count;
+    char data[data_size + 1];
+    gen_test_data(data, data_size, block_size);
+
+    std::shared_ptr<io::SeekableInputStream> stream(new MockSeekableInputStream(data, data_size));
+    io::CacheInputStream cache_stream(stream, "test_file3", data_size, 1000000);
+    cache_stream.set_enable_populate_cache(true);
+    auto& stats = cache_stream.stats();
+
+    // first read from backend
+    for (int i = 0; i < block_count; ++i) {
+        char buffer[block_size];
+        read_stream_data(&cache_stream, i * block_size, block_size, buffer);
+        ASSERT_TRUE(check_data_content(buffer, block_size, 'a' + i));
+    }
+    ASSERT_EQ(stats.read_cache_count, 0);
+    ASSERT_EQ(stats.write_cache_count, block_count);
+
+    // first read from cache
+    for (int i = 0; i < block_count; ++i) {
+        char buffer[block_size];
+        read_stream_data(&cache_stream, i * block_size, block_size, buffer);
+        ASSERT_TRUE(check_data_content(buffer, block_size, 'a' + i));
+    }
+    ASSERT_EQ(stats.read_cache_count, block_count);
+
+    // With different modification time, the old cache cannot be used
+    io::CacheInputStream cache_stream2(stream, "test_file3", data_size, 2000000);
+    cache_stream2.set_enable_populate_cache(true);
+    auto& stats2 = cache_stream2.stats();
+    for (int i = 0; i < block_count; ++i) {
+        char buffer[block_size];
+        read_stream_data(&cache_stream2, i * block_size, block_size, buffer);
+        ASSERT_TRUE(check_data_content(buffer, block_size, 'a' + i));
+    }
+    ASSERT_EQ(stats2.read_cache_count, 0);
 }
 
 } // namespace starrocks::io

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileDesc.java
@@ -9,16 +9,18 @@ public class RemoteFileDesc {
     private String fileName;
     private String compression;
     private long length;
+    private long modificationTime;
     private ImmutableList<RemoteFileBlockDesc> blockDescs;
     private boolean splittable;
     private TextFileFormatDesc textFileFormatDesc;
     private ImmutableList<String> hudiDeltaLogs;
 
-    public RemoteFileDesc(String fileName, String compression, long length,
+    public RemoteFileDesc(String fileName, String compression, long length, long modificationTime,
                           ImmutableList<RemoteFileBlockDesc> blockDescs, ImmutableList<String> hudiDeltaLogs) {
         this.fileName = fileName;
         this.compression = compression;
         this.length = length;
+        this.modificationTime = modificationTime;
         this.blockDescs = blockDescs;
         this.hudiDeltaLogs = hudiDeltaLogs;
     }
@@ -33,6 +35,10 @@ public class RemoteFileDesc {
 
     public long getLength() {
         return length;
+    }
+
+    public long getModificationTime() {
+        return modificationTime;
     }
 
     public ImmutableList<RemoteFileBlockDesc> getBlockDescs() {
@@ -67,6 +73,7 @@ public class RemoteFileDesc {
         sb.append("fileName='").append(fileName).append('\'');
         sb.append(", compression='").append(compression).append('\'');
         sb.append(", length=").append(length);
+        sb.append(", modificationTime=").append(modificationTime);
         sb.append(", blockDescs=").append(blockDescs);
         sb.append(", splittable=").append(splittable);
         sb.append(", textFileFormatDesc=").append(textFileFormatDesc);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -91,6 +91,7 @@ public class RemoteScanRangeLocations {
         hdfsScanRange.setLength(length);
         hdfsScanRange.setPartition_id(partitionId);
         hdfsScanRange.setFile_length(fileDesc.getLength());
+        hdfsScanRange.setModification_time(fileDesc.getModificationTime());
         hdfsScanRange.setFile_format(partition.getFormat().toThrift());
         hdfsScanRange.setText_file_desc(fileDesc.getTextFileFormatDesc().toThrift());
         TScanRange scanRange = new TScanRange();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
@@ -79,7 +79,8 @@ public class HiveRemoteFileIO implements RemoteFileIO {
                 BlockLocation[] blockLocations = locatedFileStatus.getBlockLocations();
                 List<RemoteFileBlockDesc> fileBlockDescs = getRemoteFileBlockDesc(blockLocations);
                 fileDescs.add(new RemoteFileDesc(fileName, "", locatedFileStatus.getLen(),
-                        ImmutableList.copyOf(fileBlockDescs), ImmutableList.of()));
+                              locatedFileStatus.getModificationTime(), ImmutableList.copyOf(fileBlockDescs),
+                              ImmutableList.of()));
             }
         } catch (Exception e) {
             LOG.error("Failed to get hive remote file's metadata on path: {}", path, e);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
@@ -78,7 +78,8 @@ public class HudiRemoteFileIO implements RemoteFileIO {
                 String fileName = baseFile.map(BaseFile::getFileName).orElse("");
                 long fileLength = baseFile.map(BaseFile::getFileLen).orElse(-1L);
                 List<String> logs = fileSlice.getLogFiles().map(HoodieLogFile::getFileName).collect(Collectors.toList());
-                fileDescs.add(new RemoteFileDesc(fileName, "", fileLength,
+                // The file name of HoodieBaseFile contains "instantTime", so we set the `modificationTime` to 0.
+                fileDescs.add(new RemoteFileDesc(fileName, "", fileLength, 0,
                         ImmutableList.of(), ImmutableList.copyOf(logs)));
             }
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileTableScanNode.java
@@ -82,6 +82,7 @@ public class FileTableScanNode extends ScanNode {
             hdfsScanRange.setOffset(blockDesc.getOffset());
             hdfsScanRange.setLength(blockDesc.getLength());
             hdfsScanRange.setFile_length(file.getLength());
+            hdfsScanRange.setModification_time(file.getModificationTime());
             hdfsScanRange.setFile_format(fileTable.getFileFormat().toThrift());
             TScanRange scanRange = new TScanRange();
             scanRange.setHdfs_scan_range(hdfsScanRange);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -246,6 +246,7 @@ public class IcebergScanNode extends ScanNode {
                 // For iceberg table we do not need partition id
                 hdfsScanRange.setPartition_id(-1);
                 hdfsScanRange.setFile_length(file.fileSizeInBytes());
+                hdfsScanRange.setModification_time(0);
                 hdfsScanRange.setFile_format(IcebergUtil.getHdfsFileFormat(file.format()).toThrift());
 
                 hdfsScanRange.setDelete_files(task.deletes().stream().map(source -> {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveRemoteFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveRemoteFileIOTest.java
@@ -34,6 +34,7 @@ public class HiveRemoteFileIOTest {
         Assert.assertEquals("000000_0", fileDesc.getFileName());
         Assert.assertEquals("", fileDesc.getCompression());
         Assert.assertEquals(20, fileDesc.getLength());
+        Assert.assertEquals(1234567890, fileDesc.getModificationTime());
         Assert.assertFalse(fileDesc.isSplittable());
         Assert.assertNull(fileDesc.getTextFileFormatDesc());
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedRemoteFileSystem.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedRemoteFileSystem.java
@@ -31,16 +31,16 @@ public class MockedRemoteFileSystem extends FileSystem {
     }
 
     public static LocatedFileStatus locatedFileStatus(Path path) {
-        return locatedFileStatus(path, 20);
+        return locatedFileStatus(path, 20, 1234567890);
     }
 
-    public static LocatedFileStatus locatedFileStatus(Path path, long fileLength) {
+    public static LocatedFileStatus locatedFileStatus(Path path, long fileLength, long modificationTime) {
         return new LocatedFileStatus(
                 fileLength,
                 false,
                 0,
                 0L,
-                0L,
+                modificationTime,
                 0L,
                 null,
                 null,

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -299,6 +299,10 @@ struct THdfsScanRange {
     10: optional bool use_hudi_jni_reader;
 
     11: optional list<TIcebergDeleteFile> delete_files;
+
+    // last modification time of the hdfs file, for data cache
+    12: optional i64 modification_time
+
 }
 
 // Specification of an individual data range which is held in its entirety


### PR DESCRIPTION
Before, we use the file path and file size compose the data cache key, which may result in access to expired cache data when the remote file is overwritten. So, we also encode the file modification time to cache key to indicate the file modification, avoid visiting expired cache.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
