### PR TITLE
[BugFix] assign wrong partitionId when multiple partition predicates

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -753,8 +753,8 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
             Long v = partitionKeyToId.get(key);
             if (v == null) {
                 partitionKeyToId.put(key, size);
-                size += 1;
                 v = size;
+                size += 1;
             }
             ret.add(v);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -194,11 +194,14 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
     // foreign key constraint for mv rewrite
     protected List<ForeignKeyConstraint> foreignKeyConstraints;
 
+    protected Map<PartitionKey, Long> partitionKeyToId;
+
     public Table(TableType type) {
         this.type = type;
         this.fullSchema = Lists.newArrayList();
         this.nameToColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
         this.relatedMaterializedViews = Sets.newConcurrentHashSet();
+        this.partitionKeyToId = Maps.newHashMap();
     }
 
     public Table(long id, String tableName, TableType type, List<Column> fullSchema) {
@@ -221,6 +224,7 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
         }
         this.createTime = Instant.now().getEpochSecond();
         this.relatedMaterializedViews = Sets.newConcurrentHashSet();
+        this.partitionKeyToId = Maps.newHashMap();
     }
 
     public void setTypeRead(boolean isTypeRead) {
@@ -717,7 +721,6 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
         return false;
     }
 
-
     public boolean supportInsert() {
         return false;
     }
@@ -741,5 +744,20 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
 
     public List<ForeignKeyConstraint> getForeignKeyConstraints() {
         return this.foreignKeyConstraints;
+    }
+
+    public synchronized List<Long> allocatePartitionIdByKey(List<PartitionKey> keys) {
+        long size = partitionKeyToId.size();
+        List<Long> ret = new ArrayList<>();
+        for (PartitionKey key : keys) {
+            Long v = partitionKeyToId.get(key);
+            if (v == null) {
+                partitionKeyToId.put(key, size);
+                size += 1;
+                v = size;
+            }
+            ret.add(v);
+        }
+        return ret;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hive;
 
 import com.google.common.collect.ImmutableList;
@@ -21,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveMetaStoreTable;
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -72,14 +73,15 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     // db -> tableName -> table
     private static final Map<String, Map<String, HiveTableInfo>> MOCK_TABLE_MAP = new CaseInsensitiveMap<>();
     private final AtomicLong idGen = new AtomicLong(0L);
-    private static final List<RemoteFileInfo> MOCKED_FILES = ImmutableList.of(
-            new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null));
+    private static final List<RemoteFileInfo> MOCKED_FILES =
+            ImmutableList.of(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null));
     public static final String MOCKED_HIVE_CATALOG_NAME = "hive0";
     public static final String MOCKED_TPCH_DB_NAME = "tpch";
     public static final String MOCKED_PARTITIONED_DB_NAME = "partitioned_db";
     public static final String MOCKED_PARTITIONED_DB_NAME2 = "partitioned_db2";
 
     private static ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
     static {
         mockTPCHTable();
         mockPartitionTable();
@@ -111,6 +113,40 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         }
     }
 
+    private static boolean isPartitionNameValueMatched(String partitionName, List<Optional<String>> values) {
+        String[] parts = partitionName.split("/");
+        if (parts.length != values.size()) {
+            return false;
+        }
+        for (int i = 0; i < parts.length; i++) {
+            Optional<String> v = values.get(i);
+            if (!v.isPresent()) {
+                continue;
+            }
+            String[] kv = parts[i].split("=");
+            if (kv.length != 2) {
+                return false;
+            }
+            if (!kv[1].equals(v.get())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> listPartitionNamesByValue(String databaseName, String tableName,
+                                                  List<Optional<String>> partitionValues) {
+        List<String> partitionNames = listPartitionNames(databaseName, tableName);
+        List<String> ret = new ArrayList<>();
+        for (String p : partitionNames) {
+            if (isPartitionNameValueMatched(p, partitionValues)) {
+                ret.add(p);
+            }
+        }
+        return ret;
+    }
+
     @Override
     public List<String> listTableNames(String dbName) {
         return new ArrayList<>(MOCK_TABLE_MAP.get(dbName).keySet());
@@ -122,10 +158,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     }
 
     @Override
-    public Statistics getTableStatistics(OptimizerContext session,
-                                         com.starrocks.catalog.Table table,
-                                         Map<ColumnRefOperator, Column> columns,
-                                         List<PartitionKey> partitionKeys,
+    public Statistics getTableStatistics(OptimizerContext session, com.starrocks.catalog.Table table,
+                                         Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
                                          ScalarOperator predicate) {
         HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) table;
         String hiveDb = hmsTable.getDbName();
@@ -165,8 +199,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         readLock();
         try {
             Map<String, PartitionInfo> partitionInfoMap =
-                    MOCK_TABLE_MAP.get(hmsTbl.getDbName()).get(hmsTbl.getTableName()).
-                            partitionInfoMap;
+                    MOCK_TABLE_MAP.get(hmsTbl.getDbName()).get(hmsTbl.getTableName()).partitionInfoMap;
             if (hmsTbl.isUnPartitioned()) {
                 return Lists.newArrayList(partitionInfoMap.get(hmsTbl.getTableName()));
             } else {
@@ -188,8 +221,9 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         }
         hiveTableInfo.partitionNames.add(partitionName);
         hiveTableInfo.remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null));
-        hiveTableInfo.partitionInfoMap.put(partitionName, new Partition(ImmutableMap.of(Partition.TRANSIENT_LAST_DDL_TIME,
-                String.valueOf(System.currentTimeMillis() / 1000)), null, null, null, false));
+        hiveTableInfo.partitionInfoMap.put(partitionName, new Partition(
+                ImmutableMap.of(Partition.TRANSIENT_LAST_DDL_TIME, String.valueOf(System.currentTimeMillis() / 1000)),
+                null, null, null, false));
     }
 
     public void updatePartitions(String dbName, String tableName, List<String> partitionNames) {
@@ -199,11 +233,15 @@ public class MockedHiveMetadata implements ConnectorMetadata {
             for (String partitionName : partitionNames) {
                 if (partitionInfoMap.containsKey(partitionName)) {
                     long modifyTime = partitionInfoMap.get(partitionName).getModifiedTime() + 1;
-                    partitionInfoMap.put(partitionName, new Partition(ImmutableMap.of(Partition.TRANSIENT_LAST_DDL_TIME,
-                            String.valueOf(modifyTime)), null, null, null, false));
+                    partitionInfoMap.put(partitionName, new Partition(
+                            ImmutableMap.of(Partition.TRANSIENT_LAST_DDL_TIME, String.valueOf(modifyTime)), null, null,
+                            null, false));
                 } else {
                     partitionInfoMap.put(partitionName, new Partition(ImmutableMap.of(Partition.TRANSIENT_LAST_DDL_TIME,
-                            String.valueOf(System.currentTimeMillis() / 1000)), null, null, null, false));
+                                                                                      String.valueOf(
+                                                                                              System.currentTimeMillis() /
+                                                                                                      1000)), null,
+                                                                      null, null, false));
                 }
             }
         } finally {
@@ -217,11 +255,15 @@ public class MockedHiveMetadata implements ConnectorMetadata {
             Map<String, PartitionInfo> partitionInfoMap = MOCK_TABLE_MAP.get(dbName).get(tableName).partitionInfoMap;
             if (partitionInfoMap.containsKey(tableName)) {
                 long modifyTime = partitionInfoMap.get(tableName).getModifiedTime() + 1;
-                partitionInfoMap.put(tableName, new Partition(ImmutableMap.of(Partition.TRANSIENT_LAST_DDL_TIME,
-                        String.valueOf(modifyTime)), null, null, null, false));
+                partitionInfoMap.put(tableName, new Partition(
+                        ImmutableMap.of(Partition.TRANSIENT_LAST_DDL_TIME, String.valueOf(modifyTime)), null, null,
+                        null, false));
             } else {
                 partitionInfoMap.put(tableName, new Partition(ImmutableMap.of(Partition.TRANSIENT_LAST_DDL_TIME,
-                        String.valueOf(System.currentTimeMillis() / 1000)), null, null, null, false));
+                                                                              String.valueOf(
+                                                                                      System.currentTimeMillis() /
+                                                                                              1000)), null, null, null,
+                                                              false));
             }
         } finally {
             writeUnlock();
@@ -229,7 +271,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     }
 
     public static void mockView() {
-        Map<String, HiveTableInfo> mockTables = MOCK_TABLE_MAP.putIfAbsent(MOCKED_TPCH_DB_NAME, new CaseInsensitiveMap<>());
+        Map<String, HiveTableInfo> mockTables =
+                MOCK_TABLE_MAP.putIfAbsent(MOCKED_TPCH_DB_NAME, new CaseInsensitiveMap<>());
         List<FieldSchema> cols = Lists.newArrayList();
         cols.add(new FieldSchema("c_custkey", "int", null));
         cols.add(new FieldSchema("c_name", "string", null));
@@ -238,12 +281,14 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("c_phone", "string", null));
         cols.add(new FieldSchema("c_mktsegment", "string", null));
         cols.add(new FieldSchema("c_comment", "string", null));
