### PR TITLE
[BugFix] Fix hive partition prune error with OR predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -450,16 +450,22 @@ public class ListPartitionPruner implements PartitionPruner {
         Set<Long> rights = evalPartitionPruneFilter(compoundPredicate.getChild(1));
         if (lefts == null && rights == null) {
             return null;
-        } else if (lefts == null) {
-            return rights;
-        } else if (rights == null) {
-            return lefts;
         }
 
         if (compoundPredicate.getCompoundType() == CompoundPredicateOperator.CompoundType.AND) {
-            lefts.retainAll(rights);
+            if (lefts == null) {
+                return rights;
+            } else if (rights == null) {
+                return lefts;
+            } else {
+                lefts.retainAll(rights);
+            }
         } else if (compoundPredicate.getCompoundType() == CompoundPredicateOperator.CompoundType.OR) {
-            lefts.addAll(rights);
+            if (lefts == null || rights == null) {
+                return null;
+            } else {
+                lefts.addAll(rights);
+            }
         }
         return lefts;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
@@ -63,4 +63,60 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
                 "     MIN/MAX PREDICATES: 5: c1 <= 2, 6: c1 >= 2\n" +
                 "     partitions=1/3");
     }
+
+    @Test
+    public void testCompoundPartitionPrune() throws Exception {
+        String sql = "select * from t1 where par_col = 0 and par_col = 5";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "0:EMPTYSET");
+
+        sql = "select * from t1 where par_col = 0 and abs(par_col) = 3 or par_col = 5";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: ((4: par_col = 0) AND (abs(4: par_col) = 3)) " +
+                "OR (4: par_col = 5), 4: par_col IN (0, 5)\n" +
+                "     partitions=1/3");
+
+        sql = "select * from t1 where abs(par_col) = 3 and par_col = 0 or par_col = 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 0)) " +
+                "OR (4: par_col = 2), 4: par_col IN (0, 2)\n" +
+                "     partitions=2/3");
+
+        sql = "select * from t1 where abs(par_col) = 3 and par_col = 10 or par_col = 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 10)) " +
+                "OR (4: par_col = 2), 4: par_col IN (10, 2)\n" +
+                "     partitions=1/3");
+
+        sql = "select * from t1 where abs(par_col) = 1 and abs(par_col) = 3 or par_col = 10";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: ((abs(4: par_col) = 1) AND " +
+                "(abs(4: par_col) = 3)) OR (4: par_col = 10)\n" +
+                "     NO EVAL-PARTITION PREDICATES: ((abs(4: par_col) = 1) AND (abs(4: par_col) = 3)) " +
+                "OR (4: par_col = 10)\n" +
+                "     partitions=3/3");
+
+        sql = "select * from t1 where par_col = 1 or par_col = 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: 4: par_col IN (1, 2)\n" +
+                "     partitions=2/3");
+
+        sql = "select * from t1 where par_col = 1 or abs(par_col) = 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: (4: par_col = 1) OR (abs(4: par_col) = 2)\n" +
+                "     NO EVAL-PARTITION PREDICATES: (4: par_col = 1) OR (abs(4: par_col) = 2)\n" +
+                "     partitions=3/3");
+
+        sql = "select * from t1 where par_col = 10 or abs(par_col) = 2";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: (4: par_col = 10) OR (abs(4: par_col) = 2)\n" +
+                "     NO EVAL-PARTITION PREDICATES: (4: par_col = 10) OR (abs(4: par_col) = 2)\n" +
+                "     partitions=3/3");
+
+        sql = "select * from t1 where abs(par_col) = 1 or abs(par_col) = 2;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: (abs(4: par_col) = 1) OR (abs(4: par_col) = 2)\n" +
+                "     NO EVAL-PARTITION PREDICATES: (abs(4: par_col) = 1) OR (abs(4: par_col) = 2)\n" +
+                "     partitions=3/3");
+    }
 }


### PR DESCRIPTION
Fixes #issue
when one filter which could prune all partitions in OR predicate, will cause partition prune error,it will prune parititions to empty. 

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
