### PR TITLE
[BugFix] jdbc mysql user/password fields are optional

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.catalog;
 
 import com.google.gson.JsonObject;
@@ -90,9 +89,11 @@ public class JDBCTable extends Table {
 
         resourceName = properties.get(RESOURCE);
         if (Strings.isNullOrEmpty(resourceName)) {
+            if (properties.get(JDBCResource.USER) == null ||
+                    properties.get(JDBCResource.PASSWORD) == null) {
+                throw new DdlException("all catalog properties must be set");
+            }
             if (Strings.isNullOrEmpty(properties.get(JDBCResource.URI)) ||
-                    Strings.isNullOrEmpty(properties.get(JDBCResource.USER)) ||
-                    Strings.isNullOrEmpty(properties.get(JDBCResource.PASSWORD)) ||
                     Strings.isNullOrEmpty(properties.get(JDBCResource.DRIVER_URL)) ||
                     Strings.isNullOrEmpty(properties.get(JDBCResource.CHECK_SUM)) ||
                     Strings.isNullOrEmpty(properties.get(JDBCResource.DRIVER_CLASS))) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -170,4 +170,14 @@ public class JDBCMetadataTest {
         Assert.assertTrue(columns.get(10).getType().equals(ScalarType.createType(PrimitiveType.INT)));
         Assert.assertTrue(columns.get(11).getType().equals(ScalarType.createType(PrimitiveType.BIGINT)));
     }
+
+    @Test
+    public void testGetTable2() {
+        // user/password are optional fields for jdbc.
+        properties.put(JDBCResource.USER, "");
+        properties.put(JDBCResource.PASSWORD, "");
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+        Table table = jdbcMetadata.getTable("test", "tbl1");
+        Assert.assertNotNull(table);
+    }
 }


### PR DESCRIPTION
Fixes #issue

For JDBC catalog, sometimes user/password fields are optional.

And if we leave user/password value empty, exception `new DdlException("all catalog properties must be set")` will be throw, and tables will be hidden.  So when you run `show tables`, there will none of them.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
