### PR TITLE
[Enhancement] add spillbytes in audit log and profile header

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -297,6 +297,10 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
                 "QueryCumulativeCpuTime", TUnit::TIME_NS,
                 RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS, TCounterMergeType::SKIP_FIRST_MERGE));
         query_cumulative_cpu->set(query_ctx->cpu_cost());
+        auto* query_spill_bytes = profile->add_counter(
+                "QuerySpillBytes", TUnit::BYTES,
+                RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_FIRST_MERGE));
+        query_spill_bytes->set(query_ctx->get_spill_bytes());
     }
 
     auto params = ExecStateReporter::create_report_exec_status_params(query_ctx, fragment_ctx, profile, status, done);

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -201,6 +201,7 @@ std::shared_ptr<QueryStatistics> QueryContext::final_query_statistic() {
     auto res = std::make_shared<QueryStatistics>();
     res->add_cpu_costs(cpu_cost());
     res->add_mem_costs(mem_cost_bytes());
+    res->add_spill_bytes(get_spill_bytes());
 
     {
         std::lock_guard l(_scan_stats_lock);

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -123,6 +123,8 @@ public class AuditEvent {
     public long bigQueryLogScanBytesThreshold = -1;
     @AuditField(value = "BigQueryLogScanRowsThreshold")
     public long bigQueryLogScanRowsThreshold = -1;
+    @AuditField(value = "SpilledBytes", ignore_zero = true)
+    public long spilledBytes = -1;
 
     public static class AuditEventBuilder {
 
@@ -215,6 +217,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setMemCostBytes(long memCostBytes) {
             auditEvent.memCostBytes = memCostBytes;
+            return this;
+        }
+
+        public AuditEventBuilder setSpilledBytes(long spilledBytes) {
+            auditEvent.spilledBytes = spilledBytes;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -174,6 +174,7 @@ public class ConnectProcessor {
             ctx.getAuditEventBuilder().setScanRows(statistics.scanRows);
             ctx.getAuditEventBuilder().setCpuCostNs(statistics.cpuCostNs == null ? -1 : statistics.cpuCostNs);
             ctx.getAuditEventBuilder().setMemCostBytes(statistics.memCostBytes == null ? -1 : statistics.memCostBytes);
+            ctx.getAuditEventBuilder().setSpilledBytes(statistics.spillBytes == null ? -1 : statistics.spillBytes);
         }
 
         if (ctx.getState().isQuery()) {
@@ -270,6 +271,7 @@ public class ConnectProcessor {
             queryDetail.setScanRows(statistics.scanRows);
             queryDetail.setCpuCostNs(statistics.cpuCostNs == null ? -1 : statistics.cpuCostNs);
             queryDetail.setMemCostBytes(statistics.memCostBytes == null ? -1 : statistics.memCostBytes);
+            queryDetail.setSpillBytes(statistics.spillBytes == null ? -1 : statistics.spillBytes);
         }
 
         QueryDetailQueue.addAndRemoveTimeoutQueryDetail(queryDetail);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -178,7 +178,8 @@ public class DefaultCoordinator extends Coordinator {
         public DefaultCoordinator createQueryScheduler(ConnectContext context, List<PlanFragment> fragments,
                                                        List<ScanNode> scanNodes,
                                                        TDescriptorTable descTable) {
-            JobSpec jobSpec = JobSpec.Factory.fromQuerySpec(context, fragments, scanNodes, descTable, TQueryType.SELECT);
+            JobSpec jobSpec =
+                    JobSpec.Factory.fromQuerySpec(context, fragments, scanNodes, descTable, TQueryType.SELECT);
             return new DefaultCoordinator(context, jobSpec, context.getSessionVariable().isEnableProfile());
         }
 
@@ -235,9 +236,11 @@ public class DefaultCoordinator extends Coordinator {
         @Override
         public DefaultCoordinator createNonPipelineBrokerLoadScheduler(Long jobId, TUniqueId queryId,
                                                                        DescriptorTable descTable,
-                                                                       List<PlanFragment> fragments, List<ScanNode> scanNodes,
+                                                                       List<PlanFragment> fragments,
+                                                                       List<ScanNode> scanNodes,
                                                                        String timezone,
-                                                                       long startTime, Map<String, String> sessionVariables,
+                                                                       long startTime,
+                                                                       Map<String, String> sessionVariables,
                                                                        ConnectContext context, long execMemLimit) {
             JobSpec jobSpec = JobSpec.Factory.fromNonPipelineBrokerLoadJobSpec(context, jobId, queryId, descTable,
                     fragments, scanNodes, timezone,
@@ -554,8 +557,9 @@ public class DefaultCoordinator extends Coordinator {
     private void deliverExecFragments() throws RpcException, UserException {
         lock();
         try {
-            Deployer deployer = new Deployer(connectContext, jobSpec, executionDAG, coordinatorPreprocessor.getCoordAddress(),
-                    this::handleErrorExecution);
+            Deployer deployer =
+                    new Deployer(connectContext, jobSpec, executionDAG, coordinatorPreprocessor.getCoordAddress(),
+                            this::handleErrorExecution);
             for (List<ExecutionFragment> concurrentFragments : executionDAG.getFragmentsInTopologicalOrderFromRoot()) {
                 deployer.deployFragments(concurrentFragments);
             }
@@ -630,7 +634,8 @@ public class DefaultCoordinator extends Coordinator {
                 for (final FragmentInstance instance : execFragment.getInstances()) {
                     TRuntimeFilterProberParams probeParam = new TRuntimeFilterProberParams();
                     probeParam.setFragment_instance_id(instance.getInstanceId());
-                    probeParam.setFragment_instance_address(coordinatorPreprocessor.getBrpcAddress(instance.getWorkerId()));
+                    probeParam.setFragment_instance_address(
+                            coordinatorPreprocessor.getBrpcAddress(instance.getWorkerId()));
                     probeParamList.add(probeParam);
                 }
                 if (jobSpec.isEnablePipeline() && kv.getValue().isBroadcastJoin() &&

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1175,6 +1175,7 @@ public class DefaultCoordinator extends Coordinator {
 
         long maxQueryCumulativeCpuTime = 0;
         long maxQueryPeakMemoryUsage = 0;
+        long maxQuerySpillBytes = 0;
 
         List<RuntimeProfile> newFragmentProfiles = Lists.newArrayList();
         for (RuntimeProfile fragmentProfile : fragmentProfiles) {
@@ -1214,6 +1215,12 @@ public class DefaultCoordinator extends Coordinator {
                     maxQueryPeakMemoryUsage = Math.max(maxQueryPeakMemoryUsage, toBeRemove.getValue());
                 }
                 instanceProfile.removeCounter("QueryPeakMemoryUsage");
+
+                toBeRemove = instanceProfile.getCounter("QuerySpillBytes");
+                if (toBeRemove != null) {
+                    maxQuerySpillBytes = Math.max(maxQuerySpillBytes, toBeRemove.getValue());
+                }
+                instanceProfile.removeCounter("QuerySpillBytes");
             }
             newFragmentProfile.addInfoString("BackendAddresses", String.join(",", backendAddresses));
             newFragmentProfile.addInfoString("InstanceIds", String.join(",", instanceIds));
@@ -1327,6 +1334,8 @@ public class DefaultCoordinator extends Coordinator {
         queryCumulativeCpuTime.setValue(maxQueryCumulativeCpuTime);
         Counter queryPeakMemoryUsage = newQueryProfile.addCounter("QueryPeakMemoryUsage", TUnit.BYTES, null);
         queryPeakMemoryUsage.setValue(maxQueryPeakMemoryUsage);
+        Counter querySpillBytes = newQueryProfile.addCounter("QuerySpillBytes", TUnit.BYTES, null);
+        querySpillBytes.setValue(maxQuerySpillBytes);
 
         return newQueryProfile;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
@@ -76,6 +76,7 @@ public class QueryDetail implements Serializable {
     private long returnRows = -1;
     private long cpuCostNs = -1;
     private long memCostBytes = -1;
+    private long spillBytes = -1;
 
     public QueryDetail() {
     }
@@ -127,6 +128,7 @@ public class QueryDetail implements Serializable {
         queryDetail.returnRows = this.returnRows;
         queryDetail.cpuCostNs = this.cpuCostNs;
         queryDetail.memCostBytes = this.memCostBytes;
+        queryDetail.spillBytes = this.spillBytes;
         return queryDetail;
     }
 
@@ -288,5 +290,9 @@ public class QueryDetail implements Serializable {
 
     public void setMemCostBytes(long memCostBytes) {
         this.memCostBytes = memCostBytes;
+    }
+
+    public void setSpillBytes(long spillBytes) {
+        this.spillBytes = spillBytes;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1475,6 +1475,9 @@ public class StmtExecutor {
         if (statisticsForAuditLog.memCostBytes == null) {
             statisticsForAuditLog.memCostBytes = 0L;
         }
+        if (statisticsForAuditLog.spillBytes == null) {
+            statisticsForAuditLog.spillBytes = 0L;
+        }
         return statisticsForAuditLog;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
@@ -72,7 +72,9 @@ public class QueryDetailQueueTest {
                 + "\"scanBytes\":10001,"
                 + "\"returnRows\":1,"
                 + "\"cpuCostNs\":1002,"
-                + "\"memCostBytes\":100003}]";
+                + "\"memCostBytes\":100003,"
+                + "\"spillBytes\":-1"
+                + "}]";
         Assert.assertEquals(jsonString, queryDetailString);
 
         queryDetails = QueryDetailQueue.getQueryDetailsAfterTime(startQueryDetail.getEventTime());


### PR DESCRIPTION
add metrics in profile header and audit log

audit log:
```
2023-08-16 13:58:43,520 [slow_query] |Client=127.0.0.1:48398|User=root|AuthorizedUser='root'@'%'|ResourceGroup=default_wg|Catalog=default_catalog|Db=ssb|State=EOF|ErrorCode=|Time=45063|ScanBytes=4800303216|ScanRows=600037902|ReturnRows=1|CpuCostNs=44879276165|MemCostBytes=535217432|StmtId=13|QueryId=d9f3251c-3bf9-11ee-8146-8e20563011de|IsQuery=true|feIp=172.17.0.1|Stmt=select count(sl), count(sk) from (select sum(lo_linenumber) sl, lo_orderkey sk from lineorder_128_buckets group by lo_orderkey) tb|Digest=2598f7a023c56bc03374481ba1d77542|PlanCpuCost=9.601207196E9|PlanMemCost=600764.0|SpilledBytes=977346042
```
profile:
```
  Execution:
     - QueryAllocatedMemoryUsage: 87.233 GB
     - QueryCumulativeCpuTime: 44s879ms
     - QueryCumulativeOperatorTime: 46s414ms
     - QueryDeallocatedMemoryUsage: 87.074 GB
     - QueryExecutionWallTime: 45s28ms
     - QueryPeakMemoryUsage: 510.423 MB
     - QuerySpilledBytes: 932.070 MB
     - ResultDeliverTime: 0ns
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
