### PR TITLE
[Enhancement] Improve credential mask util

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -60,6 +60,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     // This parameter we don't expose to user, just some people are using docker hosted tabular, it's url may
     // not the "https://api.tabular.io/ws"
     public static final String KEY_ENABLE_TABULAR_SUPPORT = "enable_tabular_support";
+    public static final String KEY_CREDENTIAL_WITH_PREFIX = ICEBERG_CUSTOM_PROPERTIES_PREFIX + "credential";
 
     private final Configuration conf;
     private final RESTCatalog delegate;

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
@@ -54,13 +54,14 @@ public class CredentialUtil {
         // Mask for iceberg rest catalog credential
         doMask(properties, IcebergRESTCatalog.KEY_CREDENTIAL_WITH_PREFIX);
 
-        // Mask for jdbc catalog's password
-        doMask(properties, JDBCResource.PASSWORD);
     }
 
     private static void doMask(Map<String, String> properties, String configKey) {
         // This key is only auxiliary authentication for Azure and does not need to be exposed.
         properties.remove(AzureCloudConfigurationFactory.AZURE_PATH_KEY);
+
+        // Remove for jdbc catalog's password
+        properties.remove(JDBCResource.PASSWORD);
 
         // do mask
         properties.computeIfPresent(configKey, (key, value) -> {

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
@@ -15,6 +15,7 @@
 package com.starrocks.credential;
 
 import com.starrocks.catalog.JDBCResource;
+import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
 import com.starrocks.credential.azure.AzureCloudConfigurationFactory;
 import com.starrocks.credential.azure.AzureStoragePath;
 import org.apache.logging.log4j.LogManager;
@@ -24,12 +25,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 
-public class CloudCredentialUtil {
-    public static final Logger LOG = LogManager.getLogger(CloudCredentialUtil.class);
+public class CredentialUtil {
+    public static final Logger LOG = LogManager.getLogger(CredentialUtil.class);
 
     private static final String MASK_CLOUD_CREDENTIAL_WORDS = "******";
 
-    public static void maskCloudCredential(Map<String, String> properties) {
+    public static void maskCredential(Map<String, String> properties) {
         // Mask for aws's credential
         doMask(properties, CloudConfigurationConstants.AWS_S3_ACCESS_KEY);
         doMask(properties, CloudConfigurationConstants.AWS_S3_SECRET_KEY);
@@ -49,13 +50,17 @@ public class CloudCredentialUtil {
         // Mask for aliyun's credential
         doMask(properties, CloudConfigurationConstants.ALIYUN_OSS_ACCESS_KEY);
         doMask(properties, CloudConfigurationConstants.ALIYUN_OSS_SECRET_KEY);
+
+        // Mask for iceberg rest catalog credential
+        doMask(properties, IcebergRESTCatalog.KEY_CREDENTIAL_WITH_PREFIX);
+
+        // Mask for jdbc catalog's password
+        doMask(properties, JDBCResource.PASSWORD);
     }
 
     private static void doMask(Map<String, String> properties, String configKey) {
         // This key is only auxiliary authentication for Azure and does not need to be exposed.
         properties.remove(AzureCloudConfigurationFactory.AZURE_PATH_KEY);
-        // Remove password of jdbc catalog
-        properties.remove(JDBCResource.PASSWORD);
 
         // do mask
         properties.computeIfPresent(configKey, (key, value) -> {

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
@@ -53,7 +53,6 @@ public class CredentialUtil {
 
         // Mask for iceberg rest catalog credential
         doMask(properties, IcebergRESTCatalog.KEY_CREDENTIAL_WITH_PREFIX);
-
     }
 
     private static void doMask(Map<String, String> properties, String configKey) {

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfigurationFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfigurationFactory.java
@@ -17,7 +17,7 @@ package com.starrocks.credential.azure;
 import com.google.common.base.Preconditions;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
-import com.starrocks.credential.CloudCredentialUtil;
+import com.starrocks.credential.CredentialUtil;
 
 import java.util.Map;
 
@@ -104,6 +104,6 @@ public class AzureCloudConfigurationFactory extends CloudConfigurationFactory {
         if (path == null) {
             return new AzureStoragePath("", "");
         }
-        return CloudCredentialUtil.parseAzureStoragePath(path);
+        return CredentialUtil.parseAzureStoragePath(path);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -100,7 +100,7 @@ import com.starrocks.common.util.OrderByPair;
 import com.starrocks.common.util.PrintableMap;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.credential.CloudCredentialUtil;
+import com.starrocks.credential.CredentialUtil;
 import com.starrocks.load.DeleteMgr;
 import com.starrocks.load.ExportJob;
 import com.starrocks.load.ExportMgr;
@@ -2731,7 +2731,7 @@ public class ShowExecutor {
             createCatalogSql.append("comment \"").append(catalog.getDisplayComment()).append("\"\n");
         }
         Map<String, String> clonedConfig = new HashMap<>(catalog.getConfig());
-        CloudCredentialUtil.maskCloudCredential(clonedConfig);
+        CredentialUtil.maskCredential(clonedConfig);
         // Properties
         createCatalogSql.append("PROPERTIES (")
                 .append(new PrintableMap<>(clonedConfig, " = ", true, true))

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -141,7 +141,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.ConnectorTableMetadataProcessor;
 import com.starrocks.connector.hive.events.MetastoreEventsProcessor;
 import com.starrocks.consistency.ConsistencyChecker;
-import com.starrocks.credential.CloudCredentialUtil;
+import com.starrocks.credential.CredentialUtil;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.ha.HAProtocol;
 import com.starrocks.ha.LeaderInfo;
@@ -2882,7 +2882,7 @@ public class GlobalStateMgr {
         } else if (table.getType() == TableType.FILE) {
             FileTable fileTable = (FileTable) table;
             Map<String, String> clonedFileProperties = new HashMap<>(fileTable.getFileProperties());
-            CloudCredentialUtil.maskCloudCredential(clonedFileProperties);
+            CredentialUtil.maskCredential(clonedFileProperties);
             addTableComment(sb, table);
 
             sb.append("\nPROPERTIES (\n");

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
@@ -64,7 +64,7 @@ public class CredentialUtilTest {
         Map<String, String> properties = new HashMap<>();
         properties.put(JDBCResource.PASSWORD, "7758258");
         CredentialUtil.maskCredential(properties);
-        Assert.assertEquals("77******58", properties.get(JDBCResource.PASSWORD));
+        Assert.assertFalse(properties.containsKey(JDBCResource.PASSWORD));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.credential;
 
+import com.starrocks.catalog.JDBCResource;
+import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
 import com.starrocks.credential.azure.AzureCloudConfigurationFactory;
 import com.starrocks.credential.azure.AzureStoragePath;
 import org.junit.Assert;
@@ -22,57 +24,73 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-public class CloudCredentialUtilTest {
+public class CredentialUtilTest {
     @Test
-    public void testMaskCloudCredential() {
+    public void testMaskCredential() {
         Map<String, String> properties = new HashMap<>();
         String key = CloudConfigurationConstants.AWS_S3_SECRET_KEY;
 
         properties.put(key, "");
-        CloudCredentialUtil.maskCloudCredential(properties);
+        CredentialUtil.maskCredential(properties);
         Assert.assertEquals("******", properties.get(key));
 
         properties.put(key, "he");
-        CloudCredentialUtil.maskCloudCredential(properties);
+        CredentialUtil.maskCredential(properties);
         Assert.assertEquals("******", properties.get(key));
 
         properties.put(key, "hehe");
-        CloudCredentialUtil.maskCloudCredential(properties);
+        CredentialUtil.maskCredential(properties);
         Assert.assertEquals("******", properties.get(key));
 
         properties.put(key, "heheh");
-        CloudCredentialUtil.maskCloudCredential(properties);
+        CredentialUtil.maskCredential(properties);
         Assert.assertEquals("he******eh", properties.get(key));
 
         properties.put(AzureCloudConfigurationFactory.AZURE_PATH_KEY, "path");
-        CloudCredentialUtil.maskCloudCredential(properties);
+        CredentialUtil.maskCredential(properties);
         Assert.assertFalse(properties.containsKey(AzureCloudConfigurationFactory.AZURE_PATH_KEY));
+    }
+
+    @Test
+    public void testMaskIcebergRestCatalogCredential() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(IcebergRESTCatalog.KEY_CREDENTIAL_WITH_PREFIX, "7758258");
+        CredentialUtil.maskCredential(properties);
+        Assert.assertEquals("77******58", properties.get(IcebergRESTCatalog.KEY_CREDENTIAL_WITH_PREFIX));
+    }
+
+    @Test
+    public void testMaskJDBCCatalogPassword() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JDBCResource.PASSWORD, "7758258");
+        CredentialUtil.maskCredential(properties);
+        Assert.assertEquals("77******58", properties.get(JDBCResource.PASSWORD));
     }
 
     @Test
     public void testAzurePathParseWithABFS() {
         String uri = "abfs://bottle@smith.dfs.core.windows.net/path/1/2";
-        AzureStoragePath path = CloudCredentialUtil.parseAzureStoragePath(uri);
+        AzureStoragePath path = CredentialUtil.parseAzureStoragePath(uri);
         Assert.assertEquals(path.getContainer(), "bottle");
         Assert.assertEquals(path.getStorageAccount(), "smith");
 
         uri = "abfss://bottle@smith.dfs.core.windows.net/path/1/2";
-        path = CloudCredentialUtil.parseAzureStoragePath(uri);
+        path = CredentialUtil.parseAzureStoragePath(uri);
         Assert.assertEquals("bottle", path.getContainer());
         Assert.assertEquals("smith", path.getStorageAccount());
 
         uri = "abfs://a@.dfs.core.windows.net/path/1/2";
-        path = CloudCredentialUtil.parseAzureStoragePath(uri);
+        path = CredentialUtil.parseAzureStoragePath(uri);
         Assert.assertEquals("", path.getContainer());
         Assert.assertEquals("", path.getStorageAccount());
 
         uri = "abfs://a@p/path/1/2";
-        path = CloudCredentialUtil.parseAzureStoragePath(uri);
+        path = CredentialUtil.parseAzureStoragePath(uri);
         Assert.assertEquals("", path.getContainer());
         Assert.assertEquals("", path.getStorageAccount());
 
         uri = "";
-        path = CloudCredentialUtil.parseAzureStoragePath(uri);
+        path = CredentialUtil.parseAzureStoragePath(uri);
         Assert.assertEquals("", path.getContainer());
         Assert.assertEquals("", path.getStorageAccount());
     }
@@ -80,22 +98,22 @@ public class CloudCredentialUtilTest {
     @Test
     public void testAzurePathParseWithWASB() {
         String uri = "wasb://bottle@smith.blob.core.windows.net/path/1/2";
-        AzureStoragePath path = CloudCredentialUtil.parseAzureStoragePath(uri);
+        AzureStoragePath path = CredentialUtil.parseAzureStoragePath(uri);
         Assert.assertEquals(path.getContainer(), "bottle");
         Assert.assertEquals(path.getStorageAccount(), "smith");
 
         uri = "wasbs://bottle@smith.blob.core.windows.net/path/1/2";
-        path = CloudCredentialUtil.parseAzureStoragePath(uri);
+        path = CredentialUtil.parseAzureStoragePath(uri);
         Assert.assertEquals("bottle", path.getContainer());
         Assert.assertEquals("smith", path.getStorageAccount());
 
         uri = "wasb://a@.blob.core.windows.net/path/1/2";
-        path = CloudCredentialUtil.parseAzureStoragePath(uri);
+        path = CredentialUtil.parseAzureStoragePath(uri);
         Assert.assertEquals("", path.getContainer());
         Assert.assertEquals("", path.getStorageAccount());
 
         uri = "wasb://a@p/path/1/2";
-        path = CloudCredentialUtil.parseAzureStoragePath(uri);
+        path = CredentialUtil.parseAzureStoragePath(uri);
         Assert.assertEquals("", path.getContainer());
         Assert.assertEquals("", path.getStorageAccount());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -1225,6 +1225,7 @@ public class ShowExecutorTest {
 
     @Test
     public void testShowCreateExternalCatalogWithMask() throws AnalysisException, DdlException {
+        // More mask logic please write in CloudCredentialUtilTest
         new MockUp<CatalogMgr>() {
             @Mock
             public Catalog getCatalogByName(String name) {
@@ -1233,7 +1234,6 @@ public class ShowExecutorTest {
                 properties.put("type", "hive");
                 properties.put("aws.s3.access_key", "iam_user_access_key");
                 properties.put("aws.s3.secret_key", "iam_user_secret_key");
-                properties.put("password", "password");
                 return new Catalog(1, "test_hive", properties, "hive_test");
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -1225,7 +1225,7 @@ public class ShowExecutorTest {
 
     @Test
     public void testShowCreateExternalCatalogWithMask() throws AnalysisException, DdlException {
-        // More mask logic please write in CloudCredentialUtilTest
+        // More mask logic please write in CredentialUtilTest
         new MockUp<CatalogMgr>() {
             @Mock
             public Catalog getCatalogByName(String name) {


### PR DESCRIPTION
Rename CloudCredentialUtil => CredentialUtil, because it's not only used by CloudCredential anymore.
Add mask for tabular rest catalog credential

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