-        StorageDescriptor sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
+        StorageDescriptor sd =
+                new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                      Maps.newHashMap());
 
-        Table hmsView1 = new Table("customer_view", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null,
-                "select c_custkey,c_name, c_address, c_nationkey, c_phone, c_mktsegment, c_comment from tpch.customer",
-                "VIRTUAL_VIEW");
+        Table hmsView1 =
+                new Table("customer_view", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null,
+                          "select c_custkey,c_name, c_address, c_nationkey, c_phone, c_mktsegment, c_comment from tpch.customer",
+                          "VIRTUAL_VIEW");
         HiveView view1 = HiveMetastoreApiConverter.toHiveView(hmsView1, MOCKED_HIVE_CATALOG_NAME);
         mockTables.put(hmsView1.getTableName(), new HiveTableInfo(view1));
 
@@ -255,14 +300,14 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("n_nationkey", "int", null));
         cols.add(new FieldSchema("n_name", "string", null));
         cols.add(new FieldSchema("n_regionkey", "int", null));
-        sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
+        sd = new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                   Maps.newHashMap());
 
-        Table hmsView2 = new Table("customer_nation_view", "tpch", null, 0,
-                0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null,
-                "select c_custkey,c_name, c_address, c_nationkey, n_nationkey, n_name, n_regionkey from " +
-                        "tpch.customer join tpch.nation on c_nationkey = n_nationkey",
-                "VIRTUAL_VIEW");
+        Table hmsView2 =
+                new Table("customer_nation_view", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(),
+                          null,
+                          "select c_custkey,c_name, c_address, c_nationkey, n_nationkey, n_name, n_regionkey from " +
+                                  "tpch.customer join tpch.nation on c_nationkey = n_nationkey", "VIRTUAL_VIEW");
         HiveView view2 = HiveMetastoreApiConverter.toHiveView(hmsView2, MOCKED_HIVE_CATALOG_NAME);
         mockTables.put(hmsView2.getTableName(), new HiveTableInfo(view2));
 
@@ -274,14 +319,14 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("c_phone", "string", null));
         cols.add(new FieldSchema("c_mktsegment", "string", null));
         cols.add(new FieldSchema("c_comment", "string", null));
-        sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
+        sd = new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                   Maps.newHashMap());
 
-        Table hmsView3 = new Table("customer_alias_view", "tpch", null, 0,
-                0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null,
-                "select c_custkey, c_name, c_address, c_nationkey, c_phone, c_mktsegment, c_comment from " +
-                        "(select * from tpch.customer)",
-                "VIRTUAL_VIEW");
+        Table hmsView3 =
+                new Table("customer_alias_view", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(),
+                          null,
+                          "select c_custkey, c_name, c_address, c_nationkey, c_phone, c_mktsegment, c_comment from " +
+                                  "(select * from tpch.customer)", "VIRTUAL_VIEW");
         HiveView view3 = HiveMetastoreApiConverter.toHiveView(hmsView3, MOCKED_HIVE_CATALOG_NAME);
         mockTables.put(hmsView3.getTableName(), new HiveTableInfo(view3));
     }
@@ -296,18 +341,21 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("r_regionkey", "int", null));
         cols.add(new FieldSchema("r_name", "string", null));
         cols.add(new FieldSchema("r_comment", "string", null));
-        StorageDescriptor sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
+        StorageDescriptor sd =
+                new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                      Maps.newHashMap());
 
         CaseInsensitiveMap<String, ColumnStatistic> regionStats = new CaseInsensitiveMap<>();
         regionStats.put("r_regionkey", new ColumnStatistic(0, 4, 0, 4, 5));
         regionStats.put("r_name", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 6.8, 5));
         regionStats.put("r_comment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 66, 5));
 
-        Table region = new Table("region", "tpch", null, 0, 0, 0,  sd,
-                Lists.newArrayList(), Maps.newHashMap(), null, null, "EXTERNAL_TABLE");
-        mockTables.put(region.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(region,
-                MOCKED_HIVE_CATALOG_NAME), ImmutableList.of(), 5, regionStats, MOCKED_FILES));
+        Table region =
+                new Table("region", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null, null,
+                          "EXTERNAL_TABLE");
+        mockTables.put(region.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(region, MOCKED_HIVE_CATALOG_NAME),
+                                         ImmutableList.of(), 5, regionStats, MOCKED_FILES));
 
         // Mock table nation
         cols = Lists.newArrayList();
@@ -315,18 +363,20 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("n_name", "string", null));
         cols.add(new FieldSchema("n_regionkey", "int", null));
         cols.add(new FieldSchema("n_comment", "string", null));
-        sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
+        sd = new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                   Maps.newHashMap());
 
         Map<String, ColumnStatistic> nationStats = new CaseInsensitiveMap<>();
         nationStats.put("n_nationkey", new ColumnStatistic(0, 24, 0, 4, 25));
         nationStats.put("n_name", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 25, 25));
         nationStats.put("n_regionkey", new ColumnStatistic(0, 4, 0, 4, 5));
         nationStats.put("n_comment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 0, 25));
-        Table nation = new Table("nation", "tpch", null, 0, 0, 0,  sd,
-                Lists.newArrayList(), Maps.newHashMap(), null, null, "EXTERNAL_TABLE");
-        mockTables.put(nation.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(nation,
-                MOCKED_HIVE_CATALOG_NAME), ImmutableList.of(), 25, nationStats, MOCKED_FILES));
+        Table nation =
+                new Table("nation", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null, null,
+                          "EXTERNAL_TABLE");
+        mockTables.put(nation.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(nation, MOCKED_HIVE_CATALOG_NAME),
+                                         ImmutableList.of(), 25, nationStats, MOCKED_FILES));
 
         // Mock table supplier
         cols = Lists.newArrayList();
@@ -337,8 +387,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("s_phone", "string", null));
         cols.add(new FieldSchema("s_acctbal", "decimal(15,2)", null));
         cols.add(new FieldSchema("s_comment", "string", null));
-        sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
+        sd = new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                   Maps.newHashMap());
 
         CaseInsensitiveMap<String, ColumnStatistic> supplierStats = new CaseInsensitiveMap<>();
         supplierStats.put("s_suppkey", new ColumnStatistic(1, 1000000.0, 0, 4, 1000000));
@@ -348,10 +398,12 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         supplierStats.put("s_phone", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 15, 1000000));
         supplierStats.put("s_acctbal", new ColumnStatistic(-998.22, 9999.72, 0, 8, 656145));
         supplierStats.put("s_comment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 101, 984748));
-        Table suppler = new Table("supplier", "tpch", null, 0, 0, 0,  sd,
-                Lists.newArrayList(), Maps.newHashMap(), null, null, "EXTERNAL_TABLE");
-        mockTables.put(suppler.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(suppler,
-                MOCKED_HIVE_CATALOG_NAME), ImmutableList.of(), 1000000, supplierStats, MOCKED_FILES));
+        Table suppler =
+                new Table("supplier", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null, null,
+                          "EXTERNAL_TABLE");
+        mockTables.put(suppler.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(suppler, MOCKED_HIVE_CATALOG_NAME),
+                                         ImmutableList.of(), 1000000, supplierStats, MOCKED_FILES));
 
         // Mock table part
         cols = Lists.newArrayList();
@@ -364,8 +416,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("p_container", "string", null));
         cols.add(new FieldSchema("p_retailprice", "decimal(15,2)", null));
         cols.add(new FieldSchema("p_comment", "string", null));
