### PR TITLE
[BugFix] Should not check `canLoad` state when finishing transaction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -839,10 +839,6 @@ public class DatabaseTransactionMgr {
                             // which means publish version task finished in replica
                             for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
                                 if (!errReplicas.contains(replica.getId())) {
-                                    // if replica not in can load state, skip it.
-                                    if (!replica.getState().canLoad()) {
-                                        continue;
-                                    }
                                     // success healthy replica condition:
                                     // 1. version is equal to partition's visible version
                                     // 2. publish version task in this replica has finished
@@ -984,10 +980,6 @@ public class DatabaseTransactionMgr {
                             for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
                                 if (!errorReplicaIds.contains(replica.getId())
                                         && replica.getLastFailedVersion() < 0) {
-                                    // if replica not in can load state, skip it.
-                                    if (!replica.getState().canLoad()) {
-                                        continue;
-                                    }
                                     // if replica not commit yet, skip it. This may happen when it's just create by clone.
                                     if (!transactionState.tabletCommitInfosContainsReplica(tablet.getId(), 
                                             replica.getBackendId())) {


### PR DESCRIPTION
This is to fix issue introduced by #26592 

Txn begin before the replica is set decommissioned and publish after that
will fail because of the check. In this case only check whether this txn has
ever committed on the decommissioned replica is enough to prevent issue
fixed by pr #26592 and #26788.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
