### PR TITLE
[BugFix] Fix materialized view rewrite when there is no partition to compensate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
@@ -29,30 +29,30 @@ import java.util.Set;
 public class MvTaskRunContext extends TaskRunContext {
 
     // all the RefBaseTable's partition name to its intersected materialized view names.
-    Map<String, Set<String>> refBaseTableMVIntersectedPartitions;
+    private Map<String, Set<String>> refBaseTableMVIntersectedPartitions;
     // all the materialized view's partition name to its intersected RefBaseTable's partition names.
-    Map<String, Set<String>> mvRefBaseTableIntersectedPartitions;
+    private Map<String, Set<String>> mvRefBaseTableIntersectedPartitions;
     // all the RefBaseTable's partition name to its partition key range.
-    Map<String, Range<PartitionKey>> refBaseTableRangePartitionMap;
+    private Map<String, Range<PartitionKey>> refBaseTableRangePartitionMap;
     // all the RefBaseTable's partition name to its list partition keys.
-    Map<String, List<List<String>>> refBaseTableListPartitionMap;
+    private Map<String, List<List<String>>> refBaseTableListPartitionMap;
     // the external ref base table's mv partition name to original partition names map because external
     // table supports multi partition columns, one converted partition name(mv partition name) may have
     // multi original partition names.
-    Map<String, Set<String>> externalRefBaseTableMVPartitionMap;
+    private Map<String, Set<String>> externalRefBaseTableMVPartitionMap;
 
     // The Table which materialized view' partition column comes from is called `RefBaseTable`:
     // - Materialized View's to-refresh partitions is synced from its `refBaseTable`.
-    Table refBaseTable;
+    private Table refBaseTable;
     // The `RefBaseTable`'s partition column which materialized view's partition column derives from
     // is called `refBaseTablePartitionColumn`.
-    Column refBaseTablePartitionColumn;
+    private Column refBaseTablePartitionColumn;
 
-    String nextPartitionStart = null;
-    String nextPartitionEnd = null;
-    ExecPlan execPlan = null;
+    private String nextPartitionStart = null;
+    private String nextPartitionEnd = null;
+    private ExecPlan execPlan = null;
 
-    int partitionTTLNumber = TableProperty.INVALID;
+    private int partitionTTLNumber = TableProperty.INVALID;
 
     public MvTaskRunContext(TaskRunContext context) {
         this.ctx = context.ctx;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1255,7 +1255,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         try {
             executor.handleDMLStmtWithProfile(execPlan, insertStmt, beginTimeInNanoSecond);
         } catch (Exception e) {
-            e.printStackTrace();
             LOG.warn("refresh materialized view {} failed: {}", materializedView.getName(), e);
             throw e;
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -901,7 +901,9 @@ public class MaterializedViewAnalyzer {
             if (table == null) {
                 throw new SemanticException("Can not find materialized view:" + mvName.getTbl(), mvName.getPos());
             }
-            Preconditions.checkState(table instanceof MaterializedView);
+            if (!(table instanceof MaterializedView)) {
+                throw new SemanticException("Can not refresh non materialized view:" + table.getName(), mvName.getPos());
+            }
             MaterializedView mv = (MaterializedView) table;
             if (!mv.isActive()) {
                 throw new SemanticException("Refresh materialized view failed because [" + mv.getName() +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -248,8 +248,6 @@ public class Optimizer {
                     preprocessor.prepareSyncMvCandidatesForPlan();
                 }
             }
-            OptimizerTraceUtil.logMVPrepare(connectContext, "There are {} candidate MVs after prepare phase",
-                    context.getCandidateMvs().size());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -200,7 +200,7 @@ public class OptimizerTraceUtil {
         PlannerProfile.LogTracer tracer = PlannerProfile.getLogTracer("REWRITE GLOBAL");
         if (tracer != null) {
             FormattingTuple ft = MessageFormatter.arrayFormat(format, object);
-            tracer.log(String.format("[%s] %s",   rule.type().name(), ft.getMessage()));
+            tracer.log(String.format("[%s] %s", rule.type().name(), ft.getMessage()));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -149,9 +149,16 @@ public class OptimizerTraceUtil {
             LOG.info("[MV TRACE] [PREPARE {}] {}", ctx.getQueryId(),
                     MessageFormatter.arrayFormat(format, object).getMessage());
         }
-        // Only record trace when mv is not null.
+
+        // Trace log if needed.
         if (mv != null) {
             PlannerProfile.LogTracer tracer = PlannerProfile.getLogTracer(mv.getName());
+            if (tracer != null) {
+                FormattingTuple ft = MessageFormatter.arrayFormat(format, object);
+                tracer.log(ft.getMessage());
+            }
+        } else {
+            PlannerProfile.LogTracer tracer = PlannerProfile.getLogTracer("PREPARE GLOBAL");
             if (tracer != null) {
                 FormattingTuple ft = MessageFormatter.arrayFormat(format, object);
                 tracer.log(ft.getMessage());
@@ -187,6 +194,13 @@ public class OptimizerTraceUtil {
                     optimizerContext.getTraceInfo().getQueryId(),
                     rule.type().name(),
                     String.format(format, object));
+        }
+
+        // Trace log if needed.
+        PlannerProfile.LogTracer tracer = PlannerProfile.getLogTracer("REWRITE GLOBAL");
+        if (tracer != null) {
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, object);
+            tracer.log(String.format("[%s] %s",   rule.type().name(), ft.getMessage()));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -789,7 +789,9 @@ public class MvUtils {
         for (LogicalScanOperator scanOperator : scanOperators) {
             List<ScalarOperator> partitionPredicate = null;
             if (scanOperator instanceof LogicalOlapScanOperator) {
-                if (isCompensate) {
+                if (!isCompensate) {
+                    partitionPredicate = ((LogicalOlapScanOperator) scanOperator).getPrunedPartitionPredicates();
+                } else {
                     // NOTE: It's not safe to get table's pruned partition predicates by
                     // `LogicalOlapScanOperator#getPrunedPartitionPredicates` :
                     //  - partitionPredicate is null if olap scan operator cannot prune partitions.
@@ -811,8 +813,6 @@ public class MvUtils {
                     // however for mv  we need: k1>='2020-02-11' and k1 < "2020-03-01"
                     partitionPredicate = compensatePartitionPredicateForOlapScan((LogicalOlapScanOperator) scanOperator,
                             columnRefFactory);
-                } else {
-                    partitionPredicate = ((LogicalOlapScanOperator) scanOperator).getPrunedPartitionPredicates();
                 }
             } else if (scanOperator instanceof LogicalHiveScanOperator) {
                 partitionPredicate = compensatePartitionPredicateForHiveScan((LogicalHiveScanOperator) scanOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -811,9 +811,7 @@ public class MvUtils {
                     // however for mv  we need: k1>='2020-02-11' and k1 < "2020-03-01"
                     partitionPredicate = compensatePartitionPredicateForOlapScan((LogicalOlapScanOperator) scanOperator,
                             columnRefFactory);
-                }
-
-                if (!isCompensate || partitionPredicate == null || partitionPredicate.isEmpty()) {
+                } else {
                     partitionPredicate = ((LogicalOlapScanOperator) scanOperator).getPrunedPartitionPredicates();
                 }
             } else if (scanOperator instanceof LogicalHiveScanOperator) {
@@ -855,9 +853,9 @@ public class MvUtils {
             return partitionPredicates;
         }
 
-        // if no partitions are selected, return empty partition predicates.
+        // if no partitions are selected, return pruned partition predicates directly.
         if (olapScanOperator.getSelectedPartitionId().isEmpty()) {
-            return partitionPredicates;
+            return olapScanOperator.getPrunedPartitionPredicates();
         }
 
         if (olapTable.getPartitionInfo() instanceof ExpressionRangePartitionInfo) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -113,14 +113,14 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             MvRewriteContext mvRewriteContext;
             if (mvContext.getMv().getRefreshScheme().isSync()) {
                 if (queryPredicateWithoutCompensate == null) {
-                    logMVRewrite(context, this, "Query partition compensate failed from sync mv.");
+                    logMVRewrite(context, this, "Query expression's partition compensate failed from sync mv.");
                     return results;
                 }
                 mvRewriteContext = new MvRewriteContext(mvContext, queryTables, queryExpression,
                         queryColumnRefRewriter, queryPredicateWithoutCompensate, onPredicates, this);
             } else {
                 if (queryPredicateSplit == null) {
-                    logMVRewrite(context, this, "Query partition compensate failed.");
+                    logMVRewrite(context, this, "Query expression's partition compensate failed");
                     return results;
                 }
                 mvRewriteContext = new MvRewriteContext(mvContext, queryTables, queryExpression,
@@ -163,7 +163,8 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         final ScalarOperator queryPartitionPredicate =
                 MvUtils.compensatePartitionPredicate(queryExpression, queryColumnRefFactory, isCompensate);
         if (queryPartitionPredicate == null) {
-            logMVRewrite(context, this, "Query partition compensate from partition prune failed without compensate.");
+            logMVRewrite(context, this, "Compensate query expression's partition predicates " +
+                    "from pruned partitions failed.");
             return null;
         }
         ScalarOperator queryPredicate = MvUtils.rewriteOptExprCompoundPredicate(queryExpression, queryColumnRefRewriter);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -238,6 +238,11 @@ public class ShowMaterializedViewTest {
         insertSql = "insert into tbl6 partition(p2) values('2022-02-02',2,10);";
         new StmtExecutor(ctx, insertSql).execute();
 
+        // wait unitl the running task run map is not empty
+        while (MapUtils.isEmpty(trm.getRunningTaskRunMap())) {
+            Thread.sleep(10);
+        }
+
         // refresh materialized view
         HashMap<String, String> taskRunProperties = new HashMap<>();
         taskRunProperties.put(TaskRun.FORCE, Boolean.toString(true));

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -238,9 +238,12 @@ public class ShowMaterializedViewTest {
         insertSql = "insert into tbl6 partition(p2) values('2022-02-02',2,10);";
         new StmtExecutor(ctx, insertSql).execute();
 
-        // wait unitl the running task run map is not empty
-        while (MapUtils.isEmpty(trm.getRunningTaskRunMap())) {
+        // wait until the running task run map is not empty
+        int maxCount = 3000;
+        int count = 0;
+        while (MapUtils.isEmpty(trm.getRunningTaskRunMap()) && count < maxCount) {
             Thread.sleep(10);
+            count++;
         }
 
         // refresh materialized view

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -3904,4 +3904,50 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
             testRewriteOK(mv, query);
         }
     }
+
+    @Test
+    public void testEmptyPartitionPrune() throws Exception {
+        starRocksAssert.withTable("\n" +
+                "CREATE TABLE test_empty_partition_tbl(\n" +
+                "  `dt` datetime DEFAULT NULL,\n" +
+                "  `col1` bigint(20) DEFAULT NULL,\n" +
+                "  `col2` bigint(20) DEFAULT NULL,\n" +
+                "  `col3` bigint(20) DEFAULT NULL,\n" +
+                "  `error_code` varchar(1048576) DEFAULT NULL\n" +
+                ")\n" +
+                "DUPLICATE KEY (dt, col1)\n" +
+                "PARTITION BY date_trunc('day', dt)\n" +
+                "--DISTRIBUTED BY RANDOM BUCKETS 32\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW  test_empty_partition_mv1 \n" +
+                "DISTRIBUTED BY HASH(col1, dt) BUCKETS 32\n" +
+                "--DISTRIBUTED BY RANDOM BUCKETS 32\n" +
+                "partition by date_trunc('day', dt)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS select\n" +
+                "      col1,\n" +
+                "        dt,\n" +
+                "        sum(col2) AS sum_col2,\n" +
+                "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
+                "    FROM\n" +
+                "        test_empty_partition_tbl AS f\n" +
+                "    GROUP BY\n" +
+                "        col1,\n" +
+                "        dt;");
+        String sql = "select\n" +
+                "      col1,\n" +
+                "        sum(col2) AS sum_col2,\n" +
+                "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
+                "    FROM\n" +
+                "        test_empty_partition_tbl AS f\n" +
+                "    WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
+                "        AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
+                "    GROUP BY col1;";
+        String plan = getFragmentPlan(sql);
+        PlanTestBase.assertContains(plan, "test_empty_partition_mv1");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -1553,57 +1553,6 @@ public class MvRewriteTest extends MvRewriteTestBase {
     }
 
     @Test
-    @Ignore
-    public void testEmptyPartitionPrune() throws Exception {
-        starRocksAssert.withTable("\n" +
-                "CREATE TABLE test_empty_partition_tbl(\n" +
-                "  `dt` datetime DEFAULT NULL,\n" +
-                "  `col1` bigint(20) DEFAULT NULL,\n" +
-                "  `col2` bigint(20) DEFAULT NULL,\n" +
-                "  `col3` bigint(20) DEFAULT NULL,\n" +
-                "  `error_code` varchar(1048576) DEFAULT NULL\n" +
-                ")\n" +
-                "DUPLICATE KEY (dt, col1)\n" +
-                "PARTITION BY date_trunc('day', dt)\n" +
-                "--DISTRIBUTED BY RANDOM BUCKETS 32\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ");");
-        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW  test_empty_partition_mv1 \n" +
-                "DISTRIBUTED BY HASH(col1, dt) BUCKETS 32\n" +
-                "--DISTRIBUTED BY RANDOM BUCKETS 32\n" +
-                "partition by date_trunc('day', dt)\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ")\n" +
-                "AS select\n" +
-                "      col1,\n" +
-                "        dt,\n" +
-                "        sum(col2) AS sum_col2,\n" +
-                "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
-                "    FROM\n" +
-                "        test_empty_partition_tbl AS f\n" +
-                "    GROUP BY\n" +
-                "        col1,\n" +
-                "        dt;");
-        cluster.runSql("test", "insert into test_empty_partition_tbl values('2023-08-16', 1, 1, 1, 'a')");
-        refreshMaterializedView("test", "test_empty_partition_mv1");
-        {
-            String sql = "select\n" +
-                    "      col1,\n" +
-                    "        sum(col2) AS sum_col2,\n" +
-                    "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
-                    "    FROM\n" +
-                    "        test_empty_partition_tbl AS f\n" +
-                    "    WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
-                    "        AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
-                    "    GROUP BY col1;";
-            String plan = getFragmentPlan(sql);
-            PlanTestBase.assertContains(plan, "test_empty_partition_mv1");
-        }
-    }
-
-    @Test
     public void testMapArrayRewrite() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test_map_array (\n" +
                 "                            k1 date,\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -1553,6 +1553,57 @@ public class MvRewriteTest extends MvRewriteTestBase {
     }
 
     @Test
+    @Ignore
+    public void testEmptyPartitionPrune() throws Exception {
+        starRocksAssert.withTable("\n" +
+                "CREATE TABLE test_empty_partition_tbl(\n" +
+                "  `dt` datetime DEFAULT NULL,\n" +
+                "  `col1` bigint(20) DEFAULT NULL,\n" +
+                "  `col2` bigint(20) DEFAULT NULL,\n" +
+                "  `col3` bigint(20) DEFAULT NULL,\n" +
+                "  `error_code` varchar(1048576) DEFAULT NULL\n" +
+                ")\n" +
+                "DUPLICATE KEY (dt, col1)\n" +
+                "PARTITION BY date_trunc('day', dt)\n" +
+                "--DISTRIBUTED BY RANDOM BUCKETS 32\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW  test_empty_partition_mv1 \n" +
+                "DISTRIBUTED BY HASH(col1, dt) BUCKETS 32\n" +
+                "--DISTRIBUTED BY RANDOM BUCKETS 32\n" +
+                "partition by date_trunc('day', dt)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS select\n" +
+                "      col1,\n" +
+                "        dt,\n" +
+                "        sum(col2) AS sum_col2,\n" +
+                "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
+                "    FROM\n" +
+                "        test_empty_partition_tbl AS f\n" +
+                "    GROUP BY\n" +
+                "        col1,\n" +
+                "        dt;");
+        cluster.runSql("test", "insert into test_empty_partition_tbl values('2023-08-16', 1, 1, 1, 'a')");
+        refreshMaterializedView("test", "test_empty_partition_mv1");
+        {
+            String sql = "select\n" +
+                    "      col1,\n" +
+                    "        sum(col2) AS sum_col2,\n" +
+                    "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
+                    "    FROM\n" +
+                    "        test_empty_partition_tbl AS f\n" +
+                    "    WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
+                    "        AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
+                    "    GROUP BY col1;";
+            String plan = getFragmentPlan(sql);
+            PlanTestBase.assertContains(plan, "test_empty_partition_mv1");
+        }
+    }
+
+    @Test
     public void testMapArrayRewrite() throws Exception {
         starRocksAssert.withTable("CREATE TABLE test_map_array (\n" +
                 "                            k1 date,\n" +

--- a/test/sql/test_materialized_view/R/test_materialized_view_rewrite2
+++ b/test/sql/test_materialized_view/R/test_materialized_view_rewrite2
@@ -1,0 +1,82 @@
+-- name: test_materialized_view_rewrite2
+CREATE TABLE test_empty_partition_tbl(
+  `dt` datetime DEFAULT NULL,
+  `col1` bigint(20) DEFAULT NULL,
+  `col2` bigint(20) DEFAULT NULL,
+  `col3` bigint(20) DEFAULT NULL,
+  `error_code` varchar(1048576) DEFAULT NULL
+)
+DUPLICATE KEY (dt, col1)
+PARTITION BY date_trunc('day', dt)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW  test_empty_partition_mv1 
+DISTRIBUTED BY RANDOM BUCKETS 32
+partition by date_trunc('day', dt)
+PROPERTIES (
+"replication_num" = "1"
+)
+AS select
+      col1,
+        dt,
+        sum(col2) AS sum_col2,
+        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3
+    FROM
+        test_empty_partition_tbl AS f
+    GROUP BY
+        col1,
+        dt;
+-- result:
+-- !result
+insert into test_empty_partition_tbl values('2023-08-16', 1, 1, 1, 'a');
+-- result:
+-- !result
+refresh materialized view test_empty_partition_mv1 with sync mode;
+function: check_hit_materialized_view("select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s')) AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s')) GROUP BY col1;", "test_empty_partition_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s')) AND (dt <= STR_TO_DATE('2023-08-16 00:00:00', '%Y-%m-%d %H:%i:%s')) GROUP BY col1;", "test_empty_partition_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt >= '2023-08-15 00:00:00' GROUP BY col1;", "test_empty_partition_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt <= '2023-08-15 00:00:00' GROUP BY col1;", "test_empty_partition_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt = '2023-08-15 00:00:00' GROUP BY col1;", "test_empty_partition_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt = '2023-08-16 00:00:00' GROUP BY col1;", "test_empty_partition_mv1")
+-- result:
+None
+-- !result
+select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s')) AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s')) GROUP BY col1;
+-- result:
+-- !result
+select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s')) AND (dt <= STR_TO_DATE('2023-08-16 00:00:00', '%Y-%m-%d %H:%i:%s')) GROUP BY col1;
+-- result:
+1	1	0
+-- !result
+select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt >= '2023-08-15 00:00:00' GROUP BY col1;
+-- result:
+1	1	0
+-- !result
+select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt <= '2023-08-15 00:00:00' GROUP BY col1;
+-- result:
+-- !result
+select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt = '2023-08-15 00:00:00' GROUP BY col1;
+-- result:
+-- !result
+select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt = '2023-08-16 00:00:00' GROUP BY col1;
+-- result:
+1	1	0
+-- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_rewrite2
+++ b/test/sql/test_materialized_view/T/test_materialized_view_rewrite2
@@ -1,0 +1,48 @@
+-- name: test_materialized_view_rewrite2
+CREATE TABLE test_empty_partition_tbl(
+  `dt` datetime DEFAULT NULL,
+  `col1` bigint(20) DEFAULT NULL,
+  `col2` bigint(20) DEFAULT NULL,
+  `col3` bigint(20) DEFAULT NULL,
+  `error_code` varchar(1048576) DEFAULT NULL
+)
+DUPLICATE KEY (dt, col1)
+PARTITION BY date_trunc('day', dt)
+--DISTRIBUTED BY RANDOM BUCKETS 32
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE MATERIALIZED VIEW  test_empty_partition_mv1 
+DISTRIBUTED BY RANDOM BUCKETS 32
+partition by date_trunc('day', dt)
+PROPERTIES (
+"replication_num" = "1"
+)
+AS select
+      col1,
+        dt,
+        sum(col2) AS sum_col2,
+        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3
+    FROM
+        test_empty_partition_tbl AS f
+    GROUP BY
+        col1,
+        dt;
+insert into test_empty_partition_tbl values('2023-08-16', 1, 1, 1, 'a');
+
+refresh materialized view test_empty_partition_mv1 with sync mode;
+
+function: check_hit_materialized_view("select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s')) AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s')) GROUP BY col1;", "test_empty_partition_mv1")
+function: check_hit_materialized_view("select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s')) AND (dt <= STR_TO_DATE('2023-08-16 00:00:00', '%Y-%m-%d %H:%i:%s')) GROUP BY col1;", "test_empty_partition_mv1")
+function: check_hit_materialized_view("select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt >= '2023-08-15 00:00:00' GROUP BY col1;", "test_empty_partition_mv1")
+function: check_hit_materialized_view("select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt <= '2023-08-15 00:00:00' GROUP BY col1;", "test_empty_partition_mv1")
+function: check_hit_materialized_view("select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt = '2023-08-15 00:00:00' GROUP BY col1;", "test_empty_partition_mv1")
+function: check_hit_materialized_view("select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt = '2023-08-16 00:00:00' GROUP BY col1;", "test_empty_partition_mv1")
+
+select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s')) AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s')) GROUP BY col1;
+select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s')) AND (dt <= STR_TO_DATE('2023-08-16 00:00:00', '%Y-%m-%d %H:%i:%s')) GROUP BY col1;
+select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt >= '2023-08-15 00:00:00' GROUP BY col1;
+select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt <= '2023-08-15 00:00:00' GROUP BY col1;
+select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt = '2023-08-15 00:00:00' GROUP BY col1;
+select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt = '2023-08-16 00:00:00' GROUP BY col1;


### PR DESCRIPTION
- If there is no partition selected in the  query, we can still use the mv to rewrite.
- add global rewrite log in `trace rewrite`

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
