### PR TITLE
[Enhancement]  optimize performance in the case that table has thousands of columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -629,7 +629,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.name, this.type);
+        return Objects.hash(this.name.toLowerCase(), this.type);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -347,17 +347,14 @@ public class QueryAnalyzer {
             } else {
                 List<Column> fullSchema = node.isBinlogQuery()
                         ? appendBinlogMetaColumns(table.getFullSchema()) : table.getFullSchema();
-                List<Column> baseSchema = node.isBinlogQuery()
-                        ? appendBinlogMetaColumns(table.getBaseSchema()) : table.getBaseSchema();
+                Set<Column> baseSchema = new HashSet<>(node.isBinlogQuery()
+                        ? appendBinlogMetaColumns(table.getBaseSchema()) : table.getBaseSchema());
                 for (Column column : fullSchema) {
-                    Field field;
-                    if (baseSchema.contains(column)) {
-                        field = new Field(column.getName(), column.getType(), tableName,
-                                new SlotRef(tableName, column.getName(), column.getName()), true, column.isAllowNull());
-                    } else {
-                        field = new Field(column.getName(), column.getType(), tableName,
-                                new SlotRef(tableName, column.getName(), column.getName()), false, column.isAllowNull());
-                    }
+                    // TODO: avoid analyze visible or not each time, cache it in schema
+                    boolean visible = baseSchema.contains(column);
+                    SlotRef slot = new SlotRef(tableName, column.getName(), column.getName());
+                    Field field = new Field(column.getName(), column.getType(), tableName, slot, visible,
+                            column.isAllowNull());
                     columns.put(field, column);
                     fields.add(field);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RelationFields.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/RelationFields.java
@@ -15,11 +15,11 @@
 package com.starrocks.sql.analyzer;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.TreeMultimap;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Multimap;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,7 +31,7 @@ public class RelationFields {
     private final List<Field> allFields;
 
     // NOTE: sort fields by name to speedup resolve performance
-    private final TreeMultimap<String, Field> names;
+    private final Multimap<String, Field> names;
     private final boolean resolveStruct;
 
     public RelationFields(Field... fields) {
@@ -43,11 +43,8 @@ public class RelationFields {
         this.allFields = ImmutableList.copyOf(fields);
         this.resolveStruct = fields.stream().anyMatch(x -> x.getType().isStructType());
         if (!resolveStruct) {
-            this.names =
-                    TreeMultimap.create(String.CASE_INSENSITIVE_ORDER, Comparator.comparing(Field::getName));
-            for (Field field : fields) {
-                this.names.put(field.getName(), field);
-            }
+            this.names = this.allFields.stream().collect(ImmutableListMultimap.toImmutableListMultimap(
+                    x -> x.getName().toLowerCase(), x -> x));
         } else {
             this.names = null;
         }
@@ -86,7 +83,8 @@ public class RelationFields {
         // Resolve the slot based on column name first, then table name
         // For the case a table with thousands of columns, resolve by table name could not reduce the cardinality,
         // but resolve by column name first could reduce it a lot
-        List<Field> resolved = names.get(name.getColumnName()).stream().collect(ImmutableList.toImmutableList());
+        List<Field> resolved =
+                names.get(name.getColumnName().toLowerCase()).stream().collect(ImmutableList.toImmutableList());
         if (name.getTblNameWithoutAnalyzed() == null) {
             return resolved;
         } else {


### PR DESCRIPTION
Fixes #issue

Optimize performance in the case that table has thousands of columns :
1. `RelationFields::resolveFields()`
2. `QueryAnalyzer:: visitTable()`

Result: reduce the analyze cost from 400ms to 15ms

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
