### PR TITLE
[BugFix] Fix query_timeout and disk_read/write metrics on nvme disk

### DIFF
--- a/be/src/util/disk_info.cpp
+++ b/be/src/util/disk_info.cpp
@@ -65,7 +65,9 @@ void DiskInfo::get_device_names() {
         }
 
         // Remove the partition# from the name.  e.g. sda2 --> sda
-        boost::trim_right_if(name, boost::is_any_of("0123456789"));
+        if (!boost::starts_with(name, "nvme")) {
+            boost::trim_right_if(name, boost::is_any_of("0123456789"));
+        }
 
         // Create a mapping of all device ids (one per partition) to the disk id.
         int major_dev_id = atoi(fields[0].c_str());
@@ -192,7 +194,9 @@ Status DiskInfo::get_disk_devices(const std::vector<std::string>& paths, std::se
                 continue;
             }
             std::string dev(basename(dev_path));
-            boost::trim_right_if(dev, boost::is_any_of("0123456789"));
+            if (!boost::starts_with(dev, "nvme")) {
+                boost::trim_right_if(dev, boost::is_any_of("0123456789"));
+            }
             if (_s_disk_name_to_disk_id.find(dev) != std::end(_s_disk_name_to_disk_id)) {
                 max_mount_size = mount_size;
                 match_dev = dev;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
@@ -142,6 +142,9 @@ public class ResultReceiver {
                 status.setStatus(new Status(TStatusCode.TIMEOUT,
                         String.format("Query exceeded time limit of %d seconds",
                                 ConnectContext.get().getSessionVariable().getQueryTimeoutS())));
+                if (MetricRepo.isInit) {
+                    MetricRepo.COUNTER_QUERY_TIMEOUT.increase(1L);
+                }
             } else {
                 status.setRpcStatus(e.getMessage());
                 SimpleScheduler.addToBlacklist(backendId);


### PR DESCRIPTION
Fixes #issue

1.  starrocks_fe_query_timeout metrics is wrong when there is a timeout query.
2. On nvme machine,  the nvme device name is /dev/nvme0n1
starrocks will trim the tail number  of nvme0n1 while the content in diskstats is 
```
259       0 nvme0n1 324643719 483405 56402081042 91440238 158439984 12790844 37694791864 644678817 0 38884821 587504232 1790 0 7501476528 150
```
 this will result in starrocks_be_disk_bytes_read/written metrics are wrong.

before fix be log is 
```
I0724 10:49:37.761263  2812 daemon.cpp:284] Disk Info:
  Num disks 2: nvme0n, vda
```
after fix be log is
```
I0814 21:13:35.537518 2311125 daemon.cpp:284] Disk Info:
  Num disks 2: nvme0n1, vda
```





## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