-        sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
+        sd = new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                   Maps.newHashMap());
 
         CaseInsensitiveMap<String, ColumnStatistic> partStats = new CaseInsensitiveMap<>();
         partStats.put("p_partkey", new ColumnStatistic(1, 20000000, 0, 8, 20000000));
@@ -377,10 +429,11 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         partStats.put("p_container", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 10, 40));
         partStats.put("p_retailprice", new ColumnStatistic(901, 2098.99, 0, 8, 120039));
         partStats.put("p_comment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 0, 3927659));
-        Table part = new Table("part", "tpch", null, 0, 0, 0,  sd,
-                Lists.newArrayList(), Maps.newHashMap(), null, null, "EXTERNAL_TABLE");
-        HiveTableInfo hiveTableInfo = new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(part, MOCKED_HIVE_CATALOG_NAME),
-                ImmutableList.of(), 20000000, partStats, MOCKED_FILES);
+        Table part = new Table("part", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null, null,
+                               "EXTERNAL_TABLE");
+        HiveTableInfo hiveTableInfo =
+                new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(part, MOCKED_HIVE_CATALOG_NAME),
+                                  ImmutableList.of(), 20000000, partStats, MOCKED_FILES);
         mockTables.put(part.getTableName(), hiveTableInfo);
 
         // Mock table partsupp
@@ -390,8 +443,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("ps_availqty", "int", null));
         cols.add(new FieldSchema("ps_supplycost", "decimal(15,2)", null));
         cols.add(new FieldSchema("ps_comment", "string", null));
-        sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
+        sd = new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                   Maps.newHashMap());
 
         CaseInsensitiveMap<String, ColumnStatistic> partSuppStats = new CaseInsensitiveMap<>();
         partSuppStats.put("ps_partkey", new ColumnStatistic(1, 20000000, 0, 8, 20000000));
@@ -399,10 +452,12 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         partSuppStats.put("ps_availqty", new ColumnStatistic(1, 9999, 0, 4, 9999));
         partSuppStats.put("ps_supplycost", new ColumnStatistic(1, 1000, 0, 8, 99864));
         partSuppStats.put("ps_comment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 199, 71873944));
-        Table partSupp = new Table("partsupp", "tpch", null, 0, 0, 0,  sd,
-                Lists.newArrayList(), Maps.newHashMap(), null, null, "EXTERNAL_TABLE");
-        mockTables.put(partSupp.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(partSupp,
-                MOCKED_HIVE_CATALOG_NAME), ImmutableList.of(), 80000000, partSuppStats, MOCKED_FILES));
+        Table partSupp =
+                new Table("partsupp", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null, null,
+                          "EXTERNAL_TABLE");
+        mockTables.put(partSupp.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(partSupp, MOCKED_HIVE_CATALOG_NAME),
+                                         ImmutableList.of(), 80000000, partSuppStats, MOCKED_FILES));
 
         // Mock customer table
         cols = Lists.newArrayList();
@@ -414,8 +469,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("c_acctbal", "decimal(15,2)", null));
         cols.add(new FieldSchema("c_mktsegment", "string", null));
         cols.add(new FieldSchema("c_comment", "string", null));
-        sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
+        sd = new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                   Maps.newHashMap());
 
         Map<String, ColumnStatistic> customerStats = new CaseInsensitiveMap<>();
         customerStats.put("c_custkey", new ColumnStatistic(1, 15000000, 0, 8, 15000000));
@@ -426,10 +481,12 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         customerStats.put("c_acctbal", new ColumnStatistic(-999.99, 9999.99, 0, 8, 1086564));
         customerStats.put("c_mktsegment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 10, 5));
         customerStats.put("c_comment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 117, 14788744));
-        Table customer = new Table("customer", "tpch", null, 0, 0, 0,  sd,
-                Lists.newArrayList(), Maps.newHashMap(), null, null, "EXTERNAL_TABLE");
-        mockTables.put(customer.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(customer,
-                MOCKED_HIVE_CATALOG_NAME), ImmutableList.of(), 15000000, customerStats, MOCKED_FILES));
+        Table customer =
+                new Table("customer", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null, null,
+                          "EXTERNAL_TABLE");
+        mockTables.put(customer.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(customer, MOCKED_HIVE_CATALOG_NAME),
+                                         ImmutableList.of(), 15000000, customerStats, MOCKED_FILES));
 
         // Mock table orders
         cols = Lists.newArrayList();
@@ -442,26 +499,28 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("o_clerk", "string", null));
         cols.add(new FieldSchema("o_shippriority", "int", null));
         cols.add(new FieldSchema("o_comment", "string", null));
-        sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
+        sd = new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                   Maps.newHashMap());
 
         CaseInsensitiveMap<String, ColumnStatistic> ordersStats = new CaseInsensitiveMap<>();
         ordersStats.put("o_orderkey", new ColumnStatistic(1, 600000000, 0, 8, 150000000));
         ordersStats.put("o_custkey", new ColumnStatistic(1, 150000000, 0, 8, 10031873));
         ordersStats.put("o_orderstatus", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 1, 3));
         ordersStats.put("o_totalprice", new ColumnStatistic(811.73, 591036.15, 0, 8, 34696580));
-        ordersStats.put("o_orderdate", new ColumnStatistic(getLongFromDateTime(
-                DateUtils.parseStringWithDefaultHSM("1992-01-01", DateUtils.DATE_FORMATTER)),
-                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("1998-08-02",
-                        DateUtils.DATE_FORMATTER)), 0, 4, 2412));
+        ordersStats.put("o_orderdate", new ColumnStatistic(
+                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("1992-01-01", DateUtils.DATE_FORMATTER)),
+                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("1998-08-02", DateUtils.DATE_FORMATTER)), 0, 4,
+                2412));
         ordersStats.put("o_orderpriority", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 15, 5));
         ordersStats.put("o_clerk", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 15, 100836));
         ordersStats.put("o_shippriority", new ColumnStatistic(0, 0, 0, 4, 1));
         ordersStats.put("o_comment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 79, 110204136));
-        Table orders = new Table("orders", "tpch", null, 0, 0, 0,  sd,
-                Lists.newArrayList(), Maps.newHashMap(), null, null, "EXTERNAL_TABLE");
-        mockTables.put(orders.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(orders,
-                MOCKED_HIVE_CATALOG_NAME), ImmutableList.of(), 150000000, ordersStats, MOCKED_FILES));
+        Table orders =
+                new Table("orders", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null, null,
+                          "EXTERNAL_TABLE");
+        mockTables.put(orders.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(orders, MOCKED_HIVE_CATALOG_NAME),
+                                         ImmutableList.of(), 150000000, ordersStats, MOCKED_FILES));
 
         // Mock table lineitem
         cols = Lists.newArrayList();
@@ -481,8 +540,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("l_shipinstruct", "string", null));
         cols.add(new FieldSchema("l_shipmode", "string", null));
         cols.add(new FieldSchema("l_comment", "string", null));
-        sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
+        sd = new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                   Maps.newHashMap());
 
         Map<String, ColumnStatistic> lineitemStats = new CaseInsensitiveMap<>();
         lineitemStats.put("l_orderkey", new ColumnStatistic(1, 600000000, 0, 8, 150000000));
@@ -495,30 +554,33 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         lineitemStats.put("l_tax", new ColumnStatistic(0, 0.08, 0, 8, 9));
         lineitemStats.put("l_returnflag", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 1, 3));
         lineitemStats.put("l_linestatus", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 1, 2));
