### PR TITLE
[Enhancement] Call request toString only when debug is enabled to avoid memory allocation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -178,7 +178,9 @@ public class LeaderImpl {
         // check task status
         // retry task by report process
         TStatus taskStatus = request.getTask_status();
-        LOG.debug("get task report: {}", request.toString());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("get task report: {}", request.toString());
+        }
         if (taskStatus.getStatus_code() != TStatusCode.OK) {
             LOG.warn("finish task reports bad. request: {}", request.toString());
         }


### PR DESCRIPTION
Fixes #issue

![image](https://github.com/StarRocks/starrocks/assets/54172532/eb1f0596-b8ae-4ec6-a3fb-e189f76be519)
More than half of memory allocation is caused by request.toString() when processing finishTask

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
