### PR TITLE
[BugFix] for dict encode column need decode if used in multi-slot conjunct

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -247,6 +247,9 @@ Status HiveDataSource::_decompose_conjunct_ctxs(RuntimeState* state) {
         }
         if (!single_slot || slot_ids.empty()) {
             _scanner_conjunct_ctxs.emplace_back(ctx);
+            for (SlotId slot_id : slot_ids) {
+                _slots_of_mutli_slot_conjunct.insert(slot_id);
+            }
             continue;
         }
 
@@ -499,6 +502,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.conjunct_ctxs = _scanner_conjunct_ctxs;
     scanner_params.conjunct_ctxs_by_slot = _conjunct_ctxs_by_slot;
     scanner_params.slots_in_conjunct = _slots_in_conjunct;
+    scanner_params.slots_of_mutli_slot_conjunct = _slots_of_mutli_slot_conjunct;
     scanner_params.min_max_conjunct_ctxs = _min_max_conjunct_ctxs;
     scanner_params.min_max_tuple_desc = _min_max_tuple_desc;
     scanner_params.hive_column_names = &_hive_column_names;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -102,6 +102,11 @@ private:
     std::unordered_map<SlotId, std::vector<ExprContext*>> _conjunct_ctxs_by_slot;
     std::unordered_set<SlotId> _slots_in_conjunct;
 
