### PR TITLE
[Enhancement] Support text-based profile analysis(4)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -38,7 +38,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
-import com.starrocks.sql.plan.ExecPlan;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -156,10 +155,10 @@ public class ProfileManager {
         return profileString;
     }
 
-    public String pushProfile(ExecPlan plan, RuntimeProfile profile) {
+    public String pushProfile(ProfilingExecPlan plan, RuntimeProfile profile) {
         String profileString = generateProfileString(profile);
         ProfileElement element = createElement(profile.getChildList().get(0).first, profileString);
-        element.plan = ProfilingExecPlan.buildFrom(plan);
+        element.plan = plan;
         String queryId = element.infoStrings.get(ProfileManager.QUERY_ID);
         // check when push in, which can ensure every element in the list has QUERY_ID column,
         // so there is no need to check when remove element from list.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
@@ -186,7 +186,7 @@ public class ProfilingExecPlan {
             PlanNode planRoot = fragment.getPlanRoot();
 
             ProfilingFragment lightFragment = new ProfilingFragment(visitSink(sink),
-                    visitNode(profilingPlan, execPlan, planRoot, visitedElements));
+                    visitNode(execPlan, planRoot, visitedElements));
             profilingPlan.addFragment(lightFragment);
         }
 
@@ -232,7 +232,7 @@ public class ProfilingExecPlan {
         return element;
     }
 
-    private static ProfilingElement visitNode(ProfilingExecPlan profilingPlan, ExecPlan execPlan, PlanNode node,
+    private static ProfilingElement visitNode(ExecPlan execPlan, PlanNode node,
                                               Map<Integer, ProfilingElement> visitedElements) {
         if (visitedElements.containsKey(node.getId().asInt())) {
             return visitedElements.get(node.getId().asInt());
@@ -244,7 +244,7 @@ public class ProfilingExecPlan {
         buildUniqueInfos(node, element);
 
         for (PlanNode child : node.getChildren()) {
-            element.addChild(visitNode(profilingPlan, execPlan, child, visitedElements));
+            element.addChild(visitNode(execPlan, child, visitedElements));
         }
 
         visitedElements.put(element.getId(), element);
@@ -252,6 +252,9 @@ public class ProfilingExecPlan {
     }
 
     private static void buildCostEstimation(ExecPlan execPlan, ProfilingElement element) {
+        if (ConnectContext.get() == null) {
+            return;
+        }
         OptExpression optExpression = execPlan.getOptExpression(element.getId());
         if (optExpression != null) {
             CostEstimate cost = CostModel.calculateCostEstimate(new ExpressionContext(optExpression));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -52,6 +52,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.Counter;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.ProfileManager;
+import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.connector.exception.RemoteFileNotFoundException;
 import com.starrocks.load.loadv2.LoadJob;
@@ -965,9 +966,10 @@ public class DefaultCoordinator extends Coordinator {
                 now - lastTime > (connectContext.getSessionVariable().getRuntimeProfileReportInterval() * 950L) &&
                 lastRuntimeProfileUpdateTime.compareAndSet(lastTime, now)) {
             RuntimeProfile profile = topProfileSupplier.get();
-            ExecPlan execPlan = execPlanSupplier.get();
+            ExecPlan plan = execPlanSupplier.get();
             profile.addChild(buildMergedQueryProfile(null));
-            ProfileManager.getInstance().pushProfile(execPlan, profile);
+            ProfilingExecPlan profilingPlan = plan == null ? null : plan.getProfilingPlan();
+            ProfileManager.getInstance().pushProfile(profilingPlan, profile);
         }
 
         lock();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -761,7 +761,8 @@ public class StmtExecutor {
                         DebugUtil.getPrettyStringMs(profileEndTime - profileBeginTime));
         StringBuilder builder = new StringBuilder();
         profile.prettyPrint(builder, "");
-        String profileContent = ProfileManager.getInstance().pushProfile(plan, profile);
+        ProfilingExecPlan profilingPlan = plan == null ? null : plan.getProfilingPlan();
+        String profileContent = ProfileManager.getInstance().pushProfile(profilingPlan, profile);
         if (context.getQueryDetail() != null) {
             context.getQueryDetail().setProfile(profileContent);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -146,14 +146,14 @@ public class ExecPlan {
         if (profilingPlan == null) {
             synchronized (this) {
                 if (profilingPlan == null) {
-                    boolean isUnset = ConnectContext.get() == null;
+                    boolean needSetCtx = ConnectContext.get() == null && this.connectContext != null;
                     try {
-                        if (isUnset) {
+                        if (needSetCtx) {
                             this.connectContext.setThreadLocalInfo();
                         }
                         profilingPlan = ProfilingExecPlan.buildFrom(this);
                     } finally {
-                        if (isUnset) {
+                        if (needSetCtx) {
                             ConnectContext.remove();
                         }
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ExecPlan.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
 import com.starrocks.common.IdGenerator;
+import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.planner.PlanNodeId;
@@ -53,6 +54,8 @@ public class ExecPlan {
     private final IdGenerator<PlanNodeId> nodeIdGenerator = PlanNodeId.createGenerator();
     private final IdGenerator<PlanFragmentId> fragmentIdGenerator = PlanFragmentId.createGenerator();
     private final Map<Integer, OptExpression> optExpressions = Maps.newHashMap();
+
+    private volatile ProfilingExecPlan profilingPlan;
 
     @VisibleForTesting
     public ExecPlan() {
@@ -137,6 +140,27 @@ public class ExecPlan {
 
     public OptExpression getOptExpression(int planNodeId) {
         return optExpressions.get(planNodeId);
+    }
+
+    public ProfilingExecPlan getProfilingPlan() {
+        if (profilingPlan == null) {
+            synchronized (this) {
+                if (profilingPlan == null) {
+                    boolean isUnset = ConnectContext.get() == null;
+                    try {
+                        if (isUnset) {
+                            this.connectContext.setThreadLocalInfo();
+                        }
+                        profilingPlan = ProfilingExecPlan.buildFrom(this);
+                    } finally {
+                        if (isUnset) {
+                            ConnectContext.remove();
+                        }
+                    }
+                }
+            }
+        }
+        return profilingPlan;
     }
 
     public String getExplainString(TExplainLevel level) {


### PR DESCRIPTION

## Main work of this pr

This is an continuation work of the previous pr #28813. This pr fixes the NPE when getting the cost extimeation of the expression. The estimation calculation requires the `ConnectContext`, which is missing during the runtime profile prcess.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
