### PR TITLE
[BugFix] Fix heap-use-after-free in UT

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -42,6 +42,7 @@
 namespace starrocks {
 
 static ThreadPool* get_thread_pool(TTaskType::type type) {
+#ifndef BE_TEST
     auto env = ExecEnv::GetInstance();
     if (UNLIKELY(env == nullptr)) {
         return nullptr;
@@ -51,6 +52,9 @@ static ThreadPool* get_thread_pool(TTaskType::type type) {
         return nullptr;
     }
     return as->get_thread_pool(type);
+#else
+    return nullptr;
+#endif
 }
 
 static int get_num_queued_tasks(TTaskType::type type) {
@@ -78,27 +82,32 @@ static int get_num_publish_active_tasks(void*) {
 }
 
 static int get_num_vacuum_queued_tasks(void*) {
+#ifndef BE_TEST
     auto tp = ExecEnv::GetInstance()->vacuum_thread_pool();
     return tp ? tp->num_queued_tasks() : 0;
+#else
+    return 0;
+#endif
 }
 
 static int get_num_vacuum_active_tasks(void*) {
+#ifndef BE_TEST
     auto tp = ExecEnv::GetInstance()->vacuum_thread_pool();
     return tp ? tp->active_threads() : 0;
+#else
+    return 0;
+#endif
 }
-
 
 static bvar::Adder<int64_t> g_publish_version_failed_tasks("lake_publish_version_failed_tasks");
 static bvar::LatencyRecorder g_publish_tablet_version_latency("lake_publish_tablet_version");
 static bvar::LatencyRecorder g_publish_tablet_version_queuing_latency("lake_putlish_tablet_version_queuing");
-#ifndef BE_TEST
 static bvar::PassiveStatus<int> g_publish_version_queued_tasks("lake_publish_version_queued_tasks",
                                                                get_num_publish_queued_tasks, nullptr);
 static bvar::PassiveStatus<int> g_publish_version_active_tasks("lake_publish_version_active_tasks",
                                                                get_num_publish_active_tasks, nullptr);
 static bvar::PassiveStatus<int> g_vacuum_queued_tasks("lake_vacuum_queued_tasks", get_num_vacuum_queued_tasks, nullptr);
 static bvar::PassiveStatus<int> g_vacuum_active_tasks("lake_vacuum_active_tasks", get_num_vacuum_active_tasks, nullptr);
-#endif
 
 using BThreadCountDownLatch = GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>;
 

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -87,15 +87,18 @@ static int get_num_vacuum_active_tasks(void*) {
     return tp ? tp->active_threads() : 0;
 }
 
+
+static bvar::Adder<int64_t> g_publish_version_failed_tasks("lake_publish_version_failed_tasks");
+static bvar::LatencyRecorder g_publish_tablet_version_latency("lake_publish_tablet_version");
+static bvar::LatencyRecorder g_publish_tablet_version_queuing_latency("lake_putlish_tablet_version_queuing");
+#ifndef BE_TEST
 static bvar::PassiveStatus<int> g_publish_version_queued_tasks("lake_publish_version_queued_tasks",
                                                                get_num_publish_queued_tasks, nullptr);
 static bvar::PassiveStatus<int> g_publish_version_active_tasks("lake_publish_version_active_tasks",
                                                                get_num_publish_active_tasks, nullptr);
-static bvar::Adder<int64_t> g_publish_version_failed_tasks("lake_publish_version_failed_tasks");
-static bvar::LatencyRecorder g_publish_tablet_version_latency("lake_publish_tablet_version");
-static bvar::LatencyRecorder g_publish_tablet_version_queuing_latency("lake_putlish_tablet_version_queuing");
 static bvar::PassiveStatus<int> g_vacuum_queued_tasks("lake_vacuum_queued_tasks", get_num_vacuum_queued_tasks, nullptr);
 static bvar::PassiveStatus<int> g_vacuum_active_tasks("lake_vacuum_active_tasks", get_num_vacuum_active_tasks, nullptr);
+#endif
 
 using BThreadCountDownLatch = GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>;
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -104,6 +104,7 @@ static bvar::LatencyRecorder g_get_txn_log_latency("lake", "get_txn_log");
 static bvar::LatencyRecorder g_put_txn_log_latency("lake", "put_txn_log");
 static bvar::LatencyRecorder g_del_txn_log_latency("lake", "del_txn_log");
 
+#ifndef BE_TEST
 static Cache* get_metacache() {
     auto mgr = ExecEnv::GetInstance()->lake_tablet_manager();
     return (mgr != nullptr) ? mgr->metacache() : nullptr;
@@ -121,6 +122,7 @@ static size_t get_metacache_usage(void*) {
 
 static bvar::PassiveStatus<size_t> g_metacache_capacity("lake", "metacache_capacity", get_metacache_capacity, nullptr);
 static bvar::PassiveStatus<size_t> g_metacache_usage("lake", "metacache_usage", get_metacache_usage, nullptr);
+#endif
 
 static StatusOr<TabletMetadataPtr> publish(TabletManager* tablet_mgr, Tablet* tablet, int64_t base_version,
                                            int64_t new_version, const int64_t* txns, int txns_size);


### PR DESCRIPTION
Fixes #29133

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
