### PR TITLE
[Enhancement] support any_value on complex type

### DIFF
--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -129,6 +129,10 @@ public:
     template <LogicalType LT>
     static AggregateFunctionPtr MakeAnyValueAggregateFunction();
 
+    static AggregateFunctionPtr MakeAnyValueSemiAggregateFunction() {
+        return std::make_shared<AnyValueSemiAggregateFunction>();
+    }
+
     template <typename NestedState, bool IsWindowFunc, bool IgnoreNull = true,
               typename NestedFunctionPtr = AggregateFunctionPtr>
     static AggregateFunctionPtr MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function);

--- a/be/src/exprs/agg/factory/aggregate_resolver.hpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver.hpp
@@ -106,6 +106,19 @@ public:
         }
     }
 
+    template <class StateType, typename SpecificAggFunctionPtr = AggregateFunctionPtr, bool IgnoreNull = true>
+    void add_general_mapping(const std::string& name, bool is_window, SpecificAggFunctionPtr fun) {
+        _general_mapping.emplace(std::make_tuple(name, false, false), fun);
+        auto nullable_agg = AggregateFactory::MakeNullableAggregateFunctionUnary<StateType, false, IgnoreNull>(fun);
+        _general_mapping.emplace(std::make_tuple(name, false, true), nullable_agg);
+
+        if (is_window) {
+            _general_mapping.emplace(std::make_tuple(name, true, false), fun);
+            auto nullable_agg = AggregateFactory::MakeNullableAggregateFunctionUnary<StateType, true, IgnoreNull>(fun);
+            _general_mapping.emplace(std::make_tuple(name, true, true), nullable_agg);
+        }
+    }
+
     template <LogicalType ArgType, LogicalType RetType, typename SpecificAggFunctionPtr = AggregateFunctionPtr>
     void add_aggregate_mapping_notnull(const std::string& name, bool is_window, SpecificAggFunctionPtr fun) {
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, false), fun);

--- a/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "exprs/agg/aggregate_factory.h"
+#include "exprs/agg/any_value.h"
 #include "exprs/agg/factory/aggregate_factory.hpp"
 #include "exprs/agg/factory/aggregate_resolver.hpp"
 #include "exprs/agg/group_concat.h"
