### PR TITLE
[BugFix] Fix table is lost bug where create/drop db and table concurrently

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1967,7 +1967,7 @@ public class LocalMetastore implements ConnectorMetadata {
         }
 
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("Database has been dropped when creating table");
             }
 
@@ -1991,6 +1991,10 @@ public class LocalMetastore implements ConnectorMetadata {
                         return;
                     }
                 }
+
+                // NOTE: The table has been added to the database, and the following procedure cannot throw exception.
+                LOG.info("Successfully create table: {}-{}, in database: {}-{}",
+                        table.getName(), table.getId(), db.getFullName(), db.getId());
 
                 CreateTableInfo createTableInfo = new CreateTableInfo(db.getFullName(), table, storageVolumeId);
                 GlobalStateMgr.getCurrentState().getEditLog().logCreateTable(createTableInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -559,8 +559,6 @@ public class OlapTableFactory implements AbstractTableFactory {
             throw e;
         }
 
-        // NOTE: The table has been added to the database, and the following procedure cannot throw exception.
-        LOG.info("Successfully create table[{};{}]", tableName, tableId);
         return table;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1523,6 +1523,11 @@ public class DatabaseTransactionMgr {
         for (TableCommitInfo tableCommitInfo : transactionState.getIdToTableCommitInfos().values()) {
             long tableId = tableCommitInfo.getTableId();
             Table table = db.getTable(tableId);
+            if (table == null) {
+                LOG.warn("updateCatalogAfterCommitted table is null, table: {}, db: {}-{}",
+                        tableId, db.getId(), db.getFullName());
+                return;
+            }
             TransactionLogApplier applier = txnLogApplierFactory.create(table);
             applier.applyCommitLog(transactionState, tableCommitInfo);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1523,11 +1523,6 @@ public class DatabaseTransactionMgr {
         for (TableCommitInfo tableCommitInfo : transactionState.getIdToTableCommitInfos().values()) {
             long tableId = tableCommitInfo.getTableId();
             Table table = db.getTable(tableId);
-            if (table == null) {
-                LOG.warn("updateCatalogAfterCommitted table is null, table: {}, db: {}-{}",
-                        tableId, db.getId(), db.getFullName());
-                return;
-            }
             TransactionLogApplier applier = txnLogApplierFactory.create(table);
             applier.applyCommitLog(transactionState, tableCommitInfo);
         }


### PR DESCRIPTION
Fixes SR-19348
The following scenes will lose table:
T1: begin to create t (id=1) on db d(id=2)
T2: db d(id=2) is dropped
T3: db d(id=3) is created
T4: table t(id=1) is created to db d(id=2)
T5: table t(id=5) is created to db d(id=3)
T6: there are some data load on t(id=5)
When system restarts, there will be two create table log, but only the first will success, which is table t(id=1), but all the operations is based on t(id=5).

The key point is on time T4, the check of database existence is based on db name, if we check based on id, the creation of t(id=1) will fail.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
