### PR TITLE
[Enhancement] Add bitmap index for decimal

### DIFF
--- a/be/src/storage/olap_type_infra.h
+++ b/be/src/storage/olap_type_infra.h
@@ -54,8 +54,7 @@ namespace starrocks {
     M(TYPE_CHAR)                       \
     M(TYPE_VARCHAR)                    \
     M(TYPE_BOOLEAN)                    \
-    M(TYPE_DECIMAL)                    \
-    M(TYPE_DECIMALV2)
+    APPLY_FOR_TYPE_DECIMAL(M)
 
 // Types that support bloomfilter(exclude tinyint/float/double)
 #define APPLY_FOR_BLOOMFILTER_TYPE(M) \
@@ -70,9 +69,6 @@ namespace starrocks {
 #define APPLY_FOR_BASIC_LOGICAL_TYPE(M) \
     APPLY_FOR_BITMAP_INDEX_TYPE(M)      \
     M(TYPE_JSON)                        \
-    M(TYPE_DECIMAL32)                   \
-    M(TYPE_DECIMAL64)                   \
-    M(TYPE_DECIMAL128)                  \
     M(TYPE_VARBINARY)
 
 #define APPLY_FOR_UNSIGNED_LOGICAL_TYPE(M) \

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/IndexDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/IndexDef.java
@@ -155,7 +155,8 @@ public class IndexDef implements ParseNode {
             String indexColName = column.getName();
             PrimitiveType colType = column.getPrimitiveType();
             if (!(colType.isDateType() ||
-                    colType.isFixedPointType() || colType.isStringType() || colType == PrimitiveType.BOOLEAN)) {
+                    colType.isFixedPointType() || colType.isDecimalV3Type() ||
+                    colType.isStringType() || colType == PrimitiveType.BOOLEAN)) {
                 throw new SemanticException(colType + " is not supported in bitmap index. "
                         + "invalid column: " + indexColName);
             } else if ((keysType == KeysType.AGG_KEYS || keysType == KeysType.UNIQUE_KEYS) && !column.isKey()) {


### PR DESCRIPTION
The bitmap index are not suitable for decimal. This pull request is to add the feature.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
