### PR TITLE
[Enhancement] Implement bthread support for future/promise

### DIFF
--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -99,6 +99,8 @@ set(UTIL_FILES
   random.cc
   stack_trace_mutex.cpp
   failpoint/fail_point.cpp
+  bthreads/future.h
+  bthreads/future_impl.cpp
 )
 
 add_library(Util STATIC

--- a/be/src/util/bthreads/future.h
+++ b/be/src/util/bthreads/future.h
@@ -1,0 +1,465 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cxxabi.h>
+
+#include "util/bthreads/future_impl.h"
+
+namespace starrocks::bthreads {
+
+// Forward declarations.
+template <typename R>
+class Future;
+
+template <typename R>
+class SharedFuture;
+
+template <typename R>
+class Promise;
+
+template <typename R>
+class FutureBase {
+public:
+    DISALLOW_COPY(FutureBase);
+
+    bool valid() const noexcept { return static_cast<bool>(_state); }
+
+    void wait() const {
+        SharedStateBase::check_state(_state);
+        _state->wait();
+    }
+
+    template <typename _Rep, typename _Period>
+    future_status wait_for(const std::chrono::duration<_Rep, _Period>& __rel) const {
+        SharedStateBase::check_state(_state);
+        return _state->wait_for(__rel);
+    }
+
+    template <typename _Clock, typename _Duration>
+    future_status wait_until(const std::chrono::time_point<_Clock, _Duration>& __abs) const {
+        SharedStateBase::check_state(_state);
+        return _state->wait_until(__abs);
+    }
+
+    SharedFuture<R> share() { return SharedFuture<R>(std::move(_state)); }
+
+protected:
+    constexpr FutureBase() noexcept : _state() {}
+
+    explicit FutureBase(std::shared_ptr<SharedState<R>> state) noexcept : _state(std::move(state)) {}
+
+    void wait_and_check_exception() const {
+        if (!static_cast<bool>(_state)) {
+            throw FutureError(future_errc::no_state);
+        }
+        this->_state->wait();
+        if (this->_state->get_exception_ptr() != nullptr) {
+            std::rethrow_exception(this->_state->get_exception_ptr());
+        }
+    }
+
+    struct Reset {
+        explicit Reset(FutureBase& future) noexcept : _future(future) {}
+        ~Reset() { _future._state.reset(); }
+        FutureBase& _future;
+    };
+
+    std::shared_ptr<SharedState<R>> _state;
+};
+
+template <typename R>
+class Future : public FutureBase<R> {
+    static_assert(!std::is_array_v<R>, "result type must not be an array");
+    static_assert(!std::is_function_v<R>, "result type must not be a function");
+    static_assert(std::is_destructible_v<R>, "result type must be destructible");
+
+    using BaseType = FutureBase<R>;
+
+public:
+    constexpr Future() noexcept : BaseType() {}
+
+    /// Move constructor
+    Future(Future&& rhs) noexcept : BaseType(std::move(rhs._state)) {}
+
+    DISALLOW_COPY(Future);
+
+    // Move assignment
+    Future& operator=(Future&& rhs) noexcept {
+        Future(std::move(rhs)).swap(*this);
+        return *this;
+    }
+
+    void swap(Future& rhs) noexcept { this->_state.swap(rhs._state); }
+
+    R get() {
+        typename BaseType::Reset reset(*this);
+        SharedStateBase::check_state(this->_state);
+        this->wait_and_check_exception();
+        return std::move(this->_state->value());
+    }
+
+private:
+    friend class Promise<R>;
+
+    explicit Future(std::shared_ptr<SharedState<R>> state) : BaseType(std::move(state)) {}
+};
+
+template <typename R>
+class Future<R&> : public FutureBase<R&> {
+    typedef FutureBase<R&> BaseType;
+
+public:
+    constexpr Future() noexcept : BaseType() {}
+
+    /// Move constructor
+    Future(Future&& rhs) noexcept : BaseType(std::move(rhs._state)) {}
+
+    DISALLOW_COPY(Future);
+
+    // Move assignment
+    Future& operator=(Future&& future) noexcept {
+        Future(std::move(future)).swap(*this);
+        return *this;
+    }
+
+    void swap(Future& rhs) noexcept { this->_state.swap(rhs._state); }
+
+    R& get() {
+        typename BaseType::Reset reset(*this);
+        SharedStateBase::check_state(this->_state);
+        this->wait_and_check_exception();
+        return this->_state->value();
+    }
+
+private:
+    friend class Promise<R&>;
+
+    explicit Future(std::shared_ptr<SharedState<R&>> state) : BaseType(std::move(state)) {}
+};
+
+template <>
+class Future<void> : public FutureBase<void> {
+    typedef FutureBase<void> BaseType;
+
+public:
+    constexpr Future() noexcept : BaseType() {}
+
+    // Move constructor
+    Future(Future&& rhs) noexcept : BaseType(std::move(rhs._state)) {}
+
+    DISALLOW_COPY(Future);
+
+    // Move assignment
+    Future& operator=(Future&& future) noexcept {
+        Future(std::move(future)).swap(*this);
+        return *this;
+    }
+
+    void swap(Future& rhs) noexcept { this->_state.swap(rhs._state); }
+
+    void get() {
+        typename BaseType::Reset reset(*this);
+        this->wait_and_check_exception();
+    }
+
+private:
+    friend class Promise<void>;
+
+    explicit Future(std::shared_ptr<SharedState<void>> state) : BaseType(std::move(state)) {}
+};
+
+template <typename R>
+inline void swap(Future<R>& x, Future<R>& y) noexcept {
+    x.swap(y);
+}
+
+template <typename R>
+class SharedFuture : public FutureBase<R> {
+    static_assert(!std::is_array_v<R>, "result type must not be an array");
+    static_assert(!std::is_function_v<R>, "result type must not be a function");
+    static_assert(std::is_destructible_v<R>, "result type must be destructible");
+
+public:
+    constexpr SharedFuture() noexcept : BaseType() {}
+
+    // Copy constructor
+    SharedFuture(const SharedFuture& rhs) noexcept : BaseType(rhs._state) {}
+
+    // Move constructor
+    SharedFuture(SharedFuture&& rhs) noexcept : BaseType(std::move(rhs._state)) {}
+
+    // Copy assignment
+    SharedFuture& operator=(const SharedFuture& rhs) {
+        this->_state = rhs._state;
+        return *this;
+    }
+
+    // Move assignment
+    SharedFuture& operator=(SharedFuture&& rhs) noexcept {
+        SharedFuture(std::move(rhs)).swap(*this);
+        return *this;
+    }
+
+    // Construct from a Future
+    SharedFuture(Future<R>&& future) noexcept : BaseType(std::move(future._state)) {}
+
+    void swap(SharedFuture& rhs) noexcept { this->_state.swap(rhs._state); }
+
+    R get() const {
+        SharedStateBase::check_state(this->_state);
+        this->wait_and_check_exception();
+        return std::move(this->_state->value());
+    }
+
+private:
+    friend class Promise<R>;
+    friend class Future<R>;
+
+    using BaseType = FutureBase<R>;
+
+    explicit SharedFuture(std::shared_ptr<SharedState<R>> state) : BaseType(std::move(state)) {}
+};
+
+template <typename R>
+class SharedFuture<R&> : public FutureBase<R&> {
+    typedef FutureBase<R&> BaseType;
+
+public:
+    constexpr SharedFuture() noexcept : BaseType() {}
+
+    // Move constructor
+    SharedFuture(SharedFuture&& rhs) noexcept : BaseType(std::move(rhs._state)) {}
+
+    // Copy constructor
+    SharedFuture(const SharedFuture& rhs) : BaseType(rhs._state) {}
+
+    // Construct from a Future
+    SharedFuture(Future<R&>&& future) : BaseType(std::move(future._state)) {}
+
+    // Copy assignment
+    SharedFuture& operator=(const SharedFuture& rhs) {
+        this->_state = rhs._state;
+        return *this;
+    }
+
+    // Move assignment
+    SharedFuture& operator=(SharedFuture&& future) noexcept {
+        Future(std::move(future)).swap(*this);
+        return *this;
+    }
+
+    void swap(SharedFuture& rhs) noexcept { this->_state.swap(rhs._state); }
+
+    R& get() const {
+        SharedStateBase::check_state(this->_state);
+        this->wait_and_check_exception();
+        return this->_state->value();
+    }
+
+private:
+    friend class Promise<R&>;
+
+    explicit SharedFuture(std::shared_ptr<SharedState<R&>> state) : BaseType(std::move(state)) {}
+};
+
+template <>
+class SharedFuture<void> : public FutureBase<void> {
+    typedef FutureBase<void> BaseType;
+
+public:
+    constexpr SharedFuture() noexcept : BaseType() {}
+
+    // Move constructor
+    SharedFuture(SharedFuture&& rhs) noexcept : BaseType(std::move(rhs._state)) {}
+
+    // Copy constructor
+    SharedFuture(const SharedFuture& rhs) : BaseType(rhs._state) {}
+
+    // Construct from a Future
+    SharedFuture(Future<void>&& future) : BaseType(std::move(future._state)) {}
+
+    // Assignment
+    SharedFuture& operator=(const SharedFuture& rhs) {
+        this->_state = rhs._state;
+        return *this;
+    }
+
+    // Move assignment
+    SharedFuture& operator=(SharedFuture&& rhs) noexcept {
+        SharedFuture(std::move(rhs)).swap(*this);
+        return *this;
+    }
+
+    void swap(SharedFuture& rhs) noexcept { _state.swap(rhs._state); }
+
+    /// Retrieving the value
+    void get() const {
+        SharedStateBase::check_state(this->_state);
+        this->wait_and_check_exception();
+    }
+
+private:
+    friend class Promise<void>;
+
+    explicit SharedFuture(std::shared_ptr<SharedState<void>> state) : BaseType(std::move(state)) {}
+};
+
+template <typename R>
+inline void swap(SharedFuture<R>& x, SharedFuture<R>& y) noexcept {
+    x.swap(y);
+}
+
+template <typename R>
+class Promise {
+    static_assert(!std::is_array_v<R>, "result type must not be an array");
+    static_assert(!std::is_function_v<R>, "result type must not be a function");
+    static_assert(std::is_destructible_v<R>, "result type must be destructible");
+
+public:
+    Promise() : _state(std::make_shared<SharedState<R>>()) {}
+
+    // Move constructor
+    Promise(Promise&& rhs) noexcept : _state(std::move(rhs._state)) {}
+
+    DISALLOW_COPY(Promise);
+
+    ~Promise() {
+        if (static_cast<bool>(_state) && !_state.unique()) _state->break_promise();
+    }
+
+    // Assignment
+    Promise& operator=(Promise&& rhs) noexcept {
+        Promise(std::move(rhs)).swap(*this);
+        return *this;
+    }
+
+    void swap(Promise& rhs) noexcept { _state.swap(rhs._state); }
+
+    // Retrieving the result
+    Future<R> get_future() {
+        SharedStateBase::check_state(_state);
+        _state->set_retrieved_flag();
+        return Future<R>(_state);
+    }
+
+    void set_value(const R& value) {
+        SharedStateBase::check_state(this->_state);
+        this->_state->set_value(value);
+    }
+
+    void set_value(R&& value) {
+        SharedStateBase::check_state(this->_state);
+        this->_state->set_value(std::move(value));
+    }
+
+    void set_exception(std::exception_ptr ex) {
+        SharedStateBase::check_state(this->_state);
+        this->_state->set_exception(ex);
+    }
+
+private:
+    std::shared_ptr<SharedState<R>> _state;
+};
+
+template <typename R>
+class Promise<R&> {
+public:
+    Promise() : _state(std::make_shared<SharedState<R&>>()) {}
+
+    // Move constructor
+    Promise(Promise&& rhs) noexcept : _state(std::move(rhs._state)) {}
+
+    DISALLOW_COPY(Promise);
+
+    ~Promise() {
+        if (static_cast<bool>(_state) && !_state.unique()) _state->break_promise();
+    }
+
+    // Assignment
+    Promise& operator=(Promise&& rhs) noexcept {
+        Promise(std::move(rhs)).swap(*this);
+        return *this;
+    }
+
+    void swap(Promise& rhs) noexcept { _state.swap(rhs._state); }
+
+    Future<R&> get_future() {
+        SharedStateBase::check_state(_state);
+        _state->set_retrieved_flag();
+        return Future<R&>(_state);
+    }
+
+    void set_value(R& value) {
+        SharedStateBase::check_state(this->_state);
+        _state->set_value(value);
+    }
+
+    void set_exception(std::exception_ptr e) {
+        SharedStateBase::check_state(this->_state);
+        _state->set_exception(e);
+    }
+
+private:
+    std::shared_ptr<SharedState<R&>> _state;
+};
+
+template <>
+class Promise<void> {
+    std::shared_ptr<SharedState<void>> _state;
+
+public:
+    Promise() : _state(std::make_shared<SharedState<void>>()) {}
+
+    // Move constructor
+    Promise(Promise&& rhs) noexcept : _state(std::move(rhs._state)) {}
+
+    DISALLOW_COPY(Promise);
+
+    ~Promise() {
+        if (static_cast<bool>(_state) && !_state.unique()) _state->break_promise();
+    }
+
+    // Assignment
+    Promise& operator=(Promise&& rhs) noexcept {
+        Promise(std::move(rhs)).swap(*this);
+        return *this;
+    }
+
+    void swap(Promise& rhs) noexcept { _state.swap(rhs._state); }
+
+    Future<void> get_future() {
+        SharedStateBase::check_state(_state);
+        _state->set_retrieved_flag();
+        return Future<void>(_state);
+    }
+
+    void set_value() {
+        SharedStateBase::check_state(this->_state);
+        _state->set_value();
+    }
+
+    void set_exception(std::exception_ptr e) {
+        SharedStateBase::check_state(this->_state);
+        _state->set_exception(e);
+    }
+};
+
+template <typename R>
+inline void swap(Promise<R>& x, Promise<R>& y) noexcept {
+    x.swap(y);
+}
+
+} // namespace starrocks::bthreads

--- a/be/src/util/bthreads/future.h
+++ b/be/src/util/bthreads/future.h
@@ -63,7 +63,7 @@ protected:
 
     void wait_and_check_exception() const {
         if (!static_cast<bool>(_state)) {
-            throw FutureError(future_errc::no_state);
+            throw future_error(future_errc::no_state);
         }
         this->_state->wait();
         if (this->_state->get_exception_ptr() != nullptr) {

--- a/be/src/util/bthreads/future.h
+++ b/be/src/util/bthreads/future.h
@@ -43,15 +43,15 @@ public:
     }
 
     template <typename _Rep, typename _Period>
-    future_status wait_for(const std::chrono::duration<_Rep, _Period>& __rel) const {
+    future_status wait_for(const std::chrono::duration<_Rep, _Period>& rel) const {
         SharedStateBase::check_state(_state);
-        return _state->wait_for(__rel);
+        return _state->wait_for(rel);
     }
 
     template <typename _Clock, typename _Duration>
-    future_status wait_until(const std::chrono::time_point<_Clock, _Duration>& __abs) const {
+    future_status wait_until(const std::chrono::time_point<_Clock, _Duration>& abs) const {
         SharedStateBase::check_state(_state);
-        return _state->wait_until(__abs);
+        return _state->wait_until(abs);
     }
 
     SharedFuture<R> share() { return SharedFuture<R>(std::move(_state)); }

--- a/be/src/util/bthreads/future_impl.cpp
+++ b/be/src/util/bthreads/future_impl.cpp
@@ -1,0 +1,54 @@
+//
+// Created by alex on 8/7/23.
+//
+
+#include "util/bthreads/future_impl.h"
+
+#include <exception>
+#include <system_error>
+
+namespace starrocks::bthreads {
+class future_error_category : public std::error_category {
+public:
+    const char* name() const noexcept override { return "bthread-future"; }
+
+    std::error_condition default_error_condition(int ev) const noexcept override {
+        switch (static_cast<future_errc>(ev)) {
+        case future_errc::broken_promise:
+            return std::error_condition{static_cast<int>(future_errc::broken_promise), future_category()};
+        case future_errc::future_already_retrieved:
+            return std::error_condition{static_cast<int>(future_errc::future_already_retrieved), future_category()};
+        case future_errc::promise_already_satisfied:
+            return std::error_condition{static_cast<int>(future_errc::promise_already_satisfied), future_category()};
+        case future_errc::no_state:
+            return std::error_condition{static_cast<int>(future_errc::no_state), future_category()};
+        default:
+            return std::error_condition{ev, *this};
+        }
+    }
+
+    bool equivalent(std::error_code const& code, int condition) const noexcept override {
+        return *this == code.category() && static_cast<int>(default_error_condition(code.value()).value()) == condition;
+    }
+
+    std::string message(int ev) const override {
+        switch (static_cast<future_errc>(ev)) {
+        case future_errc::broken_promise:
+            return std::string{"Broken promise."};
+        case future_errc::future_already_retrieved:
+            return std::string{"Future already retrieved."};
+        case future_errc::promise_already_satisfied:
+            return std::string{"Promise already satisfied."};
+        case future_errc::no_state:
+            return std::string{"No associated state."};
+        }
+        return std::string{"Unknown error."};
+    }
+};
+
+std::error_category const& future_category() noexcept {
+    static future_error_category cat;
+    return cat;
+}
+
+} // namespace starrocks::bthreads

--- a/be/src/util/bthreads/future_impl.cpp
+++ b/be/src/util/bthreads/future_impl.cpp
@@ -1,10 +1,19 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
-// Created by alex on 8/7/23.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "util/bthreads/future_impl.h"
 
-#include <exception>
 #include <system_error>
 
 namespace starrocks::bthreads {

--- a/be/src/util/bthreads/future_impl.h
+++ b/be/src/util/bthreads/future_impl.h
@@ -1,0 +1,255 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bthread/butex.h>
+
+#include <exception>
+#include <functional>
+#include <future>
+#include <optional>
+
+#include "gutil/macros.h"
+#include "util/time.h"
+
+namespace starrocks::bthreads {
+
+enum future_status { ready, timeout };
+
+enum class future_errc { future_already_retrieved = 1, promise_already_satisfied, no_state, broken_promise };
+
+extern const std::error_category& future_category() noexcept;
+} // namespace starrocks::bthreads
+
+namespace std {
+
+template <>
+struct is_error_code_enum<starrocks::bthreads::future_errc> : public true_type {};
+
+inline std::error_code make_error_code(starrocks::bthreads::future_errc e) noexcept {
+    return std::error_code{static_cast<int>(e), starrocks::bthreads::future_category()};
+}
+
+inline std::error_condition make_error_condition(starrocks::bthreads::future_errc e) noexcept {
+    return std::error_condition{static_cast<int>(e), starrocks::bthreads::future_category()};
+}
+
+} // namespace std
+
+namespace starrocks::bthreads {
+
+class FutureError : public std::system_error {
+public:
+    explicit FutureError(future_errc code) : std::system_error(std::make_error_code(code)) {}
+
+    ~FutureError() override = default;
+};
+
+template <typename R>
+class FutureBase;
+
+// Forward declarations.
+template <typename R>
+class Future;
+
+template <typename R>
+class SharedFuture;
+
+template <typename _Signature>
+class packaged_task;
+
+template <typename R>
+class Promise;
+
+class SharedStateBase {
+public:
+    virtual ~SharedStateBase() { bthread::butex_destroy(_status); }
+
+    DISALLOW_COPY_AND_MOVE(SharedStateBase);
+
+    template <typename T>
+    static void check_state(const std::shared_ptr<T>& p) {
+        if (!static_cast<bool>(p)) throw FutureError(future_errc::no_state);
+    }
+
+protected:
+    enum Status { kNotReady, kWriting, kReady };
+
+    SharedStateBase() {
+        _status = bthread::butex_create_checked<butil::atomic<int>>();
+        _status->store(Status::kNotReady, butil::memory_order_release);
+    }
+
+    std::exception_ptr get_exception_ptr() const { return _exception; }
+
+    void set_exception(std::exception_ptr exception) {
+        int expect_status = Status::kNotReady;
+        if (_status->compare_exchange_strong(expect_status, Status::kWriting, butil::memory_order_acq_rel)) {
+            _exception = exception;
+            mark_ready_ant_notify();
+        } else {
+            throw FutureError(future_errc::promise_already_satisfied);
+        }
+    }
+
+    void wait() {
+        int curr_status;
+        while ((curr_status = _status->load(butil::memory_order_acquire)) != Status::kReady) {
+            (void)bthread::butex_wait(_status, curr_status, nullptr);
+        }
+    }
+
+    template <typename Rep, typename Period>
+    future_status wait_for(const std::chrono::duration<Rep, Period>& dur) {
+        if (_status->load(butil::memory_order_acquire) == Status::kReady) return future_status::ready;
+
+        return wait_until(std::chrono::steady_clock::now() +
+                          std::chrono::ceil<std::chrono::steady_clock::duration>(dur));
+    }
+
+    template <typename Clock, typename Duration>
+    future_status wait_until(const std::chrono::time_point<Clock, Duration>& abs) {
+        int curr_status;
+        timespec ts = TimespecFromTimePoint(abs);
+        while ((curr_status = _status->load(butil::memory_order_acquire)) != Status::kReady) {
+            if (bthread::butex_wait(_status, curr_status, &ts) < 0 && errno == ETIMEDOUT) {
+                return future_status::timeout;
+            }
+        }
+        return future_status::ready;
+    }
+
+    void mark_ready_ant_notify() {
+        _status->store(Status::kReady, butil::memory_order_release);
+        bthread::butex_wake_all(_status);
+    }
+
+    void set_retrieved_flag() {
+        if (_retrieved.test_and_set()) throw FutureError(future_errc::future_already_retrieved);
+    }
+
+    void break_promise() {
+        // This function is only called when the last asynchronous result
+        // provider is abandoning this shared state, so noone can be
+        // trying to make the shared state ready at the same time
+        if (_status->load(butil::memory_order_acquire) != Status::kReady) {
+            set_exception(std::make_exception_ptr(FutureError(future_errc::broken_promise)));
+        }
+    }
+
+protected:
+    butil::atomic<int>* _status{};
+    std::atomic_flag _retrieved{};
+    std::exception_ptr _exception;
+};
+
+template <class R>
+class SharedState : public SharedStateBase {
+public:
+    SharedState() : SharedStateBase(), _result() {}
+
+    DISALLOW_COPY_AND_MOVE(SharedState);
+
+    ~SharedState() override = default;
+
+private:
+    friend class Future<R>;
+    friend class FutureBase<R>;
+    friend class Promise<R>;
+
+    R& value() noexcept { return _result.value(); }
+
+    void set_value(const R& value) {
+        int expect_status = Status::kNotReady;
+        if (_status->compare_exchange_strong(expect_status, Status::kWriting, butil::memory_order_acq_rel)) {
+            try {
+                _result = value;
+            } catch (...) {
+                _exception = std::current_exception();
+            }
+            mark_ready_ant_notify();
+        } else {
+            throw FutureError(future_errc::promise_already_satisfied);
+        }
+    }
+
+    void set_value(R&& value) {
+        int expect_status = Status::kNotReady;
+        if (_status->compare_exchange_strong(expect_status, Status::kWriting, butil::memory_order_acq_rel)) {
+            try {
+                _result = std::move(value);
+            } catch (...) {
+                _exception = std::current_exception();
+            }
+            mark_ready_ant_notify();
+        } else {
+            throw FutureError(future_errc::promise_already_satisfied);
+        }
+    }
+
+    std::optional<R> _result;
+};
+
+template <class R>
+class SharedState<R&> : public SharedStateBase {
+public:
+    SharedState() : SharedStateBase(), _result(nullptr) {}
+
+    DISALLOW_COPY_AND_MOVE(SharedState);
+
+    ~SharedState() override = default;
+
+private:
+    friend class Future<R&>;
+    friend class FutureBase<R&>;
+    friend class Promise<R&>;
+
+    R& value() noexcept { return *_result; }
+
+    void set_value(R& value) {
+        int expect_status = Status::kNotReady;
+        if (_status->compare_exchange_strong(expect_status, Status::kWriting, butil::memory_order_acq_rel)) {
+            _result = &value;
+            mark_ready_ant_notify();
+        } else {
+            throw FutureError(future_errc::promise_already_satisfied);
+        }
+    }
+
+    R* _result;
+};
+template <>
+class SharedState<void> : public SharedStateBase {
+public:
+    SharedState() : SharedStateBase() {}
+
+    DISALLOW_COPY_AND_MOVE(SharedState);
+
+    ~SharedState() override = default;
+
+private:
+    friend class Future<void>;
+    friend class FutureBase<void>;
+    friend class Promise<void>;
+
+    void set_value() {
+        int expect_status = Status::kNotReady;
+        if (_status->compare_exchange_strong(expect_status, Status::kWriting, butil::memory_order_acq_rel)) {
+            mark_ready_ant_notify();
+        } else {
+            throw FutureError(future_errc::promise_already_satisfied);
+        }
+    }
+};
+
+} // namespace starrocks::bthreads

--- a/be/src/util/bthreads/future_impl.h
+++ b/be/src/util/bthreads/future_impl.h
@@ -48,11 +48,11 @@ inline std::error_condition make_error_condition(starrocks::bthreads::future_err
 
 namespace starrocks::bthreads {
 
-class FutureError : public std::system_error {
+class future_error : public std::system_error {
 public:
-    explicit FutureError(future_errc code) : std::system_error(std::make_error_code(code)) {}
+    explicit future_error(future_errc code) : std::system_error(std::make_error_code(code)) {}
 
-    ~FutureError() override = default;
+    ~future_error() override = default;
 };
 
 template <typename R>
@@ -79,7 +79,7 @@ public:
 
     template <typename T>
     static void check_state(const std::shared_ptr<T>& p) {
-        if (!static_cast<bool>(p)) throw FutureError(future_errc::no_state);
+        if (!static_cast<bool>(p)) throw future_error(future_errc::no_state);
     }
 
 protected:
@@ -98,7 +98,7 @@ protected:
             _exception = exception;
             mark_ready_ant_notify();
         } else {
-            throw FutureError(future_errc::promise_already_satisfied);
+            throw future_error(future_errc::promise_already_satisfied);
         }
     }
 
@@ -135,7 +135,7 @@ protected:
     }
 
     void set_retrieved_flag() {
-        if (_retrieved.test_and_set()) throw FutureError(future_errc::future_already_retrieved);
+        if (_retrieved.test_and_set()) throw future_error(future_errc::future_already_retrieved);
     }
 
     void break_promise() {
@@ -143,7 +143,7 @@ protected:
         // provider is abandoning this shared state, so noone can be
         // trying to make the shared state ready at the same time
         if (_status->load(butil::memory_order_acquire) != Status::kReady) {
-            set_exception(std::make_exception_ptr(FutureError(future_errc::broken_promise)));
+            set_exception(std::make_exception_ptr(future_error(future_errc::broken_promise)));
         }
     }
 
@@ -179,7 +179,7 @@ private:
             }
             mark_ready_ant_notify();
         } else {
-            throw FutureError(future_errc::promise_already_satisfied);
+            throw future_error(future_errc::promise_already_satisfied);
         }
     }
 
@@ -193,7 +193,7 @@ private:
             }
             mark_ready_ant_notify();
         } else {
-            throw FutureError(future_errc::promise_already_satisfied);
+            throw future_error(future_errc::promise_already_satisfied);
         }
     }
 
