### PR TITLE
[BugFix] keep the constant projection stay in the join level

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
@@ -112,16 +112,18 @@ public class SemiReorderRule extends TransformationRule {
                 // like expression mapping.
                 boolean isProjectToColumnRef = entry.getValue().isColumnRef() &&
                         entry.getKey().getName().equals(((ColumnRefOperator) entry.getValue()).getName());
-                if (!isProjectToColumnRef &&
-                        leftChildJoinRightChildOutputColumns.containsAll(entry.getValue().getUsedColumns())) {
-                    rightExpression.put(entry.getKey(), entry.getValue());
-                } else if (!isProjectToColumnRef &&
-                        newSemiOutputColumns.containsAll(entry.getValue().getUsedColumns())) {
-                    semiExpression.put(entry.getKey(), entry.getValue());
-                } else if (!isProjectToColumnRef &&
-                        leftChildInputColumns.containsAll(entry.getValue().getUsedColumns())) {
-                    // left child projection produce
-                    semiExpression.put(entry.getKey(), entry.getValue());
+
+                if (!isProjectToColumnRef) {
+                    if (entry.getValue().getUsedColumns().isEmpty()) {
+                        semiExpression.put(entry.getKey(), entry.getValue());
+                    } else if (leftChildJoinRightChildOutputColumns.containsAll(entry.getValue().getUsedColumns())) {
+                        rightExpression.put(entry.getKey(), entry.getValue());
+                    } else if (newSemiOutputColumns.containsAll(entry.getValue().getUsedColumns())) {
+                        semiExpression.put(entry.getKey(), entry.getValue());
+                    } else if (leftChildInputColumns.containsAll(entry.getValue().getUsedColumns())) {
+                        // left child projection produce
+                        semiExpression.put(entry.getKey(), entry.getValue());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #issue
For sql like 
```
select t.t1a, t.xx from (
select t0.*, 1920 as xx from test_all_type t0 
where not exists (select v10 from t3 where t3.v11 =t0.t1c)
) t 
where not exists(select v7 from t2 where v9  = 10 and t2.v8 = t.t1d);
```
If we push `1920` to t3 and generate a scan node with proejction `output_col -> 1920`, we may get a wrong result if the final plan is `t3 right anti join t0 left anti join t2` because the probe side cols are being set  to null value.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [x] 2.4
