### PR TITLE
[Feature] Throttle ingestion speed when compaction cannot keep up with ingestion

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2291,15 +2291,45 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "the minimum delay between autovacuum runs on any given partition")
     public static long lake_autovacuum_partition_naptime_seconds = 180;
 
-    @ConfField(mutable = true, comment = "History versions within this time range will not be deleted by auto vacuum.\n" +
+    @ConfField(mutable = true, comment =
+            "History versions within this time range will not be deleted by auto vacuum.\n" +
             "REMINDER: Set this to a value longer than the maximum possible execution time of queries, to avoid deletion of " +
             "versions still being accessed.\n" +
             "NOTE: Increasing this value may increase the space usage of the remote storage system.")
     public static long lake_autovacuum_grace_period_minutes = 5;
 
-    @ConfField(mutable = true, comment = "time threshold in hours, if a partition has not been updated for longer than this " +
-            "threshold, auto vacuum operations will no longer be triggered for that partition")
+    @ConfField(mutable = true, comment =
+            "time threshold in hours, if a partition has not been updated for longer than this " +
+            "threshold, auto vacuum operations will no longer be triggered for that partition.\n" +
+            "Only takes effect for tables in clusters with run_mode=shared_data.\n")
     public static long lake_autovacuum_stale_partition_threshold = 12;
+
+    @ConfField(mutable = true, comment =
+            "Whether enable throttling ingestion speed when compaction score exceeds the threshold.\n" +
+            "Only takes effect for tables in clusters with run_mode=shared_data.")
+    public static boolean lake_enable_ingest_slowdown = false;
+
+    @ConfField(mutable = true, comment =
+            "Compaction score threshold above which ingestion speed slowdown is applied.\n" +
+            "NOTE: The actual effective value is the max of the configured value and " +
+            "'lake_compaction_score_selector_min_score'.")
+    public static long lake_ingest_slowdown_threshold = 100;
+
+    @ConfField(mutable = true, comment =
+            "Ratio to reduce ingestion speed for each point of compaction score over the threshold.\n" +
+            "E.g. 0.05 ratio, 10min normal ingestion, exceed threshold by:\n" +
+            " - 1 point -> Delay by 0.05 (30secs)\n" +
+            " - 5 points -> Delay by 0.25 (2.5mins)")
+    public static double lake_ingest_slowdown_ratio = 0.1;
+
+    @ConfField(mutable = true, comment =
+            "The upper limit for compaction score, only takes effect when lake_enable_ingest_slowdown=true.\n" +
+            "When the compaction score exceeds this value, data ingestion transactions will be prevented from\n" +
+            "committing. This is a soft limit, the actual compaction score may exceed the configured bound.\n" +
+            "The effective value will be set to the higher of the configured value here and " +
+            "lake_compaction_score_selector_min_score.\n" +
+            "A value of 0 represents no limit.")
+    public static long lake_compaction_score_upper_bound = 0;
 
     @ConfField(mutable = true)
     public static boolean enable_new_publish_mechanism = false;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/CommitRateLimiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/CommitRateLimiter.java
@@ -1,0 +1,155 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.common.Config;
+import com.starrocks.lake.compaction.CompactionMgr;
+import com.starrocks.lake.compaction.PartitionIdentifier;
+import com.starrocks.lake.compaction.PartitionStatistics;
+import com.starrocks.lake.compaction.Quantiles;
+import com.starrocks.transaction.CommitRateExceededException;
+import com.starrocks.transaction.TransactionState;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Objects;
+import java.util.Set;
+import javax.validation.constraints.NotNull;
+
+public class CommitRateLimiter {
+    private static final Logger LOG = LogManager.getLogger(CommitRateLimiter.class);
+
+    private final CompactionMgr compactionMgr;
+    private final TransactionState transactionState;
+    private final long tableId;
+
+    /**
+     * Creates a CommitRateLimiter object.
+     *
+     * @param compactionMgr    The CompactionMgr object used for compacting the lake table. Must not be null.
+     * @param transactionState The TransactionState object representing the current transaction state. Must not be null.
+     * @param tableId          The id of the table to which the commit rate limiter is applied.
+     *
+     */
+    public CommitRateLimiter(@NotNull CompactionMgr compactionMgr, @NotNull TransactionState transactionState, long tableId) {
+        this.compactionMgr = Objects.requireNonNull(compactionMgr, "compactionMgr is null");
+        this.transactionState = Objects.requireNonNull(transactionState, "transactionState is null");
+        this.tableId = tableId;
+    }
+
+    // Minimum absolute time allowed to commit the transaction
+    private static long getAllowCommitTime(TransactionState txnState, double compactionScore) {
+        Preconditions.checkState(txnState.getWriteDurationMs() >= 0);
+        return txnState.getWriteEndTimeMs() +
+                delayTimeMs(txnState.getWriteDurationMs(), compactionScore, slowdownThreshold(), slowdownRatio());
+    }
+
+    // How many milliseconds to delay before committing
+    private static long delayTimeMs(long writeDuration, double compactionScore, double slowdownThreshold,
+                                    double slowdownRatio) {
+        if (compactionScore <= slowdownThreshold) {
+            return 0;
+        }
+        return (long) (writeDuration * (compactionScore - slowdownThreshold) * slowdownRatio);
+    }
+
+    private static double slowdownThreshold() {
+        return Math.max(Config.lake_ingest_slowdown_threshold, Config.lake_compaction_score_selector_min_score);
+    }
+
+    private static double slowdownRatio() {
+        return Config.lake_ingest_slowdown_ratio;
+    }
+
+    // 0 means no limit
+    static long compactionScoreUpperBound() {
+        long upper = Config.lake_compaction_score_upper_bound;
+        return upper <= 0 ? 0 : (long) Math.max(upper, Config.lake_compaction_score_selector_min_score);
+    }
+
+    /**
+     * Checks the commit rate for the given partition IDs and throws a CommitRateExceededException if necessary.
+     *
+     * @param partitionIds the set of partition IDs to check. Must not be null.
+     * @throws CommitFailedException       if the allow commit time exceeds the transaction timeout
+     * @throws CommitRateExceededException if the commit rate exceeds the threshold
+     */
+    public void check(@NotNull Set<Long> partitionIds, long currentTimeMs)
+            throws CommitRateExceededException, CommitFailedException {
+        Preconditions.checkNotNull(partitionIds, "partitionIds is null");
+        // Does not limit the commit rate of compaction transactions
+        if (transactionState.getSourceType() == TransactionState.LoadJobSourceType.LAKE_COMPACTION) {
+            return;
+        }
+
+        updateWriteDuration(transactionState);
+        setAllowCommitTimeOnce(partitionIds);
+
+        long txnId = transactionState.getTransactionId();
+        long abortTime = transactionState.getPrepareTime() + transactionState.getTimeoutMs();
+
+        if (transactionState.getAllowCommitTimeMs() >= abortTime) {
+            throw new CommitFailedException("Txn " + txnId + " timed out due to ingestion slowdown", txnId);
+        }
+        if (transactionState.getAllowCommitTimeMs() > currentTimeMs) {
+            LOG.info("delay commit of txn {} for {}ms, write took {}ms", transactionState.getTransactionId(),
+                    transactionState.getAllowCommitTimeMs() - currentTimeMs,
+                    transactionState.getWriteDurationMs());
+            throw new CommitRateExceededException(txnId, transactionState.getAllowCommitTimeMs());
+        }
+        long upperBound = compactionScoreUpperBound();
+        if (upperBound > 0 && anyCompactionScoreExceedsUpperBound(partitionIds, upperBound)) {
+            throw new CommitRateExceededException(txnId, currentTimeMs + 1000/* delay 1s */);
+        }
+    }
+
+    private void updateWriteDuration(@NotNull TransactionState txnState) {
+        if (txnState.getWriteDurationMs() < 0) {
+            txnState.setWriteDurationMs(Math.max(txnState.getWriteEndTimeMs() - txnState.getPrepareTime(), 0));
+        }
+    }
+
+    private void setAllowCommitTimeOnce(@NotNull Set<Long> partitionIds) {
+        if (transactionState.getAllowCommitTimeMs() < 0) {
+            double maxCompactionScore = 0;
+            for (Long partitionId : partitionIds) {
+                maxCompactionScore = Math.max(maxCompactionScore, getPartitionCompactionScore(partitionId));
+            }
+            long allowCommitTime = getAllowCommitTime(transactionState, maxCompactionScore);
+            transactionState.setAllowCommitTimeMs(allowCommitTime);
+        }
+    }
+
+    private double getPartitionCompactionScore(@NotNull Long partitionId) {
+        long dbId = transactionState.getDbId();
+        // TODO: Should be able to fetch statistics by partition id
+        PartitionIdentifier partitionIdentifier = new PartitionIdentifier(dbId, tableId, partitionId);
+        PartitionStatistics statistics = compactionMgr.getStatistics(partitionIdentifier);
+        Quantiles compactionScore = statistics != null ? statistics.getCompactionScore() : null;
+        return compactionScore != null ? compactionScore.getMax() : 0;
+    }
+
+    private boolean anyCompactionScoreExceedsUpperBound(@NotNull Set<Long> partitionIds, long upperBound) {
+        for (Long partitionId : partitionIds) {
+            double compactionScore = getPartitionCompactionScore(partitionId);
+            if (compactionScore > upperBound) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -49,6 +49,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -394,7 +395,8 @@ public class CompactionScheduler extends Daemon {
         VisibleStateWaiter waiter;
         db.writeLock();
         try {
-            waiter = transactionMgr.commitTransaction(db.getId(), job.getTxnId(), commitInfoList, Lists.newArrayList());
+            waiter = transactionMgr.commitTransaction(db.getId(), job.getTxnId(), commitInfoList,
+                    Collections.emptyList(), null);
         } finally {
             db.writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
@@ -52,6 +52,7 @@ import com.starrocks.transaction.TabletCommitInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -192,7 +193,7 @@ public class LakeDeleteJob extends DeleteJob {
         }
 
         return GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                .commitAndPublishTransaction(db, getTransactionId(), tabletCommitInfos, Lists.newArrayList(),
+                .commitAndPublishTransaction(db, getTransactionId(), tabletCommitInfos, Collections.emptyList(),
                         timeoutMs);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -72,9 +72,12 @@ import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TReportExecStatusParams;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.BeginTransactionException;
+import com.starrocks.transaction.CommitRateExceededException;
+import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionState.TxnCoordinator;
 import com.starrocks.transaction.TransactionState.TxnSourceType;
+import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -93,6 +96,7 @@ public class BrokerLoadJob extends BulkLoadJob {
     private static final Logger LOG = LogManager.getLogger(BrokerLoadJob.class);
     private ConnectContext context;
     private List<LoadLoadingTask> newLoadingTasks = Lists.newArrayList();
+    private long writeDurationMs = 0;
 
     // only for log replay
     public BrokerLoadJob() {
@@ -382,16 +386,42 @@ public class BrokerLoadJob extends BulkLoadJob {
             cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true, true);
             return;
         }
+        while (true) {
+            try {
+                commitTransactionUnderDatabaseLock(db);
+                break;
+            } catch (CommitRateExceededException e) {
+                // Sleep and retry.
+                ThreadUtil.sleepAtLeastIgnoreInterrupts(Math.max(e.getAllowCommitTime() - System.currentTimeMillis(), 0));
+            } catch (Exception e) {
+                LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
+                        .add("database_id", dbId)
+                        .add("error_msg", "Failed to commit txn with error:" + e.getMessage())
+                        .build(), e);
+                cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true, true);
+                break;
+            }
+        }
+    }
+
+    private void commitTransactionUnderDatabaseLock(Database db) throws UserException {
         db.writeLock();
         try {
             LOG.info(new LogBuilder(LogKey.LOAD_JOB, id)
                     .add("txn_id", transactionId)
                     .add("msg", "Load job try to commit txn")
                     .build());
-            GlobalStateMgr.getCurrentGlobalTransactionMgr().commitTransaction(
-                    dbId, transactionId, commitInfos, failInfos,
-                    new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp,
-                            finishTimestamp, state, failMsg));
+            // Update the write duration before committing the transaction.
+            GlobalTransactionMgr transactionMgr = GlobalStateMgr.getCurrentGlobalTransactionMgr();
+            TransactionState transactionState = transactionMgr.getTransactionState(dbId, transactionId);
+            if (transactionState != null) {
+                transactionState.setWriteDurationMs(writeDurationMs);
+            }
+
+            transactionMgr.commitTransaction(dbId, transactionId, commitInfos, failInfos,
+                    new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp, finishTimestamp, state,
+                            failMsg));
+
             MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);
             // collect table-level metrics
             loadingStatus.travelTableCounters(kv -> {
@@ -409,13 +439,6 @@ public class BrokerLoadJob extends BulkLoadJob {
                             .increase(kv.getValue().get(TableMetricsEntity.TABLE_LOAD_FINISHED));
                 }
             });
-        } catch (UserException e) {
-            LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
-                    .add("database_id", dbId)
-                    .add("error_msg", "Failed to commit txn with error:" + e.getMessage())
-                    .build(), e);
-            cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true, true);
-            return;
         } finally {
             db.writeUnlock();
         }
@@ -434,6 +457,7 @@ public class BrokerLoadJob extends BulkLoadJob {
         if (!attachment.getRejectedRecordPaths().isEmpty()) {
             loadingStatus.setRejectedRecordPaths(attachment.getRejectedRecordPaths());
         }
+        writeDurationMs += attachment.getWriteDurationMs();
         commitInfos.addAll(attachment.getCommitInfoList());
         failInfos.addAll(attachment.getFailInfoList());
         progress = (int) ((double) finishedTaskIds.size() / idToTasks.size() * 100);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -393,7 +393,7 @@ public class BrokerLoadJob extends BulkLoadJob {
             } catch (CommitRateExceededException e) {
                 // Sleep and retry.
                 ThreadUtil.sleepAtLeastIgnoreInterrupts(Math.max(e.getAllowCommitTime() - System.currentTimeMillis(), 0));
-            } catch (Exception e) {
+            } catch (UserException e) {
                 LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
                         .add("database_id", dbId)
                         .add("error_msg", "Failed to commit txn with error:" + e.getMessage())

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadingTaskAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadingTaskAttachment.java
@@ -42,21 +42,24 @@ import java.util.Map;
 
 public class BrokerLoadingTaskAttachment extends TaskAttachment {
 
-    private Map<String, String> counters;
-    private String trackingUrl;
-    private List<TabletCommitInfo> commitInfoList;
-    private List<TabletFailInfo> failInfoList;
-    private List<String> rejectedRecordPaths;
+    private final Map<String, String> counters;
+    private final String trackingUrl;
+    private final List<TabletCommitInfo> commitInfoList;
+    private final List<TabletFailInfo> failInfoList;
+    private final List<String> rejectedRecordPaths;
+    private final long writeDurationMs;
 
     public BrokerLoadingTaskAttachment(long taskId, Map<String, String> counters, String trackingUrl,
                                        List<TabletCommitInfo> commitInfoList, List<TabletFailInfo> failInfoList,
-                                       List<String> rejectedRecordPaths) {
+                                       List<String> rejectedRecordPaths,
+                                       long writeDurationMs) {
         super(taskId);
         this.trackingUrl = trackingUrl;
         this.counters = counters;
         this.commitInfoList = commitInfoList;
         this.failInfoList = failInfoList;
         this.rejectedRecordPaths = rejectedRecordPaths;
+        this.writeDurationMs = writeDurationMs;
     }
 
     public String getCounter(String key) {
@@ -81,5 +84,9 @@ public class BrokerLoadingTaskAttachment extends TaskAttachment {
 
     public List<String> getRejectedRecordPaths() {
         return rejectedRecordPaths;
+    }
+
+    public long getWriteDurationMs() {
+        return writeDurationMs;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -244,6 +244,7 @@ public class LoadLoadingTask extends LoadTask {
                     .add("msg", "begin to execute plan")
                     .build());
         }
+        long writeBeginTime = System.currentTimeMillis();
         curCoordinator.exec();
         if (curCoordinator.join(waitSecond)) {
             Status status = curCoordinator.getExecStatus();
@@ -253,7 +254,8 @@ public class LoadLoadingTask extends LoadTask {
                         curCoordinator.getTrackingUrl(),
                         TabletCommitInfo.fromThrift(curCoordinator.getCommitInfos()),
                         TabletFailInfo.fromThrift(curCoordinator.getFailInfos()),
-                        curCoordinator.getRejectedRecordPaths());
+                        curCoordinator.getRejectedRecordPaths(),
+                        System.currentTimeMillis() - writeBeginTime);
             } else {
                 throw new LoadException(status.getErrorMsg());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -109,6 +109,7 @@ import com.starrocks.thrift.TReportExecStatusParams;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.BeginTransactionException;
+import com.starrocks.transaction.CommitRateExceededException;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletQuorumFailedException;
 import com.starrocks.transaction.TransactionState;
@@ -740,8 +741,9 @@ public class SparkLoadJob extends BulkLoadJob {
                     dbId, transactionId, commitInfos, Lists.newArrayList(),
                     new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp,
                             finishTimestamp, state, failMsg));
-        } catch (TabletQuorumFailedException e) {
+        } catch (TabletQuorumFailedException | CommitRateExceededException e) {
             // retry in next loop
+            LOG.info("Failed commit for txn {}, will retry. Error: {}", transactionId, e.getMessage());
         } finally {
             db.writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -184,12 +184,14 @@ import com.starrocks.thrift.TResultBatch;
 import com.starrocks.thrift.TSinkCommitInfo;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWorkGroup;
+import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.InsertTxnCommitAttachment;
 import com.starrocks.transaction.TabletCommitInfo;
 import com.starrocks.transaction.TabletFailInfo;
 import com.starrocks.transaction.TransactionCommitFailedException;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.transaction.VisibleStateWaiter;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -209,6 +211,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -1692,7 +1695,7 @@ public class StmtExecutor {
         String dbName = stmt.getTableName().getDb();
         String tableName = stmt.getTableName().getTbl();
         Database database = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(catalogName, dbName);
-
+        GlobalTransactionMgr transactionMgr = GlobalStateMgr.getCurrentGlobalTransactionMgr();
         final Table targetTable;
         if (stmt instanceof InsertStmt && ((InsertStmt) stmt).getTargetTable() != null) {
             targetTable = ((InsertStmt) stmt).getTargetTable();
@@ -1737,9 +1740,7 @@ public class StmtExecutor {
             authenticateParams.setHost(context.getRemoteIP());
             authenticateParams.setDb_name(externalTable.getSourceTableDbName());
             authenticateParams.setTable_names(Lists.newArrayList(externalTable.getSourceTableName()));
-            transactionId =
-                    GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                            .beginRemoteTransaction(externalTable.getSourceTableDbId(),
+            transactionId = transactionMgr.beginRemoteTransaction(externalTable.getSourceTableDbId(),
                                     Lists.newArrayList(externalTable.getSourceTableId()), label,
                                     externalTable.getSourceTableHost(),
                                     externalTable.getSourceTablePort(),
@@ -1752,7 +1753,7 @@ public class StmtExecutor {
                 || targetTable.isTableFunctionTable()) {
             // schema table and iceberg and hive table does not need txn
         } else {
-            transactionId = GlobalStateMgr.getCurrentGlobalTransactionMgr().beginTransaction(
+            transactionId = transactionMgr.beginTransaction(
                     database.getId(),
                     Lists.newArrayList(targetTable.getId()),
                     label,
@@ -1762,8 +1763,7 @@ public class StmtExecutor {
                     context.getSessionVariable().getQueryTimeoutS());
 
             // add table indexes to transaction state
-            txnState = GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                    .getTransactionState(database.getId(), transactionId);
+            txnState = transactionMgr.getTransactionState(database.getId(), transactionId);
             if (txnState == null) {
                 throw new DdlException("txn does not exist: " + transactionId);
             }
@@ -1911,7 +1911,7 @@ public class StmtExecutor {
                 if (filteredRows > 0) {
                     if (targetTable instanceof ExternalOlapTable) {
                         ExternalOlapTable externalTable = (ExternalOlapTable) targetTable;
-                        GlobalStateMgr.getCurrentGlobalTransactionMgr().abortRemoteTransaction(
+                        transactionMgr.abortRemoteTransaction(
                                 externalTable.getSourceTableDbId(), transactionId,
                                 externalTable.getSourceTableHost(),
                                 externalTable.getSourceTablePort(),
@@ -1922,7 +1922,7 @@ public class StmtExecutor {
                             targetTable.isIcebergTable() || targetTable.isTableFunctionTable()) {
                         // schema table does not need txn
                     } else {
-                        GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(
+                        transactionMgr.abortTransaction(
                                 database.getId(),
                                 transactionId,
                                 TransactionCommitFailedException.FILTER_DATA_IN_STRICT_MODE + ", tracking sql = " +
@@ -1939,7 +1939,7 @@ public class StmtExecutor {
 
             if (targetTable instanceof ExternalOlapTable) {
                 ExternalOlapTable externalTable = (ExternalOlapTable) targetTable;
-                if (GlobalStateMgr.getCurrentGlobalTransactionMgr().commitRemoteTransaction(
+                if (transactionMgr.commitRemoteTransaction(
                         externalTable.getSourceTableDbId(), transactionId,
                         externalTable.getSourceTableHost(),
                         externalTable.getSourceTablePort(),
@@ -1983,29 +1983,30 @@ public class StmtExecutor {
             } else if (targetTable instanceof TableFunctionTable) {
                 txnStatus = TransactionStatus.VISIBLE;
                 label = "FAKE_TABLE_FUNCTION_TABLE_SINK_LABEL";
+            } else if (isExplainAnalyze) {
+                transactionMgr.abortTransaction(database.getId(), transactionId, "Explain Analyze");
+                txnStatus = TransactionStatus.ABORTED;
             } else {
-                if (isExplainAnalyze) {
-                    GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                            .abortTransaction(database.getId(), transactionId, "Explain Analyze");
-                    txnStatus = TransactionStatus.ABORTED;
-                } else if (GlobalStateMgr.getCurrentGlobalTransactionMgr().commitAndPublishTransaction(
+                VisibleStateWaiter visibleWaiter = transactionMgr.retryCommitOnRateLimitExceeded(
                         database,
                         transactionId,
                         TabletCommitInfo.fromThrift(coord.getCommitInfos()),
                         TabletFailInfo.fromThrift(coord.getFailInfos()),
-                        Config.enable_sync_publish ? jobDeadLineMs - System.currentTimeMillis() :
-                                context.getSessionVariable().getTransactionVisibleWaitTimeout() * 1000,
-                        new InsertTxnCommitAttachment(loadedRows))) {
+                        new InsertTxnCommitAttachment(loadedRows),
+                        jobDeadLineMs - System.currentTimeMillis());
+
+                long publishWaitMs = Config.enable_sync_publish ? jobDeadLineMs - System.currentTimeMillis() :
+                        context.getSessionVariable().getTransactionVisibleWaitTimeout() * 1000;
+
+                if (visibleWaiter.await(publishWaitMs, TimeUnit.MILLISECONDS)) {
                     txnStatus = TransactionStatus.VISIBLE;
                     MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);
                     // collect table-level metrics
-                    if (null != targetTable) {
-                        TableMetricsEntity entity =
-                                TableMetricsRegistry.getInstance().getMetricsEntity(targetTable.getId());
-                        entity.counterInsertLoadFinishedTotal.increase(1L);
-                        entity.counterInsertLoadRowsTotal.increase(loadedRows);
-                        entity.counterInsertLoadBytesTotal.increase(loadedBytes);
-                    }
+                    TableMetricsEntity entity =
+                            TableMetricsRegistry.getInstance().getMetricsEntity(targetTable.getId());
+                    entity.counterInsertLoadFinishedTotal.increase(1L);
+                    entity.counterInsertLoadRowsTotal.increase(loadedRows);
+                    entity.counterInsertLoadBytesTotal.increase(loadedBytes);
                 } else {
                     txnStatus = TransactionStatus.COMMITTED;
                 }
@@ -2025,7 +2026,7 @@ public class StmtExecutor {
             try {
                 if (targetTable instanceof ExternalOlapTable) {
                     ExternalOlapTable externalTable = (ExternalOlapTable) targetTable;
-                    GlobalStateMgr.getCurrentGlobalTransactionMgr().abortRemoteTransaction(
+                    transactionMgr.abortRemoteTransaction(
                             externalTable.getSourceTableDbId(), transactionId,
                             externalTable.getSourceTableHost(),
                             externalTable.getSourceTablePort(),
@@ -2033,7 +2034,7 @@ public class StmtExecutor {
                 } else if (targetTable.isExternalTableWithFileSystem()) {
                     // ignored
                 } else {
-                    GlobalStateMgr.getCurrentGlobalTransactionMgr().abortTransaction(
+                    transactionMgr.abortTransaction(
                             database.getId(), transactionId,
                             errMsg,
                             coord == null ? Lists.newArrayList() : TabletFailInfo.fromThrift(coord.getFailInfos()));
@@ -2084,8 +2085,7 @@ public class StmtExecutor {
 
         String errMsg = "";
         if (txnStatus.equals(TransactionStatus.COMMITTED)) {
-            String timeoutInfo = GlobalStateMgr.getCurrentGlobalTransactionMgr()
-                    .getTxnPublishTimeoutDebugInfo(database.getId(), transactionId);
+            String timeoutInfo = transactionMgr.getTxnPublishTimeoutDebugInfo(database.getId(), transactionId);
             LOG.warn("txn {} publish timeout {}", transactionId, timeoutInfo);
             if (timeoutInfo.length() > 240) {
                 timeoutInfo = timeoutInfo.substring(0, 240) + "...";

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/CommitRateExceededException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/CommitRateExceededException.java
@@ -1,0 +1,28 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.transaction;
+
+public class CommitRateExceededException extends TransactionException {
+    private final long allowCommitTime;
+
+    public CommitRateExceededException(long transactionId, long allowCommitTime) {
+        super("Commit rate exceeds compaction throughput", transactionId);
+        this.allowCommitTime = allowCommitTime;
+    }
+
+    public long getAllowCommitTime() {
+        return allowCommitTime;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -398,6 +398,9 @@ public class DatabaseTransactionMgr {
                 && transactionState.getSourceType() != TransactionState.LoadJobSourceType.INSERT_STREAMING) {
             throw new TransactionCommitFailedException(TransactionCommitFailedException.NO_DATA_TO_LOAD_MSG);
         }
+        if (transactionState.getWriteEndTimeMs() < 0) {
+            transactionState.setWriteEndTimeMs(System.currentTimeMillis());
+        }
         if (!tabletCommitInfos.isEmpty()) {
             transactionState.setTabletCommitInfos(tabletCommitInfos);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -66,6 +66,7 @@ import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionState.LoadJobSourceType;
 import com.starrocks.transaction.TransactionState.TxnCoordinator;
 import org.apache.commons.lang3.time.StopWatch;
+import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -82,7 +83,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
-
 
 /**
  * Transaction Manager
@@ -362,29 +362,6 @@ public class GlobalTransactionMgr implements Writable {
         }
     }
 
-    @NotNull
-    public VisibleStateWaiter commitTransaction(long dbId, long transactionId,
-                                                @NotNull List<TabletCommitInfo> tabletCommitInfos)
-            throws UserException {
-        return commitTransaction(dbId, transactionId, tabletCommitInfos, Lists.newArrayList(), null);
-    }
-
-    @NotNull
-    public VisibleStateWaiter commitTransaction(long dbId, long transactionId,
-                                                @NotNull List<TabletCommitInfo> tabletCommitInfos,
-                                                @Nullable TxnCommitAttachment txnCommitAttachment)
-            throws UserException {
-        return commitTransaction(dbId, transactionId, tabletCommitInfos, Lists.newArrayList(), txnCommitAttachment);
-    }
-
-    @NotNull
-    public VisibleStateWaiter commitTransaction(long dbId, long transactionId,
-                                                @NotNull List<TabletCommitInfo> tabletCommitInfos,
-                                                @NotNull List<TabletFailInfo> tabletFailInfos)
-            throws UserException {
-        return commitTransaction(dbId, transactionId, tabletCommitInfos, tabletFailInfos, null);
-    }
-
     /**
      * @param transactionId
      * @param tabletCommitInfos
@@ -406,7 +383,8 @@ public class GlobalTransactionMgr implements Writable {
 
         LOG.debug("try to commit transaction: {}", transactionId);
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
-        return dbTransactionMgr.commitTransaction(transactionId, tabletCommitInfos, tabletFailInfos, txnCommitAttachment);
+        return dbTransactionMgr.commitTransaction(transactionId, tabletCommitInfos, tabletFailInfos,
+                txnCommitAttachment);
     }
 
     public void prepareTransaction(long dbId, long transactionId, List<TabletCommitInfo> tabletCommitInfos,
@@ -466,37 +444,107 @@ public class GlobalTransactionMgr implements Writable {
         }
     }
 
-    public boolean commitAndPublishTransaction(Database db, long transactionId,
-                                               List<TabletCommitInfo> tabletCommitInfos,
-                                               List<TabletFailInfo> tabletFailInfos, long timeoutMillis) throws UserException {
+    public boolean commitAndPublishTransaction(@NotNull Database db,
+                                               long transactionId,
+                                               @NotNull List<TabletCommitInfo> tabletCommitInfos,
+                                               @NotNull List<TabletFailInfo> tabletFailInfos,
+                                               long timeoutMillis) throws UserException {
         return commitAndPublishTransaction(db, transactionId, tabletCommitInfos, tabletFailInfos, timeoutMillis, null);
     }
 
-    public boolean commitAndPublishTransaction(Database db, long transactionId,
-                                               List<TabletCommitInfo> tabletCommitInfos,
-                                               List<TabletFailInfo> tabletFailInfos, long timeoutMillis,
-                                               TxnCommitAttachment txnCommitAttachment) throws UserException {
-        StopWatch stopWatch = new StopWatch();
-        stopWatch.start();
-        if (!db.tryWriteLock(timeoutMillis, TimeUnit.MILLISECONDS)) {
-            throw new UserException("get database write lock timeout, database="
-                    + db.getOriginName() + ", timeoutMillis=" + timeoutMillis);
+    /**
+     * Commit and wait for the transaction to become visible.
+     *
+     * @param db                   the database in which the transaction is being committed
+     * @param transactionId        the ID of the transaction to commit
+     * @param tabletCommitInfos    a list of tablet commit information
+     * @param tabletFailInfos      a list of tablet fail information
+     * @param timeoutMillis        the timeout for waiting for the transaction to become visible, in milliseconds
+     * @param txnCommitAttachment  an optional attachment to include in the transaction commit
+     * @return                     {@code true} if the transaction becomes visible within the given timeout,
+     *                             {@code false} otherwise
+     * @throws UserException                   if an error occurs during the transaction commit
+     * @throws TransactionCommitFailedException  if the transaction commit fails due to a disabled load job
+     * @note This method acquires the write lock on the database to commit transaction, callers should NOT already
+     * hold the database lock when calling this method, otherwise it will lead to deadlock.
+     */
+    public boolean commitAndPublishTransaction(@NotNull Database db,
+                                               long transactionId,
+                                               @NotNull List<TabletCommitInfo> tabletCommitInfos,
+                                               @NotNull List<TabletFailInfo> tabletFailInfos,
+                                               long timeoutMillis,
+                                               @Nullable TxnCommitAttachment txnCommitAttachment) throws UserException {
+        long dueTime = timeoutMillis != 0 ? System.currentTimeMillis() + timeoutMillis : Long.MAX_VALUE;
+        VisibleStateWaiter waiter = retryCommitOnRateLimitExceeded(db, transactionId, tabletCommitInfos,
+                tabletFailInfos, txnCommitAttachment, timeoutMillis);
+        long now = System.currentTimeMillis();
+        return waiter.await(Math.max(dueTime - now, 0), TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Executes the commit operation on the given transaction with retry mechanism
+     * in case of rate limit exceeded exception.
+     *
+     * @param db the {@link Database} object where the transaction is being committed
+     * @param transactionId the ID of the transaction to commit
+     * @param tabletCommitInfos the list of {@link TabletCommitInfo} objects containing information about the tablets
+     * to commit
+     * @param tabletFailInfos the list of {@link TabletFailInfo} objects containing information about the tablets that
+     * failed to commit
+     * @param txnCommitAttachment the optional {@link TxnCommitAttachment} object
+     * @param timeoutMs the timeout value in milliseconds for the commit operation
+     * @return a {@link VisibleStateWaiter} object used to wait for the transaction to become visible
+     * @throws UserException if an error occurs during the commit operation
+     * @note This method acquires the write lock on the database to commit transaction, callers should NOT already
+     * hold the database lock when calling this method, otherwise it will lead to deadlock.
+     */
+    @NotNull
+    public VisibleStateWaiter retryCommitOnRateLimitExceeded(
+            @NotNull Database db, long transactionId, @NotNull List<TabletCommitInfo> tabletCommitInfos,
+            @NotNull List<TabletFailInfo> tabletFailInfos,
+            @Nullable TxnCommitAttachment txnCommitAttachment,
+            long timeoutMs) throws UserException {
+        long startTime = System.currentTimeMillis();
+        while (true) {
+            try {
+                return commitTransactionUnderDatabaseWLock(db, transactionId, tabletCommitInfos, tabletFailInfos,
+                        txnCommitAttachment);
+            } catch (CommitRateExceededException e) {
+                throttleCommitOnRateExceed(e, startTime, timeoutMs);
+            } catch (Exception e) {
+                throw new UserException("fail to execute commit task: " + e.getMessage(), e);
+            }
         }
-        VisibleStateWaiter waiter;
+    }
+
+    /**
+     * Handles the case when the commit rate exceeds the limit.
+     *
+     * @param e The CommitRateExceededException to handle.
+     * @param startTimeMs The start time of the commit.
+     * @param timeoutMs The timeout duration in milliseconds. If timeoutMs is non-zero and the allowed commit time is
+     *                  greater than (startTimeMs + timeoutMs), then CommitRateExceededException is re-thrown.
+     * @throws CommitRateExceededException if the allowed commit time exceeds the timeout duration.
+     */
+    static void throttleCommitOnRateExceed(CommitRateExceededException e, long startTimeMs, long timeoutMs)
+            throws CommitRateExceededException {
+        if (timeoutMs != 0 && e.getAllowCommitTime() > (startTimeMs + timeoutMs)) {
+            throw e;
+        } else {
+            ThreadUtil.sleepAtLeastIgnoreInterrupts(e.getAllowCommitTime() - System.currentTimeMillis());
+        }
+    }
+
+    private VisibleStateWaiter commitTransactionUnderDatabaseWLock(
+            @NotNull Database db, long transactionId, @NotNull List<TabletCommitInfo> tabletCommitInfos,
+            @NotNull List<TabletFailInfo> tabletFailInfos,
+            @Nullable TxnCommitAttachment attachment) throws UserException {
+        db.writeLock();
         try {
-            waiter = commitTransaction(db.getId(), transactionId, tabletCommitInfos, tabletFailInfos,
-                    txnCommitAttachment);
+            return commitTransaction(db.getId(), transactionId, tabletCommitInfos, tabletFailInfos, attachment);
         } finally {
             db.writeUnlock();
         }
-        stopWatch.stop();
-        long publishTimeoutMillis = timeoutMillis - stopWatch.getTime();
-        if (publishTimeoutMillis < 0) {
-            // here commit transaction successfully cost too much time to cause publisTimeoutMillis is less than zero,
-            // so we just return false to indicate publish timeout
-            return false;
-        }
-        return waiter.await(publishTimeoutMillis, TimeUnit.MILLISECONDS);
     }
 
     public void abortAllRunningTransactions() throws UserException {
@@ -827,7 +875,8 @@ public class GlobalTransactionMgr implements Writable {
                 dbTransactionMgr.unprotectUpsertTransactionState(transactionState, true);
             } catch (AnalysisException e) {
                 LOG.warn("failed to get db transaction manager for {}", transactionState, e);
-                throw new IOException("failed to get db transaction manager for txn " + transactionState.getTransactionId(), e);
+                throw new IOException(
+                        "failed to get db transaction manager for txn " + transactionState.getTransactionId(), e);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.transaction;
 
 import com.google.common.base.Preconditions;
@@ -26,8 +25,12 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.Config;
 import com.starrocks.common.NoAliveBackendException;
+import com.starrocks.lake.CommitRateLimiter;
+import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.Utils;
+import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.proto.AbortTxnRequest;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
@@ -38,23 +41,27 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
 
 public class LakeTableTxnStateListener implements TransactionStateListener {
     private static final Logger LOG = LogManager.getLogger(LakeTableTxnStateListener.class);
     private final DatabaseTransactionMgr dbTxnMgr;
     // lake table or lake materialized view
-    private final OlapTable table;
+    private final LakeTable table;
 
     private Set<Long> dirtyPartitionSet;
     private Set<String> invalidDictCacheColumns;
     private Map<String, Long> validDictCacheColumns;
+    private final CompactionMgr compactionMgr;
 
-    public LakeTableTxnStateListener(DatabaseTransactionMgr dbTxnMgr, OlapTable table) {
-        this.dbTxnMgr = dbTxnMgr;
-        this.table = table;
+    public LakeTableTxnStateListener(@NotNull DatabaseTransactionMgr dbTxnMgr, @NotNull OlapTable table) {
+        this.dbTxnMgr = Objects.requireNonNull(dbTxnMgr, "dbTxnMgr is null");
+        this.table = (LakeTable) Objects.requireNonNull(table, "table is null");
+        this.compactionMgr = GlobalStateMgr.getCurrentState().getCompactionMgr();
     }
 
     @Override
@@ -64,7 +71,7 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
 
     @Override
     public void preCommit(TransactionState txnState, List<TabletCommitInfo> finishedTablets,
-            List<TabletFailInfo> failedTablets) throws TransactionException {
+                          List<TabletFailInfo> failedTablets) throws TransactionException {
         Preconditions.checkState(txnState.getTransactionStatus() != TransactionStatus.COMMITTED);
         if (table.getState() == OlapTable.OlapTableState.RESTORE) {
             throw new TransactionCommitFailedException("Cannot write RESTORE state table \"" + table.getName() + "\"");
@@ -119,13 +126,19 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
             finishedTabletsOfThisTable.add(finishedTablets.get(i).getTabletId());
         }
 
+        if (enableIngestSlowdown()) {
+            long currentTimeMs = System.currentTimeMillis();
+            new CommitRateLimiter(compactionMgr, txnState, table.getId()).check(dirtyPartitionSet, currentTimeMs);
+        }
+
         List<Long> unfinishedTablets = null;
         for (Long partitionId : dirtyPartitionSet) {
             PhysicalPartition partition = table.getPhysicalPartition(partitionId);
             List<MaterializedIndex> allIndices = txnState.getPartitionLoadedTblIndexes(table.getId(), partition);
             for (MaterializedIndex index : allIndices) {
                 Optional<Tablet> unfinishedTablet =
-                        index.getTablets().stream().filter(t -> !finishedTabletsOfThisTable.contains(t.getId())).findAny();
+                        index.getTablets().stream().filter(t -> !finishedTabletsOfThisTable.contains(t.getId()))
+                                .findAny();
                 if (!unfinishedTablet.isPresent()) {
                     continue;
                 }
@@ -222,5 +235,9 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
                 LOG.error(e);
             }
         }
+    }
+
+    static boolean enableIngestSlowdown() {
+        return Config.lake_enable_ingest_slowdown;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CommitRateLimiterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CommitRateLimiterTest.java
@@ -1,0 +1,282 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.Config;
+import com.starrocks.lake.compaction.CompactionMgr;
+import com.starrocks.lake.compaction.PartitionIdentifier;
+import com.starrocks.lake.compaction.Quantiles;
+import com.starrocks.transaction.CommitRateExceededException;
+import com.starrocks.transaction.TransactionState;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.hadoop.util.ThreadUtil;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class CommitRateLimiterTest {
+    private final long dbId = 1;
+    private final long tableId = 2;
+    private final long timeoutMs = 60_000;
+    private CompactionMgr compactionMgr;
+    private TransactionState transactionState;
+    private CommitRateLimiter limiter;
+    private final double ratio;
+    private final double threshold;
+
+    public CommitRateLimiterTest() {
+        ratio = Config.lake_ingest_slowdown_ratio;
+        threshold = Config.lake_ingest_slowdown_threshold;
+    }
+
+    @Before
+    public void before() {
+        compactionMgr = new CompactionMgr();
+        transactionState = new TransactionState(dbId, Lists.newArrayList(tableId), 123456L, "label", null,
+                TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK, null, 0, timeoutMs);
+        limiter = new CommitRateLimiter(compactionMgr, transactionState, tableId);
+    }
+
+    @Test
+    public void testEmptyPartitionList() throws CommitRateExceededException {
+        long currentTimeMs = System.currentTimeMillis();
+        transactionState.setPrepareTime(currentTimeMs - 10_000);
+        transactionState.setWriteEndTimeMs(currentTimeMs);
+
+        limiter.check(Collections.emptySet(), currentTimeMs);
+        Assert.assertEquals(transactionState.getWriteEndTimeMs(), transactionState.getAllowCommitTimeMs());
+    }
+
+    @Test
+    public void testNotThrottled() throws CommitRateExceededException {
+        long partitionId = 54321;
+        Set<Long> partitions = new HashSet<>(Collections.singletonList(partitionId));
+
+        long currentTimeMs = System.currentTimeMillis();
+        transactionState.setPrepareTime(currentTimeMs - 100);
+        transactionState.setWriteEndTimeMs(currentTimeMs);
+
+        Assert.assertTrue(ratio > 0.01);
+        Assert.assertTrue(threshold > 0);
+
+        compactionMgr.handleLoadingFinished(new PartitionIdentifier(dbId, tableId, partitionId), 3, currentTimeMs,
+                Quantiles.compute(Lists.newArrayList(threshold)));
+
+        limiter.check(partitions, currentTimeMs);
+        Assert.assertEquals(transactionState.getWriteEndTimeMs(), transactionState.getAllowCommitTimeMs());
+    }
+
+    @Test
+    public void testThrottled() {
+        long partitionId = 54321;
+        Set<Long> partitions = new HashSet<>(Collections.singletonList(partitionId));
+
+        long currentTimeMs = System.currentTimeMillis();
+        transactionState.setPrepareTime(currentTimeMs - 100);
+        transactionState.setWriteEndTimeMs(currentTimeMs);
+
+        Assert.assertTrue(ratio > 0.01);
+        Assert.assertTrue(threshold > 0);
+
+        compactionMgr.handleLoadingFinished(new PartitionIdentifier(dbId, tableId, partitionId), 3, currentTimeMs,
+                Quantiles.compute(Lists.newArrayList(threshold + 1.0)));
+
+        CommitRateExceededException e1 =
+                Assert.assertThrows(CommitRateExceededException.class, () -> limiter.check(partitions, currentTimeMs));
+        Assert.assertTrue(e1.getAllowCommitTime() > currentTimeMs);
+
+        // test retry after compaction score changed
+        compactionMgr.handleLoadingFinished(new PartitionIdentifier(dbId, tableId, partitionId), 4, currentTimeMs,
+                Quantiles.compute(Lists.newArrayList(threshold + 10.0)));
+
+        CommitRateExceededException e2 =
+                Assert.assertThrows(CommitRateExceededException.class, () -> limiter.check(partitions, currentTimeMs));
+        // allowCommitTime will not be affected by new compaction score
+        Assert.assertEquals(e1.getAllowCommitTime(), e2.getAllowCommitTime());
+    }
+
+    @Test
+    public void testDelayTime() {
+        long partitionId = 54321;
+        Set<Long> partitions = new HashSet<>(Collections.singletonList(partitionId));
+
+        long writeDurationMs = 10000;
+        long currentTimeMs = System.currentTimeMillis();
+        transactionState.setPrepareTime(currentTimeMs - 100);
+        transactionState.setWriteEndTimeMs(currentTimeMs);
+        transactionState.setWriteDurationMs(writeDurationMs);
+
+        Assert.assertTrue(ratio > 0.01);
+        Assert.assertTrue(threshold > 0);
+
+        compactionMgr.handleLoadingFinished(new PartitionIdentifier(dbId, tableId, partitionId), 3, currentTimeMs,
+                Quantiles.compute(Lists.newArrayList(threshold + 1.0)));
+
+        CommitRateExceededException e1 =
+                Assert.assertThrows(CommitRateExceededException.class, () -> limiter.check(partitions, currentTimeMs));
+        Assert.assertTrue(e1.getAllowCommitTime() > currentTimeMs);
+        Assert.assertEquals(currentTimeMs + writeDurationMs * 1.0 * ratio, e1.getAllowCommitTime(), 0.1);
+
+        // test retry after compaction score changed
+        compactionMgr.handleLoadingFinished(new PartitionIdentifier(dbId, tableId, partitionId), 4, currentTimeMs,
+                Quantiles.compute(Lists.newArrayList(threshold + 10.0)));
+
+        CommitRateExceededException e2 =
+                Assert.assertThrows(CommitRateExceededException.class, () -> limiter.check(partitions, currentTimeMs));
+        // allowCommitTime will be affected by new compaction score
+        Assert.assertEquals(e1.getAllowCommitTime(), e2.getAllowCommitTime());
+    }
+
+    @Test
+    public void testAborted() {
+        long partitionId = 54321;
+        Set<Long> partitions = new HashSet<>(Collections.singletonList(partitionId));
+
+        long currentTimeMs = System.currentTimeMillis();
+        transactionState.setPrepareTime(currentTimeMs - timeoutMs);
+        transactionState.setWriteEndTimeMs(currentTimeMs);
+
+        Assert.assertTrue(ratio > 0.01);
+        Assert.assertTrue(threshold > 0);
+
+        compactionMgr.handleLoadingFinished(new PartitionIdentifier(dbId, tableId, partitionId), 3, currentTimeMs,
+                Quantiles.compute(Lists.newArrayList(threshold + 10.0)));
+
+        CommitFailedException e1 =
+                Assert.assertThrows(CommitFailedException.class, () -> limiter.check(partitions, currentTimeMs));
+        Assert.assertTrue(e1.getMessage().contains("timed out"));
+    }
+
+    @Test
+    public void testPartitionHasNoStatistics() throws CommitRateExceededException {
+        long partitionId = 54321;
+        Set<Long> partitions = new HashSet<>(Collections.singletonList(partitionId));
+
+        long currentTimeMs = System.currentTimeMillis();
+        transactionState.setPrepareTime(currentTimeMs - 100);
+        transactionState.setWriteEndTimeMs(currentTimeMs);
+
+        Assert.assertTrue(ratio > 0.01);
+        Assert.assertTrue(threshold > 0);
+
+        limiter.check(partitions, currentTimeMs);
+        Assert.assertEquals(transactionState.getWriteEndTimeMs(), transactionState.getAllowCommitTimeMs());
+    }
+
+    @Test
+    public void testCompactionTxn() throws CommitRateExceededException {
+        long partitionId = 54321;
+        long currentTimeMs = System.currentTimeMillis();
+        Set<Long> partitions = new HashSet<>(Collections.singletonList(partitionId));
+
+        transactionState = new TransactionState(dbId, Lists.newArrayList(tableId), 123456L, "label", null,
+                TransactionState.LoadJobSourceType.LAKE_COMPACTION, null, 0, timeoutMs);
+
+        transactionState.setPrepareTime(currentTimeMs - 100);
+        transactionState.setWriteEndTimeMs(currentTimeMs);
+
+        limiter = new CommitRateLimiter(compactionMgr, transactionState, tableId);
+
+        Assert.assertTrue(ratio > 0.01);
+        Assert.assertTrue(threshold > 0);
+
+        compactionMgr.handleLoadingFinished(new PartitionIdentifier(dbId, tableId, partitionId), 3, currentTimeMs,
+                Quantiles.compute(Lists.newArrayList(threshold + 100)));
+
+        limiter.check(partitions, currentTimeMs);
+    }
+
+    @Test
+    public void testCompactionUpperBoundLimit01() {
+        long partitionId = 54321;
+        Set<Long> partitions = new HashSet<>(Collections.singletonList(partitionId));
+
+        long currentTimeMs = System.currentTimeMillis();
+        transactionState.setPrepareTime(currentTimeMs - 100);
+        transactionState.setWriteEndTimeMs(currentTimeMs);
+
+        Assert.assertTrue(ratio > 0.01);
+        Assert.assertTrue(threshold > 0);
+
+        new MockUp<CommitRateLimiter>() {
+            @Mock
+            long compactionScoreUpperBound() {
+                return (long) (threshold - 10);
+            }
+        };
+
+        // lake_compaction_score_upper_bound < compactionScore < lake_ingest_slowdown_threshold
+        double compactionScore = threshold - 5;
+        compactionMgr.handleLoadingFinished(new PartitionIdentifier(dbId, tableId, partitionId), 3, currentTimeMs,
+                Quantiles.compute(Lists.newArrayList(compactionScore)));
+
+        CommitRateExceededException e =
+                Assert.assertThrows(CommitRateExceededException.class, () -> limiter.check(partitions, currentTimeMs));
+        Assert.assertEquals(currentTimeMs + 1000, e.getAllowCommitTime());
+
+        CommitRateExceededException e2 =
+                Assert.assertThrows(CommitRateExceededException.class, () -> limiter.check(partitions, currentTimeMs));
+        Assert.assertEquals(currentTimeMs + 1000, e2.getAllowCommitTime());
+    }
+
+    @Test
+    public void testCompactionUpperBoundLimit02() {
+        long partitionId = 54321;
+        Set<Long> partitions = new HashSet<>(Collections.singletonList(partitionId));
+
+        long currentTimeMs = System.currentTimeMillis();
+        transactionState.setPrepareTime(currentTimeMs - 100);
+        transactionState.setWriteEndTimeMs(currentTimeMs);
+
+        Assert.assertTrue(ratio > 0.01);
+        Assert.assertTrue(threshold > 0);
+
+        new MockUp<CommitRateLimiter>() {
+            @Mock
+            long compactionScoreUpperBound() {
+                return (long) (threshold + 10);
+            }
+        };
+
+        // lake_ingest_slowdown_threshold < compactionScore < lake_compaction_score_upper_bound
+        double compactionScore = threshold + 5;
+        compactionMgr.handleLoadingFinished(new PartitionIdentifier(dbId, tableId, partitionId), 3, currentTimeMs,
+                Quantiles.compute(Lists.newArrayList(compactionScore)));
+
+        // Commit should be denied by lake_ingest_slowdown_threshold
+        CommitRateExceededException e =
+                Assert.assertThrows(CommitRateExceededException.class, () -> limiter.check(partitions, currentTimeMs));
+
+        ThreadUtil.sleepAtLeastIgnoreInterrupts(e.getAllowCommitTime() - currentTimeMs);
+        long newCurrentTimeMs = System.currentTimeMillis();
+
+        // Update the compaction score, make it greater than the lake_compaction_score_upper_bound
+        compactionScore = threshold + 15;
+        compactionMgr.handleLoadingFinished(new PartitionIdentifier(dbId, tableId, partitionId), 4, newCurrentTimeMs,
+                Quantiles.compute(Lists.newArrayList(compactionScore)));
+
+        // This time commit should be denied by the lake_compaction_score_upper_bound
+        CommitRateExceededException e2 = Assert.assertThrows(CommitRateExceededException.class,
+                () -> limiter.check(partitions, newCurrentTimeMs));
+        Assert.assertEquals(newCurrentTimeMs + 1000, e2.getAllowCommitTime());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -112,7 +112,8 @@ public class DatabaseTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId1, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId1, transTablets,
+                Lists.newArrayList(), null);
         DatabaseTransactionMgr masterDbTransMgr = masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1);
         assertEquals(TTransactionStatus.COMMITTED, masterDbTransMgr.getTxnStatus(transactionId1));
         masterTransMgr.finishTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId1, null);

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -37,6 +37,7 @@ package com.starrocks.transaction;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.FakeEditLog;
 import com.starrocks.catalog.FakeGlobalStateMgr;
 import com.starrocks.catalog.GlobalStateMgrTestUtil;
@@ -81,6 +82,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -89,6 +91,9 @@ import java.util.UUID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 
 public class GlobalTransactionMgrTest {
 
@@ -193,7 +198,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
+                Lists.newArrayList(), null);
         TransactionState transactionState = fakeEditLog.getTransaction(transactionId);
         // check status is committed
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
@@ -234,7 +240,8 @@ public class GlobalTransactionMgrTest {
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
+                Lists.newArrayList(), null);
 
         // follower globalStateMgr replay the transaction
         transactionState = fakeEditLog.getTransaction(transactionId);
@@ -256,7 +263,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo3);
         try {
-            masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets);
+            masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets,
+                    Lists.newArrayList(), null);
             Assert.fail();
         } catch (TabletQuorumFailedException e) {
             transactionState = masterTransMgr.getTransactionState(GlobalStateMgrTestUtil.testDbId1, transactionId2);
@@ -287,7 +295,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets,
+                Lists.newArrayList(), null);
         transactionState = fakeEditLog.getTransaction(transactionId2);
         // check status is commit
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
@@ -390,7 +399,8 @@ public class GlobalTransactionMgrTest {
 
         Deencapsulation.setField(masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1),
                 "idToRunningTransactionState", idToTransactionState);
-        masterTransMgr.commitTransaction(1L, 1L, transTablets, txnCommitAttachment);
+        masterTransMgr.commitTransaction(1L, 1L, transTablets, Lists.newArrayList(),
+                txnCommitAttachment);
 
         Assert.assertEquals(Long.valueOf(101), Deencapsulation.getField(routineLoadJob, "currentTotalRows"));
         Assert.assertEquals(Long.valueOf(1), Deencapsulation.getField(routineLoadJob, "currentErrorRows"));
@@ -462,7 +472,8 @@ public class GlobalTransactionMgrTest {
 
         Deencapsulation.setField(masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1),
                 "idToRunningTransactionState", idToTransactionState);
-        masterTransMgr.commitTransaction(1L, 1L, transTablets, txnCommitAttachment);
+        masterTransMgr.commitTransaction(1L, 1L, transTablets, Lists.newArrayList(),
+                txnCommitAttachment);
 
         Assert.assertEquals(Long.valueOf(0), Deencapsulation.getField(routineLoadJob, "currentTotalRows"));
         Assert.assertEquals(Long.valueOf(0), Deencapsulation.getField(routineLoadJob, "currentErrorRows"));
@@ -491,7 +502,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
+                Lists.newArrayList(), null);
         TransactionState transactionState = fakeEditLog.getTransaction(transactionId);
         slaveTransMgr.replayUpsertTransactionState(transactionState);
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
@@ -545,7 +557,8 @@ public class GlobalTransactionMgrTest {
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId, transTablets,
+                Lists.newArrayList(), null);
 
         // follower globalStateMgr replay the transaction
         transactionState = fakeEditLog.getTransaction(transactionId);
@@ -604,7 +617,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo3);
         try {
-            masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets);
+            masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets,
+                    Lists.newArrayList(), null);
             Assert.fail();
         } catch (TabletQuorumFailedException e) {
             transactionState = masterTransMgr.getTransactionState(GlobalStateMgrTestUtil.testDbId1, transactionId2);
@@ -620,7 +634,8 @@ public class GlobalTransactionMgrTest {
         transTablets.add(tabletCommitInfo1);
         transTablets.add(tabletCommitInfo2);
         transTablets.add(tabletCommitInfo3);
-        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets);
+        masterTransMgr.commitTransaction(GlobalStateMgrTestUtil.testDbId1, transactionId2, transTablets,
+                Lists.newArrayList(), null);
         transactionState = fakeEditLog.getTransaction(transactionId2);
         // check status is commit
         assertEquals(TransactionStatus.COMMITTED, transactionState.getTransactionStatus());
@@ -798,5 +813,55 @@ public class GlobalTransactionMgrTest {
         reader.close();
 
         Assert.assertEquals(1, followerTransMgr.getTransactionNum());
+    }
+
+    @Test
+    public void testRetryCommitOnRateLimitExceededTimeout()
+            throws UserException {
+        Database db = new Database(10, "db0");
+        GlobalTransactionMgr globalTransactionMgr = spy(new GlobalTransactionMgr(GlobalStateMgr.getCurrentState()));
+        DatabaseTransactionMgr dbTransactionMgr = spy(new DatabaseTransactionMgr(10L, GlobalStateMgr.getCurrentState(),
+                globalTransactionMgr.getTransactionIDGenerator()));
+
+        long now = System.currentTimeMillis();
+        doReturn(dbTransactionMgr).when(globalTransactionMgr).getDatabaseTransactionMgr(db.getId());
+        doThrow(new CommitRateExceededException(1001, now + 50))
+                .when(dbTransactionMgr)
+                .commitTransaction(1001L, Collections.emptyList(), Collections.emptyList(), null);
+        Assert.assertThrows(CommitRateExceededException.class, () -> globalTransactionMgr.commitAndPublishTransaction(db, 1001,
+                    Collections.emptyList(), Collections.emptyList(), 10, null));
+    }
+
+    @Test
+    public void testPublishVersionTimeout()
+            throws UserException {
+        Database db = new Database(10, "db0");
+        GlobalTransactionMgr globalTransactionMgr = spy(new GlobalTransactionMgr(GlobalStateMgr.getCurrentState()));
+        DatabaseTransactionMgr dbTransactionMgr = spy(new DatabaseTransactionMgr(10L, GlobalStateMgr.getCurrentState(),
+                globalTransactionMgr.getTransactionIDGenerator()));
+
+        long now = System.currentTimeMillis();
+        doReturn(dbTransactionMgr).when(globalTransactionMgr).getDatabaseTransactionMgr(db.getId());
+        doReturn(new VisibleStateWaiter(new TransactionState()))
+                .when(dbTransactionMgr)
+                .commitTransaction(1001L, Collections.emptyList(), Collections.emptyList(), null);
+        Assert.assertFalse(globalTransactionMgr.commitAndPublishTransaction(db, 1001,
+                Collections.emptyList(), Collections.emptyList(), 2, null));
+    }
+
+    @Test
+    public void testRetryCommitOnRateLimitExceededThrowUnexpectedException()
+            throws UserException {
+        Database db = new Database(10, "db0");
+        GlobalTransactionMgr globalTransactionMgr = spy(new GlobalTransactionMgr(GlobalStateMgr.getCurrentState()));
+        DatabaseTransactionMgr dbTransactionMgr = spy(new DatabaseTransactionMgr(10L, GlobalStateMgr.getCurrentState(),
+                globalTransactionMgr.getTransactionIDGenerator()));
+
+        doReturn(dbTransactionMgr).when(globalTransactionMgr).getDatabaseTransactionMgr(db.getId());
+        doThrow(NullPointerException.class)
+                .when(dbTransactionMgr)
+                .commitTransaction(1001L, Collections.emptyList(), Collections.emptyList(), null);
+        Assert.assertThrows(UserException.class, () -> globalTransactionMgr.commitAndPublishTransaction(db, 1001,
+                Collections.emptyList(), Collections.emptyList(), 10, null));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTxnStateListenerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeTableTxnStateListenerTest.java
@@ -1,0 +1,151 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.transaction;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.compaction.CompactionMgr;
+import com.starrocks.lake.compaction.PartitionIdentifier;
+import com.starrocks.lake.compaction.Quantiles;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TStorageMedium;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class LakeTableTxnStateListenerTest {
+    long dbId = 9;
+    long tableId = 10;
+    long partitionId = 11;
+    long indexId = 12;
+    long[] tabletId = {13, 14};
+
+    @Test
+    public void testHasUnfinishedTablet() {
+        LakeTable table = buildLakeTable();
+        DatabaseTransactionMgr databaseTransactionMgr = addDatabaseTransactionMgr();
+        LakeTableTxnStateListener listener = new LakeTableTxnStateListener(databaseTransactionMgr, table);
+        TransactionCommitFailedException exception = Assert.assertThrows(TransactionCommitFailedException.class, () -> {
+            listener.preCommit(newTransactionState(), buildPartialTabletCommitInfo(), Collections.emptyList());
+        });
+        Assert.assertTrue(exception.getMessage().contains("has unfinished tablets"));
+    }
+
+    @Test
+    public void testCommitRateExceeded() {
+        new MockUp<LakeTableTxnStateListener>() {
+            @Mock
+            boolean enableIngestSlowdown() {
+                return true;
+            }
+        };
+
+        LakeTable table = buildLakeTable();
+        DatabaseTransactionMgr databaseTransactionMgr = addDatabaseTransactionMgr();
+        LakeTableTxnStateListener listener = new LakeTableTxnStateListener(databaseTransactionMgr, table);
+        makeCompactionScoreExceedSlowdownThreshold();
+        Assert.assertThrows(CommitRateExceededException.class, () -> {
+            listener.preCommit(newTransactionState(), buildFullTabletCommitInfo(), Collections.emptyList());
+        });
+    }
+
+    @Test
+    public void testCommitRateLimiterDisabled() throws TransactionException {
+        new MockUp<LakeTableTxnStateListener>() {
+            @Mock
+            boolean enableIngestSlowdown() {
+                return false;
+            }
+        };
+
+        LakeTable table = buildLakeTable();
+        DatabaseTransactionMgr databaseTransactionMgr = addDatabaseTransactionMgr();
+        LakeTableTxnStateListener listener = new LakeTableTxnStateListener(databaseTransactionMgr, table);
+        makeCompactionScoreExceedSlowdownThreshold();
+        listener.preCommit(newTransactionState(), buildFullTabletCommitInfo(), Collections.emptyList());
+    }
+
+    private LakeTable buildLakeTable() {
+        MaterializedIndex index = new MaterializedIndex(indexId);
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentInvertedIndex();
+        for (long id : tabletId) {
+            TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, 0, 0, TStorageMedium.HDD, true);
+            invertedIndex.addTablet(id, tabletMeta);
+            index.addTablet(new LakeTablet(id), tabletMeta);
+        }
+        Partition partition = new Partition(partitionId, "p0", index, null);
+        LakeTable table = new LakeTable(
+                tableId, "t0",
+                Lists.newArrayList(new Column("c0", Type.BIGINT)),
+                KeysType.DUP_KEYS, null, null);
+        table.addPartition(partition);
+        return table;
+    }
+
+    private DatabaseTransactionMgr addDatabaseTransactionMgr() {
+        GlobalStateMgr.getCurrentGlobalTransactionMgr().addDatabaseTransactionMgr(dbId);
+        try {
+            return GlobalStateMgr.getCurrentGlobalTransactionMgr().getDatabaseTransactionMgr(dbId);
+        } catch (AnalysisException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<TabletCommitInfo> buildFullTabletCommitInfo() {
+        List<TabletCommitInfo> tabletCommitInfos = new ArrayList<>();
+        for (long id : tabletId) {
+            tabletCommitInfos.add(new TabletCommitInfo(id, 1));
+        }
+        return tabletCommitInfos;
+    }
+
+    private List<TabletCommitInfo> buildPartialTabletCommitInfo() {
+        List<TabletCommitInfo> tabletCommitInfos = new ArrayList<>();
+        tabletCommitInfos.add(new TabletCommitInfo(tabletId[0], 1));
+        return tabletCommitInfos;
+    }
+
+    private TransactionState newTransactionState() {
+        long currentTimeMs = System.currentTimeMillis();
+        TransactionState transactionState =
+                new TransactionState(dbId, Lists.newArrayList(tableId), 123456L, "label", null,
+                        TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK, null, 0, 60_000);
+        transactionState.setPrepareTime(currentTimeMs - 10_000);
+        transactionState.setWriteEndTimeMs(currentTimeMs);
+        return transactionState;
+    }
+
+    private void makeCompactionScoreExceedSlowdownThreshold() {
+        long currentTimeMs = System.currentTimeMillis();
+        CompactionMgr compactionMgr = GlobalStateMgr.getCurrentState().getCompactionMgr();
+        compactionMgr.handleLoadingFinished(new PartitionIdentifier(dbId, tableId, partitionId), 3, currentTimeMs,
+                Quantiles.compute(Lists.newArrayList(Config.lake_ingest_slowdown_threshold + 10.0)));
+    }
+}

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -961,6 +961,9 @@ struct TLoadTxnCommitRequest {
 
 struct TLoadTxnCommitResult {
     1: required Status.TStatus status
+    // If the error code is SR_EAGAIN, the BE will retry
+    // the commit after waiting for retry_interval_ms
+    2: optional i64 retry_interval_ms
 }
 
 struct TLoadTxnRollbackRequest {


### PR DESCRIPTION
Only for shared data cluster and disabled by default.

Throttle ingestion speed by delaying transaction commits.
The delay time depends on the ingestion duration and
compaction score: longer ingestion takes more delay;
higher compaction score causes more delay.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
