### PR TITLE
[Enhancement] reduce chunk buffer size in streaming aggregate

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -984,6 +984,8 @@ CONF_String(rocksdb_cf_options_string, "block_based_table_factory={block_cache={
 CONF_Int64(local_exchange_buffer_mem_limit_per_driver, "134217728"); // 128MB
 // only used for test. default: 128M
 CONF_mInt64(streaming_agg_limited_memory_size, "134217728");
+// pipeline streaming aggregate chunk buffer size
+CONF_mInt32(streaming_agg_chunk_buffer_size, "1024");
 CONF_mInt64(wait_apply_time, "6000"); // 6s
 
 // Max size of a binlog file. The default is 512MB.

--- a/be/src/exec/aggregate/agg_profile.h
+++ b/be/src/exec/aggregate/agg_profile.h
@@ -1,3 +1,17 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include "util/runtime_profile.h"
@@ -20,6 +34,9 @@ struct AggStatistics {
         rows_returned_counter = ADD_COUNTER(runtime_profile, "RowsReturned", TUnit::UNIT);
         state_destroy_timer = ADD_TIMER(runtime_profile, "StateDestroy");
         allocate_state_timer = ADD_TIMER(runtime_profile, "StateAllocate");
+
+        chunk_buffer_peak_memory = ADD_PEAK_COUNTER(runtime_profile, "ChunkBufferPeakMem", TUnit::BYTES);
+        chunk_buffer_peak_size = ADD_PEAK_COUNTER(runtime_profile, "ChunkBufferPeakSize", TUnit::UNIT);
     }
 
     // timer for build hash table and compute aggregate function
@@ -50,5 +67,8 @@ struct AggStatistics {
     RuntimeProfile::Counter* expr_release_timer{};
     RuntimeProfile::Counter* state_destroy_timer{};
     RuntimeProfile::Counter* allocate_state_timer{};
+
+    RuntimeProfile::HighWaterMarkCounter* chunk_buffer_peak_memory{};
+    RuntimeProfile::HighWaterMarkCounter* chunk_buffer_peak_size{};
 };
 } // namespace starrocks

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -22,6 +22,7 @@
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/vectorized_fwd.h"
+#include "common/config.h"
 #include "common/status.h"
 #include "exec/exec_node.h"
 #include "exec/pipeline/operator.h"
@@ -32,6 +33,7 @@
 #include "runtime/descriptors.h"
 #include "types/logical_type.h"
 #include "udf/java/utils.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 
@@ -296,6 +298,10 @@ Status Aggregator::open(RuntimeState* state) {
     }
 
     RETURN_IF_ERROR(check_has_error());
+
+    _buffer_mem_manager = std::make_unique<pipeline::ChunkBufferMemoryManager>(
+            1, config::local_exchange_buffer_mem_limit_per_driver,
+            state->chunk_size() * config::streaming_agg_chunk_buffer_size);
 
     return Status::OK();
 }
