### PR TITLE
[BugFix] Fix un-groupby column in having subquery bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
@@ -15,9 +15,11 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.Expr;
+import com.starrocks.sql.analyzer.FieldId;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
+import java.util.Map;
 
 public class SubqueryRelation extends QueryRelation {
     private final QueryStatement queryStatement;
@@ -34,6 +36,11 @@ public class SubqueryRelation extends QueryRelation {
         if (!queryRelation.hasLimit()) {
             queryRelation.clearOrder();
         }
+    }
+
+    @Override
+    public Map<Expr, FieldId> getColumnReferences() {
+        return queryStatement.getQueryRelation().getColumnReferences();
     }
 
     public QueryStatement getQueryStatement() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
@@ -176,6 +176,9 @@ public interface ParserErrorMsg {
     @BaseMessage("''{0}'' must be an aggregate expression or appear in GROUP BY clause")
     String shouldBeAggFunc(String a0);
 
+    @BaseMessage("subquery correlated column ''{0}'' in ''{1}'' must be an aggregate expression or appear in GROUP BY clause")
+    String unsupportedNoGroupBySubquery(String a0, String a1);
+
     @BaseMessage("Exist must have exact one subquery")
     String canOnlyOneExistSub();
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
@@ -1874,5 +1873,18 @@ public class SubqueryTest extends PlanTestBase {
                 " else null end end from tmp a;";
         Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
         assertContains(pair.first, "CTEAnchor(cteid=2)");
+    }
+
+    @Test
+    public void testHavingSubqueryNoGroupMode() {
+        String sql = "select v3 from t0 group by v2 having 1 > (select v4 from t1 where t0.v1 = t1.v5)";
+        long sqlMode = connectContext.getSessionVariable().getSqlMode();
+        try {
+            connectContext.getSessionVariable().setSqlMode(0);
+            Assert.assertThrows("must be an aggregate expression or appear in GROUP BY clause", SemanticException.class,
+                    () -> getFragmentPlan(sql));
+        } finally {
+            connectContext.getSessionVariable().setSqlMode(sqlMode);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/28087

col `t0_77.c_0_2` from outer aggregate scope, and not a group-by key or aggregation expression. when sql_mode isn't `ONLY_GROUP_BY`, sr will add `any_value(t0_77.c_0_2)` to fill lost column and rewrite all expressions, but it's hard to rewrite whole subquery now.  

```
MySQL h3> explain SELECT
  t2_79.c_2_0
FROM
  t2 AS t2_79, t0 AS t0_77
WHERE NULL
GROUP BY t0_77.c_0_1, t0_77.c_0_8
HAVING
  (
    MAX('1970-01-10 20:06:32')
  ) IN (
    (
      SELECT t1_78.c_1_3
      FROM t1 AS t1_78
      WHERE t0_77.c_0_2 = t1_78.c_1_4
    )
  )
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
