### PR TITLE
[BugFix] Fix local ref leak in Java UDTF

### DIFF
--- a/be/src/exprs/table_function/java_udtf_function.cpp
+++ b/be/src/exprs/table_function/java_udtf_function.cpp
@@ -29,6 +29,7 @@
 #include "udf/java/java_data_converter.h"
 #include "udf/java/java_udf.h"
 #include "udf/java/utils.h"
+#include "util/defer_op.h"
 
 namespace starrocks {
 
@@ -135,6 +136,14 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(TableFunctionSta
 
     std::vector<jvalue> call_stack;
     std::vector<jobject> rets;
+    DeferOp defer = DeferOp([&]() {
+        // clean up arrays
+        for (auto& ret : rets) {
+            if (ret) {
+                env->DeleteLocalRef(ret);
+            }
+        }
+    });
     size_t num_rows = cols[0]->size();
     size_t num_cols = cols.size();
     state->set_processed_rows(num_rows);
@@ -174,6 +183,7 @@ std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(TableFunctionSta
         // update for col
         for (int j = 0; j < len; ++j) {
             jobject vi = env->GetObjectArrayElement((jobjectArray)rets[i], j);
+            LOCAL_REF_GUARD_ENV(env, vi);
             append_jvalue(method_desc, col.get(), {.l = vi});
             release_jvalue(method_desc.is_box, {.l = vi});
         }


### PR DESCRIPTION
Fixes 
```
WARNING: JNI local refs: 264, exceeds capacity: 263
```

## What type of PR is this:
- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Checklist:
- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr will affect users' behaviors
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
