### PR TITLE
[BugFix] Fix orderby column duplicate check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -183,9 +183,7 @@ public class SelectAnalyzer {
                     .collect(Collectors.toList());
 
             Scope sourceScopeForOrder = new Scope(RelationId.anonymous(), new RelationFields(sourceForOrderFields));
-            sourceAndOutputScope = new Scope(outputScope.getRelationId(), outputScope.getRelationFields());
-            sourceAndOutputScope.setParent(sourceScopeForOrder);
-            analyzeState.setOrderScope(sourceAndOutputScope);
+            computeAndAssignOrderScope(analyzeState, sourceScopeForOrder, outputScope);
             analyzeState.setOrderSourceExpressions(orderSourceExpressions);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -520,4 +520,13 @@ public class OrderByTest extends PlanTestBase {
                 "  |  build runtime filters:\n" +
                 "  |  - filter_id = 0, build_expr = (<slot 1> 1: t1a), remote = false");
     }
+
+    @Test
+    public void testGroupByOrderBy() throws Exception {
+        String sql = "select v2,v3,v2 from t0 group by 1,2,3 order by 1,2,3";
+        String plan = getFragmentPlan(sql);
+
+        assertContains(plan, "2:SORT\n" +
+                "  |  order by: <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC");
+    }
 }


### PR DESCRIPTION
Fixes #issue
resolve handle `order by` bug, the input column for order by needs to reduce duplication

Bugs:
```
MySQL td> explain select v1, v2, v1 from t0 group by 1,2  order by 1,2;
(1064, "Getting analyzing error. Detail message: Column 'v1' is ambiguous.")
MySQL td> explain select v1, v2, v1 from t0 group by 1,2  order by 1,2;
(1064, "Getting analyzing error. Detail message: Column 'v1' is ambiguous.")
MySQL td> explain select v1, v2, v1 from t0 group by 1,2  order by 1,2;
(1064, "Getting analyzing error. Detail message: Column 'v1' is ambiguous.")
MySQL td> explain select v1, v2, v1 from t0 group by 1,2  order by 1;
(1064, "Getting analyzing error. Detail message: Column 'v1' is ambiguous.")
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
