### PR TITLE
[BugFix] ignore compare agg strict info when deriving output property

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionDisjointSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/DistributionDisjointSet.java
@@ -55,12 +55,12 @@ public class DistributionDisjointSet {
         parent.computeIfAbsent(col, Function.identity());
 
         DistributionCol root = col;
-        while (parent.get(root) != root) {
+        while (!parent.get(root).equals(root)) {
             root = parent.get(root);
         }
 
         // path compress
-        while (col != root) {
+        while (!col.equals(root)) {
             DistributionCol next = parent.get(col);
             parent.put(col, root);
             col = next;


### PR DESCRIPTION
Fixes #issue
Clients report query thread may falling in infinite loop and cannot being killed becuase of `parent.get(root) != root` always return true. We should ignore the `agg strict info` when deriving the output property. 
We just need the `null strict or relax` info to describe the down-top derving output property process. 
The `agg strict or relax` info is only used when top-down derving required property of children.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
