### PR TITLE
[BugFix] Fix table is lost bug where create/drop db and table concurrently (backport #28985)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2553,7 +2553,7 @@ public class LocalMetastore implements ConnectorMetadata {
         }
 
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("database has been dropped when creating table");
             }
             if (!db.createTableWithLock(jdbcTable, false)) {
@@ -2577,7 +2577,7 @@ public class LocalMetastore implements ConnectorMetadata {
             throw new DdlException("Failed to acquire globalStateMgr lock. Try again");
         }
         try {
-            if (getDb(db.getFullName()) == null) {
+            if (getDb(db.getId()) == null) {
                 throw new DdlException("Database has been dropped when creating table");
             }
             if (!db.createTableWithLock(table, false)) {


### PR DESCRIPTION
Fixes SR-19348
The following scenes will lose table:
T1: begin to create t (id=1) on db d(id=2)
T2: db d(id=2) is dropped
T3: db d(id=3) is created
T4: table t(id=1) is created to db d(id=2)
T5: table t(id=5) is created to db d(id=3)
T6: there are some data load on t(id=5)
When system restarts, there will be two create table log, but only the first will success, which is table t(id=1), but all the operations is based on t(id=5).

The key point is on time T4, the check of database existence is based on db name, if we check based on id, the creation of t(id=1) will fail.

backport #28985