### PR TITLE
[Feature] Fix the PR 28171 issue of postgreSQL table not being able to be queried.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -73,6 +73,15 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
     }
 
     @Override
+    public Table getTable(long id, String name, List<Column> schema, List<Column> partitionColumns, String dbName,
+                          String catalogName, Map<String, String> properties) throws DdlException {
+        properties.putIfAbsent(JDBCTable.ORIGINAL_DBNAME, dbName);
+        properties.putIfAbsent(JDBCTable.ORIGINAL_TABLENAME, name);
+        return new JDBCTable(id, "\"" + dbName + "\"" + "." + "\"" + name + "\"", schema, partitionColumns,
+                "", catalogName, properties);
+    }
+
+    @Override
     public Type convertColumnType(int dataType, String typeName, int columnSize, int digits) {
         PrimitiveType primitiveType;
         switch (dataType) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
@@ -167,6 +167,7 @@ public class PostgresSchemaResolverTest {
             Table table = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table instanceof JDBCTable);
             Assert.assertEquals("catalog.test.tbl1", table.getUUID());
+            Assert.assertEquals("\"test\".\"tbl1\"", table.getName());
         } catch (Exception e) {
             System.out.println(e.getMessage());
             Assert.fail();


### PR DESCRIPTION
Fixes https://github.com/StarRocks/StarRocksTest/issues/3700

PR 28171 Will cause the postgreSQL table to be unable to be queried，this PR fixes this issue.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
