### PR TITLE
[Enhancement] Keep the number of migration tasks running on be to a fixed number

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -298,7 +298,6 @@ public class TabletInvertedIndex {
                 tabletMigrationMap.size(), transactionsToClear.size(), transactionsToPublish.size(), (end - start));
     }
 
-<<<<<<< HEAD
     private void deleteTabletByConsistencyChecker(TabletMeta tabletMeta, long tabletId, long backendId,
                                                   String reason, Set<Long> invalidTablets) {
         if (tabletMeta != null) {
@@ -488,7 +487,7 @@ public class TabletInvertedIndex {
         }
 
         //4. If the table is Primary key, do not send
-        Database db = Catalog.getCurrentCatalog().getDb(tabletMeta.getDbId());
+        Database db = GlobalStateMgr.getCurrentState().getDb(tabletMeta.getDbId());
         if (db == null) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -35,10 +35,12 @@ import com.starrocks.common.Pair;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.system.Backend;
+import com.starrocks.task.AgentTaskQueue;
 import com.starrocks.thrift.TPartitionVersionInfo;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTablet;
 import com.starrocks.thrift.TTabletInfo;
+import com.starrocks.thrift.TTaskType;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.PartitionCommitInfo;
 import com.starrocks.transaction.TableCommitInfo;
@@ -205,16 +207,9 @@ public class TabletInvertedIndex {
                                 long partitionId = tabletMeta.getPartitionId();
                                 TStorageMedium storageMedium = storageMediumMap.get(partitionId);
                                 if (storageMedium != null && backendTabletInfo.isSetStorage_medium()) {
-                                    // If storage medium is less than 1, there is no need to send migration tasks to BE.
-                                    // Because BE will ignore this request.
                                     if (storageMedium != backendTabletInfo.getStorage_medium()) {
-                                        if (backendStorageTypeCnt <= 1) {
-                                            LOG.debug("available storage medium type count is less than 1, " +
-                                                            "no need to send migrate task. tabletId={}, backendId={}.",
-                                                    tabletId, backendId);
-                                        } else {
-                                            tabletMigrationMap.put(storageMedium, tabletId);
-                                        }
+                                        addToTabletMigrationMap(backendId, backendStorageTypeCnt, tabletId,
+                                                tabletMeta, tabletMigrationMap, storageMedium);
                                     }
                                     if (storageMedium != tabletMeta.getStorageMedium()) {
                                         tabletMeta.setStorageMedium(storageMedium);
@@ -303,6 +298,7 @@ public class TabletInvertedIndex {
                 tabletMigrationMap.size(), transactionsToClear.size(), transactionsToPublish.size(), (end - start));
     }
 
+<<<<<<< HEAD
     private void deleteTabletByConsistencyChecker(TabletMeta tabletMeta, long tabletId, long backendId,
                                                   String reason, Set<Long> invalidTablets) {
         if (tabletMeta != null) {
@@ -454,13 +450,61 @@ public class TabletInvertedIndex {
 
         // logging report
         LOG.info("TabletMetaChecker has cleaned {} invalid tablet(s), scanned {} tablet(s) on {} backend(s) in {}ms," +
-                " total tablets in recycle bin: {}, total ignored tablets: {}, up to 20 of ignored tablets: {}, " +
+                        " total tablets in recycle bin: {}, total ignored tablets: {}, up to 20 of ignored tablets: {}, " +
                         "backend tablet count info(format: backend_id=curr_tablet_count:recycle_tablet_count): {}",
                 invalidTablets.size(), scannedTabletCount, backendIds.size(),
                 System.currentTimeMillis() - startTime,
                 backendTabletNumReport.values().stream().mapToLong(p -> p.second).sum(),
                 numIgnoredTabletCausedByAbnormalState, ignoreTablets,
                 backendTabletNumReport);
+    }
+
+    private void addToTabletMigrationMap(long backendId, long backendStorageTypeCnt, long tabletId,
+                                         TabletMeta tabletMeta, ListMultimap<TStorageMedium, Long> tabletMigrationMap,
+                                         TStorageMedium storageMedium) {
+        // 1. If storage medium is less than 1, there is no need to send migration tasks to BE.
+        // Because BE will ignore this request.
+        if (backendStorageTypeCnt <= 1) {
+            LOG.debug("available storage medium type count is less than 1, " +
+                            "no need to send migrate task. tabletId={}, backendId={}.",
+                    tabletMeta, backendId);
+            return;
+        }
+
+        // 2. If size of tabletMigrationMap exceeds (Config.tablet_sched_max_migration_task_sent_once - running_tasks_on_be),
+        // dot not send more tasks. The number of tasks running on be cannot exceed Config.tablet_sched_max_migration_task_sent_once
+        if (tabletMigrationMap.size() >=
+                Config.tablet_sched_max_migration_task_sent_once
+                        - AgentTaskQueue.getTaskNum(backendId, TTaskType.STORAGE_MEDIUM_MIGRATE, false)) {
+            LOG.debug("size of tabletMigrationMap + size of running tasks on BE is bigger than {}",
+                    Config.tablet_sched_max_migration_task_sent_once);
+            return;
+        }
+
+        // 3. If the task already running on be, do not send again
+        if (AgentTaskQueue.getTask(backendId, TTaskType.STORAGE_MEDIUM_MIGRATE, tabletId) != null) {
+            LOG.debug("migrate of tablet:{} is already running on BE", tabletId);
+            return;
+        }
+
+        //4. If the table is Primary key, do not send
+        Database db = Catalog.getCurrentCatalog().getDb(tabletMeta.getDbId());
+        if (db == null) {
+            return;
+        }
+        db.readLock();
+        try {
+            OlapTable table = (OlapTable) db.getTable(tabletMeta.getTableId());
+            if (table.getKeysType() == KeysType.PRIMARY_KEYS) {
+                LOG.debug("tablet:{} is primary key table, do not support migrate", tabletId);
+                // Currently, primary key table doesn't support tablet migration between local disks.
+                return;
+            }
+        } finally {
+            db.readUnlock();
+        }
+
+        tabletMigrationMap.put(storageMedium, tabletId);
     }
 
     public Long getTabletIdByReplica(long replicaId) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1591,4 +1591,7 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static int quorom_publish_wait_time_ms = 500;
+
+    @ConfField(mutable = true)
+    public static long tablet_sched_max_migration_task_sent_once = 1000;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -848,14 +848,14 @@ public class MasterImpl {
 
             TTabletInfo reportedTablet = request.getFinish_tablet_infos().get(0);
             long tabletId = reportedTablet.getTablet_id();
-            TabletMeta tabletMeta = Catalog.getCurrentInvertedIndex().getTabletMeta(tabletId);
+            TabletMeta tabletMeta = GlobalStateMgr.getCurrentInvertedIndex().getTabletMeta(tabletId);
             if (tabletMeta == null) {
                 LOG.warn("tablet meta does not exist. tablet id: {}", tabletId);
                 return;
             }
 
             long dbId = tabletMeta.getDbId();
-            Database db = Catalog.getCurrentCatalog().getDb(dbId);
+            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
             if (db == null) {
                 LOG.warn("db does not exist. db id: {}", dbId);
                 return;
@@ -864,7 +864,7 @@ public class MasterImpl {
             db.writeLock();
             try {
                 // local migration just set path hash
-                Replica replica = Catalog.getCurrentInvertedIndex().getReplica(tabletId, task.getBackendId());
+                Replica replica = GlobalStateMgr.getCurrentInvertedIndex().getReplica(tabletId, task.getBackendId());
                 Preconditions.checkArgument(reportedTablet.isSetPath_hash());
                 replica.setPathHash(reportedTablet.getPath_hash());
             } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/MasterImpl.java
@@ -198,9 +198,7 @@ public class MasterImpl {
                 errorMsgs.add(errMsg);
                 tStatus.setError_msgs(errorMsgs);
             }
-            if (taskType != TTaskType.STORAGE_MEDIUM_MIGRATE) {
-                return result;
-            }
+            return result;
         } else {
             if (taskStatus.getStatus_code() != TStatusCode.OK) {
                 task.failed();
@@ -211,7 +209,8 @@ public class MasterImpl {
                 if (taskType != TTaskType.MAKE_SNAPSHOT && taskType != TTaskType.UPLOAD
                         && taskType != TTaskType.DOWNLOAD && taskType != TTaskType.MOVE
                         && taskType != TTaskType.CLONE && taskType != TTaskType.PUBLISH_VERSION
-                        && taskType != TTaskType.CREATE && taskType != TTaskType.UPDATE_TABLET_META_INFO) {
+                        && taskType != TTaskType.CREATE && taskType != TTaskType.UPDATE_TABLET_META_INFO
+                        && taskType != TTaskType.STORAGE_MEDIUM_MIGRATE) {
                     return result;
                 }
             }
@@ -258,7 +257,7 @@ public class MasterImpl {
                     finishClone(task, request);
                     break;
                 case STORAGE_MEDIUM_MIGRATE:
-                    finishStorageMigration(backendId, request);
+                    finishStorageMigration(task, request);
                     break;
                 case CHECK_CONSISTENCY:
                     finishConsistenctCheck(task, request);
@@ -832,43 +831,47 @@ public class MasterImpl {
         AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.CLONE, task.getSignature());
     }
 
-    private void finishStorageMigration(long backendId, TFinishTaskRequest request) {
-        // check if task success
-        if (request.getTask_status().getStatus_code() != TStatusCode.OK) {
-            LOG.warn("tablet migrate failed. signature: {}, error msg: {}", request.getSignature(),
-                    request.getTask_status().error_msgs);
-            return;
-        }
-
-        // check tablet info is set
-        if (!request.isSetFinish_tablet_infos() || request.getFinish_tablet_infos().isEmpty()) {
-            LOG.warn("migration finish tablet infos not set. signature: {}", request.getSignature());
-            return;
-        }
-
-        TTabletInfo reportedTablet = request.getFinish_tablet_infos().get(0);
-        long tabletId = reportedTablet.getTablet_id();
-        TabletMeta tabletMeta = GlobalStateMgr.getCurrentInvertedIndex().getTabletMeta(tabletId);
-        if (tabletMeta == null) {
-            LOG.warn("tablet meta does not exist. tablet id: {}", tabletId);
-            return;
-        }
-
-        long dbId = tabletMeta.getDbId();
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
-        if (db == null) {
-            LOG.warn("db does not exist. db id: {}", dbId);
-            return;
-        }
-
-        db.writeLock();
+    private void finishStorageMigration(AgentTask task, TFinishTaskRequest request) {
         try {
-            // local migration just set path hash
-            Replica replica = GlobalStateMgr.getCurrentInvertedIndex().getReplica(tabletId, backendId);
-            Preconditions.checkArgument(reportedTablet.isSetPath_hash());
-            replica.setPathHash(reportedTablet.getPath_hash());
+            // check if task success
+            if (request.getTask_status().getStatus_code() != TStatusCode.OK) {
+                LOG.warn("tablet migrate failed. signature: {}, error msg: {}", request.getSignature(),
+                        request.getTask_status().error_msgs);
+                return;
+            }
+
+            // check tablet info is set
+            if (!request.isSetFinish_tablet_infos() || request.getFinish_tablet_infos().isEmpty()) {
+                LOG.warn("migration finish tablet infos not set. signature: {}", request.getSignature());
+                return;
+            }
+
+            TTabletInfo reportedTablet = request.getFinish_tablet_infos().get(0);
+            long tabletId = reportedTablet.getTablet_id();
+            TabletMeta tabletMeta = Catalog.getCurrentInvertedIndex().getTabletMeta(tabletId);
+            if (tabletMeta == null) {
+                LOG.warn("tablet meta does not exist. tablet id: {}", tabletId);
+                return;
+            }
+
+            long dbId = tabletMeta.getDbId();
+            Database db = Catalog.getCurrentCatalog().getDb(dbId);
+            if (db == null) {
+                LOG.warn("db does not exist. db id: {}", dbId);
+                return;
+            }
+
+            db.writeLock();
+            try {
+                // local migration just set path hash
+                Replica replica = Catalog.getCurrentInvertedIndex().getReplica(tabletId, task.getBackendId());
+                Preconditions.checkArgument(reportedTablet.isSetPath_hash());
+                replica.setPathHash(reportedTablet.getPath_hash());
+            } finally {
+                db.writeUnlock();
+            }
         } finally {
-            db.writeUnlock();
+            AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.STORAGE_MEDIUM_MIGRATE, task.getSignature());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/master/ReportHandler.java
@@ -909,6 +909,7 @@ public class ReportHandler extends Daemon {
             }
         }
 
+        AgentTaskQueue.addBatchTask(batchTask);
         AgentTaskExecutor.submit(batchTask);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
@@ -297,7 +297,7 @@ public class AgentTaskQueue {
             }
         }
 
-        LOG.info("get task num with type[{}] in backend[{}]: {}. isFailed: {}",
+        LOG.debug("get task num with type[{}] in backend[{}]: {}. isFailed: {}",
                 type.name(), backendId, taskNum, isFailed);
         return taskNum;
     }


### PR DESCRIPTION
backport #29055

Currently, if there are huge number of tablets to migrate (SSD->HDD or HDD->SSD), FE will send 1000 tasks to BE every 1 minute(tablet report interval), which will cause tasks to pile up on BE, and end up with OOM.
We can use AgentTaskQueue to get the number of task running on BE, and send (Config.tablet_sched_max_migration_task_sent_once - running_tasks) tasks to BE, so that the number of migration tasks running on BE can be kept in a fixed number.