### PR TITLE
[BugFix] fix the _clean_idle_consumer_bg thread exit crash

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -414,7 +414,10 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     _stream_load_executor = new StreamLoadExecutor(this);
     _stream_context_mgr = new StreamContextMgr();
     _transaction_mgr = new TransactionMgr(this);
+
     _routine_load_task_executor = new RoutineLoadTaskExecutor(this);
+    RETURN_IF_ERROR(_routine_load_task_executor->init());
+
     _small_file_mgr = new SmallFileMgr(this, config::small_file_dir);
     _runtime_filter_worker = new RuntimeFilterWorker(this);
     _runtime_filter_cache = new RuntimeFilterCache(8);
@@ -537,6 +540,10 @@ void ExecEnv::stop() {
 
     if (_load_rpc_pool) {
         _load_rpc_pool->shutdown();
+    }
+
+    if (_routine_load_task_executor) {
+        _routine_load_task_executor->stop();
     }
 
 #ifndef BE_TEST

--- a/be/src/runtime/routine_load/data_consumer_pool.cpp
+++ b/be/src/runtime/routine_load/data_consumer_pool.cpp
@@ -154,7 +154,16 @@ void DataConsumerPool::return_consumers(DataConsumerGroup* grp) {
     }
 }
 
-Status DataConsumerPool::start_bg_worker() {
+void DataConsumerPool::stop() {
+    std::unique_lock<std::mutex> l(_lock);
+    *_is_closed = true;
+
+    if(_clean_idle_consumer_thread.joinable()) {
+        _clean_idle_consumer_thread.join();
+    }
+}
+
+void DataConsumerPool::start_bg_worker() {
     std::shared_ptr<bool> is_closed = _is_closed;
 
     _clean_idle_consumer_thread = std::thread([=] {
@@ -173,8 +182,6 @@ Status DataConsumerPool::start_bg_worker() {
         }
     });
     Thread::set_thread_name(_clean_idle_consumer_thread, "clean_idle_cm");
-    _clean_idle_consumer_thread.detach();
-    return Status::OK();
 }
 
 void DataConsumerPool::_clean_idle_consumer_bg() {

--- a/be/src/runtime/routine_load/data_consumer_pool.cpp
+++ b/be/src/runtime/routine_load/data_consumer_pool.cpp
@@ -158,7 +158,7 @@ void DataConsumerPool::stop() {
     std::unique_lock<std::mutex> l(_lock);
     *_is_closed = true;
 
-    if(_clean_idle_consumer_thread.joinable()) {
+    if (_clean_idle_consumer_thread.joinable()) {
         _clean_idle_consumer_thread.join();
     }
 }

--- a/be/src/runtime/routine_load/data_consumer_pool.h
+++ b/be/src/runtime/routine_load/data_consumer_pool.h
@@ -59,6 +59,8 @@ public:
         *_is_closed = true;
     }
 
+    void stop();
+
     // get a already initialized consumer from cache,
     // if not found in cache, create a new one.
     Status get_consumer(StreamLoadContext* ctx, std::shared_ptr<DataConsumer>* ret);
@@ -71,12 +73,11 @@ public:
     // return the consumers in consumer group to the pool
     void return_consumers(DataConsumerGroup* grp);
 
-    Status start_bg_worker();
+    void start_bg_worker();
 
 private:
     void _clean_idle_consumer_bg();
 
-private:
     std::mutex _lock;
     std::shared_ptr<bool> _is_closed;
     std::list<std::shared_ptr<DataConsumer>> _pool;

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -48,6 +48,39 @@
 
 namespace starrocks {
 
+Status RoutineLoadTaskExecutor::init() {
+    REGISTER_GAUGE_STARROCKS_METRIC(routine_load_task_count, [this]() {
+        std::lock_guard<std::mutex> l(_lock);
+        return _task_map.size();
+    })
+
+    auto st = ThreadPoolBuilder("routine_load")
+                      .set_min_threads(0)
+                      .set_max_threads(INT_MAX)
+                      .set_max_queue_size(INT_MAX)
+                      .build(&_thread_pool);
+    RETURN_IF_ERROR(st);
+
+    _data_consumer_pool.start_bg_worker();
+    return Status::OK();
+}
+
+void RoutineLoadTaskExecutor::stop() {
+    _data_consumer_pool.stop();
+
+    if (_thread_pool) {
+        _thread_pool->shutdown();
+    }
+
+    for (auto& it : _task_map) {
+        auto ctx = it.second;
+        if (ctx->unref()) {
+            delete ctx;
+        }
+    }
+    _task_map.clear();
+}
+
 Status RoutineLoadTaskExecutor::get_kafka_partition_meta(const PKafkaMetaProxyRequest& request,
                                                          std::vector<int32_t>* partition_ids, int timeout_ms,
                                                          std::string* group_id) {
@@ -340,7 +373,7 @@ void RoutineLoadTaskExecutor::exec_task(StreamLoadContext* ctx, DataConsumerPool
 
     // create data consumer group
     std::shared_ptr<DataConsumerGroup> consumer_grp;
-    HANDLE_ERROR(consumer_pool->get_consumer_grp(ctx, &consumer_grp), "failed to get consumers");
+    HANDLE_ERROR(consumer_pool->get_consumer_grp(ctx, &consumer_grp), "failed to get consumers")
 
     // create and set pipe
     std::shared_ptr<StreamLoadPipe> pipe;
@@ -376,21 +409,16 @@ void RoutineLoadTaskExecutor::exec_task(StreamLoadContext* ctx, DataConsumerPool
     ctx->body_sink = pipe;
 
     // must put pipe before executing plan fragment
-    HANDLE_ERROR(_exec_env->load_stream_mgr()->put(ctx->id, pipe), "failed to add pipe");
+    HANDLE_ERROR(_exec_env->load_stream_mgr()->put(ctx->id, pipe), "failed to add pipe")
 
-#ifndef BE_TEST
     // execute plan fragment, async
-    HANDLE_ERROR(_exec_env->stream_load_executor()->execute_plan_fragment(ctx), "failed to execute plan fragment");
-#else
-    // only for test
-    HANDLE_ERROR(_execute_plan_for_test(ctx), "test failed");
-#endif
+    HANDLE_ERROR(_exec_env->stream_load_executor()->execute_plan_fragment(ctx), "failed to execute plan fragment")
 
     // start to consume, this may block a while
-    HANDLE_ERROR(consumer_grp->start_all(ctx), "consuming failed");
+    HANDLE_ERROR(consumer_grp->start_all(ctx), "consuming failed")
 
     // wait for all consumers finished
-    HANDLE_ERROR(ctx->future.get(), "consume failed");
+    HANDLE_ERROR(ctx->future.get(), "consume failed")
 
     ctx->load_cost_nanos = MonotonicNanos() - ctx->start_nanos;
 
@@ -399,7 +427,7 @@ void RoutineLoadTaskExecutor::exec_task(StreamLoadContext* ctx, DataConsumerPool
     consumer_pool->return_consumers(consumer_grp.get());
 
     // commit txn
-    HANDLE_ERROR(_exec_env->stream_load_executor()->commit_txn(ctx), "commit failed");
+    HANDLE_ERROR(_exec_env->stream_load_executor()->commit_txn(ctx), "commit failed")
 
     // commit messages
     switch (ctx->load_src_type) {
@@ -483,46 +511,6 @@ void RoutineLoadTaskExecutor::err_handler(StreamLoadContext* ctx, const Status& 
     if (ctx->body_sink != nullptr) {
         ctx->body_sink->cancel(st);
     }
-}
-
-// for test only
-Status RoutineLoadTaskExecutor::_execute_plan_for_test(StreamLoadContext* ctx) {
-    ctx->ref();
-    auto mock_consumer = [this, ctx]() {
-        std::shared_ptr<StreamLoadPipe> pipe = _exec_env->load_stream_mgr()->get(ctx->id);
-        bool eof = false;
-        std::stringstream ss;
-        while (true) {
-            char one;
-            size_t len = 1;
-            Status st = pipe->read((uint8_t*)&one, &len, &eof);
-            if (!st.ok()) {
-                LOG(WARNING) << "read failed";
-                ctx->promise.set_value(st);
-                break;
-            }
-
-            if (eof) {
-                ctx->promise.set_value(Status::OK());
-                break;
-            }
-
-            if (one == '\n') {
-                LOG(INFO) << "get line: " << ss.str();
-                ss.str("");
-                ctx->number_loaded_rows++;
-            } else {
-                ss << one;
-            }
-        }
-        if (ctx->unref()) {
-            delete ctx;
-        }
-    };
-
-    std::thread t1(mock_consumer);
-    t1.detach();
-    return Status::OK();
 }
 
 } // namespace starrocks

--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -60,36 +60,12 @@ class RoutineLoadTaskExecutor {
 public:
     typedef std::function<void(StreamLoadContext*)> ExecFinishCallback;
 
-    RoutineLoadTaskExecutor(ExecEnv* exec_env) : _exec_env(exec_env), _data_consumer_pool(10) {
-        REGISTER_GAUGE_STARROCKS_METRIC(routine_load_task_count, [this]() {
-            std::lock_guard<std::mutex> l(_lock);
-            return _task_map.size();
-        });
-        auto st = ThreadPoolBuilder("routine_load")
-                          .set_min_threads(0)
-                          .set_max_threads(INT_MAX)
-                          .set_max_queue_size(INT_MAX)
-                          .build(&_thread_pool);
-        DCHECK(st.ok());
-        _data_consumer_pool.start_bg_worker();
-    }
+    RoutineLoadTaskExecutor(ExecEnv* exec_env) : _exec_env(exec_env), _data_consumer_pool(10) {}
 
-    ~RoutineLoadTaskExecutor() noexcept {
-        // _thread_pool.shutdown();
-        // _thread_pool.join();
+    ~RoutineLoadTaskExecutor() noexcept = default;
 
-        if (_thread_pool) {
-            _thread_pool->shutdown();
-        }
-
-        for (auto& it : _task_map) {
-            auto ctx = it.second;
-            if (ctx->unref()) {
-                delete ctx;
-            }
-        }
-        _task_map.clear();
-    }
+    Status init();
+    void stop();
 
     // submit a routine load task
     Status submit_task(const TRoutineLoadTask& task);
@@ -110,10 +86,6 @@ private:
 
     void err_handler(StreamLoadContext* ctx, const Status& st, const std::string& err_msg);
 
-    // for test only
-    Status _execute_plan_for_test(StreamLoadContext* ctx);
-
-private:
     ExecEnv* _exec_env;
     std::unique_ptr<ThreadPool> _thread_pool;
     DataConsumerPool _data_consumer_pool;

--- a/be/test/storage/task/engine_storage_migration_task_test.cpp
+++ b/be/test/storage/task/engine_storage_migration_task_test.cpp
@@ -385,6 +385,7 @@ int main(int argc, char** argv) {
     delete engine;
     // destroy exec env
     starrocks::tls_thread_status.set_mem_tracker(nullptr);
+    exec_env->stop();
     exec_env->destroy();
     global_env->stop();
 


### PR DESCRIPTION
Fixes #issue

Join the `_clean_idle_consumer_thread` before destruct `DataConsumerPool`.

```
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
*** Aborted at 1692243104 (unix time) try "date -d @1692243104" if you are using GNU date ***
PC: @          0x26bfef0 starrocks::CurrentThread::~CurrentThread()
*** SIGSEGV (@0x0) received by PID 217030 (TID 0x7f506e5ff700) from PID 0; stack trace: ***
    @          0x5a09a82 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f5092bf9630 (unknown)
    @          0x26bfef0 starrocks::CurrentThread::~CurrentThread()
    @          0x78be756 (anonymous namespace)::run()
    @     0x7f5092bf1ca2 __nptl_deallocate_tsd
    @     0x7f5092bf1eb3 start_thread
    @     0x7f509291ab0d __clone
    @                0x0 (unknown)

```

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
