### PR TITLE
[BugFix] cols file was deleted by mistake caused by txns rollback (#29265)

### DIFF
--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -221,6 +221,7 @@ public:
     uint32_t num_delete_files() const { return rowset_meta()->get_num_delete_files(); }
     uint32_t num_update_files() const { return rowset_meta()->get_num_update_files(); }
     bool has_data_files() const { return num_segments() > 0 || num_delete_files() > 0 || num_update_files() > 0; }
+    KeysType keys_type() const { return _keys_type; }
 
     // remove all files in this rowset
     // TODO should we rename the method to remove_files() to be more specific?

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1188,8 +1188,10 @@ double StorageEngine::delete_unused_rowset() {
                 << rowset->version().second;
         Status status = rowset->remove();
         LOG_IF(WARNING, !status.ok()) << "remove rowset:" << rowset->rowset_id() << " finished. status:" << status;
-        clear_rowset_delta_column_group_cache(*rowset.get());
-        status = rowset->remove_delta_column_group();
+        if (rowset->keys_type() != PRIMARY_KEYS) {
+            clear_rowset_delta_column_group_cache(*rowset.get());
+            status = rowset->remove_delta_column_group();
+        }
         LOG_IF(WARNING, !status.ok()) << "remove delta column group error rowset:" << rowset->rowset_id()
                                       << " finished. status:" << status;
     }


### PR DESCRIPTION
Problem:
When a txn info was added into txn_map but it was rollbacked later, the corresponding rowset will be added into the StorageEngine::_unused_rowset and wait to be remove in StorageEngine::delete_unused_rowset. In this case, rowset_state == COMMITTED and rowset_seg_id will always be 0 at this time. This cause a problem as following:
Romove rowset : rowset_seg_id = 0, segment_num = 2 
visible rowset 1: rowset_seg_id = 0, segment_num = 1 
visible rowset 2: rowset_seg_id = 1, segment_num = 1
 When we remove the rollback rowset in delete_unused_rowset, we will call remove_delta_column_group, and we can find the dcg in rocksdb using rowset_seg_id = 0. And we will delete cols file for visible rowset 1&2 here.

Solution:
This problem will only affect primary key table. Because non-primary table using rowsetid(unique) to encode the dcg key instead of rowset_seg_id. So we should make sure that remove_delta_column_group in StorageEngine::delete_unused_rowset only done for non-primary key table.

Fixes #29265

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
