### PR TITLE
[BugFix] Fix un-groupby column in having subquery bug (#28828)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -51,9 +51,9 @@ import com.starrocks.sql.ast.LambdaFunctionExpr;
 import com.starrocks.sql.ast.QueryStatement;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
@@ -294,11 +294,29 @@ public class AggregationAnalyzer {
         @Override
         public Boolean visitSubquery(Subquery node, Void context) {
             QueryStatement queryStatement = node.getQueryStatement();
-            List<FieldId> fieldIds = queryStatement.getQueryRelation().getColumnReferences().values().stream()
-                    .filter(fieldId -> fieldId.getRelationId().equals(sourceScope.getRelationId()))
-                    .collect(Collectors.toList());
+            for (Map.Entry<Expr, FieldId> entry : queryStatement.getQueryRelation().getColumnReferences().entrySet()) {
+                Expr expr = entry.getKey();
+                FieldId id = entry.getValue();
 
-            return groupingFields.containsAll(fieldIds);
+                if (!id.getRelationId().equals(sourceScope.getRelationId())) {
+                    continue;
+                }
+
+                if (!groupingFields.contains(id)) {
+                    if (!SqlModeHelper.check(session.getSessionVariable().getSqlMode(),
+                            SqlModeHelper.MODE_ONLY_FULL_GROUP_BY)) {
+                        if (!analyzeState.getColumnNotInGroupBy().contains(expr)) {
+                            throw new SemanticException(
+                                    "subquery correlated column %s in %s must be an aggregate " + 
+                                    "expression or appear in GROUP BY clause",
+                                    expr.toSql(), node.toSql());
+                        }
+                    } else {
+                        return false;
+                    }
+                }
+            }
+            return true;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/SubqueryRelation.java
@@ -15,8 +15,10 @@
 package com.starrocks.sql.ast;
 
 import com.starrocks.analysis.Expr;
+import com.starrocks.sql.analyzer.FieldId;
 
 import java.util.List;
+import java.util.Map;
 
 public class SubqueryRelation extends QueryRelation {
     private final QueryStatement queryStatement;
@@ -28,6 +30,11 @@ public class SubqueryRelation extends QueryRelation {
         if (!queryRelation.hasLimit()) {
             queryRelation.clearOrder();
         }
+    }
+
+    @Override
+    public Map<Expr, FieldId> getColumnReferences() {
+        return queryStatement.getQueryRelation().getColumnReferences();
     }
 
     public QueryStatement getQueryStatement() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
@@ -1877,5 +1876,18 @@ public class SubqueryTest extends PlanTestBase {
                 " else null end end from tmp a;";
         Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
         assertContains(pair.first, "CTEAnchor(cteid=2)");
+    }
+
+    @Test
+    public void testHavingSubqueryNoGroupMode() {
+        String sql = "select v3 from t0 group by v2 having 1 > (select v4 from t1 where t0.v1 = t1.v5)";
+        long sqlMode = connectContext.getSessionVariable().getSqlMode();
+        try {
+            connectContext.getSessionVariable().setSqlMode(0);
+            Assert.assertThrows("must be an aggregate expression or appear in GROUP BY clause", SemanticException.class,
+                    () -> getFragmentPlan(sql));
+        } finally {
+            connectContext.getSessionVariable().setSqlMode(sqlMode);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/28087

col `t0_77.c_0_2` from outer aggregate scope, and not a group-by key or aggregation expression. when sql_mode isn't `ONLY_GROUP_BY`, sr will add `any_value(t0_77.c_0_2)` to fill lost column and rewrite all expressions, but it's hard to rewrite whole subquery now.

```
MySQL h3> explain SELECT
  t2_79.c_2_0
FROM
  t2 AS t2_79, t0 AS t0_77
WHERE NULL
GROUP BY t0_77.c_0_1, t0_77.c_0_8
HAVING
  (
    MAX('1970-01-10 20:06:32')
  ) IN (
    (
      SELECT t1_78.c_1_3
      FROM t1 AS t1_78
      WHERE t0_77.c_0_2 = t1_78.c_1_4
    )
  )
```

Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
