### PR TITLE
[Enhancement] Add enable_materialized_view_spill to control whether enable spill in refresh mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1042,6 +1042,12 @@ public class Config extends ConfigBase {
     public static boolean enable_materialized_view = true;
 
     /**
+     * Control whether to enable spill for all materialized views in the refresh mv.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_materialized_view_spill = true;
+
+    /**
      * When the materialized view fails to start FE due to metadata problems,
      * you can try to open this configuration,
      * and he can ignore some metadata exceptions.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -396,7 +396,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ANALYZE_FOR_MV = "analyze_mv";
     public static final String QUERY_EXCLUDING_MV_NAMES = "query_excluding_mv_names";
     public static final String QUERY_INCLUDING_MV_NAMES = "query_including_mv_names";
-    public static final String ENABLE_MATERIALIZED_VIEW_SINGLE_SPILL = "enable_materialized_view_spill";
 
     public static final String ENABLE_BIG_QUERY_LOG = "enable_big_query_log";
     public static final String BIG_QUERY_LOG_CPU_SECOND_THRESHOLD = "big_query_log_cpu_second_threshold";
@@ -1118,9 +1117,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = QUERY_INCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
     private String queryIncludingMVNames = "";
-
-    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_SINGLE_SPILL)
-    private boolean enableMaterializedViewSpill = true;
 
     @VarAttr(name = ANALYZE_FOR_MV)
     private String analyzeTypeForMV = "sample";
@@ -2195,14 +2191,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public String getQueryIncludingMVNames() {
         return queryIncludingMVNames;
-    }
-
-    public boolean isEnableMaterializedViewSpill() {
-        return enableMaterializedViewSpill;
-    }
-
-    public void setEnableMaterializedViewSpill(boolean enableMaterializedViewSpill) {
-        this.enableMaterializedViewSpill = enableMaterializedViewSpill;
     }
 
     public void setQueryIncludingMVNames(String queryIncludingMVNames) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -396,6 +396,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ANALYZE_FOR_MV = "analyze_mv";
     public static final String QUERY_EXCLUDING_MV_NAMES = "query_excluding_mv_names";
     public static final String QUERY_INCLUDING_MV_NAMES = "query_including_mv_names";
+    public static final String ENABLE_MATERIALIZED_VIEW_SINGLE_SPILL = "enable_materialized_view_spill";
 
     public static final String ENABLE_BIG_QUERY_LOG = "enable_big_query_log";
     public static final String BIG_QUERY_LOG_CPU_SECOND_THRESHOLD = "big_query_log_cpu_second_threshold";
@@ -1117,6 +1118,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = QUERY_INCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
     private String queryIncludingMVNames = "";
+
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_SINGLE_SPILL)
+    private boolean enableMaterializedViewSpill = true;
 
     @VarAttr(name = ANALYZE_FOR_MV)
     private String analyzeTypeForMV = "sample";
@@ -2191,6 +2195,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public String getQueryIncludingMVNames() {
         return queryIncludingMVNames;
+    }
+
+    public boolean isEnableMaterializedViewSpill() {
+        return enableMaterializedViewSpill;
+    }
+
+    public void setEnableMaterializedViewSpill(boolean enableMaterializedViewSpill) {
+        this.enableMaterializedViewSpill = enableMaterializedViewSpill;
     }
 
     public void setQueryIncludingMVNames(String queryIncludingMVNames) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -52,6 +52,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.io.DeepCopy;
@@ -288,7 +289,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
         // enable spill by default for mv if spill is not set by default and
         // `session.enable_spill` session variable is not set.
-        if (mvSessionVariable.isEnableMaterializedViewSpill() &&
+        if (Config.enable_materialized_view_spill &&
                 !mvSessionVariable.getEnableSpill() &&
                 !mvProperty.getProperties().containsKey(MV_SESSION_ENABLE_SPILL)) {
             mvSessionVariable.setEnableSpill(true);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -286,9 +286,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             mvSessionVariable.setResourceGroup(rg);
         }
 
-        // enable spill by default for mv if spill is not set by default and `session.enable_spill` session variable
-        // is not set.
-        if (!mvSessionVariable.getEnableSpill() &&
+        // enable spill by default for mv if spill is not set by default and
+        // `session.enable_spill` session variable is not set.
+        if (mvSessionVariable.isEnableMaterializedViewSpill() &&
+                !mvSessionVariable.getEnableSpill() &&
                 !mvProperty.getProperties().containsKey(MV_SESSION_ENABLE_SPILL)) {
             mvSessionVariable.setEnableSpill(true);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -1624,14 +1624,12 @@ public class PartitionBasedMvRefreshProcessorTest {
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
-            Assert.assertTrue(execPlan.getConnectContext().getSessionVariable().isEnableMaterializedViewSpill());
             Assert.assertTrue(execPlan.getConnectContext().getSessionVariable().getEnableSpill());
         }
 
         {
             // change global config
-            String sql = "set global enable_materialized_view_spill = false";
-            new StmtExecutor(connectContext, sql).execute();
+            Config.enable_materialized_view_spill = false;
 
             // insert again.
             new StmtExecutor(connectContext, insertSql).execute();
@@ -1640,11 +1638,9 @@ public class PartitionBasedMvRefreshProcessorTest {
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
-            Assert.assertFalse(execPlan.getConnectContext().getSessionVariable().isEnableMaterializedViewSpill());
             Assert.assertFalse(execPlan.getConnectContext().getSessionVariable().getEnableSpill());
 
-            sql = "set global enable_materialized_view_spill = true";
-            new StmtExecutor(connectContext, sql).execute();
+            Config.enable_materialized_view_spill = true;
         }
     }
 
@@ -1674,7 +1670,6 @@ public class PartitionBasedMvRefreshProcessorTest {
                 taskRun.getProcessor();
         MvTaskRunContext mvContext = processor.getMvContext();
         ExecPlan execPlan = mvContext.getExecPlan();
-        Assert.assertTrue(execPlan.getConnectContext().getSessionVariable().isEnableMaterializedViewSpill());
         Assert.assertFalse(execPlan.getConnectContext().getSessionVariable().getEnableSpill());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -1597,6 +1597,88 @@ public class PartitionBasedMvRefreshProcessorTest {
     }
 
     @Test
+    public void testRefreshMaterializedViewDefaultConfig1() throws Exception {
+        starRocksAssert.useDatabase("test").withMaterializedView("create materialized view test.mv_config1\n" +
+                "partition by date_trunc('month',k1) \n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "refresh deferred manual\n" +
+                "properties(" +
+                "'replication_num' = '1',\n" +
+                "'storage_medium' = 'SSD'" +
+                ")\n" +
+                "as select k1, k2 from tbl1;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_config1"));
+
+        String insertSql = "insert into tbl1 partition(p3) values('2022-03-01', 3, 10);";
+        new StmtExecutor(connectContext, insertSql).execute();
+
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+
+        // by default, enable spill
+        {
+            taskRun.executeTaskRun();
+            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                    taskRun.getProcessor();
+            MvTaskRunContext mvContext = processor.getMvContext();
+            ExecPlan execPlan = mvContext.getExecPlan();
+            Assert.assertTrue(execPlan.getConnectContext().getSessionVariable().isEnableMaterializedViewSpill());
+            Assert.assertTrue(execPlan.getConnectContext().getSessionVariable().getEnableSpill());
+        }
+
+        {
+            // change global config
+            String sql = "set global enable_materialized_view_spill = false";
+            new StmtExecutor(connectContext, sql).execute();
+
+            // insert again.
+            new StmtExecutor(connectContext, insertSql).execute();
+            taskRun.executeTaskRun();
+            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                    taskRun.getProcessor();
+            MvTaskRunContext mvContext = processor.getMvContext();
+            ExecPlan execPlan = mvContext.getExecPlan();
+            Assert.assertFalse(execPlan.getConnectContext().getSessionVariable().isEnableMaterializedViewSpill());
+            Assert.assertFalse(execPlan.getConnectContext().getSessionVariable().getEnableSpill());
+
+            sql = "set global enable_materialized_view_spill = true";
+            new StmtExecutor(connectContext, sql).execute();
+        }
+    }
+
+    @Test
+    public void testRefreshMaterializedViewDefaultConfig2() throws Exception {
+        starRocksAssert.useDatabase("test").withMaterializedView("create materialized view test.mv_config2\n" +
+                "partition by date_trunc('month',k1) \n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "refresh deferred manual\n" +
+                "properties(" +
+                "'replication_num' = '1',\n" +
+                "'session.enable_spill' = 'false'" +
+                ")\n" +
+                "as select k1, k2 from tbl1;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_config2"));
+
+        String insertSql = "insert into tbl1 partition(p3) values('2022-03-01', 3, 10);";
+        new StmtExecutor(connectContext, insertSql).execute();
+
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+
+        taskRun.executeTaskRun();
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                taskRun.getProcessor();
+        MvTaskRunContext mvContext = processor.getMvContext();
+        ExecPlan execPlan = mvContext.getExecPlan();
+        Assert.assertTrue(execPlan.getConnectContext().getSessionVariable().isEnableMaterializedViewSpill());
+        Assert.assertFalse(execPlan.getConnectContext().getSessionVariable().getEnableSpill());
+    }
+
+    @Test
     public void testSyncPartitionWithSsdStorage() throws Exception {
         starRocksAssert.useDatabase("test").withMaterializedView("create materialized view test.mv_with_ssd\n" +
                 "partition by date_trunc('month',k1) \n" +


### PR DESCRIPTION
In v3.1, spill is enabled by default. However to avoid bad cases, now add `enable_materialized_view_spill` to control whether to spill for materialized view fresh globally.

- disable all materialized views' refresh by default.
```
admin set frontend config("enable_materialized_view_spill" = "false");
```

- disable specific materialized view's refresh
```
alter materialized view xxx set ('session.enable_spill' = 'false');
```


## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
