### PR TITLE
[BugFix] Reset enable_query_queue_statistic after each test case

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
@@ -94,7 +94,9 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
 
     private final Map<Long, ResourceGroup> mockedGroups = new ConcurrentHashMap<>();
 
-    private boolean prevQueueEnable;
+    private boolean prevQueueEnableSelect;
+    private boolean prevQueueEnableStatistic;
+    private boolean prevQueueEnableLoad;
     private int prevQueueConcurrencyHardLimit;
     private double prevQueueMemUsedPctHardLimit;
     private int prevQueuePendingTimeoutSecond;
@@ -110,7 +112,9 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
 
     @Before
     public void before() {
-        prevQueueEnable = GlobalVariable.isEnableQueryQueueSelect();
+        prevQueueEnableSelect = GlobalVariable.isEnableQueryQueueSelect();
+        prevQueueEnableStatistic = GlobalVariable.isEnableQueryQueueStatistic();
+        prevQueueEnableLoad = GlobalVariable.isEnableQueryQueueLoad();
         prevQueueConcurrencyHardLimit = GlobalVariable.getQueryQueueConcurrencyLimit();
         prevQueueMemUsedPctHardLimit = GlobalVariable.getQueryQueueMemUsedPctLimit();
         prevQueuePendingTimeoutSecond = GlobalVariable.getQueryQueuePendingTimeoutSecond();
@@ -139,7 +143,9 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
     @After
     public void after() {
         // Reset query queue configs.
-        GlobalVariable.setEnableQueryQueueSelect(prevQueueEnable);
+        GlobalVariable.setEnableQueryQueueSelect(prevQueueEnableSelect);
+        GlobalVariable.setEnableQueryQueueStatistic(prevQueueEnableStatistic);
+        GlobalVariable.setEnableQueryQueueLoad(prevQueueEnableLoad);
         GlobalVariable.setQueryQueueConcurrencyLimit(prevQueueConcurrencyHardLimit);
         GlobalVariable.setQueryQueueMemUsedPctLimit(prevQueueMemUsedPctHardLimit);
         GlobalVariable.setQueryQueuePendingTimeoutSecond(prevQueuePendingTimeoutSecond);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
@@ -142,6 +142,11 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
 
     @After
     public void after() {
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> 0 == MetricRepo.COUNTER_QUERY_QUEUE_PENDING.getValue());
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> GlobalStateMgr.getCurrentState().getSlotManager().getSlots().isEmpty());
+
         // Reset query queue configs.
         GlobalVariable.setEnableQueryQueueSelect(prevQueueEnableSelect);
         GlobalVariable.setEnableQueryQueueStatistic(prevQueueEnableStatistic);


### PR DESCRIPTION
Statistics job will be executed periodically, and some test cases in `QueryQueueTest` enables `enable_query_queue_statistic` but doesn't disable it after the case is finished. Therefore, the statistics jobs will disturb the query queue status.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
