### PR TITLE
[Tool] upgrade gcc version in centos7 toolchain

### DIFF
--- a/docker/dockerfiles/toolchains/toolchains-centos7.Dockerfile
+++ b/docker/dockerfiles/toolchains/toolchains-centos7.Dockerfile
@@ -1,8 +1,8 @@
 # Build toolchains on centos7, dev-env image can be built based on this image for centos7
-#  DOCKER_BUILDKIT=1 docker build --rm=true -f docker/dockerfiles/toolchains/centos7-toolchains.Dockerfile -t toolchains-centos7:latest docker/dockerfiles/toolchains/
+#  DOCKER_BUILDKIT=1 docker build --rm=true -f docker/dockerfiles/toolchains/toolchains-centos7.Dockerfile -t toolchains-centos7:latest docker/dockerfiles/toolchains/
 
-ARG GCC_INSTALL_HOME=/opt/gcc/usr
-ARG GCC_DOWNLOAD_URL=https://ftp.gnu.org/gnu/gcc/gcc-10.3.0/gcc-10.3.0.tar.gz
+ARG GCC_INSTALL_HOME=/opt/rh/gcc-toolset-11/root/usr
+ARG GCC_DOWNLOAD_URL=https://ftp.gnu.org/gnu/gcc/gcc-11.3.0/gcc-11.3.0.tar.gz
 ARG CMAKE_INSTALL_HOME=/opt/cmake
 ARG MAVEN_VERSION=3.6.3
 ARG MAVEN_INSTALL_HOME=/opt/maven

--- a/docker/dockerfiles/toolchains/toolchains-ubuntu.Dockerfile
+++ b/docker/dockerfiles/toolchains/toolchains-ubuntu.Dockerfile
@@ -7,7 +7,7 @@ FROM ubuntu:22.04
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
     automake binutils-dev bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 make cmake gcc g++ default-jdk git patch lld bzip2 \
-    wget unzip curl vim tree net-tools openssh-client && \
+    wget unzip curl vim tree net-tools openssh-client xz-utils && \
     DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
* centos upgrade gcc to 11.3
* install gcc to /opt/rh/gcc-toolset-11/root/usr so clang can correctly search for it
* ubuntu add xz-utils to support .xz compression

refs #29552

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [X] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
