### PR TITLE
[Enhancement] Support subqueries when creating materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -419,6 +419,12 @@ public class AnalyzerUtils {
         return tables;
     }
 
+    public static Map<TableName, Table> collectAllTableAndViewWithAlias(SelectRelation statementBase) {
+        Map<TableName, Table> tables = Maps.newHashMap();
+        new AnalyzerUtils.TableAndViewCollectorWithAlias(tables).visit(statementBase);
+        return tables;
+    }
+
     public static Multimap<String, TableRelation> collectAllTableRelation(StatementBase statementBase) {
         Multimap<String, TableRelation> tableRelations = ArrayListMultimap.create();
         new AnalyzerUtils.TableRelationCollector(tableRelations).visit(statementBase);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -2424,7 +2424,11 @@ public class CreateMaterializedViewTest {
                 "\"replication_num\" = \"1\"\n" +
                 ") " +
                 "as select k1, k2 from (select * from tbl1) tbl";
-        UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        try {
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        } catch (Exception e) {
+            Assert.fail();
+        }
     }
 
     @Test
@@ -2439,11 +2443,8 @@ public class CreateMaterializedViewTest {
                 "as select k1, k2 from (select * from tbl1) tbl";
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            Assert.fail();
         } catch (Exception e) {
-            Assert.assertEquals("Getting analyzing error at line 1, column 42." +
-                            " Detail message: resolve partition column failed.",
-                    e.getMessage());
+            Assert.fail();
         }
     }
 
@@ -2733,7 +2734,7 @@ public class CreateMaterializedViewTest {
             Database differentDb = currentState.getDb("test_mv_different_db");
             Table mv1 = differentDb.getTable("test_mv_use_different_tbl");
             Assert.assertTrue(mv1 instanceof MaterializedView);
-            
+
             newStarRocksAssert.dropDatabase("test_mv_different_db");
         } catch (Exception e) {
             Assert.fail();
@@ -2820,6 +2821,7 @@ public class CreateMaterializedViewTest {
             starRocksAssert.dropMaterializedView(mvName);
         }
     }
