### PR TITLE
[Enhancement] Support text-based profile analysis(3)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DebugUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DebugUtil.java
@@ -60,7 +60,7 @@ public class DebugUtil {
     public static long TERABYTE = 1024 * GIGABYTE;
 
     public static Pair<Double, String> getUint(long value) {
-        Double doubleValue = Double.valueOf(value);
+        double doubleValue = (double) value;
         String unit = "";
         if (value >= BILLION) {
             unit = "B";
@@ -72,8 +72,7 @@ public class DebugUtil {
             unit = "K";
             doubleValue /= THOUSAND;
         }
-        Pair<Double, String> returnValue = Pair.create(doubleValue, unit);
-        return returnValue;
+        return Pair.create(doubleValue, unit);
     }
 
     // Print the value (timestamp in ms) to builder
@@ -121,28 +120,24 @@ public class DebugUtil {
     }
 
     public static Pair<Double, String> getByteUint(long value) {
-        Double doubleValue = Double.valueOf(value);
-        String unit = "";
-        if (value == 0) {
-            // nothing
-            unit = "";
-        } else if (value > TERABYTE) {
+        double doubleValue = (double) value;
+        String unit;
+        if (value >= TERABYTE) {
             unit = "TB";
             doubleValue /= TERABYTE;
-        } else if (value > GIGABYTE) {
+        } else if (value >= GIGABYTE) {
             unit = "GB";
             doubleValue /= GIGABYTE;
-        } else if (value > MEGABYTE) {
+        } else if (value >= MEGABYTE) {
             unit = "MB";
             doubleValue /= MEGABYTE;
-        } else if (value > KILOBYTE) {
+        } else if (value >= KILOBYTE) {
             unit = "KB";
             doubleValue /= KILOBYTE;
         } else {
             unit = "B";
         }
-        Pair<Double, String> returnValue = Pair.create(doubleValue, unit);
-        return returnValue;
+        return Pair.create(doubleValue, unit);
     }
 
     public static String printId(final TUniqueId id) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -83,18 +83,15 @@ public class ProfileManager {
     public static class ProfileElement {
         public Map<String, String> infoStrings = Maps.newHashMap();
         public byte[] profileContent;
-
-        public ExecPlan plan;
-        public RuntimeProfile profile;
+        public ProfilingExecPlan plan;
 
         public List<String> toRow() {
             List<String> res = Lists.newArrayList();
-            RuntimeProfile summary = profile.getChildList().get(0).first;
-            res.add(summary.getInfoString(QUERY_ID));
-            res.add(summary.getInfoString(START_TIME));
-            res.add(summary.getInfoString(TOTAL_TIME));
-            res.add(summary.getInfoString(QUERY_STATE));
-            String statement = summary.getInfoString(SQL_STATEMENT);
+            res.add(infoStrings.get(QUERY_ID));
+            res.add(infoStrings.get(START_TIME));
+            res.add(infoStrings.get(TOTAL_TIME));
+            res.add(infoStrings.get(QUERY_STATE));
+            String statement = infoStrings.get(SQL_STATEMENT);
             if (statement.length() > 128) {
                 statement = statement.substring(0, 124) + " ...";
             }
@@ -149,8 +146,8 @@ public class ProfileManager {
                 profileString = profile.toString();
                 break;
             case "json":
-                RuntimeProfile.ProfileFormater formater = new RuntimeProfile.JsonProfileFormater();
-                profileString = formater.format(profile, "");
+                RuntimeProfile.ProfileFormatter formatter = new RuntimeProfile.JsonProfileFormater();
+                profileString = formatter.format(profile, "");
                 break;
             default:
                 profileString = profile.toString();
@@ -162,8 +159,7 @@ public class ProfileManager {
     public String pushProfile(ExecPlan plan, RuntimeProfile profile) {
         String profileString = generateProfileString(profile);
         ProfileElement element = createElement(profile.getChildList().get(0).first, profileString);
-        element.plan = plan;
-        element.profile = profile;
+        element.plan = ProfilingExecPlan.buildFrom(plan);
         String queryId = element.infoStrings.get(ProfileManager.QUERY_ID);
         // check when push in, which can ensure every element in the list has QUERY_ID column,
         // so there is no need to check when remove element from list.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
@@ -1,0 +1,394 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.AggregateInfo;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.OrderByElement;
+import com.starrocks.analysis.SlotId;
+import com.starrocks.analysis.SortInfo;
+import com.starrocks.common.Pair;
+import com.starrocks.planner.AggregationNode;
+import com.starrocks.planner.AnalyticEvalNode;
+import com.starrocks.planner.DataPartition;
+import com.starrocks.planner.DataSink;
+import com.starrocks.planner.DataStreamSink;
+import com.starrocks.planner.ExchangeNode;
+import com.starrocks.planner.JoinNode;
+import com.starrocks.planner.MultiCastDataSink;
+import com.starrocks.planner.OlapScanNode;
+import com.starrocks.planner.OlapTableSink;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.PlanNode;
+import com.starrocks.planner.ProjectNode;
+import com.starrocks.planner.ResultSink;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.planner.SelectNode;
+import com.starrocks.planner.SortNode;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.optimizer.ExpressionContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.cost.CostEstimate;
+import com.starrocks.sql.optimizer.cost.CostModel;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.sql.plan.ExecPlan;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+// This class is designed to maintain only the necessary information of ExecPlan for profile analysis
+// Because, the frontend may cache at least 500 queries, it may lead to great memory cost if we simply cache the
+// ExecPlan instance.
+public class ProfilingExecPlan {
+
+    private static final int MAX_EXPR_LENGTH = 64;
+
+    public static final class ProfilingFragment {
+        private final ProfilingElement sink;
+        private final ProfilingElement root;
+
+        public ProfilingFragment(ProfilingElement sink, ProfilingElement root) {
+            this.sink = sink;
+            this.root = root;
+        }
+
+        public ProfilingElement getSink() {
+            return sink;
+        }
+
+        public ProfilingElement getRoot() {
+            return root;
+        }
+    }
+
+    public static final class ProfilingElement {
+        private final int id;
+        private final Class<?> clazz;
+        private final List<ProfilingElement> children = Lists.newArrayList();
+        private final List<Integer> multiSinkIds = Lists.newArrayList();
+        private final List<String> titleAttributes = Lists.newArrayList();
+        private final Map<String, String> uniqueInfos = Maps.newLinkedHashMap();
+
+        private Statistics statistics;
+        private CostEstimate costEstimate;
+        private double totalCost;
+
+        public ProfilingElement(int id, Class<?> clazz) {
+            this.id = id;
+            this.clazz = clazz;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public Class<?> getClazz() {
+            return clazz;
+        }
+
+        public boolean instanceOf(Class<?> parent) {
+            return parent.isAssignableFrom(clazz);
+        }
+
+        public boolean hasChild(int i) {
+            return i < children.size();
+        }
+
+        public ProfilingElement getChild(int i) {
+            return children.get(i);
+        }
+
+        public List<ProfilingElement> getChildren() {
+            return children;
+        }
+
+        public List<Integer> getMultiSinkIds() {
+            return multiSinkIds;
+        }
+
+        public List<String> getTitleAttributes() {
+            return titleAttributes;
+        }
+
+        public Map<String, String> getUniqueInfos() {
+            return uniqueInfos;
+        }
+
+        public Statistics getStatistics() {
+            return statistics;
+        }
+
+        public CostEstimate getCostEstimate() {
+            return costEstimate;
+        }
+
+        public double getTotalCost() {
+            return totalCost;
+        }
+
+        private void addChild(ProfilingElement node) {
+            children.add(node);
+        }
+
+        private void addMultiSinkIds(List<Integer> ids) {
+            multiSinkIds.addAll(ids);
+        }
+
+        private void addTitleAttribute(String attribute) {
+            titleAttributes.add(attribute);
+        }
+
+        private void addInfo(String name, String content) {
+            uniqueInfos.put(name, content);
+        }
+
+        private void setEstimation(Statistics statistics, CostEstimate costEstimate, double totalCost) {
+            this.statistics = statistics;
+            this.costEstimate = costEstimate;
+            this.totalCost = totalCost;
+        }
+    }
+
+    public static ProfilingExecPlan buildFrom(ExecPlan execPlan) {
+        if (execPlan == null) {
+            return null;
+        }
+        ProfilingExecPlan profilingPlan = new ProfilingExecPlan();
+        ConnectContext connectContext = execPlan.getConnectContext();
+        if (connectContext != null) {
+            SessionVariable sessionVariable = connectContext.getSessionVariable();
+            profilingPlan.profileLevel = sessionVariable.getPipelineProfileLevel();
+        }
+
+        Map<Integer, ProfilingElement> visitedElements = Maps.newHashMap();
+        for (PlanFragment fragment : execPlan.getFragments()) {
+            DataSink sink = fragment.getSink();
+            PlanNode planRoot = fragment.getPlanRoot();
+
+            ProfilingFragment lightFragment = new ProfilingFragment(visitSink(sink),
+                    visitNode(profilingPlan, execPlan, planRoot, visitedElements));
+            profilingPlan.addFragment(lightFragment);
+        }
+
+        return profilingPlan;
+    }
+
+    private static ProfilingElement visitSink(DataSink sink) {
+        ProfilingElement element;
+        if (sink instanceof MultiCastDataSink || sink instanceof ResultSink) {
+            element = new ProfilingElement(-1, sink.getClass());
+        } else {
+            element = new ProfilingElement(sink.getExchNodeId().asInt(), sink.getClass());
+        }
+
+        DataPartition outputPartition = null;
+        if (sink instanceof MultiCastDataSink) {
+            List<DataStreamSink> sinks = ((MultiCastDataSink) sink).getDataStreamSinks();
+            List<Integer> ids = Lists.newArrayList();
+            if (CollectionUtils.isNotEmpty(sinks)) {
+                sinks.forEach(s -> ids.add(s.getExchNodeId().asInt()));
+                outputPartition = sinks.get(0).getOutputPartition();
+            }
+            element.addMultiSinkIds(ids);
+        } else {
+            outputPartition = sink.getOutputPartition();
+        }
+        if (outputPartition != null) {
+            element.addInfo("PartitionType", outputPartition.getType().toString());
+            if (CollectionUtils.isNotEmpty(outputPartition.getPartitionExprs())) {
+                element.addInfo("PartitionExprs", exprsToString(outputPartition.getPartitionExprs()));
+            }
+        }
+
+        if (sink instanceof ResultSink) {
+            ResultSink resultSink = (ResultSink) sink;
+            element.addInfo("SinkType", resultSink.getSinkType().toString());
+        } else if (sink instanceof OlapTableSink) {
+            OlapTableSink olapTableSink = (OlapTableSink) sink;
+            element.addInfo("Table", olapTableSink.getDstTable().getName());
+        }
+
+        return element;
+    }
+
+    private static ProfilingElement visitNode(ProfilingExecPlan profilingPlan, ExecPlan execPlan, PlanNode node,
+                                              Map<Integer, ProfilingElement> visitedElements) {
+        if (visitedElements.containsKey(node.getId().asInt())) {
+            return visitedElements.get(node.getId().asInt());
+        }
+
+        ProfilingElement element = new ProfilingElement(node.getId().asInt(), node.getClass());
+        buildCostEstimation(execPlan, element);
+        buildTitleAttribute(node, element);
+        buildUniqueInfos(node, element);
+
+        for (PlanNode child : node.getChildren()) {
+            element.addChild(visitNode(profilingPlan, execPlan, child, visitedElements));
+        }
+
+        visitedElements.put(element.getId(), element);
+        return element;
+    }
+
+    private static void buildCostEstimation(ExecPlan execPlan, ProfilingElement element) {
+        OptExpression optExpression = execPlan.getOptExpression(element.getId());
+        if (optExpression != null) {
+            CostEstimate cost = CostModel.calculateCostEstimate(new ExpressionContext(optExpression));
+            element.setEstimation(optExpression.getStatistics(), cost, optExpression.getCost());
+        }
+    }
+
+    private static void buildTitleAttribute(PlanNode node, ProfilingElement element) {
+        if (node instanceof AggregationNode) {
+            AggregationNode aggNode = (AggregationNode) node;
+            element.addTitleAttribute(aggNode.getAggInfo().isMerge() ? "merge" : "update");
+            element.addTitleAttribute(aggNode.isNeedsFinalize() ? "finalize" : "serialize");
+        } else if (node instanceof JoinNode) {
+            JoinNode joinNode = (JoinNode) node;
+            element.addTitleAttribute(joinNode.getJoinOp().toString());
+            element.addTitleAttribute(joinNode.getDistrMode().toString());
+        } else if (node instanceof SortNode) {
+            SortNode sortNode = (SortNode) node;
+            element.addTitleAttribute(sortNode.isUseTopN() ? "TOP-N" :
+                    (sortNode.getSortInfo().getPartitionExprs().isEmpty() ? "SORT" : "PARTITION-TOP-N"));
+            element.addTitleAttribute(sortNode.getTopNType().toString());
+        } else if (node instanceof ExchangeNode) {
+            ExchangeNode exchangeNode = (ExchangeNode) node;
+            if (exchangeNode.getDistributionType() != null) {
+                element.addTitleAttribute(exchangeNode.getDistributionType().toString());
+            }
+        }
+    }
+
+    private static void buildUniqueInfos(PlanNode node, ProfilingElement element) {
+        if (node instanceof AggregationNode) {
+            AggregationNode aggregationNode = (AggregationNode) node;
+            AggregateInfo aggInfo = aggregationNode.getAggInfo();
+            if (aggInfo == null) {
+                return;
+            }
+            if (CollectionUtils.isNotEmpty(aggInfo.getAggregateExprs())) {
+                element.addInfo("AggExprs", exprsToString(aggInfo.getAggregateExprs()));
+            }
+            if (CollectionUtils.isNotEmpty(aggInfo.getGroupingExprs())) {
+                element.addInfo("GroupingExprs", exprsToString(aggInfo.getGroupingExprs()));
+            }
+        } else if (node instanceof AnalyticEvalNode) {
+            AnalyticEvalNode window = (AnalyticEvalNode) node;
+            if (CollectionUtils.isNotEmpty(window.getAnalyticFnCalls())) {
+                element.addInfo("Functions", exprsToString(window.getAnalyticFnCalls()));
+            }
+            if (CollectionUtils.isNotEmpty(window.getPartitionExprs())) {
+                element.addInfo("PartitionExprs", exprsToString(window.getPartitionExprs()));
+            }
+            if (CollectionUtils.isNotEmpty(window.getOrderByElements())) {
+                element.addInfo("OrderByExprs", exprsToString(window.getOrderByElements().stream()
+                        .map(OrderByElement::getExpr).collect(Collectors.toList())));
+            }
+        } else if (node instanceof ProjectNode) {
+            ProjectNode projectNode = (ProjectNode) node;
+            if (MapUtils.isNotEmpty(projectNode.getSlotMap())) {
+                List<Pair<SlotId, Expr>> orderedExprs = new ArrayList<>();
+                for (Map.Entry<SlotId, Expr> kv : projectNode.getSlotMap().entrySet()) {
+                    orderedExprs.add(new Pair<>(kv.getKey(), kv.getValue()));
+                }
+                orderedExprs.sort(Comparator.comparingInt(o -> o.first.asInt()));
+                element.addInfo("Expression",
+                        exprsToString(orderedExprs.stream().map(kv -> kv.second).collect(Collectors.toList())));
+            }
+
+            if (MapUtils.isNotEmpty(projectNode.getCommonSlotMap())) {
+                List<Pair<SlotId, Expr>> orderedExprs = new ArrayList<>();
+                for (Map.Entry<SlotId, Expr> kv : projectNode.getCommonSlotMap().entrySet()) {
+                    orderedExprs.add(new Pair<>(kv.getKey(), kv.getValue()));
+                }
+                orderedExprs.sort(Comparator.comparingInt(o -> o.first.asInt()));
+                element.addInfo("CommonExpression",
+                        exprsToString(orderedExprs.stream().map(kv -> kv.second).collect(Collectors.toList())));
+            }
+        } else if (node instanceof JoinNode) {
+            JoinNode joinNode = (JoinNode) node;
+            if (CollectionUtils.isNotEmpty(joinNode.getEqJoinConjuncts())) {
+                element.addInfo("EqJoinConjuncts", exprsToString(joinNode.getEqJoinConjuncts()));
+            }
+        } else if (node instanceof SelectNode) {
+            SelectNode selectNode = (SelectNode) node;
+            if (CollectionUtils.isNotEmpty(selectNode.getConjuncts())) {
+                element.addInfo("Predicates", exprsToString(selectNode.getConjuncts()));
+            }
+        } else if (node instanceof SortNode) {
+            SortNode sortNode = (SortNode) node;
+            SortInfo sortInfo = sortNode.getSortInfo();
+            if (CollectionUtils.isNotEmpty(sortInfo.getPartitionExprs())) {
+                element.addInfo("PartitionExprs", exprsToString(sortInfo.getPartitionExprs()));
+            }
+            if (CollectionUtils.isNotEmpty(sortInfo.getOrderingExprs())) {
+                element.addInfo("OrderByExprs", exprsToString(sortInfo.getOrderingExprs()));
+            }
+        } else if (node instanceof ScanNode) {
+            ScanNode scanNode = (ScanNode) node;
+            if (scanNode instanceof OlapScanNode) {
+                OlapScanNode olapScanNode = (OlapScanNode) scanNode;
+                element.addInfo("Table: ", olapScanNode.getOlapTable().getName());
+            }
+        }
+    }
+
+    private static String exprsToString(List<? extends Expr> exprs) {
+        List<String> exprContents = exprs.stream()
+                .map(Expr::toSql)
+                .collect(Collectors.toList());
+        int lastIndex = -1;
+        int length = 0;
+        int originalSize = exprs.size();
+        for (int i = 0; i < originalSize; i++) {
+            if (length + exprContents.get(i).length() > MAX_EXPR_LENGTH) {
+                break;
+            }
+            lastIndex = i;
+            length += exprContents.get(i).length();
+        }
+        if (lastIndex >= 0) {
+            exprContents = exprContents.subList(0, lastIndex + 1);
+        }
+        if (lastIndex < originalSize - 1) {
+            exprContents.add("...");
+        }
+        return "[" + String.join(", ", exprContents) + "]";
+    }
+
+    private int profileLevel;
+    private final List<ProfilingFragment> fragments = new ArrayList<>();
+
+    public int getProfileLevel() {
+        return profileLevel;
+    }
+
+    public List<ProfilingFragment> getFragments() {
+        return fragments;
+    }
+
+    private void addFragment(ProfilingFragment fragment) {
+        fragments.add(fragment);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
@@ -198,7 +198,8 @@ public class ProfilingExecPlan {
         if (sink instanceof MultiCastDataSink || sink instanceof ResultSink) {
             element = new ProfilingElement(-1, sink.getClass());
         } else {
-            element = new ProfilingElement(sink.getExchNodeId().asInt(), sink.getClass());
+            element = new ProfilingElement(sink.getExchNodeId() == null ? -1 : sink.getExchNodeId().asInt(),
+                    sink.getClass());
         }
 
         DataPartition outputPartition = null;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -339,12 +339,12 @@ public class RuntimeProfile {
     //  3. Counters
     //  4. Children
     public void prettyPrint(StringBuilder builder, String prefix) {
-        ProfileFormater formater = new DefaultProfileFormater(builder);
-        formater.format(this, prefix);
+        ProfileFormatter formatter = new DefaultProfileFormatter(builder);
+        formatter.format(this, prefix);
     }
 
     public String toString() {
-        ProfileFormater formater = new DefaultProfileFormater();
+        ProfileFormatter formater = new DefaultProfileFormatter();
         return formater.format(this);
     }
 
@@ -357,66 +357,55 @@ public class RuntimeProfile {
 
     private static String printCounter(long value, TUnit type) {
         StringBuilder builder = new StringBuilder();
-        long tmpValue = value;
-        switch (type) {
-            case UNIT: {
-                Pair<Double, String> pair = DebugUtil.getUint(tmpValue);
+        try (Formatter fmt = new Formatter()) {
+            if (type == TUnit.UNIT || type == TUnit.UNIT_PER_SECOND) {
+                Pair<Double, String> pair = DebugUtil.getUint(value);
                 if (pair.second.isEmpty()) {
-                    builder.append(tmpValue);
+                    builder.append(value);
                 } else {
-                    builder.append(pair.first).append(pair.second)
-                            .append(" (").append(tmpValue).append(")");
+                    builder.append(fmt.format("%.3f", pair.first)).append(pair.second)
+                            .append(" (").append(value).append(")");
                 }
-                break;
-            }
-            case TIME_NS: {
-                if (tmpValue >= DebugUtil.BILLION) {
+                if (type == TUnit.UNIT_PER_SECOND) {
+                    builder.append(" /sec");
+                }
+            } else if (type == TUnit.BYTES || type == TUnit.BYTES_PER_SECOND) {
+                Pair<Double, String> pair = DebugUtil.getByteUint(value);
+                builder.append(fmt.format("%.3f", pair.first)).append(" ").append(pair.second);
+                if (type == TUnit.BYTES_PER_SECOND) {
+                    builder.append("/sec");
+                }
+            } else if (type == TUnit.TIME_NS) {
+                if (value >= DebugUtil.BILLION) {
                     // If the time is over a second, print it up to ms.
-                    tmpValue /= DebugUtil.MILLION;
-                    DebugUtil.printTimeMs(tmpValue, builder);
-                } else if (tmpValue >= DebugUtil.MILLION) {
+                    value /= DebugUtil.MILLION;
+                    DebugUtil.printTimeMs(value, builder);
+                } else if (value >= DebugUtil.MILLION) {
                     // if the time is over a ms, print it up to microsecond in the unit of ms.
-                    tmpValue /= 1000;
-                    builder.append(tmpValue / 1000).append(".").append(tmpValue % 1000).append("ms");
-                } else if (tmpValue > 1000) {
+                    value /= DebugUtil.THOUSAND;
+                    long remain = value % DebugUtil.THOUSAND;
+                    if (remain == 0) {
+                        builder.append(value / DebugUtil.THOUSAND).append("ms");
+                    } else {
+                        builder.append(value / DebugUtil.THOUSAND).append(".")
+                                .append(String.format("%03d", remain)).append("ms");
+                    }
+                } else if (value >= DebugUtil.THOUSAND) {
                     // if the time is over a microsecond, print it using unit microsecond
-                    builder.append(tmpValue / 1000).append(".").append(tmpValue % 1000).append("us");
+                    long remain = value % DebugUtil.THOUSAND;
+                    if (remain == 0) {
+                        builder.append(value / DebugUtil.THOUSAND).append("us");
+                    } else {
+                        builder.append(value / DebugUtil.THOUSAND).append(".")
+                                .append(String.format("%03d", remain)).append("us");
+                    }
                 } else {
-                    builder.append(tmpValue).append("ns");
+                    builder.append(value).append("ns");
                 }
-                break;
-            }
-            case BYTES: {
-                Pair<Double, String> pair = DebugUtil.getByteUint(tmpValue);
-                Formatter fmt = new Formatter();
-                builder.append(fmt.format("%.2f", pair.first)).append(" ").append(pair.second);
-                fmt.close();
-                break;
-            }
-            case BYTES_PER_SECOND: {
-                Pair<Double, String> pair = DebugUtil.getByteUint(tmpValue);
-                builder.append(pair.first).append(" ").append(pair.second).append("/sec");
-                break;
-            }
-            case DOUBLE_VALUE: {
-                Formatter fmt = new Formatter();
-                builder.append(fmt.format("%.2f", (double) tmpValue));
-                fmt.close();
-                break;
-            }
-            case UNIT_PER_SECOND: {
-                Pair<Double, String> pair = DebugUtil.getUint(tmpValue);
-                if (pair.second.isEmpty()) {
-                    builder.append(tmpValue);
-                } else {
-                    builder.append(pair.first).append(pair.second)
-                            .append(" ").append("/sec");
-                }
-                break;
-            }
-            default: {
+            } else if (type == TUnit.DOUBLE_VALUE) {
+                builder.append(fmt.format("%.3f", (double) value));
+            } else {
                 Preconditions.checkState(false, "type=" + type);
-                break;
             }
         }
         return builder.toString();
@@ -755,7 +744,7 @@ public class RuntimeProfile {
         profile.getChildList().forEach(pair -> removeRedundantMinMaxMetrics(pair.first));
     }
 
-    interface ProfileFormater {
+    interface ProfileFormatter {
 
         // Print the profile:
         //  1. Profile Name
@@ -767,15 +756,15 @@ public class RuntimeProfile {
         String format(RuntimeProfile profile);
     }
 
-    static class DefaultProfileFormater implements ProfileFormater {
+    static class DefaultProfileFormatter implements ProfileFormatter {
 
         private final StringBuilder builder;
 
-        DefaultProfileFormater(StringBuilder builder) {
+        DefaultProfileFormatter(StringBuilder builder) {
             this.builder = builder;
         }
 
-        DefaultProfileFormater() {
+        DefaultProfileFormatter() {
             this.builder = new StringBuilder();
         }
 
@@ -857,7 +846,7 @@ public class RuntimeProfile {
         }
     }
 
-    static class JsonProfileFormater implements ProfileFormater {
+    static class JsonProfileFormater implements ProfileFormatter {
         private final JsonObject builder;
 
         JsonProfileFormater() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfileParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfileParser.java
@@ -1,0 +1,330 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.common.util;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.starrocks.thrift.TUnit;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.util.LinkedList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This class is used for reconstruct RuntimeProfile from plain text
+ */
+public class RuntimeProfileParser {
+    private static final Pattern BYTE_COUNTER_PATTERN =
+            Pattern.compile("^- (.*?): (-?\\d+\\.\\d+) (KB|MB|GB|TB|B)$");
+    private static final Pattern BYTE_PER_SEC_COUNTER_PATTERN =
+            Pattern.compile("^- (.*?): (-?\\d+\\.\\d+) (KB|MB|GB|TB|B)/sec$");
+    private static final Pattern UNIT_COUNTER_PATTERN =
+            Pattern.compile("^- (.*?): (-?\\d+(\\.\\d+)?([eE][-+]?\\d+)?)[BMK]?( \\((-?\\d+(\\.\\d+)?)\\))?$");
+    private static final Pattern UNIT_PER_SEC_COUNTER_PATTERN =
+            Pattern.compile("^- (.*?): (-?\\d+(\\.\\d+)?([eE][-+]?\\d+)?)[BMK]?( \\((-?\\d+(\\.\\d+)?)\\))? /sec$");
+    private static final Pattern TIMER_PATTERN =
+            Pattern.compile("^- (.*?): (((-?\\d+(\\.\\d+)?)(ms|us|ns|h|m|s))+)$");
+    private static final Pattern TIMER_SEGMENT_PATTERN =
+            Pattern.compile("(-?\\d+(\\.\\d+)?)(ms|us|ns|h|m|s)");
+    private static final Pattern INFO_STRING_PATTERN =
+            Pattern.compile("^- (.*?): (.*?)$");
+
+    public static RuntimeProfile parseFrom(String content) {
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(content));
+        // (profile, profileIndent, counterStack(name, counter, counterIndent))
+        LinkedList<ProfileTuple> profileStack = Lists.newLinkedList();
+        RuntimeProfile root = null;
+        try {
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                int curIndent = getIndentWidth(line);
+                String item = line.substring(curIndent);
+                if (StringUtils.isBlank(item)) {
+                    continue;
+                }
+                String profileName;
+                CounterTuple counterTuple;
+                InfoStringTuple infoStringTuple;
+                if ((profileName = tryGetProfileName(item)) != null) {
+                    RuntimeProfile profile = new RuntimeProfile(profileName);
+                    if (root == null) {
+                        root = profile;
+                    }
+
+                    while (!profileStack.isEmpty() && profileStack.peek().indent >= curIndent) {
+                        profileStack.pop();
+                    }
+
+                    if (!profileStack.isEmpty()) {
+                        profileStack.peek().profile.addChild(profile);
+                    }
+
+                    profileStack.push(new ProfileTuple(profile, curIndent));
+                } else if ((counterTuple = tryParseCounter(item)) != null) {
+                    Preconditions.checkState(!profileStack.isEmpty());
+                    ProfileTuple profileTuple = profileStack.peek();
+
+                    while (!profileTuple.counterStack.isEmpty() &&
+                            profileTuple.counterStack.peek().indent >= curIndent) {
+                        profileTuple.counterStack.pop();
+                    }
+
+                    Counter counter;
+                    RuntimeProfile profile = profileTuple.profile;
+                    if (profileTuple.counterStack.isEmpty()) {
+                        counter = profile.addCounter(counterTuple.name, counterTuple.type, null);
+                        counter.setValue(counterTuple.value);
+                    } else {
+                        String parent = profileTuple.counterStack.peek().name;
+                        counter = profile.addCounter(counterTuple.name, counterTuple.type, null, parent);
+                        counter.setValue(counterTuple.value);
+                    }
+
+                    counterTuple.indent = curIndent;
+                    profileTuple.counterStack.push(counterTuple);
+                } else if ((infoStringTuple = tryParseInfoString(item)) != null) {
+                    Preconditions.checkState(!profileStack.isEmpty());
+                    ProfileTuple profileTuple = profileStack.peek();
+                    profileTuple.profile.addInfoString(infoStringTuple.name, infoStringTuple.content);
+                }
+            }
+        } catch (IOException e) {
+            return null;
+        }
+
+        return root;
+    }
+
+    private static int getIndentWidth(String line) {
+        for (int i = 0; i < line.length(); i++) {
+            if (!Character.isWhitespace(line.charAt(i))) {
+                return i;
+            }
+        }
+        return line.length();
+    }
+
+    private static String tryGetProfileName(String item) {
+        if (!item.startsWith("-") && item.endsWith(":")) {
+            return item.substring(0, item.length() - 1);
+        }
+        return null;
+    }
+
+    private static CounterTuple tryParseCounter(String item) {
+        CounterTuple counterTuple = tryParseByteCounter(item);
+        if (counterTuple != null) {
+            return counterTuple;
+        }
+        counterTuple = tryParseBytePerSecCounter(item);
+        if (counterTuple != null) {
+            return counterTuple;
+        }
+        counterTuple = tryParseUnitCounter(item);
+        if (counterTuple != null) {
+            return counterTuple;
+        }
+        counterTuple = tryParseUnitPerSecCounter(item);
+        if (counterTuple != null) {
+            return counterTuple;
+        }
+        return tryParseTimer(item);
+    }
+
+    private static InfoStringTuple tryParseInfoString(String item) {
+        Matcher matcher = INFO_STRING_PATTERN.matcher(item);
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        String name = matcher.group(1);
+        String content = matcher.group(2);
+
+        return new InfoStringTuple(name, content);
+    }
+
+    private static CounterTuple tryParseByteCounter(String item) {
+        Matcher matcher = BYTE_COUNTER_PATTERN.matcher(item);
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        String name = matcher.group(1);
+        BigDecimal value = new BigDecimal(matcher.group(2));
+        String unit = matcher.group(3);
+
+        return new CounterTuple(name, TUnit.BYTES,
+                value.multiply(new BigDecimal(Long.toString(getByteFactor(unit)))).longValue());
+    }
+
+    private static CounterTuple tryParseBytePerSecCounter(String item) {
+        Matcher matcher = BYTE_PER_SEC_COUNTER_PATTERN.matcher(item);
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        String name = matcher.group(1);
+        BigDecimal value = new BigDecimal(matcher.group(2));
+        String unit = matcher.group(3);
+
+        return new CounterTuple(name, TUnit.BYTES_PER_SECOND,
+                value.multiply(new BigDecimal(Long.toString(getByteFactor(unit)))).longValue());
+    }
+
+    private static long getByteFactor(String unit) {
+        long factor = 1;
+        if (unit != null) {
+            switch (unit) {
+                case "KB":
+                    factor = DebugUtil.KILOBYTE;
+                    break;
+                case "MB":
+                    factor = DebugUtil.MEGABYTE;
+                    break;
+                case "GB":
+                    factor = DebugUtil.GIGABYTE;
+                    break;
+                case "TB":
+                    factor = DebugUtil.TERABYTE;
+                    break;
+                default:
+                    break;
+            }
+        }
+        return factor;
+    }
+
+    private static CounterTuple tryParseUnitCounter(String item) {
+        Matcher matcher = UNIT_COUNTER_PATTERN.matcher(item);
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        String name = matcher.group(1);
+        String value = matcher.group(2);
+        String preciseValue = matcher.group(6);
+
+        if (StringUtils.isNotBlank(preciseValue)) {
+            return new CounterTuple(name, TUnit.UNIT, Long.parseLong(preciseValue));
+        } else {
+            long lValue = Long.parseLong(value);
+            if (lValue > 1000) {
+                return null;
+            }
+            return new CounterTuple(name, TUnit.UNIT, lValue);
+        }
+    }
+
+    private static CounterTuple tryParseUnitPerSecCounter(String item) {
+        Matcher matcher = UNIT_PER_SEC_COUNTER_PATTERN.matcher(item);
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        String name = matcher.group(1);
+        String value = matcher.group(2);
+        String preciseValue = matcher.group(6);
+
+        if (StringUtils.isNotBlank(preciseValue)) {
+            return new CounterTuple(name, TUnit.UNIT_PER_SECOND, Long.parseLong(preciseValue));
+        } else {
+            long lValue = Long.parseLong(value);
+            if (lValue > 1000) {
+                return null;
+            }
+            return new CounterTuple(name, TUnit.UNIT_PER_SECOND, lValue);
+        }
+    }
+
+    private static CounterTuple tryParseTimer(String item) {
+        Matcher matcher = TIMER_PATTERN.matcher(item);
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        String name = matcher.group(1);
+        String timeSegments = matcher.group(2);
+        Matcher segmentMatcher = TIMER_SEGMENT_PATTERN.matcher(timeSegments);
+
+        BigDecimal total = new BigDecimal("0");
+        while (segmentMatcher.find()) {
+            BigDecimal value = new BigDecimal(segmentMatcher.group(1));
+            String unit = segmentMatcher.group(3);
+
+            long factor;
+            switch (unit) {
+                case "us":
+                    factor = DebugUtil.THOUSAND;
+                    break;
+                case "ms":
+                    factor = DebugUtil.MILLION;
+                    break;
+                case "s":
+                    factor = DebugUtil.BILLION;
+                    break;
+                case "m":
+                    factor = (long) DebugUtil.MINUTE * DebugUtil.MILLION;
+                    break;
+                case "h":
+                    factor = (long) DebugUtil.HOUR * DebugUtil.MILLION;
+                    break;
+                default:
+                    factor = 1;
+            }
+
+            total = total.add(value.multiply(new BigDecimal(Long.toString(factor))));
+        }
+
+        return new CounterTuple(name, TUnit.TIME_NS, total.longValue());
+    }
+
+    private static final class ProfileTuple {
+        private final RuntimeProfile profile;
+        private final int indent;
+        private final LinkedList<CounterTuple> counterStack = Lists.newLinkedList();
+
+        private ProfileTuple(RuntimeProfile profile, int indent) {
+            this.profile = profile;
+            this.indent = indent;
+        }
+    }
+
+    private static final class CounterTuple {
+        private final String name;
+        private final TUnit type;
+        private final long value;
+        private int indent;
+
+        private CounterTuple(String name, TUnit type, long value) {
+            this.name = name;
+            this.type = type;
+            this.value = value;
+        }
+    }
+
+    private static final class InfoStringTuple {
+        private final String name;
+        private final String content;
+
+        private InfoStringTuple(String name, String content) {
+            this.name = name;
+            this.content = content;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
@@ -159,9 +159,15 @@ public class ExplainAnalyzer {
 
     public ExplainAnalyzer(ProfilingExecPlan plan, RuntimeProfile queryProfile, List<Integer> planNodeIds) {
         this.plan = plan;
-        this.summaryProfile = queryProfile.getChild("Summary");
-        this.plannerProfile = queryProfile.getChild("Planner");
-        this.executionProfile = queryProfile.getChild("Execution");
+        if (this.plan == null) {
+            this.summaryProfile = null;
+            this.plannerProfile = null;
+            this.executionProfile = null;
+        } else {
+            this.summaryProfile = queryProfile.getChild("Summary");
+            this.plannerProfile = queryProfile.getChild("Planner");
+            this.executionProfile = queryProfile.getChild("Execution");
+        }
         if (CollectionUtils.isNotEmpty(planNodeIds)) {
             detailPlanNodeIds.addAll(planNodeIds);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
@@ -18,40 +18,24 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.starrocks.analysis.AggregateInfo;
-import com.starrocks.analysis.Expr;
-import com.starrocks.analysis.OrderByElement;
-import com.starrocks.analysis.SlotId;
-import com.starrocks.analysis.SortInfo;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.Counter;
+import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.planner.AggregationNode;
 import com.starrocks.planner.AnalyticEvalNode;
-import com.starrocks.planner.DataPartition;
-import com.starrocks.planner.DataSink;
-import com.starrocks.planner.DataStreamSink;
 import com.starrocks.planner.ExchangeNode;
 import com.starrocks.planner.JoinNode;
 import com.starrocks.planner.MultiCastDataSink;
-import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.OlapTableSink;
-import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanNode;
-import com.starrocks.planner.ProjectNode;
 import com.starrocks.planner.ResultSink;
 import com.starrocks.planner.ScanNode;
-import com.starrocks.planner.SelectNode;
 import com.starrocks.planner.SortNode;
 import com.starrocks.planner.UnionNode;
-import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.SessionVariable;
-import com.starrocks.sql.optimizer.ExpressionContext;
-import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.cost.CostEstimate;
-import com.starrocks.sql.optimizer.cost.CostModel;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
-import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.thrift.TUnit;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
@@ -59,9 +43,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -83,9 +65,8 @@ public class ExplainAnalyzer {
 
     private static final int RESULT_SINK_PSEUDO_PLAN_NODE_ID = Integer.MAX_VALUE;
     private static final Pattern PLAN_NODE_ID = Pattern.compile("^.*?\\(.*?plan_node_id=([-0-9]+)\\)$");
-    private static final int MAX_EXPR_LENGTH = 64;
 
-    // Colors
+    // ANSI Characters
     private static final String ANSI_RESET = "\u001B[0m";
     private static final String ANSI_BOLD = "\u001B[1m";
     private static final String ANSI_RED = "\u001B[31m";
@@ -114,8 +95,8 @@ public class ExplainAnalyzer {
         return Integer.parseInt(matcher.group(1));
     }
 
-    public static String analyze(ExecPlan execPlan, RuntimeProfile profile, List<Integer> planNodeIds) {
-        ExplainAnalyzer analyzer = new ExplainAnalyzer(execPlan, profile, planNodeIds);
+    public static String analyze(ProfilingExecPlan plan, RuntimeProfile profile, List<Integer> planNodeIds) {
+        ExplainAnalyzer analyzer = new ExplainAnalyzer(plan, profile, planNodeIds);
         return analyzer.analyze();
     }
 
@@ -136,7 +117,7 @@ public class ExplainAnalyzer {
         private final String content;
     }
 
-    private final ExecPlan execPlan;
+    private final ProfilingExecPlan plan;
     private final RuntimeProfile summaryProfile;
     private final RuntimeProfile plannerProfile;
     private final RuntimeProfile executionProfile;
@@ -176,8 +157,8 @@ public class ExplainAnalyzer {
         return transformedName.toString();
     }
 
-    public ExplainAnalyzer(ExecPlan execPlan, RuntimeProfile queryProfile, List<Integer> planNodeIds) {
-        this.execPlan = execPlan;
+    public ExplainAnalyzer(ProfilingExecPlan plan, RuntimeProfile queryProfile, List<Integer> planNodeIds) {
+        this.plan = plan;
         this.summaryProfile = queryProfile.getChild("Summary");
         this.plannerProfile = queryProfile.getChild("Planner");
         this.executionProfile = queryProfile.getChild("Execution");
@@ -187,7 +168,7 @@ public class ExplainAnalyzer {
     }
 
     public String analyze() {
-        if (summaryProfile == null || plannerProfile == null || executionProfile == null) {
+        if (plan == null || summaryProfile == null || plannerProfile == null || executionProfile == null) {
             return null;
         }
 
@@ -208,14 +189,8 @@ public class ExplainAnalyzer {
     }
 
     private void parseProfile() {
-        ConnectContext connectContext = execPlan.getConnectContext();
-        if (connectContext != null) {
-            SessionVariable sessionVariable = connectContext.getSessionVariable();
-            if (sessionVariable != null) {
-                Preconditions.checkState(sessionVariable.getPipelineProfileLevel() == 1,
-                        "please set `pipeline_profile_level` to 1");
-            }
-        }
+        Preconditions.checkState(plan.getProfileLevel() == 1,
+                "please set `pipeline_profile_level` to 1");
 
         String queryState = summaryProfile.getInfoString("Query State");
         if (Objects.equals(queryState, "Running")) {
@@ -248,45 +223,45 @@ public class ExplainAnalyzer {
         }
 
         // Bind plan element
-        for (PlanFragment fragment : execPlan.getFragments()) {
-            DataSink sink = fragment.getSink();
-            if (sink instanceof ResultSink || sink instanceof OlapTableSink) {
+        plan.getFragments().forEach((fragment) -> {
+            ProfilingExecPlan.ProfilingElement sink = fragment.getSink();
+            if (sink.instanceOf(ResultSink.class) || sink.instanceOf(OlapTableSink.class)) {
                 NodeInfo resultNodeInfo = allNodeInfos.get(RESULT_SINK_PSEUDO_PLAN_NODE_ID);
                 if (resultNodeInfo == null) {
                     resultNodeInfo = new NodeInfo(isRuntimeProfile, RESULT_SINK_PSEUDO_PLAN_NODE_ID, true, null, null);
                     allNodeInfos.put(resultNodeInfo.planNodeId, resultNodeInfo);
                 }
-                resultNodeInfo.planElement = sink;
+                resultNodeInfo.element = sink;
             }
 
-            PlanNode planNode = fragment.getPlanRoot();
-            Queue<PlanNode> queue = Lists.newLinkedList();
+            ProfilingExecPlan.ProfilingElement planNode = fragment.getRoot();
+            Queue<ProfilingExecPlan.ProfilingElement> queue = Lists.newLinkedList();
             queue.offer(planNode);
             while (!queue.isEmpty()) {
                 int num = queue.size();
                 for (int i = 0; i < num; i++) {
-                    PlanNode peek = queue.poll();
+                    ProfilingExecPlan.ProfilingElement peek = queue.poll();
                     Preconditions.checkNotNull(peek);
-                    NodeInfo nodeInfo = allNodeInfos.get(peek.getId().asInt());
+                    NodeInfo nodeInfo = allNodeInfos.get(peek.getId());
                     if (nodeInfo == null) {
-                        nodeInfo = new NodeInfo(isRuntimeProfile, peek.getId().asInt(), true, null, null);
+                        nodeInfo = new NodeInfo(isRuntimeProfile, peek.getId(), true, null, null);
                         allNodeInfos.put(nodeInfo.planNodeId, nodeInfo);
                     }
-                    nodeInfo.planElement = peek;
+                    nodeInfo.element = peek;
 
-                    for (PlanNode child : peek.getChildren()) {
+                    for (ProfilingExecPlan.ProfilingElement child : peek.getChildren()) {
                         queue.offer(child);
                     }
                 }
             }
-        }
+        });
 
         allNodeInfos.values().forEach(NodeInfo::initState);
 
         allNodeInfos.values().forEach(nodeInfo -> {
             if (nodeInfo.planNodeId == RESULT_SINK_PSEUDO_PLAN_NODE_ID) {
                 nodeInfo.outputRowNums = searchMetricFromUpperLevel(nodeInfo, "CommonMetrics", "PushRowNum");
-            } else if (nodeInfo.planElement instanceof UnionNode) {
+            } else if (nodeInfo.element.instanceOf(UnionNode.class)) {
                 nodeInfo.outputRowNums = sumUpMetric(nodeInfo, false, false, "CommonMetrics", "PullRowNum");
             } else {
                 nodeInfo.outputRowNums = searchMetricFromUpperLevel(nodeInfo, "CommonMetrics", "PullRowNum");
@@ -294,9 +269,9 @@ public class ExplainAnalyzer {
         });
 
         for (NodeInfo nodeInfo : allNodeInfos.values()) {
-            if (nodeInfo.planElement instanceof ScanNode) {
+            if (nodeInfo.element.instanceOf(ScanNode.class)) {
                 allScanNodeInfos.add(nodeInfo);
-            } else if (nodeInfo.planElement instanceof ExchangeNode) {
+            } else if (nodeInfo.element.instanceOf(ExchangeNode.class)) {
                 allExchangeNodeInfos.add(nodeInfo);
             }
         }
@@ -323,8 +298,8 @@ public class ExplainAnalyzer {
 
         // 1. Brief information
         pushIndent(GraphElement.LEAF_METRIC_INDENT);
-        if (execPlan.getFragments().stream()
-                .anyMatch(fragment -> fragment.getSink() instanceof OlapTableSink)) {
+        if (plan.getFragments().stream()
+                .anyMatch(fragment -> fragment.getSink().instanceOf(OlapTableSink.class))) {
             appendSummaryLine("Attention: ", ANSI_BOLD + ANSI_BLACK_ON_RED,
                     "The transaction of the statement will be aborted, and no data will be actually inserted!!!",
                     ANSI_RESET);
@@ -440,14 +415,14 @@ public class ExplainAnalyzer {
     }
 
     private void appendExecutionInfo() {
-        for (int i = 0; i < execPlan.getFragments().size(); i++) {
-            PlanFragment fragment = execPlan.getFragments().get(i);
+        for (int i = 0; i < plan.getFragments().size(); i++) {
+            ProfilingExecPlan.ProfilingFragment fragment = plan.getFragments().get(i);
             RuntimeProfile fragmentProfile = executionProfile.getChildList().get(i).first;
             appendFragment(fragment, fragmentProfile);
         }
     }
 
-    private void appendFragment(PlanFragment fragment, RuntimeProfile fragmentProfile) {
+    private void appendFragment(ProfilingExecPlan.ProfilingFragment fragment, RuntimeProfile fragmentProfile) {
         appendDetailLine(fragmentProfile.getName());
         pushIndent(GraphElement.NON_LEAF_METRIC_INDENT);
         appendDetailLine("BackendNum: ", fragmentProfile.getCounter("BackendNum"));
@@ -461,21 +436,18 @@ public class ExplainAnalyzer {
         }
         popIndent(); // metric indent
 
-        DataSink sink = fragment.getSink();
+        ProfilingExecPlan.ProfilingElement sink = fragment.getSink();
         NodeInfo sinkInfo = null;
         boolean isFinalSink = false;
-        DataPartition outputPartition = null;
-        if (sink instanceof MultiCastDataSink) {
-            List<DataStreamSink> sinks = ((MultiCastDataSink) sink).getDataStreamSinks();
+        if (sink.instanceOf(MultiCastDataSink.class)) {
             List<String> ids = Lists.newArrayList();
-            if (CollectionUtils.isNotEmpty(sinks)) {
-                sinks.forEach(s -> ids.add(Integer.toString(s.getExchNodeId().asInt())));
-                outputPartition = sinks.get(0).getOutputPartition();
+            if (CollectionUtils.isNotEmpty(sink.getMultiSinkIds())) {
+                sink.getMultiSinkIds().forEach(id -> ids.add(Integer.toString(id)));
             }
-            appendDetailLine(GraphElement.LST_OPERATOR_INDENT, transformNodeName(sink.getClass()),
+            appendDetailLine(GraphElement.LST_OPERATOR_INDENT, transformNodeName(sink.getClazz()),
                     String.format(" (ids=[%s])", String.join(", ", ids)));
         } else {
-            if (sink instanceof ResultSink || sink instanceof OlapTableSink) {
+            if (sink.instanceOf(ResultSink.class) || sink.instanceOf(OlapTableSink.class)) {
                 isFinalSink = true;
                 // Calculate result sink's time info, other sink's type will be properly processed
                 // at the receiver side fragment through exchange node
@@ -487,11 +459,10 @@ public class ExplainAnalyzer {
                     setCoralColor();
                 }
             } else {
-                sinkInfo = allNodeInfos.get(sink.getExchNodeId().asInt());
+                sinkInfo = allNodeInfos.get(sink.getId());
             }
-            outputPartition = sink.getOutputPartition();
-            appendDetailLine(GraphElement.LST_OPERATOR_INDENT, transformNodeName(sink.getClass()),
-                    isFinalSink ? "" : String.format(" (id=%d)", sink.getExchNodeId().asInt()));
+            appendDetailLine(GraphElement.LST_OPERATOR_INDENT, transformNodeName(sink.getClazz()),
+                    isFinalSink ? "" : String.format(" (id=%d)", sink.getId()));
         }
         pushIndent(GraphElement.LAST_CHILD_OPERATOR_INDENT);
         pushIndent(GraphElement.NON_LEAF_METRIC_INDENT);
@@ -508,33 +479,24 @@ public class ExplainAnalyzer {
             // Output Rows
             appendDetailLine("OutputRows: ", resultNodeInfo.outputRowNums);
         }
-        if (outputPartition != null) {
-            appendDetailLine("PartitionType: ", outputPartition.getType());
-            if (CollectionUtils.isNotEmpty(outputPartition.getPartitionExprs())) {
-                appendExprs("PartitionExprs", outputPartition.getPartitionExprs());
-            }
-        }
-        if (sink instanceof ResultSink) {
-            ResultSink resultSink = (ResultSink) sink;
-            appendDetailLine("SinkType: ", resultSink.getSinkType());
-        } else if (sink instanceof OlapTableSink) {
-            OlapTableSink olapTableSink = (OlapTableSink) sink;
-            appendDetailLine("Table: ", olapTableSink.getDstTable().getName());
-        }
+        sink.getUniqueInfos().forEach((key, value) -> appendDetailLine(key, ": ", value));
+
         if (isFinalSink) {
             resetColor();
         }
         popIndent(); // metric indent
 
-        leftOrderTraverse(fragment.getPlanRoot(), null, -1, null);
+        leftOrderTraverse(fragment.getRoot(), null, -1, null);
 
         popIndent(); // child operator indent
 
         appendDetailLine();
     }
 
-    private void leftOrderTraverse(PlanNode cur, PlanNode parent, int index, String preTitleAttribute) {
-        int planNodeId = cur.getId().asInt();
+    private void leftOrderTraverse(ProfilingExecPlan.ProfilingElement cur, ProfilingExecPlan.ProfilingElement parent,
+                                   int index,
+                                   String preTitleAttribute) {
+        int planNodeId = cur.getId();
         NodeInfo nodeInfo = allNodeInfos.get(planNodeId);
         Preconditions.checkNotNull(nodeInfo);
 
@@ -558,7 +520,7 @@ public class ExplainAnalyzer {
 
         boolean shouldTraverseChildren = cur.getChildren() != null
                 && cur.getChildren().size() > 0
-                && !(cur instanceof ExchangeNode);
+                && !(cur.instanceOf(ExchangeNode.class));
         if (!shouldTraverseChildren) {
             pushIndent(GraphElement.LEAF_METRIC_INDENT);
         } else {
@@ -572,10 +534,10 @@ public class ExplainAnalyzer {
         if (shouldTraverseChildren) {
             for (int i = 0; i < cur.getChildren().size(); i++) {
                 String childTitleAttribute = null;
-                if (nodeInfo.planElement instanceof JoinNode) {
+                if (nodeInfo.element.instanceOf(JoinNode.class)) {
                     childTitleAttribute = (i == 0 ? "PROBE" : "BUILD");
                 }
-                leftOrderTraverse(cur.getChild(i), cur, i, childTitleAttribute);
+                leftOrderTraverse(cur.getChildren().get(i), cur, i, childTitleAttribute);
             }
         }
 
@@ -588,22 +550,22 @@ public class ExplainAnalyzer {
         }
 
         // 1. Cost Estimation
-        OptExpression optExpression = execPlan.getOptExpression(nodeInfo.planNodeId);
-        if (optExpression != null) {
-            CostEstimate cost = CostModel.calculateCostEstimate(new ExpressionContext(optExpression));
-            if (optExpression.getStatistics().getColumnStatistics().values().stream()
-                    .allMatch(ColumnStatistic::isUnknown)) {
+        if (nodeInfo.element.getStatistics() != null && nodeInfo.element.getCostEstimate() != null) {
+            Statistics statistics = nodeInfo.element.getStatistics();
+            CostEstimate cost = nodeInfo.element.getCostEstimate();
+            double totalCost = nodeInfo.element.getTotalCost();
+            if (statistics.getColumnStatistics().values().stream().allMatch(ColumnStatistic::isUnknown)) {
                 appendDetailLine("Estimates: [",
-                        "row: ", (long) optExpression.getStatistics().getOutputRowCount(),
-                        ", cpu: ?, memory: ?, network: ?, cost: ", optExpression.getCost(),
+                        "row: ", (long) statistics.getOutputRowCount(),
+                        ", cpu: ?, memory: ?, network: ?, cost: ", totalCost,
                         "]");
             } else {
                 appendDetailLine("Estimates: [",
-                        "row: ", (long) optExpression.getStatistics().getOutputRowCount(),
+                        "row: ", (long) statistics.getOutputRowCount(),
                         ", cpu: ", String.format("%.2f", cost.getCpuCost()),
                         ", memory: ", String.format("%.2f", cost.getMemoryCost()),
                         ", network: ", String.format("%.2f", cost.getNetworkCost()),
-                        ", cost: ", String.format("%.2f", optExpression.getCost()),
+                        ", cost: ", String.format("%.2f", totalCost),
                         "]");
             }
         } else {
@@ -615,11 +577,11 @@ public class ExplainAnalyzer {
         items.addAll(Arrays.asList("TotalTime: ", nodeInfo.totalTime,
                 String.format(" (%.2f%%)", nodeInfo.totalTimePercentage)));
         items.addAll(Arrays.asList(" [CPUTime: ", nodeInfo.cpuTime));
-        if (nodeInfo.planElement instanceof ExchangeNode) {
+        if (nodeInfo.element.instanceOf(ExchangeNode.class)) {
             if (nodeInfo.networkTime != null) {
                 items.addAll(Arrays.asList(", NetworkTime: ", nodeInfo.networkTime));
             }
-        } else if (nodeInfo.planElement instanceof ScanNode) {
+        } else if (nodeInfo.element.instanceOf(ScanNode.class)) {
             if (nodeInfo.scanTime != null) {
                 items.addAll(Arrays.asList(", ScanTime: ", nodeInfo.scanTime));
             }
@@ -665,17 +627,17 @@ public class ExplainAnalyzer {
     // operator will process. And sometimes, child operator may already finish its execution, so we can get the output
     // row number from its lowest child along the hierarchy path.
     private Counter getTotalRowNum(NodeInfo rootInfo) {
-        if (!(rootInfo.planElement instanceof PlanNode)) {
+        if (!(rootInfo.element.instanceOf(PlanNode.class))) {
             return null;
         }
-        PlanNode cur = (PlanNode) rootInfo.planElement;
+        ProfilingExecPlan.ProfilingElement cur = rootInfo.element;
         while (true) {
-            NodeInfo curNodeInfo = allNodeInfos.get(cur.getId().asInt());
+            NodeInfo curNodeInfo = allNodeInfos.get(cur.getId());
             if (curNodeInfo.state.isInit()) {
                 return null;
             } else if (curNodeInfo.state.isFinished()) {
                 return curNodeInfo.outputRowNums;
-            } else if (cur instanceof AggregationNode) {
+            } else if (cur.instanceOf(AggregationNode.class)) {
                 return null;
             } else if (CollectionUtils.isEmpty(cur.getChildren()) || cur.getChildren().size() > 1) {
                 return null;
@@ -686,25 +648,21 @@ public class ExplainAnalyzer {
     }
 
     private void appendOperatorUniqueInfo(NodeInfo nodeInfo) {
-        if (nodeInfo.planElement instanceof AggregationNode) {
-            AggregationNode aggregationNode = (AggregationNode) nodeInfo.planElement;
-            AggregateInfo aggInfo = aggregationNode.getAggInfo();
-            if (aggInfo == null) {
-                return;
-            }
-            if (CollectionUtils.isNotEmpty(aggInfo.getAggregateExprs())) {
-                appendExprs("AggExprs", aggInfo.getAggregateExprs());
-            }
-            if (CollectionUtils.isNotEmpty(aggInfo.getGroupingExprs())) {
-                appendExprs("GroupingExprs", aggInfo.getGroupingExprs());
-            }
+        if (nodeInfo.element.instanceOf(JoinNode.class)) {
+            Counter buildTime = searchMetric(nodeInfo, false, "_JOIN_BUILD (", true,
+                    "CommonMetrics", "OperatorTotalTime");
+            Counter probeTime = searchMetric(nodeInfo, false, "_JOIN_PROBE (", true,
+                    "CommonMetrics", "OperatorTotalTime");
+            appendDetailLine("BuildTime: ", buildTime);
+            appendDetailLine("ProbeTime: ", probeTime);
+        } else if (nodeInfo.element.instanceOf(AggregationNode.class)) {
             Optional<RuntimeProfile> cacheOptional = nodeInfo.pseudoOperatorProfiles.stream()
                     .filter(profile -> profile.getName().contains("CACHE ("))
                     .findAny();
-            if (cacheOptional.isPresent() && aggregationNode.hasChild(0) &&
-                    aggregationNode.getChild(0) instanceof ScanNode) {
-                PlanNode scanNode = aggregationNode.getChild(0);
-                NodeInfo scanNodeInfo = allNodeInfos.get(scanNode.getId().asInt());
+            if (cacheOptional.isPresent() && nodeInfo.element.hasChild(0) &&
+                    nodeInfo.element.getChild(0).instanceOf(ScanNode.class)) {
+                ProfilingExecPlan.ProfilingElement scanNode = nodeInfo.element.getChild(0);
+                NodeInfo scanNodeInfo = allNodeInfos.get(scanNode.getId());
                 Counter tabletNum = searchMetric(scanNodeInfo, false, null, false,
                         "UniqueMetrics", "TabletCount");
                 Counter cachePassthroughTabletNum = searchMetric(nodeInfo, true, "CACHE (", false,
@@ -728,71 +686,9 @@ public class ExplainAnalyzer {
                             "]");
                 }
             }
-        } else if (nodeInfo.planElement instanceof AnalyticEvalNode) {
-            AnalyticEvalNode window = (AnalyticEvalNode) nodeInfo.planElement;
-            if (CollectionUtils.isNotEmpty(window.getAnalyticFnCalls())) {
-                appendExprs("Functions", window.getAnalyticFnCalls());
-            }
-            if (CollectionUtils.isNotEmpty(window.getPartitionExprs())) {
-                appendExprs("PartitionExprs", window.getPartitionExprs());
-            }
-            if (CollectionUtils.isNotEmpty(window.getOrderByElements())) {
-                appendExprs("OrderByExprs", window.getOrderByElements().stream()
-                        .map(OrderByElement::getExpr).collect(Collectors.toList()));
-            }
-        } else if (nodeInfo.planElement instanceof ProjectNode) {
-            ProjectNode projectNode = (ProjectNode) nodeInfo.planElement;
-            if (MapUtils.isNotEmpty(projectNode.getSlotMap())) {
-                List<Pair<SlotId, Expr>> orderedExprs = new ArrayList<>();
-                for (Map.Entry<SlotId, Expr> kv : projectNode.getSlotMap().entrySet()) {
-                    orderedExprs.add(new Pair<>(kv.getKey(), kv.getValue()));
-                }
-                orderedExprs.sort(Comparator.comparingInt(o -> o.first.asInt()));
-                appendExprs("Expression",
-                        orderedExprs.stream().map(kv -> kv.second).collect(Collectors.toList()));
-            }
-
-            if (MapUtils.isNotEmpty(projectNode.getCommonSlotMap())) {
-                List<Pair<SlotId, Expr>> orderedExprs = new ArrayList<>();
-                for (Map.Entry<SlotId, Expr> kv : projectNode.getCommonSlotMap().entrySet()) {
-                    orderedExprs.add(new Pair<>(kv.getKey(), kv.getValue()));
-                }
-                orderedExprs.sort(Comparator.comparingInt(o -> o.first.asInt()));
-                appendExprs("CommonExpression",
-                        orderedExprs.stream().map(kv -> kv.second).collect(Collectors.toList()));
-            }
-        } else if (nodeInfo.planElement instanceof JoinNode) {
-            JoinNode joinNode = (JoinNode) nodeInfo.planElement;
-            Counter buildTime = searchMetric(nodeInfo, false, "_JOIN_BUILD (", true,
-                    "CommonMetrics", "OperatorTotalTime");
-            Counter probeTime = searchMetric(nodeInfo, false, "_JOIN_PROBE (", true,
-                    "CommonMetrics", "OperatorTotalTime");
-            appendDetailLine("BuildTime: ", buildTime);
-            appendDetailLine("ProbeTime: ", probeTime);
-            if (CollectionUtils.isNotEmpty(joinNode.getEqJoinConjuncts())) {
-                appendExprs("EqJoinConjuncts", joinNode.getEqJoinConjuncts());
-            }
-        } else if (nodeInfo.planElement instanceof SelectNode) {
-            SelectNode selectNode = (SelectNode) nodeInfo.planElement;
-            if (CollectionUtils.isNotEmpty(selectNode.getConjuncts())) {
-                appendExprs("Predicates", selectNode.getConjuncts());
-            }
-        } else if (nodeInfo.planElement instanceof SortNode) {
-            SortNode sortNode = (SortNode) nodeInfo.planElement;
-            SortInfo sortInfo = sortNode.getSortInfo();
-            if (CollectionUtils.isNotEmpty(sortInfo.getPartitionExprs())) {
-                appendExprs("PartitionExprs", sortInfo.getPartitionExprs());
-            }
-            if (CollectionUtils.isNotEmpty(sortInfo.getOrderingExprs())) {
-                appendExprs("OrderByExprs", sortInfo.getOrderingExprs());
-            }
-        } else if (nodeInfo.planElement instanceof ScanNode) {
-            ScanNode scanNode = (ScanNode) nodeInfo.planElement;
-            if (scanNode instanceof OlapScanNode) {
-                OlapScanNode olapScanNode = (OlapScanNode) scanNode;
-                appendDetailLine("Table: ", olapScanNode.getOlapTable().getName());
-            }
         }
+
+        nodeInfo.element.getUniqueInfos().forEach((key, value) -> appendDetailLine(key, ": ", value));
     }
 
     private void appendOperatorDetailInfo(NodeInfo nodeInfo) {
@@ -924,29 +820,6 @@ public class ExplainAnalyzer {
             items.add(ANSI_RESET);
         }
         appendDetailLine(items.toArray());
-    }
-
-    private void appendExprs(String metricName, List<? extends Expr> exprs) {
-        List<String> exprContents = exprs.stream()
-                .map(Expr::toSql)
-                .collect(Collectors.toList());
-        int lastIndex = -1;
-        int length = 0;
-        int originalSize = exprs.size();
-        for (int i = 0; i < originalSize; i++) {
-            if (length + exprContents.get(i).length() > MAX_EXPR_LENGTH) {
-                break;
-            }
-            lastIndex = i;
-            length += exprContents.get(i).length();
-        }
-        if (lastIndex >= 0) {
-            exprContents = exprContents.subList(0, lastIndex + 1);
-        }
-        if (lastIndex < originalSize - 1) {
-            exprContents.add("...");
-        }
-        appendDetailLine(metricName, ": [", String.join(", ", exprContents), "]");
     }
 
     private static Counter searchMetric(NodeInfo nodeInfo, boolean searchPseudoOperator, String pattern,
@@ -1136,7 +1009,7 @@ public class ExplainAnalyzer {
         private final List<RuntimeProfile> operatorProfiles;
         private final List<RuntimeProfile> pseudoOperatorProfiles;
 
-        private Object planElement;
+        private ProfilingExecPlan.ProfilingElement element;
         private Counter totalTime;
         private Counter cpuTime;
         private Counter networkTime;
@@ -1179,7 +1052,7 @@ public class ExplainAnalyzer {
         }
 
         public String getDetailAttributes() {
-            if (planElement instanceof ScanNode) {
+            if (element.instanceOf(ScanNode.class)) {
                 return "[ScanTime = IOTaskExecTime + IOTaskWaitTime]";
             }
             return "";
@@ -1203,8 +1076,8 @@ public class ExplainAnalyzer {
         }
 
         public boolean isMemoryConsumingOperator() {
-            return planElement instanceof AggregationNode || planElement instanceof JoinNode
-                    || planElement instanceof SortNode || planElement instanceof AnalyticEvalNode;
+            return element.instanceOf(AggregationNode.class) || element.instanceOf(JoinNode.class)
+                    || element.instanceOf(SortNode.class) || element.instanceOf(AnalyticEvalNode.class);
         }
 
         public void merge(NodeInfo other) {
@@ -1218,12 +1091,12 @@ public class ExplainAnalyzer {
             if (cpuTime != null) {
                 totalTime.update(cpuTime.getValue());
             }
-            if (planElement instanceof ExchangeNode) {
+            if (element.instanceOf(ExchangeNode.class)) {
                 networkTime = searchMetric(this, false, null, true, "UniqueMetrics", "NetworkTime");
                 if (networkTime != null) {
                     totalTime.update(networkTime.getValue());
                 }
-            } else if (planElement instanceof ScanNode) {
+            } else if (element.instanceOf(ScanNode.class)) {
                 scanTime = searchMetric(this, false, null, true, "UniqueMetrics", "ScanTime");
                 if (scanTime != null) {
                     totalTime.update(scanTime.getValue());
@@ -1244,34 +1117,14 @@ public class ExplainAnalyzer {
 
         public String getTitle() {
             StringBuilder titleBuilder = new StringBuilder();
-            titleBuilder.append(transformNodeName(planElement.getClass()));
-            if (!(planElement instanceof ResultSink) && !(planElement instanceof OlapTableSink)) {
+            titleBuilder.append(transformNodeName(element.getClazz()));
+            if (!(element.instanceOf(ResultSink.class) && !(element.instanceOf(OlapTableSink.class)))) {
                 titleBuilder.append(String.format(" (id=%d) ", planNodeId));
             }
             // Attributes
-            List<String> attributes = Lists.newArrayList();
-            if (planElement instanceof AggregationNode) {
-                AggregationNode aggNode = (AggregationNode) planElement;
-                attributes.add(aggNode.getAggInfo().isMerge() ? "merge" : "update");
-                attributes.add(aggNode.isNeedsFinalize() ? "finalize" : "serialize");
-            } else if (planElement instanceof JoinNode) {
-                JoinNode joinNode = (JoinNode) planElement;
-                attributes.add(joinNode.getJoinOp().toString());
-                attributes.add(joinNode.getDistrMode().toString());
-            } else if (planElement instanceof SortNode) {
-                SortNode sortNode = (SortNode) planElement;
-                attributes.add(sortNode.isUseTopN() ? "TOP-N" :
-                        (sortNode.getSortInfo().getPartitionExprs().isEmpty() ? "SORT" : "PARTITION-TOP-N"));
-                attributes.add(sortNode.getTopNType().toString());
-            } else if (planElement instanceof ExchangeNode) {
-                ExchangeNode exchangeNode = (ExchangeNode) planElement;
-                if (exchangeNode.getDistributionType() != null) {
-                    attributes.add(exchangeNode.getDistributionType().toString());
-                }
-            }
-            if (CollectionUtils.isNotEmpty(attributes)) {
+            if (CollectionUtils.isNotEmpty(element.getTitleAttributes())) {
                 titleBuilder.append('[')
-                        .append(String.join(", ", attributes))
+                        .append(String.join(", ", element.getTitleAttributes()))
                         .append(']');
             }
             if (isRuntimeProfile) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/DebugUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/DebugUtilTest.java
@@ -62,7 +62,7 @@ public class DebugUtilTest {
         Pair<Double, String> result;
         result = DebugUtil.getByteUint(0);
         Assert.assertEquals(result.first, Double.valueOf(0.0));
-        Assert.assertEquals(result.second, "");
+        Assert.assertEquals(result.second, "B");
 
         result = DebugUtil.getByteUint(123);     // B
         Assert.assertEquals(result.first, Double.valueOf(123.0));

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileParserTest.java
@@ -1,0 +1,278 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.common.util;
+
+import com.starrocks.thrift.TUnit;
+import org.junit.Assert;
+import org.junit.Test;
+import org.sparkproject.guava.collect.Maps;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Map;
+
+public class RuntimeProfileParserTest {
+
+    private static void addCounter(RuntimeProfile profile, String name, TUnit type, long value) {
+        Counter counter = profile.addCounter(name, type, null);
+        counter.setValue(value);
+    }
+
+    private static void addCounter(RuntimeProfile profile, String name, TUnit type, long value, String parent) {
+        Counter counter = profile.addCounter(name, type, null, parent);
+        counter.setValue(value);
+    }
+
+    private static String getContent(RuntimeProfile profile) {
+        StringBuilder builder = new StringBuilder();
+        profile.prettyPrint(builder, "");
+        return builder.toString();
+    }
+
+    private static Map<String, Integer> getLineCounter(String content) {
+        Map<String, Integer> lineCounter = Maps.newHashMap();
+        BufferedReader reader = new BufferedReader(new StringReader(content));
+        String line;
+        try {
+            while ((line = reader.readLine()) != null) {
+                lineCounter.merge(line, 1, Integer::sum);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return lineCounter;
+    }
+
+    private static void checkParser(RuntimeProfile profile) {
+        final String originalContent = getContent(profile);
+        RuntimeProfile rebuildProfile = RuntimeProfileParser.parseFrom(originalContent);
+        Assert.assertNotNull(rebuildProfile);
+        final String rebuildContent = getContent(rebuildProfile);
+
+        Map<String, Integer> originalLineCounter = getLineCounter(originalContent);
+        Map<String, Integer> rebuildLineCounter = getLineCounter(rebuildContent);
+        Assert.assertEquals(originalLineCounter, rebuildLineCounter);
+    }
+
+    @Test
+    public void testInfoString() {
+        RuntimeProfile profile = new RuntimeProfile("level 1");
+
+        profile.addInfoString("info1", "content1");
+        profile.addInfoString("info2", "content2");
+        profile.addInfoString("info3", "content3");
+        profile.addInfoString("info4", "content4");
+        profile.addInfoString("info5", "content5");
+        profile.addInfoString("info6", "100000000");
+
+        checkParser(profile);
+    }
+
+    @Test
+    public void testTimeNs() {
+        RuntimeProfile profile = new RuntimeProfile("level 1");
+
+        addCounter(profile, "timer1", TUnit.TIME_NS, 0);
+        addCounter(profile, "timer2", TUnit.TIME_NS, 50);
+        addCounter(profile, "timer3", TUnit.TIME_NS, DebugUtil.THOUSAND);
+        addCounter(profile, "timer4", TUnit.TIME_NS, 50L * DebugUtil.THOUSAND);
+        addCounter(profile, "timer5", TUnit.TIME_NS, DebugUtil.MILLION);
+        addCounter(profile, "timer6", TUnit.TIME_NS, 50L * DebugUtil.MILLION);
+        addCounter(profile, "timer7", TUnit.TIME_NS, DebugUtil.BILLION);
+        addCounter(profile, "timer8", TUnit.TIME_NS, 30L * DebugUtil.BILLION);
+        addCounter(profile, "timer9", TUnit.TIME_NS, 90L * DebugUtil.BILLION);
+        addCounter(profile, "timer10", TUnit.TIME_NS, 1800L * DebugUtil.BILLION);
+        addCounter(profile, "timer11", TUnit.TIME_NS, 7200L * DebugUtil.BILLION);
+        addCounter(profile, "timer12", TUnit.TIME_NS, 9000L * DebugUtil.BILLION);
+
+        checkParser(profile);
+    }
+
+    @Test
+    public void testUnit() {
+        RuntimeProfile profile = new RuntimeProfile("level 1");
+
+        addCounter(profile, "unit1", TUnit.UNIT, 0);
+        addCounter(profile, "unit2", TUnit.UNIT, 50);
+        addCounter(profile, "unit3", TUnit.UNIT, DebugUtil.THOUSAND);
+        addCounter(profile, "unit4", TUnit.UNIT, 50L * DebugUtil.THOUSAND);
+        addCounter(profile, "unit5", TUnit.UNIT, DebugUtil.MILLION);
+        addCounter(profile, "unit6", TUnit.UNIT, 50L * DebugUtil.MILLION);
+        addCounter(profile, "unit7", TUnit.UNIT, DebugUtil.BILLION);
+        addCounter(profile, "unit8", TUnit.UNIT, 50L * DebugUtil.BILLION);
+        addCounter(profile, "unit9", TUnit.UNIT, 50L * DebugUtil.BILLION + 500L * DebugUtil.MILLION);
+
+        checkParser(profile);
+    }
+
+    @Test
+    public void testUnitPerSec() {
+        RuntimeProfile profile = new RuntimeProfile("level 1");
+
+        addCounter(profile, "unitPerSec1", TUnit.UNIT_PER_SECOND, 0);
+        addCounter(profile, "unitPerSec2", TUnit.UNIT_PER_SECOND, 50);
+        addCounter(profile, "unitPerSec3", TUnit.UNIT_PER_SECOND, DebugUtil.THOUSAND);
+        addCounter(profile, "unitPerSec4", TUnit.UNIT_PER_SECOND, 50L * DebugUtil.THOUSAND);
+        addCounter(profile, "unitPerSec5", TUnit.UNIT_PER_SECOND, DebugUtil.MILLION);
+        addCounter(profile, "unitPerSec6", TUnit.UNIT_PER_SECOND, 50L * DebugUtil.MILLION);
+        addCounter(profile, "unitPerSec7", TUnit.UNIT_PER_SECOND, DebugUtil.BILLION);
+        addCounter(profile, "unitPerSec8", TUnit.UNIT_PER_SECOND, 50L * DebugUtil.BILLION);
+
+        checkParser(profile);
+    }
+
+    @Test
+    public void testBytes() {
+        RuntimeProfile profile = new RuntimeProfile("level 1");
+
+        addCounter(profile, "byte1", TUnit.BYTES, 0);
+        addCounter(profile, "byte2", TUnit.BYTES, 50);
+        addCounter(profile, "byte3", TUnit.BYTES, DebugUtil.KILOBYTE);
+        addCounter(profile, "byte4", TUnit.BYTES, 50L * DebugUtil.KILOBYTE);
+        addCounter(profile, "byte5", TUnit.BYTES, DebugUtil.MEGABYTE);
+        addCounter(profile, "byte6", TUnit.BYTES, 50L * DebugUtil.MEGABYTE);
+        addCounter(profile, "byte7", TUnit.BYTES, DebugUtil.GIGABYTE);
+        addCounter(profile, "byte8", TUnit.BYTES, 50L * DebugUtil.GIGABYTE);
+        addCounter(profile, "byte9", TUnit.BYTES, DebugUtil.TERABYTE);
+        addCounter(profile, "byte10", TUnit.BYTES, 50L * DebugUtil.TERABYTE);
+
+        checkParser(profile);
+    }
+
+    @Test
+    public void testBytesPerSec() {
+        RuntimeProfile profile = new RuntimeProfile("level 1");
+
+        addCounter(profile, "bytePerSec1", TUnit.BYTES_PER_SECOND, 0);
+        addCounter(profile, "bytePerSec2", TUnit.BYTES_PER_SECOND, 50);
+        addCounter(profile, "bytePerSec3", TUnit.BYTES_PER_SECOND, DebugUtil.KILOBYTE);
+        addCounter(profile, "bytePerSec4", TUnit.BYTES_PER_SECOND, 50L * DebugUtil.KILOBYTE);
+        addCounter(profile, "bytePerSec5", TUnit.BYTES_PER_SECOND, DebugUtil.MEGABYTE);
+        addCounter(profile, "bytePerSec6", TUnit.BYTES_PER_SECOND, 50L * DebugUtil.MEGABYTE);
+        addCounter(profile, "bytePerSec7", TUnit.BYTES_PER_SECOND, DebugUtil.GIGABYTE);
+        addCounter(profile, "bytePerSec8", TUnit.BYTES_PER_SECOND, 50L * DebugUtil.GIGABYTE);
+        addCounter(profile, "bytePerSec9", TUnit.BYTES_PER_SECOND, DebugUtil.TERABYTE);
+        addCounter(profile, "bytePerSec10", TUnit.BYTES_PER_SECOND, 50L * DebugUtil.TERABYTE);
+
+        checkParser(profile);
+    }
+
+    @Test
+    public void testCounterHierarchy() {
+        RuntimeProfile profile = new RuntimeProfile("level 1");
+
+        addCounter(profile, "byte1", TUnit.BYTES, 1);
+        addCounter(profile, "byte1-1", TUnit.BYTES, 2, "byte1");
+        addCounter(profile, "byte1-2", TUnit.BYTES, 3, "byte1");
+        addCounter(profile, "byte1-2-1", TUnit.BYTES, 4, "byte1-2");
+        addCounter(profile, "byte1-2-2", TUnit.BYTES, 5, "byte1-2");
+        addCounter(profile, "byte1-3", TUnit.BYTES, 6, "byte1");
+        addCounter(profile, "byte1-3-1", TUnit.BYTES, 7, "byte1-3");
+        addCounter(profile, "byte2", TUnit.BYTES, 8);
+
+        checkParser(profile);
+    }
+
+    @Test
+    public void testEmptyProfileHierarchy() {
+        RuntimeProfile level1 = new RuntimeProfile("level 1");
+
+        RuntimeProfile level2 = new RuntimeProfile("level 2");
+        level1.addChild(level2);
+
+        RuntimeProfile level3 = new RuntimeProfile("level 3");
+        level2.addChild(level3);
+
+        RuntimeProfile level4 = new RuntimeProfile("level 4");
+        level3.addChild(level4);
+
+        RuntimeProfile level32 = new RuntimeProfile("level 3_2");
+        level2.addChild(level32);
+
+        RuntimeProfile level42 = new RuntimeProfile("level 4_2");
+        level3.addChild(level42);
+
+        RuntimeProfile level22 = new RuntimeProfile("level 2_2");
+        level1.addChild(level22);
+
+        checkParser(level1);
+    }
+
+    @Test
+    public void testProfileHierarchy() {
+        RuntimeProfile level1 = new RuntimeProfile("level 1");
+        addCounter(level1, "byte1", TUnit.BYTES, 1);
+
+        RuntimeProfile level2 = new RuntimeProfile("level 2");
+        addCounter(level2, "byte1", TUnit.BYTES, 2);
+        level1.addChild(level2);
+
+        RuntimeProfile level3 = new RuntimeProfile("level 3");
+        addCounter(level3, "byte1", TUnit.BYTES, 3);
+        level2.addChild(level3);
+
+        RuntimeProfile level4 = new RuntimeProfile("level 4");
+        addCounter(level4, "byte1", TUnit.BYTES, 4);
+        level3.addChild(level4);
+
+        RuntimeProfile level32 = new RuntimeProfile("level 3_2");
+        addCounter(level32, "byte1", TUnit.BYTES, 5);
+        level2.addChild(level32);
+
+        RuntimeProfile level42 = new RuntimeProfile("level 4_2");
+        addCounter(level42, "byte1", TUnit.BYTES, 6);
+        level3.addChild(level42);
+
+        RuntimeProfile level22 = new RuntimeProfile("level 2_2");
+        addCounter(level22, "byte1", TUnit.BYTES, 7);
+        level1.addChild(level22);
+
+        checkParser(level1);
+    }
+
+    @Test
+    public void testProfileHierarchy2() {
+        RuntimeProfile query = new RuntimeProfile("Query");
+
+        RuntimeProfile summary = new RuntimeProfile("Summary");
+        summary.addInfoString("Query Id", "xxx");
+        query.addChild(summary);
+
+        RuntimeProfile execution = new RuntimeProfile("Execution");
+        addCounter(execution, "QueryAllocatedMemoryUsage", TUnit.BYTES, 1);
+        summary.addChild(execution);
+
+        RuntimeProfile pipeline = new RuntimeProfile("Pipeline (id=0)");
+        addCounter(pipeline, "ActiveTime", TUnit.TIME_NS, 1);
+        addCounter(pipeline, "__MIN_OF_ActiveTime", TUnit.TIME_NS, 2, "ActiveTime");
+        addCounter(pipeline, "__MAX_OF_ActiveTime", TUnit.TIME_NS, 3, "ActiveTime");
+        addCounter(pipeline, "BlockByInputEmpty", TUnit.TIME_NS, 4);
+        addCounter(pipeline, "DriverPrepareTime", TUnit.TIME_NS, 5);
+        addCounter(pipeline, "__MIN_OF_DriverPrepareTime", TUnit.TIME_NS, 6, "DriverPrepareTime");
+        addCounter(pipeline, "__MAX_OF_DriverPrepareTime", TUnit.TIME_NS, 7, "DriverPrepareTime");
+        addCounter(pipeline, "DriverTotalTime", TUnit.TIME_NS, 8);
+        addCounter(pipeline, "__MIN_OF_DriverTotalTime", TUnit.TIME_NS, 9, "DriverTotalTime");
+        addCounter(pipeline, "__MAX_OF_DriverTotalTime", TUnit.TIME_NS, 10, "DriverTotalTime");
+        addCounter(pipeline, "GlobalScheduleCount", TUnit.UNIT, 11);
+        addCounter(pipeline, "__MIN_OF_GlobalScheduleCount", TUnit.UNIT, 11, "GlobalScheduleCount");
+        addCounter(pipeline, "__MAX_OF_GlobalScheduleCount", TUnit.UNIT, 12, "GlobalScheduleCount");
+        addCounter(pipeline, "GlobalScheduleTime", TUnit.TIME_NS, 13);
+        addCounter(pipeline, "__MIN_OF_GlobalScheduleTime", TUnit.TIME_NS, 14, "GlobalScheduleTime");
+        addCounter(pipeline, "__MAX_OF_GlobalScheduleTime", TUnit.TIME_NS, 15, "GlobalScheduleTime");
+        execution.addChild(pipeline);
+
+        checkParser(query);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
@@ -57,6 +57,58 @@ import java.util.Set;
 
 public class RuntimeProfileTest {
 
+    private static void testCounterPrinter(TUnit type, long value, String expected) {
+        Counter counter = new Counter(type, null, value);
+        String printContent = RuntimeProfile.printCounter(counter);
+        Assert.assertEquals(expected, printContent);
+    }
+
+    @Test
+    public void testCounterPrinter() {
+        testCounterPrinter(TUnit.BYTES, 0, "0.000 B");
+        testCounterPrinter(TUnit.BYTES, DebugUtil.KILOBYTE - 1, "1023.000 B");
+        testCounterPrinter(TUnit.BYTES, DebugUtil.KILOBYTE, "1.000 KB");
+        testCounterPrinter(TUnit.BYTES, DebugUtil.MEGABYTE, "1.000 MB");
+        testCounterPrinter(TUnit.BYTES, DebugUtil.GIGABYTE, "1.000 GB");
+        testCounterPrinter(TUnit.BYTES, DebugUtil.TERABYTE, "1.000 TB");
+        testCounterPrinter(TUnit.BYTES, 2 * DebugUtil.TERABYTE + 200 * DebugUtil.GIGABYTE, "2.195 TB");
+
+        testCounterPrinter(TUnit.BYTES_PER_SECOND, 0, "0.000 B/sec");
+        testCounterPrinter(TUnit.BYTES_PER_SECOND, DebugUtil.KILOBYTE - 1, "1023.000 B/sec");
+        testCounterPrinter(TUnit.BYTES_PER_SECOND, DebugUtil.KILOBYTE, "1.000 KB/sec");
+        testCounterPrinter(TUnit.BYTES_PER_SECOND, DebugUtil.MEGABYTE, "1.000 MB/sec");
+        testCounterPrinter(TUnit.BYTES_PER_SECOND, DebugUtil.GIGABYTE, "1.000 GB/sec");
+        testCounterPrinter(TUnit.BYTES_PER_SECOND, DebugUtil.TERABYTE, "1.000 TB/sec");
+        testCounterPrinter(TUnit.BYTES_PER_SECOND, 2 * DebugUtil.TERABYTE + 200 * DebugUtil.GIGABYTE, "2.195 TB/sec");
+
+        testCounterPrinter(TUnit.UNIT, 0, "0");
+        testCounterPrinter(TUnit.UNIT, 999, "999");
+        testCounterPrinter(TUnit.UNIT, DebugUtil.THOUSAND, "1.000K (1000)");
+        testCounterPrinter(TUnit.UNIT, DebugUtil.MILLION, "1.000M (1000000)");
+        testCounterPrinter(TUnit.UNIT, DebugUtil.BILLION, "1.000B (1000000000)");
+        testCounterPrinter(TUnit.UNIT, 2L * DebugUtil.BILLION + 200L * DebugUtil.MILLION, "2.200B (2200000000)");
+
+        testCounterPrinter(TUnit.UNIT_PER_SECOND, 0, "0 /sec");
+        testCounterPrinter(TUnit.UNIT_PER_SECOND, 999, "999 /sec");
+        testCounterPrinter(TUnit.UNIT_PER_SECOND, DebugUtil.THOUSAND, "1.000K (1000) /sec");
+        testCounterPrinter(TUnit.UNIT_PER_SECOND, DebugUtil.MILLION, "1.000M (1000000) /sec");
+        testCounterPrinter(TUnit.UNIT_PER_SECOND, DebugUtil.BILLION, "1.000B (1000000000) /sec");
+        testCounterPrinter(TUnit.UNIT_PER_SECOND, 2L * DebugUtil.BILLION + 200L * DebugUtil.MILLION,
+                "2.200B (2200000000) /sec");
+
+        testCounterPrinter(TUnit.TIME_NS, 0, "0ns");
+        testCounterPrinter(TUnit.TIME_NS, 999, "999ns");
+        testCounterPrinter(TUnit.TIME_NS, DebugUtil.THOUSAND, "1us");
+        testCounterPrinter(TUnit.TIME_NS, DebugUtil.MILLION, "1ms");
+        testCounterPrinter(TUnit.TIME_NS, DebugUtil.BILLION, "1s0ms");
+        testCounterPrinter(TUnit.TIME_NS, 30L * DebugUtil.BILLION, "30s0ms");
+        testCounterPrinter(TUnit.TIME_NS, 60L * DebugUtil.BILLION, "1m");
+        testCounterPrinter(TUnit.TIME_NS, 90L * DebugUtil.BILLION, "1m30s");
+        testCounterPrinter(TUnit.TIME_NS, 3600L * DebugUtil.BILLION, "1h");
+        testCounterPrinter(TUnit.TIME_NS, 5400L * DebugUtil.BILLION, "1h30m");
+        testCounterPrinter(TUnit.TIME_NS, 5490L * DebugUtil.BILLION, "1h31m");
+    }
+
     @Test
     public void testSortChildren() {
         RuntimeProfile profile = new RuntimeProfile("profile");
@@ -601,13 +653,12 @@ public class RuntimeProfileTest {
 
         JsonObject jsonObjchild11 = jsonObjchild1.getAsJsonObject("child11");
         Assert.assertEquals(jsonObjchild11.getAsJsonPrimitive("child11_key").getAsString(), "child11_value");
-        Assert.assertEquals(jsonObjchild11.getAsJsonPrimitive("count2").getAsString(), "1.0K /sec");
-        Assert.assertEquals(jsonObjchild11.getAsJsonPrimitive("data_size").getAsString(), "10.0 KB/sec");
+        Assert.assertEquals(jsonObjchild11.getAsJsonPrimitive("count2").getAsString(), "1.000K (1000) /sec");
+        Assert.assertEquals(jsonObjchild11.getAsJsonPrimitive("data_size").getAsString(), "10.000 KB/sec");
 
         JsonObject jsonObjchild12 = jsonObjchild1.getAsJsonObject("child12");
         Assert.assertEquals(jsonObjchild12.getAsJsonPrimitive("count3").getAsString(), "15");
-        Assert.assertEquals(jsonObjchild12.getAsJsonPrimitive("data_size").getAsString(), "10.00 KB");
-        Assert.assertEquals(jsonObjchild12.getAsJsonPrimitive("time_ns").getAsString(), "1.0ms");
-
+        Assert.assertEquals(jsonObjchild12.getAsJsonPrimitive("data_size").getAsString(), "10.000 KB");
+        Assert.assertEquals(jsonObjchild12.getAsJsonPrimitive("time_ns").getAsString(), "1ms");
     }
 }


### PR DESCRIPTION
## Main work of this pr

This pr is an continuation work of https://github.com/StarRocks/starrocks/pull/28479, solving the memory issue that the profile manager may use too many memory for caching the instance of `RuntimeProfile` and `ExecPlan`

This pr introduce a `ProfilingExecPlan`, similar to `ExecPlan`, but only contains the necessary information that required by profile analysis.

And we no longer cache the instance of `RuntimeProfile`, and we reconstructs the `RuntimeProfile` instance by parsing from plain text.

## Result

The memory usage decrease from 3.1G to 287M after executing 500 ssb/tpch/tpcds queries (the maximum cached profile is 500 by default)

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
