### PR TITLE
[Enhancement] Compatible with the default partition value of the new hudi version

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakePartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DeltaLakePartitionKey.java
@@ -14,13 +14,17 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
 public class DeltaLakePartitionKey extends PartitionKey implements NullablePartitionKey  {
     public DeltaLakePartitionKey() {
         super();
     }
 
     @Override
-    public String nullPartitionValue() {
-        return DeltaLakeTable.PARTITION_NULL_VALUE;
+    public List<String> nullPartitionValueList() {
+        return ImmutableList.of(DeltaLakeTable.PARTITION_NULL_VALUE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HivePartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HivePartitionKey.java
@@ -15,7 +15,10 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.ImmutableList;
 import com.starrocks.connector.hive.HiveMetaClient;
+
+import java.util.List;
 
 public class HivePartitionKey extends PartitionKey implements NullablePartitionKey {
     public HivePartitionKey() {
@@ -23,7 +26,7 @@ public class HivePartitionKey extends PartitionKey implements NullablePartitionK
     }
 
     @Override
-    public String nullPartitionValue() {
-        return HiveMetaClient.PARTITION_NULL_VALUE;
+    public List<String> nullPartitionValueList() {
+        return ImmutableList.of(HiveMetaClient.PARTITION_NULL_VALUE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiPartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiPartitionKey.java
@@ -15,7 +15,10 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.ImmutableList;
 import com.starrocks.connector.hive.HiveMetaClient;
+
+import java.util.List;
 
 public class HudiPartitionKey extends PartitionKey implements NullablePartitionKey {
     public HudiPartitionKey() {
@@ -23,7 +26,7 @@ public class HudiPartitionKey extends PartitionKey implements NullablePartitionK
     }
 
     @Override
-    public String nullPartitionValue() {
-        return HiveMetaClient.HUDI_PARTITION_NULL_VALUE;
+    public List<String> nullPartitionValueList() {
+        return ImmutableList.of(HiveMetaClient.PARTITION_NULL_VALUE, HiveMetaClient.HUDI_PARTITION_NULL_VALUE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergPartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergPartitionKey.java
@@ -15,7 +15,10 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.ImmutableList;
 import com.starrocks.connector.iceberg.IcebergApiConverter;
+
+import java.util.List;
 
 public class IcebergPartitionKey extends PartitionKey implements NullablePartitionKey {
     public IcebergPartitionKey() {
@@ -23,7 +26,7 @@ public class IcebergPartitionKey extends PartitionKey implements NullablePartiti
     }
 
     @Override
-    public String nullPartitionValue() {
-        return IcebergApiConverter.PARTITION_NULL_VALUE;
+    public List<String> nullPartitionValueList() {
+        return ImmutableList.of(IcebergApiConverter.PARTITION_NULL_VALUE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCPartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCPartitionKey.java
@@ -15,6 +15,9 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 
 public class JDBCPartitionKey extends PartitionKey implements NullablePartitionKey {
     public JDBCPartitionKey() {
@@ -22,7 +25,7 @@ public class JDBCPartitionKey extends PartitionKey implements NullablePartitionK
     }
 
     @Override
-    public String nullPartitionValue() {
-        return JDBCTable.PARTITION_NULL_VALUE;
+    public List<String> nullPartitionValueList() {
+        return ImmutableList.of(JDBCTable.PARTITION_NULL_VALUE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/NullablePartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/NullablePartitionKey.java
@@ -15,8 +15,12 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
 public interface NullablePartitionKey {
-    default String nullPartitionValue() {
-        return "";
+    default List<String> nullPartitionValueList() {
+        return ImmutableList.of("");
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
@@ -64,6 +64,10 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
     private static final Logger LOG = LogManager.getLogger(PartitionKey.class);
     private List<LiteralExpr> keys;
     private List<PrimitiveType> types;
+    // Records the string corresponding to partition value when the partition value is null
+    // for hive, it's __HIVE_DEFAULT_PARTITION__
+    // for hudi， it's __HIVE_DEFAULT_PARTITION__ or default
+    private String nullPartitionValue = "";
 
     private static final DateLiteral SHADOW_DATE_LITERAL = new DateLiteral(0, 0, 0);
     private static final DateLiteral SHADOW_DATETIME_LITERAL = new DateLiteral(0, 0, 0, 0, 0, 0, 0);
@@ -78,6 +82,14 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
     public PartitionKey(List<LiteralExpr> keyValue, List<PrimitiveType> keyType) {
         keys = keyValue;
         types = keyType;
+    }
+
+    public void setNullPartitionValue(String nullPartitionValue) {
+        this.nullPartitionValue = nullPartitionValue;
+    }
+
+    public String getNullPartitionValue() {
+        return nullPartitionValue;
     }
 
     // Factory methods

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -122,7 +122,8 @@ public class PartitionUtil {
             if (rawValue == null) {
                 rawValue = "null";
             }
-            if (((NullablePartitionKey) partitionKey).nullPartitionValue().equals(rawValue)) {
+            if (((NullablePartitionKey) partitionKey).nullPartitionValueList().contains(rawValue)) {
+                partitionKey.setNullPartitionValue(rawValue);
                 exprValue = NullLiteral.create(type);
             } else {
                 exprValue = LiteralExpr.create(rawValue, type);
@@ -191,7 +192,7 @@ public class PartitionUtil {
         List<String> values = new ArrayList<>(literalValues.size());
         for (LiteralExpr value : literalValues) {
             if (value instanceof NullLiteral) {
-                values.add(((NullablePartitionKey) key).nullPartitionValue());
+                values.add(key.getNullPartitionValue());
             } else if (value instanceof BoolLiteral) {
                 BoolLiteral boolValue = ((BoolLiteral) value);
                 values.add(String.valueOf(boolValue.getValue()));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -23,6 +23,7 @@ import com.starrocks.analysis.BoolLiteral;
 import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.PartitionKey;
@@ -35,6 +36,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HiveMetaClient;
 import com.starrocks.connector.hive.HivePartitionName;
+import com.starrocks.connector.iceberg.IcebergApiConverter;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -85,6 +87,20 @@ public class PartitionUtilTest {
         Assert.assertEquals("a", res.get(1));
         Assert.assertEquals("3.0", res.get(2));
         Assert.assertEquals(HiveMetaClient.PARTITION_NULL_VALUE, res.get(3));
+    }
+
+    @Test
+    public void testCreateIcebergPartitionKey() throws AnalysisException {
+        PartitionKey partitionKey = createPartitionKey(
+                Lists.newArrayList("1", "a", "3.0", IcebergApiConverter.PARTITION_NULL_VALUE), partColumns, Table.TableType.ICEBERG);
+        Assert.assertEquals("(\"1\", \"a\", \"3.0\", \"NULL\")", partitionKey.toSql());
+    }
+
+    @Test
+    public void testCreateDeltaLakePartitionKey() throws AnalysisException {
+        PartitionKey partitionKey = createPartitionKey(
+                Lists.newArrayList("1", "a", "3.0", DeltaLakeTable.PARTITION_NULL_VALUE), partColumns, Table.TableType.DELTALAKE);
+        Assert.assertEquals("(\"1\", \"a\", \"3.0\", \"NULL\")", partitionKey.toSql());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector;
 
 import com.google.common.collect.ImmutableList;
@@ -70,7 +69,8 @@ public class PartitionUtilTest {
     @Test
     public void testCreateHudiPartitionKey() throws AnalysisException {
         PartitionKey partitionKey = createPartitionKey(
-                Lists.newArrayList("1", "a", "3.0", HiveMetaClient.HUDI_PARTITION_NULL_VALUE), partColumns, Table.TableType.HUDI);
+                Lists.newArrayList("1", "a", "3.0", HiveMetaClient.HUDI_PARTITION_NULL_VALUE), partColumns,
+                Table.TableType.HUDI);
         Assert.assertEquals("(\"1\", \"a\", \"3.0\", \"NULL\")", partitionKey.toSql());
         List<String> res = PartitionUtil.fromPartitionKey(partitionKey);
         Assert.assertEquals("1", res.get(0));
@@ -78,9 +78,9 @@ public class PartitionUtilTest {
         Assert.assertEquals("3.0", res.get(2));
         Assert.assertEquals(HiveMetaClient.HUDI_PARTITION_NULL_VALUE, res.get(3));
 
-
         partitionKey = createPartitionKey(
-                Lists.newArrayList("1", "a", "3.0", HiveMetaClient.PARTITION_NULL_VALUE), partColumns, Table.TableType.HUDI);
+                Lists.newArrayList("1", "a", "3.0", HiveMetaClient.PARTITION_NULL_VALUE), partColumns,
+                Table.TableType.HUDI);
         Assert.assertEquals("(\"1\", \"a\", \"3.0\", \"NULL\")", partitionKey.toSql());
         res = PartitionUtil.fromPartitionKey(partitionKey);
         Assert.assertEquals("1", res.get(0));
@@ -92,14 +92,16 @@ public class PartitionUtilTest {
     @Test
     public void testCreateIcebergPartitionKey() throws AnalysisException {
         PartitionKey partitionKey = createPartitionKey(
-                Lists.newArrayList("1", "a", "3.0", IcebergApiConverter.PARTITION_NULL_VALUE), partColumns, Table.TableType.ICEBERG);
+                Lists.newArrayList("1", "a", "3.0", IcebergApiConverter.PARTITION_NULL_VALUE), partColumns,
+                Table.TableType.ICEBERG);
         Assert.assertEquals("(\"1\", \"a\", \"3.0\", \"NULL\")", partitionKey.toSql());
     }
 
     @Test
     public void testCreateDeltaLakePartitionKey() throws AnalysisException {
         PartitionKey partitionKey = createPartitionKey(
-                Lists.newArrayList("1", "a", "3.0", DeltaLakeTable.PARTITION_NULL_VALUE), partColumns, Table.TableType.DELTALAKE);
+                Lists.newArrayList("1", "a", "3.0", DeltaLakeTable.PARTITION_NULL_VALUE), partColumns,
+                Table.TableType.DELTALAKE);
         Assert.assertEquals("(\"1\", \"a\", \"3.0\", \"NULL\")", partitionKey.toSql());
     }
 
@@ -131,7 +133,7 @@ public class PartitionUtilTest {
 
     @Test
     public void testToPartitionValues() {
-        String  partitionNames = "a=1/b=2/c=3";
+        String partitionNames = "a=1/b=2/c=3";
         Assert.assertEquals(Lists.newArrayList("1", "2", "3"), toPartitionValues(partitionNames));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -70,6 +70,21 @@ public class PartitionUtilTest {
         PartitionKey partitionKey = createPartitionKey(
                 Lists.newArrayList("1", "a", "3.0", HiveMetaClient.HUDI_PARTITION_NULL_VALUE), partColumns, Table.TableType.HUDI);
         Assert.assertEquals("(\"1\", \"a\", \"3.0\", \"NULL\")", partitionKey.toSql());
+        List<String> res = PartitionUtil.fromPartitionKey(partitionKey);
+        Assert.assertEquals("1", res.get(0));
+        Assert.assertEquals("a", res.get(1));
+        Assert.assertEquals("3.0", res.get(2));
+        Assert.assertEquals(HiveMetaClient.HUDI_PARTITION_NULL_VALUE, res.get(3));
+
+
+        partitionKey = createPartitionKey(
+                Lists.newArrayList("1", "a", "3.0", HiveMetaClient.PARTITION_NULL_VALUE), partColumns, Table.TableType.HUDI);
+        Assert.assertEquals("(\"1\", \"a\", \"3.0\", \"NULL\")", partitionKey.toSql());
+        res = PartitionUtil.fromPartitionKey(partitionKey);
+        Assert.assertEquals("1", res.get(0));
+        Assert.assertEquals("a", res.get(1));
+        Assert.assertEquals("3.0", res.get(2));
+        Assert.assertEquals(HiveMetaClient.PARTITION_NULL_VALUE, res.get(3));
     }
 
     @Test


### PR DESCRIPTION
old hudi version use `default` as null partition value, new hudi version use `__HIVE_DEFAULT_PARTITION__` as partition value

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