@@ -72,6 +73,7 @@ void AggregateFuncResolver::register_others() {
     add_array_mapping<TYPE_DATETIME, TYPE_INT>("window_funnel");
     add_array_mapping<TYPE_DATE, TYPE_INT>("window_funnel");
 
+    add_general_mapping<AnyValueSemiState>("any_value", false, AggregateFactory::MakeAnyValueSemiAggregateFunction());
     add_general_mapping_notnull("array_agg2", false, AggregateFactory::MakeArrayAggAggregateFunctionV2());
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -840,6 +840,10 @@ public class FunctionSet {
             addBuiltin(AggregateFunction.createBuiltin(FunctionSet.COUNT,
                     Lists.newArrayList(t), Type.BIGINT, Type.BIGINT, false, true, true));
 
+            // ANY_VALUE
+            addBuiltin(AggregateFunction.createBuiltin(ANY_VALUE,
+                    Lists.newArrayList(t), t, t, true, false, false));
+
             if (t.isPseudoType()) {
                 continue; // Only function `Count` support pseudo types now.
             }
@@ -874,10 +878,6 @@ public class FunctionSet {
             addBuiltin(AggregateFunction.createBuiltin(NDV,
                     Lists.newArrayList(t), Type.BIGINT, Type.VARBINARY,
                     true, false, true));
-
-            // ANY_VALUE
-            addBuiltin(AggregateFunction.createBuiltin(ANY_VALUE,
-                    Lists.newArrayList(t), t, t, true, false, false));
 
             // APPROX_COUNT_DISTINCT
             // alias of ndv, compute approx count distinct use HyperLogLog

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PolymorphicFunctionAnalyzer.java
@@ -41,32 +41,6 @@ import java.util.List;
 public class PolymorphicFunctionAnalyzer {
     private static final Logger LOGGER = LogManager.getLogger(PolymorphicFunctionAnalyzer.class);
 
-    private static Type getSuperType(Type t1, Type t2) {
-        if (t1.matchesType(t2)) {
-            return t1;
-        }
-        if (t1.isNull()) {
-            return t2;
-        }
-        if (t2.isNull()) {
-            return t1;
-        }
-        if (t1.isScalarType() && t2.isScalarType()) {
-            Type commonType = Type.getCommonType(t1, t2);
-            return commonType.isValid() ? commonType : null;
-        }
-        if (t1.isArrayType() && t2.isArrayType()) {
-            Type superElementType = getSuperType(((ArrayType) t1).getItemType(), ((ArrayType) t2).getItemType());
-            return superElementType != null ? new ArrayType(superElementType) : null;
-        }
-        if (t1.isMapType() && t2.isMapType()) {
-            Type superKeyType = getSuperType(((MapType) t1).getKeyType(), ((MapType) t2).getKeyType());
-            Type superValueType = getSuperType(((MapType) t1).getValueType(), ((MapType) t2).getValueType());
-            return superKeyType != null && superValueType != null ? new MapType(superKeyType, superValueType) : null;
-        }
-        return null;
-    }
-
     private static Function newScalarFunction(ScalarFunction fn, List<Type> newArgTypes, Type newRetType) {
         ScalarFunction newFn = new ScalarFunction(fn.getFunctionName(), newArgTypes, newRetType,
                 fn.getLocation(), fn.getSymbolName(), fn.getPrepareFnSymbol(),
@@ -227,6 +201,7 @@ public class PolymorphicFunctionAnalyzer {
             .put(FunctionSet.COALESCE, new CommonDeduce())
             // it's mock, need handle it in expressionAnalyzer
             .put(FunctionSet.NAMED_STRUCT, new RowDeduce())
+            .put(FunctionSet.ANY_VALUE, types -> types[0])
             .build();
 
     private static Function resolveByDeducingReturnType(Function fn, Type[] inputArgTypes) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MapTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MapTypeTest.java
@@ -54,4 +54,14 @@ public class MapTypeTest extends PlanTestBase {
                     "MAP<TINYINT,MAP<TINYINT,TINYINT>> to MAP<INT,VARCHAR(65533)>.");
         }
     }
+
+    @Test
+    public void testComplexAnyValue() throws Exception {
+        String sql = "select any_value(c2) from test_map limit 1";
+        String plan = getFragmentPlan(sql);
+        assertContains("1:AGGREGATE (update finalize)\n" +
+                "  |  output: any_value(3: c2)\n" +
+                "  |  group by: \n" +
+                "  |  limit: 1");
+    }
 }

--- a/test/sql/test_semi/R/test_any_value
+++ b/test/sql/test_semi/R/test_any_value
@@ -148,3 +148,11 @@ select any_value([9,2,3]), any_value(map{1:row(19, [119, 229, 339]), 2:row(22, [
 -- result:
 [9,2,3]	{1:{"col1":19,"col2":[119,229,339]},2:{"col1":22,"col2":[229,229,339]}}	{"col1":1,"col2":[{"col1":1,"col2":9},{"col1":2,"col2":9}],"col3":{1:19,2:29},"col4":{"col1":1,"col2":9}}
 -- !result
+select any_value(distinct v1) from t0;
+-- result:
+[REGEX].*Getting syntax error at line.*
+-- !result
+select v1, v3, any_value(v2) over (partition by v3) from t0;
+-- result:
+[REGEX].*not supported with OVER clause.*
+-- !result

--- a/test/sql/test_semi/R/test_any_value
+++ b/test/sql/test_semi/R/test_any_value
@@ -1,0 +1,150 @@
+-- name: test_any_value @system
+CREATE TABLE `sc3` (
+  `v1` bigint(20) NULL COMMENT "",
+  `a1` ARRAY<INT> NULL,
+  `a2` ARRAY<STRUCT<a INT, b INT>> NULL,
+  `m1` MAP<INT, INT> NULL,
+  `m2` MAP<INT, STRUCT<c INT, b ARRAY<INT>>> NULL,
+  `s1` STRUCT<s1 int, s2 ARRAY<STRUCT<a int, b int>>, s3 MAP<INT, INT>, s4 Struct<e INT, f INT>>
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t0` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NOT NULL COMMENT "",
+  `v3` string NULL COMMENT "",
+  `v4` string NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into sc3 values (1, [1,2,3],[row(1,11),row(2,21),row(3,31)], map{1:11, 2:21}, map{1:row(11, [111, 221, 331]), 2:row(22, [221, 221, 331])}, row(1, [row(1,1), row(2,1)], map{1:11, 2:21}, row(1,1)));
+-- result:
+-- !result
+insert into sc3 values (2, [2,2,3],[row(1,12),row(2,22),row(3,32)], map{1:12, 2:22}, map{1:row(12, [112, 222, 332]), 2:row(22, [222, 222, 332])}, row(1, [row(1,2), row(2,2)], map{1:12, 2:22}, row(1,2)));
+-- result:
+-- !result
+insert into sc3 values (3, [3,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+-- result:
+-- !result
+insert into sc3 values (1, [4,2,3],[row(1,14),row(2,24),row(3,34)], map{1:14, 2:24}, map{1:row(14, [114, 224, 334]), 2:row(22, [224, 224, 334])}, row(1, [row(1,4), row(2,4)], map{1:14, 2:24}, row(1,4)));
+-- result:
+-- !result
+insert into sc3 values (2, [5,2,3],[row(1,15),row(2,25),row(3,35)], map{1:15, 2:25}, map{1:row(15, [115, 225, 335]), 2:row(22, [225, 225, 335])}, row(1, [row(1,5), row(2,5)], map{1:15, 2:25}, row(1,5)));
+-- result:
+-- !result
+insert into sc3 values (3, [6,2,3],[row(1,16),row(2,26),row(3,36)], map{1:16, 2:26}, map{1:row(16, [116, 226, 336]), 2:row(22, [226, 226, 336])}, row(1, [row(1,6), row(2,6)], map{1:16, 2:26}, row(1,6)));
+-- result:
+-- !result
+insert into sc3 values (1, [7,2,3],[row(1,17),row(2,27),row(3,37)], map{1:17, 2:27}, map{1:row(17, [117, 227, 337]), 2:row(22, [227, 227, 337])}, row(1, [row(1,7), row(2,7)], map{1:17, 2:27}, row(1,7)));
+-- result:
+-- !result
+insert into sc3 values (2, [8,2,3],[row(1,18),row(2,28),row(3,38)], map{1:18, 2:28}, map{1:row(18, [118, 228, 338]), 2:row(22, [228, 228, 338])}, row(1, [row(1,8), row(2,8)], map{1:18, 2:28}, row(1,8)));
+-- result:
+-- !result
+insert into sc3 values (3, [9,2,3],[row(1,19),row(2,29),row(3,39)], map{1:19, 2:29}, map{1:row(19, [119, 229, 339]), 2:row(22, [229, 229, 339])}, row(1, [row(1,9), row(2,9)], map{1:19, 2:29}, row(1,9)));
+-- result:
+-- !result
+insert into sc3 values (4, [9,2,3],NULL, NULL, NULL, NULL);
+-- result:
+-- !result
+insert into sc3 values (4, [9,2,3],NULL, NULL, NULL, NULL);
+-- result:
+-- !result
+insert into sc3 values (4, [9,2,3],NULL, NULL, NULL, NULL);
+-- result:
+-- !result
+insert into sc3 values (4, [9,2,3],NULL, NULL, NULL, NULL);
+-- result:
+-- !result
+insert into sc3 values (4, [9,2,3],NULL, NULL, NULL, NULL);
+-- result:
+-- !result
+insert into t0 values (1, 1, '1', '1');
+-- result:
+-- !result
+insert into t0 values (2, 2, '2', '2');
+-- result:
+-- !result
+insert into t0 values (3, 3, '3', '3');
+-- result:
+-- !result
+insert into t0 values (1, 1, '1', '1');
+-- result:
+-- !result
+insert into t0 values (2, 2, '2', '2');
+-- result:
+-- !result
+insert into t0 values (3, 3, '3', '3');
+-- result:
+-- !result
+insert into t0 values (1, 1, '1', '1');
+-- result:
+-- !result
+insert into t0 values (2, 2, '2', '2');
+-- result:
+-- !result
+insert into t0 values (3, 3, '3', '3');
+-- result:
+-- !result
+insert into t0 values (11, 11, '1', '11');
+-- result:
+-- !result
+insert into t0 values (22, 22, '1', '22');
+-- result:
+-- !result
+insert into t0 values (33, 33, '1', '33');
+-- result:
+-- !result
+insert into t0 values (11, 11, NULL, '11');
+-- result:
+-- !result
+insert into t0 values (22, 22, NULL, '22');
+-- result:
+-- !result
+insert into t0 values (33, 33, NULL, '33');
+-- result:
+-- !result
+select any_value(v1), any_value(a1), any_value(a2), any_value(m1), any_value(m2), any_value(s1) from sc3;
+-- result:
+[REGEX]\d.*
+-- !result
+select any_value(a1), any_value(a2), any_value(m1), any_value(m2), any_value(s1) from sc3 where v1 = 2 group by v1;
+-- result:
+[REGEX].*\[(2|5|8),2,3\].*
+-- !result
+select any_value(a1), any_value(a2), any_value(m1), any_value(m2), any_value(s1) from sc3 where v1 = 4;
+-- result:
+[9,2,3]	None	None	None	None
+-- !result
+select any_value(v1), any_value(v2), any_value(v3), any_value(v4) from t0;
+-- result:
+[REGEX]\d.*
+-- !result
+select any_value(12), any_value(123), any_value('a') from t0;
+-- result:
+12	123	a
+-- !result
+select any_value([9,2,3]), any_value(map{1:row(19, [119, 229, 339]), 2:row(22, [229, 229, 339])}), any_value(row(1, [row(1,9), row(2,9)], map{1:19, 2:29}, row(1,9))) from sc3;
+-- result:
+[9,2,3]	{1:{"col1":19,"col2":[119,229,339]},2:{"col1":22,"col2":[229,229,339]}}	{"col1":1,"col2":[{"col1":1,"col2":9},{"col1":2,"col2":9}],"col3":{1:19,2:29},"col4":{"col1":1,"col2":9}}
+-- !result

--- a/test/sql/test_semi/T/test_any_value
+++ b/test/sql/test_semi/T/test_any_value
@@ -1,0 +1,81 @@
+-- name: test_any_value @system
+
+CREATE TABLE `sc3` (
+  `v1` bigint(20) NULL COMMENT "",
+  `a1` ARRAY<INT> NULL,
+  `a2` ARRAY<STRUCT<a INT, b INT>> NULL,
+  `m1` MAP<INT, INT> NULL,
+  `m2` MAP<INT, STRUCT<c INT, b ARRAY<INT>>> NULL,
+  `s1` STRUCT<s1 int, s2 ARRAY<STRUCT<a int, b int>>, s3 MAP<INT, INT>, s4 Struct<e INT, f INT>>
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `t0` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NOT NULL COMMENT "",
+  `v3` string NULL COMMENT "",
+  `v4` string NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+
+insert into sc3 values (1, [1,2,3],[row(1,11),row(2,21),row(3,31)], map{1:11, 2:21}, map{1:row(11, [111, 221, 331]), 2:row(22, [221, 221, 331])}, row(1, [row(1,1), row(2,1)], map{1:11, 2:21}, row(1,1)));
+insert into sc3 values (2, [2,2,3],[row(1,12),row(2,22),row(3,32)], map{1:12, 2:22}, map{1:row(12, [112, 222, 332]), 2:row(22, [222, 222, 332])}, row(1, [row(1,2), row(2,2)], map{1:12, 2:22}, row(1,2)));
+insert into sc3 values (3, [3,2,3],[row(1,13),row(2,23),row(3,33)], map{1:13, 2:23}, map{1:row(13, [113, 223, 333]), 2:row(22, [223, 223, 333])}, row(1, [row(1,3), row(2,3)], map{1:13, 2:23}, row(1,3)));
+insert into sc3 values (1, [4,2,3],[row(1,14),row(2,24),row(3,34)], map{1:14, 2:24}, map{1:row(14, [114, 224, 334]), 2:row(22, [224, 224, 334])}, row(1, [row(1,4), row(2,4)], map{1:14, 2:24}, row(1,4)));
+insert into sc3 values (2, [5,2,3],[row(1,15),row(2,25),row(3,35)], map{1:15, 2:25}, map{1:row(15, [115, 225, 335]), 2:row(22, [225, 225, 335])}, row(1, [row(1,5), row(2,5)], map{1:15, 2:25}, row(1,5)));
+insert into sc3 values (3, [6,2,3],[row(1,16),row(2,26),row(3,36)], map{1:16, 2:26}, map{1:row(16, [116, 226, 336]), 2:row(22, [226, 226, 336])}, row(1, [row(1,6), row(2,6)], map{1:16, 2:26}, row(1,6)));
+insert into sc3 values (1, [7,2,3],[row(1,17),row(2,27),row(3,37)], map{1:17, 2:27}, map{1:row(17, [117, 227, 337]), 2:row(22, [227, 227, 337])}, row(1, [row(1,7), row(2,7)], map{1:17, 2:27}, row(1,7)));
+insert into sc3 values (2, [8,2,3],[row(1,18),row(2,28),row(3,38)], map{1:18, 2:28}, map{1:row(18, [118, 228, 338]), 2:row(22, [228, 228, 338])}, row(1, [row(1,8), row(2,8)], map{1:18, 2:28}, row(1,8)));
+insert into sc3 values (3, [9,2,3],[row(1,19),row(2,29),row(3,39)], map{1:19, 2:29}, map{1:row(19, [119, 229, 339]), 2:row(22, [229, 229, 339])}, row(1, [row(1,9), row(2,9)], map{1:19, 2:29}, row(1,9)));
+insert into sc3 values (4, [9,2,3],NULL, NULL, NULL, NULL);
+insert into sc3 values (4, [9,2,3],NULL, NULL, NULL, NULL);
+insert into sc3 values (4, [9,2,3],NULL, NULL, NULL, NULL);
+insert into sc3 values (4, [9,2,3],NULL, NULL, NULL, NULL);
+insert into sc3 values (4, [9,2,3],NULL, NULL, NULL, NULL);
+
+insert into t0 values (1, 1, '1', '1');
+insert into t0 values (2, 2, '2', '2');
+insert into t0 values (3, 3, '3', '3');
+insert into t0 values (1, 1, '1', '1');
+insert into t0 values (2, 2, '2', '2');
+insert into t0 values (3, 3, '3', '3');
+insert into t0 values (1, 1, '1', '1');
+insert into t0 values (2, 2, '2', '2');
+insert into t0 values (3, 3, '3', '3');
+
+insert into t0 values (11, 11, '1', '11');
+insert into t0 values (22, 22, '1', '22');
+insert into t0 values (33, 33, '1', '33');
+insert into t0 values (11, 11, NULL, '11');
+insert into t0 values (22, 22, NULL, '22');
+insert into t0 values (33, 33, NULL, '33');
+
+
+select any_value(v1), any_value(a1), any_value(a2), any_value(m1), any_value(m2), any_value(s1) from sc3;
+select any_value(a1), any_value(a2), any_value(m1), any_value(m2), any_value(s1) from sc3 where v1 = 2 group by v1;
+select any_value(a1), any_value(a2), any_value(m1), any_value(m2), any_value(s1) from sc3 where v1 = 4;
+select any_value(v1), any_value(v2), any_value(v3), any_value(v4) from t0;
+select any_value(12), any_value(123), any_value('a') from t0;
+select any_value([9,2,3]), any_value(map{1:row(19, [119, 229, 339]), 2:row(22, [229, 229, 339])}), any_value(row(1, [row(1,9), row(2,9)], map{1:19, 2:29}, row(1,9))) from sc3;
+
+select any_value(distinct v1) from t0;
+select v1, v3, any_value(v2) over (partition by v3) from t0;


### PR DESCRIPTION
Fixes #issue

Support `any_value` on array/map/struct

```
MySQL test> select any_value(v1), any_value(a1), any_value(m1), any_value(s1) from sc3 ;
+---------------+---------------+---------------+---------------------------------------------------------------------------------+
| any_value(v1) | any_value(a1) | any_value(m1) | any_value(s1)                                                                   |
+---------------+---------------+---------------+---------------------------------------------------------------------------------+
| 1             | [1,2,3]       | {1:11,2:21}   | {"s1":1,"s2":[{"a":1,"b":1},{"a":2,"b":1}],"s3":{1:11,2:21},"s4":{"e":1,"f":1}} |
+---------------+---------------+---------------+---------------------------------------------------------------------------------+
```


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
