### PR TITLE
[BugFix] fix partial update by column not work in broker load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -139,6 +139,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     protected String timezone = TimeUtils.DEFAULT_TIME_ZONE;
     @SerializedName("p")
     protected boolean partialUpdate = false;
+    @SerializedName("pum")
     protected String partialUpdateMode = "row";
     @SerializedName("pr")
     protected int priority = LoadPriority.NORMAL_VALUE;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -144,6 +144,7 @@ public class LoadLoadingTask extends LoadTask {
             loadPlanner = new LoadPlanner(callback.getCallbackId(), loadId, txnId, db.getId(), table, strictMode,
                     timezone, timeoutS, createTimestamp, partialUpdate, context, sessionVariables, execMemLimit, execMemLimit,
                     brokerDesc, fileGroups, fileStatusList, fileNum);
+            loadPlanner.setPartialUpdateMode(partialUpdateMode);
             loadPlanner.plan();
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
@@ -52,6 +52,7 @@ import com.starrocks.thrift.TExpr;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TOpType;
+import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TPlanFragment;
 import com.starrocks.thrift.TPlanNode;
 import com.starrocks.thrift.TPlanNodeType;
@@ -1064,6 +1065,23 @@ public class LoadPlannerTest {
             // check fragment
             List<PlanFragment> fragments = planner.getFragments();
             Assert.assertEquals(1, fragments.size());
+        }
+        {
+            // set partial update mode
+            LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                    timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                    brokerDesc, fileGroups, fileStatusesList, 1);
+            planner.setPartialUpdateMode(TPartialUpdateMode.COLUMN_UPSERT_MODE);
+            planner.plan();
+        }
+        {
+            // complete table sink
+            LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
+                    timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
+                    brokerDesc, fileGroups, fileStatusesList, 1);
+            planner.setPartialUpdateMode(TPartialUpdateMode.COLUMN_UPSERT_MODE);
+            planner.plan();
+            planner.completeTableSink(100);
         }
     }
 }


### PR DESCRIPTION
If we want to use partial update by column in broker load, set `partial_update_mode` to column.
```
LOAD LABEL test_db.table4
(
    data infile("hdfs://<hdfs_host>:<hdfs_port>/example4.csv")
    into table table4
    format as "csv"
    (id, name)
)
with broker
properties
(
    "partial_update" = "true",
    "partial_update_mode" = "column"
);
```
But it doesn't work when `enable_pipeline_load` = true. 

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
