### PR TITLE
[BugFix] stuck when finish_publish_version_thread exits

### DIFF
--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -606,6 +606,7 @@ void StorageEngine::stop() {
     JOIN_THREAD(_unused_rowset_monitor_thread)
     JOIN_THREAD(_garbage_sweeper_thread)
     JOIN_THREAD(_disk_stat_monitor_thread)
+    wake_finish_publish_vesion_thread();
     JOIN_THREAD(_finish_publish_version_thread)
 
     JOIN_THREADS(_base_compaction_threads)
@@ -617,7 +618,7 @@ void StorageEngine::stop() {
     JOIN_THREADS(_manual_compaction_threads)
     JOIN_THREADS(_tablet_checkpoint_threads)
 
-    JOIN_THREAD(_pk_index_major_compaction_thread);
+    JOIN_THREAD(_pk_index_major_compaction_thread)
 
     JOIN_THREAD(_fd_cache_clean_thread)
     JOIN_THREAD(_adjust_cache_thread)

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -454,8 +454,6 @@ private:
 
     std::unique_ptr<PublishVersionManager> _publish_version_manager;
 
-    HeartbeatFlags* _heartbeat_flags = nullptr;
-
     std::unordered_map<int64_t, std::shared_ptr<AutoIncrementMeta>> _auto_increment_meta_map;
 
     std::mutex _auto_increment_mutex;


### PR DESCRIPTION
Fixes #issue

```
void* StorageEngine::_finish_publish_version_thread_callback(void* arg) {
    while (!_bg_worker_stopped.load(std::memory_order_consume)) {
        int32_t interval = config::finish_publish_version_internal;
        {
            std::unique_lock<std::mutex> wl(_finish_publish_version_mutex);
            while (!_publish_version_manager->has_pending_task() &&
                   !_bg_worker_stopped.load(std::memory_order_consume)) {
                _finish_publish_version_cv.wait(wl);
            }
            _publish_version_manager->finish_publish_version_task();
            if (interval <= 0) {
                LOG(WARNING) << "finish_publish_version_internal config is illegal: " << interval << ", force set to 1";
                interval = 1000;
            }
        }
        std::this_thread::sleep_for(std::chrono::milliseconds(interval));
    }

    return nullptr;
}
```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
