### PR TITLE
[Enhancement] improve persistent index l0 memory usage

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -956,7 +956,8 @@ CONF_Bool(block_cache_direct_io_enable, "false");
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB
-CONF_mInt64(l0_max_mem_usage, "67108864");  // 64MB
+CONF_mInt64(l0_min_mem_usage, "2097152");   // 2MB
+CONF_mInt64(l0_max_mem_usage, "104857600"); // 100MB
 // if l0_mem_size exceeds this value, l0 need snapshot
 CONF_mInt64(l0_snapshot_size, "16777216"); // 16MB
 CONF_mInt64(max_tmp_l1_num, "10");

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -296,6 +296,8 @@ public:
 
     bool limit_exceeded() const { return _limit >= 0 && _limit < consumption(); }
 
+    bool limit_exceeded_by_ratio(int64_t ratio) const { return _limit >= 0 && (_limit * ratio / 100) < consumption(); }
+
     void set_limit(int64_t limit) { _limit = limit; }
 
     int64_t limit() const { return _limit; }

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -2905,7 +2905,6 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta, IOStat* stat) 
     //   2. _l1 is exist, merge _l0 and _l1
     // rebuild _l0 and _l1
     // In addition, there may be I/O waste because we append wals firstly and do _flush_l0 or _merge_compaction.
-    const auto l0_mem_size = _l0->memory_usage();
     uint64_t l1_l2_file_size = _l1_l2_file_size();
     bool do_minor_compaction = false;
     // if l1 is not empty,
@@ -2923,7 +2922,7 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta, IOStat* stat) 
     } else {
         if (l1_l2_file_size != 0) {
             // and l0 memory usage is large enough,
-            if (l0_mem_size * config::l0_l1_merge_ratio > l1_l2_file_size) {
+            if (_l0_is_full()) {
                 // do l0 l1 merge compaction
                 _flushed = true;
                 if (_enable_minor_compaction()) {
@@ -2938,7 +2937,7 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta, IOStat* stat) 
                 }
             }
             // if l1 is empty, and l0 memory usage is large enough
-        } else if (l0_mem_size > config::l0_snapshot_size) {
+        } else if (_l0_is_full()) {
             // do flush l0
             _flushed = true;
             RETURN_IF_ERROR(_flush_l0());
@@ -3453,12 +3452,16 @@ bool PersistentIndex::_can_dump_directly() {
     return _dump_bound() <= config::l0_snapshot_size;
 }
 
-bool PersistentIndex::_need_flush_advance() {
+bool PersistentIndex::_l0_is_full() {
     const auto l0_mem_size = _l0->memory_usage();
-    uint64_t l1_l2_file_size = _l1_l2_file_size();
-    bool flush_advance = (l1_l2_file_size != 0) ? l0_mem_size * config::l0_l1_merge_ratio > l1_l2_file_size
-                                                : l0_mem_size > config::l0_max_mem_usage;
-    return flush_advance;
+    auto manager = StorageEngine::instance()->update_manager();
+    return l0_mem_size >= config::l0_max_mem_usage ||
+           (manager->mem_tracker()->limit_exceeded_by_ratio(config::memory_urgent_level) &&
+            l0_mem_size >= config::l0_min_mem_usage);
+}
+
+bool PersistentIndex::_need_flush_advance() {
+    return _l0_is_full();
 }
 
 bool PersistentIndex::_need_merge_advance() {

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -727,6 +727,8 @@ private:
 
     size_t _get_tmp_l1_count();
 
+    bool _l0_is_full();
+
 protected:
     // prevent concurrent operations
     // Currently there are only concurrent read/write conflicts for _l1_vec between apply_thread and commit_thread

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3691,20 +3691,4 @@ TEST_F(TabletUpdatesTest, multiple_delete_and_upsert) {
     ASSERT_TRUE(count == keys.size());
 }
 
-TEST_F(TabletUpdatesTest, test_pk_index_compaction) {
-    srand(GetCurrentTimeMicros());
-    _tablet = create_tablet(rand(), rand());
-    _tablet->set_enable_persistent_index(true);
-    std::vector<int64_t> keys;
-    for (int i = 0; i < 100; i++) {
-        keys.push_back(i);
-    }
-    ASSERT_TRUE(_tablet->rowset_commit(2, create_rowset(_tablet, keys), 60000).ok());
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    auto tablets = StorageEngine::instance()->tablet_manager()->pick_tablets_to_do_pk_index_major_compaction();
-    EXPECT_TRUE(!tablets.empty());
-    // trigger pk index compaction
-    ASSERT_OK(tablets[0].first->updates()->pk_index_major_compaction());
-}
-
 } // namespace starrocks


### PR DESCRIPTION
This PR will improve persistent index l0 memory usage, and add some config items:
```
CONF_mInt64(l0_min_mem_usage, "2097152");   // 2MB
CONF_mInt64(l0_max_mem_usage, "104857600"); // 100MB
```

Whether l0 should flush or merge into l1, isn't longer controlled by `l0_l1_merge_ratio` any more. L0 should flush or merge into l1, when:
```
1. l0 memory usage >= config::l0_max_mem_usage, or
2. l0 memory usage >= config::l0_min_mem_usage && update module memory usage is in urgent
```


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
