### PR TITLE
[Enhancement] Slows down transaction commit if compaction score is high

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -146,8 +146,8 @@ void StreamLoadAction::handle(HttpRequest* req) {
     if (ctx->status.ok()) {
         ctx->status = _handle(ctx);
         if (!ctx->status.ok() && ctx->status.code() != TStatusCode::PUBLISH_TIMEOUT) {
-            LOG(WARNING) << "Fail to handle streaming load, id=" << ctx->id
-                         << " errmsg=" << ctx->status.get_error_msg();
+            LOG(WARNING) << "Fail to handle streaming load, id=" << ctx->id << " errmsg=" << ctx->status.get_error_msg()
+                         << " " << ctx->brief();
         }
     }
     ctx->load_cost_nanos = MonotonicNanos() - ctx->start_nanos;

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -474,7 +474,7 @@ void RoutineLoadTaskExecutor::exec_task(StreamLoadContext* ctx, DataConsumerPool
 }
 
 void RoutineLoadTaskExecutor::err_handler(StreamLoadContext* ctx, const Status& st, const std::string& err_msg) {
-    LOG(WARNING) << err_msg;
+    LOG(WARNING) << err_msg << " " << ctx->brief();
     ctx->status = st;
     if (ctx->need_rollback) {
         _exec_env->stream_load_executor()->rollback_txn(ctx);

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -36,8 +36,11 @@
 
 #include <fmt/format.h>
 
+#include <string_view>
+
 #include "agent/master_info.h"
 #include "common/status.h"
+#include "common/statusor.h"
 #include "common/utils.h"
 #include "gen_cpp/FrontendService.h"
 #include "runtime/client_cache.h"
@@ -57,6 +60,13 @@ TLoadTxnCommitResult k_stream_load_commit_result;
 TLoadTxnRollbackResult k_stream_load_rollback_result;
 Status k_stream_load_plan_status;
 #endif
+
+static Status commit_txn_internal(const TLoadTxnCommitRequest& request, int64_t deadline, const AuthInfo& auth,
+                                  int32_t rpc_timeout_ms);
+static StatusOr<TTransactionStatus::type> get_txn_status(const AuthInfo& auth, std::string_view db,
+                                                         std::string_view table, int64_t txn_id);
+static bool wait_txn_visible_until(const AuthInfo& auth, std::string_view db, std::string_view table, int64_t txn_id,
+                                   int64_t deadline);
 
 Status StreamLoadExecutor::execute_plan_fragment(StreamLoadContext* ctx) {
     StarRocksMetrics::instance()->txn_exec_plan_total.increment(1);
@@ -208,10 +218,15 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
     // set attachment if has
     TTxnCommitAttachment attachment;
     if (collect_load_stat(ctx, &attachment)) {
-        request.txnCommitAttachment = attachment;
+        request.txnCommitAttachment = std::move(attachment);
         request.__isset.txnCommitAttachment = true;
     }
 
+    return commit_txn_internal(request, ctx->load_deadline_sec, ctx->auth, rpc_timeout_ms);
+}
+
+Status commit_txn_internal(const TLoadTxnCommitRequest& request, int64_t deadline, const AuthInfo& auth,
+                           int32_t rpc_timeout_ms) {
     TNetworkAddress master_addr = get_master_address();
     TLoadTxnCommitResult result;
 #ifndef BE_TEST
@@ -229,49 +244,60 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
 #else
     result = k_stream_load_commit_result;
 #endif
-    // Return if this transaction is committed successful; otherwise, we need try
-    // to rollback this transaction.
     Status status(result.status);
-    if (!status.ok()) {
-        LOG(WARNING) << "commit transaction failed, errmsg=" << status.get_error_msg() << ctx->brief();
-        if (status.code() == TStatusCode::PUBLISH_TIMEOUT) {
-            ctx->need_rollback = false;
-            if (ctx->load_deadline_sec > UnixSeconds()) {
-                //wait for apply finish
-                TGetLoadTxnStatusRequest v_request;
-                TGetLoadTxnStatusResult v_result;
-                set_request_auth(&v_request, ctx->auth);
-                v_request.db = ctx->db;
-                v_request.tbl = ctx->table;
-                v_request.txnId = ctx->txn_id;
-                while (ctx->load_deadline_sec > UnixSeconds()) {
-                    sleep(std::min((int64_t)config::get_txn_status_internal_sec,
-                                   ctx->load_deadline_sec - UnixSeconds()));
-                    auto visiable_st = ThriftRpcHelper::rpc<FrontendServiceClient>(
-                            master_addr.hostname, master_addr.port,
-                            [&v_request, &v_result](FrontendServiceConnection& client) {
-                                client->getLoadTxnStatus(v_result, v_request);
-                            },
-                            config::txn_commit_rpc_timeout_ms);
-                    if (!visiable_st.ok()) {
-                        return status;
-                    } else {
-                        if (v_result.status == TTransactionStatus::VISIBLE) {
-                            return Status::OK();
-                        } else if (v_result.status == TTransactionStatus::COMMITTED) {
-                            continue;
-                        } else {
-                            return status;
-                        }
-                    }
-                }
-            }
-        }
+    if (status.ok()) {
+        return status;
+    } else if (status.code() == TStatusCode::PUBLISH_TIMEOUT) {
+        bool visible = wait_txn_visible_until(auth, request.db, request.tbl, request.txnId, deadline);
+        return visible ? Status::OK() : status;
+    } else if (result.__isset.allow_retry && result.allow_retry) {
+        LOG(WARNING) << "commit transaction " << request.txnId << " failed, will retry after sleeping "
+                     << result.retry_interval_ms << "ms. errmsg=" << status.get_error_msg();
+        std::this_thread::sleep_for(std::chrono::milliseconds(result.retry_interval_ms));
+        return commit_txn_internal(request, deadline, auth, rpc_timeout_ms);
+    } else {
         return status;
     }
-    // commit success, set need_rollback to false
-    ctx->need_rollback = false;
-    return Status::OK();
+}
+
+StatusOr<TTransactionStatus::type> get_txn_status(const AuthInfo& auth, std::string_view db, std::string_view table,
+                                                  int64_t txn_id) {
+    TNetworkAddress master_addr = get_master_address();
+    TGetLoadTxnStatusRequest request;
+    TGetLoadTxnStatusResult result;
+
+    set_request_auth(&request, auth);
+    request.db = db;
+    request.tbl = table;
+    request.txnId = txn_id;
+
+    auto st = ThriftRpcHelper::rpc<FrontendServiceClient>(
+            master_addr.hostname, master_addr.port,
+            [&request, &result](FrontendServiceConnection& client) { client->getLoadTxnStatus(result, request); },
+            config::txn_commit_rpc_timeout_ms);
+    if (!st.ok()) {
+        return st;
+    } else {
+        return result.status;
+    }
+}
+
+bool wait_txn_visible_until(const AuthInfo& auth, std::string_view db, std::string_view table, int64_t txn_id,
+                            int64_t deadline) {
+    while (deadline > UnixSeconds()) {
+        sleep(std::min((int64_t)config::get_txn_status_internal_sec, deadline - UnixSeconds()));
+        auto status_or = get_txn_status(auth, db, table, txn_id);
+        if (!status_or.ok()) {
+            return false;
+        } else if (status_or.value() == TTransactionStatus::VISIBLE) {
+            return true;
+        } else if (status_or.value() == TTransactionStatus::COMMITTED) {
+            continue;
+        } else {
+            return false;
+        }
+    }
+    return false;
 }
 
 Status StreamLoadExecutor::prepare_txn(StreamLoadContext* ctx) {

--- a/be/src/runtime/stream_load/stream_load_executor.h
+++ b/be/src/runtime/stream_load/stream_load_executor.h
@@ -37,8 +37,8 @@
 namespace starrocks {
 
 class ExecEnv;
-class StreamLoadContext;
 class Status;
+class StreamLoadContext;
 class TTxnCommitAttachment;
 
 class StreamLoadExecutor {

--- a/be/src/runtime/stream_load/transaction_mgr.cpp
+++ b/be/src/runtime/stream_load/transaction_mgr.cpp
@@ -258,6 +258,7 @@ Status TransactionMgr::commit_transaction(const HttpRequest* req, std::string* r
 
         st = _commit_transaction(ctx, boost::iequals(TXN_PREPARE, req->param(HTTP_TXN_OP_KEY)));
         if (!st.ok()) {
+            LOG(ERROR) << "Fail to commit txn: " << st << " " << ctx->brief();
             ctx->status = st;
             if (ctx->need_rollback) {
                 _rollback_transaction(ctx);

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2259,15 +2259,41 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "the minimum delay between autovacuum runs on any given partition")
     public static long lake_autovacuum_partition_naptime_seconds = 180;
 
-    @ConfField(mutable = true, comment = "History versions within this time range will not be deleted by auto vacuum.\n" +
+    @ConfField(mutable = true, comment =
+            "History versions within this time range will not be deleted by auto vacuum.\n" +
             "REMINDER: Set this to a value longer than the maximum possible execution time of queries, to avoid deletion of " +
             "versions still being accessed.\n" +
             "NOTE: Increasing this value may increase the space usage of the remote storage system.")
     public static long lake_autovacuum_grace_period_minutes = 5;
 
-    @ConfField(mutable = true, comment = "time threshold in hours, if a partition has not been updated for longer than this " +
-            "threshold, auto vacuum operations will no longer be triggered for that partition")
+    @ConfField(mutable = true, comment =
+            "time threshold in hours, if a partition has not been updated for longer than this " +
+            "threshold, auto vacuum operations will no longer be triggered for that partition.\n" +
+            "Only takes effect for tables in clusters with run_mode=shared_data.\n")
     public static long lake_autovacuum_stale_partition_threshold = 12;
+
+    @ConfField(mutable = true, comment =
+            "Whether enable delaying ingestion transaction commits when compaction score exceeds the threshold.\n" +
+            "Only takes effect for tables in clusters with run_mode=shared_data.\n" +
+            "Enabling this may reduce small files and improve query performance, but may increase ingestion\n" +
+            "transaction duration.")
+    public static boolean lake_enable_delay_commit = false;
+
+    @ConfField(mutable = true, comment =
+            "Delaying transaction commits if the compaction score of a table exceeds this threshold.\n" +
+            "Only takes effect for tables in clusters with run_mode=shared_data.\n" +
+            "NOTE: The actual effective value is the max of the configured value and " +
+            "'lake_compaction_score_selector_min_score'.")
+    public static long lake_delay_commit_compaction_score_threshold = 50;
+
+    @ConfField(mutable = true, comment =
+            "Ratio to reduce commit speed if compaction score exceeds threshold.\n" +
+            "Only takes effect for tables in clusters with run_mode=shared_data.\n" +
+            "Commit will be delayed by this percentage of the data write duration.\n" +
+            "E.g. with write duration 10min, ratio 0.1:\n" +
+            "- exceed 3 points -> 30% of 10min -> 3min delay\n" +
+            "- Exceed 5 points -> 50% of 10min -> 5min delay\n")
+    public static double lake_delay_commit_compaction_score_ratio = 0.1;
 
     @ConfField(mutable = true)
     public static boolean enable_new_publish_mechanism = false;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/CommitRateLimiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/CommitRateLimiter.java
@@ -1,0 +1,122 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.common.Config;
+import com.starrocks.lake.compaction.CompactionMgr;
+import com.starrocks.lake.compaction.PartitionIdentifier;
+import com.starrocks.lake.compaction.PartitionStatistics;
+import com.starrocks.lake.compaction.Quantiles;
+import com.starrocks.transaction.CommitRateExceededException;
+import com.starrocks.transaction.TransactionState;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Objects;
+import java.util.Set;
+import javax.validation.constraints.NotNull;
+
+public class CommitRateLimiter {
+    private static final Logger LOG = LogManager.getLogger(CommitRateLimiter.class);
+
+    private final CompactionMgr compactionMgr;
+    private final LakeTable table;
+    private final TransactionState transactionState;
+
+    /**
+     * Creates a CommitRateLimiter object.
+     *
+     * @param compactionMgr    The CompactionMgr object used for compacting the lake table. Must not be null.
+     * @param table            The LakeTable object to which the commit rate limiter is applied. Must not be null.
+     * @param transactionState The TransactionState object representing the current transaction state. Must not be null.
+     */
+    public CommitRateLimiter(@NotNull CompactionMgr compactionMgr,
+                             @NotNull LakeTable table,
+                             @NotNull TransactionState transactionState) {
+        this.compactionMgr = Objects.requireNonNull(compactionMgr, "compactionMgr is null");
+        this.table = Objects.requireNonNull(table, "table is null");
+        this.transactionState = Objects.requireNonNull(transactionState, "transactionState is null");
+    }
+
+    private static long getCommitTime(TransactionState transactionState, double maxCompactionScore, double threshold) {
+        double slowDownPercentage = (maxCompactionScore - threshold) * Config.lake_delay_commit_compaction_score_ratio;
+        // The time spending on data writing
+        long writeDurationMs = transactionState.getDoneWriteTime() - transactionState.getPrepareTime();
+        // The bigger "writeDurationMs" is, the bigger "slowDownTime" is
+        long slowDownTime = (long) (writeDurationMs * slowDownPercentage);
+        return transactionState.getDoneWriteTime() + slowDownTime;
+    }
+
+    /**
+     * Checks the commit rate for the given partition IDs and throws a CommitRateExceededException if necessary.
+     *
+     * @param partitionIds the set of partition IDs to check. Must not be null.
+     * @throws CommitFailedException if the allow commit time exceeds the transaction timeout
+     * @throws CommitRateExceededException if the commit rate exceeds the threshold
+     */
+    public void check(@NotNull Set<Long> partitionIds) throws CommitRateExceededException, CommitFailedException {
+        Preconditions.checkNotNull(partitionIds, "partitionIds is null");
+        // Does not limit the commit rate of compaction transactions
+        if (transactionState.getSourceType() == TransactionState.LoadJobSourceType.LAKE_COMPACTION) {
+            return;
+        }
+        long txnId = transactionState.getTransactionId();
+        long currentMs = System.currentTimeMillis();
+        if (transactionState.getAllowCommitTime() < 0) {
+            long dbId = transactionState.getDbId();
+            long tableId = table.getId();
+            long maxWaitForTime = 0;
+            for (Long partitionId : partitionIds) {
+                PartitionIdentifier partitionIdentifier = new PartitionIdentifier(dbId, tableId, partitionId);
+                maxWaitForTime = Math.max(maxWaitForTime, commitWaitForTime(partitionIdentifier, currentMs));
+            }
+            transactionState.setAllowCommitTime(currentMs + maxWaitForTime);
+            if (maxWaitForTime > 0) {
+                LOG.info("delay commit of txn {} for {}ms, write took {}ms", txnId, maxWaitForTime,
+                        transactionState.getDoneWriteTime() - transactionState.getPrepareTime());
+            }
+        }
+        long abortTime = transactionState.getPrepareTime() + transactionState.getTimeoutMs();
+        if (transactionState.getAllowCommitTime() >= abortTime) {
+            throw new CommitFailedException("Txn " + txnId + " timed out due to commit throttling", txnId);
+        }
+        if (transactionState.getAllowCommitTime() > currentMs) {
+            throw new CommitRateExceededException(txnId, transactionState.getAllowCommitTime());
+        }
+    }
+
+    private long commitWaitForTime(@NotNull PartitionIdentifier partitionIdentifier, long currentMilliseconds) {
+        PartitionStatistics statistics = compactionMgr.getStatistics(partitionIdentifier);
+        Quantiles compactionScore = statistics != null ? statistics.getCompactionScore() : null;
+        if (compactionScore == null) {
+            return 0;
+        }
+        double maxCompactionScore = compactionScore.getMax();
+        double threshold = Math.max(Config.lake_delay_commit_compaction_score_threshold,
+                Config.lake_compaction_score_selector_min_score);
+        if (maxCompactionScore <= threshold) {
+            return 0;
+        }
+        long commitTime = getCommitTime(transactionState, maxCompactionScore, threshold);
+        long commitWaitMs = commitTime - currentMilliseconds;
+        if (commitWaitMs < 0) {
+            return 0;
+        } else {
+            return commitWaitMs;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -49,6 +49,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -394,7 +395,8 @@ public class CompactionScheduler extends Daemon {
         VisibleStateWaiter waiter;
         db.writeLock();
         try {
-            waiter = transactionMgr.commitTransaction(db.getId(), job.getTxnId(), commitInfoList, Lists.newArrayList());
+            waiter = transactionMgr.commitTransaction(db.getId(), job.getTxnId(), commitInfoList,
+                    Collections.emptyList(), null);
         } finally {
             db.writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
@@ -52,6 +52,7 @@ import com.starrocks.transaction.TabletCommitInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -192,7 +193,7 @@ public class LakeDeleteJob extends DeleteJob {
         }
 
         return GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                .commitAndPublishTransaction(db, getTransactionId(), tabletCommitInfos, Lists.newArrayList(),
+                .commitAndPublishTransaction(db, getTransactionId(), tabletCommitInfos, Collections.emptyList(),
                         timeoutMs);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -134,6 +134,7 @@ import com.starrocks.thrift.TTableMeta;
 import com.starrocks.thrift.TTabletInfo;
 import com.starrocks.thrift.TTabletMeta;
 import com.starrocks.thrift.TTaskType;
+import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionState;
@@ -1252,12 +1253,13 @@ public class LeaderImpl {
             TxnCommitAttachment attachment = TxnCommitAttachment.fromThrift(request.getCommit_attachment());
             long timeoutMs = request.isSetCommit_timeout_ms() ? request.getCommit_timeout_ms() :
                     Config.external_table_commit_timeout_ms;
-            boolean ret = GlobalStateMgr.getCurrentGlobalTransactionMgr().commitAndPublishTransaction(
-                    db, request.getTxn_id(),
+            GlobalTransactionMgr transactionMgr = GlobalStateMgr.getCurrentGlobalTransactionMgr();
+            boolean visible = transactionMgr.commitAndPublishTransaction(db, request.getTxn_id(),
                     TabletCommitInfo.fromThrift(request.getCommit_infos()),
                     TabletFailInfo.fromThrift(request.getFail_infos()),
-                    timeoutMs, attachment);
-            if (!ret) { // timeout
+                    timeoutMs,
+                    attachment);
+            if (!visible) { // timeout
                 TStatus status = new TStatus(TStatusCode.TIMEOUT);
                 status.setError_msgs(Lists.newArrayList("commit and publish txn timeout"));
                 response.setStatus(status);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -108,6 +108,7 @@ import com.starrocks.thrift.TReportExecStatusParams;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.BeginTransactionException;
+import com.starrocks.transaction.CommitRateExceededException;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletQuorumFailedException;
 import com.starrocks.transaction.TransactionState;
@@ -732,8 +733,8 @@ public class SparkLoadJob extends BulkLoadJob {
                     dbId, transactionId, commitInfos, Lists.newArrayList(),
                     new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp,
                             finishTimestamp, state, failMsg));
-        } catch (TabletQuorumFailedException e) {
-            // retry in next loop
+        } catch (TabletQuorumFailedException | CommitRateExceededException e) {
+            LOG.info("Failed commit for txn {}, will retry. Error: {}", transactionId, e.getMessage());
         } finally {
             db.writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -172,12 +172,14 @@ import com.starrocks.thrift.TResultBatch;
 import com.starrocks.thrift.TSinkCommitInfo;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWorkGroup;
+import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionCommitFailedException;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.transaction.VisibleStateWaiter;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -194,6 +196,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -1561,6 +1564,7 @@ public class StmtExecutor {
         String dbName = stmt.getTableName().getDb();
         String tableName = stmt.getTableName().getTbl();
         Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
+        GlobalTransactionMgr transactionMgr = GlobalStateMgr.getCurrentGlobalTransactionMgr();
         final Table targetTable;
         if (stmt instanceof InsertStmt && ((InsertStmt) stmt).getTargetTable() != null) {
             targetTable = ((InsertStmt) stmt).getTargetTable();
@@ -1604,9 +1608,7 @@ public class StmtExecutor {
             authenticateParams.setHost(context.getRemoteIP());
             authenticateParams.setDb_name(externalTable.getSourceTableDbName());
             authenticateParams.setTable_names(Lists.newArrayList(externalTable.getSourceTableName()));
-            transactionId =
-                    GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                            .beginRemoteTransaction(externalTable.getSourceTableDbId(),
+            transactionId = transactionMgr.beginRemoteTransaction(externalTable.getSourceTableDbId(),
                                     Lists.newArrayList(externalTable.getSourceTableId()), label,
                                     externalTable.getSourceTableHost(),
                                     externalTable.getSourceTablePort(),
@@ -1618,7 +1620,7 @@ public class StmtExecutor {
         } else if (targetTable instanceof SystemTable || targetTable instanceof IcebergTable) {
             // schema table and iceberg table does not need txn
         } else {
-            transactionId = GlobalStateMgr.getCurrentGlobalTransactionMgr().beginTransaction(
+            transactionId = transactionMgr.beginTransaction(
                     database.getId(),
                     Lists.newArrayList(targetTable.getId()),
                     label,
@@ -1628,8 +1630,7 @@ public class StmtExecutor {
                     context.getSessionVariable().getQueryTimeoutS());
 
             // add table indexes to transaction state
-            txnState = GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                    .getTransactionState(database.getId(), transactionId);
+            txnState = transactionMgr.getTransactionState(database.getId(), transactionId);
             if (txnState == null) {
                 throw new DdlException("txn does not exist: " + transactionId);
             }
@@ -1770,7 +1771,7 @@ public class StmtExecutor {
                 if (filteredRows > 0) {
                     if (targetTable instanceof ExternalOlapTable) {
                         ExternalOlapTable externalTable = (ExternalOlapTable) targetTable;
-                        GlobalStateMgr.getCurrentGlobalTransactionMgr().abortRemoteTransaction(
+                        transactionMgr.abortRemoteTransaction(
                                 externalTable.getSourceTableDbId(), transactionId,
                                 externalTable.getSourceTableHost(),
                                 externalTable.getSourceTablePort(),
@@ -1780,7 +1781,7 @@ public class StmtExecutor {
                     } else if (targetTable instanceof SystemTable || targetTable instanceof IcebergTable) {
                         // schema table does not need txn
                     } else {
-                        GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(
+                        transactionMgr.abortTransaction(
                                 database.getId(),
                                 transactionId,
                                 TransactionCommitFailedException.FILTER_DATA_IN_STRICT_MODE + ", tracking sql = " +
@@ -1797,7 +1798,7 @@ public class StmtExecutor {
 
             if (targetTable instanceof ExternalOlapTable) {
                 ExternalOlapTable externalTable = (ExternalOlapTable) targetTable;
-                if (GlobalStateMgr.getCurrentGlobalTransactionMgr().commitRemoteTransaction(
+                if (transactionMgr.commitRemoteTransaction(
                         externalTable.getSourceTableDbId(), transactionId,
                         externalTable.getSourceTableHost(),
                         externalTable.getSourceTablePort(),
@@ -1822,29 +1823,30 @@ public class StmtExecutor {
                 context.getGlobalStateMgr().getMetadataMgr().finishSink(catalogName, dbName, tableName, commitInfos);
                 txnStatus = TransactionStatus.VISIBLE;
                 label = "FAKE_ICEBERG_SINK_LABEL";
+            } else if (isExplainAnalyze) {
+                transactionMgr.abortTransaction(database.getId(), transactionId, "Explain Analyze");
+                txnStatus = TransactionStatus.ABORTED;
             } else {
-                if (isExplainAnalyze) {
-                    GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                            .abortTransaction(database.getId(), transactionId, "Explain Analyze");
-                    txnStatus = TransactionStatus.ABORTED;
-                } else if (GlobalStateMgr.getCurrentGlobalTransactionMgr().commitAndPublishTransaction(
+                VisibleStateWaiter visibleWaiter = transactionMgr.retryCommitOnRateLimitExceeded(
                         database,
                         transactionId,
                         TabletCommitInfo.fromThrift(coord.getCommitInfos()),
                         TabletFailInfo.fromThrift(coord.getFailInfos()),
-                        Config.enable_sync_publish ? jobDeadLineMs - System.currentTimeMillis() : 
-                                            context.getSessionVariable().getTransactionVisibleWaitTimeout() * 1000,
-                        new InsertTxnCommitAttachment(loadedRows))) {
+                        new InsertTxnCommitAttachment(loadedRows),
+                        jobDeadLineMs - System.currentTimeMillis());
+
+                long publishWaitMs = Config.enable_sync_publish ? jobDeadLineMs - System.currentTimeMillis() :
+                        context.getSessionVariable().getTransactionVisibleWaitTimeout() * 1000;
+
+                if (visibleWaiter.await(publishWaitMs, TimeUnit.MILLISECONDS)) {
                     txnStatus = TransactionStatus.VISIBLE;
                     MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);
                     // collect table-level metrics
-                    if (null != targetTable) {
-                        TableMetricsEntity entity =
-                                TableMetricsRegistry.getInstance().getMetricsEntity(targetTable.getId());
-                        entity.counterInsertLoadFinishedTotal.increase(1L);
-                        entity.counterInsertLoadRowsTotal.increase(loadedRows);
-                        entity.counterInsertLoadBytesTotal.increase(loadedBytes);
-                    }
+                    TableMetricsEntity entity =
+                            TableMetricsRegistry.getInstance().getMetricsEntity(targetTable.getId());
+                    entity.counterInsertLoadFinishedTotal.increase(1L);
+                    entity.counterInsertLoadRowsTotal.increase(loadedRows);
+                    entity.counterInsertLoadBytesTotal.increase(loadedBytes);
                 } else {
                     txnStatus = TransactionStatus.COMMITTED;
                 }
@@ -1864,13 +1866,13 @@ public class StmtExecutor {
             try {
                 if (targetTable instanceof ExternalOlapTable) {
                     ExternalOlapTable externalTable = (ExternalOlapTable) targetTable;
-                    GlobalStateMgr.getCurrentGlobalTransactionMgr().abortRemoteTransaction(
+                    transactionMgr.abortRemoteTransaction(
                             externalTable.getSourceTableDbId(), transactionId,
                             externalTable.getSourceTableHost(),
                             externalTable.getSourceTablePort(),
                             errMsg);
                 } else {
-                    GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(
+                    transactionMgr.abortTransaction(
                             database.getId(), transactionId,
                             errMsg,
                             coord == null ? Lists.newArrayList() : TabletFailInfo.fromThrift(coord.getFailInfos()));
@@ -1919,8 +1921,7 @@ public class StmtExecutor {
 
         String errMsg = "";
         if (txnStatus.equals(TransactionStatus.COMMITTED)) {
-            String timeoutInfo = GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                    .getTxnPublishTimeoutDebugInfo(database.getId(), transactionId);
+            String timeoutInfo = transactionMgr.getTxnPublishTimeoutDebugInfo(database.getId(), transactionId);
             LOG.warn("txn {} publish timeout {}", transactionId, timeoutInfo);
             if (timeoutInfo.length() > 240) {
                 timeoutInfo = timeoutInfo.substring(0, 240) + "...";

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/CommitRateExceededException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/CommitRateExceededException.java
@@ -1,0 +1,28 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.transaction;
+
+public class CommitRateExceededException extends TransactionException {
+    private final long allowCommitTime;
+
+    public CommitRateExceededException(long transactionId, long allowCommitTime) {
+        super("Commit rate exceeds compaction throughput", transactionId);
+        this.allowCommitTime = allowCommitTime;
+    }
+
+    public long getAllowCommitTime() {
+        return allowCommitTime;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -398,6 +398,9 @@ public class DatabaseTransactionMgr {
                 && transactionState.getSourceType() != TransactionState.LoadJobSourceType.INSERT_STREAMING) {
             throw new TransactionCommitFailedException(TransactionCommitFailedException.NO_DATA_TO_LOAD_MSG);
         }
+        if (transactionState.getDoneWriteTime() < 0) {
+            transactionState.setDoneWriteTime(System.currentTimeMillis());
+        }
         if (!tabletCommitInfos.isEmpty()) {
             transactionState.setTabletCommitInfos(tabletCommitInfos);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -66,6 +66,7 @@ import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionState.LoadJobSourceType;
 import com.starrocks.transaction.TransactionState.TxnCoordinator;
 import org.apache.commons.lang3.time.StopWatch;
+import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -82,7 +83,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
-
 
 /**
  * Transaction Manager
@@ -362,29 +362,6 @@ public class GlobalTransactionMgr implements Writable {
         }
     }
 
-    @NotNull
-    public VisibleStateWaiter commitTransaction(long dbId, long transactionId,
-                                                @NotNull List<TabletCommitInfo> tabletCommitInfos)
-            throws UserException {
-        return commitTransaction(dbId, transactionId, tabletCommitInfos, Lists.newArrayList(), null);
-    }
-
-    @NotNull
-    public VisibleStateWaiter commitTransaction(long dbId, long transactionId,
-                                                @NotNull List<TabletCommitInfo> tabletCommitInfos,
-                                                @Nullable TxnCommitAttachment txnCommitAttachment)
-            throws UserException {
-        return commitTransaction(dbId, transactionId, tabletCommitInfos, Lists.newArrayList(), txnCommitAttachment);
-    }
-
-    @NotNull
-    public VisibleStateWaiter commitTransaction(long dbId, long transactionId,
-                                                @NotNull List<TabletCommitInfo> tabletCommitInfos,
-                                                @NotNull List<TabletFailInfo> tabletFailInfos)
-            throws UserException {
-        return commitTransaction(dbId, transactionId, tabletCommitInfos, tabletFailInfos, null);
-    }
-
     /**
      * @param transactionId
      * @param tabletCommitInfos
@@ -406,7 +383,8 @@ public class GlobalTransactionMgr implements Writable {
 
         LOG.debug("try to commit transaction: {}", transactionId);
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
-        return dbTransactionMgr.commitTransaction(transactionId, tabletCommitInfos, tabletFailInfos, txnCommitAttachment);
+        return dbTransactionMgr.commitTransaction(transactionId, tabletCommitInfos, tabletFailInfos,
+                txnCommitAttachment);
     }
 
     public void prepareTransaction(long dbId, long transactionId, List<TabletCommitInfo> tabletCommitInfos,
@@ -466,37 +444,111 @@ public class GlobalTransactionMgr implements Writable {
         }
     }
 
-    public boolean commitAndPublishTransaction(Database db, long transactionId,
-                                               List<TabletCommitInfo> tabletCommitInfos,
-                                               List<TabletFailInfo> tabletFailInfos, long timeoutMillis) throws UserException {
+    public boolean commitAndPublishTransaction(@NotNull Database db,
+                                               long transactionId,
+                                               @NotNull List<TabletCommitInfo> tabletCommitInfos,
+                                               @NotNull List<TabletFailInfo> tabletFailInfos,
+                                               long timeoutMillis) throws UserException {
         return commitAndPublishTransaction(db, transactionId, tabletCommitInfos, tabletFailInfos, timeoutMillis, null);
     }
 
-    public boolean commitAndPublishTransaction(Database db, long transactionId,
-                                               List<TabletCommitInfo> tabletCommitInfos,
-                                               List<TabletFailInfo> tabletFailInfos, long timeoutMillis,
-                                               TxnCommitAttachment txnCommitAttachment) throws UserException {
-        StopWatch stopWatch = new StopWatch();
-        stopWatch.start();
-        if (!db.tryWriteLock(timeoutMillis, TimeUnit.MILLISECONDS)) {
-            throw new UserException("get database write lock timeout, database="
-                    + db.getOriginName() + ", timeoutMillis=" + timeoutMillis);
+    /**
+     * Commit and wait for the transaction to become visible.
+     *
+     * @param db                   the database in which the transaction is being committed
+     * @param transactionId        the ID of the transaction to commit
+     * @param tabletCommitInfos    a list of tablet commit information
+     * @param tabletFailInfos      a list of tablet fail information
+     * @param timeoutMillis        the timeout for waiting for the transaction to become visible, in milliseconds
+     * @param txnCommitAttachment  an optional attachment to include in the transaction commit
+     * @return                     {@code true} if the transaction becomes visible within the given timeout,
+     *                             {@code false} otherwise
+     * @throws UserException                   if an error occurs during the transaction commit
+     * @throws TransactionCommitFailedException  if the transaction commit fails due to a disabled load job
+     * @note This method acquires the write lock on the database to commit transaction, callers should NOT already
+     * hold the database lock when calling this method, otherwise it will lead to deadlock.
+     */
+    public boolean commitAndPublishTransaction(@NotNull Database db,
+                                               long transactionId,
+                                               @NotNull List<TabletCommitInfo> tabletCommitInfos,
+                                               @NotNull List<TabletFailInfo> tabletFailInfos,
+                                               long timeoutMillis,
+                                               @Nullable TxnCommitAttachment txnCommitAttachment) throws UserException {
+        long dueTime = timeoutMillis != 0 ? System.currentTimeMillis() + timeoutMillis : Long.MAX_VALUE;
+        VisibleStateWaiter waiter = retryCommitOnRateLimitExceeded(db, transactionId, tabletCommitInfos,
+                tabletFailInfos, txnCommitAttachment, timeoutMillis);
+        long now = System.currentTimeMillis();
+        if (now < dueTime) {
+            return waiter.await(dueTime - now, TimeUnit.MILLISECONDS);
+        } else {
+            return false;
         }
-        VisibleStateWaiter waiter;
+    }
+
+    /**
+     * Executes the commit operation on the given transaction with retry mechanism
+     * in case of rate limit exceeded exception.
+     *
+     * @param db the {@link Database} object where the transaction is being committed
+     * @param transactionId the ID of the transaction to commit
+     * @param tabletCommitInfos the list of {@link TabletCommitInfo} objects containing information about the tablets
+     * to commit
+     * @param tabletFailInfos the list of {@link TabletFailInfo} objects containing information about the tablets that
+     * failed to commit
+     * @param txnCommitAttachment the optional {@link TxnCommitAttachment} object
+     * @param timeoutMs the timeout value in milliseconds for the commit operation
+     * @return a {@link VisibleStateWaiter} object used to wait for the transaction to become visible
+     * @throws UserException if an error occurs during the commit operation
+     * @note This method acquires the write lock on the database to commit transaction, callers should NOT already
+     * hold the database lock when calling this method, otherwise it will lead to deadlock.
+     */
+    @NotNull
+    public VisibleStateWaiter retryCommitOnRateLimitExceeded(
+            @NotNull Database db, long transactionId, @NotNull List<TabletCommitInfo> tabletCommitInfos,
+            @NotNull List<TabletFailInfo> tabletFailInfos,
+            @Nullable TxnCommitAttachment txnCommitAttachment,
+            long timeoutMs) throws UserException {
+        long startTime = System.currentTimeMillis();
+        while (true) {
+            try {
+                return commitTransactionUnderDatabaseWLock(db, transactionId, tabletCommitInfos, tabletFailInfos,
+                        txnCommitAttachment);
+            } catch (CommitRateExceededException e) {
+                throttleCommitOnRateExceed(e, startTime, timeoutMs);
+            } catch (Exception e) {
+                throw new UserException("fail to execute commit task: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Handles the case when the commit rate exceeds the limit.
+     *
+     * @param e The CommitRateExceededException to handle.
+     * @param startTimeMs The start time of the commit.
+     * @param timeoutMs The timeout duration in milliseconds. If timeoutMs is non-zero and the allowed commit time is
+     *                  greater than (startTimeMs + timeoutMs), then CommitRateExceededException is re-thrown.
+     * @throws CommitRateExceededException if the allowed commit time exceeds the timeout duration.
+     */
+    static void throttleCommitOnRateExceed(CommitRateExceededException e, long startTimeMs, long timeoutMs)
+            throws CommitRateExceededException {
+        if (timeoutMs != 0 && e.getAllowCommitTime() > (startTimeMs + timeoutMs)) {
+            throw e;
+        } else {
+            ThreadUtil.sleepAtLeastIgnoreInterrupts(e.getAllowCommitTime() - System.currentTimeMillis());
+        }
+    }
+
+    private VisibleStateWaiter commitTransactionUnderDatabaseWLock(
+            @NotNull Database db, long transactionId, @NotNull List<TabletCommitInfo> tabletCommitInfos,
+            @NotNull List<TabletFailInfo> tabletFailInfos,
+            @Nullable TxnCommitAttachment attachment) throws UserException {
+        db.writeLock();
         try {
-            waiter = commitTransaction(db.getId(), transactionId, tabletCommitInfos, tabletFailInfos,
-                    txnCommitAttachment);
+            return commitTransaction(db.getId(), transactionId, tabletCommitInfos, tabletFailInfos, attachment);
         } finally {
             db.writeUnlock();
         }
-        stopWatch.stop();
-        long publishTimeoutMillis = timeoutMillis - stopWatch.getTime();
-        if (publishTimeoutMillis < 0) {
-            // here commit transaction successfully cost too much time to cause publisTimeoutMillis is less than zero,
-            // so we just return false to indicate publish timeout
-            return false;
-        }
-        return waiter.await(publishTimeoutMillis, TimeUnit.MILLISECONDS);
     }
 
     public void abortAllRunningTransactions() throws UserException {
@@ -827,7 +879,8 @@ public class GlobalTransactionMgr implements Writable {
                 dbTransactionMgr.unprotectUpsertTransactionState(transactionState, true);
             } catch (AnalysisException e) {
                 LOG.warn("failed to get db transaction manager for {}", transactionState, e);
-                throw new IOException("failed to get db transaction manager for txn " + transactionState.getTransactionId(), e);
+                throw new IOException(
+                        "failed to get db transaction manager for txn " + transactionState.getTransactionId(), e);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -271,6 +271,8 @@ public class TransactionState implements Writable {
     private boolean hasSendTask;
     private long publishVersionTime = -1;
     private long publishVersionFinishTime = -1;
+    private long doneWriteTime = -1;
+    private long allowCommitTime = -1;
 
     @SerializedName("cb")
     private long callbackId = -1;
@@ -691,6 +693,8 @@ public class TransactionState implements Writable {
         sb.append(", error replicas num: ").append(errorReplicas.size());
         sb.append(", replica ids: ").append(Joiner.on(",").join(errorReplicas.stream().limit(5).toArray()));
         sb.append(", prepare time: ").append(prepareTime);
+        sb.append(", done write time: ").append(doneWriteTime);
+        sb.append(", allow commit time: ").append(allowCommitTime);
         sb.append(", commit time: ").append(commitTime);
         sb.append(", finish time: ").append(finishTime);
         if (commitTime > prepareTime) {
@@ -1022,5 +1026,21 @@ public class TransactionState implements Writable {
 
     public String getTraceParent() {
         return traceParent;
+    }
+
+    public long getDoneWriteTime() {
+        return doneWriteTime;
+    }
+
+    public void setDoneWriteTime(long doneWriteTime) {
+        this.doneWriteTime = doneWriteTime;
+    }
+
+    public long getAllowCommitTime() {
+        return allowCommitTime;
+    }
+
+    public void setAllowCommitTime(long allowCommitTime) {
+        this.allowCommitTime = allowCommitTime;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -112,7 +112,8 @@ public class DatabaseTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId1, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId1, transTablets,
+                Lists.newArrayList(), null);
         DatabaseTransactionMgr masterDbTransMgr = masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
         assertEquals(TTransactionStatus.COMMITTED, masterDbTransMgr.getTxnStatus(transactionId1));
         masterTransMgr.finishTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId1, null);

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -193,7 +193,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
+                Lists.newArrayList(), null);
         TransactionState transactionState = fakeEditLog.getTransaction(transactionId);
         // check status is committed
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
@@ -234,7 +235,8 @@ public class GlobalTransactionMgrTest {
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
+                Lists.newArrayList(), null);
 
         // follower globalStateMgr replay the transaction
         transactionState = fakeEditLog.getTransaction(transactionId);
@@ -256,7 +258,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo3);
         try {
-            masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets);
+            masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets,
+                    Lists.newArrayList(), null);
             Assert.fail();
         } catch (TabletQuorumFailedException e) {
             transactionState = masterTransMgr.getTransactionState(GlobalStateMgrTestUtil.testDbId1, transactionId2);
@@ -287,7 +290,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets,
+                Lists.newArrayList(), null);
         transactionState = fakeEditLog.getTransaction(transactionId2);
         // check status is commit
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
@@ -390,7 +394,8 @@ public class GlobalTransactionMgrTest {
 
         Deencapsulation.setField(masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1),
                 "idToRunningTransactionState", idToTransactionState);
-        masterTransMgr.commitTransaction(1L, 1L, transTablets, txnCommitAttachment);
+        masterTransMgr.commitTransaction(1L, 1L, transTablets, Lists.newArrayList(),
+                txnCommitAttachment);
 
         Assert.assertEquals(Long.valueOf(101), Deencapsulation.getField(routineLoadJob, "currentTotalRows"));
         Assert.assertEquals(Long.valueOf(1), Deencapsulation.getField(routineLoadJob, "currentErrorRows"));
@@ -462,7 +467,8 @@ public class GlobalTransactionMgrTest {
 
         Deencapsulation.setField(masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1),
                 "idToRunningTransactionState", idToTransactionState);
-        masterTransMgr.commitTransaction(1L, 1L, transTablets, txnCommitAttachment);
+        masterTransMgr.commitTransaction(1L, 1L, transTablets, Lists.newArrayList(),
+                txnCommitAttachment);
 
         Assert.assertEquals(Long.valueOf(0), Deencapsulation.getField(routineLoadJob, "currentTotalRows"));
         Assert.assertEquals(Long.valueOf(0), Deencapsulation.getField(routineLoadJob, "currentErrorRows"));
@@ -491,7 +497,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
+                Lists.newArrayList(), null);
         TransactionState transactionState = fakeEditLog.getTransaction(transactionId);
         slaveTransMgr.replayUpsertTransactionState(transactionState);
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
@@ -545,7 +552,8 @@ public class GlobalTransactionMgrTest {
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
+                Lists.newArrayList(), null);
 
         // follower globalStateMgr replay the transaction
         transactionState = fakeEditLog.getTransaction(transactionId);
@@ -604,7 +612,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo3);
         try {
-            masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets);
+            masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets,
+                    Lists.newArrayList(), null);
             Assert.fail();
         } catch (TabletQuorumFailedException e) {
             transactionState = masterTransMgr.getTransactionState(GlobalStateMgrTestUtil.testDbId1, transactionId2);
@@ -620,7 +629,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets,
+                Lists.newArrayList(), null);
         transactionState = fakeEditLog.getTransaction(transactionId2);
         // check status is commit
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -922,6 +922,8 @@ struct TLoadTxnCommitRequest {
 
 struct TLoadTxnCommitResult {
     1: required Status.TStatus status
+    2: optional bool allow_retry
+    3: optional i64 retry_interval_ms
 }
 
 struct TLoadTxnRollbackRequest {


### PR DESCRIPTION
Reduce overall ingestion rate by delaying transaction commit.
delay_time = write_duration * (compaction_score - lake_compaction_score_slowdown_threshold) * lake_compaction_score_slowdown_ratio.
Where the `write_duration` is the real time spend on data writing.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
