### PR TITLE
[Enhancement][Cherry-pick][Branch-2.5] Support sync publish version for primary key table (#27055)

### DIFF
--- a/be/src/agent/finish_task.h
+++ b/be/src/agent/finish_task.h
@@ -5,5 +5,4 @@ namespace starrocks {
 class TFinishTaskRequest;
 
 void finish_task(const TFinishTaskRequest& finish_task_request);
-
 } // namespace starrocks

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -48,6 +48,7 @@
 #include "storage/data_dir.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/olap_common.h"
+#include "storage/publish_version_manager.h"
 #include "storage/snapshot_manager.h"
 #include "storage/storage_engine.h"
 #include "storage/task/engine_alter_tablet_task.h"
@@ -494,6 +495,10 @@ void* PublishVersionTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         const auto& publish_version_task = *priority_tasks.top();
         LOG(INFO) << "get publish version task txn_id: " << publish_version_task.task_req.transaction_id
                   << " priority queue size: " << priority_tasks.size();
+        bool enable_sync_publish = publish_version_task.task_req.enable_sync_publish;
+        if (enable_sync_publish) {
+            wait_time = 0;
+        }
         StarRocksMetrics::instance()->publish_task_request_total.increment(1);
         auto& finish_task_request = finish_task_requests.emplace_back();
         finish_task_request.__set_backend(BackendOptions::get_localBackend());
@@ -503,23 +508,40 @@ void* PublishVersionTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         batch_publish_latency += MonotonicMillis() - start_ts;
         priority_tasks.pop();
 
-        if (priority_tasks.empty() || finish_task_requests.size() > PUBLISH_VERSION_BATCH_SIZE ||
-            batch_publish_latency > config::max_batch_publish_latency_ms) {
-            int64_t t0 = MonotonicMillis();
-            StorageEngine::instance()->txn_manager()->flush_dirs(affected_dirs);
-            int64_t t1 = MonotonicMillis();
-            // notify FE when all tasks of group have been finished.
-            for (auto& finish_task_request : finish_task_requests) {
-                finish_task(finish_task_request);
-                remove_task_info(finish_task_request.task_type, finish_task_request.signature);
+        if (!enable_sync_publish) {
+            if (priority_tasks.empty() || finish_task_requests.size() > PUBLISH_VERSION_BATCH_SIZE ||
+                batch_publish_latency > config::max_batch_publish_latency_ms) {
+                int64_t t0 = MonotonicMillis();
+                StorageEngine::instance()->txn_manager()->flush_dirs(affected_dirs);
+                int64_t t1 = MonotonicMillis();
+                // notify FE when all tasks of group have been finished.
+                for (auto& finish_task_request : finish_task_requests) {
+                    finish_task(finish_task_request);
+                    remove_task_info(finish_task_request.task_type, finish_task_request.signature);
+                }
+                int64_t t2 = MonotonicMillis();
+                LOG(INFO) << "batch flush " << finish_task_requests.size()
+                          << " txn publish task(s). #dir:" << affected_dirs.size() << " flush:" << t1 - t0
+                          << "ms finish_task_rpc:" << t2 - t1 << "ms";
+                finish_task_requests.clear();
+                affected_dirs.clear();
+                batch_publish_latency = 0;
             }
-            int64_t t2 = MonotonicMillis();
-            LOG(INFO) << "batch flush " << finish_task_requests.size()
-                      << " txn publish task(s). #dir:" << affected_dirs.size() << " flush:" << t1 - t0
-                      << "ms finish_task_rpc:" << t2 - t1 << "ms";
-            finish_task_requests.clear();
-            affected_dirs.clear();
-            batch_publish_latency = 0;
+        } else {
+            if (priority_tasks.empty() || finish_task_requests.size() > PUBLISH_VERSION_BATCH_SIZE ||
+                batch_publish_latency > config::max_batch_publish_latency_ms) {
+                int64_t finish_task_size = finish_task_requests.size();
+                int64_t t0 = MonotonicMillis();
+                StorageEngine::instance()->txn_manager()->flush_dirs(affected_dirs);
+                int64_t t1 = MonotonicMillis();
+                StorageEngine::instance()->publish_version_manager()->wait_publish_task_apply_finish(
+                        std::move(finish_task_requests));
+                StorageEngine::instance()->wake_finish_publish_vesion_thread();
+                affected_dirs.clear();
+                batch_publish_latency = 0;
+                LOG(INFO) << "batch submit " << finish_task_size << " finish publish version task "
+                          << "txn publish task(s). #dir:" << affected_dirs.size() << " flush:" << t1 - t0 << "ms";
+            }
         }
     }
     return nullptr;

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -955,5 +955,8 @@ CONF_mBool(enable_pk_value_column_zonemap, "true");
 // Max size of key columns size of primary key table, default value is 128 bytes
 CONF_mInt32(primary_key_limit_size, "128");
 CONF_mBool(enable_http_stream_load_limit, "false");
+CONF_mInt32(finish_publish_version_internal, "100");
+
+CONF_mInt32(get_txn_status_internal_sec, "30");
 
 } // namespace starrocks::config

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -187,7 +187,6 @@ Status StreamLoadAction::_handle(StreamLoadContext* ctx) {
     int64_t commit_and_publish_start_time = MonotonicNanos();
     RETURN_IF_ERROR(_exec_env->stream_load_executor()->commit_txn(ctx));
     ctx->commit_and_publish_txn_cost_nanos = MonotonicNanos() - commit_and_publish_start_time;
-
     return Status::OK();
 }
 
@@ -311,7 +310,6 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, StreamLoadContext* ct
     int64_t begin_txn_start_time = MonotonicNanos();
     RETURN_IF_ERROR(_exec_env->stream_load_executor()->begin_txn(ctx));
     ctx->begin_txn_cost_nanos = MonotonicNanos() - begin_txn_start_time;
-
     // process put file
     return _process_put(http_req, ctx);
 }
@@ -547,7 +545,6 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req, StreamLoadContext* 
         }
         ctx->put_result.params.query_options.mem_limit = exec_mem_limit;
     }
-
     return _exec_env->stream_load_executor()->execute_plan_fragment(ctx);
 }
 

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -255,6 +255,7 @@ public:
 
     TStreamLoadPutRequest request;
 
+    int64_t load_deadline_sec = -1;
     std::unique_ptr<ConcurrentLimiterGuard> _http_limiter_guard;
 
 public:

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -161,6 +161,7 @@ Status StreamLoadExecutor::begin_txn(StreamLoadContext* ctx) {
     }
     ctx->txn_id = result.txnId;
     ctx->need_rollback = true;
