### PR TITLE
[BugFix] Fix wrong avg cached cpu cores when dropping backend

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendCoreStat.java
@@ -35,9 +35,17 @@ public class BackendCoreStat {
 
     public static void setNumOfHardwareCoresOfBe(long be, int numOfCores) {
         Integer previous = numOfHardwareCoresPerBe.put(be, numOfCores);
-        LOG.info("set numOfHardwareCoresOfBe of be({}) to {}, current cpuCores stats: {}", be, numOfCores,
+        LOG.info("set numOfHardwareCores of be({}) to {}, current cpuCores stats: {}", be, numOfCores,
                 numOfHardwareCoresPerBe);
         if (previous == null || previous != numOfCores) {
+            cachedAvgNumOfHardwareCores.set(-1);
+        }
+    }
+
+    public static void removeNumOfHardwareCoresOfBe(long be) {
+        Integer previous = numOfHardwareCoresPerBe.remove(be);
+        LOG.info("remove numOfHardwareCores of be({}), current cpuCores stats: {}", be, numOfHardwareCoresPerBe);
+        if (previous != null) {
             cachedAvgNumOfHardwareCores.set(-1);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -502,7 +502,11 @@ public class ComputeNode implements IComputable, Writable {
             if (this.cpuCores != hbResponse.getCpuCores()) {
                 isChanged = true;
                 this.cpuCores = hbResponse.getCpuCores();
-                BackendCoreStat.setNumOfHardwareCoresOfBe(hbResponse.getBeId(), hbResponse.getCpuCores());
+
+                // BackendCoreStat is a global state, checkpoint should not modify it.
+                if (!GlobalStateMgr.isCheckpointThread()) {
+                    BackendCoreStat.setNumOfHardwareCoresOfBe(hbResponse.getBeId(), hbResponse.getCpuCores());
+                }
             }
 
             heartbeatErrMsg = "";

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -300,6 +300,9 @@ public class SystemInfoService implements GsonPostProcessable {
         // update idToComputeNode
         idToComputeNodeRef.remove(dropComputeNode.getId());
 
+        // remove from BackendCoreStat
+        BackendCoreStat.removeNumOfHardwareCoresOfBe(dropComputeNode.getId());
+
         // remove worker
         if (RunMode.allowCreateLakeTable()) {
             long starletPort = dropComputeNode.getStarletPort();
@@ -403,6 +406,9 @@ public class SystemInfoService implements GsonPostProcessable {
         Map<Long, AtomicLong> copiedReportVerions = Maps.newHashMap(idToReportVersionRef);
         copiedReportVerions.remove(droppedBackend.getId());
         idToReportVersionRef = ImmutableMap.copyOf(copiedReportVerions);
+
+        // remove from BackendCoreStat
+        BackendCoreStat.removeNumOfHardwareCoresOfBe(droppedBackend.getId());
 
         // remove worker
         if (RunMode.allowCreateLakeTable()) {
@@ -978,6 +984,12 @@ public class SystemInfoService implements GsonPostProcessable {
         // update idToComputeNode
         ComputeNode cn = idToComputeNodeRef.remove(computeNodeId);
 
+        // BackendCoreStat is a global state, checkpoint should not modify it.
+        if (!GlobalStateMgr.isCheckpointThread()) {
+            // remove from BackendCoreStat
+            BackendCoreStat.removeNumOfHardwareCoresOfBe(computeNodeId);
+        }
+
         // clear map in starosAgent
         if (RunMode.allowCreateLakeTable()) {
             long starletPort = cn.getStarletPort();
@@ -998,6 +1010,12 @@ public class SystemInfoService implements GsonPostProcessable {
         Map<Long, AtomicLong> copiedReportVerions = Maps.newHashMap(idToReportVersionRef);
         copiedReportVerions.remove(backend.getId());
         idToReportVersionRef = ImmutableMap.copyOf(copiedReportVerions);
+
+        // BackendCoreStat is a global state, checkpoint should not modify it.
+        if (!GlobalStateMgr.isCheckpointThread()) {
+            // remove from BackendCoreStat
+            BackendCoreStat.removeNumOfHardwareCoresOfBe(backend.getId());
+        }
 
         // clear map in starosAgent
         if (RunMode.allowCreateLakeTable()) {
@@ -1134,12 +1152,15 @@ public class SystemInfoService implements GsonPostProcessable {
         }
         idToReportVersionRef = ImmutableMap.copyOf(idToReportVersion);
 
-        // update BackendCoreStat
-        for (ComputeNode node : idToBackendRef.values()) {
-            BackendCoreStat.setNumOfHardwareCoresOfBe(node.getId(), node.getCpuCores());
-        }
-        for (ComputeNode node : idToComputeNodeRef.values()) {
-            BackendCoreStat.setNumOfHardwareCoresOfBe(node.getId(), node.getCpuCores());
+        // BackendCoreStat is a global state, checkpoint should not modify it.
+        if (!GlobalStateMgr.isCheckpointThread()) {
+            // update BackendCoreStat
+            for (ComputeNode node : idToBackendRef.values()) {
+                BackendCoreStat.setNumOfHardwareCoresOfBe(node.getId(), node.getCpuCores());
+            }
+            for (ComputeNode node : idToComputeNodeRef.values()) {
+                BackendCoreStat.setNumOfHardwareCoresOfBe(node.getId(), node.getCpuCores());
+            }
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/system/BackendTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/BackendTest.java
@@ -37,6 +37,16 @@ public class BackendTest {
         BackendCoreStat.setNumOfHardwareCoresOfBe(1, 16);
         Assert.assertEquals(16, BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
         Assert.assertEquals(8, BackendCoreStat.getDefaultDOP());
+
+        // add new backend 2
+        BackendCoreStat.setNumOfHardwareCoresOfBe(2, 8);
+        Assert.assertEquals(12, BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
+        Assert.assertEquals(6, BackendCoreStat.getDefaultDOP());
+
+        // remove new backend 2
+        BackendCoreStat.removeNumOfHardwareCoresOfBe(2);
+        Assert.assertEquals(16, BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
+        Assert.assertEquals(8, BackendCoreStat.getDefaultDOP());
     }
 
     @Test


### PR DESCRIPTION
1. remove cached be cpu cores from BackendCoreStat when dropping backend/compute node.
2. should not modify BackendCoreStat when doing checkpoint.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