+
     @Test
     public void testExprAlias() throws Exception {
         testMVColumnAlias("c_1_9 + 1");
@@ -2846,15 +2848,15 @@ public class CreateMaterializedViewTest {
     @Test
     public void testMvNullable() throws Exception {
         starRocksAssert.withTable("create table emps (\n" +
-                "    empid int not null,\n" +
-                "    deptno int not null,\n" +
-                "    name varchar(25) not null,\n" +
-                "    salary double\n" +
-                ")\n" +
-                "distributed by hash(`empid`) buckets 10\n" +
-                "properties (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ");")
+                        "    empid int not null,\n" +
+                        "    deptno int not null,\n" +
+                        "    name varchar(25) not null,\n" +
+                        "    salary double\n" +
+                        ")\n" +
+                        "distributed by hash(`empid`) buckets 10\n" +
+                        "properties (\n" +
+                        "\"replication_num\" = \"1\"\n" +
+                        ");")
                 .withTable("create table depts (\n" +
                         "    deptno int not null,\n" +
                         "    name varchar(25) not null\n" +
@@ -2899,7 +2901,7 @@ public class CreateMaterializedViewTest {
 
         starRocksAssert.dropTable("emps");
         starRocksAssert.dropTable("depts");
-	}
+    }
 
     @Test
     public void testSelectFromSyncMV() throws Exception {
@@ -3319,10 +3321,102 @@ public class CreateMaterializedViewTest {
         try {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+        starRocksAssert.dropTable("list_partition_tbl1");
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithTableAlias1() throws Exception {
+        String sql = "create materialized view mv1 " +
+                "partition by k1 " +
+                "distributed by hash(k2) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select t0.k1, t0.k2, t0.sum as sum0 " +
+                "from (select k1, k2, sum(v1) as sum from tbl1 group by k1, k2) t0 where t0.k2 > 10";
+        try {
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithTableAlias2() throws Exception {
+        String sql = "create materialized view mv1 " +
+                "partition by k1 " +
+                "distributed by hash(k2) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select t0.k1, t0.k2, t0.sum as sum0, t1.sum as sum1, t2.sum as sum2 " +
+                "from (select k1, k2, sum(v1) as sum from tbl1 group by k1, k2) t0 " +
+                "left join (select  k1, k2, sum(v1) as sum from tbl1 group by k1, k2) t1 on t0.k1=t1.k2 " +
+                "left join (select k1, k2, sum(v1) as sum from tbl1 group by k1, k2) t2 on t0.k1=t2.k1;";
+        try {
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        } catch (Exception e) {
             e.printStackTrace();
-            Assert.fail();
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCreateMvWithViewAndSubQuery() throws Exception {
+        starRocksAssert.withView("create view view_1 as " +
+                "select k1, s2 from (select tb1.k1, k2 s2 from tbl1 tb1) t where t.k1 > 10;");
+        starRocksAssert.withView("create view view_2 as " +
+                "select k1, s2 from (select v1.k1, v1.s2 from view_1 v1) t where t.k1 > 10;");
+        starRocksAssert.withView("create view view_3 as " +
+                "select d1, s2 from (select date_trunc('month',k1) d1, v1.s2 from view_1 v1)t where d1 is not null;");
+        {
+            String sql = "create materialized view mv1\n" +
+                    "partition by date_trunc('month',k1)\n" +
+                    "distributed by hash(s2) buckets 10\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ")\n" +
+                    "as select k1, s2 from view_1;";
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         }
 
-        starRocksAssert.dropTable("list_partition_tbl1");
+        {
+            String sql = "create materialized view mv1\n" +
+                    "partition by date_trunc('month',k1)\n" +
+                    "distributed by hash(s2) buckets 10\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ")\n" +
+                    "as select view_1.k1, view_2.s2 from view_1 join view_2 on view_1.k1=view_2.k1;";
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        }
+
+        {
+            String sql = "create materialized view mv1\n" +
+                    "partition by d1\n" +
+                    "distributed by hash(s2) buckets 10\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ")\n" +
+                    "as select v3.d1, v3.s2 from view_3 v3;";
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        }
+
+        {
+            String sql = "create materialized view mv1\n" +
+                    "partition by date_trunc('month',k1)\n" +
+                    "distributed by hash(s2) buckets 10\n" +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ")\n" +
+                    "as select view_1.k1, view_2.s2 from view_1 join view_2 on view_1.k1=view_2.k1;";
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        }
+
+        starRocksAssert.dropView("view_1");
+        starRocksAssert.dropView("view_2");
+        starRocksAssert.dropView("view_3");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -153,6 +153,124 @@ public class MvRewriteTest extends MvRewriteTestBase {
     }
 
     @Test
+    public void testMVWithViewAndSubQuery1() throws Exception {
+        {
+            starRocksAssert.withView("create view view1 as " +
+                    " SELECT v1, t1d, t1c from (select t0.v1 as v1, test_all_type.t1d, test_all_type.t1c" +
+                    " from t0 join test_all_type" +
+                    " on t0.v1 = test_all_type.t1d) t" +
+                    " where v1 < 100");
+
+            createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +
+                    " distributed by hash(v1)" +
+                    " as " +
+                    " SELECT * from view1");
+            {
+                String query = "SELECT (test_all_type.t1d + 1) * 2, test_all_type.t1c" +
+                        " from t0 join test_all_type on t0.v1 = test_all_type.t1d where t0.v1 < 100";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "join_mv_1");
+            }
+
+            {
+                String query = "SELECT (t1d + 1) * 2, t1c from view1 where v1 < 100";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "join_mv_1");
+            }
+            starRocksAssert.dropView("view1");
+            dropMv("test", "join_mv_1");
+        }
+
+        // nested views
+        {
+            starRocksAssert.withView("create view view1 as " +
+                    " SELECT v1 from t0");
+
+            starRocksAssert.withView("create view view2 as " +
+                    " SELECT t1d, t1c from test_all_type");
+
+            starRocksAssert.withView("create view view3 as " +
+                    " SELECT v1, t1d, t1c from (select view1.v1, view2.t1d, view2.t1c" +
+                    " from view1 join view2" +
+                    " on view1.v1 = view2.t1d) t" +
+                    " where v1 < 100");
+
+            createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +
+                    " distributed by hash(v1)" +
+                    " as " +
+                    " SELECT * from view3");
+            {
+                String query = "SELECT (test_all_type.t1d + 1) * 2, test_all_type.t1c" +
+                        " from t0 join test_all_type on t0.v1 = test_all_type.t1d where t0.v1 < 100";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "join_mv_1");
+            }
+
+            {
+                String query = "SELECT (t1d + 1) * 2, t1c" +
+                        " from view3 where v1 < 100";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "join_mv_1");
+            }
+
+            starRocksAssert.dropView("view1");
+            starRocksAssert.dropView("view2");
+            starRocksAssert.dropView("view3");
+            dropMv("test", "join_mv_1");
+        }
+
+        // duplicate views
+        {
+            starRocksAssert.withView("create view view1 as " +
+                    " SELECT v1 from t0");
+
+            createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +
+                    " distributed by hash(v11)" +
+                    " as " +
+                    " SELECT v11, v12 from (select vv1.v1 v11, vv2.v1 v12 from view1 vv1 join view1 vv2 on vv1.v1 = vv2.v1 ) t");
+            {
+                String query = "SELECT vv1.v1, vv2.v1 from view1 vv1 join view1 vv2 on vv1.v1 = vv2.v1";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "join_mv_1");
+            }
+
+            starRocksAssert.dropView("view1");
+            dropMv("test", "join_mv_1");
+        }
+
+        {
+            starRocksAssert.withView("create view view1 as " +
+                    " select deptno1, deptno2, empid, name " +
+                    "from " +
+                    "(SELECT emps_par.deptno as deptno1, depts.deptno as deptno2, emps_par.empid, emps_par.name from emps_par " +
+                    "join depts" +
+                    " on emps_par.deptno = depts.deptno) t");
+
+            createAndRefreshMv("test", "join_mv_2", "create materialized view join_mv_2" +
+                    " distributed by hash(deptno2)" +
+                    " partition by deptno1" +
+                    " as " +
+                    " SELECT deptno1, deptno2, empid, name from view1 union SELECT deptno1, deptno2, empid, name from view1");
+
+            createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +
+                    " distributed by hash(deptno2)" +
+                    " partition by deptno1" +
+                    " as " +
+                    " SELECT deptno1, deptno2, empid, name from view1");
+
+            {
+                String query = "SELECT deptno1, deptno2, empid, name from view1";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "join_mv_1");
+            }
+
+            starRocksAssert.dropView("view1");
+            dropMv("test", "join_mv_1");
+            dropMv("test", "join_mv_2");
+        }
+    }
+
+    @Test
     public void testJoinMvRewrite() throws Exception {
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000000);
         createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +

