### PR TITLE
[BugFix] forbid transforming botJoin projection refs cols from both children

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/JoinHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/JoinHelper.java
@@ -156,4 +156,16 @@ public class JoinHelper {
         return type.isCrossJoin() || JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN.equals(type) ||
                 (type.isInnerJoin() && equalOnPredicate.isEmpty()) || JoinOperator.HINT_BROADCAST.equals(hint);
     }
+
+    public static boolean validateJoinExpr(OptExpression joinExpr) {
+        ColumnRefSet requiredCols = ((LogicalJoinOperator) joinExpr.getOp()).getRequiredChildInputColumns();
+        joinExpr.inputAt(0).deriveLogicalPropertyItself();
+        joinExpr.inputAt(1).deriveLogicalPropertyItself();
+
+        ColumnRefSet left = joinExpr.inputAt(0).getOutputColumns();
+        ColumnRefSet right = joinExpr.inputAt(1).getOutputColumns();
+        requiredCols.except(left);
+        requiredCols.except(right);
+        return requiredCols.isEmpty();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -96,7 +96,7 @@ public final class ColumnRefOperator extends ScalarOperator {
     }
 
     public static String toString(Collection<ColumnRefOperator> columns) {
-        StringJoiner joiner = new StringJoiner("{", ", ", "}");
+        StringJoiner joiner = new StringJoiner(", ", "{", "}");
         for (ColumnRefOperator column : columns) {
             joiner.add(column.toString());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociativityRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinAssociativityRule.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.sql.optimizer.ExpressionContext;
+import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -236,7 +237,11 @@ public class JoinAssociativityRule extends TransformationRule {
             }
 
             OptExpression topJoin = OptExpression.create(topJoinOperator, left, newRightChildJoin);
-            return Lists.newArrayList(topJoin);
+            if (JoinHelper.validateJoinExpr(topJoin)) {
+                return Lists.newArrayList(topJoin);
+            } else {
+                return Collections.emptyList();
+            }
         } else {
 
             //If all the columns in onPredicate come from one side, it means that it is CrossJoin, and give up this Plan
@@ -247,7 +252,11 @@ public class JoinAssociativityRule extends TransformationRule {
             }
 
             OptExpression topJoin = OptExpression.create(topJoinOperator, leftChild1, newRightChildJoin);
-            return Lists.newArrayList(topJoin);
+            if (JoinHelper.validateJoinExpr(topJoin)) {
+                return Lists.newArrayList(topJoin);
+            } else {
+                return Collections.emptyList();
+            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SemiReorderRule.java
@@ -5,6 +5,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.JoinOperator;
+import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -20,6 +21,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +61,20 @@ public class SemiReorderRule extends TransformationRule {
 
         if (bottomJoin.getJoinType().isOuterJoin() || bottomJoin.hasLimit()) {
             return false;
+        }
+
+        LogicalJoinOperator leftChildJoin = (LogicalJoinOperator) input.inputAt(0).getOp();
+        if (leftChildJoin.getProjection() != null) {
+            Projection projection = leftChildJoin.getProjection();
+            // 1. Forbidden expression column on join-reorder
+            // 2. Forbidden on-predicate use columns from two children at same time
+            for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : projection.getColumnRefMap().entrySet()) {
+                if (!entry.getValue().isColumnRef() &&
+                        entry.getValue().getUsedColumns().isIntersect(input.inputAt(0).inputAt(0).getOutputColumns()) &&
+                        entry.getValue().getUsedColumns().isIntersect(input.inputAt(0).inputAt(1).getOutputColumns())) {
+                    return false;
+                }
+            }
         }
 
         // Because the X and Z nodes will be used to build a new semi join,
@@ -102,8 +118,9 @@ public class SemiReorderRule extends TransformationRule {
         ColumnRefSet leftChildJoinRightChildOutputColumns = leftChildJoinRightChild.getOutputColumns();
 
         Projection leftChildJoinProjection = leftChildJoin.getProjection();
-        HashMap<ColumnRefOperator, ScalarOperator> rightExpression = new HashMap<>();
-        HashMap<ColumnRefOperator, ScalarOperator> semiExpression = new HashMap<>();
+        Map<ColumnRefOperator, ScalarOperator> rightExpression = new HashMap<>();
+        Map<ColumnRefOperator, ScalarOperator> semiExpression = new HashMap<>();
+
         if (leftChildJoinProjection != null) {
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : leftChildJoinProjection.getColumnRefMap()
                     .entrySet()) {
@@ -147,7 +164,8 @@ public class SemiReorderRule extends TransformationRule {
         if (semiExpression.isEmpty()) {
             newSemiJoin = new LogicalJoinOperator.Builder().withOperator(topJoin)
                     .setLimit(Operator.DEFAULT_LIMIT)
-                    .setProjection(new Projection(projectMap)).build();
+                    .setProjection(new Projection(projectMap))
+                    .build();
         } else {
             semiExpression.putAll(projectMap);
             newSemiJoin = new LogicalJoinOperator.Builder().withOperator(topJoin)
@@ -182,6 +200,11 @@ public class SemiReorderRule extends TransformationRule {
         }
 
         OptExpression semiOpt = OptExpression.create(newSemiJoin, input.inputAt(0).inputAt(0), input.inputAt(1));
-        return Lists.newArrayList(OptExpression.create(newTopJoin, semiOpt, newRightChild));
+        OptExpression newTopJoinExpr = OptExpression.create(newTopJoin, semiOpt, newRightChild);
+        if (JoinHelper.validateJoinExpr(newTopJoinExpr)) {
+            return Lists.newArrayList(newTopJoinExpr);
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -398,6 +398,7 @@ public class JoinTest extends PlanTestBase {
         assertContains(plan, "1:Project\n" +
                 "  |  <slot 1> : 1: v1\n" +
                 "  |  <slot 4> : 49\n" +
+                "  |  <slot 25> : CAST(49 AS DOUBLE)\n" +
                 "  |  <slot 26> : CAST(49 AS VARCHAR(1048576))\n" +
                 "  |  \n" +
                 "  0:OlapScanNode");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -656,7 +656,7 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "9:Project\n" +
                 "  |  <slot 3> : 3: t1c\n" +
-                "  |  <slot 21> : 21: expr\n" +
+                "  |  <slot 21> : 37\n" +
                 "  |  <slot 22> : 22: P_PARTKEY\n" +
                 "  |  <slot 23> : 23: P_NAME\n" +
                 "  |  <slot 24> : 24: P_MFGR\n" +
@@ -667,7 +667,7 @@ public class JoinTest extends PlanTestBase {
                 "  |  <slot 29> : 29: P_RETAILPRICE\n" +
                 "  |  <slot 30> : 30: P_COMMENT\n" +
                 "  |  <slot 31> : 31: PAD\n" +
-                "  |  <slot 40> : CAST(21: expr AS INT)");
+                "  |  <slot 40> : CAST(37 AS INT)");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -395,10 +395,9 @@ public class JoinTest extends PlanTestBase {
                 "\n" +
                 "WHERE l1.tc < s0.t1c";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  1:Project\n" +
+        assertContains(plan, "1:Project\n" +
                 "  |  <slot 1> : 1: v1\n" +
                 "  |  <slot 4> : 49\n" +
-                "  |  <slot 25> : CAST(49 AS DOUBLE)\n" +
                 "  |  <slot 26> : CAST(49 AS VARCHAR(1048576))\n" +
                 "  |  \n" +
                 "  0:OlapScanNode");
@@ -656,7 +655,7 @@ public class JoinTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "9:Project\n" +
                 "  |  <slot 3> : 3: t1c\n" +
-                "  |  <slot 21> : 37\n" +
+                "  |  <slot 21> : 21: expr\n" +
                 "  |  <slot 22> : 22: P_PARTKEY\n" +
                 "  |  <slot 23> : 23: P_NAME\n" +
                 "  |  <slot 24> : 24: P_MFGR\n" +
@@ -667,7 +666,7 @@ public class JoinTest extends PlanTestBase {
                 "  |  <slot 29> : 29: P_RETAILPRICE\n" +
                 "  |  <slot 30> : 30: P_COMMENT\n" +
                 "  |  <slot 31> : 31: PAD\n" +
-                "  |  <slot 40> : CAST(37 AS INT)");
+                "  |  <slot 40> : CAST(21: expr AS INT)");
     }
 
     @Test
@@ -2751,5 +2750,28 @@ public class JoinTest extends PlanTestBase {
                 "  |  join op: LEFT SEMI JOIN\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  other join predicates: 19: v4 = CAST(1 AS BIGINT)");
+    }
+
+    @Test
+    public void testProjectionInBotJoin() throws Exception {
+        String sql = "select * from (select coalesce(v1, v4), v2, v3 , v4 from t0 join t1) t " +
+                "where v2 in (select v7 from t2 where t.v3 = t2.v8)";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "7:HASH JOIN\n" +
+                "  |  join op: LEFT SEMI JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 2: v2 = 8: v7\n" +
+                "  |  equal join conjunct: 3: v3 = 9: v8\n" +
+                "  |  \n" +
+                "  |----6:EXCHANGE\n" +
+                "  |    \n" +
+                "  4:Project\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 3> : 3: v3\n" +
+                "  |  <slot 4> : 4: v4\n" +
+                "  |  <slot 7> : coalesce(1: v1, 4: v4)\n" +
+                "  |  \n" +
+                "  3:NESTLOOP JOIN\n" +
+                "  |  join op: CROSS JOIN");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -526,7 +526,25 @@ public class UtFrameUtils {
         }
     }
 
-    private static Pair<String, ExecPlan> getQueryExecPlan(QueryStatement statement, ConnectContext connectContext) {
+    private static Pair<String, ExecPlan> getQueryExecPlan(QueryStatement statement, ConnectContext connectContext)
+            throws Exception {
+
+        Map<String, String> optHints = null;
+        SessionVariable sessionVariableBackup = connectContext.getSessionVariable();
+        if (statement.getQueryRelation() instanceof SelectRelation) {
+            SelectRelation selectRelation = (SelectRelation) statement.getQueryRelation();
+            optHints = selectRelation.getSelectList().getOptHints();
+        }
+
+        if (optHints != null) {
+            SessionVariable sessionVariable = (SessionVariable) sessionVariableBackup.clone();
+            for (String key : optHints.keySet()) {
+                VariableMgr.setVar(sessionVariable,
+                        new SetVar(key, new StringLiteral(optHints.get(key))), true);
+            }
+            connectContext.setSessionVariable(sessionVariable);
+        }
+
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
 
         LogicalPlan logicalPlan;


### PR DESCRIPTION
## problem
For sql like:
```
select * from (select coalesce(v1, v4), v2, v3 , v4 from t0 join t1) t 
where v2 in (select v7 from t2 where t.v3 = t2.v8)
```
the original join order is (t0 join t1) left semi join t2.  The top projection contains `<slot 7> : 7: coalesce` and the projection of bottom join is `<slot 7> : coalesce(1: v1, 4: v4)`. 
If we want to transform the order to (t0 semi join t2) join t1, we alse need to rewrite the top projection to `<slot 7> : coalesce(1: v1, 4: v4)`.  For now, we unsupport this rewrite step. So we need forbid using the SemiReorderRule to transform plan where botJoin projection refs cols from both children.



## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
