### PR TITLE
[Enhancement]min-max conjuncts use original slotid

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -339,8 +339,8 @@ public class OptExternalPartitionPruner {
             throws AnalysisException {
         ScanOperatorPredicates scanOperatorPredicates = operator.getScanOperatorPredicates();
         for (ScalarOperator scalarOperator : scanOperatorPredicates.getNonPartitionConjuncts()) {
-            if (isSupportedMinMaxConjuncts(scalarOperator)) {
-                addMinMaxConjuncts(scalarOperator, operator, context);
+            if (isSupportedMinMaxConjuncts(operator, scalarOperator)) {
+                addMinMaxConjuncts(scalarOperator, operator);
             }
         }
     }
@@ -349,11 +349,14 @@ public class OptExternalPartitionPruner {
      * Only conjuncts of the form <column> <op> <constant> and <column> in <constant> are supported,
      * and <op> must be one of LT, LE, GE, GT, or EQ.
      */
-    private static boolean isSupportedMinMaxConjuncts(ScalarOperator operator) {
+    private static boolean isSupportedMinMaxConjuncts(LogicalScanOperator scanOperator, ScalarOperator operator) {
         if (operator instanceof BinaryPredicateOperator) {
             ScalarOperator leftChild = operator.getChild(0);
             ScalarOperator rightChild = operator.getChild(1);
             if (!(leftChild.isColumnRef()) || !(rightChild.isConstantRef())) {
+                return false;
+            }
+            if (!scanOperator.getColRefToColumnMetaMap().containsKey((ColumnRefOperator) leftChild)) {
                 return false;
             }
             return !((ConstantOperator) rightChild).isNull();
@@ -364,6 +367,9 @@ public class OptExternalPartitionPruner {
             if (((InPredicateOperator) operator).isNotIn()) {
                 return false;
             }
+            if (!scanOperator.getColRefToColumnMetaMap().containsKey((ColumnRefOperator) operator.getChild(0))) {
+                return false;
+            }
             return ((InPredicateOperator) operator).allValuesMatch(ScalarOperator::isConstantRef) &&
                     !((InPredicateOperator) operator).hasAnyNullValues();
         } else {
@@ -371,20 +377,19 @@ public class OptExternalPartitionPruner {
         }
     }
 
-    private static void addMinMaxConjuncts(ScalarOperator scalarOperator, LogicalScanOperator operator,
-            OptimizerContext context) throws AnalysisException {
+    private static void addMinMaxConjuncts(ScalarOperator scalarOperator, LogicalScanOperator operator)
+            throws AnalysisException {
         List<ScalarOperator> minMaxConjuncts = operator.getScanOperatorPredicates().getMinMaxConjuncts();
         if (scalarOperator instanceof BinaryPredicateOperator) {
             BinaryPredicateOperator binaryPredicateOperator = (BinaryPredicateOperator) scalarOperator;
             ScalarOperator leftChild = binaryPredicateOperator.getChild(0);
             ScalarOperator rightChild = binaryPredicateOperator.getChild(1);
             if (binaryPredicateOperator.getBinaryType().isEqual()) {
-                minMaxConjuncts.add(buildMinMaxConjunct(BinaryType.LE, leftChild, rightChild, operator, context));
-                minMaxConjuncts.add(buildMinMaxConjunct(BinaryType.GE, leftChild, rightChild, operator, context));
+                minMaxConjuncts.add(buildMinMaxConjunct(BinaryType.LE, leftChild, rightChild, operator));
+                minMaxConjuncts.add(buildMinMaxConjunct(BinaryType.GE, leftChild, rightChild, operator));
             } else if (binaryPredicateOperator.getBinaryType().isRange()) {
                 minMaxConjuncts.add(
-                        buildMinMaxConjunct(binaryPredicateOperator.getBinaryType(), leftChild, rightChild, operator,
-                                context));
+                        buildMinMaxConjunct(binaryPredicateOperator.getBinaryType(), leftChild, rightChild, operator));
             }
         } else if (scalarOperator instanceof InPredicateOperator) {
             InPredicateOperator inPredicateOperator = (InPredicateOperator) scalarOperator;
@@ -402,19 +407,20 @@ public class OptExternalPartitionPruner {
             Preconditions.checkState(min != null);
 
             BinaryPredicateOperator minBound =
-                    buildMinMaxConjunct(BinaryType.GE, inPredicateOperator.getChild(0), min, operator, context);
+                    buildMinMaxConjunct(BinaryType.GE, inPredicateOperator.getChild(0), min, operator);
             BinaryPredicateOperator maxBound =
-                    buildMinMaxConjunct(BinaryType.LE, inPredicateOperator.getChild(0), max, operator, context);
+                    buildMinMaxConjunct(BinaryType.LE, inPredicateOperator.getChild(0), max, operator);
             minMaxConjuncts.add(minBound);
             minMaxConjuncts.add(maxBound);
         }
     }
 
     private static BinaryPredicateOperator buildMinMaxConjunct(BinaryType type, ScalarOperator left,
-            ScalarOperator right, LogicalScanOperator operator, OptimizerContext context) throws AnalysisException {
+            ScalarOperator right, LogicalScanOperator operator) throws AnalysisException {
         ScanOperatorPredicates scanOperatorPredicates = operator.getScanOperatorPredicates();
-        ColumnRefOperator newColumnRef = context.getColumnRefFactory().create(left, left.getType(), left.isNullable());
-        scanOperatorPredicates.getMinMaxColumnRefMap().put(newColumnRef, operator.getColRefToColumnMetaMap().get(left));
-        return new BinaryPredicateOperator(type, newColumnRef, right);
+        ColumnRefOperator columnRefOperator = (ColumnRefOperator) left;
+        scanOperatorPredicates.getMinMaxColumnRefMap().putIfAbsent(columnRefOperator,
+                operator.getColRefToColumnMetaMap().get(columnRefOperator));
+        return new BinaryPredicateOperator(type, columnRefOperator, right);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -889,7 +889,7 @@ public class PlanFragmentBuilder {
                     slotDescriptor.setIsNullable(column.isAllowNull());
                     slotDescriptor.setIsMaterialized(true);
                     context.getColRefToExpr()
-                            .put(columnRefOperator, new SlotRef(columnRefOperator.toString(), slotDescriptor));
+                            .putIfAbsent(columnRefOperator, new SlotRef(columnRefOperator.toString(), slotDescriptor));
                 }
             }
             minMaxTuple.computeMemLayout();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PushDownMinMaxConjunctsRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PushDownMinMaxConjunctsRuleTest.java
@@ -15,8 +15,8 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
-import com.google.common.collect.Maps;
 import com.starrocks.analysis.BinaryType;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.Memo;
@@ -31,6 +31,9 @@ import com.starrocks.sql.optimizer.operator.scalar.PredicateOperator;
 import mockit.Mocked;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 
 public class PushDownMinMaxConjunctsRuleTest {
@@ -38,19 +41,38 @@ public class PushDownMinMaxConjunctsRuleTest {
     public void transformIceberg(@Mocked IcebergTable table) {
         ExternalScanPartitionPruneRule rule0 = ExternalScanPartitionPruneRule.ICEBERG_SCAN;
 
-        PredicateOperator binaryPredicateOperator = new BinaryPredicateOperator(
-                BinaryType.EQ, new ColumnRefOperator(1, Type.INT, "id", true),
+        ColumnRefOperator colRef = new ColumnRefOperator(1, Type.INT, "id", true);
+        Column col = new Column("id", Type.INT, true);
+        PredicateOperator binaryPredicateOperator = new BinaryPredicateOperator(BinaryType.EQ, colRef,
                 ConstantOperator.createInt(1));
 
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<>();
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = new HashMap<>();
+        colRefToColumnMetaMap.put(colRef, col);
+        columnMetaToColRefMap.put(col, colRef);
         OptExpression scan =
-                new OptExpression(new LogicalIcebergScanOperator(table,
-                                Maps.newHashMap(), Maps.newHashMap(), -1, binaryPredicateOperator));
-        scan.getInputs().add(scan);
+                new OptExpression(new LogicalIcebergScanOperator(table, colRefToColumnMetaMap, columnMetaToColRefMap,
+                        -1, binaryPredicateOperator));
 
         assertEquals(0, ((LogicalIcebergScanOperator) scan.getOp()).getScanOperatorPredicates().getMinMaxConjuncts().size());
 
         rule0.transform(scan, new OptimizerContext(new Memo(), new ColumnRefFactory()));
 
         assertEquals(2, ((LogicalIcebergScanOperator) scan.getOp()).getScanOperatorPredicates().getMinMaxConjuncts().size());
+
+        PredicateOperator binaryPredicateOperatorNoPushDown = new BinaryPredicateOperator(BinaryType.EQ,
+                new ColumnRefOperator(2, Type.INT, "id_noexist", true), ConstantOperator.createInt(1));
+
+        OptExpression scanNoPushDown =
+                new OptExpression(new LogicalIcebergScanOperator(table, colRefToColumnMetaMap, columnMetaToColRefMap,
+                        -1, binaryPredicateOperatorNoPushDown));
+
+        assertEquals(0,
+                ((LogicalIcebergScanOperator) scanNoPushDown.getOp()).getScanOperatorPredicates().getMinMaxConjuncts().size());
+
+        rule0.transform(scanNoPushDown, new OptimizerContext(new Memo(), new ColumnRefFactory()));
+
+        assertEquals(0,
+                ((LogicalIcebergScanOperator) scanNoPushDown.getOp()).getScanOperatorPredicates().getMinMaxConjuncts().size());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -165,8 +165,7 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
         PlanTestBase.assertContains(plan1, "hive_union_mv_1");
         PlanTestBase.assertContains(plan1, "1:HdfsScanNode\n" +
                 "     TABLE: supplier\n" +
-                "     NON-PARTITION PREDICATES: 13: s_suppkey < 10, 13: s_suppkey >= 5");
-
+                "     NON-PARTITION PREDICATES: 12: s_suppkey < 10, 12: s_suppkey >= 5");
         dropMv("test", "hive_union_mv_1");
     }
 
@@ -194,8 +193,7 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
 
         String query1 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 10";
         String plan = getFragmentPlan(query1);
-        PlanTestBase.assertContains(plan, "TABLE: supplier", "NON-PARTITION PREDICATES: 19: s_suppkey < 10, 19: s_suppkey >= 5");
-
+        PlanTestBase.assertContains(plan, "TABLE: supplier", "NON-PARTITION PREDICATES: 18: s_suppkey < 10, 18: s_suppkey >= 5");
         connectContext.getSessionVariable().setUseNthExecPlan(0);
         dropMv("test", "hive_union_mv_1");
         dropMv("test", "hive_join_mv_1");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -401,9 +401,9 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
                 ImmutableList.of("l_shipdate=1998-01-02"));
         String plan = getFragmentPlan(query);
         PlanTestBase.assertContains(plan, "hive_parttbl_mv_2", "lineitem_par",
-                "PARTITION PREDICATES: (((23: l_shipdate < '1998-01-03') OR (23: l_shipdate >= '1998-01-06'))" +
-                        " AND (23: l_shipdate >= '1998-01-02')) OR (23: l_shipdate IS NULL)",
-                "NON-PARTITION PREDICATES: 21: l_orderkey > 100");
+                "PARTITION PREDICATES: (((22: l_shipdate < '1998-01-03') OR (22: l_shipdate >= '1998-01-06'))" +
+                        " AND (22: l_shipdate >= '1998-01-02')) OR (22: l_shipdate IS NULL)",
+                "NON-PARTITION PREDICATES: 20: l_orderkey > 100");
 
         dropMv("test", "hive_parttbl_mv_2");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
@@ -45,7 +45,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
                 "     TABLE: t1\n" +
                 "     PARTITION PREDICATES: 4: par_col = 1\n" +
                 "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
-                "     MIN/MAX PREDICATES: 5: c1 <= 2, 6: c1 >= 2\n" +
+                "     MIN/MAX PREDICATES: 1: c1 <= 2, 1: c1 >= 2\n" +
                 "     partitions=1/3");
 
         sql = "select * from t1 where par_col = abs(-1) and c1 = 2";
@@ -55,7 +55,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
                 "     PARTITION PREDICATES: 4: par_col = CAST(abs(-1) AS INT)\n" +
                 "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
                 "     NO EVAL-PARTITION PREDICATES: 4: par_col = CAST(abs(-1) AS INT)\n" +
-                "     MIN/MAX PREDICATES: 5: c1 <= 2, 6: c1 >= 2\n" +
+                "     MIN/MAX PREDICATES: 1: c1 <= 2, 1: c1 >= 2\n" +
                 "     partitions=3/3");
 
         sql = "select * from t1 where par_col = 1+1 and c1 = 2";
@@ -64,7 +64,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
                 "     TABLE: t1\n" +
                 "     PARTITION PREDICATES: 4: par_col = 2\n" +
                 "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
-                "     MIN/MAX PREDICATES: 5: c1 <= 2, 6: c1 >= 2\n" +
+                "     MIN/MAX PREDICATES: 1: c1 <= 2, 1: c1 >= 2\n" +
                 "     partitions=1/3");
     }
 

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q1.sql
@@ -114,14 +114,14 @@ OutPut Exchange Id: 03
 |  7 <-> [7: l_discount, DECIMAL64(15,2), true]
 |  9 <-> [9: l_returnflag, VARCHAR, true]
 |  10 <-> [10: l_linestatus, VARCHAR, true]
-|  17 <-> [32: multiply, DECIMAL128(33,4), true]
-|  18 <-> [32: multiply, DECIMAL128(33,4), true] * cast(1 + [8: l_tax, DECIMAL64(15,2), true] as DECIMAL128(16,2))
+|  17 <-> [31: multiply, DECIMAL128(33,4), true]
+|  18 <-> [31: multiply, DECIMAL128(33,4), true] * cast(1 + [8: l_tax, DECIMAL64(15,2), true] as DECIMAL128(16,2))
 |  common expressions:
-|  32 <-> [28: cast, DECIMAL128(15,2), true] * [31: cast, DECIMAL128(18,2), true]
-|  28 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
-|  29 <-> [7: l_discount, DECIMAL64(15,2), true]
-|  30 <-> 1 - [29: cast, DECIMAL64(18,2), true]
-|  31 <-> cast([30: subtract, DECIMAL64(18,2), true] as DECIMAL128(18,2))
+|  27 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
+|  28 <-> [7: l_discount, DECIMAL64(15,2), true]
+|  29 <-> 1 - [28: cast, DECIMAL64(18,2), true]
+|  30 <-> cast([29: subtract, DECIMAL64(18,2), true] as DECIMAL128(18,2))
+|  31 <-> [27: cast, DECIMAL128(15,2), true] * [30: cast, DECIMAL128(18,2), true]
 |  cardinality: 600037902
 |  column statistics:
 |  * l_quantity-->[1.0, 50.0, 0.0, 8.0, 50.0] ESTIMATE
@@ -135,7 +135,7 @@ OutPut Exchange Id: 03
 0:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 11: l_shipdate <= '1998-12-01'
-MIN/MAX PREDICATES: 27: l_shipdate <= '1998-12-01'
+MIN/MAX PREDICATES: 11: l_shipdate <= '1998-12-01'
 partitions=1/1
 avgRowSize=70.0
 cardinality: 600037902

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q10.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q10.sql
@@ -184,7 +184,7 @@ OutPut Exchange Id: 13
 6:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 26: l_returnflag = 'R'
-MIN/MAX PREDICATES: 40: l_returnflag <= 'R', 41: l_returnflag >= 'R'
+MIN/MAX PREDICATES: 26: l_returnflag <= 'R', 26: l_returnflag >= 'R'
 partitions=1/1
 avgRowSize=25.0
 cardinality: 200012634
@@ -214,7 +214,7 @@ OutPut Exchange Id: 10
 8:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 13: o_orderdate >= '1994-05-01', 13: o_orderdate < '1994-08-01'
-MIN/MAX PREDICATES: 42: o_orderdate >= '1994-05-01', 43: o_orderdate < '1994-08-01'
+MIN/MAX PREDICATES: 13: o_orderdate >= '1994-05-01', 13: o_orderdate < '1994-08-01'
 partitions=1/1
 avgRowSize=20.0
 cardinality: 5738046

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q11.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q11.sql
@@ -230,7 +230,7 @@ OutPut Exchange Id: 16
 14:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 32: n_name = 'PERU'
-MIN/MAX PREDICATES: 39: n_name <= 'PERU', 40: n_name >= 'PERU'
+MIN/MAX PREDICATES: 32: n_name <= 'PERU', 32: n_name >= 'PERU'
 partitions=1/1
 avgRowSize=29.0
 cardinality: 1
@@ -343,7 +343,7 @@ OutPut Exchange Id: 04
 2:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 14: n_name = 'PERU'
-MIN/MAX PREDICATES: 41: n_name <= 'PERU', 42: n_name >= 'PERU'
+MIN/MAX PREDICATES: 14: n_name <= 'PERU', 14: n_name >= 'PERU'
 partitions=1/1
 avgRowSize=29.0
 cardinality: 1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q12.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q12.sql
@@ -146,7 +146,7 @@ OutPut Exchange Id: 03
 1:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 24: l_shipmode IN ('REG AIR', 'MAIL'), 21: l_commitdate < 22: l_receiptdate, 20: l_shipdate < 21: l_commitdate, 22: l_receiptdate >= '1997-01-01', 22: l_receiptdate < '1998-01-01'
-MIN/MAX PREDICATES: 30: l_shipmode >= 'MAIL', 31: l_shipmode <= 'REG AIR', 32: l_receiptdate >= '1997-01-01', 33: l_receiptdate < '1998-01-01'
+MIN/MAX PREDICATES: 24: l_shipmode >= 'MAIL', 24: l_shipmode <= 'REG AIR', 22: l_receiptdate >= '1997-01-01', 22: l_receiptdate < '1998-01-01'
 partitions=1/1
 avgRowSize=30.0
 cardinality: 6125233

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
@@ -44,7 +44,7 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 08
 
 7:AGGREGATE (update serialize)
-|  aggregate: sum[(if[(21: p_type LIKE 'PROMO%', [37: multiply, DECIMAL128(33,4), true], 0); args: BOOLEAN,DECIMAL128,DECIMAL128; result: DECIMAL128(33,4); args nullable: true; result nullable: true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true], sum[([27: expr, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
+|  aggregate: sum[(if[(21: p_type LIKE 'PROMO%', [35: multiply, DECIMAL128(33,4), true], 0); args: BOOLEAN,DECIMAL128,DECIMAL128; result: DECIMAL128(33,4); args nullable: true; result nullable: true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true], sum[([27: expr, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
 |  cardinality: 1
 |  column statistics:
 |  * sum-->[-Infinity, Infinity, 0.0, 16.0, 1.0] ESTIMATE
@@ -53,14 +53,14 @@ OutPut Exchange Id: 08
 6:Project
 |  output columns:
 |  21 <-> [21: p_type, VARCHAR, true]
-|  27 <-> [37: multiply, DECIMAL128(33,4), true]
-|  37 <-> [37: multiply, DECIMAL128(33,4), true]
+|  27 <-> [35: multiply, DECIMAL128(33,4), true]
+|  35 <-> [35: multiply, DECIMAL128(33,4), true]
 |  common expressions:
-|  33 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
-|  34 <-> [7: l_discount, DECIMAL64(15,2), true]
-|  35 <-> 1 - [34: cast, DECIMAL64(18,2), true]
-|  36 <-> cast([35: subtract, DECIMAL64(18,2), true] as DECIMAL128(18,2))
-|  37 <-> [33: cast, DECIMAL128(15,2), true] * [36: cast, DECIMAL128(18,2), true]
+|  32 <-> [7: l_discount, DECIMAL64(15,2), true]
+|  33 <-> 1 - [32: cast, DECIMAL64(18,2), true]
+|  34 <-> cast([33: subtract, DECIMAL64(18,2), true] as DECIMAL128(18,2))
+|  35 <-> [31: cast, DECIMAL128(15,2), true] * [34: cast, DECIMAL128(18,2), true]
+|  31 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
 |  cardinality: 6653886
 |  column statistics:
 |  * p_type-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
@@ -112,7 +112,7 @@ OutPut Exchange Id: 04
 2:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 11: l_shipdate >= '1997-02-01', 11: l_shipdate < '1997-03-01'
-MIN/MAX PREDICATES: 31: l_shipdate >= '1997-02-01', 32: l_shipdate < '1997-03-01'
+MIN/MAX PREDICATES: 11: l_shipdate >= '1997-02-01', 11: l_shipdate < '1997-03-01'
 partitions=1/1
 avgRowSize=28.0
 cardinality: 6653886

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q15.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q15.sql
@@ -253,7 +253,7 @@ OutPut Exchange Id: 09
 6:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 36: l_shipdate >= '1995-07-01', 36: l_shipdate < '1995-10-01'
-MIN/MAX PREDICATES: 46: l_shipdate >= '1995-07-01', 47: l_shipdate < '1995-10-01'
+MIN/MAX PREDICATES: 36: l_shipdate >= '1995-07-01', 36: l_shipdate < '1995-10-01'
 partitions=1/1
 avgRowSize=40.0
 cardinality: 21862767
@@ -291,7 +291,7 @@ OutPut Exchange Id: 04
 1:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 18: l_shipdate >= '1995-07-01', 18: l_shipdate < '1995-10-01'
-MIN/MAX PREDICATES: 48: l_shipdate >= '1995-07-01', 49: l_shipdate < '1995-10-01'
+MIN/MAX PREDICATES: 18: l_shipdate >= '1995-07-01', 18: l_shipdate < '1995-10-01'
 partitions=1/1
 avgRowSize=40.0
 cardinality: 21862767

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q16.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q16.sql
@@ -199,7 +199,7 @@ OutPut Exchange Id: 03
 2:HdfsScanNode
 TABLE: part
 NON-PARTITION PREDICATES: 9: p_brand != 'Brand#43', NOT (10: p_type LIKE 'PROMO BURNISHED%'), 11: p_size IN (31, 43, 9, 6, 18, 11, 25, 1)
-MIN/MAX PREDICATES: 24: p_size >= 1, 25: p_size <= 43
+MIN/MAX PREDICATES: 11: p_size >= 1, 11: p_size <= 43
 partitions=1/1
 avgRowSize=47.0
 cardinality: 2304000

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q17.sql
@@ -158,7 +158,7 @@ OutPut Exchange Id: 03
 1:HdfsScanNode
 TABLE: part
 NON-PARTITION PREDICATES: 20: p_brand = 'Brand#35', 23: p_container = 'JUMBO CASE'
-MIN/MAX PREDICATES: 48: p_brand <= 'Brand#35', 49: p_brand >= 'Brand#35', 50: p_container <= 'JUMBO CASE', 51: p_container >= 'JUMBO CASE'
+MIN/MAX PREDICATES: 20: p_brand <= 'Brand#35', 20: p_brand >= 'Brand#35', 23: p_container <= 'JUMBO CASE', 23: p_container >= 'JUMBO CASE'
 partitions=1/1
 avgRowSize=28.0
 cardinality: 20000

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q19.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q19.sql
@@ -109,7 +109,7 @@ OutPut Exchange Id: 04
 3:HdfsScanNode
 TABLE: part
 NON-PARTITION PREDICATES: 20: p_brand IN ('Brand#45', 'Brand#11', 'Brand#21'), 22: p_size <= 15, 23: p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG', 'MED BAG', 'MED BOX', 'MED PKG', 'MED PACK', 'LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'), 22: p_size >= 1
-MIN/MAX PREDICATES: 28: p_brand >= 'Brand#11', 29: p_brand <= 'Brand#45', 30: p_size <= 15, 31: p_container >= 'LG BOX', 32: p_container <= 'SM PKG', 33: p_size >= 1
+MIN/MAX PREDICATES: 20: p_brand >= 'Brand#11', 20: p_brand <= 'Brand#45', 22: p_size <= 15, 23: p_container >= 'LG BOX', 23: p_container <= 'SM PKG', 22: p_size >= 1
 partitions=1/1
 avgRowSize=32.0
 cardinality: 5714286
@@ -141,7 +141,7 @@ OutPut Exchange Id: 02
 0:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 5: l_quantity >= 5, 5: l_quantity <= 35, 15: l_shipmode IN ('AIR', 'AIR REG'), 14: l_shipinstruct = 'DELIVER IN PERSON'
-MIN/MAX PREDICATES: 34: l_quantity >= 5, 35: l_quantity <= 35, 36: l_shipmode >= 'AIR', 37: l_shipmode <= 'AIR REG', 38: l_shipinstruct <= 'DELIVER IN PERSON', 39: l_shipinstruct >= 'DELIVER IN PERSON'
+MIN/MAX PREDICATES: 5: l_quantity >= 5, 5: l_quantity <= 35, 15: l_shipmode >= 'AIR', 15: l_shipmode <= 'AIR REG', 14: l_shipinstruct <= 'DELIVER IN PERSON', 14: l_shipinstruct >= 'DELIVER IN PERSON'
 partitions=1/1
 avgRowSize=67.0
 cardinality: 26240725

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q2.sql
@@ -296,7 +296,7 @@ OutPut Exchange Id: 14
 12:HdfsScanNode
 TABLE: part
 NON-PARTITION PREDICATES: 6: p_size = 12, 5: p_type LIKE '%COPPER'
-MIN/MAX PREDICATES: 53: p_size <= 12, 54: p_size >= 12
+MIN/MAX PREDICATES: 6: p_size <= 12, 6: p_size >= 12
 partitions=1/1
 avgRowSize=62.0
 cardinality: 100000
@@ -431,7 +431,7 @@ OutPut Exchange Id: 04
 2:HdfsScanNode
 TABLE: region
 NON-PARTITION PREDICATES: 27: r_name = 'AMERICA'
-MIN/MAX PREDICATES: 51: r_name <= 'AMERICA', 52: r_name >= 'AMERICA'
+MIN/MAX PREDICATES: 27: r_name <= 'AMERICA', 27: r_name >= 'AMERICA'
 partitions=1/1
 avgRowSize=10.8
 cardinality: 1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q20.sql
@@ -164,7 +164,7 @@ OutPut Exchange Id: 19
 17:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 9: n_name = 'ARGENTINA'
-MIN/MAX PREDICATES: 49: n_name <= 'ARGENTINA', 50: n_name >= 'ARGENTINA'
+MIN/MAX PREDICATES: 9: n_name <= 'ARGENTINA', 9: n_name >= 'ARGENTINA'
 partitions=1/1
 avgRowSize=29.0
 cardinality: 1
@@ -338,7 +338,7 @@ OutPut Exchange Id: 03
 0:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 29: l_suppkey IS NOT NULL, 37: l_shipdate >= '1993-01-01', 37: l_shipdate < '1994-01-01'
-MIN/MAX PREDICATES: 47: l_shipdate >= '1993-01-01', 48: l_shipdate < '1994-01-01'
+MIN/MAX PREDICATES: 37: l_shipdate >= '1993-01-01', 37: l_shipdate < '1994-01-01'
 partitions=1/1
 avgRowSize=24.0
 cardinality: 86738152

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q21.sql
@@ -315,7 +315,7 @@ OutPut Exchange Id: 13
 11:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 34: n_name = 'CANADA'
-MIN/MAX PREDICATES: 72: n_name <= 'CANADA', 73: n_name >= 'CANADA'
+MIN/MAX PREDICATES: 34: n_name <= 'CANADA', 34: n_name >= 'CANADA'
 partitions=1/1
 avgRowSize=29.0
 cardinality: 1
@@ -339,7 +339,7 @@ OutPut Exchange Id: 07
 5:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 26: o_orderstatus = 'F'
-MIN/MAX PREDICATES: 74: o_orderstatus <= 'F', 75: o_orderstatus >= 'F'
+MIN/MAX PREDICATES: 26: o_orderstatus <= 'F', 26: o_orderstatus >= 'F'
 partitions=1/1
 avgRowSize=9.0
 cardinality: 50000000

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q22.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q22.sql
@@ -204,7 +204,7 @@ OutPut Exchange Id: 06
 3:HdfsScanNode
 TABLE: customer
 NON-PARTITION PREDICATES: 14: c_acctbal > 0.00, substring(13: c_phone, 1, 2) IN ('21', '28', '24', '32', '35', '34', '37')
-MIN/MAX PREDICATES: 32: c_acctbal > 0.00
+MIN/MAX PREDICATES: 14: c_acctbal > 0.00
 partitions=1/1
 avgRowSize=23.0
 cardinality: 6818187

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q3.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q3.sql
@@ -141,7 +141,7 @@ OutPut Exchange Id: 09
 3:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 13: o_orderdate < '1995-03-11'
-MIN/MAX PREDICATES: 37: o_orderdate < '1995-03-11'
+MIN/MAX PREDICATES: 13: o_orderdate < '1995-03-11'
 partitions=1/1
 avgRowSize=24.0
 cardinality: 72661123
@@ -169,7 +169,7 @@ OutPut Exchange Id: 06
 4:HdfsScanNode
 TABLE: customer
 NON-PARTITION PREDICATES: 7: c_mktsegment = 'HOUSEHOLD'
-MIN/MAX PREDICATES: 38: c_mktsegment <= 'HOUSEHOLD', 39: c_mktsegment >= 'HOUSEHOLD'
+MIN/MAX PREDICATES: 7: c_mktsegment <= 'HOUSEHOLD', 7: c_mktsegment >= 'HOUSEHOLD'
 partitions=1/1
 avgRowSize=18.0
 cardinality: 3000000
@@ -197,7 +197,7 @@ OutPut Exchange Id: 02
 0:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 28: l_shipdate > '1995-03-11'
-MIN/MAX PREDICATES: 36: l_shipdate > '1995-03-11'
+MIN/MAX PREDICATES: 28: l_shipdate > '1995-03-11'
 partitions=1/1
 avgRowSize=28.0
 cardinality: 323426370

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q4.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q4.sql
@@ -122,7 +122,7 @@ OutPut Exchange Id: 05
 3:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 5: o_orderdate >= '1994-09-01', 5: o_orderdate < '1994-12-01'
-MIN/MAX PREDICATES: 28: o_orderdate >= '1994-09-01', 29: o_orderdate < '1994-12-01'
+MIN/MAX PREDICATES: 5: o_orderdate >= '1994-09-01', 5: o_orderdate < '1994-12-01'
 partitions=1/1
 avgRowSize=27.0
 cardinality: 5675676

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q5.sql
@@ -183,7 +183,7 @@ OutPut Exchange Id: 17
 15:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 13: o_orderdate >= '1995-01-01', 13: o_orderdate < '1996-01-01'
-MIN/MAX PREDICATES: 52: o_orderdate >= '1995-01-01', 53: o_orderdate < '1996-01-01'
+MIN/MAX PREDICATES: 13: o_orderdate >= '1995-01-01', 13: o_orderdate < '1996-01-01'
 partitions=1/1
 avgRowSize=20.0
 cardinality: 22765073
@@ -354,7 +354,7 @@ OutPut Exchange Id: 05
 3:HdfsScanNode
 TABLE: region
 NON-PARTITION PREDICATES: 46: r_name = 'AFRICA'
-MIN/MAX PREDICATES: 50: r_name <= 'AFRICA', 51: r_name >= 'AFRICA'
+MIN/MAX PREDICATES: 46: r_name <= 'AFRICA', 46: r_name >= 'AFRICA'
 partitions=1/1
 avgRowSize=10.8
 cardinality: 1

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q6.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q6.sql
@@ -48,7 +48,7 @@ OutPut Exchange Id: 03
 0:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 11: l_shipdate >= '1995-01-01', 11: l_shipdate < '1996-01-01', 7: l_discount >= 0.02, 7: l_discount <= 0.04, 5: l_quantity < 24
-MIN/MAX PREDICATES: 19: l_shipdate >= '1995-01-01', 20: l_shipdate < '1996-01-01', 21: l_discount >= 0.02, 22: l_discount <= 0.04, 23: l_quantity < 24
+MIN/MAX PREDICATES: 11: l_shipdate >= '1995-01-01', 11: l_shipdate < '1996-01-01', 7: l_discount >= 0.02, 7: l_discount <= 0.04, 5: l_quantity < 24
 partitions=1/1
 avgRowSize=44.0
 cardinality: 8142765

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q7.sql
@@ -262,7 +262,7 @@ OutPut Exchange Id: 14
 2:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 18: l_shipdate >= '1995-01-01', 18: l_shipdate <= '1996-12-31'
-MIN/MAX PREDICATES: 56: l_shipdate >= '1995-01-01', 57: l_shipdate <= '1996-12-31'
+MIN/MAX PREDICATES: 18: l_shipdate >= '1995-01-01', 18: l_shipdate <= '1996-12-31'
 partitions=1/1
 avgRowSize=32.0
 cardinality: 173476304
@@ -348,7 +348,7 @@ OutPut Exchange Id: 08
 4:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 42: n_name IN ('CANADA', 'IRAN')
-MIN/MAX PREDICATES: 54: n_name >= 'CANADA', 55: n_name <= 'IRAN'
+MIN/MAX PREDICATES: 42: n_name >= 'CANADA', 42: n_name <= 'IRAN'
 partitions=1/1
 avgRowSize=29.0
 cardinality: 25
@@ -365,7 +365,7 @@ OutPut Exchange Id: 06
 5:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 46: n_name IN ('IRAN', 'CANADA')
-MIN/MAX PREDICATES: 52: n_name >= 'CANADA', 53: n_name <= 'IRAN'
+MIN/MAX PREDICATES: 46: n_name >= 'CANADA', 46: n_name <= 'IRAN'
 partitions=1/1
 avgRowSize=29.0
 cardinality: 25

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
@@ -110,14 +110,14 @@ OutPut Exchange Id: 34
 32:Project
 |  output columns:
 |  61 <-> year[([37: o_orderdate, DATE, true]); args: DATE; result: SMALLINT; args nullable: true; result nullable: true]
-|  62 <-> [77: multiply, DECIMAL128(33,4), true]
-|  63 <-> if[([55: n_name, VARCHAR, true] = 'IRAN', [77: multiply, DECIMAL128(33,4), true], 0); args: BOOLEAN,DECIMAL128,DECIMAL128; result: DECIMAL128(33,4); args nullable: true; result nullable: true]
+|  62 <-> [71: multiply, DECIMAL128(33,4), true]
+|  63 <-> if[([55: n_name, VARCHAR, true] = 'IRAN', [71: multiply, DECIMAL128(33,4), true], 0); args: BOOLEAN,DECIMAL128,DECIMAL128; result: DECIMAL128(33,4); args nullable: true; result nullable: true]
 |  common expressions:
-|  73 <-> cast([22: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
-|  74 <-> [23: l_discount, DECIMAL64(15,2), true]
-|  75 <-> 1 - [74: cast, DECIMAL64(18,2), true]
-|  76 <-> cast([75: subtract, DECIMAL64(18,2), true] as DECIMAL128(18,2))
-|  77 <-> [73: cast, DECIMAL128(15,2), true] * [76: cast, DECIMAL128(18,2), true]
+|  67 <-> cast([22: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
+|  68 <-> [23: l_discount, DECIMAL64(15,2), true]
+|  69 <-> 1 - [68: cast, DECIMAL64(18,2), true]
+|  70 <-> cast([69: subtract, DECIMAL64(18,2), true] as DECIMAL128(18,2))
+|  71 <-> [67: cast, DECIMAL128(15,2), true] * [70: cast, DECIMAL128(18,2), true]
 |  cardinality: 242843
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
@@ -325,7 +325,7 @@ OutPut Exchange Id: 18
 16:HdfsScanNode
 TABLE: part
 NON-PARTITION PREDICATES: 5: p_type = 'ECONOMY ANODIZED STEEL'
-MIN/MAX PREDICATES: 71: p_type <= 'ECONOMY ANODIZED STEEL', 72: p_type >= 'ECONOMY ANODIZED STEEL'
+MIN/MAX PREDICATES: 5: p_type <= 'ECONOMY ANODIZED STEEL', 5: p_type >= 'ECONOMY ANODIZED STEEL'
 partitions=1/1
 avgRowSize=33.0
 cardinality: 133333
@@ -368,7 +368,7 @@ OutPut Exchange Id: 14
 0:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 37: o_orderdate >= '1995-01-01', 37: o_orderdate <= '1996-12-31'
-MIN/MAX PREDICATES: 69: o_orderdate >= '1995-01-01', 70: o_orderdate <= '1996-12-31'
+MIN/MAX PREDICATES: 37: o_orderdate >= '1995-01-01', 37: o_orderdate <= '1996-12-31'
 partitions=1/1
 avgRowSize=20.0
 cardinality: 45530146
@@ -478,7 +478,7 @@ OutPut Exchange Id: 05
 3:HdfsScanNode
 TABLE: region
 NON-PARTITION PREDICATES: 59: r_name = 'MIDDLE EAST'
-MIN/MAX PREDICATES: 67: r_name <= 'MIDDLE EAST', 68: r_name >= 'MIDDLE EAST'
+MIN/MAX PREDICATES: 59: r_name <= 'MIDDLE EAST', 59: r_name >= 'MIDDLE EAST'
 partitions=1/1
 avgRowSize=10.8
 cardinality: 1

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q1.sql
@@ -23,9 +23,9 @@ order by
 [result]
 TOP-N (order by [[9: l_returnflag ASC NULLS FIRST, 10: l_linestatus ASC NULLS FIRST]])
     TOP-N (order by [[9: l_returnflag ASC NULLS FIRST, 10: l_linestatus ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{115: sum=sum(115: sum), 116: count=sum(116: count), 117: sum=sum(117: sum), 118: sum=sum(118: sum), 119: sum=sum(119: sum), 120: sum=sum(120: sum), 121: count=sum(121: count), 122: count=sum(122: count), 123: count=sum(123: count)}] group by [[81: l_returnflag, 82: l_linestatus]] having [null]
-            EXCHANGE SHUFFLE[81, 82]
-                AGGREGATE ([LOCAL] aggregate [{115: sum=sum(87: sum_discount), 116: count=sum(88: count_discount), 117: sum=sum(83: sum_qty), 118: sum=sum(85: sum_base_price), 119: sum=sum(89: sum_disc_price), 120: sum=sum(90: sum_charge), 121: count=sum(91: count_order), 122: count=sum(84: count_qty), 123: count=sum(86: count_base_price)}] group by [[81: l_returnflag, 82: l_linestatus]] having [null]
-                    SCAN (mv[lineitem_agg_mv1] columns[80: l_shipdate, 81: l_returnflag, 82: l_linestatus, 83: sum_qty, 84: count_qty, 85: sum_base_price, 86: count_base_price, 87: sum_discount, 88: count_discount, 89: sum_disc_price, 90: sum_charge, 91: count_order] predicate[80: l_shipdate <= 1998-12-01])
+        AGGREGATE ([GLOBAL] aggregate [{114: count=sum(114: count), 115: sum=sum(115: sum), 116: sum=sum(116: sum), 117: sum=sum(117: sum), 118: sum=sum(118: sum), 119: count=sum(119: count), 120: count=sum(120: count), 121: count=sum(121: count), 122: sum=sum(122: sum)}] group by [[29: l_returnflag, 30: l_linestatus]] having [null]
+            EXCHANGE SHUFFLE[29, 30]
+                AGGREGATE ([LOCAL] aggregate [{114: count=sum(36: count_discount), 115: sum=sum(31: sum_qty), 116: sum=sum(33: sum_base_price), 117: sum=sum(37: sum_disc_price), 118: sum=sum(38: sum_charge), 119: count=sum(39: count_order), 120: count=sum(32: count_qty), 121: count=sum(34: count_base_price), 122: sum=sum(35: sum_discount)}] group by [[29: l_returnflag, 30: l_linestatus]] having [null]
+                    SCAN (mv[lineitem_agg_mv1] columns[28: l_shipdate, 29: l_returnflag, 30: l_linestatus, 31: sum_qty, 32: count_qty, 33: sum_base_price, 34: count_base_price, 35: sum_discount, 36: count_discount, 37: sum_disc_price, 38: sum_charge, 39: count_order] predicate[28: l_shipdate <= 1998-12-01])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q20.sql
@@ -48,14 +48,12 @@ TOP-N (order by [[2: s_name ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[17]
                             SCAN (columns{17,18} predicate[17: p_partkey IS NOT NULL AND 18: p_name LIKE sienna%])
                     EXCHANGE SHUFFLE[28]
-                        AGGREGATE ([GLOBAL] aggregate [{149: sum=sum(149: sum)}] group by [[132: l_partkey, 130: l_suppkey]] having [null]
-                            EXCHANGE SHUFFLE[132, 130]
-                                AGGREGATE ([LOCAL] aggregate [{149: sum=sum(133: sum_qty)}] group by [[132: l_partkey, 130: l_suppkey]] having [null]
-                                    SCAN (mv[lineitem_agg_mv2] columns[130: l_suppkey, 131: l_shipdate, 132: l_partkey, 133: sum_qty] predicate[131: l_shipdate >= 1993-01-01 AND 131: l_shipdate < 1994-01-01])
+                        AGGREGATE ([GLOBAL] aggregate [{145: sum=sum(145: sum)}] group by [[65: l_partkey, 63: l_suppkey]] having [null]
+                            EXCHANGE SHUFFLE[65, 63]
+                                AGGREGATE ([LOCAL] aggregate [{145: sum=sum(66: sum_qty)}] group by [[65: l_partkey, 63: l_suppkey]] having [null]
+                                    SCAN (mv[lineitem_agg_mv2] columns[63: l_suppkey, 64: l_shipdate, 65: l_partkey, 66: sum_qty] predicate[64: l_shipdate >= 1993-01-01 AND 64: l_shipdate < 1994-01-01])
             EXCHANGE SHUFFLE[1]
                 INNER JOIN (join-predicate [4: s_nationkey = 8: n_nationkey] post-join-predicate [null])
                     SCAN (columns{1,2,3,4} predicate[4: s_nationkey IS NOT NULL])
                     EXCHANGE BROADCAST
-                        SCAN (columns{8,9,147,148} predicate[9: n_name = ARGENTINA])
-[end]
-
+                        SCAN (columns{8,9} predicate[9: n_name = ARGENTINA])

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q22.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q22.sql
@@ -50,9 +50,9 @@ TOP-N (order by [[29: substring ASC NULLS FIRST]])
                                 SCAN (columns{1,5,6} predicate[substring(5: c_phone, 1, 2) IN (21, 28, 24, 32, 35, 34, 37)])
                                 EXCHANGE BROADCAST
                                     ASSERT LE 1
-                                        AGGREGATE ([GLOBAL] aggregate [{97: count=sum(97: count), 96: sum=sum(96: sum)}] group by [[]] having [null]
+                                        AGGREGATE ([GLOBAL] aggregate [{95: sum=sum(95: sum), 96: count=sum(96: count)}] group by [[]] having [null]
                                             EXCHANGE GATHER
-                                                AGGREGATE ([LOCAL] aggregate [{97: count=sum(39: c_count), 96: sum=sum(40: c_sum)}] group by [[]] having [null]
+                                                AGGREGATE ([LOCAL] aggregate [{95: sum=sum(40: c_sum), 96: count=sum(39: c_count)}] group by [[]] having [null]
                                                     SCAN (mv[customer_agg_mv1] columns[37: c_acctbal, 38: substring_phone, 39: c_count, 40: c_sum] predicate[37: c_acctbal > 0.00 AND 38: substring_phone IN (21, 24, 28, 32, 34, 35, 37)])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q5.sql
@@ -29,6 +29,6 @@ TOP-N (order by [[49: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{49: sum=sum(49: sum)}] group by [[42: n_name]] having [null]
             EXCHANGE SHUFFLE[42]
                 AGGREGATE ([LOCAL] aggregate [{49: sum=sum(48: expr)}] group by [[42: n_name]] having [null]
-                    SCAN (mv[lineitem_mv] columns[75: c_nationkey, 90: o_orderdate, 101: s_nationkey, 103: l_saleprice, 109: n_name2, 112: r_name2] predicate[75: c_nationkey = 101: s_nationkey AND 90: o_orderdate >= 1995-01-01 AND 90: o_orderdate < 1996-01-01 AND 112: r_name2 = AFRICA])
+                    SCAN (mv[lineitem_mv] columns[112: c_nationkey, 127: o_orderdate, 138: s_nationkey, 140: l_saleprice, 146: n_name2, 149: r_name2] predicate[138: s_nationkey = 112: c_nationkey AND 127: o_orderdate >= 1995-01-01 AND 127: o_orderdate < 1996-01-01 AND 149: r_name2 = AFRICA])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/scheduler/external/hive/tpch/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/external/hive/tpch/q1.sql
@@ -87,19 +87,19 @@ PLAN FRAGMENT 2
   |  <slot 7> : 7: l_discount
   |  <slot 9> : 9: l_returnflag
   |  <slot 10> : 10: l_linestatus
-  |  <slot 17> : 32: multiply
-  |  <slot 18> : 32: multiply * CAST(1 + CAST(8: l_tax AS DECIMAL64(16,2)) AS DECIMAL128(16,2))
+  |  <slot 17> : 31: multiply
+  |  <slot 18> : 31: multiply * CAST(1 + CAST(8: l_tax AS DECIMAL64(16,2)) AS DECIMAL128(16,2))
   |  common expressions:
-  |  <slot 32> : 28: cast * 31: cast
-  |  <slot 28> : CAST(6: l_extendedprice AS DECIMAL128(15,2))
-  |  <slot 29> : CAST(7: l_discount AS DECIMAL64(18,2))
-  |  <slot 30> : 1 - 29: cast
-  |  <slot 31> : CAST(30: subtract AS DECIMAL128(18,2))
+  |  <slot 27> : CAST(6: l_extendedprice AS DECIMAL128(15,2))
+  |  <slot 28> : CAST(7: l_discount AS DECIMAL64(18,2))
+  |  <slot 29> : 1 - 28: cast
+  |  <slot 30> : CAST(29: subtract AS DECIMAL128(18,2))
+  |  <slot 31> : 27: cast * 30: cast
   |  
   0:HdfsScanNode
      TABLE: lineitem
      NON-PARTITION PREDICATES: 11: l_shipdate <= '1998-12-01'
-     MIN/MAX PREDICATES: 27: l_shipdate <= '1998-12-01'
+     MIN/MAX PREDICATES: 11: l_shipdate <= '1998-12-01'
      partitions=1/1
      cardinality=600037902
      avgRowSize=70.0


### PR DESCRIPTION
Fixes #issue

There is no need to generate new slotid for min-max conjuncts, 
using original slotid make the operation in be convenient.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
