### PR TITLE
[BugFix] push worker thread can not pop NORMAL Priority task (#7628)

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -74,7 +74,8 @@ AgentServer::AgentServer(ExecEnv* exec_env, const TMasterInfo& master_info)
     CREATE_AND_START_POOL(PUBLISH_VERSION, _publish_version_workers, 1);
     CREATE_AND_START_POOL(CLEAR_TRANSACTION_TASK, _clear_transaction_task_workers,
                           config::clear_transaction_task_worker_count);
-    CREATE_AND_START_POOL(DELETE, _delete_workers, config::delete_worker_count);
+    CREATE_AND_START_POOL(DELETE, _delete_workers,
+                          config::delete_worker_count_normal_priority + config::delete_worker_count_high_priority);
     CREATE_AND_START_POOL(ALTER_TABLE, _alter_tablet_workers, config::alter_tablet_worker_count);
     CREATE_AND_START_POOL(CLONE, _clone_workers, config::clone_worker_count);
     CREATE_AND_START_POOL(STORAGE_MEDIUM_MIGRATE, _storage_medium_migrate_workers,

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -114,8 +114,7 @@ void TaskWorkerPool::start() {
         _callback_function = _clear_transaction_task_worker_thread_callback;
         break;
     case TaskWorkerType::DELETE:
-        _worker_count = config::delete_worker_count;
-        _callback_function = _push_worker_thread_callback;
+        _callback_function = _delete_worker_thread_callback;
         break;
     case TaskWorkerType::ALTER_TABLE:
         _callback_function = _alter_tablet_worker_thread_callback;
@@ -567,8 +566,8 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
 
     TPriority::type priority = TPriority::NORMAL;
 
-    if (worker_pool_this->_task_worker_type != DELETE) {
-        int32_t push_worker_count_high_priority = config::push_worker_count_high_priority;
+    int32_t push_worker_count_high_priority = config::push_worker_count_high_priority;
+    {
         std::lock_guard worker_thread_lock(worker_pool_this->_worker_thread_lock);
         if (s_worker_count < push_worker_count_high_priority) {
             ++s_worker_count;
@@ -580,7 +579,96 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
         AgentStatus status = STARROCKS_SUCCESS;
         TAgentTaskRequestPtr agent_task_req;
         do {
-            agent_task_req = worker_pool_this->_pop_task(TPriority::HIGH);
+            agent_task_req = worker_pool_this->_pop_task(priority);
+            if (agent_task_req == nullptr) {
+                // there is no high priority task. notify other thread to handle normal task
+                worker_pool_this->_worker_thread_condition_variable->notify_one();
+                break;
+            }
+        } while (false);
+
+        if (worker_pool_this->_stopped) {
+            break;
+        }
+        if (agent_task_req == nullptr) {
+            // there is no high priority task in queue
+            sleep(1);
+            continue;
+        }
+        auto& push_req = agent_task_req->push_req;
+
+        LOG(INFO) << "get push task. signature: " << agent_task_req->signature << " priority: " << priority
+                  << " push_type: " << push_req.push_type;
+        std::vector<TTabletInfo> tablet_infos;
+
+        EngineBatchLoadTask engine_task(push_req, &tablet_infos, agent_task_req->signature, &status,
+                                        ExecEnv::GetInstance()->load_mem_tracker());
+        worker_pool_this->_env->storage_engine()->execute_task(&engine_task);
+
+        if (status == STARROCKS_PUSH_HAD_LOADED) {
+            // remove the task and not return to fe
+            worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+            continue;
+        }
+        // Return result to fe
+        std::vector<string> error_msgs;
+        TStatus task_status;
+
+        TFinishTaskRequest finish_task_request;
+        finish_task_request.__set_backend(BackendOptions::get_localBackend());
+        finish_task_request.__set_task_type(agent_task_req->task_type);
+        finish_task_request.__set_signature(agent_task_req->signature);
+
+        if (status == STARROCKS_SUCCESS) {
+            VLOG(3) << "push ok. signature: " << agent_task_req->signature << ", push_type: " << push_req.push_type;
+            error_msgs.emplace_back("push success");
+
+            _s_report_version.fetch_add(1, std::memory_order_relaxed);
+
+            task_status.__set_status_code(TStatusCode::OK);
+            finish_task_request.__set_finish_tablet_infos(tablet_infos);
+        } else if (status == STARROCKS_TASK_REQUEST_ERROR) {
+            LOG(WARNING) << "push request push_type invalid. type: " << push_req.push_type
+                         << ", signature: " << agent_task_req->signature;
+            error_msgs.emplace_back("push request push_type invalid.");
+            task_status.__set_status_code(TStatusCode::ANALYSIS_ERROR);
+        } else {
+            LOG(WARNING) << "push failed, error_code: " << status << ", signature: " << agent_task_req->signature;
+            error_msgs.emplace_back("push failed");
+            task_status.__set_status_code(TStatusCode::RUNTIME_ERROR);
+        }
+        task_status.__set_error_msgs(error_msgs);
+        finish_task_request.__set_task_status(task_status);
+        finish_task_request.__set_report_version(_s_report_version.load(std::memory_order_relaxed));
+
+        worker_pool_this->_finish_task(finish_task_request);
+        worker_pool_this->_remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+    }
+
+    return (void*)nullptr;
+}
+
+void* TaskWorkerPool::_delete_worker_thread_callback(void* arg_this) {
+    static uint32_t s_worker_count = 0;
+
+    auto* worker_pool_this = (TaskWorkerPool*)arg_this;
+
+    TPriority::type priority = TPriority::NORMAL;
+
+    int32_t delete_worker_count_high_priority = config::delete_worker_count_high_priority;
+    {
+        std::lock_guard worker_thread_lock(worker_pool_this->_worker_thread_lock);
+        if (s_worker_count < delete_worker_count_high_priority) {
+            ++s_worker_count;
+            priority = TPriority::HIGH;
+        }
+    }
+
+    while (true) {
+        AgentStatus status = STARROCKS_SUCCESS;
+        TAgentTaskRequestPtr agent_task_req;
+        do {
+            agent_task_req = worker_pool_this->_pop_task(priority);
             if (agent_task_req == nullptr) {
                 // there is no high priority task. notify other thread to handle normal task
                 worker_pool_this->_worker_thread_condition_variable->notify_one();
@@ -590,7 +678,7 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
 
             int num_of_remove_task = 0;
             if (push_req.push_type == TPushType::CANCEL_DELETE) {
-                LOG(INFO) << "get push task. remove delete task txn_id: " << push_req.transaction_id
+                LOG(INFO) << "get delete push task. remove delete task txn_id: " << push_req.transaction_id
                           << " priority: " << priority << " push_type: " << push_req.push_type;
 
                 std::lock_guard l(worker_pool_this->_worker_thread_lock);
@@ -624,7 +712,7 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
         }
         auto& push_req = agent_task_req->push_req;
 
-        LOG(INFO) << "get push task. signature: " << agent_task_req->signature << " priority: " << priority
+        LOG(INFO) << "get delete push task. signature: " << agent_task_req->signature << " priority: " << priority
                   << " push_type: " << push_req.push_type;
         std::vector<TTabletInfo> tablet_infos;
 
@@ -650,7 +738,8 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
         }
 
         if (status == STARROCKS_SUCCESS) {
-            VLOG(3) << "push ok. signature: " << agent_task_req->signature << ", push_type: " << push_req.push_type;
+            VLOG(3) << "delete push ok. signature: " << agent_task_req->signature
+                    << ", push_type: " << push_req.push_type;
             error_msgs.emplace_back("push success");
 
             _s_report_version.fetch_add(1, std::memory_order_relaxed);
@@ -658,13 +747,14 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
             task_status.__set_status_code(TStatusCode::OK);
             finish_task_request.__set_finish_tablet_infos(tablet_infos);
         } else if (status == STARROCKS_TASK_REQUEST_ERROR) {
-            LOG(WARNING) << "push request push_type invalid. type: " << push_req.push_type
+            LOG(WARNING) << "delete push request push_type invalid. type: " << push_req.push_type
                          << ", signature: " << agent_task_req->signature;
             error_msgs.emplace_back("push request push_type invalid.");
             task_status.__set_status_code(TStatusCode::ANALYSIS_ERROR);
         } else {
-            LOG(WARNING) << "push failed, error_code: " << status << ", signature: " << agent_task_req->signature;
-            error_msgs.emplace_back("push failed");
+            LOG(WARNING) << "delete push failed, error_code: " << status
+                         << ", signature: " << agent_task_req->signature;
+            error_msgs.emplace_back("delete push failed");
             task_status.__set_status_code(TStatusCode::RUNTIME_ERROR);
         }
         task_status.__set_error_msgs(error_msgs);

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -615,7 +615,7 @@ void* TaskWorkerPool::_push_worker_thread_callback(void* arg_this) {
         TStatus task_status;
 
         TFinishTaskRequest finish_task_request;
-        finish_task_request.__set_backend(BackendOptions::get_localBackend());
+        finish_task_request.__set_backend(worker_pool_this->_backend);
         finish_task_request.__set_task_type(agent_task_req->task_type);
         finish_task_request.__set_signature(agent_task_req->signature);
 

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -99,6 +99,7 @@ private:
                                                const TPublishVersionRequest publish_version_req,
                                                std::set<TTabletId>* tablet_ids,
                                                std::vector<TTabletId>* error_tablet_ids);
+    static void* _delete_worker_thread_callback(void* arg_this);
     static void* _publish_version_worker_thread_callback(void* arg_this);
     static void* _clear_transaction_task_worker_thread_callback(void* arg_this);
     static void* _alter_tablet_worker_thread_callback(void* arg_this);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -88,7 +88,9 @@ CONF_Int32(transaction_publish_version_worker_count, "8");
 // The count of thread to clear transaction task.
 CONF_Int32(clear_transaction_task_worker_count, "1");
 // The count of thread to delete.
-CONF_Int32(delete_worker_count, "3");
+CONF_Int32(delete_worker_count_normal_priority, "2");
+// The count of thread to high priority delete.
+CONF_Int32(delete_worker_count_high_priority, "1");
 // The count of thread to alter table.
 CONF_Int32(alter_tablet_worker_count, "3");
 // The count of thread to clone.


### PR DESCRIPTION
In the current implementation, the push worker thread can only pop the HIGH Priority tasks, it can not pop the NORMAL priority tasks.

I fix this bug in this pr, also I split the delete_workers from the _push_worker_thread_callback, I add a stand-alone function _delete_worker_thread_callback for delete_workers
