### PR TITLE
[BugFix] fix mistakenly pushed-down subfield to child

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RowOutputInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/RowOutputInfo.java
@@ -132,6 +132,10 @@ public class RowOutputInfo {
         return Lists.newArrayList(chooseOutputMap().values());
     }
 
+    public List<ColumnOutputInfo> getCommonColInfo() {
+        return Lists.newArrayList(commonColInfo.values());
+    }
+
     public List<ColumnRefOperator> getOutputColRefs() {
         return chooseOutputMap().values().stream().map(e -> e.getColumnRef()).collect(Collectors.toList());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/LambdaFunctionOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/LambdaFunctionOperator.java
@@ -122,7 +122,10 @@ public class LambdaFunctionOperator extends ScalarOperator {
 
     @Override
     public ColumnRefSet getUsedColumns() {
-        return lambdaExpr.getUsedColumns();
+        ColumnRefSet usedCols = lambdaExpr.getUsedColumns();
+        columnRefMap.values().stream().forEach(e -> usedCols.union(e.getUsedColumns()));
+        usedCols.except(new ColumnRefSet(columnRefMap.keySet()));
+        return usedCols;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PushDownSubfieldRule.java
@@ -271,10 +271,10 @@ public class PushDownSubfieldRule implements TreeRewriteRule {
                 ScalarOperator subfieldExpr = entry.getValue();
                 ColumnRefSet subfieldUseColumns = context.pushDownExprUseColumns.get(subfieldExpr);
 
-                if (leftOutput.isIntersect(subfieldUseColumns)) {
+                if (leftOutput.containsAll(subfieldUseColumns)) {
                     leftContext.put(index, subfieldExpr);
                     childSubfieldOutputs.union(index);
-                } else if (rightOutput.isIntersect(subfieldUseColumns)) {
+                } else if (rightOutput.containsAll(subfieldUseColumns)) {
                     rightContext.put(index, subfieldExpr);
                     childSubfieldOutputs.union(index);
                 } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -77,7 +77,6 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
         private void checkOptWithoutChild(OptExpression optExpression) {
             RowOutputInfo rowOutputInfo = optExpression.getRowOutputInfo();
             Operator operator = optExpression.getOp();
-            // only need check operator with projection
             if (operator instanceof LogicalScanOperator || operator instanceof PhysicalScanOperator
                     || operator instanceof LogicalValuesOperator || operator instanceof PhysicalValuesOperator) {
                 ColumnRefSet inputCols = ColumnRefSet.createByIds(rowOutputInfo.getOriginalColOutputInfo().keySet());
@@ -92,7 +91,7 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
                 for (ColumnOutputInfo col : rowOutputInfo.getCommonColInfo()) {
                     usedCols.except(col.getColumnRef().getUsedColumns());
                 }
-                checkInputCols(inputCols, rowOutputInfo.getUsedColumnRefSet(), optExpression);
+                checkInputCols(inputCols, usedCols, optExpression);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -24,12 +24,15 @@ import com.starrocks.sql.optimizer.operator.ColumnOutputInfo;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalSetOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalSetOperation;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.task.TaskContext;
-import org.apache.commons.collections4.MapUtils;
 
 import java.util.List;
 
@@ -73,8 +76,10 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
 
         private void checkOptWithoutChild(OptExpression optExpression) {
             RowOutputInfo rowOutputInfo = optExpression.getRowOutputInfo();
+            Operator operator = optExpression.getOp();
             // only need check operator with projection
-            if (MapUtils.isNotEmpty(rowOutputInfo.getColOutputInfo())) {
+            if (operator instanceof LogicalScanOperator || operator instanceof PhysicalScanOperator
+                    || operator instanceof LogicalValuesOperator || operator instanceof PhysicalValuesOperator) {
                 ColumnRefSet inputCols = ColumnRefSet.createByIds(rowOutputInfo.getOriginalColOutputInfo().keySet());
                 ColumnRefSet usedCols = new ColumnRefSet();
                 for (ColumnOutputInfo col : rowOutputInfo.getColumnOutputInfo()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -612,4 +612,17 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "  |  other predicates: [15: expr, INT, true] = 2");
         assertContains(plan, "ColumnAccessPath: [/st1/s2, /st2/s2, /st3/s1, /st4/ss3/s31]");
     }
+
+    @Test
+    public void testExprRefMultipleTableCols() throws Exception {
+        String sql = "select t.c1, t.c2.s1 from (select array_map(x -> (x + t.v1), t.a1) c1, t.st1 c2 from " +
+                "(select pc0.a1, sc0.* from pc0 join sc0) t) t join pc0";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "1:Project\n" +
+                "  |  <slot 8> : 8: v1\n" +
+                "  |  <slot 27> : 9: st1.s1",
+                "5:Project\n" +
+                        "  |  <slot 16> : array_map(<slot 15> -> CAST(<slot 15> AS BIGINT) + 8: v1, 7: a1)\n" +
+                        "  |  <slot 27> : 27: expr");
+    }
 }

--- a/test/sql/test_array/R/test_array
+++ b/test/sql/test_array/R/test_array
@@ -49,6 +49,8 @@ None
 None
 None
 -- !result
+
+
 -- name: testArrayTopN
 CREATE TABLE array_top_n
     (c1 int,
@@ -100,11 +102,13 @@ select * from array_top_n order by c2[1] limit 4,10;
 select * from array_top_n order by c2[1] limit 5,10;
 -- result:
 -- !result
+
 -- name: test_array_test01
 select ARRAY<INT>[], [], ARRAY<STRING>['abc'], [123, NULL, 1.0], ['abc', NULL];
 -- result:
 []	[]	["abc"]	[123.0,null,1.0]	["abc",null]
 -- !result
+
 -- name: testArrayPredicate
 CREATE TABLE array_data_type
     (c1 int,
@@ -178,4 +182,12 @@ select c4 > c5 from array_data_type;
 0
 0
 1
+-- !result
+select * from (select array_map(x -> x*2 + x*2, [1,3]) col1) t1 join (select array_map(x -> x*2 + x*2, c3) col2 from  array_data_type) t2;
+-- result:
+[4,12]	None
+[4,12]	[88,44,132]
+[4,12]	None
+[4,12]	[88,44,132]
+[4,12]	[88,44,132]
 -- !result

--- a/test/sql/test_array/T/test_array
+++ b/test/sql/test_array/T/test_array
@@ -33,6 +33,7 @@ insert into array_data_type (c1, c2, c3, c4,c5) values
 
 select c4 = c5 from array_data_type;
 select c4 > c5 from array_data_type;
+select * from (select array_map(x -> x*2 + x*2, [1,3]) col1) t1 join (select array_map(x -> x*2 + x*2, c3) col2 from  array_data_type) t2;
 
 -- name: testArrayVarchar
 CREATE TABLE array_data_type_1


### PR DESCRIPTION
For sql like
```
select t.c1, t.c2.s1 from 
(
select array_map(x -> (x + t.v1), t.a1) c1, t.st1 c2 from (select pc0.a1, sc0.* from pc0 join sc0) t
) t join pc0
```
When we try push the `array_map` expr to a child , the child must output all these used cols in the expr. The `array_map` used cols from both table `pc0` and `sc0`, pushing it to any child is wrong. We should keep it above the join operator.

Other changes:
- add input dependency check to scanOperator and valuesOperator.
- ensure lambdaOperator `getUsedColumns` result just contains outer ref cols instead of lambda common sub output cols after common expr reuse rule.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
