### PR TITLE
[BugFix] include immintrin.h only in X86_64

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -15,8 +15,10 @@
 #include "exprs/string_functions.h"
 
 #include <hs/hs.h>
+#ifdef __x86_64__
 #include <immintrin.h>
 #include <mmintrin.h>
+#endif
 #include <re2/re2.h>
 
 #include <algorithm>


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