-        lineitemStats.put("l_shipdate", new ColumnStatistic(getLongFromDateTime(
-                DateUtils.parseStringWithDefaultHSM("1992-01-02", DateUtils.DATE_FORMATTER)),
-                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("1998-12-01", DateUtils.DATE_FORMATTER)),
-                0, 4, 2526));
-        lineitemStats.put("l_commitdate", new ColumnStatistic(getLongFromDateTime(
-                DateUtils.parseStringWithDefaultHSM("1992-01-31", DateUtils.DATE_FORMATTER)),
-                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("1998-10-31", DateUtils.DATE_FORMATTER)),
-                0, 4, 2466));
-        lineitemStats.put("l_receiptdate", new ColumnStatistic(getLongFromDateTime(DateUtils.parseStringWithDefaultHSM(
-                "1992-01-03", DateUtils.DATE_FORMATTER)),
-                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("1998-12-31", DateUtils.DATE_FORMATTER)),
-                0, 4, 2554));
+        lineitemStats.put("l_shipdate", new ColumnStatistic(
+                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("1992-01-02", DateUtils.DATE_FORMATTER)),
+                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("1998-12-01", DateUtils.DATE_FORMATTER)), 0, 4,
+                2526));
+        lineitemStats.put("l_commitdate", new ColumnStatistic(
+                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("1992-01-31", DateUtils.DATE_FORMATTER)),
+                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("1998-10-31", DateUtils.DATE_FORMATTER)), 0, 4,
+                2466));
+        lineitemStats.put("l_receiptdate", new ColumnStatistic(
+                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("1992-01-03", DateUtils.DATE_FORMATTER)),
+                getLongFromDateTime(DateUtils.parseStringWithDefaultHSM("1998-12-31", DateUtils.DATE_FORMATTER)), 0, 4,
+                2554));
         lineitemStats.put("l_shipinstruct", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 25, 4));
         lineitemStats.put("l_shipmode", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 10, 7));
         lineitemStats.put("l_comment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 44, 142089728));
-        Table lineitem = new Table("lineitem", "tpch", null, 0, 0, 0,  sd,
-                Lists.newArrayList(), Maps.newHashMap(), null, null, "EXTERNAL_TABLE");
-        mockTables.put(lineitem.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(lineitem,
-                MOCKED_HIVE_CATALOG_NAME), ImmutableList.of(), 600037902, lineitemStats, MOCKED_FILES));
+        Table lineitem =
+                new Table("lineitem", "tpch", null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null, null,
+                          "EXTERNAL_TABLE");
+        mockTables.put(lineitem.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(lineitem, MOCKED_HIVE_CATALOG_NAME),
+                                         ImmutableList.of(), 600037902, lineitemStats, MOCKED_FILES));
     }
 
     public static void mockPartitionTable() {
         mockLineItem();
         mockLineItemWithMultiPartitionColumns();
+        mockLineItemWithMultiPartitionColumns2();
         mockT1();
         mockT2();
         mockT3();
@@ -540,10 +602,12 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("o_shippriority", "int", null));
         cols.add(new FieldSchema("o_comment", "string", null));
 
-        StorageDescriptor sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
-        Table orders = new Table("orders", "partitioned_db", null, 0, 0, 0,  sd,
-                ImmutableList.of(new FieldSchema("o_orderdate", "Date", null)), Maps.newHashMap(), null, null, "EXTERNAL_TABLE");
+        StorageDescriptor sd =
+                new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                      Maps.newHashMap());
+        Table orders = new Table("orders", "partitioned_db", null, 0, 0, 0, sd,
+                                 ImmutableList.of(new FieldSchema("o_orderdate", "Date", null)), Maps.newHashMap(),
+                                 null, null, "EXTERNAL_TABLE");
 
         Column partitionColumn = new Column("o_orderdate", Type.DATE);
 
@@ -554,8 +618,9 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         LocalDate endDate = LocalDate.of(1993, 12, 31);
         LocalDate curDate = startDate;
         while (!curDate.equals(endDate)) {
-            partitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(curDate.getYear(), curDate.getMonthValue(),
-                    curDate.getDayOfMonth())), ImmutableList.of(PrimitiveType.DATE)));
+            partitionKeyList.add(new PartitionKey(ImmutableList.of(
+                    new DateLiteral(curDate.getYear(), curDate.getMonthValue(), curDate.getDayOfMonth())),
+                                                  ImmutableList.of(PrimitiveType.DATE)));
             String partitionName = "o_orderdate=" + curDate.format(DATE_FORMATTER_UNIX);
             partitionNames.add(partitionName);
             curDate = curDate.plusDays(1);
@@ -566,19 +631,22 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         Map<String, HivePartitionStats> hivePartitionStatsMap = Maps.newHashMap();
         List<String> partitionColumnNames = ImmutableList.of("o_orderdate");
 
-        ColumnStatistic partitionColumnStats = getPartitionColumnStatistic(partitionColumn, partitionKeyList,
-                partitionColumnNames, hivePartitionStatsMap, avgNumPerPartition, rowCount);
+        ColumnStatistic partitionColumnStats =
+                getPartitionColumnStatistic(partitionColumn, partitionKeyList, partitionColumnNames,
+                                            hivePartitionStatsMap, avgNumPerPartition, rowCount);
 
         List<RemoteFileInfo> remoteFileInfos = Lists.newArrayList();
-        partitionNames.forEach(k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
+        partitionNames.forEach(
+                k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
 
         List<String> colNames = cols.stream().map(FieldSchema::getName).collect(Collectors.toList());
-        Map<String, ColumnStatistic> columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
-                col -> ColumnStatistic.unknown()));
+        Map<String, ColumnStatistic> columnStatisticMap =
+                colNames.stream().collect(Collectors.toMap(Function.identity(), col -> ColumnStatistic.unknown()));
         columnStatisticMap.put("o_orderdate", partitionColumnStats);
 
-        mockTables.put(orders.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(
-                orders, MOCKED_HIVE_CATALOG_NAME), partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
+        mockTables.put(orders.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(orders, MOCKED_HIVE_CATALOG_NAME),
+                                         partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
 
     }
 
@@ -602,29 +670,32 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("l_shipinstruct", "string", null));
         cols.add(new FieldSchema("l_shipmode", "string", null));
         cols.add(new FieldSchema("l_comment", "string", null));
-        StorageDescriptor sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
-        Table lineItemPar = new Table("lineitem_par", "partitioned_db", null, 0, 0, 0,  sd,
-                ImmutableList.of(new FieldSchema("l_shipdate", "Date", null)), Maps.newHashMap(), null, null, "EXTERNAL_TABLE");
+        StorageDescriptor sd =
+                new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                      Maps.newHashMap());
+        Table lineItemPar = new Table("lineitem_par", "partitioned_db", null, 0, 0, 0, sd,
+                                      ImmutableList.of(new FieldSchema("l_shipdate", "Date", null)), Maps.newHashMap(),
+                                      null, null, "EXTERNAL_TABLE");
 
         Column partitionColumn = new Column("l_shipdate", Type.DATE);
 
         List<PartitionKey> lineitemPartitionKeyList = Lists.newArrayList();
-        lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 1)),
-                ImmutableList.of(PrimitiveType.DATE)));
-        lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 2)),
-                ImmutableList.of(PrimitiveType.DATE)));
-        lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 3)),
-                ImmutableList.of(PrimitiveType.DATE)));
-        lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 4)),
-                ImmutableList.of(PrimitiveType.DATE)));
-        lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 5)),
-                ImmutableList.of(PrimitiveType.DATE)));
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 1)), ImmutableList.of(PrimitiveType.DATE)));
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 2)), ImmutableList.of(PrimitiveType.DATE)));
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 3)), ImmutableList.of(PrimitiveType.DATE)));
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 4)), ImmutableList.of(PrimitiveType.DATE)));
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 5)), ImmutableList.of(PrimitiveType.DATE)));
 
         List<String> partitionNames = Lists.newArrayList();
-        partitionNames.addAll(ImmutableList.of("l_shipdate=" + HiveMetaClient.PARTITION_NULL_VALUE,
-                "l_shipdate=1998-01-01", "l_shipdate=1998-01-02", "l_shipdate=1998-01-03",
-                "l_shipdate=1998-01-04", "l_shipdate=1998-01-05"));
+        partitionNames.addAll(
+                ImmutableList.of("l_shipdate=" + HiveMetaClient.PARTITION_NULL_VALUE, "l_shipdate=1998-01-01",
+                                 "l_shipdate=1998-01-02", "l_shipdate=1998-01-03", "l_shipdate=1998-01-04",
+                                 "l_shipdate=1998-01-05"));
 
         List<String> partitionColumnNames = ImmutableList.of("l_shipdate");
 
@@ -632,19 +703,22 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         double avgNumPerPartition = rowCount / partitionNames.size();
         Map<String, HivePartitionStats> hivePartitionStatsMap = Maps.newHashMap();
 