--- a/test/sql/test_materialized_view/R/test_materialized_view_with_subquery
+++ b/test/sql/test_materialized_view/R/test_materialized_view_with_subquery
@@ -8,22 +8,23 @@ CREATE TABLE test_pk_tbl1 (
     flag string
 )
 PRIMARY KEY(dt_hour, col1)
-PARTITION BY RANGE(`dt_hour`)()
+PARTITION BY RANGE(`dt_hour`) (
+    PARTITION p20230817 VALUES LESS THAN ('2023-08-17')
+)
 DISTRIBUTED BY HASH(col1) BUCKETS 16
 PROPERTIES (
     "replication_num" = "1"
 );
 -- result:
 -- !result
+insert into test_pk_tbl1 values ('2023-08-16', 'a', '0', 'a', 'b', '1'),  ('2023-08-16', 'b', '0', 'a', 'b', '3');
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_pk_mv_with_subquery1
 PARTITION BY (`dt_hour`)
 DISTRIBUTED BY HASH(`dt_hour`,`col1`) BUCKETS 8
-REFRESH ASYNC START('2023-08-11 11:05:00') EVERY (interval 2 minute)
 PROPERTIES (
-"replication_num" = "1",
-"storage_medium" = "HDD",
-"partition_ttl_number"="72",
-"partition_refresh_number"="72"
+    "replication_num" = "1"
 )
 AS
 SELECT t0.col1, t0.dt_hour, t0.c_col2 as col2, t0.c_col3 as col3, t1.c_col2 as col4, t1.c_col3 as col5
@@ -33,8 +34,8 @@ FROM
              COUNT(DISTINCT CASE WHEN flag = '1' THEN col2 ELSE NULL END) AS c_col2,
              COUNT(DISTINCT CASE WHEN flag = '1' THEN col3 ELSE NULL END) AS c_col3 
       FROM test_pk_tbl1
