### PR TITLE
[BugFix] Getting analyzing error when hit the expression rewrite for generated column (#29247)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -79,6 +79,8 @@ import com.starrocks.persist.EditLog;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalyzeState;
+import com.starrocks.sql.analyzer.ExpressionAnalyzer;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
@@ -581,6 +583,11 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                             RewriteAliasVisitor visitor =
                                                 new RewriteAliasVisitor(sourceScope, outputScope,
                                                     outputExprs, ConnectContext.get());
+
+                            ExpressionAnalyzer.analyzeExpression(expr, new AnalyzeState(), new Scope(RelationId.anonymous(),
+                                    new RelationFields(tbl.getBaseSchema().stream().map(col -> new Field(col.getName(),
+                                        col.getType(), tableName, null)).collect(Collectors.toList()))),
+                                            ConnectContext.get());
 
                             Expr materializedColumnExpr = expr.accept(visitor, null);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnDef.java
@@ -210,7 +210,7 @@ public class ColumnDef implements ParseNode {
     }
 
     public Expr materializedColumnExpr() {
-        return materializedColumnExpr;
+        return materializedColumnExpr.clone();
     }
 
     // The columns will obey NULL constraint if not specified. The primary key column should abide by the NOT NULL constraint default to be compatible with ANSI.

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -126,7 +126,7 @@ CREATE DATABASE test_materialized_column_in_materialized_view;
 USE test_materialized_column_in_materialized_view;
 -- result:
 -- !result
-CREATE TABLE t ( id BIGINT NOT NULL, mc BIGINT AS (id) ) Unique KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1");
+CREATE TABLE t ( id BIGINT NOT NULL, mc BIGINT AS (id + 1) ) Unique KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1");
 -- result:
 -- !result
 CREATE MATERIALIZED VIEW mv1 DISTRIBUTED BY HASH(id) BUCKETS 10 REFRESH ASYNC AS SELECT id, mc FROM t;
@@ -137,34 +137,15 @@ INSERT INTO t VALUES (1);
 -- !result
 SELECT * FROM t;
 -- result:
-1	1
+1	2
 -- !result
-select sleep(5);
--- result:
-1
--- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
 SELECT * FROM mv1;
 -- result:
-1	1
+1	2
 -- !result
-ALTER TABLE t modify COLUMN mc BIGINT AS (id);
+DROP MATERIALIZED VIEW mv1;
 -- result:
--- !result
-function: wait_alter_table_finish()
--- result:
-None
--- !result
-REFRESH MATERIALIZED VIEW mv1;
--- result:
-E: (1064, 'Getting analyzing error at line 1, column 26. Detail message: Refresh materialized view failed because [mv1] is not active. You can try to active it with ALTER MATERIALIZED VIEW mv1 ACTIVE; .')
--- !result
-select sleep(5);
--- result:
-1
--- !result
-SELECT * FROM mv1;
--- result:
-1	1
 -- !result
 DROP TABLE t;
 -- result:
@@ -546,8 +527,8 @@ SHOW CREATE TABLE t;
 -- result:
 t	CREATE TABLE `t` (
   `id` bigint(20) NOT NULL COMMENT "",
-  `newcol1` bigint(20) NULL AS `test_add_multiple_column`.`t`.`id` * 10 COMMENT "",
-  `newcol2` bigint(20) NULL AS `test_add_multiple_column`.`t`.`id` * 100 COMMENT ""
+  `newcol1` bigint(20) NULL AS id * 10 COMMENT "",
+  `newcol2` bigint(20) NULL AS id * 100 COMMENT ""
 ) ENGINE=OLAP 
 UNIQUE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 7 
@@ -578,8 +559,8 @@ t	CREATE TABLE `t` (
   `id` bigint(20) NOT NULL COMMENT "",
   `newcol3` bigint(20) NULL DEFAULT "0" COMMENT "",
   `newcol4` bigint(20) NULL DEFAULT "0" COMMENT "",
-  `newcol1` bigint(20) NULL AS `test_add_multiple_column`.`t`.`id` * 10 COMMENT "",
-  `newcol2` bigint(20) NULL AS `test_add_multiple_column`.`t`.`id` * 100 COMMENT ""
+  `newcol1` bigint(20) NULL AS id * 10 COMMENT "",
+  `newcol2` bigint(20) NULL AS id * 100 COMMENT ""
 ) ENGINE=OLAP 
 UNIQUE KEY(`id`)
 DISTRIBUTED BY HASH(`id`) BUCKETS 7 

--- a/test/sql/test_materialized_column/T/test_materialized_column
+++ b/test/sql/test_materialized_column/T/test_materialized_column
@@ -113,23 +113,16 @@ DROP DATABASE test_normal_column_schema_change;
 CREATE DATABASE test_materialized_column_in_materialized_view;
 USE test_materialized_column_in_materialized_view;
 
-CREATE TABLE t ( id BIGINT NOT NULL, mc BIGINT AS (id) ) Unique KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1");
+CREATE TABLE t ( id BIGINT NOT NULL, mc BIGINT AS (id + 1) ) Unique KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 7 PROPERTIES("replication_num" = "1");
 
 CREATE MATERIALIZED VIEW mv1 DISTRIBUTED BY HASH(id) BUCKETS 10 REFRESH ASYNC AS SELECT id, mc FROM t;
 
 INSERT INTO t VALUES (1);
 SELECT * FROM t;
-select sleep(5);
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
 SELECT * FROM mv1;
 
-ALTER TABLE t modify COLUMN mc BIGINT AS (id);
-function: wait_alter_table_finish()
-
-REFRESH MATERIALIZED VIEW mv1;
-select sleep(5);
-
-SELECT * FROM mv1;
-
+DROP MATERIALIZED VIEW mv1;
 DROP TABLE t;
 
 DROP DATABASE test_materialized_column_in_materialized_view;


### PR DESCRIPTION
Problem:
If the expression in query hits the rewriting to generated column, it will get analyzing error if using a alias for the table. Because the default table name for slotRef in generated column expression will be the original one if the column is add by schema change rather than create table stmt.

Solution:
keep the expression unanalyze when schema change.

Fixes #29247

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
