### PR TITLE
[Enhancement] Mark statistics Job and no need queued jobs for query queue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoExecutor.java
@@ -52,6 +52,9 @@ public class RepoExecutor {
         return SingletonHolder.INSTANCE;
     }
 
+    private RepoExecutor() {
+    }
+
     public void executeDML(String sql) {
         try {
             ConnectContext context = createConnectContext();

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoExecutor.java
@@ -43,10 +43,13 @@ import java.util.List;
 public class RepoExecutor {
 
     private static final Logger LOG = LogManager.getLogger(RepoExecutor.class);
-    private static final RepoExecutor INSTANCE = new RepoExecutor();
+
+    private static class SingletonHolder {
+        private static final RepoExecutor INSTANCE = new RepoExecutor();
+    }
 
     public static RepoExecutor getInstance() {
-        return INSTANCE;
+        return SingletonHolder.INSTANCE;
     }
 
     public void executeDML(String sql) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoExecutor.java
@@ -51,8 +51,8 @@ public class RepoExecutor {
 
     public void executeDML(String sql) {
         try {
-            ConnectContext context = StatisticUtils.buildConnectContext();
-            context.setThreadLocalInfo();
+            ConnectContext context = createConnectContext();
+
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             Preconditions.checkState(parsedStmt instanceof DmlStmt, "the statement should be dml");
             DmlStmt dmlStmt = (DmlStmt) parsedStmt;
@@ -71,8 +71,7 @@ public class RepoExecutor {
 
     public List<TResultBatch> executeDQL(String sql) {
         try {
-            ConnectContext context = StatisticUtils.buildConnectContext();
-            context.setThreadLocalInfo();
+            ConnectContext context = createConnectContext();
 
             // TODO: use json sink protocol, instead of statistic protocol
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
@@ -95,8 +94,7 @@ public class RepoExecutor {
 
     public void executeDDL(String sql) {
         try {
-            ConnectContext context = StatisticUtils.buildConnectContext();
-            context.setThreadLocalInfo();
+            ConnectContext context = createConnectContext();
 
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             Analyzer.analyze(parsedStmt, context);
@@ -107,6 +105,13 @@ public class RepoExecutor {
         } finally {
             ConnectContext.remove();
         }
+    }
+
+    private static ConnectContext createConnectContext() {
+        ConnectContext context = StatisticUtils.buildConnectContext();
+        context.setThreadLocalInfo();
+        context.setNeedQueued(false);
+        return context;
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -187,6 +187,7 @@ public class ConnectContext {
 
     protected boolean isStatisticsConnection = false;
     protected boolean isStatisticsJob = false;
+    protected boolean needQueued = true;
 
     protected DumpInfo dumpInfo;
 
@@ -639,6 +640,14 @@ public class ConnectContext {
 
     public void setStatisticsJob(boolean statisticsJob) {
         isStatisticsJob = statisticsJob;
+    }
+
+    public boolean isNeedQueued() {
+        return needQueued;
+    }
+
+    public void setNeedQueued(boolean needQueued) {
+        this.needQueued = needQueued;
     }
 
     public ConnectContext getParent() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -118,6 +118,10 @@ public class QueryQueueManager {
     }
 
     public boolean needCheckQueue(DefaultCoordinator coord) {
+        if (!coord.getJobSpec().isNeedQueued()) {
+            return false;
+        }
+
         // The queries only using schema meta will never been queued, because a MySQL client will
         // query schema meta after the connection is established.
         List<ScanNode> scanNodes = coord.getScanNodes();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -477,7 +477,7 @@ public class StmtExecutor {
 
             if (parsedStmt instanceof QueryStatement) {
                 context.getState().setIsQuery(true);
-                final boolean isStatisticsJob = AnalyzerUtils.isStatisticsJob(context, parsedStmt);
+                final boolean isStatisticsJob = context.isStatisticsJob() || AnalyzerUtils.isStatisticsJob(context, parsedStmt);
                 context.setStatisticsJob(isStatisticsJob);
 
                 // sql's blacklist is enabled through enable_sql_blacklist.
@@ -1701,7 +1701,7 @@ public class StmtExecutor {
                 type = TLoadJobType.INSERT_VALUES;
             }
 
-            context.setStatisticsJob(AnalyzerUtils.isStatisticsJob(context, parsedStmt));
+            context.setStatisticsJob(context.isStatisticsJob() || AnalyzerUtils.isStatisticsJob(context, parsedStmt));
             if (!targetTable.isIcebergTable()) {
                 jobId = context.getGlobalStateMgr().getLoadMgr().registerLoadJob(
                         label,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -57,10 +57,10 @@ public class JobSpec {
      */
     private final TDescriptorTable descTable;
 
+    private final ConnectContext connectContext;
     private final boolean enablePipeline;
     private final boolean enableStreamPipeline;
     private final boolean isBlockQuery;
-    private final boolean isStatisticsJob;
 
     /**
      * Why we use query global?
@@ -321,7 +321,7 @@ public class JobSpec {
         this.enablePipeline = builder.enablePipeline;
         this.enableStreamPipeline = builder.enableStreamPipeline;
         this.isBlockQuery = builder.isBlockQuery;
-        this.isStatisticsJob = builder.isStatisticsJob;
+        this.connectContext = builder.connectContext;
 
         this.queryGlobals = builder.queryGlobals;
         this.queryOptions = builder.queryOptions;
@@ -413,7 +413,11 @@ public class JobSpec {
     }
 
     public boolean isStatisticsJob() {
-        return isStatisticsJob;
+        return connectContext.isStatisticsJob();
+    }
+
+    public boolean isNeedQueued() {
+        return connectContext.isNeedQueued();
     }
 
     public boolean isStreamLoad() {
@@ -435,7 +439,7 @@ public class JobSpec {
         private boolean enablePipeline;
         private boolean enableStreamPipeline;
         private boolean isBlockQuery;
-        private boolean isStatisticsJob;
+        private ConnectContext connectContext;
 
         private TQueryGlobals queryGlobals;
         private TQueryOptions queryOptions;
@@ -451,7 +455,7 @@ public class JobSpec {
             this.resourceGroup(newResourceGroup);
 
             this.enablePipeline(isEnablePipeline(context, fragments));
-            this.isStatisticsJob = context.isStatisticsJob();
+            this.connectContext = context;
 
             return this;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVMaintenanceJob.java
@@ -231,6 +231,7 @@ public class MVMaintenanceJob implements Writable, GsonPreProcessable, GsonPostP
         // TODO(murphy) fill current user
         // Build connection context
         this.connectContext = StatisticUtils.buildConnectContext();
+        this.connectContext.setNeedQueued(false);
         Database db = GlobalStateMgr.getCurrentState().getDb(view.getDbId());
         this.connectContext.getSessionVariable().setQueryTimeoutS(MV_QUERY_TIMEOUT);
         if (db != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -84,6 +84,7 @@ public class StatisticUtils {
         context.getSessionVariable().setParallelExecInstanceNum(1);
         context.getSessionVariable().setQueryTimeoutS((int) Config.statistic_collect_query_timeout);
         context.getSessionVariable().setEnablePipelineEngine(true);
+        context.setStatisticsJob(true);
         context.setDatabase(StatsConstants.STATISTICS_DB_NAME);
         context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
         context.setCurrentUserIdentity(UserIdentity.ROOT);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
@@ -197,6 +197,15 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
                     "select TABLE_CATALOG from information_schema.tables UNION ALL select count(1) from lineitem");
             Assert.assertTrue(manager.needCheckQueue(coordinator));
         }
+
+        {
+            // 4. set connectContext.needQueued to false.
+            connectContext.setNeedQueued(false);
+            DefaultCoordinator coordinator = getSchedulerWithQueryId(
+                    "select TABLE_CATALOG from information_schema.tables UNION ALL select count(1) from lineitem");
+            Assert.assertFalse(manager.needCheckQueue(coordinator));
+            connectContext.setNeedQueued(true);
+        }
     }
 
     @Test


### PR DESCRIPTION

Mark all jobs using `StatisticUtils.buildConnectContext` to statistics Jobs, except jobs from MVExecutor and RepoExecutor.
Mark jobs from MVExecutor and RepoExecutor as no need queued.

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