-        ColumnStatistic partitionColumnStats = getPartitionColumnStatistic(partitionColumn, lineitemPartitionKeyList,
-                partitionColumnNames, hivePartitionStatsMap, avgNumPerPartition, rowCount);
+        ColumnStatistic partitionColumnStats =
+                getPartitionColumnStatistic(partitionColumn, lineitemPartitionKeyList, partitionColumnNames,
+                                            hivePartitionStatsMap, avgNumPerPartition, rowCount);
 
         List<RemoteFileInfo> remoteFileInfos = Lists.newArrayList();
-        partitionNames.forEach(k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
+        partitionNames.forEach(
+                k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
 
         List<String> colNames = cols.stream().map(FieldSchema::getName).collect(Collectors.toList());
-        Map<String, ColumnStatistic> columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
-                col -> ColumnStatistic.unknown()));
+        Map<String, ColumnStatistic> columnStatisticMap =
+                colNames.stream().collect(Collectors.toMap(Function.identity(), col -> ColumnStatistic.unknown()));
         columnStatisticMap.put("l_shipdate", partitionColumnStats);
 
-        mockTables.put(lineItemPar.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(
-                lineItemPar, MOCKED_HIVE_CATALOG_NAME), partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
+        mockTables.put(lineItemPar.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(lineItemPar, MOCKED_HIVE_CATALOG_NAME),
+                                         partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
     }
 
     public static void mockLineItemWithMultiPartitionColumns() {
@@ -666,42 +740,40 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("l_shipinstruct", "string", null));
         cols.add(new FieldSchema("l_shipmode", "string", null));
         cols.add(new FieldSchema("l_comment", "string", null));
-        StorageDescriptor sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
-        Table lineItemPar = new Table("lineitem_mul_par", "partitioned_db", null, 0, 0, 0,  sd,
-                ImmutableList.of(new FieldSchema("l_shipdate", "Date", null),
-                        new FieldSchema("l_orderkey", "int", null)),
-                Maps.newHashMap(), null, null, "EXTERNAL_TABLE");
+        StorageDescriptor sd =
+                new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                      Maps.newHashMap());
+        Table lineItemPar = new Table("lineitem_mul_par", "partitioned_db", null, 0, 0, 0, sd,
+                                      ImmutableList.of(new FieldSchema("l_shipdate", "Date", null),
+                                                       new FieldSchema("l_orderkey", "int", null)), Maps.newHashMap(),
+                                      null, null, "EXTERNAL_TABLE");
 
         Column partitionColumn1 = new Column("l_shipdate", Type.DATE);
         Column partitionColumn2 = new Column("l_orderkey", Type.INT);
 
         List<PartitionKey> lineitemPartitionKeyList = Lists.newArrayList();
         lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 1), new IntLiteral(1)),
-                ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+                                                      ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
         lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 1), new IntLiteral(2)),
-                ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+                                                      ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
         lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 1), new IntLiteral(3)),
-                ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+                                                      ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
         lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 2), new IntLiteral(2)),
-                ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+                                                      ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
         lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 2), new IntLiteral(10)),
-                ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+                                                      ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
         lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 3), new IntLiteral(5)),
-                ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+                                                      ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
         lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 4), new IntLiteral(5)),
-                ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+                                                      ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
         lineitemPartitionKeyList.add(new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 5), new IntLiteral(1)),
-                ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+                                                      ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
 
-        List<String> partitionNames = ImmutableList.of("l_shipdate=1998-01-01/l_orderkey=1",
-                "l_shipdate=1998-01-01/l_orderkey=2",
-                "l_shipdate=1998-01-01/l_orderkey=3",
-                "l_shipdate=1998-01-02/l_orderkey=2",
-                "l_shipdate=1998-01-02/l_orderkey=10",
-                "l_shipdate=1998-01-03/l_orderkey=5",
-                "l_shipdate=1998-01-04/l_orderkey=5",
-                "l_shipdate=1998-01-05/l_orderkey=1");
+        List<String> partitionNames =
+                ImmutableList.of("l_shipdate=1998-01-01/l_orderkey=1", "l_shipdate=1998-01-01/l_orderkey=2",
+                                 "l_shipdate=1998-01-01/l_orderkey=3", "l_shipdate=1998-01-02/l_orderkey=2",
+                                 "l_shipdate=1998-01-02/l_orderkey=10", "l_shipdate=1998-01-03/l_orderkey=5",
+                                 "l_shipdate=1998-01-04/l_orderkey=5", "l_shipdate=1998-01-05/l_orderkey=1");
 
         List<String> partitionColumnNames = ImmutableList.of("l_shipdate", "l_orderkey");
 
@@ -709,22 +781,116 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         double avgNumPerPartition = rowCount / partitionNames.size();
         Map<String, HivePartitionStats> hivePartitionStatsMap = Maps.newHashMap();
 
-        ColumnStatistic partitionColumnStats1 = getPartitionColumnStatistic(partitionColumn1, lineitemPartitionKeyList,
-                partitionColumnNames, hivePartitionStatsMap, avgNumPerPartition, rowCount);
-        ColumnStatistic partitionColumnStats2 = getPartitionColumnStatistic(partitionColumn2, lineitemPartitionKeyList,
-                partitionColumnNames, hivePartitionStatsMap, avgNumPerPartition, rowCount);
+        ColumnStatistic partitionColumnStats1 =
+                getPartitionColumnStatistic(partitionColumn1, lineitemPartitionKeyList, partitionColumnNames,
+                                            hivePartitionStatsMap, avgNumPerPartition, rowCount);
+        ColumnStatistic partitionColumnStats2 =
+                getPartitionColumnStatistic(partitionColumn2, lineitemPartitionKeyList, partitionColumnNames,
+                                            hivePartitionStatsMap, avgNumPerPartition, rowCount);
 
         List<RemoteFileInfo> remoteFileInfos = Lists.newArrayList();
-        partitionNames.forEach(k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
+        partitionNames.forEach(
+                k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
 
         List<String> colNames = cols.stream().map(FieldSchema::getName).collect(Collectors.toList());
-        Map<String, ColumnStatistic> columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
-                col -> ColumnStatistic.unknown()));
+        Map<String, ColumnStatistic> columnStatisticMap =
+                colNames.stream().collect(Collectors.toMap(Function.identity(), col -> ColumnStatistic.unknown()));
         columnStatisticMap.put("l_shipdate", partitionColumnStats1);
         columnStatisticMap.put("l_orderkey", partitionColumnStats2);
 
