### PR TITLE
[BugFix] fix clound native primary key table file gc

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -38,7 +38,9 @@ static std::string delvec_cache_key(int64_t tablet_id, const DelvecPagePB& page)
 }
 
 MetaFileBuilder::MetaFileBuilder(Tablet tablet, std::shared_ptr<TabletMetadata> metadata)
-        : _tablet(tablet), _tablet_meta(std::move(metadata)), _update_mgr(_tablet.update_mgr()) {}
+        : _tablet(tablet), _tablet_meta(std::move(metadata)), _update_mgr(_tablet.update_mgr()) {
+    _trash_files = std::make_shared<std::vector<std::string>>();
+}
 
 void MetaFileBuilder::append_delvec(const DelVectorPtr& delvec, uint32_t segment_id) {
     if (delvec->cardinality() > 0) {
@@ -54,19 +56,26 @@ void MetaFileBuilder::append_delvec(const DelVectorPtr& delvec, uint32_t segment
     }
 }
 
-void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write) {
+void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::vector<std::string>& orphan_files) {
     auto rowset = _tablet_meta->add_rowsets();
     rowset->CopyFrom(op_write.rowset());
     rowset->set_id(_tablet_meta->next_rowset_id());
     // if rowset don't contain segment files, still inc next_rowset_id
     _tablet_meta->set_next_rowset_id(_tablet_meta->next_rowset_id() + std::max(1, rowset->segments_size()));
+    // collect trash files
+    for (const auto& orphan_file : orphan_files) {
+        _trash_files->push_back(orphan_file);
+    }
+    for (const auto& del_file : op_write.dels()) {
+        _trash_files->push_back(del_file);
+    }
     _has_update_index = true;
 }
 
 void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction) {
     // delete input rowsets
     std::stringstream del_range_ss;
-    std::vector<std::pair<uint32_t, uint32_t> > delete_delvec_sid_range;
+    std::vector<std::pair<uint32_t, uint32_t>> delete_delvec_sid_range;
     struct Finder {
         uint32_t id;
         bool operator()(const uint32_t rowid) const { return rowid == id; }

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -38,7 +38,7 @@ public:
     // append delvec to builder's buffer
     void append_delvec(const DelVectorPtr& delvec, uint32_t segment_id);
     // handle txn log
-    void apply_opwrite(const TxnLogPB_OpWrite& op_write);
+    void apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::vector<std::string>& orphan_files);
     void apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction);
     // finalize will generate and sync final meta state to storage.
     // |txn_id| the maximum applied transaction ID, used to construct the delvec file name, and
@@ -50,6 +50,8 @@ public:
     // when apply or finalize fail, need to clear primary index cache
     void handle_failure();
     bool has_update_index() const { return _has_update_index; }
+    // collect files that need to removed
+    std::shared_ptr<std::vector<std::string>> trash_files() { return _trash_files; }
 
 private:
     // update delvec in tablet meta
@@ -71,6 +73,8 @@ private:
     std::unordered_map<uint32_t, DelVectorPtr> _segmentid_to_delvec;
     // from cache key to segment id
     std::unordered_map<std::string, uint32_t> _cache_key_to_segment_id;
+    // ready to be removed
+    std::shared_ptr<std::vector<std::string>> _trash_files;
 };
 
 class MetaFileReader {

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -448,7 +448,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(const TxnLogPB_OpWrite&
 }
 
 Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata,
-                                          Tablet* tablet) {
+                                          Tablet* tablet, std::vector<std::string>* orphan_files) {
     // const_cast for paritial update to rewrite segment file in op_write
     RowsetMetadata* rowset_meta = const_cast<TxnLogPB_OpWrite*>(&op_write)->mutable_rowset();
     auto root_path = tablet->metadata_root_location();
@@ -509,6 +509,8 @@ Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, cons
     // rename segment file
     for (int i = 0; i < rowset_meta->segments_size(); i++) {
         if (need_rename[i]) {
+            // after rename, add old segment to orphan files, for gc later.
+            orphan_files->push_back(rowset_meta->segments(i));
             rowset_meta->set_segments(i, op_write.rewrite_segments(i));
         }
     }

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -60,7 +60,8 @@ public:
     Status load(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, int64_t base_version, Tablet* tablet,
                 const MetaFileBuilder* builder, bool need_check_conflict);
 
-    Status rewrite_segment(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet);
+    Status rewrite_segment(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet,
+                           std::vector<std::string>* orphan_files);
 
     const std::vector<ColumnUniquePtr>& upserts() const { return _upserts; }
     const std::vector<ColumnUniquePtr>& deletes() const { return _deletes; }

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -105,6 +105,8 @@ public:
 
     [[nodiscard]] Status delete_segment(int64_t tablet_id, std::string_view segment_name);
 
+    [[nodiscard]] Status delete_del(int64_t tablet_id, std::string_view del_name);
+
     // Transform a txn log into versioned txn log(i.e., rename `{tablet_id}_{txn_id}.log` to `{tablet_id}_{log_version}.vlog`)
     [[nodiscard]] Status publish_log_version(int64_t tablet_id, int64_t txn_id, int64 log_version);
 

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -84,6 +84,8 @@ public:
 
     Status finish() override { return _builder.finalize(_max_txn_id); }
 
+    std::shared_ptr<std::vector<std::string>> trash_files() override { return _builder.trash_files(); }
+
 private:
     Status apply_write_log(const TxnLogPB_OpWrite& op_write, int64_t txn_id) {
         if (op_write.dels_size() == 0 && op_write.rowset().num_rows() == 0 &&
@@ -163,6 +165,8 @@ public:
         _metadata->set_version(_new_version);
         return _tablet.put_metadata(_metadata);
     }
+
+    std::shared_ptr<std::vector<std::string>> trash_files() override { return nullptr; }
 
 private:
     Status apply_write_log(const TxnLogPB_OpWrite& op_write) {

--- a/be/src/storage/lake/txn_log_applier.h
+++ b/be/src/storage/lake/txn_log_applier.h
@@ -35,6 +35,8 @@ public:
     virtual Status apply(const TxnLogPB& tnx_log) = 0;
 
     virtual Status finish() = 0;
+
+    virtual std::shared_ptr<std::vector<std::string>> trash_files() = 0;
 };
 
 std::unique_ptr<TxnLogApplier> new_txn_log_applier(Tablet tablet, TabletMetadataPtr metadata, int64_t new_version);

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -79,7 +79,8 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     RETURN_IF_ERROR(state.load(op_write, metadata, base_version, tablet, builder, true));
     _update_state_cache.update_object_size(state_entry, state.memory_usage());
     // 3. rewrite segment file if it is partial update
-    RETURN_IF_ERROR(state.rewrite_segment(op_write, metadata, tablet));
+    std::vector<std::string> orphan_files;
+    RETURN_IF_ERROR(state.rewrite_segment(op_write, metadata, tablet, &orphan_files));
     PrimaryIndex::DeletesMap new_deletes;
     for (uint32_t i = 0; i < op_write.rowset().segments_size(); i++) {
         new_deletes[rowset_id + i] = {};
@@ -152,7 +153,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     for (auto&& each : new_del_vecs) {
         builder->append_delvec(each.second, each.first);
     }
-    builder->apply_opwrite(op_write);
+    builder->apply_opwrite(op_write, orphan_files);
 
     TRACE_COUNTER_INCREMENT("rowsetid", rowset_id);
     TRACE_COUNTER_INCREMENT("#upserts", upserts.size());


### PR DESCRIPTION
In current implementation, we don't do data file gc by tabletMeta reference any more, so we need to remove `.del` and rewrite segment file after transaction publish finish.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
