### PR TITLE
[BugFix] Don't always get hedged read metrics

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -776,7 +776,7 @@ CONF_mDouble(scan_use_query_mem_ratio, "0.25");
 CONF_Double(connector_scan_use_query_mem_ratio, "0.3");
 
 // hdfs hedged read
-CONF_mBool(hdfs_client_enable_hedged_read, "false");
+CONF_Bool(hdfs_client_enable_hedged_read, "false");
 // dfs.client.hedged.read.threadpool.size
 CONF_Int32(hdfs_client_hedged_read_threadpool_size, "128");
 // dfs.client.hedged.read.threshold.millis

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -130,13 +130,15 @@ StatusOr<std::unique_ptr<io::NumericStatistics>> HdfsInputStream::get_numeric_st
         stats->append("TotalZeroCopyBytesRead", hdfs_statistics->totalZeroCopyBytesRead);
         hdfsFileFreeReadStatistics(hdfs_statistics);
 
-        struct hdfsHedgedReadMetrics* hdfs_hedged_read_statistics = nullptr;
-        r = hdfsGetHedgedReadMetrics(_fs, &hdfs_hedged_read_statistics);
-        if (r == 0) {
-            stats->append("TotalHedgedReadOps", hdfs_hedged_read_statistics->hedgedReadOps);
-            stats->append("TotalHedgedReadOpsInCurThread", hdfs_hedged_read_statistics->hedgedReadOpsInCurThread);
-            stats->append("TotalHedgedReadOpsWin", hdfs_hedged_read_statistics->hedgedReadOpsWin);
-            hdfsFreeHedgedReadMetrics(hdfs_hedged_read_statistics);
+        if (config::hdfs_client_enable_hedged_read) {
+            struct hdfsHedgedReadMetrics* hdfs_hedged_read_statistics = nullptr;
+            r = hdfsGetHedgedReadMetrics(_fs, &hdfs_hedged_read_statistics);
+            if (r == 0) {
+                stats->append("TotalHedgedReadOps", hdfs_hedged_read_statistics->hedgedReadOps);
+                stats->append("TotalHedgedReadOpsInCurThread", hdfs_hedged_read_statistics->hedgedReadOpsInCurThread);
+                stats->append("TotalHedgedReadOpsWin", hdfs_hedged_read_statistics->hedgedReadOpsWin);
+                hdfsFreeHedgedReadMetrics(hdfs_hedged_read_statistics);
+            }
         }
         return Status::OK();
     });


### PR DESCRIPTION
Some people will customize Hadoop component, but it may not support hedged read, If we still insist on getting hedged read metrics, it will occur BE crashed.
![img_v2_366d774b-8839-442f-b038-fe3e0b6f80ag](https://github.com/StarRocks/starrocks/assets/18729228/1fb1df69-cecb-4eb3-8fcd-68b7391bdc14)



## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
