### PR TITLE
[Cherry-pick][branch-2.5][BugFix] Fix query hive int partition column like '02' error (#28941)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
@@ -50,6 +50,8 @@ public class IntLiteral extends LiteralExpr {
     public static final long BIG_INT_MAX = Long.MAX_VALUE;
     private long value;
 
+    private String stringValue = null;
+
     /**
      * C'tor forcing type, e.g., due to implicit cast
      */
@@ -139,6 +141,7 @@ public class IntLiteral extends LiteralExpr {
 
         this.value = longValue;
         this.type = type;
+        this.stringValue = value;
         analysisDone();
     }
 
@@ -296,7 +299,7 @@ public class IntLiteral extends LiteralExpr {
 
     @Override
     public String getStringValue() {
-        return Long.toString(value);
+        return stringValue != null ? stringValue : Long.toString(value);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -28,6 +28,7 @@ import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -88,6 +89,29 @@ public class PartitionUtilTest {
         LiteralExpr boolTrue1 = new BoolLiteral(true);
         partitionKey.pushColumn(boolTrue1, PrimitiveType.BOOLEAN);
         Assert.assertEquals(Lists.newArrayList("true"), fromPartitionKey(partitionKey));
+    }
+
+    @Test
+    public void testHiveIntPartitionNames() throws Exception {
+        List<String> partitionValues = Lists.newArrayList("2007-01-01", "01");
+        List<Column> columns = new ArrayList<>();
+        columns.add(new Column("a", Type.fromPrimitiveType(PrimitiveType.DATE)));
+        columns.add(new Column("b", Type.fromPrimitiveType(PrimitiveType.INT)));
+
+        PartitionKey partitionKey = PartitionUtil.createPartitionKey(partitionValues, columns, Table.TableType.HIVE);
+        List<String> res = PartitionUtil.fromPartitionKey(partitionKey);
+        Assert.assertEquals("2007-01-01", res.get(0));
+        Assert.assertEquals("01", res.get(1));
+
+        partitionValues = Lists.newArrayList("125", "0125");
+        columns = new ArrayList<>();
+        columns.add(new Column("a", Type.fromPrimitiveType(PrimitiveType.INT)));
+        columns.add(new Column("b", Type.fromPrimitiveType(PrimitiveType.INT)));
+
+        partitionKey = PartitionUtil.createPartitionKey(partitionValues, columns, Table.TableType.HIVE);
+        res = PartitionUtil.fromPartitionKey(partitionKey);
+        Assert.assertEquals("125", res.get(0));
+        Assert.assertEquals("0125", res.get(1));
     }
 
     @Test


### PR DESCRIPTION
some hive int partition column could be '01','02', not '1','2', we need to store the origin string value.

Fixes #issue

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
