### PR TITLE
[BugFix] Fix bool type variable for RleEncoder

### DIFF
--- a/be/src/storage/rowset/rle_page.h
+++ b/be/src/storage/rowset/rle_page.h
@@ -93,7 +93,11 @@ public:
         for (int i = 0; i < count; ++i) {
             // note: vals is not guaranteed to be aligned for now, thus memcpy here
             CppType value;
-            memcpy(&value, &new_vals[i], SIZE_OF_TYPE);
+            if constexpr (std::is_same<CppType, bool>::value) {
+                value = (new_vals[i] != 0);
+            } else {
+                memcpy(&value, &new_vals[i], SIZE_OF_TYPE);
+            }
             _rle_encoder->Put(value);
         }
 

--- a/be/src/storage/rowset/rle_page.h
+++ b/be/src/storage/rowset/rle_page.h
@@ -93,7 +93,7 @@ public:
         for (int i = 0; i < count; ++i) {
             // note: vals is not guaranteed to be aligned for now, thus memcpy here
             CppType value;
-            if constexpr (std::is_same<CppType, bool>::value) {
+            if constexpr (std::is_same_v<CppType, bool>) {
                 value = (new_vals[i] != 0);
             } else {
                 memcpy(&value, &new_vals[i], SIZE_OF_TYPE);


### PR DESCRIPTION
Fixes #https://github.com/StarRocks/StarRocksTest/issues/3012

When variable is bool type, `RleEncoder` requires value to be 1 or 0. However, when we use `memcpy` to assign a value to bool type variable, the value could larger than 1.


## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