-      WHERE ((DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(DATE_SUB(NOW(), INTERVAL 8 hour))
-          AND timezone = '0') OR (DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(Now()) AND timezone = '8'))
+      WHERE ((DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(DATE_SUB(DATE('2023-08-17 09:00:00'), INTERVAL 8 hour))
+          AND timezone = '0') OR (DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE('2023-08-16') AND timezone = '8'))
      AND (flag = '1' OR flag = '2')
 GROUP BY col1, dt_hour) t0
     LEFT JOIN
@@ -42,16 +43,10 @@ GROUP BY col1, dt_hour) t0
              COUNT(DISTINCT CASE WHEN flag = '1' THEN col2 ELSE NULL END) AS c_col2,
              COUNT(DISTINCT CASE WHEN flag = '1' THEN col3 ELSE NULL END) AS c_col3 
       FROM test_pk_tbl1
-      WHERE ((DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(DATE_SUB(NOW(), INTERVAL 8 hour))
-          AND timezone = '0') OR (DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(Now()) AND timezone = '8'))
+      WHERE ((DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(DATE_SUB(DATE('2023-08-17 08:00:006'), INTERVAL 8 hour))
+          AND timezone = '0') OR (DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE('2023-08-16') AND timezone = '8'))
      AND (flag = '1' OR flag = '4')
 GROUP BY col1, dt_hour) t1 ON t0.col1 = t1.col1;
--- result:
--- !result
-alter table test_pk_tbl1 ADD PARTITION IF NOT EXISTS p20230817 VALUES LESS THAN ('2023-08-17');
--- result:
--- !result
-insert into test_pk_tbl1 values ('2023-08-16', 'a', '0', 'a', 'b', '1'),  ('2023-08-16', 'b', '0', 'a', 'b', '3');
 -- result:
 -- !result
 refresh materialized view test_pk_mv_with_subquery1 with sync mode;

--- a/test/sql/test_materialized_view/R/test_materialized_view_with_subquery
+++ b/test/sql/test_materialized_view/R/test_materialized_view_with_subquery
@@ -1,0 +1,66 @@
+-- name: test_materialized_view_with_subquery
+CREATE TABLE test_pk_tbl1 (
+    dt_hour datetime,
+    col1 string,
+    timezone string,
+    col2 string,
+    col3 string,
+    flag string
+)
+PRIMARY KEY(dt_hour, col1)
+PARTITION BY RANGE(`dt_hour`)()
+DISTRIBUTED BY HASH(col1) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_pk_mv_with_subquery1
+PARTITION BY (`dt_hour`)
+DISTRIBUTED BY HASH(`dt_hour`,`col1`) BUCKETS 8
+REFRESH ASYNC START('2023-08-11 11:05:00') EVERY (interval 2 minute)
+PROPERTIES (
+"replication_num" = "1",
+"storage_medium" = "HDD",
+"partition_ttl_number"="72",
+"partition_refresh_number"="72"
+)
+AS
+SELECT t0.col1, t0.dt_hour, t0.c_col2 as col2, t0.c_col3 as col3, t1.c_col2 as col4, t1.c_col3 as col5
+FROM
+    ( SELECT col1,
+             dt_hour,
+             COUNT(DISTINCT CASE WHEN flag = '1' THEN col2 ELSE NULL END) AS c_col2,
+             COUNT(DISTINCT CASE WHEN flag = '1' THEN col3 ELSE NULL END) AS c_col3 
+      FROM test_pk_tbl1
+      WHERE ((DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(DATE_SUB(NOW(), INTERVAL 8 hour))
+          AND timezone = '0') OR (DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(Now()) AND timezone = '8'))
+     AND (flag = '1' OR flag = '2')
+GROUP BY col1, dt_hour) t0
+    LEFT JOIN
+    ( SELECT col1, dt_hour,
+             COUNT(DISTINCT CASE WHEN flag = '1' THEN col2 ELSE NULL END) AS c_col2,
+             COUNT(DISTINCT CASE WHEN flag = '1' THEN col3 ELSE NULL END) AS c_col3 
+      FROM test_pk_tbl1
+      WHERE ((DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(DATE_SUB(NOW(), INTERVAL 8 hour))
+          AND timezone = '0') OR (DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(Now()) AND timezone = '8'))
+     AND (flag = '1' OR flag = '4')
+GROUP BY col1, dt_hour) t1 ON t0.col1 = t1.col1;
+-- result:
+-- !result
+alter table test_pk_tbl1 ADD PARTITION IF NOT EXISTS p20230817 VALUES LESS THAN ('2023-08-17');
+-- result:
+-- !result
+insert into test_pk_tbl1 values ('2023-08-16', 'a', '0', 'a', 'b', '1'),  ('2023-08-16', 'b', '0', 'a', 'b', '3');
+-- result:
+-- !result
+refresh materialized view test_pk_mv_with_subquery1 with sync mode;
+select * from test_pk_tbl1 order by col1;
+-- result:
+2023-08-16 00:00:00	a	0	a	b	1
+2023-08-16 00:00:00	b	0	a	b	3
+-- !result
+select * from test_pk_mv_with_subquery1 order by col1;
+-- result:
+a	2023-08-16 00:00:00	1	1	1	1
+-- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_with_subquery
+++ b/test/sql/test_materialized_view/T/test_materialized_view_with_subquery
@@ -8,21 +8,21 @@ CREATE TABLE test_pk_tbl1 (
     flag string
 )
 PRIMARY KEY(dt_hour, col1)
