### PR TITLE
[BugFix] Thread pools that differentiate between sparkload tasks and brokerloa…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -899,6 +899,12 @@ public class Config extends ConfigBase {
     public static int max_broker_load_job_concurrency = 5;
 
     /**
+     * The spark load task executor pool size, this pool size limits the max running spark load tasks.
+     */
+    @ConfField(mutable = true)
+    public static int max_spark_load_job_concurrency = 5;
+
+    /**
      * Same meaning as *tablet_create_timeout_second*, but used when delete a tablet.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -174,7 +174,7 @@ public class BrokerLoadJob extends BulkLoadJob {
     protected void unprotectedExecuteJob() throws LoadException {
         LoadTask task = new BrokerLoadPendingTask(this, fileGroupAggInfo.getAggKeyToFileGroups(), brokerDesc);
         idToTasks.put(task.getSignature(), task);
-        submitTask(GlobalStateMgr.getCurrentState().getPendingLoadTaskScheduler(), task);
+        submitTask(GlobalStateMgr.getCurrentState().getPendingBrokerLoadTaskScheduler(), task);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -271,7 +271,12 @@ public abstract class BulkLoadJob extends LoadJob {
                 // load id will be added to loadStatistic when executing this task
                 try {
                     if (loadTask.getTaskType() == LoadTask.TaskType.PENDING) {
-                        submitTask(GlobalStateMgr.getCurrentState().getPendingLoadTaskScheduler(), loadTask);
+                        if (loadTask instanceof SparkLoadPendingTask) {
+                            submitTask(GlobalStateMgr.getCurrentState().getPendingSparkLoadTaskScheduler(), loadTask);
+                        }
+                        if (loadTask instanceof BrokerLoadPendingTask) {
+                            submitTask(GlobalStateMgr.getCurrentState().getPendingBrokerLoadTaskScheduler(), loadTask);
+                        }
                     } else if (loadTask.getTaskType() == LoadTask.TaskType.LOADING) {
                         submitTask(GlobalStateMgr.getCurrentState().getLoadingLoadTaskScheduler(), loadTask);
                     } else {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -247,7 +247,7 @@ public class SparkLoadJob extends BulkLoadJob {
                 sparkResource, brokerDesc);
         task.init();
         idToTasks.put(task.getSignature(), task);
-        submitTask(GlobalStateMgr.getCurrentState().getPendingLoadTaskScheduler(), task);
+        submitTask(GlobalStateMgr.getCurrentState().getPendingSparkLoadTaskScheduler(), task);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -461,7 +461,9 @@ public class GlobalStateMgr {
     private TabletChecker tabletChecker;
 
     // Thread pools for pending and loading task, separately
-    private LeaderTaskExecutor pendingLoadTaskScheduler;
+    private LeaderTaskExecutor pendingBrokerLoadTaskScheduler;
+    // Thread pools for pending spark load task
+    private LeaderTaskExecutor pendingSparkLoadTaskScheduler;
     private PriorityLeaderTaskExecutor loadingLoadTaskScheduler;
 
     private LoadJobScheduler loadJobScheduler;
@@ -710,9 +712,11 @@ public class GlobalStateMgr {
         this.tabletScheduler = new TabletScheduler(stat);
         this.tabletChecker = new TabletChecker(tabletScheduler, stat);
 
-        this.pendingLoadTaskScheduler =
-                new LeaderTaskExecutor("pending_load_task_scheduler", Config.max_broker_load_job_concurrency,
+        this.pendingBrokerLoadTaskScheduler =
+                new LeaderTaskExecutor("pending_broker_load_task_scheduler", Config.max_broker_load_job_concurrency,
                         Config.desired_max_waiting_jobs, !isCkptGlobalState);
+        this.pendingSparkLoadTaskScheduler = new LeaderTaskExecutor("pending_spark_load_task_scheduler",
+                Config.max_spark_load_job_concurrency, Config.desired_max_waiting_jobs, !isCkptGlobalState);
         // One load job will be split into multiple loading tasks, the queue size is not
         // determined, so set desired_max_waiting_jobs * 10
         this.loadingLoadTaskScheduler = new PriorityLeaderTaskExecutor("loading_load_task_scheduler",
@@ -1332,7 +1336,9 @@ public class GlobalStateMgr {
         heartbeatMgr.setLeader(nodeMgr.getClusterId(), nodeMgr.getToken(), epoch);
         heartbeatMgr.start();
         // New load scheduler
-        pendingLoadTaskScheduler.start();
+        pendingBrokerLoadTaskScheduler.start();
+        // New spark load scheduler
+        pendingSparkLoadTaskScheduler.start();
         loadingLoadTaskScheduler.start();
         loadMgr.prepareJobs();
         loadJobScheduler.start();
@@ -3137,8 +3143,12 @@ public class GlobalStateMgr {
         return loadMgr;
     }
 
-    public LeaderTaskExecutor getPendingLoadTaskScheduler() {
-        return pendingLoadTaskScheduler;
+    public LeaderTaskExecutor getPendingBrokerLoadTaskScheduler() {
+        return pendingBrokerLoadTaskScheduler;
+    }
+
+    public LeaderTaskExecutor getPendingSparkLoadTaskScheduler() {
+        return pendingSparkLoadTaskScheduler;
     }
 
     public PriorityLeaderTaskExecutor getLoadingLoadTaskScheduler() {

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadJobTest.java
@@ -227,7 +227,7 @@ public class SparkLoadJobTest {
                 pendingTask.init();
                 pendingTask.getSignature();
                 result = pendingTaskId;
-                globalStateMgr.getPendingLoadTaskScheduler();
+                globalStateMgr.getPendingSparkLoadTaskScheduler();
                 result = executor;
                 executor.submit((SparkLoadPendingTask) any);
                 result = true;


### PR DESCRIPTION
Separate thread pools for sparkload tasks and brokerload tasks to prevent each task from being time-consuming and interfering with each other's task submission

Fixes #28779 

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4