### PR TITLE
[BugFix] Fix use-after-free of SchemaLoadTrackingLogsScanner

### DIFF
--- a/be/src/exec/schema_scanner/schema_load_tracking_logs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_load_tracking_logs_scanner.cpp
@@ -108,7 +108,8 @@ Status SchemaLoadTrackingLogsScanner::fill_chunk(ChunkPtr* chunk) {
                                   [&ss, last = _tracking_msg_vec.end() - 1](const auto& s) {
                                       ss << s << (s == *last ? "" : "\n");
                                   });
-                    Slice msg = Slice(ss.str());
+                    std::string tmp_str = ss.str();
+                    Slice msg = Slice(tmp_str);
                     fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&msg);
                 } else {
                     down_cast<NullableColumn*>(column.get())->append_nulls(1);


### PR DESCRIPTION
Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/3087)

ss.str() is one local var, already released before execute `fill_column_with_slot`.

```
crash log:
==2761==ERROR: AddressSanitizer: heap-use-after-free on address 0x60b000ca1280 at pc 0x000009bdfe27 bp 0x7f566078ad80 sp 0x7f566078ad78
READ of size 1 at 0x60b000ca1280 thread T243 (pip_wg_scan_io)
    #0 0x9bdfe26 in decltype (::new ((void*)(0)) unsigned char((declval<char&>)())) std::construct_at<unsigned char, char&>(unsigned char*, char&) /opt/gcc/usr/include/c++/10.3.0/bits/stl_construct.h:97
    #1 0x9bdfeaa in void std::allocator_traits<std::allocator<unsigned char> >::construct<unsigned char, char&>(std::allocator<unsigned char>&, unsigned char*, char&) /opt/gcc/usr/include/c++/10.3.0/bits/alloc_traits.h:514
    #2 0x9bdf441 in void starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> >::construct<unsigned char, char&>(unsigned char*, char&) /root/starrocks/be/src/util/raw_container.h:69
    #3 0x9bdca44 in std::enable_if<std::__and_<std::allocator_traits<starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > >::__construct_helper<unsigned char, char&>::type>::value, void>::type std::allocator_traits<starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > >::_S_construct<unsigned char, char&>(starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> >&, unsigned char*, char&) /opt/gcc/usr/include/c++/10.3.0/bits/alloc_traits.h:247
    #4 0x9bd9f73 in decltype (_S_construct({parm#1}, {parm#2}, (forward<char&>)({parm#3}))) std::allocator_traits<starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > >::construct<unsigned char, char&>(starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> >&, unsigned char*, char&) /opt/gcc/usr/include/c++/10.3.0/bits/alloc_traits.h:360
    #5 0x9bd4921 in unsigned char* std::__uninitialized_copy_a<char*, unsigned char*, starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > >(char*, char*, unsigned char*, starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> >&) /opt/gcc/usr/include/c++/10.3.0/bits/stl_uninitialized.h:311
    #6 0x9bc9ad8 in void std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > >::_M_range_insert<char*>(__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > > >, char*, char*, std::forward_iterator_tag) /opt/gcc/usr/include/c++/10.3.0/bits/vector.tcc:778
    #7 0x9bbac6e in void std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > >::_M_insert_dispatch<char*>(__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > > >, char*, char*, std::__false_type) /opt/gcc/usr/include/c++/10.3.0/bits/stl_vector.h:1665
    #8 0x9ba647c in __gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > > > std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > >::insert<char*, void>(__gnu_cxx::__normal_iterator<unsigned char const*, std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > > >, char*, char*) /opt/gcc/usr/include/c++/10.3.0/bits/stl_vector.h:1383
    #9 0x9b8358f in starrocks::BinaryColumnBase<unsigned int>::append(starrocks::Slice const&) /root/starrocks/be/src/column/binary_column.h:167
    #10 0xd24e6d1 in void starrocks::fill_data_column_with_slot<(starrocks::LogicalType)17>(starrocks::Column*, void*) /root/starrocks/be/src/exec/schema_scanner/schema_helper.h:116
    #11 0xd24e23d in void starrocks::fill_column_with_slot<(starrocks::LogicalType)17>(starrocks::Column*, void*) /root/starrocks/be/src/exec/schema_scanner/schema_helper.h:127
    #12 0xd2808d3 in starrocks::SchemaLoadTrackingLogsScanner::fill_chunk(std::shared_ptr<starrocks::Chunk>*) /root/starrocks/be/src/exec/schema_scanner/schema_load_tracking_logs_scanner.cpp:112
    #13 0xd281dca in starrocks::SchemaLoadTrackingLogsScanner::get_next(std::shared_ptr<starrocks::Chunk>*, bool*) /root/starrocks/be/src/exec/schema_scanner/schema_load_tracking_logs_scanner.cpp:160
    #14 0xd3f5dd5 in starrocks::pipeline::OlapSchemaChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*) /root/starrocks/be/src/exec/pipeline/scan/olap_schema_chunk_source.cpp:132
    #15 0xd3d0b33 in starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*) /root/starrocks/be/src/exec/pipeline/scan/chunk_source.cpp:67
    #16 0xc3deac7 in operator() /root/starrocks/be/src/exec/pipeline/scan/scan_operator.cpp:400
    #17 0xc3e4345 in __invoke_impl<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::<lambda()>&> /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:60
    #18 0xc3e41f3 in __invoke_r<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::<lambda()>&> /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:110
    #19 0xc3e4068 in _M_invoke /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:291
    #20 0x9ae6d83 in std::function<void ()>::operator()() const /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
    #21 0xc916608 in starrocks::workgroup::ScanExecutor::worker_thread() /root/starrocks/be/src/exec/workgroup/scan_executor.cpp:70
    #22 0xc915e2d in operator() /root/starrocks/be/src/exec/workgroup/scan_executor.cpp:34
    #23 0xc917de3 in __invoke_impl<void, starrocks::workgroup::ScanExecutor::initialize(int)::<lambda()>&> /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:60
    #24 0xc9179b2 in __invoke_r<void, starrocks::workgroup::ScanExecutor::initialize(int)::<lambda()>&> /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:110
    #25 0xc91734f in _M_invoke /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:291
    #26 0x9ae6d83 in std::function<void ()>::operator()() const /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
    #27 0xa533efd in starrocks::FunctionRunnable::run() /root/starrocks/be/src/util/threadpool.cpp:58
    #28 0xa5309bc in starrocks::ThreadPool::dispatch_thread() /root/starrocks/be/src/util/threadpool.cpp:553
    #29 0xa54d7ef in void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:73
    #30 0xa54d2da in std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:95
    #31 0xa54c223 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /opt/gcc/usr/include/c++/10.3.0/functional:416
    #32 0xa54b191 in void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>() /opt/gcc/usr/include/c++/10.3.0/functional:499
    #33 0xa548ceb in void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) (/home/disk1/sr/be/lib/starrocks_be+0xa548ceb)
    #34 0xa545659 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&) /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:110
    #35 0xa541944 in std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:291
    #36 0x9ae6d83 in std::function<void ()>::operator()() const /opt/gcc/usr/include/c++/10.3.0/bits/std_function.h:622
    #37 0xa518286 in starrocks::Thread::supervise_thread(void*) /root/starrocks/be/src/util/thread.cpp:364
    #38 0x7f56ec0b0ea4 in start_thread (/lib64/libpthread.so.0+0x7ea4)
    #39 0x7f56eb6cbb0c in clone (/lib64/libc.so.6+0xfeb0c)
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