-        mockTables.put(lineItemPar.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(
-                lineItemPar, MOCKED_HIVE_CATALOG_NAME), partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
+        mockTables.put(lineItemPar.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(lineItemPar, MOCKED_HIVE_CATALOG_NAME),
+                                         partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
+    }
+
+    public static void mockLineItemWithMultiPartitionColumns2() {
+        MOCK_TABLE_MAP.putIfAbsent(MOCKED_PARTITIONED_DB_NAME, new CaseInsensitiveMap<>());
+        Map<String, HiveTableInfo> mockTables = MOCK_TABLE_MAP.get(MOCKED_PARTITIONED_DB_NAME);
+
+        List<FieldSchema> cols = Lists.newArrayList();
+        cols.add(new FieldSchema("l_orderkey", "int", null));
+        cols.add(new FieldSchema("l_partkey", "int", null));
+        cols.add(new FieldSchema("l_suppkey", "int", null));
+        cols.add(new FieldSchema("l_linenumber", "int", null));
+        cols.add(new FieldSchema("l_quantity", "decimal(15,2)", null));
+        cols.add(new FieldSchema("l_extendedprice", "decimal(15,2)", null));
+        cols.add(new FieldSchema("l_discount", "decimal(15,2)", null));
+        cols.add(new FieldSchema("l_tax", "decimal(15,2)", null));
+        cols.add(new FieldSchema("l_linestatus", "string", null));
+        cols.add(new FieldSchema("l_commitdate", "date", null));
+        cols.add(new FieldSchema("l_receiptdate", "date", null));
+        cols.add(new FieldSchema("l_shipinstruct", "string", null));
+        cols.add(new FieldSchema("l_shipmode", "string", null));
+        cols.add(new FieldSchema("l_comment", "string", null));
+        StorageDescriptor sd =
+                new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                      Maps.newHashMap());
+        Table lineItemPar = new Table("lineitem_mul_par2", "partitioned_db", null, 0, 0, 0, sd,
+                                      ImmutableList.of(new FieldSchema("l_shipdate", "Date", null),
+                                                       new FieldSchema("l_returnflag", "string", null)),
+                                      Maps.newHashMap(), null, null, "EXTERNAL_TABLE");
+
+        Column partitionColumn1 = new Column("l_shipdate", Type.DATE);
+        Column partitionColumn2 = new Column("l_returnflag", Type.VARCHAR);
+
+        List<PartitionKey> lineitemPartitionKeyList = Lists.newArrayList();
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 1), new StringLiteral("A")),
+                                 ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 1), new StringLiteral("R")),
+                                 ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 1), new StringLiteral("N")),
+                                 ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 2), new StringLiteral("A")),
+                                 ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 2), new StringLiteral("R")),
+                                 ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 3), new StringLiteral("N")),
+                                 ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 4), new StringLiteral("A")),
+                                 ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+        lineitemPartitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new DateLiteral(1998, 1, 5), new StringLiteral("R")),
+                                 ImmutableList.of(PrimitiveType.DATE, PrimitiveType.INT)));
+
+        List<String> partitionNames =
+                ImmutableList.of("l_shipdate=1998-01-01/l_returnflag=A", "l_shipdate=1998-01-01/l_returnflag=R",
+                                 "l_shipdate=1998-01-01/l_returnflag=N", "l_shipdate=1998-01-02/l_returnflag=A",
+                                 "l_shipdate=1998-01-02/l_returnflag=R", "l_shipdate=1998-01-03/l_returnflag=N",
+                                 "l_shipdate=1998-01-04/l_returnflag=A", "l_shipdate=1998-01-05/l_returnflag=R");
+
+        List<String> partitionColumnNames = ImmutableList.of("l_shipdate", "l_returnflag");
+
+        double rowCount = 600037902;
+        double avgNumPerPartition = rowCount / partitionNames.size();
+        Map<String, HivePartitionStats> hivePartitionStatsMap = Maps.newHashMap();
+
+        ColumnStatistic partitionColumnStats1 =
+                getPartitionColumnStatistic(partitionColumn1, lineitemPartitionKeyList, partitionColumnNames,
+                                            hivePartitionStatsMap, avgNumPerPartition, rowCount);
+        ColumnStatistic partitionColumnStats2 =
+                getPartitionColumnStatistic(partitionColumn2, lineitemPartitionKeyList, partitionColumnNames,
+                                            hivePartitionStatsMap, avgNumPerPartition, rowCount);
+
+        List<RemoteFileInfo> remoteFileInfos = Lists.newArrayList();
+        partitionNames.forEach(
+                k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
+
+        List<String> colNames = cols.stream().map(FieldSchema::getName).collect(Collectors.toList());
+        Map<String, ColumnStatistic> columnStatisticMap =
+                colNames.stream().collect(Collectors.toMap(Function.identity(), col -> ColumnStatistic.unknown()));
+        columnStatisticMap.put("l_shipdate", partitionColumnStats1);
+        columnStatisticMap.put("l_returnflag", partitionColumnStats2);
+
+        mockTables.put(lineItemPar.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(lineItemPar, MOCKED_HIVE_CATALOG_NAME),
+                                         partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
     }
 
     public static void mockSimpleTable(String dbName, String tableName) {
@@ -735,37 +901,43 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("c1", "int", null));
         cols.add(new FieldSchema("c2", "string", null));
         cols.add(new FieldSchema("c3", "string", null));
-        StorageDescriptor sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
-        Table mockTable = new Table(tableName, dbName, null, 0, 0, 0,  sd,
-                ImmutableList.of(new FieldSchema("par_col", "int", null)), Maps.newHashMap(),
-                null, null, "EXTERNAL_TABLE");
+        StorageDescriptor sd =
+                new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                      Maps.newHashMap());
+        Table mockTable = new Table(tableName, dbName, null, 0, 0, 0, sd,
+                                    ImmutableList.of(new FieldSchema("par_col", "int", null)), Maps.newHashMap(), null,
+                                    null, "EXTERNAL_TABLE");
         List<String> partitionNames = ImmutableList.of("par_col=0", "par_col=1", "par_col=2");
         Map<String, HivePartitionStats> hivePartitionStatsMap = Maps.newHashMap();
         double avgNumPerPartition = (double) (100 / 3);
         double rowCount = 100;
 
         List<PartitionKey> partitionKeyList = Lists.newArrayList();
-        partitionKeyList.add(new PartitionKey(ImmutableList.of(new IntLiteral(0)), ImmutableList.of(PrimitiveType.INT)));
-        partitionKeyList.add(new PartitionKey(ImmutableList.of(new IntLiteral(1)), ImmutableList.of(PrimitiveType.INT)));
-        partitionKeyList.add(new PartitionKey(ImmutableList.of(new IntLiteral(2)), ImmutableList.of(PrimitiveType.INT)));
+        partitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new IntLiteral(0)), ImmutableList.of(PrimitiveType.INT)));
+        partitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new IntLiteral(1)), ImmutableList.of(PrimitiveType.INT)));
+        partitionKeyList.add(
+                new PartitionKey(ImmutableList.of(new IntLiteral(2)), ImmutableList.of(PrimitiveType.INT)));
         Column partitionColumn = new Column("par_col", Type.INT);
         List<String> partitionColumnNames = ImmutableList.of("par_col");
-        ColumnStatistic partitionColumnStats = getPartitionColumnStatistic(partitionColumn, partitionKeyList,
-                partitionColumnNames, hivePartitionStatsMap, avgNumPerPartition, rowCount);
+        ColumnStatistic partitionColumnStats =
+                getPartitionColumnStatistic(partitionColumn, partitionKeyList, partitionColumnNames,
+                                            hivePartitionStatsMap, avgNumPerPartition, rowCount);
 
         Map<String, ColumnStatistic> columnStatisticMap;
         List<String> colNames = cols.stream().map(FieldSchema::getName).collect(Collectors.toList());
-        columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
-                col -> ColumnStatistic.unknown()));
+        columnStatisticMap =
+                colNames.stream().collect(Collectors.toMap(Function.identity(), col -> ColumnStatistic.unknown()));
         columnStatisticMap.put("par_col", partitionColumnStats);
 
         List<RemoteFileInfo> remoteFileInfos = Lists.newArrayList();
