### PR TITLE
[Enhancement] improve map columns's remove dup key performence

### DIFF
--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -714,15 +714,21 @@ void MapColumn::remove_duplicated_keys(bool need_recursive) {
 
     uint32_t new_offset = 0;
     for (auto i = 0; i < size; ++i) {
-        for (auto j = _offsets->get_data()[i]; j < _offsets->get_data()[i + 1]; ++j) {
-            for (auto k = j + 1; k < _offsets->get_data()[i + 1]; ++k) {
-                if (hash[j] == hash[k] && _keys->equals(j, *_keys, k)) {
+        std::unordered_multimap<uint32_t, uint32_t> key_hash_to_offsets;
+        key_hash_to_offsets.reserve(_offsets->get_data()[i + 1] - _offsets->get_data()[i]);
+        for (int32_t j = _offsets->get_data()[i + 1] - 1; j >= 0 && j >= _offsets->get_data()[i]; --j) {
+            auto same_hash_offsets = key_hash_to_offsets.equal_range(hash[j]);
+            for (auto it = same_hash_offsets.first; it != same_hash_offsets.second; ++it) {
+                if (_keys->equals(j, *_keys, it->second)) {
                     filter[j] = 0;
                     has_duplicated_keys = true;
                     break;
                 }
             }
             new_offset += filter[j];
+            if (filter[j] != 0) {
+                key_hash_to_offsets.emplace(hash[j], (uint32_t)j);
+            }
         }
         offsets_vec.push_back(new_offset);
     }


### PR DESCRIPTION
Improve map columns's remove dup key performence, complexity from O(n^2) to O(n).

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
