### PR TITLE
[BugFix] Fix the array_contains_all crash in asan mode (#29170)

### DIFF
--- a/be/src/exprs/vectorized/array_functions.cpp
+++ b/be/src/exprs/vectorized/array_functions.cpp
@@ -663,9 +663,6 @@ private:
                            const NullColumn::Container* null_map_targets) {
         using ValueType = std::conditional_t<std::is_same_v<ArrayColumn, ElementColumn>, uint8_t,
                                              typename ElementColumn::ValueType>;
-        [[maybe_unused]] auto elements_ptr = (const ValueType*)(elements.raw_data());
-        [[maybe_unused]] auto targets_ptr = (const ValueType*)(targets.raw_data());
-
         [[maybe_unused]] auto is_null = [](const NullColumn::Container* null_map, size_t idx) -> bool {
             return (*null_map)[idx] != 0;
         };
@@ -707,6 +704,8 @@ private:
                 if constexpr (std::is_same_v<ArrayColumn, ElementColumn>) {
                     found = (elements.compare_at(j, i, targets, -1) == 0);
                 } else {
+                    auto elements_ptr = (const ValueType*)(elements.raw_data());
+                    auto targets_ptr = (const ValueType*)(targets.raw_data());
                     found = (elements_ptr[j] == targets_ptr[i]);
                 }
                 if (found) {


### PR DESCRIPTION
Fixes https://github.com/StarRocks/StarRocksTest/issues/3488

```
*** Aborted at 1691983217 (unix time) try "date -d @1691983217" if you are using GNU date ***
PC: @     0x7face2ed9387 __GI_raise
*** SIGABRT (@0x3e8000009b7) received by PID 2487 (TID 0x7fac796fe700) from PID 2487; stack trace: ***
    @         0x146e2a12 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7face398e630 (unknown)
    @     0x7face2ed9387 __GI_raise
    @     0x7face2edaa78 __GI_abort
    @          0x9c17fbb starrocks::failure_function()
    @         0x146d63ed google::LogMessage::Fail()
    @         0x146d885f google::LogMessage::SendToLog()
    @         0x146d5f3e google::LogMessage::Flush()
    @         0x146d8e69 google::LogMessageFatal::~LogMessageFatal()
    @          0xb4a910f starrocks::MapColumn::raw_data()
    @         0x135a6554 starrocks::ArrayHasImpl<>::__process<>()
    @         0x1358c53b starrocks::ArrayHasImpl<>::_process<>()
    @         0x134e8b71 starrocks::ArrayHasImpl<>::_array_has<>()
    @         0x134bdc18 starrocks::ArrayHasImpl<>::_array_has_non_nullable()
    @         0x134b1fdc starrocks::ArrayHasImpl<>::_array_has_generic()
    @         0x13469c46 starrocks::ArrayHasImpl<>::evaluate()
    @         0x134520ee starrocks::ArrayFunctions::array_contains_all()
    @         0x108285f4 starrocks::VectorizedFunctionCallExpr::evaluate_checked()
    @          0xf507172 starrocks::ExprContext::evaluate()
    @          0xf5069a7 starrocks::ExprContext::evaluate()
    @          0xc3997a8 starrocks::pipeline::ProjectOperator::push_chunk()
    @          0xc6fd6a4 starrocks::pipeline::PipelineDriver::process()
    @          0xc6c2a60 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xc6c149c _ZZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiENKUlvE_clEv
    @          0xc6cbb36 _ZSt13__invoke_implIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_JEET_St14__invoke_otherOT0_DpOT1_
    @          0xc6cb02f _ZSt10__invoke_rIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES6_E4typeEOS7_DpOS8_
    @          0xc6ca200 _ZNSt17_Function_handlerIFvvEZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_E9_M_invokeERKSt9_Any_data
    @          0x9b06d96 std::function<>::operator()()
    @          0xa5549b2 starrocks::FunctionRunnable::run()
    @          0xa551471 starrocks::ThreadPool::dispatch_thread()
    @          0xa56e2a4 std::__invoke_impl<>()
    @          0xa56dd8f std::__invoke<>()
```

```
F0814 15:11:50.687348 190676 map_column.cpp:60] Check failed: false Don't support map column raw_data
```