### PR TITLE
[BugFix] fix bug on getuuid of pg with catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -42,6 +42,9 @@ public class JDBCTable extends Table {
     private static final String TABLE = "table";
     private static final String RESOURCE = "resource";
 
+    public static final String ORIGINAL_TABLENAME = "original_tablename";
+    public static final String ORIGINAL_DBNAME = "original_dbname";
+
     @SerializedName(value = "tn")
     private String jdbcTable;
     @SerializedName(value = "rn")
@@ -118,6 +121,9 @@ public class JDBCTable extends Table {
     @Override
     public String getUUID() {
         if (!Strings.isNullOrEmpty(catalogName)) {
+            if (!Strings.isNullOrEmpty(properties.get(ORIGINAL_DBNAME))) {
+                return String.join(".", catalogName, properties.get(ORIGINAL_DBNAME), properties.get(ORIGINAL_TABLENAME));
+            }
             return String.join(".", catalogName, dbName, name);
         } else {
             return Long.toString(id);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -67,6 +67,8 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
     @Override
     public Table getTable(long id, String name, List<Column> schema, String dbName, String catalogName,
                           Map<String, String> properties) throws DdlException {
+        properties.putIfAbsent(JDBCTable.ORIGINAL_DBNAME, dbName);
+        properties.putIfAbsent(JDBCTable.ORIGINAL_TABLENAME, name);
         return new JDBCTable(id, "\"" + dbName + "\"" + "." + "\"" + name + "\"", schema, "", catalogName, properties);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
@@ -166,6 +166,7 @@ public class PostgresSchemaResolverTest {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
+            Assert.assertEquals("catalog.test.tbl1", table.getUUID());
         } catch (Exception e) {
             System.out.println(e.getMessage());
             Assert.fail();


### PR DESCRIPTION
Fixes #issue https://github.com/StarRocks/starrocks/issues/29288

pg has schema->db->table, when use it with catalog, we merge db&table name as jdbc tablename, 
and to support upper case in name, we add double quotation marks to the name. when generate uuid, 
these will lead to error, store the original name in properties and use original name to generate uuid. 

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