-        partitionNames.forEach(k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
+        partitionNames.forEach(
+                k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
 
-        mockTables.put(mockTable.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.
-                toHiveTable(mockTable, MOCKED_HIVE_CATALOG_NAME), partitionNames, (long) rowCount, columnStatisticMap,
-                remoteFileInfos));
+        mockTables.put(mockTable.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(mockTable, MOCKED_HIVE_CATALOG_NAME),
+                                         partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
     }
 
     public static void mockT1() {
@@ -788,83 +960,91 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         cols.add(new FieldSchema("c1", "int", null));
         cols.add(new FieldSchema("c2", "string", null));
         cols.add(new FieldSchema("c3", "string", null));
-        StorageDescriptor sd = new StorageDescriptor(cols, "", "",  "", false, -1, null, Lists.newArrayList(),
-                Lists.newArrayList(), Maps.newHashMap());
-        Table t1 = new Table("t1_par", "partitioned_db", null, 0, 0, 0,  sd,
-                ImmutableList.of(new FieldSchema("par_col", "int", null),
-                        new FieldSchema("par_date", "date", null)), Maps.newHashMap(),
-                null, null, "EXTERNAL_TABLE");
-        List<String> partitionNames = ImmutableList.of("par_col=0/par_date=2020-01-01",
-                "par_col=0/par_date=2020-01-02",
-                "par_col=0/par_date=2020-01-03",
-                "par_col=1/par_date=2020-01-02",
-                "par_col=1/par_date=2020-01-03",
-                "par_col=3/par_date=2020-01-04");
+        StorageDescriptor sd =
+                new StorageDescriptor(cols, "", "", "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
+                                      Maps.newHashMap());
+        Table t1 = new Table("t1_par", "partitioned_db", null, 0, 0, 0, sd,
+                             ImmutableList.of(new FieldSchema("par_col", "int", null),
+                                              new FieldSchema("par_date", "date", null)), Maps.newHashMap(), null, null,
+                             "EXTERNAL_TABLE");
+        List<String> partitionNames = ImmutableList.of("par_col=0/par_date=2020-01-01", "par_col=0/par_date=2020-01-02",
+                                                       "par_col=0/par_date=2020-01-03", "par_col=1/par_date=2020-01-02",
+                                                       "par_col=1/par_date=2020-01-03",
+                                                       "par_col=3/par_date=2020-01-04");
         Map<String, HivePartitionStats> hivePartitionStatsMap = Maps.newHashMap();
         double avgNumPerPartition = (double) (100 / 3);
         double rowCount = 100;
 
         List<PartitionKey> partitionKeyList = Lists.newArrayList();
         partitionKeyList.add(new PartitionKey(ImmutableList.of(new IntLiteral(0), new DateLiteral(2020, 1, 1)),
-                ImmutableList.of(PrimitiveType.INT, PrimitiveType.DATE)));
+                                              ImmutableList.of(PrimitiveType.INT, PrimitiveType.DATE)));
         partitionKeyList.add(new PartitionKey(ImmutableList.of(new IntLiteral(0), new DateLiteral(2020, 1, 2)),
-                ImmutableList.of(PrimitiveType.INT, PrimitiveType.DATE)));
+                                              ImmutableList.of(PrimitiveType.INT, PrimitiveType.DATE)));
         partitionKeyList.add(new PartitionKey(ImmutableList.of(new IntLiteral(0), new DateLiteral(2020, 1, 3)),
-                ImmutableList.of(PrimitiveType.INT, PrimitiveType.DATE)));
+                                              ImmutableList.of(PrimitiveType.INT, PrimitiveType.DATE)));
         partitionKeyList.add(new PartitionKey(ImmutableList.of(new IntLiteral(1), new DateLiteral(2020, 1, 2)),
-                ImmutableList.of(PrimitiveType.INT, PrimitiveType.DATE)));
+                                              ImmutableList.of(PrimitiveType.INT, PrimitiveType.DATE)));
         partitionKeyList.add(new PartitionKey(ImmutableList.of(new IntLiteral(1), new DateLiteral(2020, 1, 3)),
-                ImmutableList.of(PrimitiveType.INT, PrimitiveType.DATE)));
+                                              ImmutableList.of(PrimitiveType.INT, PrimitiveType.DATE)));
         partitionKeyList.add(new PartitionKey(ImmutableList.of(new IntLiteral(3), new DateLiteral(2020, 1, 4)),
-                ImmutableList.of(PrimitiveType.INT, PrimitiveType.DATE)));
+                                              ImmutableList.of(PrimitiveType.INT, PrimitiveType.DATE)));
 
         Column partitionColumn1 = new Column("par_col", Type.INT);
         Column partitionColumn2 = new Column("par_date", Type.DATE);
 
         List<String> partitionColumnNames = ImmutableList.of("par_col", "par_date");
-        ColumnStatistic partitionColumnStats1 = getPartitionColumnStatistic(partitionColumn1, partitionKeyList,
-                partitionColumnNames, hivePartitionStatsMap, avgNumPerPartition, rowCount);
-        ColumnStatistic partitionColumnStats2 = getPartitionColumnStatistic(partitionColumn2, partitionKeyList,
-                partitionColumnNames, hivePartitionStatsMap, avgNumPerPartition, rowCount);
+        ColumnStatistic partitionColumnStats1 =
+                getPartitionColumnStatistic(partitionColumn1, partitionKeyList, partitionColumnNames,
+                                            hivePartitionStatsMap, avgNumPerPartition, rowCount);
+        ColumnStatistic partitionColumnStats2 =
+                getPartitionColumnStatistic(partitionColumn2, partitionKeyList, partitionColumnNames,
+                                            hivePartitionStatsMap, avgNumPerPartition, rowCount);
 
         Map<String, ColumnStatistic> columnStatisticMap;
         List<String> colNames = cols.stream().map(FieldSchema::getName).collect(Collectors.toList());
-        columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
-                col -> ColumnStatistic.unknown()));
+        columnStatisticMap =
+                colNames.stream().collect(Collectors.toMap(Function.identity(), col -> ColumnStatistic.unknown()));
         columnStatisticMap.put("par_col", partitionColumnStats1);
         columnStatisticMap.put("par_date", partitionColumnStats2);
 
         List<RemoteFileInfo> remoteFileInfos = Lists.newArrayList();
-        partitionNames.forEach(k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
+        partitionNames.forEach(
+                k -> remoteFileInfos.add(new RemoteFileInfo(RemoteFileInputFormat.ORC, ImmutableList.of(), null)));
 
-        mockTables.put(t1.getTableName(), new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(t1, MOCKED_HIVE_CATALOG_NAME),
-                partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
+        mockTables.put(t1.getTableName(),
+                       new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(t1, MOCKED_HIVE_CATALOG_NAME),
+                                         partitionNames, (long) rowCount, columnStatisticMap, remoteFileInfos));
     }
 
     public static ColumnStatistic getPartitionColumnStatistic(Column partitionColumn,
                                                               List<PartitionKey> partitionKeyList,
                                                               List<String> partitionColumnNames,
                                                               Map<String, HivePartitionStats> hivePartitionStatsMap,
-                                                              double avgNumPerPartition,
-                                                              double rowCount) {
+                                                              double avgNumPerPartition, double rowCount) {
         HiveMetaClient metaClient = new HiveMetaClient(new HiveConf());
         HiveMetastore metastore = new HiveMetastore(metaClient, MOCKED_HIVE_CATALOG_NAME);
-        CachingHiveMetastore cachingHiveMetastore = createCatalogLevelInstance(
-                metastore, Executors.newSingleThreadExecutor(), 0, 0, 0, false);
-        HiveMetastoreOperations hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, false,
-                new Configuration(), MetastoreType.HMS, "hive_catalog");
+        CachingHiveMetastore cachingHiveMetastore =
+                createCatalogLevelInstance(metastore, Executors.newSingleThreadExecutor(), 0, 0, 0, false);
+        HiveMetastoreOperations hmsOps =
+                new HiveMetastoreOperations(cachingHiveMetastore, false, new Configuration(), MetastoreType.HMS,
+                                            "hive_catalog");
         RemoteFileIO remoteFileIO = new HiveRemoteFileIO(new Configuration());
-        CachingRemoteFileIO cacheIO = CachingRemoteFileIO.createCatalogLevelInstance(remoteFileIO,
-                Executors.newSingleThreadExecutor(), 0, 0, 0);
-        RemoteFileOperations fileOps = new RemoteFileOperations(cacheIO, Executors.newSingleThreadExecutor(), false, false);
+        CachingRemoteFileIO cacheIO =
+                CachingRemoteFileIO.createCatalogLevelInstance(remoteFileIO, Executors.newSingleThreadExecutor(), 0, 0,
+                                                               0);
+        RemoteFileOperations fileOps =
+                new RemoteFileOperations(cacheIO, Executors.newSingleThreadExecutor(), false, false);
 
         HiveStatisticsProvider hiveStatisticsProvider = new HiveStatisticsProvider(hmsOps, fileOps);
         try {
-            Method method = HiveStatisticsProvider.class.getDeclaredMethod("createPartitionColumnStatistics",
-                    Column.class, List.class, Map.class, List.class, double.class, double.class);
+            Method method =
+                    HiveStatisticsProvider.class.getDeclaredMethod("createPartitionColumnStatistics", Column.class,
+                                                                   List.class, Map.class, List.class, double.class,
+                                                                   double.class);
             method.setAccessible(true);
-            return (ColumnStatistic) method.invoke(hiveStatisticsProvider, partitionColumn,
-                    partitionKeyList, hivePartitionStatsMap, partitionColumnNames, avgNumPerPartition, rowCount);
+            return (ColumnStatistic) method.invoke(hiveStatisticsProvider, partitionColumn, partitionKeyList,
+                                                   hivePartitionStatsMap, partitionColumnNames, avgNumPerPartition,
+                                                   rowCount);
         } catch (Exception e) {
             throw new StarRocksConnectorException("get partition statistics failed", e);
         }
@@ -878,24 +1058,21 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         private List<RemoteFileInfo> remoteFileInfos;
         private Map<String, PartitionInfo> partitionInfoMap = Maps.newHashMap();
 
