### PR TITLE
[BugFix] concurrent-safe issue of cached cpu cores

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
@@ -29,14 +29,14 @@ public class BackendCoreStat {
 
     private static int DEFAULT_CORES_OF_BE = 1;
 
-    private static final ConcurrentHashMap<Long, Integer> numOfHardwareCoresPerBe = new ConcurrentHashMap<>();
+    private static ConcurrentHashMap<Long, Integer> numOfHardwareCoresPerBe = new ConcurrentHashMap<>();
     private static AtomicInteger cachedAvgNumOfHardwareCores = new AtomicInteger(-1);
-    private static final ReentrantLock lock = new ReentrantLock();
+    private static ReentrantLock lock = new ReentrantLock();
 
     public static void setNumOfHardwareCoresOfBe(long be, int numOfCores) {
         Integer previous = numOfHardwareCoresPerBe.put(be, numOfCores);
-        LOG.info("set numOfHardwareCoresOfBe of be({}) to {}", be, numOfCores);
-        LOG.info("current cpuCores stats: {}", numOfHardwareCoresPerBe);
+        LOG.info("set numOfHardwareCoresOfBe of be({}) to {}, current cpuCores stats: {}", be, numOfCores,
+                numOfHardwareCoresPerBe);
         if (previous == null || previous != numOfCores) {
             cachedAvgNumOfHardwareCores.set(-1);
         }
@@ -85,8 +85,8 @@ public class BackendCoreStat {
                     / numOfHardwareCoresPerBe.size();
             avg = Math.max(DEFAULT_CORES_OF_BE, avg);
             cachedAvgNumOfHardwareCores.set(avg);
-            LOG.info("update avgNumOfHardwareCoresOfBe to {}", avg);
-            LOG.info("current cpuCores stats: {}", numOfHardwareCoresPerBe);
+            LOG.info("update avgNumOfHardwareCoresOfBe to {}, current cpuCores stats: {}", avg,
+                    numOfHardwareCoresPerBe);
             return avg;
         } finally {
             lock.unlock();

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
@@ -16,11 +16,16 @@
 package com.starrocks.system;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class BackendCoreStat {
+
+    private static final Logger LOG = LogManager.getLogger(BackendCoreStat.class);
+
     private static int DEFAULT_CORES_OF_BE = 1;
 
     private static ConcurrentHashMap<Long, Integer> numOfHardwareCoresPerBe = new ConcurrentHashMap<>();
@@ -28,6 +33,8 @@ public class BackendCoreStat {
 
     public static void setNumOfHardwareCoresOfBe(long be, int numOfCores) {
         Integer previous = numOfHardwareCoresPerBe.put(be, numOfCores);
+        LOG.info("set numOfHardwareCoresOfBe of be({}) to {}", be, numOfCores);
+        LOG.info("current cpuCores stats: {}", numOfHardwareCoresPerBe);
         if (previous == null || previous != numOfCores) {
             cachedAvgNumOfHardwareCores.set(-1);
         }
@@ -79,6 +86,8 @@ public class BackendCoreStat {
         snapshotAvg = 0;
         // Update the cached value if numOfHardwareCoresPerBe is changed(cachedAvgNumOfHardwareCores = -1)
         cachedAvgNumOfHardwareCores.compareAndSet(snapshotAvg, newAvg);
+        LOG.info("update avgNumOfHardwareCoresOfBe to {}", newAvg);
+        LOG.info("current cpuCores stats: {}", numOfHardwareCoresPerBe);
         return newAvg;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class BackendCoreStat {
 
@@ -28,8 +29,9 @@ public class BackendCoreStat {
 
     private static int DEFAULT_CORES_OF_BE = 1;
 
-    private static ConcurrentHashMap<Long, Integer> numOfHardwareCoresPerBe = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<Long, Integer> numOfHardwareCoresPerBe = new ConcurrentHashMap<>();
     private static AtomicInteger cachedAvgNumOfHardwareCores = new AtomicInteger(-1);
+    private static final ReentrantLock lock = new ReentrantLock();
 
     public static void setNumOfHardwareCoresOfBe(long be, int numOfCores) {
         Integer previous = numOfHardwareCoresPerBe.put(be, numOfCores);
@@ -67,28 +69,28 @@ public class BackendCoreStat {
     }
 
     public static int getAvgNumOfHardwareCoresOfBe() {
+        // optimistic path
         int snapshotAvg = cachedAvgNumOfHardwareCores.get();
         if (snapshotAvg > 0) {
             return snapshotAvg;
         }
 
-        cachedAvgNumOfHardwareCores.compareAndSet(snapshotAvg, 0);
-        Integer[] numCoresArray = new Integer[0];
-        numCoresArray = numOfHardwareCoresPerBe.values().toArray(numCoresArray);
-        if (numCoresArray.length == 0) {
-            return DEFAULT_CORES_OF_BE;
+        // pessimistic path
+        try {
+            lock.lock();
+            if (numOfHardwareCoresPerBe.isEmpty()) {
+                return DEFAULT_CORES_OF_BE;
+            }
+            int avg = numOfHardwareCoresPerBe.values().stream().reduce(Integer::sum).orElse(0)
+                    / numOfHardwareCoresPerBe.size();
+            avg = Math.max(DEFAULT_CORES_OF_BE, avg);
+            cachedAvgNumOfHardwareCores.set(avg);
+            LOG.info("update avgNumOfHardwareCoresOfBe to {}", avg);
+            LOG.info("current cpuCores stats: {}", numOfHardwareCoresPerBe);
+            return avg;
+        } finally {
+            lock.unlock();
         }
-        int sum = 0;
-        for (Integer v : numCoresArray) {
-            sum += v;
-        }
-        int newAvg = sum / numCoresArray.length;
-        snapshotAvg = 0;
-        // Update the cached value if numOfHardwareCoresPerBe is changed(cachedAvgNumOfHardwareCores = -1)
-        cachedAvgNumOfHardwareCores.compareAndSet(snapshotAvg, newAvg);
-        LOG.info("update avgNumOfHardwareCoresOfBe to {}", newAvg);
-        LOG.info("current cpuCores stats: {}", numOfHardwareCoresPerBe);
-        return newAvg;
     }
 
     public static int getDefaultDOP() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
@@ -81,9 +81,8 @@ public class BackendCoreStat {
             if (numOfHardwareCoresPerBe.isEmpty()) {
                 return DEFAULT_CORES_OF_BE;
             }
-            int avg = numOfHardwareCoresPerBe.values().stream().reduce(Integer::sum).orElse(0)
-                    / numOfHardwareCoresPerBe.size();
-            avg = Math.max(DEFAULT_CORES_OF_BE, avg);
+            int sum = numOfHardwareCoresPerBe.values().stream().reduce(Integer::sum).get();
+            int avg = sum / numOfHardwareCoresPerBe.size();
             cachedAvgNumOfHardwareCores.set(avg);
             LOG.info("update avgNumOfHardwareCoresOfBe to {}, current cpuCores stats: {}", avg,
                     numOfHardwareCoresPerBe);

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q1.sql
@@ -171,7 +171,7 @@ column statistics:
   "be_number": 3,
   "be_core_stat": {
     "numOfHardwareCoresPerBe": "{}",
-    "cachedAvgNumOfHardwareCores": 0
+    "cachedAvgNumOfHardwareCores": -1
   },
   "exception": []
 }

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q20.sql
@@ -397,7 +397,7 @@ column statistics:
   "be_number": 3,
   "be_core_stat": {
     "numOfHardwareCoresPerBe": "{}",
-    "cachedAvgNumOfHardwareCores": 0
+    "cachedAvgNumOfHardwareCores": -1
   },
   "exception": []
 }

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q5.sql
@@ -410,7 +410,7 @@ column statistics:
   "be_number": 3,
   "be_core_stat": {
     "numOfHardwareCoresPerBe": "{}",
-    "cachedAvgNumOfHardwareCores": 0
+    "cachedAvgNumOfHardwareCores": -1
   },
   "exception": []
 }

--- a/fe/fe-core/src/test/resources/sql/tpchcost/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchcost/q7.sql
@@ -419,7 +419,7 @@ column statistics:
   "be_number": 3,
   "be_core_stat": {
     "numOfHardwareCoresPerBe": "{}",
-    "cachedAvgNumOfHardwareCores": 0
+    "cachedAvgNumOfHardwareCores": -1
   },
   "exception": []
 }


### PR DESCRIPTION
Fixes #issue

Changes:
1. Print the stats when updating
2. Use a pessimistic lock when updating cached values

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
