### PR TITLE
[BugFix] Fix datetime column has different precision when hive table use timestamp as partition column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
@@ -60,6 +60,8 @@ public class DateLiteral extends LiteralExpr {
     private static final DateLiteral MAX_DATE = new DateLiteral(9999, 12, 31);
     private static final DateLiteral MIN_DATETIME = new DateLiteral(0, 1, 1, 0, 0, 0, 0);
     private static final DateLiteral MAX_DATETIME = new DateLiteral(9999, 12, 31, 23, 59, 59, 999999);
+    // The default precision of datetime is 0
+    private int precision = 0;
 
     // Date Literal persist type in meta
     private enum DateLiteralType {
@@ -171,6 +173,9 @@ public class DateLiteral extends LiteralExpr {
             second = dateTime.getSecond();
             microsecond = dateTime.getNano() / 1000;
             this.type = type;
+            if (type.isDatetime() && s.contains(".") && microsecond == 0) {
+                precision = s.length() - s.indexOf(".") - 1;
+            }
         } catch (Exception ex) {
             throw new AnalysisException("date literal [" + s + "] is invalid");
         }
@@ -413,6 +418,10 @@ public class DateLiteral extends LiteralExpr {
 
     public long getMicrosecond() {
         return microsecond;
+    }
+
+    public int getPrecision() {
+        return precision;
     }
 
     private long year;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -63,6 +63,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -204,9 +205,16 @@ public class PartitionUtil {
             return String.format("%04d-%02d-%02d", dateLiteral.getYear(), dateLiteral.getMonth(), dateLiteral.getDay());
         } else {
             if (dateLiteral.getMicrosecond() == 0) {
-                // 2007-01-01 10:35:00 => 2007-01-01 10:35:00.0
-                return String.format("%04d-%02d-%02d %02d:%02d:%02d.0", dateLiteral.getYear(), dateLiteral.getMonth(),
-                        dateLiteral.getDay(), dateLiteral.getHour(), dateLiteral.getMinute(), dateLiteral.getSecond());
+                String datetime = String.format("%04d-%02d-%02d %02d:%02d:%02d", dateLiteral.getYear(),
+                        dateLiteral.getMonth(),
+                        dateLiteral.getDay(), dateLiteral.getHour(), dateLiteral.getMinute(),
+                        dateLiteral.getSecond());
+                if (dateLiteral.getPrecision() > 0) {
+                    // 2007-01-01 10:35:00 => 2007-01-01 10:35:00.000000(precision=6)
+                    datetime = datetime + "." +
+                            String.join("", Collections.nCopies(dateLiteral.getPrecision(), "0"));
+                }
+                return datetime;
             } else {
                 // 2007-01-01 10:35:00.123000 => 2007-01-01 10:35:00.123
                 return String.format("%04d-%02d-%02d %02d:%02d:%02d.%6d", dateLiteral.getYear(), dateLiteral.getMonth(),

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -115,6 +115,18 @@ public class PartitionUtilTest {
         List<String> res = PartitionUtil.fromPartitionKey(partitionKey);
         Assert.assertEquals("2007-01-01 10:35:00.0", res.get(0));
         Assert.assertEquals("2007-01-01 10:35:00.123", res.get(1));
+
+        partitionValues = Lists.newArrayList("2007-01-01 10:35:00", "2007-01-01 10:35:00.00",
+                "2007-01-01 10:35:00.000");
+        columns = new ArrayList<>();
+        columns.add(new Column("a", Type.fromPrimitiveType(PrimitiveType.DATETIME)));
+        columns.add(new Column("b", Type.fromPrimitiveType(PrimitiveType.DATETIME)));
+        columns.add(new Column("c", Type.fromPrimitiveType(PrimitiveType.DATETIME)));
+        partitionKey = PartitionUtil.createPartitionKey(partitionValues, columns, Table.TableType.HIVE);
+        res = PartitionUtil.fromPartitionKey(partitionKey);
+        Assert.assertEquals("2007-01-01 10:35:00", res.get(0));
+        Assert.assertEquals("2007-01-01 10:35:00.00", res.get(1));
+        Assert.assertEquals("2007-01-01 10:35:00.000", res.get(2));
     }
 
     @Test


### PR DESCRIPTION
hive timestamp may has different prescision, eg, '2023-01-01 12:00:00' or '2023-01-01 12:00:00.0', they are same time, but as partition column, it will has different partition name, so we need to record the prescision to use the same partition name

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