@@ -222,7 +222,7 @@ private:
             _result = &value;
             mark_ready_ant_notify();
         } else {
-            throw FutureError(future_errc::promise_already_satisfied);
+            throw future_error(future_errc::promise_already_satisfied);
         }
     }
 
@@ -247,7 +247,7 @@ private:
         if (_status->compare_exchange_strong(expect_status, Status::kWriting, butil::memory_order_acq_rel)) {
             mark_ready_ant_notify();
         } else {
-            throw FutureError(future_errc::promise_already_satisfied);
+            throw future_error(future_errc::promise_already_satisfied);
         }
     }
 };

--- a/be/src/util/bthreads/future_impl.h
+++ b/be/src/util/bthreads/future_impl.h
@@ -65,9 +65,6 @@ class Future;
 template <typename R>
 class SharedFuture;
 
-template <typename _Signature>
-class packaged_task;
-
 template <typename R>
 class Promise;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -330,7 +330,10 @@ set(EXEC_FILES
         ./util/block_compression_test.cpp
         ./util/blocking_queue_test.cpp
         ./util/brpc_stub_cache_test.cpp
+        ./util/bthreads/future_test.cpp
+        ./util/bthreads/promise_test.cpp
         ./util/bthreads/shared_mutex_test.cpp
+        ./util/bthreads/shared_future_test.cpp
         ./util/c_string_test.cpp
         ./util/cidr_test.cpp
         ./util/coding_test.cpp

--- a/be/test/util/bthreads/future_test.cpp
+++ b/be/test/util/bthreads/future_test.cpp
@@ -75,12 +75,12 @@ TEST(FutureTest, test_exception_no_state01) {
                 try {
                     f.get();
                     EXPECT_FALSE(true) << "unreachable";
-                } catch (const FutureError& e) {
+                } catch (const future_error& e) {
                     EXPECT_EQ(std::make_error_code(future_errc::no_state), e.code());
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(FutureTest, test_exception_no_state02) {
@@ -94,12 +94,12 @@ TEST(FutureTest, test_exception_no_state02) {
                 try {
                     f.get();
                     EXPECT_FALSE(true) << "unreachable";
-                } catch (const FutureError& e) {
+                } catch (const future_error& e) {
                     EXPECT_EQ(std::make_error_code(future_errc::no_state), e.code());
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(FutureTest, test_exception_no_state03) {
@@ -112,12 +112,12 @@ TEST(FutureTest, test_exception_no_state03) {
                 try {
                     f.get();
                     EXPECT_FALSE(true) << "unreachable";
-                } catch (const FutureError& e) {
+                } catch (const future_error& e) {
                     EXPECT_EQ(std::make_error_code(future_errc::no_state), e.code());
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 static int value = 99;

--- a/be/test/util/bthreads/future_test.cpp
+++ b/be/test/util/bthreads/future_test.cpp
@@ -1,0 +1,315 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/bthreads/future.h"
+
+#include <bthread/bthread.h>
+#include <gtest/gtest.h>
+
+namespace starrocks::bthreads {
+namespace {
+class ClassType {
+private:
+    int x;
+};
+
+class AbstractClass {
+public:
+    virtual ~AbstractClass() = default;
+    virtual void foo() = 0;
+};
+
+Future<int> get() {
+    return Promise<int>().get_future();
+}
+
+} // namespace
+
+TEST(FutureTest, test_default_ctor) {
+    Future<int> p1;
+    EXPECT_FALSE(p1.valid());
+    Future<int&> p2;
+    EXPECT_FALSE(p2.valid());
+    Future<void> p3;
+    EXPECT_FALSE(p3.valid());
+    Future<ClassType> p4;
+    EXPECT_FALSE(p4.valid());
+    Future<AbstractClass&> p5;
+    EXPECT_FALSE(p5.valid());
+}
+
+TEST(FutureTest, test_move) {
+    Promise<int> p1;
+    Future<int> f1(p1.get_future());
+    Future<int> f2(std::move(f1));
+    EXPECT_TRUE(f2.valid());
+    EXPECT_FALSE(f1.valid());
+}
+
+TEST(FutureTest, test_move_assign) {
+    Future<int> p1;
+    Future<int> p2 = get();
+    p1 = std::move(p2);
+    EXPECT_TRUE(p1.valid());
+    EXPECT_FALSE(p2.valid());
+}
+
+TEST(FutureTest, test_exception_no_state01) {
+    bthreads::Promise<int> p;
+    bthreads::Future<int> f = p.get_future();
+    p.set_value(10);
+    EXPECT_EQ(10, f.get());
+    EXPECT_THROW(
+            {
+                try {
+                    f.get();
+                    EXPECT_FALSE(true) << "unreachable";
+                } catch (const FutureError& e) {
+                    EXPECT_EQ(std::make_error_code(future_errc::no_state), e.code());
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(FutureTest, test_exception_no_state02) {
+    bthreads::Promise<int&> p;
+    bthreads::Future<int&> f = p.get_future();
+    int i = 1;
+    p.set_value(i);
+    EXPECT_EQ(&i, &f.get());
+    EXPECT_THROW(
+            {
+                try {
+                    f.get();
+                    EXPECT_FALSE(true) << "unreachable";
+                } catch (const FutureError& e) {
+                    EXPECT_EQ(std::make_error_code(future_errc::no_state), e.code());
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(FutureTest, test_exception_no_state03) {
+    bthreads::Promise<void> p;
+    bthreads::Future<void> f = p.get_future();
+    p.set_value();
+    f.get();
+    EXPECT_THROW(
+            {
+                try {
+                    f.get();
+                    EXPECT_FALSE(true) << "unreachable";
+                } catch (const FutureError& e) {
+                    EXPECT_EQ(std::make_error_code(future_errc::no_state), e.code());
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+static int value = 99;
+
+TEST(FutureTest, test_get01) {
+    Promise<int> p1;
+    Future<int> f1(p1.get_future());
+
+    p1.set_value(value);
+    EXPECT_EQ(value, f1.get());
+    EXPECT_FALSE(f1.valid());
+}
+
+TEST(FutureTest, test_get02) {
+    Promise<int&> p1;
+    Future<int&> f1(p1.get_future());
+
+    p1.set_value(value);
+    EXPECT_EQ(&f1.get(), &value);
+    EXPECT_FALSE(f1.valid());
+}
+
+TEST(FutureTest, test_get03) {
+    Promise<void> p1;
+    Future<void> f1(p1.get_future());
+
+    p1.set_value();
+    f1.get();
+    EXPECT_FALSE(f1.valid());
+}
+
+TEST(FutureTest, test_get04) {
+    Promise<int> p1;
+    Future<int> f1(p1.get_future());
+
+    p1.set_exception(std::make_exception_ptr(value));
+    try {
+        (void)f1.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_EQ(e, value);
+    }
+    EXPECT_FALSE(f1.valid());
+}
+
+TEST(FutureTest, test_get05) {
+    Promise<int&> p1;
+    Future<int&> f1(p1.get_future());
+
+    p1.set_exception(std::make_exception_ptr(value));
+    try {
+        (void)f1.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_EQ(e, value);
+    }
+    EXPECT_FALSE(f1.valid());
+}
+
+TEST(FutureTest, test_get06) {
+    Promise<void> p1;
+    Future<void> f1(p1.get_future());
+
+    p1.set_exception(std::make_exception_ptr(value));
+    try {
+        f1.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_EQ(value, e);
+    }
+    EXPECT_FALSE(f1.valid());
+}
+
+static int iterations = 200;
+
+template <typename Duration>
+static double print(const char* desc, Duration dur) {
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(dur).count();
+    double d = double(ns) / iterations;
+    std::cout << desc << ": " << ns << "ns for " << iterations << " calls, avg " << d << "ns per call\n";
+    return d;
+}
+
+TEST(FutureTest, test_share01) {
+    Promise<int> p1;
+    Future<int> f1(p1.get_future());
+    SharedFuture<int> f2 = f1.share();
+
+    p1.set_value(value);
+    EXPECT_TRUE(f2.get() == value);
+}
+
+TEST(FutureTest, test_share02) {
+    Promise<int&> p1;
+    Future<int&> f1(p1.get_future());
+    SharedFuture<int&> f2 = f1.share();
+
+    p1.set_value(value);
+    EXPECT_TRUE(&f2.get() == &value);
+}
+
+TEST(FutureTest, test_share03) {
+    Promise<void> p1;
+    Future<void> f1(p1.get_future());
+    SharedFuture<void> f2 = f1.share();
+
+    p1.set_value();
+    f2.get();
+}
+
+TEST(FutureTest, test_valid) {
+    Future<int> f0;
+    EXPECT_TRUE(!f0.valid());
+
+    Promise<int> p1;
+    Future<int> f1(p1.get_future());
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_value(1);
+
+    EXPECT_TRUE(f1.valid());
+
+    f1 = std::move(f0);
+
+    EXPECT_TRUE(!f1.valid());
+    EXPECT_TRUE(!f0.valid());
+}
+
+static void fut_wait(Future<void>& f) {
+    f.wait();
+}
+
+static void* fut_wait2(void* arg) {
+    auto f = static_cast<Future<void>*>(arg);
+    f->wait();
+    return nullptr;
+}
+
+TEST(FutureTest, test_wait01) {
+    Promise<void> p1;
+    Future<void> f1(p1.get_future());
+
+    std::thread t1(fut_wait, std::ref(f1));
+
+    p1.set_value();
+    t1.join();
+}
+
+TEST(FutureTest, test_wait02) {
+    Promise<void> p1;
+    Future<void> f1(p1.get_future());
+
+    bthread_t t1;
+    ASSERT_EQ(0, bthread_start_background(&t1, nullptr, fut_wait2, &f1));
+
+    p1.set_value();
+    bthread_join(t1, nullptr);
+}
+
+TEST(FutureTest, test_wait_for01) {
+    Promise<int> p1;
+    Future<int> f1(p1.get_future());
+
+    std::chrono::milliseconds delay(100);
+
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::timeout);
+
+    p1.set_value(1);
+
+    auto before = std::chrono::system_clock::now();
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
+    EXPECT_TRUE(std::chrono::system_clock::now() < (before + delay));
+}
+
+static std::chrono::system_clock::time_point make_time(int i) {
+    return std::chrono::system_clock::now() + std::chrono::milliseconds(i);
+}
+
+TEST(FutureTest, test_wait_until01) {
+    Promise<int> p1;
+    Future<int> f1(p1.get_future());
+
+    auto when = make_time(10);
+    EXPECT_TRUE(f1.wait_until(when) == future_status::timeout);
+    EXPECT_TRUE(std::chrono::system_clock::now() >= when);
+
+    p1.set_value(1);
+
+    when = make_time(100);
+    EXPECT_TRUE(f1.wait_until(when) == future_status::ready);
+    EXPECT_TRUE(std::chrono::system_clock::now() < when);
+}
+
+} // namespace starrocks::bthreads

--- a/be/test/util/bthreads/promise_test.cpp
+++ b/be/test/util/bthreads/promise_test.cpp
@@ -1,0 +1,783 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bthread/bthread.h>
+#include <gtest/gtest.h>
+
+#include "util/bthreads/future.h"
+
+namespace starrocks::bthreads {
+namespace {
+class AbstractClass {
+public:
+    virtual ~AbstractClass() = default;
+    virtual void foo() = 0;
+};
+} // namespace
+
+TEST(PromiseTest, test_default_ctor01) {
+    Promise<int> p1;
+    Promise<int&> p2;
+    Promise<void> p3;
+    Promise<Future<int>> p4;
+    Promise<AbstractClass&> p5;
+}
+
+TEST(PromiseTest, test_move_ctor) {
+    Promise<int> p1;
+    p1.set_value(3);
+    Promise<int> p2(std::move(p1));
+    EXPECT_TRUE(p2.get_future().get() == 3);
+    EXPECT_THROW(
+            {
+                try {
+                    p1.get_future();
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(PromiseTest, test_move_assign) {
+    Promise<int> p1;
+    p1.set_value(3);
+    Promise<int> p2;
+    p2 = std::move(p1);
+    EXPECT_TRUE(p2.get_future().get() == 3);
+    EXPECT_THROW(
+            {
+                try {
+                    p1.get_future();
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(PromiseTest, test_get_future01) {
+    Promise<int&> p1;
+    Future<int&> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    int i1 = 0;
+
+    p1.set_value(i1);
+
+    int& i2 = f1.get();
+
+    EXPECT_TRUE(&i1 == &i2);
+}
+
+TEST(PromiseTest, test_get_future02) {
+    Promise<int&> p1;
+    p1.get_future();
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.get_future();
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::future_already_retrieved));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(PromiseTest, test_get_future03) {
+    Promise<int> p1;
+    p1.get_future();
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.get_future();
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::future_already_retrieved));
+                    throw;
+                }
+            },
+            FutureError);
+}
+TEST(PromiseTest, test_get_future04) {
+    Promise<void> p1;
+    p1.get_future();
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.get_future();
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::future_already_retrieved));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(PromiseTest, test_exception01) {
+    Promise<int> p1;
+    Future<int> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_exception(std::make_exception_ptr(0));
+
+    EXPECT_THROW({ f1.get(); }, int);
+    EXPECT_TRUE(!f1.valid());
+}
+
+TEST(PromiseTest, test_exception02) {
+    Promise<int&> p1;
+    Future<int&> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_exception(std::make_exception_ptr(0));
+
+    EXPECT_THROW({ f1.get(); }, int);
+    EXPECT_TRUE(!f1.valid());
+}
+
+TEST(PromiseTest, test_exception03) {
+    Promise<void> p1;
+    Future<void> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_exception(std::make_exception_ptr(0));
+
+    EXPECT_THROW({ f1.get(); }, int);
+    EXPECT_TRUE(!f1.valid());
+}
+
+TEST(PromiseTest, test_exception04) {
+    Promise<int> p1;
+    Future<int> f1 = p1.get_future();
+
+    p1.set_exception(std::make_exception_ptr(0));
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(1));
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                    EXPECT_TRUE(false);
+                } catch (int i) {
+                    EXPECT_TRUE(i == 0);
+                    throw;
+                }
+            },
+            int);
+}
+
+TEST(PromiseTest, test_exception05) {
+    Promise<int> p1;
+    Future<int> f1 = p1.get_future();
+
+    p1.set_value(2);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(0));
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(PromiseTest, test_exception06) {
+    Promise<int&> p1;
+    Future<int&> f1 = p1.get_future();
+
+    p1.set_exception(std::make_exception_ptr(0));
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(1));
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                    EXPECT_TRUE(false);
+                } catch (int i) {
+                    EXPECT_TRUE(i == 0);
+                    throw;
+                }
+            },
+            int);
+}
+
+TEST(PromiseTest, test_exception07) {
+    Promise<int&> p1;
+    Future<int&> f1 = p1.get_future();
+
+    int i = 2;
+    p1.set_value(i);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(0));
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(PromiseTest, test_exception08) {
+    Promise<void> p1;
+    Future<void> f1 = p1.get_future();
+
+    p1.set_exception(std::make_exception_ptr(0));
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(1));
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                    EXPECT_TRUE(false);
+                } catch (int i) {
+                    EXPECT_TRUE(i == 0);
+                    throw;
+                }
+            },
+            int);
+}
+
+TEST(PromiseTest, test_exception09) {
+    Promise<void> p1;
+    Future<void> f1 = p1.get_future();
+
+    p1.set_value();
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(0));
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(PromiseTest, test_exception10) {
+    Promise<int> p1;
+    Promise<int> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(1));
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(PromiseTest, test_exception11) {
+    Promise<int&> p1;
+    Promise<int&> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(1));
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(PromiseTest, test_exception12) {
+    Promise<void> p1;
+    Promise<void> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(1));
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(PromiseTest, test_set_value01) {
+    Promise<int> p1;
+    Future<int> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_value(0);
+
+    int&& i1 = f1.get();
+
+    EXPECT_TRUE(i1 == 0);
+}
+
+namespace {
+struct NonCopyableStruct {
+    int val;
+
+    NonCopyableStruct() : val(0) {}
+
+    NonCopyableStruct(int inval) : val(inval) {}
+
+    NonCopyableStruct& operator=(int newval) {
+        val = newval;
+        return *this;
+    }
+
+    NonCopyableStruct(const NonCopyableStruct&) = delete;
+    NonCopyableStruct& operator=(const NonCopyableStruct&) = delete;
+
+    NonCopyableStruct(NonCopyableStruct&& in) noexcept { val = in.val; }
+
+    NonCopyableStruct& operator=(NonCopyableStruct&& in) {
+        CHECK(this != &in);
+        val = in.val;
+        return *this;
+    }
+};
+} // namespace
+
+TEST(PromiseTest, test_set_value02) {
+    Promise<NonCopyableStruct> p1;
+    Future<NonCopyableStruct> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_value(NonCopyableStruct(1));
+
+    NonCopyableStruct r1(f1.get());
+
+    EXPECT_TRUE(!f1.valid());
+    EXPECT_TRUE(r1.val == 1);
+}
+
+TEST(PromiseTest, test_set_value03) {
+    Promise<int&> p1;
+    Future<int&> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    int i1 = 0;
+    p1.set_value(i1);
+    int& i2 = f1.get();
+
+    EXPECT_TRUE(!f1.valid());
+    EXPECT_TRUE(&i1 == &i2);
+}
+
+TEST(PromiseTest, test_set_value04) {
+    Promise<void> p1;
+    Future<void> f1 = p1.get_future();
+
+    EXPECT_TRUE(f1.valid());
+
+    p1.set_value();
+    f1.get();
+
+    EXPECT_TRUE(!f1.valid());
+}
+
+TEST(PromiseTest, test_set_value05) {
+    Promise<int> p1;
+    Future<int> f1 = p1.get_future();
+
+    p1.set_value(1);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value(2);
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
+    EXPECT_TRUE(f1.get() == 1);
+}
+
+TEST(PromiseTest, test_set_value06) {
+    Promise<int> p1;
+    Future<int> f1 = p1.get_future();
+
+    p1.set_value(3);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(4));
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
+    EXPECT_TRUE(f1.get() == 3);
+}
+
+TEST(PromiseTest, test_set_value07) {
+    Promise<int> p1;
+    Future<int> f1 = p1.get_future();
+
+    p1.set_exception(std::make_exception_ptr(4));
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value(3);
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                    EXPECT_TRUE(false);
+                } catch (int e) {
+                    EXPECT_TRUE(e == 4);
+                    throw;
+                }
+            },
+            int);
+}
+
+TEST(PromiseTest, test_set_value08) {
+    Promise<int&> p1;
+    Future<int&> f1 = p1.get_future();
+
+    int i = 1;
+    p1.set_value(i);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value(i);
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
+    EXPECT_TRUE(f1.get() == 1);
+}
+
+TEST(PromiseTest, test_set_value09) {
+    Promise<int&> p1;
+    Future<int&> f1 = p1.get_future();
+
+    int i = 3;
+    p1.set_value(i);
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(4));
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
+    EXPECT_TRUE(f1.get() == 3);
+}
+
+TEST(PromiseTest, test_set_value10) {
+    Promise<int&> p1;
+    Future<int&> f1 = p1.get_future();
+
+    p1.set_exception(std::make_exception_ptr(4));
+
+    EXPECT_THROW(
+            {
+                try {
+                    int i = 3;
+                    p1.set_value(i);
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                    EXPECT_TRUE(false);
+                } catch (int e) {
+                    EXPECT_TRUE(e == 4);
+                    throw;
+                }
+            },
+            int);
+}
+
+TEST(PromiseTest, test_set_value11) {
+    Promise<void> p1;
+    Future<void> f1 = p1.get_future();
+
+    p1.set_value();
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value();
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
+    f1.get();
+}
+
+TEST(PromiseTest, test_set_value12) {
+    Promise<void> p1;
+    Future<void> f1 = p1.get_future();
+
+    p1.set_value();
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_exception(std::make_exception_ptr(4));
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
+    f1.get();
+}
+
+TEST(PromiseTest, test_set_value13) {
+    Promise<void> p1;
+    Future<void> f1 = p1.get_future();
+
+    p1.set_exception(std::make_exception_ptr(4));
+
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value();
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
+                    throw;
+                }
+            },
+            FutureError);
+
+    std::chrono::milliseconds delay(1);
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
+    EXPECT_THROW(
+            {
+                try {
+                    f1.get();
+                    EXPECT_TRUE(false);
+                } catch (int e) {
+                    EXPECT_TRUE(e == 4);
+                    throw;
+                }
+            },
+            int);
+}
+
+// Check for no_state error condition (PR libstdc++/80316)
+
+TEST(PromiseTest, test_set_value14) {
+    Promise<int> p1;
+    Promise<int> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value(1);
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(PromiseTest, test_set_value15) {
+    Promise<int&> p1;
+    Promise<int&> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    int i = 0;
+                    p1.set_value(i);
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(PromiseTest, test_set_value16) {
+    Promise<void> p1;
+    Promise<void> p2(std::move(p1));
+    EXPECT_THROW(
+            {
+                try {
+                    p1.set_value();
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+namespace {
+struct tester {
+    tester(int);
+    tester(const tester&);
+    tester() = delete;
+    // tester& operator=(const tester&);
+};
+
+Promise<tester> pglobal;
+Future<tester> fglobal = pglobal.get_future();
+
+auto delay = std::chrono::milliseconds(1);
+
+tester::tester(int) {
+    EXPECT_TRUE(fglobal.wait_for(delay) == future_status::timeout);
+}
+
+tester::tester(const tester&) {
+    // if this copy happens while a mutex is locked next line could deadlock:
+    EXPECT_TRUE(fglobal.wait_for(delay) == future_status::timeout);
+}
+} // namespace
+
+TEST(PromiseTest, test_set_value17) {
+    pglobal.set_value(tester(1));
+
+    EXPECT_TRUE(fglobal.wait_for(delay) == future_status::ready);
+}
+
+TEST(PromiseTest, test_swap) {
+    Promise<int> p1;
+    Promise<int> p2;
+    p1.set_value(1);
+    p1.swap(p2);
+    auto delay = std::chrono::milliseconds(1);
+    EXPECT_TRUE(p1.get_future().wait_for(delay) == future_status::timeout);
+    EXPECT_TRUE(p2.get_future().wait_for(delay) == future_status::ready);
+}
+
+} // namespace starrocks::bthreads

--- a/be/test/util/bthreads/promise_test.cpp
+++ b/be/test/util/bthreads/promise_test.cpp
@@ -44,12 +44,12 @@ TEST(PromiseTest, test_move_ctor) {
                 try {
                     p1.get_future();
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(PromiseTest, test_move_assign) {
@@ -63,12 +63,12 @@ TEST(PromiseTest, test_move_assign) {
                 try {
                     p1.get_future();
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(PromiseTest, test_get_future01) {
@@ -95,12 +95,12 @@ TEST(PromiseTest, test_get_future02) {
                 try {
                     p1.get_future();
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::future_already_retrieved));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(PromiseTest, test_get_future03) {
@@ -112,12 +112,12 @@ TEST(PromiseTest, test_get_future03) {
                 try {
                     p1.get_future();
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::future_already_retrieved));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 TEST(PromiseTest, test_get_future04) {
     Promise<void> p1;
@@ -128,12 +128,12 @@ TEST(PromiseTest, test_get_future04) {
                 try {
                     p1.get_future();
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::future_already_retrieved));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(PromiseTest, test_exception01) {
@@ -183,12 +183,12 @@ TEST(PromiseTest, test_exception04) {
                 try {
                     p1.set_exception(std::make_exception_ptr(1));
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 
     EXPECT_THROW(
             {
@@ -214,12 +214,12 @@ TEST(PromiseTest, test_exception05) {
                 try {
                     p1.set_exception(std::make_exception_ptr(0));
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(PromiseTest, test_exception06) {
@@ -233,12 +233,12 @@ TEST(PromiseTest, test_exception06) {
                 try {
                     p1.set_exception(std::make_exception_ptr(1));
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 
     EXPECT_THROW(
             {
@@ -265,12 +265,12 @@ TEST(PromiseTest, test_exception07) {
                 try {
                     p1.set_exception(std::make_exception_ptr(0));
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(PromiseTest, test_exception08) {
@@ -284,12 +284,12 @@ TEST(PromiseTest, test_exception08) {
                 try {
                     p1.set_exception(std::make_exception_ptr(1));
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 
     EXPECT_THROW(
             {
@@ -315,12 +315,12 @@ TEST(PromiseTest, test_exception09) {
                 try {
                     p1.set_exception(std::make_exception_ptr(0));
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(PromiseTest, test_exception10) {
@@ -331,12 +331,12 @@ TEST(PromiseTest, test_exception10) {
                 try {
                     p1.set_exception(std::make_exception_ptr(1));
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(PromiseTest, test_exception11) {
@@ -347,12 +347,12 @@ TEST(PromiseTest, test_exception11) {
                 try {
                     p1.set_exception(std::make_exception_ptr(1));
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(PromiseTest, test_exception12) {
@@ -363,12 +363,12 @@ TEST(PromiseTest, test_exception12) {
                 try {
                     p1.set_exception(std::make_exception_ptr(1));
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(PromiseTest, test_set_value01) {
@@ -461,12 +461,12 @@ TEST(PromiseTest, test_set_value05) {
                 try {
                     p1.set_value(2);
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 
     std::chrono::milliseconds delay(1);
     EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
@@ -484,12 +484,12 @@ TEST(PromiseTest, test_set_value06) {
                 try {
                     p1.set_exception(std::make_exception_ptr(4));
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 
     std::chrono::milliseconds delay(1);
     EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
@@ -507,12 +507,12 @@ TEST(PromiseTest, test_set_value07) {
                 try {
                     p1.set_value(3);
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 
     std::chrono::milliseconds delay(1);
     EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
@@ -541,12 +541,12 @@ TEST(PromiseTest, test_set_value08) {
                 try {
                     p1.set_value(i);
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 
     std::chrono::milliseconds delay(1);
     EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
@@ -565,12 +565,12 @@ TEST(PromiseTest, test_set_value09) {
                 try {
                     p1.set_exception(std::make_exception_ptr(4));
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 
     std::chrono::milliseconds delay(1);
     EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
@@ -589,12 +589,12 @@ TEST(PromiseTest, test_set_value10) {
                     int i = 3;
                     p1.set_value(i);
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 
     std::chrono::milliseconds delay(1);
     EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
@@ -622,12 +622,12 @@ TEST(PromiseTest, test_set_value11) {
                 try {
                     p1.set_value();
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 
     std::chrono::milliseconds delay(1);
     EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
@@ -645,12 +645,12 @@ TEST(PromiseTest, test_set_value12) {
                 try {
                     p1.set_exception(std::make_exception_ptr(4));
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 
     std::chrono::milliseconds delay(1);
     EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
@@ -668,12 +668,12 @@ TEST(PromiseTest, test_set_value13) {
                 try {
                     p1.set_value();
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::promise_already_satisfied));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 
     std::chrono::milliseconds delay(1);
     EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
@@ -700,12 +700,12 @@ TEST(PromiseTest, test_set_value14) {
                 try {
                     p1.set_value(1);
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(PromiseTest, test_set_value15) {
@@ -717,12 +717,12 @@ TEST(PromiseTest, test_set_value15) {
                     int i = 0;
                     p1.set_value(i);
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(PromiseTest, test_set_value16) {
@@ -733,12 +733,12 @@ TEST(PromiseTest, test_set_value16) {
                 try {
                     p1.set_value();
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 namespace {

--- a/be/test/util/bthreads/shared_future_test.cpp
+++ b/be/test/util/bthreads/shared_future_test.cpp
@@ -71,12 +71,12 @@ TEST(SharedFutureTest, test_exception_01) {
                 try {
                     f.get();
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(SharedFutureTest, test_exception02) {
@@ -86,12 +86,12 @@ TEST(SharedFutureTest, test_exception02) {
                 try {
                     f.get();
                     EXPECT_TRUE(false);
-                } catch (FutureError& e) {
+                } catch (future_error& e) {
                     EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
                     throw;
                 }
             },
-            FutureError);
+            future_error);
 }
 
 TEST(SharedFutureTest, test_exception03) {
@@ -99,7 +99,7 @@ TEST(SharedFutureTest, test_exception03) {
     try {
         f.get();
         EXPECT_TRUE(false);
-    } catch (FutureError& e) {
+    } catch (future_error& e) {
         EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
     }
 }

--- a/be/test/util/bthreads/shared_future_test.cpp
+++ b/be/test/util/bthreads/shared_future_test.cpp
@@ -1,0 +1,306 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bthread/bthread.h>
+#include <gtest/gtest.h>
+
+#include "util/bthreads/future.h"
+
+namespace starrocks::bthreads {
+
+namespace {
+class ClassType {
+private:
+    int x;
+};
+
+class AbstractClass {
+public:
+    virtual ~AbstractClass() = default;
+    virtual void foo() = 0;
+};
+SharedFuture<int> get() {
+    return Promise<int>().get_future();
+}
+} // namespace
+
+TEST(SharedFutureTest, test_default_ctor) {
+    bool __attribute__((unused)) test = true;
+
+    SharedFuture<int> p1;
+    EXPECT_TRUE(!p1.valid());
+    SharedFuture<int&> p2;
+    EXPECT_TRUE(!p2.valid());
+    SharedFuture<void> p3;
+    EXPECT_TRUE(!p3.valid());
+    SharedFuture<ClassType> p4;
+    EXPECT_TRUE(!p4.valid());
+    SharedFuture<AbstractClass&> p5;
+    EXPECT_TRUE(!p5.valid());
+}
+
+TEST(SharedFutureTest, test_move_ctor) {
+    Promise<int> p1;
+    SharedFuture<int> f1(p1.get_future());
+    SharedFuture<int> f2(std::move(f1));
+}
+
+TEST(SharedFutureTest, test_move_assign) {
+    SharedFuture<int> p1;
+    SharedFuture<int> p2 = get();
+    p1 = std::move(p2);
+    EXPECT_TRUE(p1.valid());
+    EXPECT_TRUE(!p2.valid());
+}
+
+TEST(SharedFutureTest, test_exception_01) {
+    SharedFuture<int> f;
+    EXPECT_THROW(
+            {
+                try {
+                    f.get();
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(SharedFutureTest, test_exception02) {
+    SharedFuture<int&> f;
+    EXPECT_THROW(
+            {
+                try {
+                    f.get();
+                    EXPECT_TRUE(false);
+                } catch (FutureError& e) {
+                    EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
+                    throw;
+                }
+            },
+            FutureError);
+}
+
+TEST(SharedFutureTest, test_exception03) {
+    SharedFuture<void> f;
+    try {
+        f.get();
+        EXPECT_TRUE(false);
+    } catch (FutureError& e) {
+        EXPECT_TRUE(e.code() == std::make_error_code(future_errc::no_state));
+    }
+}
+
+static int value = 99;
+
+TEST(SharedFutureTest, test_get01) {
+    Promise<int> p1;
+    const SharedFuture<int> f1(p1.get_future());
+    SharedFuture<int> f2(f1);
+
+    p1.set_value(value);
+    EXPECT_TRUE(f1.get() == value);
+    EXPECT_TRUE(f2.get() == value);
+}
+
+TEST(SharedFutureTest, test_get02) {
+    Promise<int&> p1;
+    const SharedFuture<int&> f1(p1.get_future());
+    SharedFuture<int&> f2(f1);
+
+    p1.set_value(value);
+    EXPECT_TRUE(&f1.get() == &value);
+    EXPECT_TRUE(&f2.get() == &value);
+}
+
+TEST(SharedFutureTest, test_get03) {
+    Promise<void> p1;
+    const SharedFuture<void> f1(p1.get_future());
+    SharedFuture<void> f2(f1);
+
+    p1.set_value();
+    f1.get();
+    f2.get();
+}
+
+TEST(SharedFutureTest, test_get04) {
+    Promise<int> p1;
+    SharedFuture<int> f1(p1.get_future());
+    SharedFuture<int> f2(f1);
+
+    p1.set_exception(std::make_exception_ptr(value));
+    try {
+        (void)f1.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_TRUE(e == value);
+    }
+    try {
+        (void)f2.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_TRUE(e == value);
+    }
+}
+
+TEST(SharedFutureTest, test_get05) {
+    Promise<int&> p1;
+    SharedFuture<int&> f1(p1.get_future());
+    SharedFuture<int&> f2(f1);
+
+    p1.set_exception(std::make_exception_ptr(value));
+    try {
+        (void)f1.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_TRUE(e == value);
+    }
+    try {
+        (void)f2.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_TRUE(e == value);
+    }
+}
+
+TEST(SharedFutureTest, test_get06) {
+    Promise<void> p1;
+    SharedFuture<void> f1(p1.get_future());
+    SharedFuture<void> f2(f1);
+
+    p1.set_exception(std::make_exception_ptr(value));
+    try {
+        f1.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_TRUE(e == value);
+    }
+    try {
+        f2.get();
+        EXPECT_TRUE(false);
+    } catch (int& e) {
+        EXPECT_TRUE(e == value);
+    }
+}
+
+TEST(SharedFutureTest, test_valid01) {
+    SharedFuture<int> f0;
+
+    EXPECT_TRUE(!f0.valid());
+
+    Promise<int> p1;
+    SharedFuture<int> f1(p1.get_future());
+    SharedFuture<int> f2(f1);
+
+    EXPECT_TRUE(f1.valid());
+    EXPECT_TRUE(f2.valid());
+
+    p1.set_value(1);
+
+    EXPECT_TRUE(f1.valid());
+    EXPECT_TRUE(f2.valid());
+
+    f1 = std::move(f0);
+
+    EXPECT_TRUE(!f0.valid());
+    EXPECT_TRUE(!f1.valid());
+    EXPECT_TRUE(f2.valid());
+}
+
+static void fut_wait(SharedFuture<void> f) {
+    f.wait();
+}
+
+static void* fut_wait02(void* arg) {
+    auto f = static_cast<SharedFuture<void>*>(arg);
+    f->wait();
+    return nullptr;
+}
+
+TEST(SharedFutureTest, test_wait01) {
+    Promise<void> p1;
+    SharedFuture<void> f1(p1.get_future());
+
+    std::thread t1(fut_wait, f1);
+    std::thread t2(fut_wait, f1);
+    std::thread t3(fut_wait, f1);
+
+    p1.set_value();
+    t1.join();
+    t2.join();
+    t3.join();
+}
+
+TEST(SharedFutureTest, test_wait02) {
+    Promise<void> p1;
+    SharedFuture<void> f1(p1.get_future());
+
+    bthread_t t1, t2, t3;
+    EXPECT_EQ(0, bthread_start_background(&t1, nullptr, fut_wait02, &f1));
+    EXPECT_EQ(0, bthread_start_background(&t2, nullptr, fut_wait02, &f1));
+    EXPECT_EQ(0, bthread_start_background(&t3, nullptr, fut_wait02, &f1));
+
+    p1.set_value();
+
+    bthread_join(t1, nullptr);
+    bthread_join(t2, nullptr);
+    bthread_join(t3, nullptr);
+}
+
+TEST(SharedFutureTest, test_wait_for01) {
+    Promise<int> p1;
+    SharedFuture<int> f1(p1.get_future());
+    SharedFuture<int> f2(f1);
+
+    std::chrono::milliseconds delay(100);
+
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::timeout);
+    EXPECT_TRUE(f2.wait_for(delay) == future_status::timeout);
+
+    p1.set_value(1);
+
+    auto before = std::chrono::system_clock::now();
+    EXPECT_TRUE(f1.wait_for(delay) == future_status::ready);
+    EXPECT_TRUE(f2.wait_for(delay) == future_status::ready);
+    EXPECT_TRUE(std::chrono::system_clock::now() < (before + 2 * delay));
+}
+
+static std::chrono::system_clock::time_point make_time(int i) {
+    return std::chrono::system_clock::now() + std::chrono::milliseconds(i);
+}
+
+TEST(SharedFutureTest, test_wait_until01) {
+    Promise<int> p1;
+    SharedFuture<int> f1(p1.get_future());
+    SharedFuture<int> f2(f1);
+
+    auto when = make_time(10);
+    EXPECT_TRUE(f1.wait_until(make_time(10)) == future_status::timeout);
+    EXPECT_TRUE(std::chrono::system_clock::now() >= when);
+
+    when = make_time(10);
+    EXPECT_TRUE(f2.wait_until(make_time(10)) == future_status::timeout);
+    EXPECT_TRUE(std::chrono::system_clock::now() >= when);
+
+    p1.set_value(1);
+
+    when = make_time(100);
+    EXPECT_TRUE(f1.wait_until(when) == future_status::ready);
+    EXPECT_TRUE(f2.wait_until(when) == future_status::ready);
+    EXPECT_TRUE(std::chrono::system_clock::now() < when);
+}
+
+} // namespace starrocks::bthreads


### PR DESCRIPTION
bthreads::future::get() will now suspend the current bthread instead of blocking the pthread when the result is not ready yet. Waiting on a bthreads::future automatically resumes the bthread when the result is available. This allows non-blocking waiting on asynchronous results in a bthread by leveraging bthread suspensions.

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
