### PR TITLE
[BugFix] Fix dead lock on planner when there are multi dbs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -45,6 +45,8 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.thrift.TResultSinkType;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -243,7 +245,9 @@ public class StatementPlanner {
         if (dbs == null) {
             return;
         }
-        for (Database db : dbs.values()) {
+        List<Database> dbList = new ArrayList<>(dbs.values());
+        dbList.sort(Comparator.comparingLong(Database::getId));
+        for (Database db : dbList) {
             db.readLock();
         }
     }


### PR DESCRIPTION
The lock request sequence should be unique, even though the lock type is read. The following scenes will fall into dead lock if the request sequence is random:
T1: thread1(planner) got the read lock for db1.
T2: thread2(planner) got the read lock for db2.
T3: thread3(Transaction) request for the write lock of db1, this thread will hang because the read lock is hold by thread1.
T4: thread4(Transaction) request for the write lock of db2, this thread will hang because the read lock is hold by thread2.
T5: thread1 request for the read lock of db2, but there is write request of db2 before, so this thread will hang.
T6: thread2 request for the read lock of db1, but there is write request of db1 before, so this thread will hang.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