-        public HiveTableInfo(HiveTable table,
-                             List<String> partitionNames,
-                             long rowCount,
-                             Map<String, ColumnStatistic> columnStatsMap,
-                             List<RemoteFileInfo> remoteFileInfos) {
+        public HiveTableInfo(HiveTable table, List<String> partitionNames, long rowCount,
+                             Map<String, ColumnStatistic> columnStatsMap, List<RemoteFileInfo> remoteFileInfos) {
             this.table = table;
             this.partitionNames = partitionNames;
             this.rowCount = rowCount;
             this.columnStatsMap = columnStatsMap;
             this.remoteFileInfos = remoteFileInfos;
             if (partitionNames.isEmpty()) {
-                this.partitionInfoMap.put(table.getTableName(),
-                        new Partition(ImmutableMap.of(Partition.TRANSIENT_LAST_DDL_TIME,
-                                String.valueOf(System.currentTimeMillis() / 1000)), null, null, null, false));
+                this.partitionInfoMap.put(table.getTableName(), new Partition(
+                        ImmutableMap.of(Partition.TRANSIENT_LAST_DDL_TIME,
+                                        String.valueOf(System.currentTimeMillis() / 1000)), null, null, null, false));
             } else {
-                this.partitionInfoMap = partitionNames.stream().collect(Collectors.
-                        toMap(k -> k, k -> new Partition(ImmutableMap.of(Partition.TRANSIENT_LAST_DDL_TIME,
-                                String.valueOf(System.currentTimeMillis() / 1000)), null, null, null, false)));
+                this.partitionInfoMap = partitionNames.stream().collect(Collectors.toMap(k -> k, k -> new Partition(
+                        ImmutableMap.of(Partition.TRANSIENT_LAST_DDL_TIME,
+                                        String.valueOf(System.currentTimeMillis() / 1000)), null, null, null, false)));
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
@@ -124,6 +124,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
                 "     partitions=3/3");
     }
 
+    @Test
     public void testHivePartitionPredicatesPrune() throws Exception {
         String sql = "select a.l_orderkey,\n" +
                 "    b.l_partkey\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.DdlException;
+import com.starrocks.planner.HdfsScanNode;
+import com.starrocks.planner.ScanNode;
 import com.starrocks.server.GlobalStateMgr;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.List;
 
 public class HivePartitionPruneTest extends ConnectorPlanTestBase {
     @Before
@@ -118,5 +122,35 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
         assertContains(plan, "PARTITION PREDICATES: (abs(4: par_col) = 1) OR (abs(4: par_col) = 2)\n" +
                 "     NO EVAL-PARTITION PREDICATES: (abs(4: par_col) = 1) OR (abs(4: par_col) = 2)\n" +
                 "     partitions=3/3");
+    }
+
+    public void testHivePartitionPredicatesPrune() throws Exception {
+        String sql = "select a.l_orderkey,\n" +
+                "    b.l_partkey\n" +
+                "from (\n" +
+                "        select l_orderkey,\n" +
+                "            l_partkey\n" +
+                "        from lineitem_mul_par2\n" +
+                "        where l_shipdate = '1998-01-01'\n" +
+                "            and l_returnflag = 'R'\n" +
+                "        limit 10\n" +
+                "    ) a\n" +
+                "    join (\n" +
+                "        select l_orderkey,\n" +
+                "            l_partkey\n" +
+                "        from lineitem_mul_par2\n" +
+                "        where l_shipdate = '1998-01-01'\n" +
+                "            and l_returnflag = 'A'\n" +
+                "        limit 10\n" +
+                "    ) b on a.l_orderkey = b.l_orderkey";
+        ExecPlan plan = getExecPlan(sql);
+        List<ScanNode> scanNodes = plan.getScanNodes();
+        Assert.assertEquals(scanNodes.size(), 2);
+        HdfsScanNode node0 = (HdfsScanNode) scanNodes.get(0);
+        HdfsScanNode node1 = (HdfsScanNode) scanNodes.get(1);
+        Assert.assertEquals(node0.getScanNodePredicates().getSelectedPartitionIds().size(), 1);
+        Assert.assertEquals(node1.getScanNodePredicates().getSelectedPartitionIds().size(), 1);
+        Assert.assertFalse(node0.getScanNodePredicates().getSelectedPartitionIds().equals(
+                node1.getScanNodePredicates().getSelectedPartitionIds()));
     }
 }


### PR DESCRIPTION
Fixes #issue

## How

A hive table with two-level partitions(dt/date and type/string).

```
CREATE TABLE `lineitem_partition` (
  `l_orderkey` int(11) DEFAULT NULL,
  `l_partkey` int(11) DEFAULT NULL,
  `l_suppkey` int(11) DEFAULT NULL,
  `l_linenumber` int(11) DEFAULT NULL,
  `l_quantity` decimal64(15, 2) DEFAULT NULL,
  `l_extendedprice` decimal64(15, 2) DEFAULT NULL,
  `l_discount` decimal64(15, 2) DEFAULT NULL,
  `l_tax` decimal64(15, 2) DEFAULT NULL,
  `l_linestatus` varchar(1048576) DEFAULT NULL,
  `l_commitdate` date DEFAULT NULL,
  `l_receiptdate` date DEFAULT NULL,
  `l_shipinstruct` varchar(1048576) DEFAULT NULL,
  `l_shipmode` varchar(1048576) DEFAULT NULL,
  `l_comment` varchar(1048576) DEFAULT NULL,
  `l_shipdate` date DEFAULT NULL,
  `l_returnflag` varchar(1048576) DEFAULT NULL
)
PARTITION BY ( l_shipdate, l_returnflag )
```

And we run the following query on that table

```
select a.l_orderkey,
    b.l_partkey
from (
        select l_orderkey,
            l_partkey
        from lineitem_partition
        where l_shipdate = '1992-01-02'
            and l_returnflag = 'R'
        limit 10
    ) a
    join (
        select l_orderkey,
            l_partkey
        from lineitem_partition
        where l_shipdate = '1992-01-02'
            and l_returnflag = 'A'
        limit 10
    ) b on a.l_orderkey = b.l_orderkey;
```

We have subqueries on a single table but different partition predicates. And we will get error messages like. The root cause is we have a wrong file path.

> ERROR 1064 (HY000): code=404(SdkErrorType:133), message=The specified key does not exist.: file = oss://starrocks-dla-data-zhangjiakou/zhangyan/dataset/tpch_100g/parquet/lz4/lineitem_partition/l_shipdate=1992-01-02/l_returnflag=R/20230803_075851_00001_y9f6q_44460157-c4a5-43db-85a6-f0b71b773b18

## Why 

In `src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java`, we will prune hive table partitions by sending predicates to HMS. But unfortunately, we can only pass string literal predicates.

So for predicate like `l_shipdate = '1992-01-02'  and l_returnflag = 'R',  We will get partitions like

```
0: 1992-01-02/R
1: 1992-01-03/R
2: 1992-01-04/R
....
```
Since we use predicate `l_shipdate = '1992-01-02'  and l_returnflag = 'R'`, the partitionId is 0.

For predicates like `l_shipdate = '1992-01-02'  and l_returnflag = 'A',  We will get a partition whose id is 0.

----

But here is the problem, for two different predicates, we both get partition_id 0. But obviously, they are different. 

And when this wrong information passed down to BE, BE will wrong partition key and build up wrong file path.

If we look into it, the non-existed path is

> oss://starrocks-dla-data-zhangjiakou/zhangyan/dataset/tpch_100g/parquet/lz4/lineitem_partition/l_shipdate=1992-01-02/l_returnflag=R/20230803_075851_00001_y9f6q_44460157-c4a5-43db-85a6-f0b71b773b18

but actually, there is a existing path with a different prefix

> oss://starrocks-dla-data-zhangjiakou/zhangyan/dataset/tpch_100g/parquet/lz4/lineitem_partition/l_shipdate=1992-01-02/l_returnflag=A/20230803_075851_00001_y9f6q_44460157-c4a5-43db-85a6-f0b71b773b18

<img width="2233" alt="image" src="https://github.com/StarRocks/starrocks/assets/1081215/814b20af-af82-4b47-abd0-7577a8f550dd">


## Fix

So for a single table, we have to make sure the partition id unique.  So I add a field `partitionKeyToId` in `Table`. When we are going to allocate partitionId, we will use this field to make sure partitionId is unique.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4