### PR TITLE
[BugFix] Fix the openjdk installation command in start_fe.sh

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -82,7 +82,7 @@ Please take the following steps to resolve this issue:
 1. Install OpenJDK 8 or higher using your Linux distribution's package manager.
 For example:
 sudo apt install openjdk-8-jdk  (on Ubuntu/Debian)
-sudo yum install java-1.8.0-openjdk (on CentOS/RHEL)
+sudo yum install java-1.8.0-openjdk-devel (on CentOS/RHEL)
 2. Set the JAVA_HOME environment variable to point to your installed OpenJDK directory.
 For example:
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64


### PR DESCRIPTION
OpenJDK official description：The java-1.8.0-openjdk package contains just the Java Runtime Environment. If you want to develop Java programs then install the java-1.8.0-openjdk-devel package.

Reference URL：https://openjdk.org/install/

Therefore, modify the openjdk installation command in start_fe.sh to: sudo yum install java-1.8.0-openjdk-devel.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