+    // used for reader to decide decode or not
+    // if only used by filter(not output) and only used in conjunct_ctx_by_slot
+    // there is no need to decode.
+    std::unordered_set<SlotId> _slots_of_mutli_slot_conjunct;
+
     // partition conjuncts of each partition slot.
     std::vector<ExprContext*> _partition_conjunct_ctxs;
     std::vector<ExprContext*> _partition_values;

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -105,6 +105,9 @@ Status HdfsScanner::_build_scanner_context() {
         column.col_type = slot->type();
         column.slot_id = slot->id();
         column.col_name = slot->col_name();
+        column.decode_needed =
+                slot->is_output_column() || _scanner_params.slots_of_mutli_slot_conjunct.find(slot->id()) !=
+                                                    _scanner_params.slots_of_mutli_slot_conjunct.end();
 
         ctx.materialized_columns.emplace_back(std::move(column));
     }

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -129,6 +129,8 @@ struct HdfsScannerParams {
     // all conjuncts except `conjunct_ctxs_by_slot`
     std::vector<ExprContext*> conjunct_ctxs;
     std::unordered_set<SlotId> slots_in_conjunct;
+    // slot used by conjunct_ctxs
+    std::unordered_set<SlotId> slots_of_mutli_slot_conjunct;
     bool eval_conjunct_ctxs = true;
 
     // conjunct ctxs grouped by slot.
@@ -193,6 +195,7 @@ struct HdfsScannerContext {
         SlotId slot_id;
         std::string col_name;
         SlotDescriptor* slot_desc;
+        bool decode_needed = true;
 
         std::string formated_col_name(bool case_sensitive) {
             return case_sensitive ? col_name : boost::algorithm::to_lower_copy(col_name);

--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -139,7 +139,7 @@ public:
 
     void set_need_parse_levels(bool need_parse_levels) override { _reader->set_need_parse_levels(need_parse_levels); }
 
-    bool try_to_use_dict_filter(ExprContext* ctx, bool is_output_column, const SlotId slotId,
+    bool try_to_use_dict_filter(ExprContext* ctx, bool is_decode_needed, const SlotId slotId,
                                 const std::vector<std::string>& sub_field_path, const size_t& layer) override {
         if (sub_field_path.size() != layer) {
             return false;
@@ -152,7 +152,7 @@ public:
         if (_column_all_pages_dict_encoded()) {
             if (_dict_filter_ctx == nullptr) {
                 _dict_filter_ctx = std::make_unique<ColumnDictFilterContext>();
-                _dict_filter_ctx->is_output_column = is_output_column;
+                _dict_filter_ctx->is_decode_needed = is_decode_needed;
                 _dict_filter_ctx->sub_field_path = sub_field_path;
                 _dict_filter_ctx->slot_id = slotId;
             }
@@ -188,7 +188,7 @@ public:
         if (_dict_filter_ctx == nullptr) {
             dst->swap_column(*src);
         } else {
-            if (_dict_filter_ctx->is_output_column) {
+            if (_dict_filter_ctx->is_decode_needed) {
                 ColumnPtr& dict_values = dst;
                 dict_values->resize(0);
 
@@ -839,7 +839,7 @@ public:
         }
     }
 
-    bool try_to_use_dict_filter(ExprContext* ctx, bool is_output_column, const SlotId slotId,
+    bool try_to_use_dict_filter(ExprContext* ctx, bool is_decode_needed, const SlotId slotId,
                                 const std::vector<std::string>& sub_field_path, const size_t& layer) override {
         if (sub_field_path.size() <= layer) {
             return false;
@@ -852,7 +852,7 @@ public:
         if (_child_readers[sub_field] == nullptr) {
             return false;
         }
-        return _child_readers[sub_field]->try_to_use_dict_filter(ctx, is_output_column, slotId, sub_field_path,
+        return _child_readers[sub_field]->try_to_use_dict_filter(ctx, is_decode_needed, slotId, sub_field_path,
                                                                  layer + 1);
     }
 

--- a/be/src/formats/parquet/column_reader.h
+++ b/be/src/formats/parquet/column_reader.h
@@ -55,7 +55,7 @@ struct ColumnDictFilterContext {
     // preds transformed from `_conjunct_ctxs` for each dict filter column
     ColumnPredicate* predicate;
     // is output column ? if just used for filter, decode is no need
-    bool is_output_column;
+    bool is_decode_needed;
     SlotId slot_id;
     std::vector<std::string> sub_field_path;
     ObjectPool obj_pool;
@@ -106,7 +106,7 @@ public:
         return Status::NotSupported("get_dict_values is not supported");
     }
 
-    virtual bool try_to_use_dict_filter(ExprContext* ctx, bool is_output_column, const SlotId slotId,
+    virtual bool try_to_use_dict_filter(ExprContext* ctx, bool is_decode_needed, const SlotId slotId,
                                         const std::vector<std::string>& sub_field_path, const size_t& layer) {
         return false;
     }

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -342,7 +342,6 @@ Status GroupReader::_create_column_reader(const GroupReaderParam::Column& column
 
 void GroupReader::_process_columns_and_conjunct_ctxs() {
     const auto& conjunct_ctxs_by_slot = _param.conjunct_ctxs_by_slot;
-    const auto& slots = _param.tuple_desc->slots();
     int read_col_idx = 0;
 
     for (auto& column : _param.read_cols) {
@@ -350,8 +349,7 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
         if (conjunct_ctxs_by_slot.find(slot_id) != conjunct_ctxs_by_slot.end()) {
             for (ExprContext* ctx : conjunct_ctxs_by_slot.at(slot_id)) {
                 std::vector<std::string> sub_field_path;
-                if (_try_to_use_dict_filter(column, ctx, sub_field_path,
-                                            slots[column.col_idx_in_chunk]->is_output_column())) {
+                if (_try_to_use_dict_filter(column, ctx, sub_field_path, column.decode_needed)) {
                     _use_as_dict_filter_column(read_col_idx, slot_id, sub_field_path);
                 } else {
                     _left_conjunct_ctxs.emplace_back(ctx);
@@ -374,7 +372,7 @@ void GroupReader::_process_columns_and_conjunct_ctxs() {
 }
 
 bool GroupReader::_try_to_use_dict_filter(const GroupReaderParam::Column& column, ExprContext* ctx,
-                                          std::vector<std::string>& sub_field_path, bool is_output_column) {
+                                          std::vector<std::string>& sub_field_path, bool is_decode_needed) {
     const Expr* root_expr = ctx->root();
     std::vector<std::vector<std::string>> subfields;
     root_expr->get_subfields(&subfields);
@@ -389,7 +387,7 @@ bool GroupReader::_try_to_use_dict_filter(const GroupReaderParam::Column& column
         sub_field_path = subfields[0];
     }
 
-    if (_column_readers[column.slot_id]->try_to_use_dict_filter(ctx, is_output_column, column.slot_id, sub_field_path,
+    if (_column_readers[column.slot_id]->try_to_use_dict_filter(ctx, is_decode_needed, column.slot_id, sub_field_path,
                                                                 0)) {
         return true;
     } else {

--- a/be/src/formats/parquet/group_reader.h
+++ b/be/src/formats/parquet/group_reader.h
@@ -49,6 +49,7 @@ struct GroupReaderParam {
         const TIcebergSchemaField* t_iceberg_schema_field = nullptr;
 
         SlotId slot_id;
+        bool decode_needed;
     };
 
     const TupleDescriptor* tuple_desc = nullptr;
@@ -111,7 +112,7 @@ public:
     void _process_columns_and_conjunct_ctxs();
 
     bool _try_to_use_dict_filter(const GroupReaderParam::Column& column, ExprContext* ctx,
-                                 std::vector<std::string>& sub_field_path, bool is_output_column);
+                                 std::vector<std::string>& sub_field_path, bool is_decode_needed);
 
     void _init_read_chunk();
 

--- a/be/src/formats/parquet/meta_helper.cpp
+++ b/be/src/formats/parquet/meta_helper.cpp
@@ -53,8 +53,9 @@ void ParquetMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContex
         if (field_idx < 0) continue;
 
         auto parquet_type = _file_metadata->schema().get_stored_column_by_field_idx(field_idx)->physical_type;
-        GroupReaderParam::Column column = _build_column(field_idx, materialized_column.col_idx, parquet_type,
-                                                        materialized_column.col_type, materialized_column.slot_id);
+        GroupReaderParam::Column column =
+                _build_column(field_idx, materialized_column.col_idx, parquet_type, materialized_column.col_type,
+                              materialized_column.slot_id, materialized_column.decode_needed);
         read_cols.emplace_back(column);
     }
 }
@@ -122,7 +123,7 @@ void IcebergMetaHelper::prepare_read_columns(const std::vector<HdfsScannerContex
 
         GroupReaderParam::Column column =
                 _build_column(field_idx, materialized_column.col_idx, parquet_type, materialized_column.col_type,
-                              materialized_column.slot_id, iceberg_it->second);
+                              materialized_column.slot_id, materialized_column.decode_needed, iceberg_it->second);
         read_cols.emplace_back(column);
     }
 }

--- a/be/src/formats/parquet/meta_helper.h
+++ b/be/src/formats/parquet/meta_helper.h
@@ -63,6 +63,7 @@ protected:
     GroupReaderParam::Column _build_column(int32_t field_idx_in_parquet, int32_t col_idx_in_chunk,
                                            const tparquet::Type::type& col_type_in_parquet,
                                            const TypeDescriptor& col_type_in_chunk, const SlotId& slot_id,
+                                           bool decode_needed,
                                            const TIcebergSchemaField* t_iceberg_schema_field = nullptr) const {
         GroupReaderParam::Column column{};
         column.field_idx_in_parquet = field_idx_in_parquet;
@@ -71,6 +72,7 @@ protected:
         column.col_type_in_chunk = col_type_in_chunk;
         column.slot_id = slot_id;
         column.t_iceberg_schema_field = t_iceberg_schema_field;
+        column.decode_needed = decode_needed;
         return column;
     }
 

--- a/be/test/formats/parquet/file_reader_test.cpp
+++ b/be/test/formats/parquet/file_reader_test.cpp
@@ -656,6 +656,7 @@ HdfsScannerContext* FileReaderTest::_create_file_struct_in_struct_prune_and_no_o
     (tupleDescriptor->slots())[1] = new_slot;
     ctx->tuple_desc = tupleDescriptor;
     Utils::make_column_info_vector(ctx->tuple_desc, &ctx->materialized_columns);
+    ctx->materialized_columns[1].decode_needed = false;
     ctx->scan_ranges.emplace_back(_create_scan_range(file_path));
 
     return ctx;

--- a/test/sql/test_external_file/R/test_parquet_struct_in_struct
+++ b/test/sql/test_external_file/R/test_parquet_struct_in_struct
@@ -61,6 +61,10 @@ select * from struct_in_struct where c_struct_struct.c_struct.c0 in ('55', '56')
 856	9145	{"c0":"56","c1":"45"}	{"c0":"56","c_struct":{"c0":"56","c1":"45"}}
 956	9045	{"c0":"56","c1":"45"}	{"c0":"56","c_struct":{"c0":"56","c1":"45"}}
 -- !result
+select count(*) from struct_in_struct where c_struct_struct.c_struct.c0 in ('55', '56') and c_struct_struct.c_struct.c0 = c_struct.c0;
+-- result:
+200
+-- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_struct_in_struct/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0

--- a/test/sql/test_external_file/T/test_parquet_struct_in_struct
+++ b/test/sql/test_external_file/T/test_parquet_struct_in_struct
@@ -35,4 +35,7 @@ select * from struct_in_struct where c_struct_struct.c_struct.c0 in ('55', '56')
 
 select * from struct_in_struct where c_struct_struct.c_struct.c0 in ('55', '56') and c_struct.c0 in ('56', '57') and c0 < 1000;
 
+-- filed is not output column but in conjunct of multi-slot, decode is needed
+select count(*) from struct_in_struct where c_struct_struct.c_struct.c0 in ('55', '56') and c_struct_struct.c_struct.c0 = c_struct.c0;
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_parquet_struct_in_struct/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
For Column reader to decide decode or not, when column is not output and not used in multi-slot conjunct (like col_a + col_b > 10); 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
