### PR TITLE
[BugFix] Fix BE crash when null lowcard column not fill with default value

### DIFF
--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -84,7 +84,9 @@ public:
             }
         } else if (input->is_nullable()) {
             // is nullable
-            const auto* null_column = down_cast<NullableColumn*>(input.get());
+            auto* null_column = down_cast<NullableColumn*>(input.get());
+            // fill data to 0 if input value is null
+            null_column->fill_null_with_default();
             const auto* data_column = down_cast<LowCardDictColumn*>(null_column->data_column().get());
             // we could use data_column to avoid check null
             // because 0 in LowCardDictColumn means null

--- a/test/sql/test_global_dict/R/dict_basic_query
+++ b/test/sql/test_global_dict/R/dict_basic_query
@@ -1,0 +1,109 @@
+-- name: test_dict_basic_query
+CREATE TABLE `t1` (
+  `v1` varchar(20) NOT NULL COMMENT "",
+  `v2` varchar(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+create table t2 like t1;
+-- result:
+-- !result
+create table t3 like t1;
+-- result:
+-- !result
+insert into t1 SELECT generate_series%100, generate_series%255 FROM TABLE(generate_series(1, 65535));
+-- result:
+-- !result
+insert into t2 SELECT generate_series%100, generate_series%255 FROM TABLE(generate_series(1, 65535));
+-- result:
+-- !result
+insert into t3 SELECT generate_series%100 + 1000, generate_series%255 + 1000 FROM TABLE(generate_series(1, 65535));
+-- result:
+-- !result
+[UC]analyze full table t1;
+-- result:
+-- !result
+[UC]analyze full table t2;
+-- result:
+-- !result
+[UC]analyze full table t3;
+-- result:
+-- !result
+function: wait_global_dict_ready('v1', 't1')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('v1', 't2')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('v1', 't3')
+-- result:
+
+-- !result
+select lower(l.v1) as r1, upper(r.v2) as r2 from t1 l join t2 r on l.v2 = r.v2 order by r1, r2 limit 2;
+-- result:
+0	0
+0	0
+-- !result
+select lower(l.v1) as r1, if(l.v1 is null, 1, 0) as r2, upper(r.v2)  as r3 from t1 l join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+-- result:
+0	0	0
+0	0	0
+-- !result
+select lower(l.v1) as r1, if(l.v1 is null, 1, r.v2) as r2, upper(r.v2) as r3 from t1 l join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2; 
+select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+-- result:
+0	0	0
+0	0	0
+-- !result
+select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l left join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+-- result:
+0	None	0
+0	None	0
+-- !result
+select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l right join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+-- result:
+0	None	0
+0	None	0
+-- !result
+select lower(l.v1) as r1, if(l.v1 = 1, 1, null) as r2, upper(r.v2) as r3 from t1 l right join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+-- result:
+0	None	0
+0	None	0
+-- !result
+select lower(l.v1) as r1, upper(r.v2) as r2 from t1 l join t3 r on l.v2 = r.v2 order by r1, r2 limit 2;
+-- result:
+-- !result
+select lower(l.v1) as r1, if(l.v1 is null, 1, 0) as r2, upper(r.v2)  as r3 from t1 l join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+-- result:
+-- !result
+select lower(l.v1) as r1, if(l.v1 is null, 1, r.v2) as r2, upper(r.v2) as r3 from t1 l join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2; 
+select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+-- result:
+-- !result
+select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l left join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+-- result:
+0	None	None
+0	None	None
+-- !result
+select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l right join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+-- result:
+None	1	1000
+None	1	1000
+-- !result
+select lower(l.v1) as r1, if(l.v1 = 1, 1, null) as r2, upper(r.v2) as r3 from t1 l right join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+-- result:
+None	None	1000
+None	None	1000
+-- !result

--- a/test/sql/test_global_dict/T/dict_basic_query
+++ b/test/sql/test_global_dict/T/dict_basic_query
@@ -1,0 +1,48 @@
+-- name: test_dict_basic_query
+
+CREATE TABLE `t1` (
+  `v1` varchar(20) NOT NULL COMMENT "",
+  `v2` varchar(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+create table t2 like t1;
+create table t3 like t1;
+
+-- prepare data and analyze
+insert into t1 SELECT generate_series%100, generate_series%255 FROM TABLE(generate_series(1, 65535));
+insert into t2 SELECT generate_series%100, generate_series%255 FROM TABLE(generate_series(1, 65535));
+insert into t3 SELECT generate_series%100 + 1000, generate_series%255 + 1000 FROM TABLE(generate_series(1, 65535));
+
+[UC]analyze full table t1;
+[UC]analyze full table t2;
+[UC]analyze full table t3;
+
+function: wait_global_dict_ready('v1', 't1')
+function: wait_global_dict_ready('v1', 't2')
+function: wait_global_dict_ready('v1', 't3')
+
+select lower(l.v1) as r1, upper(r.v2) as r2 from t1 l join t2 r on l.v2 = r.v2 order by r1, r2 limit 2;
+select lower(l.v1) as r1, if(l.v1 is null, 1, 0) as r2, upper(r.v2)  as r3 from t1 l join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+select lower(l.v1) as r1, if(l.v1 is null, 1, r.v2) as r2, upper(r.v2) as r3 from t1 l join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2; 
+select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l left join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l right join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+select lower(l.v1) as r1, if(l.v1 = 1, 1, null) as r2, upper(r.v2) as r3 from t1 l right join t2 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+
+select lower(l.v1) as r1, upper(r.v2) as r2 from t1 l join t3 r on l.v2 = r.v2 order by r1, r2 limit 2;
+select lower(l.v1) as r1, if(l.v1 is null, 1, 0) as r2, upper(r.v2)  as r3 from t1 l join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+select lower(l.v1) as r1, if(l.v1 is null, 1, r.v2) as r2, upper(r.v2) as r3 from t1 l join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2; 
+select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l left join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+select lower(l.v1) as r1, if(l.v1 is null, 1, null) as r2, upper(r.v2) as r3 from t1 l right join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;
+select lower(l.v1) as r1, if(l.v1 = 1, 1, null) as r2, upper(r.v2) as r3 from t1 l right join t3 r on l.v2 = r.v2 order by r1, r2, r3 limit 2;


### PR DESCRIPTION
Possible conditions
1. right outer join produces nullcolumn. 
2. project has an expression that applies low-cardinality optimization.

Because the nullable column is set to null, but the corresponding data column has a value other than 0. It will cause gather access crash.

```
*** SIGSEGV (@0x615f7f91dcfc) received by PID 1545343 (TID 0x7f8d8eb8f640) from PID 2140265724; stack trace: ***
    @         0x14cbf98a google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f8eb72a2520 (unknown)
    @         0x1345fdf2 starrocks::SIMDGather::gather<>()
    @         0x1345f56e starrocks::DictFuncExpr::_code_convert()
    @         0x1345eaa4 starrocks::DictFuncExpr::evaluate_checked()
    @         0x10bb339a starrocks::DictMappingExpr::evaluate_checked()
    @          0xf8ba02d starrocks::ExprContext::evaluate()
    @          0xf8b980e starrocks::ExprContext::evaluate()
    @          0xc3d6e14 starrocks::pipeline::ProjectOperator::push_chunk()
    @          0xc78aa6a starrocks::pipeline::PipelineDriver::process()
    @          0xc74ac5f starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xc7494d4 _ZZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiENKUlvE_clEv
    @          0xc754256 _ZSt13__invoke_implIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_JEET_St14__invoke_otherOT0_DpOT1_
    @          0xc753647 _ZSt10__invoke_rIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES6_E4typeEOS7_DpOS8_
    @          0xc752768 _ZNSt17_Function_handlerIFvvEZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_E9_M_invokeERKSt9_Any_data
    @          0x9878c44 std::function<>::operator()()
    @          0xa3a063c starrocks::FunctionRunnable::run()
    @          0xa39cc86 starrocks::ThreadPool::dispatch_thread()
    @          0xa3bc4ac std::__invoke_impl<>()
    @          0xa3bbf3b std::__invoke<>()
    @          0xa3badf8 _ZNSt5_BindIFMN9starrocks10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @          0xa3b9b35 std::_Bind<>::operator()<>()
    @          0xa3b72b4 std::__invoke_impl<>()
    @          0xa3b3390 _ZSt10__invoke_rIvRSt5_BindIFMN9starrocks10ThreadPoolEFvvEPS2_EEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESA_E4typeEOSB_DpOSC_
    @          0xa3af19d std::_Function_handler<>::_M_invoke()
    @          0x9878c44 std::function<>::operator()()
    @          0xa382254 starrocks::Thread::supervise_thread()
    @     0x7f8eb72f4b43 (unknown)
    @     0x7f8eb7386a00 (unknown)
    @                0x0 (unknown)
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