+    ctx->load_deadline_sec = UnixSeconds() + result.timeout;
 
     return Status::OK();
 }
@@ -210,6 +211,36 @@ Status StreamLoadExecutor::commit_txn(StreamLoadContext* ctx) {
         LOG(WARNING) << "commit transaction failed, errmsg=" << status.get_error_msg() << ctx->brief();
         if (status.code() == TStatusCode::PUBLISH_TIMEOUT) {
             ctx->need_rollback = false;
+            if (ctx->load_deadline_sec > UnixSeconds()) {
+                //wait for apply finish
+                TGetLoadTxnStatusRequest v_request;
+                TGetLoadTxnStatusResult v_result;
+                set_request_auth(&v_request, ctx->auth);
+                v_request.db = ctx->db;
+                v_request.tbl = ctx->table;
+                v_request.txnId = ctx->txn_id;
+                while (ctx->load_deadline_sec > UnixSeconds()) {
+                    sleep(std::min((int64_t)config::get_txn_status_internal_sec,
+                                   ctx->load_deadline_sec - UnixSeconds()));
+                    auto visiable_st = ThriftRpcHelper::rpc<FrontendServiceClient>(
+                            master_addr.hostname, master_addr.port,
+                            [&v_request, &v_result](FrontendServiceConnection& client) {
+                                client->getLoadTxnStatus(v_result, v_request);
+                            },
+                            config::txn_commit_rpc_timeout_ms);
+                    if (!visiable_st.ok()) {
+                        return status;
+                    } else {
+                        if (v_result.status == TTransactionStatus::VISIBLE) {
+                            return Status::OK();
+                        } else if (v_result.status == TTransactionStatus::COMMITTED) {
+                            continue;
+                        } else {
+                            return status;
+                        }
+                    }
+                }
+            }
         }
         return status;
     }

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(Storage STATIC
     segment_replicate_executor.cpp
     metadata_util.cpp
     kv_store.cpp
+    publish_version_manager.cpp
     olap_common.cpp
     olap_server.cpp
     options.cpp

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -34,12 +34,7 @@
 #include "storage/compaction_manager.h"
 #include "storage/olap_common.h"
 #include "storage/olap_define.h"
-<<<<<<< HEAD
-=======
-#include "storage/persistent_index_compaction_manager.h"
 #include "storage/publish_version_manager.h"
->>>>>>> 519ef2ca13 ([Enhancement] Support sync publish version for primary key table (#27055))
-#include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
 #include "storage/update_manager.h"
 #include "util/gc_helper.h"

--- a/be/src/storage/publish_version_manager.cpp
+++ b/be/src/storage/publish_version_manager.cpp
@@ -1,0 +1,180 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "publish_version_manager.h"
+
+#include "agent/finish_task.h"
+#include "agent/task_signatures_manager.h"
+#include "common/config.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
+#include "storage/tablet_manager.h"
+#include "util/cpu_info.h"
+
+namespace starrocks {
+const int MIN_FINISH_PUBLISH_WORKER_COUNT = 8;
+
+Status PublishVersionManager::init() {
+    int max_thread_count = config::transaction_publish_version_worker_count;
+    if (max_thread_count <= 0) {
+        max_thread_count = CpuInfo::num_cores();
+    }
+    max_thread_count = std::max(max_thread_count, MIN_FINISH_PUBLISH_WORKER_COUNT);
+    RETURN_IF_ERROR(ThreadPoolBuilder("finish_publish_version")
+                            .set_min_threads(MIN_FINISH_PUBLISH_WORKER_COUNT)
+                            .set_max_threads(max_thread_count)
+                            .build(&_finish_publish_version_thread_pool));
+    return Status::OK();
+}
+
+PublishVersionManager::~PublishVersionManager() {
+    if (_finish_publish_version_thread_pool) {
+        _finish_publish_version_thread_pool->shutdown();
+    }
+    _finish_task_requests.clear();
+    _waitting_finish_task_requests.clear();
+    _unapplied_tablet_by_txn.clear();
+}
+
+// should under lock
+bool PublishVersionManager::_all_task_applied(const TFinishTaskRequest& finish_task_request) {
+    if (finish_task_request.task_status.status_code != TStatusCode::OK) {
+        return true;
+    }
+    auto& tablet_versions = finish_task_request.tablet_publish_versions;
+    bool all_task_applied = true;
+    std::set<std::pair<int64_t, int64_t>> unapplied_tablet;
+    for (auto& tablet_version : tablet_versions) {
+        int64_t tablet_id = tablet_version.tablet_id;
+        int64_t request_version = tablet_version.version;
+
+        TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
+        if (tablet != nullptr) {
+            if (tablet->keys_type() != KeysType::PRIMARY_KEYS) {
+                return true;
+            }
+            if (tablet->max_readable_version() < request_version) {
+                all_task_applied = false;
+                unapplied_tablet.insert(std::make_pair(tablet_id, request_version));
+            }
+            VLOG(1) << "tablet: " << tablet->tablet_id() << " max_readable_version is "
+                    << tablet->max_readable_version() << ", request_version is " << request_version;
+        }
+    }
+
+    if (!all_task_applied) {
+        _unapplied_tablet_by_txn[finish_task_request.signature] = std::move(unapplied_tablet);
+    }
+    return all_task_applied;
+}
+
+bool PublishVersionManager::_left_task_applied(const TFinishTaskRequest& finish_task_request) {
+    bool applied = true;
+    int64_t signature = finish_task_request.signature;
+    std::set<std::pair<int64_t, int64_t>> unapplied_tablet;
+    auto iter = _unapplied_tablet_by_txn.find(signature);
+    if (iter == _unapplied_tablet_by_txn.end()) {
+        return true;
+    }
+    for (auto& tablet_pair : iter->second) {
+        int64_t tablet_id = tablet_pair.first;
+        int64_t request_version = tablet_pair.second;
+        TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
+        if (tablet != nullptr) {
+            DCHECK(tablet->keys_type() == KeysType::PRIMARY_KEYS);
+            if (tablet->max_readable_version() < request_version) {
+                applied = false;
+                unapplied_tablet.insert(std::make_pair(tablet_id, request_version));
+            }
+            VLOG(1) << "tablet: " << tablet->tablet_id() << " max_readable_version is "
+                    << tablet->max_readable_version() << ", request_version is " << request_version;
+        }
+    }
+    if (!applied) {
+        iter->second.swap(unapplied_tablet);
+    } else {
+        _unapplied_tablet_by_txn.erase(signature);
+    }
+    return applied;
+}
+
+Status PublishVersionManager::wait_publish_task_apply_finish(std::vector<TFinishTaskRequest> finish_task_requests) {
+    std::lock_guard wl(_lock);
+    for (size_t i = 0; i < finish_task_requests.size(); i++) {
+        if (_all_task_applied(finish_task_requests[i])) {
+            _finish_task_requests[finish_task_requests[i].signature] = std::move(finish_task_requests[i]);
+        } else {
+            _waitting_finish_task_requests[finish_task_requests[i].signature] = std::move(finish_task_requests[i]);
+        }
+    }
+    CHECK(has_pending_task());
+    return Status::OK();
+}
+
+void PublishVersionManager::update_tablet_version(TFinishTaskRequest& finish_task_request) {
+    auto& tablet_versions = finish_task_request.tablet_versions;
+    for (int32_t i = 0; i < tablet_versions.size(); i++) {
+        int64_t tablet_id = tablet_versions[i].tablet_id;
+        TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
+        if (tablet != nullptr) {
+            tablet_versions[i].__set_version(tablet->max_readable_version());
+        }
+    }
+}
+
+Status PublishVersionManager::finish_publish_version_task() {
+    std::vector<int64_t> erase_finish_task_signature;
+    std::vector<int64_t> erase_waitting_finish_task_signature;
+    {
+        std::lock_guard wl(_lock);
+        Status st;
+        for (auto& [signature, finish_task_request] : _finish_task_requests) {
+            // submit finish task
+            st = _finish_publish_version_thread_pool->submit_func(
+                    [this, finish_request = std::move(finish_task_request)]() mutable {
+                        update_tablet_version(finish_request);
+#ifndef BE_TEST
+                        finish_task(finish_request);
+#endif
+                        remove_task_info(finish_request.task_type, finish_request.signature);
+                    });
+            erase_finish_task_signature.emplace_back(signature);
+        }
+
+        std::vector<int64_t> clear_txn;
+        for (auto& [signature, finish_task_request] : _waitting_finish_task_requests) {
+            if (_left_task_applied(finish_task_request)) {
+                st = _finish_publish_version_thread_pool->submit_func(
+                        [this, finish_request = std::move(finish_task_request)]() mutable {
+                            update_tablet_version(finish_request);
+#ifndef BE_TEST
+                            finish_task(finish_request);
+#endif
+                            remove_task_info(finish_request.task_type, finish_request.signature);
+                        });
+                erase_waitting_finish_task_signature.emplace_back(signature);
+            }
+        }
+        for (auto& signature : erase_finish_task_signature) {
+            _finish_task_requests.erase(signature);
+        }
+        for (auto& signature : erase_waitting_finish_task_signature) {
+            _waitting_finish_task_requests.erase(signature);
+            _unapplied_tablet_by_txn.erase(signature);
+        }
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/publish_version_manager.cpp
+++ b/be/src/storage/publish_version_manager.cpp
@@ -15,7 +15,7 @@
 #include "publish_version_manager.h"
 
 #include "agent/finish_task.h"
-#include "agent/task_signatures_manager.h"
+#include "agent/task_singatures_manager.h"
 #include "common/config.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"

--- a/be/src/storage/publish_version_manager.h
+++ b/be/src/storage/publish_version_manager.h
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <condition_variable>
+#include <map>
+#include <mutex>
+#include <set>
+
+#include "common/status.h"
+#include "gen_cpp/MasterService_types.h"
+#include "util/threadpool.h"
+
+namespace starrocks {
+
+using FinishTaskRequestPtr = std::shared_ptr<TFinishTaskRequest>;
+
+class PublishVersionManager {
+public:
+    Status init();
+    ~PublishVersionManager();
+    Status wait_publish_task_apply_finish(std::vector<TFinishTaskRequest> finish_task_requests);
+    bool has_pending_task() { return !_finish_task_requests.empty() || !_waitting_finish_task_requests.empty(); }
+    Status finish_publish_version_task();
+    void update_tablet_version(TFinishTaskRequest& finish_task_request);
+
+    size_t finish_task_requests_size() { return _finish_task_requests.size(); }
+    size_t waitting_finish_task_requests_size() { return _waitting_finish_task_requests.size(); }
+
+private:
+    bool _all_task_applied(const TFinishTaskRequest& finish_task_request);
+    bool _left_task_applied(const TFinishTaskRequest& finish_task_request);
+
+private:
+    mutable std::mutex _lock;
+
+    std::map<int64_t, TFinishTaskRequest> _finish_task_requests;
+    std::map<int64_t, TFinishTaskRequest> _waitting_finish_task_requests;
+    std::map<int64_t, std::set<std::pair<int64_t, int64_t>>> _unapplied_tablet_by_txn;
+    std::unique_ptr<ThreadPool> _finish_publish_version_thread_pool;
+};
+
+} // namespace starrocks

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -42,6 +42,7 @@
 #include "storage/compaction_manager.h"
 #include "storage/data_dir.h"
 #include "storage/memtable_flush_executor.h"
+#include "storage/publish_version_manager.h"
 #include "storage/rowset/rowset_meta.h"
 #include "storage/rowset/rowset_meta_manager.h"
 #include "storage/rowset/unique_rowset_id_generator.h"
@@ -90,7 +91,8 @@ StorageEngine::StorageEngine(const EngineOptions& options)
           _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
           _memtable_flush_executor(nullptr),
           _update_manager(new UpdateManager(options.update_mem_tracker)),
-          _compaction_manager(new CompactionManager()) {
+          _compaction_manager(new CompactionManager()),
+          _publish_version_manager(new PublishVersionManager()) {
 #ifdef BE_TEST
     _p_instance = _s_instance;
     _s_instance = this;
@@ -168,6 +170,8 @@ Status StorageEngine::_open() {
     RETURN_IF_ERROR_WITH_WARN(_check_file_descriptor_number(), "check fd number failed");
 
     RETURN_IF_ERROR_WITH_WARN(_update_manager->init(), "init update_manager failed");
+
+    RETURN_IF_ERROR_WITH_WARN(_publish_version_manager->init(), "init publish_version_manager failed");
 
     auto dirs = get_stores<false>();
 
@@ -562,6 +566,7 @@ void StorageEngine::stop() {
     JOIN_THREAD(_unused_rowset_monitor_thread)
     JOIN_THREAD(_garbage_sweeper_thread)
     JOIN_THREAD(_disk_stat_monitor_thread)
+    JOIN_THREAD(_finish_publish_version_thread)
 
     JOIN_THREADS(_base_compaction_threads)
     JOIN_THREADS(_cumulative_compaction_threads)

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -753,6 +753,20 @@ int64_t Tablet::max_continuous_version() const {
     }
 }
 
+int64_t Tablet::max_readable_version() const {
+    if (_updates != nullptr) {
+        return _updates->max_readable_version();
+    } else {
+        std::shared_lock rdlock(_meta_lock);
+        int64_t v = _timestamped_version_tracker.get_max_continuous_version();
+        if (tablet_state() == TABLET_RUNNING) {
+            // only check when tablet in running state
+            DCHECK_EQ(v, _max_continuous_version_from_beginning_unlocked().second);
+        }
+        return v;
+    }
+}
+
 void Tablet::calculate_cumulative_point() {
     std::unique_lock wrlock(_meta_lock);
     if (_cumulative_point != kInvalidCumulativePoint) {
@@ -1097,6 +1111,7 @@ void Tablet::build_tablet_report_info(TTabletInfo* tablet_info) {
             // and perform state modification operations.
         }
         tablet_info->__set_version(max_version);
+        tablet_info->__set_max_readable_version(max_version);
         // TODO: support getting minReadableVersion
         tablet_info->__set_min_readable_version(_timestamped_version_tracker.get_min_readable_version());
         tablet_info->__set_version_count(_tablet_meta->version_count());

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -183,6 +183,7 @@ public:
 
     // Same as max_continuous_version_from_beginning, only return end version, using a more efficient implementation
     int64_t max_continuous_version() const;
+    int64_t max_readable_version() const;
 
     int64_t last_cumu_compaction_failure_time() { return _last_cumu_compaction_failure_millis; }
     void set_last_cumu_compaction_failure_time(int64_t millis) { _last_cumu_compaction_failure_millis = millis; }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -435,6 +435,11 @@ int64_t TabletUpdates::max_version() const {
     return _edit_version_infos.empty() ? 0 : _edit_version_infos.back()->version.major();
 }
 
+int64_t TabletUpdates::max_readable_version() const {
+    std::lock_guard rl(_lock);
+    return _edit_version_infos.empty() ? 0 : _edit_version_infos[_apply_version_idx]->version.major();
+}
+
 Status TabletUpdates::get_rowsets_total_stats(const std::vector<uint32_t>& rowsets, size_t* total_rows,
                                               size_t* total_dels) {
     string err_rowsets;
@@ -2334,6 +2339,7 @@ size_t TabletUpdates::_get_rowset_num_deletes(const Rowset& rowset) {
 
 void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
     int64_t min_readable_version = 0;
+    int64_t max_readable_version = 0;
     int64_t version = 0;
     bool has_pending = false;
     int64_t version_count = 0;
@@ -2344,6 +2350,7 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
             LOG(WARNING) << "tablet delete when get_tablet_info_extra tablet:" << _tablet.tablet_id();
         } else {
             min_readable_version = _edit_version_infos[0]->version.major();
+            max_readable_version = _edit_version_infos[_apply_version_idx]->version.major();
             auto& last = _edit_version_infos.back();
             version = last->version.major();
             rowsets = last->rowsets;
@@ -2375,6 +2382,7 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
     }
     info->__set_version(version);
     info->__set_min_readable_version(min_readable_version);
+    info->__set_max_readable_version(max_readable_version);
     info->__set_version_miss(has_pending);
     info->__set_version_count(version_count);
     info->__set_row_count(total_row);

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -105,6 +105,8 @@ public:
     // get latest version's version
     int64_t max_version() const;
 
+    int64_t max_readable_version() const;
+
     // get total number of committed and pending rowsets
     size_t version_count() const;
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -239,6 +239,7 @@ set(EXEC_FILES
         ./storage/rowset_merger_test.cpp
         ./storage/schema_change_test.cpp
         ./storage/publish_version_task_test.cpp
+        ./storage/publish_version_manager_test.cpp
         ./storage/get_use_pk_index_test.cpp
         ./runtime/buffer_control_block_test.cpp
         ./runtime/datetime_value_test.cpp

--- a/be/test/storage/publish_version_manager_test.cpp
+++ b/be/test/storage/publish_version_manager_test.cpp
@@ -1,0 +1,262 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/publish_version_manager.h"
+
+#include <gtest/gtest.h>
+
+#include "agent/agent_common.h"
+#include "agent/agent_server.h"
+#include "agent/publish_version.h"
+#include "butil/file_util.h"
+#include "column/column_helper.h"
+#include "column/column_pool.h"
+#include "common/config.h"
+#include "exec/pipeline/query_context.h"
+#include "fs/fs_util.h"
+#include "gtest/gtest.h"
+#include "storage/chunk_helper.h"
+#include "storage/delta_writer.h"
+#include "storage/empty_iterator.h"
+#include "storage/options.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_meta.h"
+#include "storage/tablet_reader.h"
+#include "storage/txn_manager.h"
+#include "storage/union_iterator.h"
+#include "storage/update_manager.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class PublishVersionManagerTest : public testing::Test {
+public:
+    void SetUp() override {
+        _publish_version_manager = starrocks::StorageEngine::instance()->publish_version_manager();
+        _finish_publish_version_thread = std::thread([this] { _finish_publish_version_thread_callback(nullptr); });
+        Thread::set_thread_name(_finish_publish_version_thread, "finish_publish_version");
+    }
+
+    void TearDown() override {
+        if (_tablet) {
+            StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
+            _tablet.reset();
+        }
+        _stopped.store(true, std::memory_order_release);
+        _finish_publish_version_cv.notify_all();
+        if (_finish_publish_version_thread.joinable()) {
+            _finish_publish_version_thread.join();
+        }
+    }
+
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                  Column* one_delete = nullptr, bool empty = false, bool has_merge_condition = false) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = &tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        if (has_merge_condition) {
+            writer_context.merge_condition = "v2";
+        }
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        if (empty) {
+            return *writer->build();
+        }
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        auto& cols = chunk->columns();
+        for (int64_t key : keys) {
+            if (schema.num_key_fields() == 1) {
+                cols[0]->append_datum(Datum(key));
+            } else {
+                cols[0]->append_datum(Datum(key));
+                string v = fmt::to_string(key * 234234342345);
+                cols[1]->append_datum(Datum(Slice(v)));
+                cols[2]->append_datum(Datum((int32_t)key));
+            }
+            int vcol_start = schema.num_key_fields();
+            cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            if (cols[vcol_start + 1]->is_binary()) {
+                string v = fmt::to_string(key % 1000 + 2);
+                cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+            } else {
+                cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+            }
+        }
+        if (one_delete == nullptr && !keys.empty()) {
+            CHECK_OK(writer->flush_chunk(*chunk));
+        } else if (one_delete == nullptr) {
+            CHECK_OK(writer->flush());
+        } else if (one_delete != nullptr) {
+            CHECK_OK(writer->flush_chunk_with_deletes(*chunk, *one_delete));
+        }
+        return *writer->build();
+    }
+
+    void* _finish_publish_version_thread_callback(void* arg) {
+        while (!_stopped.load(std::memory_order_consume)) {
+            int32_t interval = config::finish_publish_version_internal;
+            {
+                std::unique_lock<std::mutex> wl(_finish_publish_version_mutex);
+                CHECK(_publish_version_manager != nullptr);
+                while (!_publish_version_manager->has_pending_task() && !_stopped.load(std::memory_order_consume)) {
+                    _finish_publish_version_cv.wait(wl);
+                }
+                _publish_version_manager->finish_publish_version_task();
+                if (interval <= 0) {
+                    LOG(WARNING) << "finish_publish_version_internal config is illegal: " << interval
+                                 << ", force set to 1";
+                    interval = 1000;
+                }
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(interval));
+        }
+
+        return nullptr;
+    }
+
+public:
+    TabletSharedPtr _tablet;
+    std::thread _finish_publish_version_thread;
+    std::mutex _finish_publish_version_mutex;
+    std::condition_variable _finish_publish_version_cv;
+    std::atomic<bool> _stopped{false};
+    PublishVersionManager* _publish_version_manager;
+};
+
+static ChunkIteratorPtr create_tablet_iterator(TabletReader& reader, Schema& schema) {
+    TabletReaderParams params;
+    if (!reader.prepare().ok()) {
+        LOG(ERROR) << "reader prepare failed";
+        return nullptr;
+    }
+    std::vector<ChunkIteratorPtr> seg_iters;
+    if (!reader.get_segment_iterators(params, &seg_iters).ok()) {
+        LOG(ERROR) << "reader get segment iterators fail";
+        return nullptr;
+    }
+    if (seg_iters.empty()) {
+        return new_empty_iterator(schema, DEFAULT_CHUNK_SIZE);
+    }
+    return new_union_iterator(seg_iters);
+}
+
+static ssize_t read_until_eof(const ChunkIteratorPtr& iter) {
+    auto chunk = ChunkHelper::new_chunk(iter->schema(), 100);
+    size_t count = 0;
+    while (true) {
+        auto st = iter->get_next(chunk.get());
+        if (st.is_end_of_file()) {
+            break;
+        } else if (st.ok()) {
+            count += chunk->num_rows();
+            chunk->reset();
+        } else {
+            LOG(WARNING) << "read error: " << st.to_string();
+            return -1;
+        }
+    }
+    return count;
+}
+
+static ssize_t read_tablet(const TabletSharedPtr& tablet, int64_t version) {
+    Schema schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+    TabletReader reader(tablet, Version(0, version), schema);
+    auto iter = create_tablet_iterator(reader, schema);
+    if (iter == nullptr) {
+        return -1;
+    }
+    return read_until_eof(iter);
+}
+
+TEST_F(PublishVersionManagerTest, test_publish_task) {
+    _tablet = create_tablet(rand(), rand());
+    // write
+    const int N = 1000;
+    std::vector<int64_t> keys;
+    for (int i = 0; i < N; i++) {
+        keys.push_back(i);
+    }
+    auto rs0 = create_rowset(_tablet, keys);
+    ASSERT_TRUE(_tablet->rowset_commit(2, rs0).ok());
+    _tablet->updates()->stop_apply(true);
+    auto rs1 = create_rowset(_tablet, keys);
+    ASSERT_TRUE(_tablet->rowset_commit(3, rs1).ok());
+    std::vector<TFinishTaskRequest> finish_task_requests;
+    auto& finish_task_request = finish_task_requests.emplace_back();
+    finish_task_request.signature = 2222;
+    auto& tablet_publish_versions = finish_task_request.tablet_publish_versions;
+    auto& pair = tablet_publish_versions.emplace_back();
+    pair.__set_tablet_id(_tablet->tablet_id());
+    pair.__set_version(3);
+    _publish_version_manager->wait_publish_task_apply_finish(std::move(finish_task_requests));
+    _finish_publish_version_cv.notify_one();
+
+    ASSERT_EQ(0, _publish_version_manager->finish_task_requests_size());
+    ASSERT_EQ(1, _publish_version_manager->waitting_finish_task_requests_size());
+    _tablet->updates()->stop_apply(false);
+    _tablet->updates()->check_for_apply();
+    ASSERT_EQ(N, read_tablet(_tablet, 3));
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    ASSERT_EQ(0, _publish_version_manager->finish_task_requests_size());
+    ASSERT_EQ(0, _publish_version_manager->waitting_finish_task_requests_size());
+}
+
+} // namespace starrocks

--- a/be/test/storage/publish_version_manager_test.cpp
+++ b/be/test/storage/publish_version_manager_test.cpp
@@ -42,7 +42,7 @@
 #include "storage/update_manager.h"
 #include "testutil/assert.h"
 
-namespace starrocks {
+namespace starrocks::vectorized {
 
 class PublishVersionManagerTest : public testing::Test {
 public:

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1993,6 +1993,8 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_new_publish_mechanism = false;
 
+    @ConfField(mutable = true)
+    public static boolean enable_sync_publish = false;
     /**
      * Normally FE will quit when replaying a bad journal. This configuration provides a bypass mechanism.
      * If this was set to a positive value, FE will skip the corresponding bad journals before it quits.

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -586,7 +586,11 @@ public class ReportHandler extends Daemon {
                             // just select the dest schema hash
                             for (TTabletInfo tabletInfo : backendTablets.get(tabletId).getTablet_infos()) {
                                 if (tabletInfo.getSchema_hash() == schemaHash) {
-                                    backendVersion = tabletInfo.getVersion();
+                                    if (Config.enable_sync_publish) {
+                                        backendVersion = tabletInfo.getMax_readable_version();
+                                    } else {
+                                        backendVersion = tabletInfo.getVersion();
+                                    }
                                     backendMinReadableVersion = tabletInfo.getMin_readable_version();
                                     rowCount = tabletInfo.getRow_count();
                                     dataSize = tabletInfo.getData_size();
@@ -973,8 +977,10 @@ public class ReportHandler extends Daemon {
             for (long txnId : map.keySet()) {
                 long commitTime = transactionsToCommitTime.get(txnId);
                 PublishVersionTask task =
-                        new PublishVersionTask(backendId, txnId, dbId, commitTime, map.get(txnId), null, null,
-                                createPublishVersionTaskTime, null);
+                        new PublishVersionTask(backendId, txnId, dbId, commitTime,
+                                map.get(txnId), null, null,
+                                createPublishVersionTaskTime, null,
+                                Config.enable_sync_publish);
                 batchTask.addTask(task);
                 // add to AgentTaskQueue for handling finish report.
                 AgentTaskQueue.addTask(task);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/TaskAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/TaskAttachment.java
@@ -27,4 +27,5 @@ public class TaskAttachment {
     public long getTaskId() {
         return taskId;
     }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1435,6 +1435,7 @@ public class StmtExecutor {
             QeProcessorImpl.INSTANCE.registerQuery(context.getExecutionId(), queryInfo);
             coord.exec();
 
+            long jobDeadLineMs = System.currentTimeMillis() + context.getSessionVariable().getQueryTimeoutS() * 1000;
             coord.join(context.getSessionVariable().getQueryTimeoutS());
             if (!coord.isDone()) {
                 /*
@@ -1532,7 +1533,8 @@ public class StmtExecutor {
                         transactionId,
                         TabletCommitInfo.fromThrift(coord.getCommitInfos()),
                         TabletFailInfo.fromThrift(coord.getFailInfos()),
-                        context.getSessionVariable().getTransactionVisibleWaitTimeout() * 1000,
+                        Config.enable_sync_publish ? jobDeadLineMs - System.currentTimeMillis() : 
+                                            context.getSessionVariable().getTransactionVisibleWaitTimeout() * 1000,
                         new InsertTxnCommitAttachment(loadedRows))) {
                     txnStatus = TransactionStatus.VISIBLE;
                     MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1150,6 +1150,11 @@ public class GlobalStateMgr {
         }
     }
 
+    public void setFrontendNodeType(FrontendNodeType newType) {
+        // just for test, don't call it directly
+        feType = newType;
+    }
+
     // start all daemon threads only running on Master
     private void startLeaderOnlyDaemonThreads() {
         if (Config.integrate_starmgr) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -106,6 +106,8 @@ import com.starrocks.thrift.TGetDBPrivsParams;
 import com.starrocks.thrift.TGetDBPrivsResult;
 import com.starrocks.thrift.TGetDbsParams;
 import com.starrocks.thrift.TGetDbsResult;
+import com.starrocks.thrift.TGetLoadTxnStatusRequest;
+import com.starrocks.thrift.TGetLoadTxnStatusResult;
 import com.starrocks.thrift.TGetTableMetaRequest;
 import com.starrocks.thrift.TGetTableMetaResponse;
 import com.starrocks.thrift.TGetTablePrivsParams;
@@ -155,6 +157,7 @@ import com.starrocks.thrift.TTableStatus;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.thrift.TTaskInfo;
 import com.starrocks.thrift.TTaskRunInfo;
+import com.starrocks.thrift.TTransactionStatus;
 import com.starrocks.thrift.TUpdateExportTaskStatusRequest;
 import com.starrocks.thrift.TUpdateResourceUsageRequest;
 import com.starrocks.thrift.TUpdateResourceUsageResponse;
@@ -904,6 +907,13 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
         TStatus status = new TStatus(TStatusCode.OK);
         result.setStatus(status);
+        long timeoutSecond = request.isSetTimeout() ? request.getTimeout() : Config.stream_load_default_timeout_second;
+        if (Config.enable_sync_publish) {
+            result.setTimeout(timeoutSecond);
+        } else {
+            result.setTimeout(0);
+        }
+        
         try {
             result.setTxnId(loadTxnBeginImpl(request, clientAddr));
         } catch (DuplicatedRequestException e) {
@@ -1075,6 +1085,42 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             default:
                 break;
         }
+    }
+
+    @Override
+    public TGetLoadTxnStatusResult getLoadTxnStatus(TGetLoadTxnStatusRequest request) throws TException {
+        String clientAddr = getClientAddrAsString();
+        LOG.info("receive get txn status request. db: {}, tbl: {}, txn_id: {}, backend: {}",
+                request.getDb(), request.getTbl(), request.getTxnId(), clientAddr);
+        LOG.debug("get txn status request: {}", request);
+
+        TGetLoadTxnStatusResult result = new TGetLoadTxnStatusResult();
+        // if current node is not master, reject the request
+        if (!GlobalStateMgr.getCurrentState().isLeader()) {
+            LOG.warn("current fe is not leader");
+            result.setStatus(TTransactionStatus.UNKNOWN);
+            return result;
+        }
+
+        // get database
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        String dbName = request.getDb();
+        Database db = globalStateMgr.getDb(dbName);
+        if (db == null) {
+            LOG.warn("unknown database, database=" + dbName);
+            result.setStatus(TTransactionStatus.UNKNOWN);
+            return result;
+        }
+
+        try {
+            TTransactionStatus status = GlobalStateMgr.getCurrentGlobalTransactionMgr().getTxnStatus(db, request.getTxnId());
+            LOG.debug("txn {} status is {}", request.getTxnId(), status);
+            result.setStatus(status);
+        } catch (Throwable e) {
+            result.setStatus(TTransactionStatus.UNKNOWN);
+            LOG.warn("catch unknown result.", e);
+        }
+        return result;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
@@ -51,10 +51,11 @@ public class PublishVersionTask extends AgentTask {
     private final long commitTimestamp;
     private final TransactionState txnState;
     private Span span;
+    private boolean enableSyncPublish;
 
     public PublishVersionTask(long backendId, long transactionId, long dbId, long commitTimestamp,
                               List<TPartitionVersionInfo> partitionVersionInfos, String traceParent, Span txnSpan,
-                              long createTime, TransactionState state) {
+                              long createTime, TransactionState state, boolean enableSyncPublish) {
         super(null, backendId, TTaskType.PUBLISH_VERSION, dbId, -1L, -1L, -1L, -1L, transactionId, createTime, traceParent);
         this.transactionId = transactionId;
         this.partitionVersionInfos = partitionVersionInfos;
@@ -62,6 +63,7 @@ public class PublishVersionTask extends AgentTask {
         this.isFinished = false;
         this.commitTimestamp = commitTimestamp;
         this.txnState = state;
+        this.enableSyncPublish = enableSyncPublish;
         if (txnSpan != null) {
             span = TraceManager.startSpan("publish_version_task", txnSpan);
             span.setAttribute("backend_id", backendId);
@@ -76,6 +78,7 @@ public class PublishVersionTask extends AgentTask {
         TPublishVersionRequest publishVersionRequest = new TPublishVersionRequest(transactionId, partitionVersionInfos);
         publishVersionRequest.setCommit_timestamp(commitTimestamp);
         publishVersionRequest.setTxn_trace_parent(traceParent);
+        publishVersionRequest.setEnable_sync_publish(enableSyncPublish);
         return publishVersionRequest;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -45,6 +45,7 @@ import com.starrocks.thrift.TCommitRemoteTxnResponse;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTabletCommitInfo;
+import com.starrocks.thrift.TTransactionStatus;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionState.LoadJobSourceType;
 import com.starrocks.transaction.TransactionState.TxnCoordinator;
@@ -490,6 +491,11 @@ public class GlobalTransactionMgr implements Writable {
     public void abortTransaction(Long dbId, String label, String reason) throws UserException {
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
         dbTransactionMgr.abortTransaction(label, reason);
+    }
+
+    public TTransactionStatus getTxnStatus(Database db, long transactionId) throws UserException {
+        DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(db.getId());
+        return dbTransactionMgr.getTxnStatus(transactionId);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -924,7 +924,8 @@ public class TransactionState implements Writable {
                     traceParent,
                     txnSpan,
                     createTime,
-                    this);
+                    this,
+                    Config.enable_sync_publish);
             this.addPublishVersionTask(backendId, task);
             tasks.add(task);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/DecommissionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/DecommissionTest.java
@@ -39,6 +39,7 @@ public class DecommissionTest {
     @Test
     public void testDecommission() throws Exception {
         PseudoCluster cluster = PseudoCluster.getInstance();
+        Config.statistic_collect_query_timeout = 3600;
         int numTable = 10;
         final String[] tableNames = new String[numTable];
         final String[] createTableSqls = new String[numTable];

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -204,7 +204,7 @@ public class PseudoCluster {
     public ClusterConfig getConfig() {
         return config;
     }
-
+    
     public PseudoBackend getBackend(long beId) {
         String host = backendIdToHost.get(beId);
         if (host == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoFrontend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoFrontend.java
@@ -163,6 +163,7 @@ public class PseudoFrontend {
             try {
                 // init config
                 new Config().init(frontend.getRunningDir() + "/conf/fe.conf");
+                Config.statistic_collect_query_timeout = 60;
 
                 // check it after Config is initialized, otherwise the config 'check_java_version' won't work.
                 if (!JdkUtils.checkJavaVersion()) {

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -2,20 +2,26 @@
 
 package com.starrocks.service;
 
-
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.qe.QueryQueueManager;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TAuthInfo;
+import com.starrocks.thrift.TGetLoadTxnStatusRequest;
+import com.starrocks.thrift.TGetLoadTxnStatusResult;
 import com.starrocks.thrift.TGetTablesInfoRequest;
 import com.starrocks.thrift.TGetTablesInfoResponse;
 import com.starrocks.thrift.TResourceUsage;
 import com.starrocks.thrift.TTableInfo;
 import com.starrocks.thrift.TTransactionStatus;
+import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TUpdateResourceUsageRequest;
 import com.starrocks.thrift.TUserIdentity;
 import com.starrocks.transaction.TransactionState;
@@ -33,6 +39,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.UUID;
 
 public class FrontendServiceImplTest {
 
@@ -166,8 +173,10 @@ public class FrontendServiceImplTest {
         Table table = db.getTable("site_access_day");
         UUID uuid = UUID.randomUUID();
         TUniqueId requestId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+        List<Long> tableIdList = Lists.newArrayList();
+        tableIdList.add(table.getId());
         long transactionId = GlobalStateMgr.getCurrentGlobalTransactionMgr().beginTransaction(db.getId(),
-                             Lists.newArrayList(table.getId()), "1jdc689-xd232", requestId,
+                             tableIdList, "1jdc689-xd232", requestId,
                              new TxnCoordinator(TxnSourceType.BE, "1.1.1.1"),
                              TransactionState.LoadJobSourceType.BACKEND_STREAMING, -1, 600);
         FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -169,8 +169,23 @@ public class FrontendServiceImplTest {
 
     @Test
     public void testGetLoadTxnStatus() throws Exception {
-        Database db = GlobalStateMgr.getCurrentState().getDb("test");
-        Table table = db.getTable("site_access_day");
+        starRocksAssert.withDatabase("test_table").useDatabase("test_table")
+                .withTable("CREATE TABLE `pk_table` (\n" +
+                        "  `k1` date NULL COMMENT \"\",\n" +
+                        "  `v1` int(11) NULL COMMENT \"\",\n" +
+                        "  `v2` int(11) NULL COMMENT \"\"\n" +
+                        ") ENGINE=OLAP \n" +
+                        "PRIMARY KEY(`k1`)\n" +
+                        "DISTRIBUTED BY HASH(k1) BUCKETS 1\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"in_memory\" = \"false\",\n" +
+                        "\"enable_persistent_index\" = \"false\",\n" +
+                        "\"replicated_storage\" = \"true\",\n" +
+                        "\"compression\" = \"LZ4\"\n" +
+                        ")")
+        Database db = GlobalStateMgr.getCurrentState().getDb("test_table");
+        Table table = db.getTable("pk_table");
         UUID uuid = UUID.randomUUID();
         TUniqueId requestId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
         List<Long> tableIdList = Lists.newArrayList();
@@ -186,7 +201,7 @@ public class FrontendServiceImplTest {
         request.setTxnId(100);
         TGetLoadTxnStatusResult result1 = impl.getLoadTxnStatus(request);
         Assert.assertEquals(TTransactionStatus.UNKNOWN, result1.getStatus());
-        request.setDb("test");
+        request.setDb("test_table");
         TGetLoadTxnStatusResult result2 = impl.getLoadTxnStatus(request);
         Assert.assertEquals(TTransactionStatus.UNKNOWN, result2.getStatus());
         request.setTxnId(transactionId);

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -183,7 +183,7 @@ public class FrontendServiceImplTest {
                         "\"enable_persistent_index\" = \"false\",\n" +
                         "\"replicated_storage\" = \"true\",\n" +
                         "\"compression\" = \"LZ4\"\n" +
-                        ")")
+                        ")");
         Database db = GlobalStateMgr.getCurrentState().getDb("test_table");
         Table table = db.getTable("pk_table");
         UUID uuid = UUID.randomUUID();

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -171,7 +171,7 @@ public class FrontendServiceImplTest {
     public void testGetLoadTxnStatus() throws Exception {
         starRocksAssert.withDatabase("test_table").useDatabase("test_table")
                 .withTable("CREATE TABLE `pk_table` (\n" +
-                        "  `k1` date NULL COMMENT \"\",\n" +
+                        "  `k1` date NOT NULL COMMENT \"\",\n" +
                         "  `v1` int(11) NULL COMMENT \"\",\n" +
                         "  `v2` int(11) NULL COMMENT \"\"\n" +
                         ") ENGINE=OLAP \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -34,6 +34,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.meta.MetaContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TTransactionStatus;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -106,6 +107,8 @@ public class DatabaseTransactionMgrTest {
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
         masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId1, transTablets);
+        DatabaseTransactionMgr masterDbTransMgr = masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
+        assertEquals(TTransactionStatus.COMMITTED, masterDbTransMgr.getTxnStatus(transactionId1));
         masterTransMgr.finishTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId1, null);
         lableToTxnId.put(GlobalStateMgrTestUtil.testTxnLable1, transactionId1);
 
@@ -162,13 +165,16 @@ public class DatabaseTransactionMgrTest {
                 masterDbTransMgr.getTransactionState(lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable1));
         assertEquals(txnId1.longValue(), transactionState1.getTransactionId());
         assertEquals(TransactionStatus.VISIBLE, transactionState1.getTransactionStatus());
+        assertEquals(TTransactionStatus.VISIBLE, masterDbTransMgr.getTxnStatus(txnId1.longValue()));
 
         Long txnId2 = masterDbTransMgr.unprotectedGetTxnIdsByLabel(GlobalStateMgrTestUtil.testTxnLable2).iterator().next();
         assertEquals(txnId2, lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable2));
         TransactionState transactionState2 = masterDbTransMgr.getTransactionState(txnId2);
         assertEquals(txnId2.longValue(), transactionState2.getTransactionId());
         assertEquals(TransactionStatus.PREPARE, transactionState2.getTransactionStatus());
+        assertEquals(TTransactionStatus.PREPARE, masterDbTransMgr.getTxnStatus(txnId2.longValue())); 
 
+        assertEquals(TTransactionStatus.UNKNOWN, masterDbTransMgr.getTxnStatus(12134)); 
     }
 
     @Test
@@ -181,6 +187,7 @@ public class DatabaseTransactionMgrTest {
         assertEquals(0, masterDbTransMgr.getRunningRoutineLoadTxnNums());
         assertEquals(2, masterDbTransMgr.getFinishedTxnNums());
         assertEquals(4, masterDbTransMgr.getTransactionNum());
+        assertEquals(TTransactionStatus.ABORTED, masterDbTransMgr.getTxnStatus(txnId2));
 
         long txnId3 = lableToTxnId.get(GlobalStateMgrTestUtil.testTxnLable3);
         masterDbTransMgr.abortTransaction(txnId3, "test abort transaction", null);
@@ -188,6 +195,7 @@ public class DatabaseTransactionMgrTest {
         assertEquals(0, masterDbTransMgr.getRunningRoutineLoadTxnNums());
         assertEquals(3, masterDbTransMgr.getFinishedTxnNums());
         assertEquals(4, masterDbTransMgr.getTransactionNum());
+        assertEquals(TTransactionStatus.ABORTED, masterDbTransMgr.getTxnStatus(txnId3));
     }
 
     @Test

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -262,6 +262,7 @@ struct TPublishVersionRequest {
     3: optional bool strict_mode = false // Deprecated
     4: optional i64 commit_timestamp
     5: optional string txn_trace_parent
+    6: optional bool enable_sync_publish = false
 }
 
 struct TClearAlterTaskRequest {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -557,6 +557,7 @@ struct TLoadTxnBeginResult {
     1: required Status.TStatus status
     2: optional i64 txnId
     3: optional string job_status // if label already used, set status of existing job
+    4: optional i64 timeout
 }
 
 // StreamLoad request, used to load a streaming to engine
@@ -689,6 +690,21 @@ struct TLoadTxnRollbackRequest {
     9: optional i64 auth_code
     10: optional TTxnCommitAttachment txnCommitAttachment
     11: optional list<Types.TTabletFailInfo> failInfos
+}
+
+struct TGetLoadTxnStatusResult {
+    1: required Status.TTransactionStatus status
+}
+
+struct TGetLoadTxnStatusRequest {
+    1: optional string cluster
+    2: required string user
+    3: required string passwd
+    4: required string db
+    5: required string tbl
+    6: optional string user_ip
+    7: optional i64 auth_code
+    8: required i64 txnId
 }
 
 struct TLoadTxnRollbackResult {
@@ -1159,5 +1175,7 @@ service FrontendService {
     TUpdateResourceUsageResponse updateResourceUsage(1: TUpdateResourceUsageRequest request)
 
     TGetTabletScheduleResponse getTabletSchedule(1: TGetTabletScheduleRequest request)
+    
+    TGetLoadTxnStatusResult getLoadTxnStatus(1: TGetLoadTxnStatusRequest request)
 }
 

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -50,6 +50,7 @@ struct TTabletInfo {
     // skip num 17 because num 17 is used in later version, so we skip it in 
     // order to support degrade
     18: optional bool is_error_state
+    19: optional Types.TVersion max_readable_version
 }
 
 struct TTabletVersionPair {
@@ -75,6 +76,7 @@ struct TFinishTaskRequest {
     15: optional i64 copy_size
     16: optional i64 copy_time_ms
     17: optional list<TTabletVersionPair> tablet_versions;
+    18: optional list<TTabletVersionPair> tablet_publish_versions;
 }
 
 struct TTablet {

--- a/gensrc/thrift/Status.thrift
+++ b/gensrc/thrift/Status.thrift
@@ -19,7 +19,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-namespace cpp starrocks
+namespace cpp starrocks 
 namespace java com.starrocks.thrift
 
 include "StatusCode.thrift"
@@ -28,3 +28,11 @@ struct TStatus {
   2: optional list<string> error_msgs
 }
 
+enum TTransactionStatus {
+    UNKNOWN = 0,
+    PREPARE = 1,
+    COMMITTED = 2,
+    VISIBLE = 3,
+    ABORTED = 4,
+    PREPARED = 5
+} 


### PR DESCRIPTION
The pr refactor publish version mechanism and BE will return publish version request success until all version is queryable. The main improvement is to support sync publish a version for the primary key table and we will query the specified version data immediately if we return publish version success.
