### PR TITLE
[Enhancement] Keep the number of migration tasks running on be to a fixed number

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -55,7 +55,6 @@ public class Replica implements Writable {
     public static final VersionComparator<Replica> VERSION_DESC_COMPARATOR = new VersionComparator<Replica>();
 
     public static final int DEPRECATED_PROP_SCHEMA_HASH = 0;
-    public static final int DEPRECATED_PROP_PATH_HASH = 0;
 
     public enum ReplicaState {
         NORMAL,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -50,10 +50,12 @@ import com.starrocks.lake.LakeTablet;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.system.Backend;
+import com.starrocks.task.AgentTaskQueue;
 import com.starrocks.thrift.TPartitionVersionInfo;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TTablet;
 import com.starrocks.thrift.TTabletInfo;
+import com.starrocks.thrift.TTaskType;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.PartitionCommitInfo;
 import com.starrocks.transaction.TableCommitInfo;
@@ -208,17 +210,9 @@ public class TabletInvertedIndex {
                             long partitionId = tabletMeta.getPartitionId();
                             TStorageMedium storageMedium = storageMediumMap.get(partitionId);
                             if (storageMedium != null && backendTabletInfo.isSetStorage_medium()) {
-                                // If storage medium is less than 1, there is no need to send migration tasks to BE.
-                                // Because BE will ignore this request.
                                 if (storageMedium != backendTabletInfo.getStorage_medium()) {
-                                    if (backendStorageTypeCnt <= 1) {
-                                        LOG.debug("available storage medium type count is less than 1, " +
-                                                        "no need to send migrate task. tabletId={}, backendId={}.",
-                                                tabletId, backendId);
-                                    } else if (tabletMigrationMap.size() <=
-                                            Config.tablet_sched_max_migration_task_sent_once) {
-                                        tabletMigrationMap.put(storageMedium, tabletId);
-                                    }
+                                    addToTabletMigrationMap(backendId, backendStorageTypeCnt, tabletId,
+                                            tabletMeta, tabletMigrationMap, storageMedium);
                                 }
                                 if (storageMedium != tabletMeta.getStorageMedium()) {
                                     tabletMeta.setStorageMedium(storageMedium);
@@ -304,6 +298,54 @@ public class TabletInvertedIndex {
                         + " cost: {} ms", backendId, tabletSyncMap.size(),
                 tabletDeleteFromMeta.size(), foundTabletsWithValidSchema.size(), foundTabletsWithInvalidSchema.size(),
                 tabletMigrationMap.size(), transactionsToClear.size(), transactionsToPublish.size(), (end - start));
+    }
+
+    private void addToTabletMigrationMap(long backendId, long backendStorageTypeCnt, long tabletId,
+                                         TabletMeta tabletMeta, ListMultimap<TStorageMedium, Long> tabletMigrationMap,
+                                         TStorageMedium storageMedium) {
+        // 1. If storage medium is less than 1, there is no need to send migration tasks to BE.
+        // Because BE will ignore this request.
+        if (backendStorageTypeCnt <= 1) {
+            LOG.debug("available storage medium type count is less than 1, " +
+                            "no need to send migrate task. tabletId={}, backendId={}.",
+                    tabletMeta, backendId);
+            return;
+        }
+
+        // 2. If size of tabletMigrationMap exceeds (Config.tablet_sched_max_migration_task_sent_once - running_tasks_on_be),
+        // dot not send more tasks. The number of tasks running on be cannot exceed Config.tablet_sched_max_migration_task_sent_once
+        if (tabletMigrationMap.size() >=
+                Config.tablet_sched_max_migration_task_sent_once
+                        - AgentTaskQueue.getTaskNum(backendId, TTaskType.STORAGE_MEDIUM_MIGRATE, false)) {
+            LOG.debug("size of tabletMigrationMap + size of running tasks on BE is bigger than {}",
+                    Config.tablet_sched_max_migration_task_sent_once);
+            return;
+        }
+
+        // 3. If the task already running on be, do not send again
+        if (AgentTaskQueue.getTask(backendId, TTaskType.STORAGE_MEDIUM_MIGRATE, tabletId) != null) {
+            LOG.debug("migrate of tablet:{} is already running on BE", tabletId);
+            return;
+        }
+
+        //4. If the table is Primary key, do not send
+        Database db = GlobalStateMgr.getCurrentState().getDb(tabletMeta.getDbId());
+        if (db == null) {
+            return;
+        }
+        db.readLock();
+        try {
+            OlapTable table = (OlapTable) db.getTable(tabletMeta.getTableId());
+            if (table.getKeysType() == KeysType.PRIMARY_KEYS) {
+                LOG.debug("tablet:{} is primary key table, do not support migrate", tabletId);
+                // Currently, primary key table doesn't support tablet migration between local disks.
+                return;
+            }
+        } finally {
+            db.readUnlock();
+        }
+
+        tabletMigrationMap.put(storageMedium, tabletId);
     }
 
     private void deleteTabletByConsistencyChecker(TabletMeta tabletMeta, long tabletId, long backendId,

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LocalTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LocalTabletsProcDir.java
@@ -157,7 +157,7 @@ public class LocalTabletsProcDir implements ProcDirInterface {
                         tabletInfo.add(localTablet.getCheckedVersion());
                         tabletInfo.add(0);
                         tabletInfo.add(replica.getVersionCount());
-                        tabletInfo.add(Replica.DEPRECATED_PROP_PATH_HASH);
+                        tabletInfo.add(replica.getPathHash());
                         Backend backend = backendMap.get(replica.getBackendId());
                         String metaUrl;
                         String compactionUrl;

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -212,9 +212,7 @@ public class LeaderImpl {
                 errorMsgs.add(errMsg);
                 tStatus.setError_msgs(errorMsgs);
             }
-            if (taskType != TTaskType.STORAGE_MEDIUM_MIGRATE) {
-                return result;
-            }
+            return result;
         } else {
             if (taskStatus.getStatus_code() != TStatusCode.OK) {
                 task.failed();
@@ -226,7 +224,21 @@ public class LeaderImpl {
                         && taskType != TTaskType.DOWNLOAD && taskType != TTaskType.MOVE
                         && taskType != TTaskType.CLONE && taskType != TTaskType.PUBLISH_VERSION
                         && taskType != TTaskType.CREATE && taskType != TTaskType.UPDATE_TABLET_META_INFO
-                        && taskType != TTaskType.DROP_AUTO_INCREMENT_MAP) {
+                        && taskType != TTaskType.DROP_AUTO_INCREMENT_MAP
+                        && taskType != TTaskType.STORAGE_MEDIUM_MIGRATE) {
+                    if (taskType == TTaskType.REALTIME_PUSH) {
+                        PushTask pushTask = (PushTask) task;
+                        if (pushTask.getPushType() == TPushType.DELETE) {
+                            LOG.info("remove push replica. tabletId: {}, backendId: {}", task.getSignature(),
+                                     pushTask.getBackendId());
+
+                            String failMsg = "Backend: " + task.getBackendId() + "Tablet: " + pushTask.getTabletId() +
+                                             " error msg: " + taskStatus.getError_msgs().toString();
+                            pushTask.countDownLatch(pushTask.getBackendId(), pushTask.getTabletId(), failMsg);
+                            AgentTaskQueue.removeTask(pushTask.getBackendId(), TTaskType.REALTIME_PUSH, 
+                                                      task.getSignature());
+                        }
+                    }
                     return result;
                 }
             }
@@ -260,7 +272,7 @@ public class LeaderImpl {
                     finishClone(task, request);
                     break;
                 case STORAGE_MEDIUM_MIGRATE:
-                    finishStorageMigration(backendId, request);
+                    finishStorageMigration(task, request);
                     break;
                 case CHECK_CONSISTENCY:
                     finishConsistenctCheck(task, request);
@@ -691,43 +703,47 @@ public class LeaderImpl {
         AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.CLONE, task.getSignature());
     }
 
-    private void finishStorageMigration(long backendId, TFinishTaskRequest request) {
-        // check if task success
-        if (request.getTask_status().getStatus_code() != TStatusCode.OK) {
-            LOG.warn("tablet migrate failed. signature: {}, error msg: {}", request.getSignature(),
-                    request.getTask_status().error_msgs);
-            return;
-        }
-
-        // check tablet info is set
-        if (!request.isSetFinish_tablet_infos() || request.getFinish_tablet_infos().isEmpty()) {
-            LOG.warn("migration finish tablet infos not set. signature: {}", request.getSignature());
-            return;
-        }
-
-        TTabletInfo reportedTablet = request.getFinish_tablet_infos().get(0);
-        long tabletId = reportedTablet.getTablet_id();
-        TabletMeta tabletMeta = GlobalStateMgr.getCurrentInvertedIndex().getTabletMeta(tabletId);
-        if (tabletMeta == null) {
-            LOG.warn("tablet meta does not exist. tablet id: {}", tabletId);
-            return;
-        }
-
-        long dbId = tabletMeta.getDbId();
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
-        if (db == null) {
-            LOG.warn("db does not exist. db id: {}", dbId);
-            return;
-        }
-
-        db.writeLock();
+    private void finishStorageMigration(AgentTask task, TFinishTaskRequest request) {
         try {
-            // local migration just set path hash
-            Replica replica = GlobalStateMgr.getCurrentInvertedIndex().getReplica(tabletId, backendId);
-            Preconditions.checkArgument(reportedTablet.isSetPath_hash());
-            replica.setPathHash(reportedTablet.getPath_hash());
+            // check if task success
+            if (request.getTask_status().getStatus_code() != TStatusCode.OK) {
+                LOG.warn("tablet migrate failed. signature: {}, error msg: {}", request.getSignature(),
+                        request.getTask_status().error_msgs);
+                return;
+            }
+
+            // check tablet info is set
+            if (!request.isSetFinish_tablet_infos() || request.getFinish_tablet_infos().isEmpty()) {
+                LOG.warn("migration finish tablet infos not set. signature: {}", request.getSignature());
+                return;
+            }
+
+            TTabletInfo reportedTablet = request.getFinish_tablet_infos().get(0);
+            long tabletId = reportedTablet.getTablet_id();
+            TabletMeta tabletMeta = GlobalStateMgr.getCurrentInvertedIndex().getTabletMeta(tabletId);
+            if (tabletMeta == null) {
+                LOG.warn("tablet meta does not exist. tablet id: {}", tabletId);
+                return;
+            }
+
+            long dbId = tabletMeta.getDbId();
+            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            if (db == null) {
+                LOG.warn("db does not exist. db id: {}", dbId);
+                return;
+            }
+
+            db.writeLock();
+            try {
+                // local migration just set path hash
+                Replica replica = GlobalStateMgr.getCurrentInvertedIndex().getReplica(tabletId, task.getBackendId());
+                Preconditions.checkArgument(reportedTablet.isSetPath_hash());
+                replica.setPathHash(reportedTablet.getPath_hash());
+            } finally {
+                db.writeUnlock();
+            }
         } finally {
-            db.writeUnlock();
+            AgentTaskQueue.removeTask(task.getBackendId(), TTaskType.STORAGE_MEDIUM_MIGRATE, task.getSignature());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -234,7 +234,7 @@ public class LeaderImpl {
 
                             String failMsg = "Backend: " + task.getBackendId() + "Tablet: " + pushTask.getTabletId() +
                                              " error msg: " + taskStatus.getError_msgs().toString();
-                            pushTask.countDownLatch(pushTask.getBackendId(), pushTask.getTabletId(), failMsg);
+                            pushTask.countDownLatch(pushTask.getBackendId(), pushTask.getTabletId());
                             AgentTaskQueue.removeTask(pushTask.getBackendId(), TTaskType.REALTIME_PUSH, 
                                                       task.getSignature());
                         }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -226,19 +226,6 @@ public class LeaderImpl {
                         && taskType != TTaskType.CREATE && taskType != TTaskType.UPDATE_TABLET_META_INFO
                         && taskType != TTaskType.DROP_AUTO_INCREMENT_MAP
                         && taskType != TTaskType.STORAGE_MEDIUM_MIGRATE) {
-                    if (taskType == TTaskType.REALTIME_PUSH) {
-                        PushTask pushTask = (PushTask) task;
-                        if (pushTask.getPushType() == TPushType.DELETE) {
-                            LOG.info("remove push replica. tabletId: {}, backendId: {}", task.getSignature(),
-                                     pushTask.getBackendId());
-
-                            String failMsg = "Backend: " + task.getBackendId() + "Tablet: " + pushTask.getTabletId() +
-                                             " error msg: " + taskStatus.getError_msgs().toString();
-                            pushTask.countDownLatch(pushTask.getBackendId(), pushTask.getTabletId());
-                            AgentTaskQueue.removeTask(pushTask.getBackendId(), TTaskType.REALTIME_PUSH, 
-                                                      task.getSignature());
-                        }
-                    }
                     return result;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -44,7 +44,6 @@ import com.google.common.collect.Sets;
 import com.starrocks.binlog.BinlogConfig;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.LocalTablet.TabletStatus;
 import com.starrocks.catalog.MaterializedIndex;
@@ -982,20 +981,6 @@ public class ReportHandler extends Daemon {
             for (int i = 0; i < tabletMetaList.size(); i++) {
                 long tabletId = tabletIds.get(i);
                 TabletMeta tabletMeta = tabletMetaList.get(i);
-                Database db = GlobalStateMgr.getCurrentState().getDb(tabletMeta.getDbId());
-                if (db == null) {
-                    continue;
-                }
-                db.readLock();
-                try {
-                    OlapTable table = (OlapTable) db.getTable(tabletMeta.getTableId());
-                    if (table.getKeysType() == KeysType.PRIMARY_KEYS) {
-                        // Currently, primary key table doesn't support tablet migration between local disks.
-                        continue;
-                    }
-                } finally {
-                    db.readUnlock();
-                }
                 // always get old schema hash(as effective one)
                 int effectiveSchemaHash = tabletMeta.getOldSchemaHash();
                 StorageMediaMigrationTask task = new StorageMediaMigrationTask(backendId, tabletId,
@@ -1004,6 +989,7 @@ public class ReportHandler extends Daemon {
             }
         }
 
+        AgentTaskQueue.addBatchTask(batchTask);
         AgentTaskExecutor.submit(batchTask);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
@@ -305,7 +305,7 @@ public class AgentTaskQueue {
             }
         }
 
-        LOG.info("get task num with type[{}] in backend[{}]: {}. isFailed: {}",
+        LOG.debug("get task num with type[{}] in backend[{}]: {}. isFailed: {}",
                 type.name(), backendId, taskNum, isFailed);
         return taskNum;
     }


### PR DESCRIPTION
backport #29055

Currently, if there are huge number of tablets to migrate (SSD->HDD or HDD->SSD), FE will send 1000 tasks to BE every 1 minute(tablet report interval), which will cause tasks to pile up on BE, and end up with OOM.
We can use AgentTaskQueue to get the number of task running on BE, and send (Config.tablet_sched_max_migration_task_sent_once - running_tasks) tasks to BE, so that the number of migration tasks running on BE can be kept in a fixed number.