### PR TITLE
[BugFix] search globalUdfFunction only when GlobalStateMgr() is available (#29386)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -127,6 +127,7 @@ import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SetType;
 import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.system.Frontend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.FrontendService;
@@ -1479,7 +1480,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         result.setStatus(status);
         try {
             result.setParams(streamLoadPutImpl(request));
-        } catch (UserException e) {
+        } catch (UserException | StarRocksPlannerException e) {
             LOG.warn("failed to get stream load plan: {}", e.getMessage());
             status.setStatus_code(TStatusCode.ANALYSIS_ERROR);
             status.addToError_msgs(e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -208,7 +208,7 @@ public class AnalyzerUtils {
 
     public static Function getUdfFunction(ConnectContext context, FunctionName fnName, Type[] argTypes) {
         Function fn = getDBUdfFunction(context, fnName, argTypes);
-        if (fn == null) {
+        if (fn == null && context.getGlobalStateMgr() != null) {
             fn = getGlobalUdfFunction(context, fnName, argTypes);
         }
         if (fn != null) {


### PR DESCRIPTION
* fixes #29209
* take StarRocksPlannerException as ANALYSIS_ERROR error, so the user can get detailed error info.


(cherry picked from commit c461da8a98ee1011ed9fc7de51c31ae7533a83bd)

Fixes #issue

## What type of PR is this:
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
