### PR TITLE
[BugFix][Cherry-Pick][Branch-2.3] Fix Be crash in ASAN mode if load a unapplied rowset from disk (#22331)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -251,14 +251,17 @@ Status TabletUpdates::_load_from_pb(const TabletUpdatesPB& tablet_updates_pb) {
         stats->num_rows = rowset->num_rows();
         stats->byte_size = rowset->data_disk_size();
         stats->num_dels = 0;
-        for (int i = 0; i < rowset->num_segments(); i++) {
-            auto itr = del_vector_cardinality_by_rssid.find(rsid + i);
-            if (itr != del_vector_cardinality_by_rssid.end() && itr->second != -1) {
-                stats->num_dels += itr->second;
-            } else {
-                std::string msg = strings::Substitute("delvec not found for rowset $0 segment $1", rsid, i);
-                LOG(ERROR) << msg;
-                DCHECK(false);
+        // the unapplied rowsets have no delete vector yet, so we only need to check the applied rowsets
+        if (unapplied_rowsets.find(rsid) == unapplied_rowsets.end()) {
+            for (int i = 0; i < rowset->num_segments(); i++) {
+                auto itr = del_vector_cardinality_by_rssid.find(rsid + i);
+                if (itr != del_vector_cardinality_by_rssid.end() && itr->second != -1) {
+                    stats->num_dels += itr->second;
+                } else {
+                    std::string msg = strings::Substitute("delvec not found for rowset $0 segment $1", rsid, i);
+                    LOG(ERROR) << msg;
+                    return Status::InternalError(msg);
+                }
             }
         }
         DCHECK_LE(stats->num_dels, stats->num_rows) << " tabletid:" << _tablet.tablet_id() << " rowset:" << rsid;
@@ -1414,8 +1417,8 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
         std::lock_guard lg(_rowset_stats_lock);
         auto iter = _rowset_stats.find(rowset_id);
         if (iter == _rowset_stats.end()) {
-            string msg = Substitute("inconsistent rowset_stats, rowset not found tablet=$0 rowsetid=$1 $2",
-                                    _tablet.tablet_id(), rowset_id);
+            string msg = strings::Substitute("inconsistent rowset_stats, rowset not found tablet=$0 rowsetid=$1",
+                                             _tablet.tablet_id(), rowset_id);
             DCHECK(false) << msg;
             LOG(ERROR) << msg;
         } else {


### PR DESCRIPTION
The following code in `TabletUpdates`
```
    for (auto& [rsid, rowset] : _rowsets) {
        auto stats = std::make_unique<RowsetStats>();
        stats->num_segments = rowset->num_segments();
        stats->num_rows = rowset->num_rows();
        stats->byte_size = rowset->data_disk_size();
        stats->num_dels = 0;
        for (int i = 0; i < rowset->num_segments(); i++) {
            auto itr = del_vector_cardinality_by_rssid.find(rsid + i);
            if (itr != del_vector_cardinality_by_rssid.end() && itr->second != -1) {
                stats->num_dels += itr->second;
            } else {
                std::string msg = strings::Substitute("delvec not found for rowset $0 segment $1", rsid, i);
                LOG(ERROR) << msg;
                DCHECK(false); // BE will crash in this line if we find a unapplied rowset
            }
        }
        DCHECK_LE(stats->num_dels, stats->num_rows) << " tabletid:" << _tablet.tablet_id() << " rowset:" << rsid;
        _calc_compaction_score(stats.get());
        std::lock_guard lg(_rowset_stats_lock);
        _rowset_stats.emplace(rsid, std::move(stats));
    }
```
The `del_vector_cardinality_by_rssid` keep the all applied rowset and `_rowsets` keep the all commited rowset.  So if a rowset already commit but not apply, we can not find the rowset in `del_vector_cardinality_by_rssid` because this rowset does not have delete vector and this will cause BE crash in ASAN mode.