-PARTITION BY RANGE(`dt_hour`)()
+PARTITION BY RANGE(`dt_hour`) (
+    PARTITION p20230817 VALUES LESS THAN ('2023-08-17')
+)
 DISTRIBUTED BY HASH(col1) BUCKETS 16
 PROPERTIES (
     "replication_num" = "1"
 );
 
+insert into test_pk_tbl1 values ('2023-08-16', 'a', '0', 'a', 'b', '1'),  ('2023-08-16', 'b', '0', 'a', 'b', '3');
+
 CREATE MATERIALIZED VIEW test_pk_mv_with_subquery1
 PARTITION BY (`dt_hour`)
 DISTRIBUTED BY HASH(`dt_hour`,`col1`) BUCKETS 8
-REFRESH ASYNC START('2023-08-11 11:05:00') EVERY (interval 2 minute)
 PROPERTIES (
-"replication_num" = "1",
-"storage_medium" = "HDD",
-"partition_ttl_number"="72",
-"partition_refresh_number"="72"
+    "replication_num" = "1"
 )
 AS
 SELECT t0.col1, t0.dt_hour, t0.c_col2 as col2, t0.c_col3 as col3, t1.c_col2 as col4, t1.c_col3 as col5
@@ -32,8 +32,8 @@ FROM
              COUNT(DISTINCT CASE WHEN flag = '1' THEN col2 ELSE NULL END) AS c_col2,
              COUNT(DISTINCT CASE WHEN flag = '1' THEN col3 ELSE NULL END) AS c_col3 
       FROM test_pk_tbl1
-      WHERE ((DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(DATE_SUB(NOW(), INTERVAL 8 hour))
-          AND timezone = '0') OR (DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(Now()) AND timezone = '8'))
+      WHERE ((DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(DATE_SUB(DATE('2023-08-17 09:00:00'), INTERVAL 8 hour))
+          AND timezone = '0') OR (DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE('2023-08-16') AND timezone = '8'))
      AND (flag = '1' OR flag = '2')
 GROUP BY col1, dt_hour) t0
     LEFT JOIN
@@ -41,13 +41,10 @@ GROUP BY col1, dt_hour) t0
              COUNT(DISTINCT CASE WHEN flag = '1' THEN col2 ELSE NULL END) AS c_col2,
              COUNT(DISTINCT CASE WHEN flag = '1' THEN col3 ELSE NULL END) AS c_col3 
       FROM test_pk_tbl1
-      WHERE ((DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(DATE_SUB(NOW(), INTERVAL 8 hour))
-          AND timezone = '0') OR (DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(Now()) AND timezone = '8'))
+      WHERE ((DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(DATE_SUB(DATE('2023-08-17 08:00:006'), INTERVAL 8 hour))
+          AND timezone = '0') OR (DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE('2023-08-16') AND timezone = '8'))
      AND (flag = '1' OR flag = '4')
 GROUP BY col1, dt_hour) t1 ON t0.col1 = t1.col1;
-
-alter table test_pk_tbl1 ADD PARTITION IF NOT EXISTS p20230817 VALUES LESS THAN ('2023-08-17');
-insert into test_pk_tbl1 values ('2023-08-16', 'a', '0', 'a', 'b', '1'),  ('2023-08-16', 'b', '0', 'a', 'b', '3');
 
 refresh materialized view test_pk_mv_with_subquery1 with sync mode;
 select * from test_pk_tbl1 order by col1;

