### PR TITLE
[BugFix] Disable compile libdeflate in arm

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1217,10 +1217,10 @@ build_serdes
 build_datasketches
 build_async_profiler
 build_fiu
-build_libdeflate
 
 if [[ "${MACHINE_TYPE}" != "aarch64" ]]; then
     build_breakpad
+    build_libdeflate
 fi
 
 # strip unnecessary debug symbol for binaries in thirdparty


### PR DESCRIPTION
This is step one.
Next step will change BE code, make sure BE can compile successfully in arm.

Error msg in arm:
```bash
-- Build files have been written to: /root/starrocks/thirdparty/src/libdeflate-1.18/build
[ 13%] Building C object CMakeFiles/libdeflate_static.dir/lib/arm/cpu_features.c.o
[ 13%] Building C object CMakeFiles/libdeflate_shared.dir/lib/arm/cpu_features.c.o
[ 13%] Building C object CMakeFiles/libdeflate_static.dir/lib/utils.c.o
[ 13%] Building C object CMakeFiles/libdeflate_shared.dir/lib/utils.c.o
[ 17%] Building C object CMakeFiles/libdeflate_shared.dir/lib/x86/cpu_features.c.o
[ 20%] Building C object CMakeFiles/libdeflate_static.dir/lib/x86/cpu_features.c.o
[ 24%] Building C object CMakeFiles/libdeflate_shared.dir/lib/deflate_compress.c.o
[ 27%] Building C object CMakeFiles/libdeflate_static.dir/lib/deflate_compress.c.o
[ 31%] Building C object CMakeFiles/libdeflate_shared.dir/lib/deflate_decompress.c.o
[ 34%] Building C object CMakeFiles/libdeflate_static.dir/lib/deflate_decompress.c.o
[ 37%] Building C object CMakeFiles/libdeflate_shared.dir/lib/adler32.c.o
[ 41%] Building C object CMakeFiles/libdeflate_static.dir/lib/adler32.c.o
/tmp/cc76t1Kc.s: Assembler messages:
/tmp/cc76t1Kc.s:2522: Error: unknown architectural extension `dotprod'
/tmp/cc76t1Kc.s:2793: Error: unknown mnemonic `udot' -- `udot v19.4s,v18.16b,v27.16b'
/tmp/cc76t1Kc.s:2800: Error: unknown mnemonic `udot' -- `udot v21.4s,v17.16b,v26.16b'
/tmp/cc76t1Kc.s:2811: Error: unknown mnemonic `udot' -- `udot v2.4s,v16.16b,v25.16b'
/tmp/cc76t1Kc.s:2825: Error: unknown mnemonic `udot' -- `udot v4.4s,v18.16b,v1.16b'
/tmp/cc76t1Kc.s:2839: Error: unknown mnemonic `udot' -- `udot v5.4s,v17.16b,v1.16b'
/tmp/cc76t1Kc.s:2853: Error: unknown mnemonic `udot' -- `udot v0.4s,v16.16b,v1.16b'
/tmp/cc76t1Kc.s:2932: Error: unknown mnemonic `udot' -- `udot v6.4s,v16.16b,v1.16b'
/tmp/cc76t1Kc.s:2941: Error: unknown mnemonic `udot' -- `udot v23.4s,v16.16b,v24.16b'
[ 44%] Building C object CMakeFiles/libdeflate_static.dir/lib/zlib_compress.c.o
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