@@ -605,20 +611,40 @@ bool Aggregator::is_chunk_buffer_empty() {
 }
 
 ChunkPtr Aggregator::poll_chunk_buffer() {
-    std::lock_guard<std::mutex> l(_buffer_mutex);
-    if (_buffer.empty()) {
-        return nullptr;
+    ChunkPtr chunk;
+    {
+        std::lock_guard<std::mutex> l(_buffer_mutex);
+        if (_buffer.empty()) {
+            return nullptr;
+        }
+        chunk = _buffer.front();
+        _buffer.pop();
     }
-    ChunkPtr chunk = _buffer.front();
-    _buffer.pop();
-    _buffer_size--;
+    size_t mem_usage = chunk->memory_usage();
+    size_t num_rows = chunk->num_rows();
+    _buffer_mem_manager->update_memory_usage(-mem_usage, -num_rows);
+
+    COUNTER_ADD(_agg_stat->chunk_buffer_peak_memory, -mem_usage);
+    COUNTER_ADD(_agg_stat->chunk_buffer_peak_size, -1);
+
     return chunk;
 }
 
 void Aggregator::offer_chunk_to_buffer(const ChunkPtr& chunk) {
-    std::lock_guard<std::mutex> l(_buffer_mutex);
-    _buffer.push(chunk);
-    _buffer_size++;
+    {
+        std::lock_guard<std::mutex> l(_buffer_mutex);
+        _buffer.push(chunk);
+    }
+
+    size_t mem_usage = chunk->memory_usage();
+    size_t num_rows = chunk->num_rows();
+    _buffer_mem_manager->update_memory_usage(mem_usage, num_rows);
+    COUNTER_ADD(_agg_stat->chunk_buffer_peak_memory, mem_usage);
+    COUNTER_ADD(_agg_stat->chunk_buffer_peak_size, 1);
+}
+
+bool Aggregator::is_chunk_buffer_full() {
+    return _buffer_mem_manager->is_full();
 }
 
 bool Aggregator::should_expand_preagg_hash_tables(size_t prev_row_returned, size_t input_chunk_size, int64_t ht_mem,

--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -31,6 +31,7 @@
 #include "common/statusor.h"
 #include "exec/aggregate/agg_hash_variant.h"
 #include "exec/aggregate/agg_profile.h"
+#include "exec/chunk_buffer_memory_manager.h"
 #include "exec/pipeline/context_with_dependency.h"
 #include "exec/pipeline/spill_process_channel.h"
 #include "exprs/agg/aggregate_factory.h"
@@ -244,7 +245,6 @@ AggregatorParamsPtr convert_to_aggregator_params(const TPlanNode& tnode);
 // it contains common data struct and algorithm of aggregation
 class Aggregator : public pipeline::ContextWithDependency {
 public:
-    static constexpr auto MAX_CHUNK_BUFFER_SIZE = 1024;
 #ifdef NDEBUG
     static constexpr size_t two_level_memory_threshold = 33554432; // 32M, L3 Cache
 #else
@@ -315,8 +315,8 @@ public:
 
     bool is_chunk_buffer_empty();
     ChunkPtr poll_chunk_buffer();
-    size_t chunk_buffer_size() { return _buffer_size.load(std::memory_order_acquire); }
     void offer_chunk_to_buffer(const ChunkPtr& chunk);
+    bool is_chunk_buffer_full();
 
     bool should_expand_preagg_hash_tables(size_t prev_row_returned, size_t input_chunk_size, int64_t ht_mem,
                                           int64_t ht_rows) const;
@@ -412,8 +412,8 @@ protected:
     // only used in pipeline engine
     std::atomic<bool> _is_sink_complete = false;
     // only used in pipeline engine
-    std::atomic_int _buffer_size{};
     std::queue<ChunkPtr> _buffer;
+    std::unique_ptr<pipeline::ChunkBufferMemoryManager> _buffer_mem_manager;
     std::mutex _buffer_mutex;
 
     // Certain aggregates require a finalize step, which is the final step of the

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.h
@@ -35,8 +35,7 @@ public:
 
     bool has_output() const override { return false; }
     bool need_input() const override {
-        return !is_finished() && !_aggregator->is_streaming_all_states() &&
-               _aggregator->chunk_buffer_size() < Aggregator::MAX_CHUNK_BUFFER_SIZE;
+        return !is_finished() && !_aggregator->is_streaming_all_states() && !_aggregator->is_chunk_buffer_full();
     }
     bool is_finished() const override { return _is_finished || _aggregator->is_finished(); }
     Status set_finishing(RuntimeState* state) override;

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_sink_operator.h
@@ -35,8 +35,7 @@ public:
 
     bool has_output() const override { return false; }
     bool need_input() const override {
-        return !is_finished() && !_aggregator->is_streaming_all_states() &&
-               _aggregator->chunk_buffer_size() < Aggregator::MAX_CHUNK_BUFFER_SIZE;
+        return !is_finished() && !_aggregator->is_streaming_all_states() && !_aggregator->is_chunk_buffer_full();
     }
     bool is_finished() const override { return _is_finished || _aggregator->is_finished(); }
     Status set_finishing(RuntimeState* state) override;

--- a/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/sorted_aggregate_streaming_sink_operator.cpp
@@ -40,7 +40,7 @@ void SortedAggregateStreamingSinkOperator::close(RuntimeState* state) {
 }
 
 bool SortedAggregateStreamingSinkOperator::need_input() const {
-    return !is_finished() && _aggregator->chunk_buffer_size() < Aggregator::MAX_CHUNK_BUFFER_SIZE;
+    return !is_finished() && !_aggregator->is_chunk_buffer_full();
 }
 
 bool SortedAggregateStreamingSinkOperator::is_finished() const {

--- a/be/src/exec/pipeline/exchange/local_exchange.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange.cpp
@@ -14,12 +14,14 @@
 
 #include "exec/pipeline/exchange/local_exchange.h"
 
+#include <memory>
+
 #include "column/chunk.h"
 #include "exec/pipeline/exchange/shuffler.h"
 #include "exprs/expr_context.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks::pipeline {
-
 Status Partitioner::partition_chunk(const ChunkPtr& chunk, int32_t num_partitions,
                                     std::vector<uint32_t>& partition_row_indexes) {
     size_t num_rows = chunk->num_rows();
@@ -116,14 +118,14 @@ Status RandomPartitioner::shuffle_channel_ids(const ChunkPtr& chunk, int32_t num
     return Status::OK();
 }
 
-PartitionExchanger::PartitionExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
+PartitionExchanger::PartitionExchanger(const std::shared_ptr<ChunkBufferMemoryManager>& memory_manager,
                                        LocalExchangeSourceOperatorFactory* source, const TPartitionType::type part_type,
                                        const std::vector<ExprContext*>& partition_expr_ctxs)
         : LocalExchanger(strings::Substitute("Partition($0)", to_string(part_type)), memory_manager, source),
           _part_type(part_type),
           _partition_exprs(partition_expr_ctxs) {}
 
-KeyPartitionExchanger::KeyPartitionExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
+KeyPartitionExchanger::KeyPartitionExchanger(const std::shared_ptr<ChunkBufferMemoryManager>& memory_manager,
                                              LocalExchangeSourceOperatorFactory* source,
                                              const std::vector<ExprContext*>& partition_expr_ctxs,
                                              const size_t num_sinks)

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -18,10 +18,11 @@
 #include <utility>
 
 #include "column/vectorized_fwd.h"
-#include "exec/pipeline/exchange/local_exchange_memory_manager.h"
+#include "exec/chunk_buffer_memory_manager.h"
 #include "exec/pipeline/exchange/local_exchange_source_operator.h"
 #include "exec/pipeline/exchange/shuffler.h"
 #include "exprs/expr_context.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 class ExprContext;
@@ -108,7 +109,7 @@ public:
 // Exchange the local data from local sink operator to local source operator
 class LocalExchanger {
 public:
-    explicit LocalExchanger(std::string name, std::shared_ptr<LocalExchangeMemoryManager> memory_manager,
+    explicit LocalExchanger(std::string name, std::shared_ptr<ChunkBufferMemoryManager> memory_manager,
                             LocalExchangeSourceOperatorFactory* source)
             : _name(std::move(name)), _memory_manager(std::move(memory_manager)), _source(source) {}
 
@@ -164,7 +165,7 @@ public:
 
 protected:
     const std::string _name;
-    std::shared_ptr<LocalExchangeMemoryManager> _memory_manager;
+    std::shared_ptr<ChunkBufferMemoryManager> _memory_manager;
     std::atomic<int32_t> _sink_number = 0;
     LocalExchangeSourceOperatorFactory* _source;
 
@@ -175,11 +176,11 @@ protected:
 // Exchange the local data for shuffle
 class PartitionExchanger final : public LocalExchanger {
 public:
-    PartitionExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
+    PartitionExchanger(const std::shared_ptr<ChunkBufferMemoryManager>& memory_manager,
                        LocalExchangeSourceOperatorFactory* source, const TPartitionType::type part_type,
                        const std::vector<ExprContext*>& _partition_expr_ctxs);
 
-    virtual ~PartitionExchanger() = default;
+    ~PartitionExchanger() override = default;
 
     Status prepare(RuntimeState* state) override;
     void close(RuntimeState* state) override;
@@ -205,7 +206,7 @@ class KeyPartitionExchanger final : public LocalExchanger {
     using Partition2RowIndexes = std::map<PartitionKeyPtr, RowIndexPtr, PartitionKeyComparator>;
 
 public:
-    KeyPartitionExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
+    KeyPartitionExchanger(const std::shared_ptr<ChunkBufferMemoryManager>& memory_manager,
                           LocalExchangeSourceOperatorFactory* source,
                           const std::vector<ExprContext*>& _partition_expr_ctxs, size_t num_sinks);
 
@@ -220,7 +221,7 @@ private:
 // Exchange the local data for broadcast
 class BroadcastExchanger final : public LocalExchanger {
 public:
-    BroadcastExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
+    BroadcastExchanger(const std::shared_ptr<ChunkBufferMemoryManager>& memory_manager,
                        LocalExchangeSourceOperatorFactory* source)
             : LocalExchanger("Broadcast", memory_manager, source) {}
 
@@ -232,7 +233,7 @@ public:
 // Exchange the local data for one local source operation
 class PassthroughExchanger final : public LocalExchanger {
 public:
-    PassthroughExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
+    PassthroughExchanger(const std::shared_ptr<ChunkBufferMemoryManager>& memory_manager,
                          LocalExchangeSourceOperatorFactory* source)
             : LocalExchanger("Passthrough", memory_manager, source) {}
 
@@ -247,7 +248,7 @@ private:
 // Random shuffle for each chunk of source.
 class RandomPassthroughExchanger final : public LocalExchanger {
 public:
-    RandomPassthroughExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
+    RandomPassthroughExchanger(const std::shared_ptr<ChunkBufferMemoryManager>& memory_manager,
                                LocalExchangeSourceOperatorFactory* source)
             : LocalExchanger("RandomPassthrough", memory_manager, source) {}
 
@@ -264,7 +265,7 @@ private:
 // random shuffle each rows for the input chunk to seperate it evenly.
 class AdaptivePassthroughExchanger final : public LocalExchanger {
 public:
-    AdaptivePassthroughExchanger(const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager,
+    AdaptivePassthroughExchanger(const std::shared_ptr<ChunkBufferMemoryManager>& memory_manager,
                                  LocalExchangeSourceOperatorFactory* source)
             : LocalExchanger("AdaptivePassthrough", memory_manager, source) {}
 

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.cpp
@@ -27,9 +27,10 @@ Status LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk) {
         return Status::OK();
     }
     size_t memory_usage = chunk->memory_usage();
-    _memory_manager->update_memory_usage(memory_usage);
+    size_t num_rows = chunk->num_rows();
     _local_memory_usage += memory_usage;
     _full_chunk_queue.emplace(std::move(chunk));
+    _memory_manager->update_memory_usage(memory_usage, num_rows);
 
     return Status::OK();
 }
@@ -42,10 +43,10 @@ Status LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk, const std::shared_
     if (_is_finished) {
         return Status::OK();
     }
-    _memory_manager->update_memory_usage(memory_usage);
     _partition_chunk_queue.emplace(std::move(chunk), std::move(indexes), from, size, memory_usage);
     _partition_rows_num += size;
     _local_memory_usage += memory_usage;
+    _memory_manager->update_memory_usage(memory_usage, size);
 
     return Status::OK();
 }
@@ -86,7 +87,7 @@ Status LocalExchangeSourceOperator::add_chunk(ChunkPtr chunk, const std::shared_
     }
 
     _local_memory_usage += memory_usage;
-    _memory_manager->update_memory_usage(memory_usage);
+    _memory_manager->update_memory_usage(memory_usage, size);
 
     return Status::OK();
 }
@@ -120,7 +121,7 @@ Status LocalExchangeSourceOperator::set_finished(RuntimeState* state) {
     // clear _key_partition_pending_chunks
     { [[maybe_unused]] typeof(_partitions) tmp = std::move(_partitions); }
     // Subtract the number of rows of buffered chunks from row_count of _memory_manager and make it unblocked.
-    _memory_manager->update_memory_usage(-_local_memory_usage);
+    _memory_manager->update_memory_usage(-_local_memory_usage, -_partition_rows_num);
     _partition_rows_num = 0;
     _local_memory_usage = 0;
     return Status::OK();
@@ -156,7 +157,8 @@ ChunkPtr LocalExchangeSourceOperator::_pull_passthrough_chunk(RuntimeState* stat
         ChunkPtr chunk = std::move(_full_chunk_queue.front());
         _full_chunk_queue.pop();
         size_t memory_usage = chunk->memory_usage();
-        _memory_manager->update_memory_usage(-memory_usage);
+        size_t num_rows = chunk->num_rows();
+        _memory_manager->update_memory_usage(-memory_usage, -num_rows);
         _local_memory_usage -= memory_usage;
         return chunk;
     }
@@ -166,7 +168,7 @@ ChunkPtr LocalExchangeSourceOperator::_pull_passthrough_chunk(RuntimeState* stat
 
 ChunkPtr LocalExchangeSourceOperator::_pull_shuffle_chunk(RuntimeState* state) {
     std::vector<PartitionChunk> selected_partition_chunks;
-    size_t rows_num = 0;
+    size_t num_rows = 0;
     size_t memory_usage = 0;
     // Lock during pop partition chunks from queue.
     {
@@ -175,22 +177,22 @@ ChunkPtr LocalExchangeSourceOperator::_pull_shuffle_chunk(RuntimeState* state) {
         DCHECK(!_partition_chunk_queue.empty());
 
         while (!_partition_chunk_queue.empty() &&
-               rows_num + _partition_chunk_queue.front().size <= state->chunk_size()) {
-            rows_num += _partition_chunk_queue.front().size;
+               num_rows + _partition_chunk_queue.front().size <= state->chunk_size()) {
+            num_rows += _partition_chunk_queue.front().size;
             memory_usage += _partition_chunk_queue.front().memory_usage;
             selected_partition_chunks.emplace_back(std::move(_partition_chunk_queue.front()));
             _partition_chunk_queue.pop();
         }
-        _partition_rows_num -= rows_num;
+        _partition_rows_num -= num_rows;
         _local_memory_usage -= memory_usage;
-        _memory_manager->update_memory_usage(-memory_usage);
+        _memory_manager->update_memory_usage(-memory_usage, -num_rows);
     }
     if (selected_partition_chunks.empty()) {
         throw std::runtime_error("local exchange gets empty shuffled chunk.");
     }
     // Unlock during merging partition chunks into a full chunk.
     ChunkPtr chunk = selected_partition_chunks[0].chunk->clone_empty_with_slot();
-    chunk->reserve(rows_num);
+    chunk->reserve(num_rows);
     for (const auto& partition_chunk : selected_partition_chunks) {
         chunk->append_selective(*partition_chunk.chunk, partition_chunk.indexes->data(), partition_chunk.from,
                                 partition_chunk.size);
@@ -200,7 +202,7 @@ ChunkPtr LocalExchangeSourceOperator::_pull_shuffle_chunk(RuntimeState* state) {
 
 ChunkPtr LocalExchangeSourceOperator::_pull_key_partition_chunk(RuntimeState* state) {
     std::vector<PartitionChunk> selected_partition_chunks;
-    size_t rows_num = 0;
+    size_t num_rows = 0;
     size_t memory_usage = 0;
 
     {
@@ -211,23 +213,23 @@ ChunkPtr LocalExchangeSourceOperator::_pull_key_partition_chunk(RuntimeState* st
         DCHECK(!pendingPartitionChunks.partition_chunk_queue.empty());
 
         while (!pendingPartitionChunks.partition_chunk_queue.empty() &&
-               rows_num + pendingPartitionChunks.partition_chunk_queue.front().size <= state->chunk_size()) {
-            rows_num += pendingPartitionChunks.partition_chunk_queue.front().size;
+               num_rows + pendingPartitionChunks.partition_chunk_queue.front().size <= state->chunk_size()) {
+            num_rows += pendingPartitionChunks.partition_chunk_queue.front().size;
             memory_usage += pendingPartitionChunks.partition_chunk_queue.front().memory_usage;
 
             selected_partition_chunks.emplace_back(std::move(pendingPartitionChunks.partition_chunk_queue.front()));
             pendingPartitionChunks.partition_chunk_queue.pop();
         }
 
-        pendingPartitionChunks.partition_row_nums -= rows_num;
+        pendingPartitionChunks.partition_row_nums -= num_rows;
         pendingPartitionChunks.memory_usage -= memory_usage;
         _local_memory_usage -= memory_usage;
-        _memory_manager->update_memory_usage(-memory_usage);
+        _memory_manager->update_memory_usage(-memory_usage, -num_rows);
     }
 
     // Unlock during merging partition chunks into a full chunk.
     ChunkPtr chunk = selected_partition_chunks[0].chunk->clone_empty_with_slot();
-    chunk->reserve(rows_num);
+    chunk->reserve(num_rows);
     for (const auto& partition_chunk : selected_partition_chunks) {
         chunk->append_selective(*partition_chunk.chunk, partition_chunk.indexes->data(), partition_chunk.from,
                                 partition_chunk.size);

--- a/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_source_operator.h
@@ -18,7 +18,7 @@
 #include <queue>
 #include <utility>
 
-#include "exec/pipeline/exchange/local_exchange_memory_manager.h"
+#include "exec/chunk_buffer_memory_manager.h"
 #include "exec/pipeline/source_operator.h"
 
 namespace starrocks::pipeline {
@@ -88,7 +88,7 @@ class LocalExchangeSourceOperator final : public SourceOperator {
 
 public:
     LocalExchangeSourceOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
-                                const std::shared_ptr<LocalExchangeMemoryManager>& memory_manager)
+                                const std::shared_ptr<ChunkBufferMemoryManager>& memory_manager)
             : SourceOperator(factory, id, "local_exchange_source", plan_node_id, driver_sequence),
               _memory_manager(memory_manager) {
         _local_memory_limit = _memory_manager->get_memory_limit_per_driver() * 0.8;
@@ -166,7 +166,7 @@ private:
 
     // TODO(KKS): make it lock free
     mutable std::mutex _chunk_lock;
-    const std::shared_ptr<LocalExchangeMemoryManager>& _memory_manager;
+    const std::shared_ptr<ChunkBufferMemoryManager>& _memory_manager;
     std::map<PartitionKeyPtr, PendingPartitionChunks, PartitionKeyComparator> _partitions;
 
     // STREAM MV
@@ -176,7 +176,7 @@ private:
 class LocalExchangeSourceOperatorFactory final : public SourceOperatorFactory {
 public:
     LocalExchangeSourceOperatorFactory(int32_t id, int32_t plan_node_id,
-                                       std::shared_ptr<LocalExchangeMemoryManager> memory_manager)
+                                       std::shared_ptr<ChunkBufferMemoryManager> memory_manager)
             : SourceOperatorFactory(id, "local_exchange_source", plan_node_id),
               _memory_manager(std::move(memory_manager)) {}
 
@@ -192,7 +192,7 @@ public:
     std::vector<LocalExchangeSourceOperator*>& get_sources() { return _sources; }
 
 private:
-    std::shared_ptr<LocalExchangeMemoryManager> _memory_manager;
+    std::shared_ptr<ChunkBufferMemoryManager> _memory_manager;
     std::vector<LocalExchangeSourceOperator*> _sources;
 };
 

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/pipeline/pipeline_builder.h"
 
+#include "common/config.h"
 #include "exec/exec_node.h"
 #include "exec/pipeline/adaptive/collect_stats_context.h"
 #include "exec/pipeline/adaptive/collect_stats_sink_operator.h"
@@ -38,7 +39,8 @@ OpFactories PipelineBuilderContext::maybe_interpolate_local_broadcast_exchange(R
     }
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(num_receivers);
+    auto mem_mgr = std::make_shared<ChunkBufferMemoryManager>(num_receivers,
+                                                              config::local_exchange_buffer_mem_limit_per_driver);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     local_exchange_source->set_runtime_state(state);
@@ -96,7 +98,8 @@ OpFactories PipelineBuilderContext::_maybe_interpolate_local_passthrough_exchang
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
     int max_input_dop = std::max(num_receivers, static_cast<int>(source_op->degree_of_parallelism()));
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(max_input_dop);
+    auto mem_mgr = std::make_shared<ChunkBufferMemoryManager>(max_input_dop,
+                                                              config::local_exchange_buffer_mem_limit_per_driver);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     local_exchange_source->set_runtime_state(state);
@@ -131,7 +134,8 @@ void PipelineBuilderContext::maybe_interpolate_local_passthrough_exchange_for_si
     auto* source_operator =
             down_cast<SourceOperatorFactory*>(_fragment_context->pipelines().back()->source_operator_factory());
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(source_operator_dop);
+    auto mem_mgr = std::make_shared<ChunkBufferMemoryManager>(source_operator_dop,
+                                                              config::local_exchange_buffer_mem_limit_per_driver);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     auto exchanger = std::make_shared<PassthroughExchanger>(mem_mgr, local_exchange_source.get());
@@ -157,8 +161,9 @@ void PipelineBuilderContext::maybe_interpolate_local_key_partition_exchange_for_
     auto* source_operator =
             down_cast<SourceOperatorFactory*>(_fragment_context->pipelines().back()->source_operator_factory());
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(source_operator_dop * state->chunk_size() *
-                                                                localExchangeBufferChunks());
+    auto mem_mgr = std::make_shared<ChunkBufferMemoryManager>(
+            source_operator_dop * state->chunk_size() * localExchangeBufferChunks(),
+            config::local_exchange_buffer_mem_limit_per_driver);
     auto local_shuffle_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     auto local_exchanger = std::make_shared<KeyPartitionExchanger>(mem_mgr, local_shuffle_source.get(),
@@ -217,7 +222,8 @@ OpFactories PipelineBuilderContext::_do_maybe_interpolate_local_shuffle_exchange
 
     // To make sure at least one partition source operator is ready to output chunk before sink operators are full.
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(shuffle_partitions_num);
+    auto mem_mgr = std::make_shared<ChunkBufferMemoryManager>(shuffle_partitions_num,
+                                                              config::local_exchange_buffer_mem_limit_per_driver);
     auto local_shuffle_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     local_shuffle_source->set_runtime_state(state);
@@ -263,7 +269,8 @@ OpFactories PipelineBuilderContext::maybe_gather_pipelines_to_one(RuntimeState* 
     }
 
     auto pseudo_plan_node_id = next_pseudo_plan_node_id();
-    auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(max_input_dop);
+    auto mem_mgr = std::make_shared<ChunkBufferMemoryManager>(max_input_dop,
+                                                              config::local_exchange_buffer_mem_limit_per_driver);
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
     local_exchange_source->set_runtime_state(state);

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -73,6 +73,9 @@ inline unsigned long long operator"" _ms(unsigned long long x) {
     (profile)->add_counter(name, type, RuntimeProfile::Counter::create_strategy(type, merge_type))
 #define ADD_TIMER(profile, name) \
     (profile)->add_counter(name, TUnit::TIME_NS, RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS))
+#define ADD_PEAK_COUNTER(profile, name, type) \
+    (profile)->AddHighWaterMarkCounter(       \
+            name, type, RuntimeProfile::Counter::create_strategy(type, TCounterMergeType::SKIP_FIRST_MERGE))
 #define ADD_CHILD_COUNTER(profile, name, type, parent) \
     (profile)->add_child_counter(name, type, RuntimeProfile::Counter::create_strategy(type), parent)
 #define ADD_CHILD_COUNTER_SKIP_MERGE(profile, name, type, merge_type, parent) \

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -43,8 +43,8 @@ OpFactories PipelineTestBase::maybe_interpolate_local_passthrough_exchange(OpFac
     auto* source_operator = down_cast<SourceOperatorFactory*>(pred_operators[0].get());
     if (source_operator->degree_of_parallelism() > 1) {
         auto pseudo_plan_node_id = -200;
-        auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(config::vector_chunk_size,
-                                                                    config::local_exchange_buffer_mem_limit_per_driver);
+        auto mem_mgr = std::make_shared<ChunkBufferMemoryManager>(config::vector_chunk_size,
+                                                                  config::local_exchange_buffer_mem_limit_per_driver);
         auto local_exchange_source =
                 std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
         auto local_exchange = std::make_shared<PassthroughExchanger>(mem_mgr, local_exchange_source.get());

--- a/be/test/exec/pipeline/pipeline_test_base.cpp
+++ b/be/test/exec/pipeline/pipeline_test_base.cpp
@@ -17,6 +17,7 @@
 #include <random>
 
 #include "column/nullable_column.h"
+#include "common/config.h"
 #include "exec/pipeline/fragment_context.h"
 #include "exec/pipeline/pipeline_driver_executor.h"
 #include "exec/workgroup/work_group.h"
@@ -42,7 +43,8 @@ OpFactories PipelineTestBase::maybe_interpolate_local_passthrough_exchange(OpFac
     auto* source_operator = down_cast<SourceOperatorFactory*>(pred_operators[0].get());
     if (source_operator->degree_of_parallelism() > 1) {
         auto pseudo_plan_node_id = -200;
-        auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(config::vector_chunk_size);
+        auto mem_mgr = std::make_shared<LocalExchangeMemoryManager>(config::vector_chunk_size,
+                                                                    config::local_exchange_buffer_mem_limit_per_driver);
         auto local_exchange_source =
                 std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), pseudo_plan_node_id, mem_mgr);
         auto local_exchange = std::make_shared<PassthroughExchanger>(mem_mgr, local_exchange_source.get());

--- a/be/test/exec/stream/stream_pipeline_test.cpp
+++ b/be/test/exec/stream/stream_pipeline_test.cpp
@@ -123,7 +123,8 @@ OpFactories StreamPipelineTest::maybe_interpolate_local_passthrough_exchange(OpF
     auto* source_operator = down_cast<SourceOperatorFactory*>(pred_operators[0].get());
     if (source_operator->degree_of_parallelism() > 1) {
         auto pseudo_plan_node_id = -200;
-        auto mem_mgr = std::make_shared<pipeline::LocalExchangeMemoryManager>(config::vector_chunk_size);
+        auto mem_mgr = std::make_shared<pipeline::ChunkBufferMemoryManager>(
+                config::vector_chunk_size, config::local_exchange_buffer_mem_limit_per_driver);
         auto local_exchange_source = std::make_shared<pipeline::LocalExchangeSourceOperatorFactory>(
                 next_operator_id(), pseudo_plan_node_id, mem_mgr);
 


### PR DESCRIPTION
1. add memory limit for streaming agg
2. add profile for streaming agg
eg:
```
             - ChunkBufferPeakMem: 48.00 MB
             - ChunkBufferPeakSize: 1.024K (1024)
```


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
