### PR TITLE
[BugFix] fix partial update char column miss padding

### DIFF
--- a/test/sql/test_partial_update_column_mode/R/test_partial_update_char_padding
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update_char_padding
@@ -1,0 +1,92 @@
+-- name: test_partial_update_char_padding
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      v1 CHAR(20),
+      v2 VARCHAR(20),
+      v3 CHAR(20)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+set partial_update_mode = "column";
+-- result:
+-- !result
+insert into tab1 values (1, 'aaa', 'aaa', 'aaa'), 
+(2, 'aaa', 'aaa', 'aaa'), 
+(3, 'aaa', 'aaa', 'aaa'), 
+(4, 'aaa', 'aaa', 'aaa');
+-- result:
+-- !result
+select * from tab1;
+-- result:
+2	aaa	aaa	aaa
+1	aaa	aaa	aaa
+4	aaa	aaa	aaa
+3	aaa	aaa	aaa
+-- !result
+update tab1 set v1 = 'bbb' where k1 = 2;
+-- result:
+-- !result
+select * from tab1;
+-- result:
+1	aaa	aaa	aaa
+4	aaa	aaa	aaa
+3	aaa	aaa	aaa
+2	bbb	aaa	aaa
+-- !result
+select * from tab1 where v1 = 'bbb';
+-- result:
+2	bbb	aaa	aaa
+-- !result
+select * from tab1 where v1 <> 'bbb';
+-- result:
+4	aaa	aaa	aaa
+1	aaa	aaa	aaa
+3	aaa	aaa	aaa
+-- !result
+update tab1 set v2 = 'bbb' where k1 = 3;
+-- result:
+-- !result
+select * from tab1;
+-- result:
+1	aaa	aaa	aaa
+3	aaa	bbb	aaa
+2	bbb	aaa	aaa
+4	aaa	aaa	aaa
+-- !result
+select * from tab1 where v2 = 'bbb';
+-- result:
+3	aaa	bbb	aaa
+-- !result
+select * from tab1 where v2 <> 'bbb';
+-- result:
+2	bbb	aaa	aaa
+4	aaa	aaa	aaa
+1	aaa	aaa	aaa
+-- !result
+update tab1 set v3 = 'bbb' where k1 = 4;
+-- result:
+-- !result
+select * from tab1;
+-- result:
+1	aaa	aaa	aaa
+2	bbb	aaa	aaa
+3	aaa	bbb	aaa
+4	aaa	aaa	bbb
+-- !result
+select * from tab1 where v3 = 'bbb';
+-- result:
+4	aaa	aaa	bbb
+-- !result
+select * from tab1 where v3 <> 'bbb';
+-- result:
+1	aaa	aaa	aaa
+2	bbb	aaa	aaa
+3	aaa	bbb	aaa
+-- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update_char_padding
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update_char_padding
@@ -1,0 +1,32 @@
+-- name: test_partial_update_char_padding
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      v1 CHAR(20),
+      v2 VARCHAR(20),
+      v3 CHAR(20)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1"
+);
+set partial_update_mode = "column";
+insert into tab1 values (1, 'aaa', 'aaa', 'aaa'), 
+(2, 'aaa', 'aaa', 'aaa'), 
+(3, 'aaa', 'aaa', 'aaa'), 
+(4, 'aaa', 'aaa', 'aaa');
+select * from tab1;
+update tab1 set v1 = 'bbb' where k1 = 2;
+select * from tab1;
+select * from tab1 where v1 = 'bbb';
+select * from tab1 where v1 <> 'bbb';
+update tab1 set v2 = 'bbb' where k1 = 3;
+select * from tab1;
+select * from tab1 where v2 = 'bbb';
+select * from tab1 where v2 <> 'bbb';
+update tab1 set v3 = 'bbb' where k1 = 4;
+select * from tab1;
+select * from tab1 where v3 = 'bbb';
+select * from tab1 where v3 <> 'bbb';


### PR DESCRIPTION
When partial update char column using column mode, miss padding, fix this. e,g:
```
CREATE table tab1 (
      k1 INTEGER,
      v1 CHAR(20),
      v2 VARCHAR(20),
      v3 CHAR(20)
)
ENGINE=OLAP
PRIMARY KEY(`k1`)
DISTRIBUTED BY HASH(`k1`) BUCKETS 10
PROPERTIES (
    "replication_num" = "1"
);
set partial_update_mode = "column";
insert into tab1 values (1, 'aaa', 'aaa', 'aaa'), 
(2, 'aaa', 'aaa', 'aaa'), 
(3, 'aaa', 'aaa', 'aaa'), 
(4, 'aaa', 'aaa', 'aaa');
select * from tab1;
update tab1 set v1 = 'bbb' where k1 = 2;
select * from tab1 where v1 <> 'bbb';
# result should only contains three rows, but all rows return
-- unexpect result:
1	aaa	aaa	aaa
4	aaa	aaa	aaa
3	aaa	aaa	aaa
2	bbb	aaa	aaa
```
Fixes #20436

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
