### PR TITLE
[BugFix] Forget to delete RpcClosure

### DIFF
--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -712,6 +712,7 @@ void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_relay(PTransmitRunti
     }
 
     auto* rpc_closure = new RuntimeFilterRpcClosure();
+    DeferOp deferop([&] { rpc_closure->Run(); });
     rpc_closure->ref();
     doris::PBackendService_Stub* stub = _exec_env->brpc_stub_cache()->get_stub(first_dest.address);
     _exec_env->add_rf_event(


### PR DESCRIPTION
Memory leak detected in ASAN mode
```
Direct leak of 5632 byte(s) in 8 object(s) allocated from:
    #0 0x9abd577 in operator new(unsigned long) ../../.././libsanitizer/asan/asan_new_delete.cpp:99
    #1 0xa11db28 in starrocks::RuntimeFilterWorker::_deliver_broadcast_runtime_filter_relay(starrocks::PTransmitRuntimeFilterParams&&, std::vector<starrocks::TRuntimeFilterDestination, std::allocator<starrocks::TRuntimeFilterDestination> >&&, int) /root/starrocks/be/src/runtime/runtime_filter_worker.cpp:714
    #2 0xa11d1a4 in starrocks::RuntimeFilterWorker::_process_send_broadcast_runtime_filter_event(starrocks::PTransmitRuntimeFilterParams&&, std::vector<starrocks::TRuntimeFilterDestination, std::allocator<starrocks::TRuntimeFilterDestination> >&&, int) /root/starrocks/be/src/runtime/runtime_filter_worker.cpp:686
    #3 0xa121164 in starrocks::RuntimeFilterWorker::execute() /root/starrocks/be/src/runtime/runtime_filter_worker.cpp:842
    #4 0xa117d25 in operator() /root/starrocks/be/src/runtime/runtime_filter_worker.cpp:456
    #5 0xa1244cf in __invoke_impl<void, starrocks::RuntimeFilterWorker::RuntimeFilterWorker(starrocks::ExecEnv*)::<lambda()> > /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:60
    #6 0xa124484 in __invoke<starrocks::RuntimeFilterWorker::RuntimeFilterWorker(starrocks::ExecEnv*)::<lambda()> > /opt/gcc/usr/include/c++/10.3.0/bits/invoke.h:95
    #7 0xa124431 in _M_invoke<0> /opt/gcc/usr/include/c++/10.3.0/thread:264
    #8 0xa124405 in operator() /opt/gcc/usr/include/c++/10.3.0/thread:271
    #9 0xa1243e9 in _M_run /opt/gcc/usr/include/c++/10.3.0/thread:215
    #10 0x16b300df in execute_native_thread_routine ../../../.././libstdc++-v3/src/c++11/[thread.cc:80](http://thread.cc/)
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