--- a/test/sql/test_materialized_view/T/test_materialized_view_with_subquery
+++ b/test/sql/test_materialized_view/T/test_materialized_view_with_subquery
@@ -1,0 +1,54 @@
+-- name: test_materialized_view_with_subquery
+CREATE TABLE test_pk_tbl1 (
+    dt_hour datetime,
+    col1 string,
+    timezone string,
+    col2 string,
+    col3 string,
+    flag string
+)
+PRIMARY KEY(dt_hour, col1)
+PARTITION BY RANGE(`dt_hour`)()
+DISTRIBUTED BY HASH(col1) BUCKETS 16
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+CREATE MATERIALIZED VIEW test_pk_mv_with_subquery1
+PARTITION BY (`dt_hour`)
+DISTRIBUTED BY HASH(`dt_hour`,`col1`) BUCKETS 8
+REFRESH ASYNC START('2023-08-11 11:05:00') EVERY (interval 2 minute)
+PROPERTIES (
+"replication_num" = "1",
+"storage_medium" = "HDD",
+"partition_ttl_number"="72",
+"partition_refresh_number"="72"
+)
+AS
+SELECT t0.col1, t0.dt_hour, t0.c_col2 as col2, t0.c_col3 as col3, t1.c_col2 as col4, t1.c_col3 as col5
+FROM
+    ( SELECT col1,
+             dt_hour,
+             COUNT(DISTINCT CASE WHEN flag = '1' THEN col2 ELSE NULL END) AS c_col2,
+             COUNT(DISTINCT CASE WHEN flag = '1' THEN col3 ELSE NULL END) AS c_col3 
+      FROM test_pk_tbl1
+      WHERE ((DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(DATE_SUB(NOW(), INTERVAL 8 hour))
+          AND timezone = '0') OR (DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(Now()) AND timezone = '8'))
+     AND (flag = '1' OR flag = '2')
+GROUP BY col1, dt_hour) t0
+    LEFT JOIN
+    ( SELECT col1, dt_hour,
+             COUNT(DISTINCT CASE WHEN flag = '1' THEN col2 ELSE NULL END) AS c_col2,
+             COUNT(DISTINCT CASE WHEN flag = '1' THEN col3 ELSE NULL END) AS c_col3 
+      FROM test_pk_tbl1
+      WHERE ((DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(DATE_SUB(NOW(), INTERVAL 8 hour))
+          AND timezone = '0') OR (DATE_FORMAT(dt_hour, '%Y-%m-%d') = DATE(Now()) AND timezone = '8'))
+     AND (flag = '1' OR flag = '4')
+GROUP BY col1, dt_hour) t1 ON t0.col1 = t1.col1;
+
+alter table test_pk_tbl1 ADD PARTITION IF NOT EXISTS p20230817 VALUES LESS THAN ('2023-08-17');
+insert into test_pk_tbl1 values ('2023-08-16', 'a', '0', 'a', 'b', '1'),  ('2023-08-16', 'b', '0', 'a', 'b', '3');
+
+refresh materialized view test_pk_mv_with_subquery1 with sync mode;
+select * from test_pk_tbl1 order by col1;
+select * from test_pk_mv_with_subquery1 order by col1;


### PR DESCRIPTION
Fixes #26078

Support subqueries in creating materialized view for partitioned mv. 

Original if mv's defination contains subquery, the analyzer cannot resolve the partition column comes from.

Refactor `resolvePartitionExpr ` to try to resolve the partition column from each subquery relations to find the partition column comes from.

eg:
```
    public void testCreateMaterializedViewWithTableAlias1() throws Exception {
        String sql = "create materialized view mv1 " +
                "partition by k1 " +
                "distributed by hash(k2) buckets 10 " +
                "PROPERTIES (\n" +
                "\"replication_num\" = \"1\"" +
                ") " +
                "as select t0.k1, t0.k2, t0.sum as sum0 " +
                "from (select k1, k2, sum(v1) as sum from tbl1 group by k1, k2) t0 where t0.k2 > 10";
        try {
            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
        } catch (Exception e) {
            e.printStackTrace();
            Assert.fail(e.getMessage());
        }
    }
```
## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
