### PR TITLE
[Enhancement] Keep the number of migration tasks running on be to a fixed number

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -29,12 +29,15 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
 import com.starrocks.catalog.Replica.ReplicaState;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.system.Backend;
+import com.starrocks.task.AgentTaskQueue;
 import com.starrocks.thrift.TPartitionVersionInfo;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTablet;
 import com.starrocks.thrift.TTabletInfo;
+import com.starrocks.thrift.TTaskType;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.PartitionCommitInfo;
 import com.starrocks.transaction.TableCommitInfo;
@@ -190,16 +193,9 @@ public class TabletInvertedIndex {
                                 long partitionId = tabletMeta.getPartitionId();
                                 TStorageMedium storageMedium = storageMediumMap.get(partitionId);
                                 if (storageMedium != null && backendTabletInfo.isSetStorage_medium()) {
-                                    // If storage medium is less than 1, there is no need to send migration tasks to BE.
-                                    // Because BE will ignore this request.
                                     if (storageMedium != backendTabletInfo.getStorage_medium()) {
-                                        if (backendStorageTypeCnt <= 1) {
-                                            LOG.debug("available storage medium type count is less than 1, " +
-                                                            "no need to send migrate task. tabletId={}, backendId={}.",
-                                                            tabletId, backendId);
-                                        } else {
-                                            tabletMigrationMap.put(storageMedium, tabletId);
-                                        }
+                                        addToTabletMigrationMap(backendId, backendStorageTypeCnt, tabletId,
+                                                tabletMeta, tabletMigrationMap, storageMedium);
                                     }
                                     if (storageMedium != tabletMeta.getStorageMedium()) {
                                         tabletMeta.setStorageMedium(storageMedium);
@@ -285,6 +281,54 @@ public class TabletInvertedIndex {
                         + " cost: {} ms", backendId, tabletSyncMap.size(),
                 tabletDeleteFromMeta.size(), foundTabletsWithValidSchema.size(), foundTabletsWithInvalidSchema.size(),
                 tabletMigrationMap.size(), transactionsToClear.size(), transactionsToPublish.size(), (end - start));
+    }
+
+    private void addToTabletMigrationMap(long backendId, long backendStorageTypeCnt, long tabletId,
+                                         TabletMeta tabletMeta, ListMultimap<TStorageMedium, Long> tabletMigrationMap,
+                                         TStorageMedium storageMedium) {
+        // 1. If storage medium is less than 1, there is no need to send migration tasks to BE.
+        // Because BE will ignore this request.
+        if (backendStorageTypeCnt <= 1) {
+            LOG.debug("available storage medium type count is less than 1, " +
+                            "no need to send migrate task. tabletId={}, backendId={}.",
+                    tabletMeta, backendId);
+            return;
+        }
+
+        // 2. If size of tabletMigrationMap exceeds (Config.tablet_sched_max_migration_task_sent_once - running_tasks_on_be),
+        // dot not send more tasks. The number of tasks running on be cannot exceed Config.tablet_sched_max_migration_task_sent_once
+        if (tabletMigrationMap.size() >=
+                Config.tablet_sched_max_migration_task_sent_once
+                        - AgentTaskQueue.getTaskNum(backendId, TTaskType.STORAGE_MEDIUM_MIGRATE, false)) {
+            LOG.debug("size of tabletMigrationMap + size of running tasks on BE is bigger than {}",
+                    Config.tablet_sched_max_migration_task_sent_once);
+            return;
+        }
+
+        // 3. If the task already running on be, do not send again
+        if (AgentTaskQueue.getTask(backendId, TTaskType.STORAGE_MEDIUM_MIGRATE, tabletId) != null) {
+            LOG.debug("migrate of tablet:{} is already running on BE", tabletId);
+            return;
+        }
+
+        //4. If the table is Primary key, do not send
+        Database db = Catalog.getCurrentCatalog().getDb(tabletMeta.getDbId());
+        if (db == null) {
+            return;
+        }
+        db.readLock();
+        try {
+            OlapTable table = (OlapTable) db.getTable(tabletMeta.getTableId());
+            if (table.getKeysType() == KeysType.PRIMARY_KEYS) {
+                LOG.debug("tablet:{} is primary key table, do not support migrate", tabletId);
+                // Currently, primary key table doesn't support tablet migration between local disks.
+                return;
+            }
+        } finally {
+            db.readUnlock();
+        }
+
+        tabletMigrationMap.put(storageMedium, tabletId);
     }
 
     public Long getTabletIdByReplica(long replicaId) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1503,4 +1503,7 @@ public class Config extends ConfigBase {
      */
     @ConfField
     public static String ssl_truststore_password = "";
+
+    @ConfField(mutable = true)
+    public static long tablet_sched_max_migration_task_sent_once = 1000;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -858,6 +858,7 @@ public class ReportHandler extends Daemon {
             }
         }
 
+        AgentTaskQueue.addBatchTask(batchTask);
         AgentTaskExecutor.submit(batchTask);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
@@ -297,7 +297,7 @@ public class AgentTaskQueue {
             }
         }
 
-        LOG.info("get task num with type[{}] in backend[{}]: {}. isFailed: {}",
+        LOG.debug("get task num with type[{}] in backend[{}]: {}. isFailed: {}",
                 type.name(), backendId, taskNum, isFailed);
         return taskNum;
     }


### PR DESCRIPTION
backport #29055

Currently, if there are huge number of tablets to migrate (SSD->HDD or HDD->SSD), FE will send 1000 tasks to BE every 1 minute(tablet report interval), which will cause tasks to pile up on BE, and end up with OOM.
We can use AgentTaskQueue to get the number of task running on BE, and send (Config.tablet_sched_max_migration_task_sent_once - running_tasks) tasks to BE, so that the number of migration tasks running on BE can be kept in a fixed number.