### PR TITLE
[BugFix] Fix the array_contains_all crash in asan mode

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -346,7 +346,7 @@ private:
         if (array->is_nullable()) {
             auto nullable = down_cast<const NullableColumn*>(array.get());
             auto array_col = down_cast<const ArrayColumn*>(nullable->data_column().get());
-            ASSIGN_OR_RETURN(auto result, _array_remove_non_nullable(*array_col, *target));
+            ASSIGN_OR_RETURN(auto result, _array_remove_non_nullable(*array_col, *target))
             DCHECK_EQ(nullable->size(), result->size());
             return NullableColumn::create(std::move(result), nullable->null_column());
         }
@@ -669,7 +669,7 @@ private:
         if (array.is_nullable()) {
             auto nullable = down_cast<const NullableColumn*>(&array);
             auto array_col = down_cast<const ArrayColumn*>(nullable->data_column().get());
-            ASSIGN_OR_RETURN(auto result, _array_contains_non_nullable(*array_col, target));
+            ASSIGN_OR_RETURN(auto result, _array_contains_non_nullable(*array_col, target))
             DCHECK_EQ(nullable->size(), result->size());
             if (!nullable->has_null()) {
                 return result;
@@ -697,9 +697,6 @@ private:
                                                      std::is_same_v<MapColumn, ElementColumn> ||
                                                      std::is_same_v<StructColumn, ElementColumn>,
                                              uint8_t, typename ElementColumn::ValueType>;
-
-        [[maybe_unused]] auto elements_ptr = (const ValueType*)(elements.raw_data());
-        [[maybe_unused]] auto targets_ptr = (const ValueType*)(targets.raw_data());
 
         [[maybe_unused]] auto is_null = [](const NullColumn::Container* null_map, size_t idx) -> bool {
             return (*null_map)[idx] != 0;
@@ -744,6 +741,8 @@ private:
                               std::is_same_v<JsonColumn, ElementColumn>) {
                     found = (elements.equals(j, targets, i) == 1);
                 } else {
+                    auto elements_ptr = (const ValueType*)(elements.raw_data());
+                    auto targets_ptr = (const ValueType*)(targets.raw_data());
                     found = (elements_ptr[j] == targets_ptr[i]);
                 }
                 if (found) {
@@ -947,7 +946,7 @@ private:
             return _array_has_non_nullable(*array_col, *target_col);
         }
 
-        ASSIGN_OR_RETURN(auto result, _array_has_non_nullable(*array_col, *target_col));
+        ASSIGN_OR_RETURN(auto result, _array_has_non_nullable(*array_col, *target_col))
         DCHECK_EQ(array_col->size(), result->size());
         return NullableColumn::create(std::move(result), merge_nullcolum(array_nullable, target_nullable));
     }


### PR DESCRIPTION
Fixes https://github.com/StarRocks/StarRocksTest/issues/3488

```
*** Aborted at 1691983217 (unix time) try "date -d @1691983217" if you are using GNU date ***
PC: @     0x7face2ed9387 __GI_raise
*** SIGABRT (@0x3e8000009b7) received by PID 2487 (TID 0x7fac796fe700) from PID 2487; stack trace: ***
    @         0x146e2a12 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7face398e630 (unknown)
    @     0x7face2ed9387 __GI_raise
    @     0x7face2edaa78 __GI_abort
    @          0x9c17fbb starrocks::failure_function()
    @         0x146d63ed google::LogMessage::Fail()
    @         0x146d885f google::LogMessage::SendToLog()
    @         0x146d5f3e google::LogMessage::Flush()
    @         0x146d8e69 google::LogMessageFatal::~LogMessageFatal()
    @          0xb4a910f starrocks::MapColumn::raw_data()
    @         0x135a6554 starrocks::ArrayHasImpl<>::__process<>()
    @         0x1358c53b starrocks::ArrayHasImpl<>::_process<>()
    @         0x134e8b71 starrocks::ArrayHasImpl<>::_array_has<>()
    @         0x134bdc18 starrocks::ArrayHasImpl<>::_array_has_non_nullable()
    @         0x134b1fdc starrocks::ArrayHasImpl<>::_array_has_generic()
    @         0x13469c46 starrocks::ArrayHasImpl<>::evaluate()
    @         0x134520ee starrocks::ArrayFunctions::array_contains_all()
    @         0x108285f4 starrocks::VectorizedFunctionCallExpr::evaluate_checked()
    @          0xf507172 starrocks::ExprContext::evaluate()
    @          0xf5069a7 starrocks::ExprContext::evaluate()
    @          0xc3997a8 starrocks::pipeline::ProjectOperator::push_chunk()
    @          0xc6fd6a4 starrocks::pipeline::PipelineDriver::process()
    @          0xc6c2a60 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xc6c149c _ZZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiENKUlvE_clEv
    @          0xc6cbb36 _ZSt13__invoke_implIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_JEET_St14__invoke_otherOT0_DpOT1_
    @          0xc6cb02f _ZSt10__invoke_rIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES6_E4typeEOS7_DpOS8_
    @          0xc6ca200 _ZNSt17_Function_handlerIFvvEZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_E9_M_invokeERKSt9_Any_data
    @          0x9b06d96 std::function<>::operator()()
    @          0xa5549b2 starrocks::FunctionRunnable::run()
    @          0xa551471 starrocks::ThreadPool::dispatch_thread()
    @          0xa56e2a4 std::__invoke_impl<>()
    @          0xa56dd8f std::__invoke<>()
```

```
F0814 15:11:50.687348 190676 map_column.cpp:60] Check failed: false Don't support map column raw_data
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
