### PR TITLE
 [Doc]2.5.9 sparkload supports date/datetime/decimal as bucketing cols #28810

### DIFF
--- a/docs/loading/SparkLoad.md
+++ b/docs/loading/SparkLoad.md
@@ -4,6 +4,9 @@ This load uses external Apache Spark™ resources to pre-process imported data, 
 
 Spark load is an **asynchronous** import method that requires users to create Spark-type import jobs via the MySQL protocol and view the import results using `SHOW LOAD`.
 
+> **NOTICE**
+> Earlier than v3.0.4, the bucketing column of the StarRocks table cannot be of DATE, DATETIME, or DECIMAL type when Spark Load is used to load data into a StarRocks table.
+
 ## Terminology explanation
 
 * **Spark ETL**: Mainly responsible for ETL of data in the import process, including global dictionary construction (BITMAP type), partitioning, sorting, aggregation, etc.

--- a/docs/loading/SparkLoad.md
+++ b/docs/loading/SparkLoad.md
@@ -5,7 +5,7 @@ This load uses external Apache Spark™ resources to pre-process imported data, 
 Spark load is an **asynchronous** import method that requires users to create Spark-type import jobs via the MySQL protocol and view the import results using `SHOW LOAD`.
 
 > **NOTICE**
-> Earlier than v2.5.9, the bucketing column of the StarRocks table cannot be of DATE, DATETIME, or DECIMAL type when Spark Load is used to load data into a StarRocks table.
+> In versions earlier than v2.5.9, the bucketing column of a StarRocks table cannot be of DATE, DATETIME, or DECIMAL type when Spark Load is used to load data into this table.
 
 ## Terminology explanation
 

--- a/docs/loading/SparkLoad.md
+++ b/docs/loading/SparkLoad.md
@@ -5,7 +5,7 @@ This load uses external Apache Spark™ resources to pre-process imported data, 
 Spark load is an **asynchronous** import method that requires users to create Spark-type import jobs via the MySQL protocol and view the import results using `SHOW LOAD`.
 
 > **NOTICE**
-> Earlier than v3.0.4, the bucketing column of the StarRocks table cannot be of DATE, DATETIME, or DECIMAL type when Spark Load is used to load data into a StarRocks table.
+> Earlier than v2.5.9, the bucketing column of the StarRocks table cannot be of DATE, DATETIME, or DECIMAL type when Spark Load is used to load data into a StarRocks table.
 
 ## Terminology explanation
 


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
