### PR TITLE
[BugFix] fix persistent index l0 not found after load from tablet

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3966,16 +3966,16 @@ Status PersistentIndex::_minor_compaction(PersistentIndexMetaPB* index_meta) {
     const std::string new_l1_filename =
             strings::Substitute("$0/index.l1.$1.$2", _path, _version.major(), _version.minor());
     const size_t tmp_l1_cnt = _get_tmp_l1_count();
-    // maybe need to append wal in 1.a
-    bool need_append_wal = false;
+    // maybe need to dump snapshot in 1.a
+    bool need_snapshot = false;
     if (tmp_l1_cnt == 1) {
         // step 1.a
         // move tmp l1 to l1
         std::string tmp_l1_filename = _l1_vec[_has_l1 ? 1 : 0]->filename();
         RETURN_IF_ERROR(FileSystem::Default()->link_file(tmp_l1_filename, new_l1_filename));
         if (_l0->size() > 0) {
-            // check if need to append wal
-            need_append_wal = true;
+            // check if need to dump snapshot
+            need_snapshot = true;
         }
         LOG(INFO) << "PersistentIndex minor compaction, link from tmp-l1: " << tmp_l1_filename
                   << " to l1: " << new_l1_filename;
@@ -4024,7 +4024,7 @@ Status PersistentIndex::_minor_compaction(PersistentIndexMetaPB* index_meta) {
     _version.to_pb(index_meta->mutable_version());
     _version.to_pb(index_meta->mutable_l1_version());
     MutableIndexMetaPB* l0_meta = index_meta->mutable_l0_meta();
-    RETURN_IF_ERROR(_l0->commit(l0_meta, _version, need_append_wal ? kAppendWAL : kFlush));
+    RETURN_IF_ERROR(_l0->commit(l0_meta, _version, need_snapshot ? kSnapshot : kFlush));
     return Status::OK();
 }
 


### PR DESCRIPTION
In minor compaction, if just one tmp l1 is generated, we will move this tmp l1 to l1 and if l0 still has some data, l0 will commit with kAppendWal, which is not correct because when we load from tablet, we already skip append wal before. This will cause l0 not found error.
So we change kAppendWal to kSnapshot.

## What type of PR is this:
- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
