### PR TITLE
[BugFix] Add enable_materialized_view_rewrite_greedy_mode param to control fast withdraw for mv rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -285,7 +285,7 @@ public class AlterJobMgr {
             materializedView.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMap();
             GlobalStateMgr.getCurrentState().updateBaseTableRelatedMv(materializedView.getDbId(),
                     materializedView, baseTableInfos);
-            materializedView.setActive(true);
+            materializedView.setActive();
         } else if (AlterMaterializedViewStatusClause.INACTIVE.equalsIgnoreCase(status)) {
             materializedView.setInactiveAndReason("user use alter materialized view set status to inactive");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -421,9 +421,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         }
     }
 
-    // context used in mv rewrite
-    // just in memory now
-    // there are only reads after first-time write
+    // Materialized view plan cache used for mv rewrite, it is kept in memory for now.
+    // NOTE: Invalidate this when the materialized view is activated again.
+    // TODO: Add more policies to valid/invalidate this:
+    //  - When session variables changed
+    //  - When executes multi times.
     private MVRewriteContextCache mvRewriteContextCache;
 
     public MaterializedView() {
@@ -492,9 +494,13 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return active;
     }
 
-    public void setActive(boolean active) {
-        this.active = active;
-        this.inactiveReason = null;
+    /**
+     * active the materialized again & reload the state.
+     */
+    public void setActive() {
+        // reset mv rewrite cache when it is active again
+        this.mvRewriteContextCache = null;
+        this.active = true;
     }
 
     public void setInactiveAndReason(String reason) {
@@ -863,7 +869,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             boolean desiredActive = active;
             active = false;
             boolean reloadActive = onReloadImpl();
-            setActive(desiredActive && reloadActive);
+            if (desiredActive && reloadActive) {
+                setActive();
+            }
         } catch (Throwable e) {
             LOG.error("reload mv failed: {}", this, e);
             setInactiveAndReason("reload failed: " + e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -300,9 +300,11 @@ public class Log4jConfig extends XmlConfiguration {
         strSub = new StrSubstitutor(new Interpolator(properties));
         newXmlConfTemplate = strSub.replace(newXmlConfTemplate);
 
-        System.out.println("=====");
-        System.out.println(newXmlConfTemplate);
-        System.out.println("=====");
+        if (!FeConstants.runningUnitTest && !FeConstants.isReplayFromQueryDump) {
+            System.out.println("=====");
+            System.out.println(newXmlConfTemplate);
+            System.out.println("=====");
+        }
 
         // new SimpleLog4jConfiguration with xmlConfTemplate
         ByteArrayInputStream bis = new ByteArrayInputStream(newXmlConfTemplate.getBytes("UTF-8"));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -410,8 +410,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ANALYZE_FOR_MV = "analyze_mv";
     public static final String QUERY_EXCLUDING_MV_NAMES = "query_excluding_mv_names";
     public static final String QUERY_INCLUDING_MV_NAMES = "query_including_mv_names";
-    public static final String ENABLE_MATERIALIZED_VIEW_REWRITE_FAST_WITHDRAW =
-            "enable_materialized_view_rewrite_fast_withdraw";
+    public static final String ENABLE_MATERIALIZED_VIEW_REWRITE_GREEDY_MODE =
+            "enable_materialized_view_rewrite_greedy_mode";
 
     public static final String ENABLE_BIG_QUERY_LOG = "enable_big_query_log";
     public static final String BIG_QUERY_LOG_CPU_SECOND_THRESHOLD = "big_query_log_cpu_second_threshold";
@@ -1132,9 +1132,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_SINGLE_TABLE_VIEW_DELTA_REWRITE, flag = VariableMgr.INVISIBLE)
     private boolean enableMaterializedViewSingleTableViewDeltaRewrite = false;
 
-    // Enable fast withdraw rewrite to cut down optimizer time for mv rewrite.
-    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_REWRITE_FAST_WITHDRAW)
-    private boolean enableMaterializedViewRewriteFastWithDraw = true;
+    // Enable greedy mode in mv rewrite to cut down optimizer time for mv rewrite:
+    // - Use plan cache if possible to avoid regenerating plan tree.
+    // - Use the max plan tree to rewrite in view-delta mode to avoid too many rewrites.
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_REWRITE_GREEDY_MODE)
+    private boolean enableMaterializedViewRewriteGreedyMode = true;
 
     @VarAttr(name = QUERY_EXCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
     private String queryExcludingMVNames = "";
@@ -2209,12 +2211,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableMaterializedViewSingleTableViewDeltaRewrite = enableMaterializedViewSingleTableViewDeltaRewrite;
     }
 
-    public void setEnableMaterializedViewRewriteFastWithDraw(boolean enableMaterializedViewRewriteFastWithDraw) {
-        this.enableMaterializedViewRewriteFastWithDraw = enableMaterializedViewRewriteFastWithDraw;
+    public void setEnableMaterializedViewRewriteGreedyMode(boolean enableMaterializedViewRewriteGreedyMode) {
+        this.enableMaterializedViewRewriteGreedyMode = enableMaterializedViewRewriteGreedyMode;
     }
 
-    public boolean isEnableMaterializedViewRewriteFastWithDraw() {
-        return this.enableMaterializedViewRewriteFastWithDraw;
+    public boolean isEnableMaterializedViewRewriteGreedyMode() {
+        return this.enableMaterializedViewRewriteGreedyMode;
     }
 
     public String getQueryExcludingMVNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1136,7 +1136,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // - Use plan cache if possible to avoid regenerating plan tree.
     // - Use the max plan tree to rewrite in view-delta mode to avoid too many rewrites.
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_REWRITE_GREEDY_MODE)
-    private boolean enableMaterializedViewRewriteGreedyMode = true;
+    private boolean enableMaterializedViewRewriteGreedyMode = false;
 
     @VarAttr(name = QUERY_EXCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
     private String queryExcludingMVNames = "";

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -410,6 +410,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ANALYZE_FOR_MV = "analyze_mv";
     public static final String QUERY_EXCLUDING_MV_NAMES = "query_excluding_mv_names";
     public static final String QUERY_INCLUDING_MV_NAMES = "query_including_mv_names";
+    public static final String ENABLE_MATERIALIZED_VIEW_REWRITE_FAST_WITHDRAW =
+            "enable_materialized_view_rewrite_fast_withdraw";
 
     public static final String ENABLE_BIG_QUERY_LOG = "enable_big_query_log";
     public static final String BIG_QUERY_LOG_CPU_SECOND_THRESHOLD = "big_query_log_cpu_second_threshold";
@@ -1129,6 +1131,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     //      try to rewrite by single table mvs and is determined by rule rather than by cost.
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_SINGLE_TABLE_VIEW_DELTA_REWRITE, flag = VariableMgr.INVISIBLE)
     private boolean enableMaterializedViewSingleTableViewDeltaRewrite = false;
+
+    // Enable fast withdraw rewrite to cut down optimizer time for mv rewrite.
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_REWRITE_FAST_WITHDRAW)
+    private boolean enableMaterializedViewRewriteFastWithDraw = true;
 
     @VarAttr(name = QUERY_EXCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
     private String queryExcludingMVNames = "";
@@ -2201,6 +2207,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setEnableMaterializedViewSingleTableViewDeltaRewrite(
             boolean enableMaterializedViewSingleTableViewDeltaRewrite) {
         this.enableMaterializedViewSingleTableViewDeltaRewrite = enableMaterializedViewSingleTableViewDeltaRewrite;
+    }
+
+    public void setEnableMaterializedViewRewriteFastWithDraw(boolean enableMaterializedViewRewriteFastWithDraw) {
+        this.enableMaterializedViewRewriteFastWithDraw = enableMaterializedViewRewriteFastWithDraw;
+    }
+
+    public boolean isEnableMaterializedViewRewriteFastWithDraw() {
+        return this.enableMaterializedViewRewriteFastWithDraw;
     }
 
     public String getQueryExcludingMVNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -218,7 +218,8 @@ public class MvRewritePreprocessor {
         }
 
         MaterializedView.MVRewriteContextCache mvRewriteContextCache = mv.getPlanContext();
-        if (mvRewriteContextCache == null) {
+        if (!connectContext.getSessionVariable().isEnableMaterializedViewRewriteFastWithDraw() ||
+                mvRewriteContextCache == null) {
             // build mv query logical plan
             MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();
             // optimize the sql by rule and disable rule based materialized view rewrite
@@ -235,9 +236,19 @@ public class MvRewritePreprocessor {
             mvRewriteContextCache = mvOptimizer.optimize(mv, connectContext, optimizerConfig);
             mv.setPlanContext(mvRewriteContextCache);
         }
+        if (mvRewriteContextCache == null) {
+            logMVPrepare(connectContext, mv, "[SYNC={}] MV plan is not valid: {}, cannot generate plan for rewrite",
+                        isSyncMV, mv.getName());
+            return;
+        }
         if (!mvRewriteContextCache.isValidMvPlan()) {
-            logMVPrepare(connectContext, mv, "[SYNC={}] MV plan is not valid: {}, plan:\n {}",
-                    isSyncMV, mv.getName(), mvRewriteContextCache.getLogicalPlan().explain());
+            if (mvRewriteContextCache.getLogicalPlan() != null) {
+                logMVPrepare(connectContext, mv, "[SYNC={}] MV plan is not valid: {}, plan:\n {}",
+                        isSyncMV, mv.getName(), mvRewriteContextCache.getLogicalPlan().explain());
+            } else {
+                logMVPrepare(connectContext, mv, "[SYNC={}] MV plan is not valid: {}",
+                        isSyncMV, mv.getName());
+            }
             return;
         }
 
@@ -268,7 +279,10 @@ public class MvRewritePreprocessor {
             return;
         }
 
+        Preconditions.checkState(mvRewriteContextCache != null);
         OptExpression mvPlan = mvRewriteContextCache.getLogicalPlan();
+        Preconditions.checkState(mvPlan != null);
+
         ScalarOperator mvPartialPartitionPredicates = null;
         if (mv.getPartitionInfo() instanceof ExpressionRangePartitionInfo && !partitionNamesToRefresh.isEmpty()) {
             // when mv is partitioned and there are some refreshed partitions,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -218,7 +218,7 @@ public class MvRewritePreprocessor {
         }
 
         MaterializedView.MVRewriteContextCache mvRewriteContextCache = mv.getPlanContext();
-        if (!connectContext.getSessionVariable().isEnableMaterializedViewRewriteFastWithDraw() ||
+        if (!connectContext.getSessionVariable().isEnableMaterializedViewRewriteGreedyMode() ||
                 mvRewriteContextCache == null) {
             // build mv query logical plan
             MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -218,7 +218,7 @@ public class MvRewritePreprocessor {
         }
 
         MaterializedView.MVRewriteContextCache mvRewriteContextCache = mv.getPlanContext();
-        if (!connectContext.getSessionVariable().isEnableMaterializedViewRewriteGreedyMode() ||
+        if (connectContext.getSessionVariable().isEnableMaterializedViewRewriteGreedyMode() ||
                 mvRewriteContextCache == null) {
             // build mv query logical plan
             MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
@@ -44,6 +44,22 @@ import java.util.stream.Collectors;
 import static com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil.findArithmeticFunction;
 
 public class MvNormalizePredicateRule extends NormalizePredicateRule {
+    // Comparator to normalize predicates, only use scalar operators' string to compare.
+    private static final Comparator<ScalarOperator> SCALAR_OPERATOR_COMPARATOR = new Comparator<ScalarOperator>() {
+        @Override
+        public int compare(ScalarOperator o1, ScalarOperator o2) {
+            if (o1 == null && o2 == null) {
+                return 0;
+            } else if (o1 == null) {
+                return -1;
+            } else if (o2 == null) {
+                return 1;
+            } else {
+                return o1.toString().compareTo(o2.toString());
+            }
+        }
+    };
+
     // Normalize Binary Predicate
     // for integer type:
     // a < 3 => a <= 2
@@ -54,17 +70,17 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
     @Override
     public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator predicate,
                                                ScalarOperatorRewriteContext context) {
-        ScalarOperator tmp = super.visitBinaryPredicate(predicate, context);
-        Preconditions.checkState(tmp instanceof BinaryPredicateOperator);
-        BinaryPredicateOperator binary = (BinaryPredicateOperator) tmp;
+        ScalarOperator binaryPredicate = super.visitBinaryPredicate(predicate, context);
+        Preconditions.checkState(binaryPredicate instanceof BinaryPredicateOperator);
+        BinaryPredicateOperator binary = (BinaryPredicateOperator) binaryPredicate;
         if (binary.getChild(0).isVariable() && binary.getChild(1).isConstantRef()) {
             ConstantOperator constantOperator = (ConstantOperator) binary.getChild(1);
             if (!constantOperator.getType().isIntegerType()) {
-                return tmp;
+                return binaryPredicate;
             }
             ConstantOperator one = createConstantIntegerOne(constantOperator.getType());
             if (one == null) {
-                return tmp;
+                return binaryPredicate;
             }
             Type[] argsType = {constantOperator.getType(), constantOperator.getType()};
             switch (binary.getBinaryType()) {
@@ -93,8 +109,17 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
                 default:
                     break;
             }
+        } else {
+            // Normalize left and right, eg: `a < b` should be the same with `b > a`.
+            ScalarOperator l = binary.getChild(0);
+            ScalarOperator r = binary.getChild(1);
+            if (SCALAR_OPERATOR_COMPARATOR.compare(l, r) > 0) {
+                return binary.commutative();
+            } else {
+                return binaryPredicate;
+            }
         }
-        return tmp;
+        return binaryPredicate;
     }
 
     // should maintain sequence for case:
@@ -103,9 +128,7 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
     @Override
     public ScalarOperator visitCompoundPredicate(CompoundPredicateOperator predicate,
                                                  ScalarOperatorRewriteContext context) {
-        Comparator<ScalarOperator> byToString =
-                (ScalarOperator o1, ScalarOperator o2) -> o1.toString().compareTo(o2.toString());
-        Set<ScalarOperator> after = Sets.newTreeSet(byToString);
+        Set<ScalarOperator> after = Sets.newTreeSet(SCALAR_OPERATOR_COMPARATOR);
         if (predicate.isAnd()) {
             List<ScalarOperator> before = Utils.extractConjuncts(predicate);
             after.addAll(before);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
@@ -109,15 +109,6 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
                 default:
                     break;
             }
-        } else {
-            // Normalize left and right, eg: `a < b` should be the same with `b > a`.
-            ScalarOperator l = binary.getChild(0);
-            ScalarOperator r = binary.getChild(1);
-            if (SCALAR_OPERATOR_COMPARATOR.compare(l, r) > 0) {
-                return binary.commutative();
-            } else {
-                return binaryPredicate;
-            }
         }
         return binaryPredicate;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -149,7 +149,7 @@ public class MaterializedViewRewriter {
             // MV : A JOIN B JOIN C
             // To fast rewrite, only need to check `A JOIN B JOIN C` pattern rather than
             // `A JOIN B JOIN C JOIN D`.
-            if (optimizerContext.getSessionVariable().isEnableMaterializedViewRewriteGreedyMode()) {
+            if (!optimizerContext.getSessionVariable().isEnableMaterializedViewRewriteGreedyMode()) {
                 for (OptExpression child : queryExpression.getInputs()) {
                     final List<Table> childTables = MvUtils.getAllTables(child);
                     if (Sets.newHashSet(childTables).contains(mvTables)) {
@@ -185,7 +185,7 @@ public class MaterializedViewRewriter {
             // To avoid join reorder producing plan bomb, record query's max tables to be only matched.
             // But if query contains non inner/left outer joins which cannot be used to view delta join,
             // not use `intersectingTables` anymore.
-            if (optimizerContext.getSessionVariable().isEnableMaterializedViewRewriteGreedyMode() &&
+            if (!optimizerContext.getSessionVariable().isEnableMaterializedViewRewriteGreedyMode() &&
                     !queryTables.containsAll(materializationContext.getIntersectingTables())) {
                 return false;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -145,6 +145,19 @@ public class MaterializedViewRewriter {
         // because optimizer will match MV's pattern which is subset of query opt tree
         // from top-down iteration.
         if (matchMode == MatchMode.COMPLETE) {
+            // Q  : A JOIN B JOIN C JOIN D
+            // MV : A JOIN B JOIN C
+            // To fast rewrite, only need to check `A JOIN B JOIN C` pattern rather than
+            // `A JOIN B JOIN C JOIN D`.
+            if (optimizerContext.getSessionVariable().isEnableMaterializedViewRewriteFastWithDraw()) {
+                for (OptExpression child : queryExpression.getInputs()) {
+                    final List<Table> childTables = MvUtils.getAllTables(child);
+                    if (Sets.newHashSet(childTables).contains(mvTables)) {
+                        return false;
+                    }
+                }
+            }
+
             // If all join types are inner/cross, no need check join orders: eg a inner join b or b inner join a.
             boolean isQueryAllEqualInnerJoin = MvUtils.isAllEqualInnerOrCrossJoin(queryExpression);
             boolean isMVAllEqualInnerJoin = MvUtils.isAllEqualInnerOrCrossJoin(mvExpression);
@@ -169,15 +182,20 @@ public class MaterializedViewRewriter {
                 return false;
             }
             // only consider query with most common tables to optimize performance
-            if (!queryTables.containsAll(materializationContext.getIntersectingTables())) {
+            // To avoid join reorder producing plan bomb, record query's max tables to be only matched.
+            // But if query contains non inner/left outer joins which cannot be used to view delta join,
+            // not use `intersectingTables` anymore.
+            if (optimizerContext.getSessionVariable().isEnableMaterializedViewRewriteFastWithDraw() &&
+                    !queryTables.containsAll(materializationContext.getIntersectingTables())) {
                 return false;
             }
-            if (!MvUtils.getAllJoinOperators(queryExpression).stream().allMatch(joinOperator ->
-                    joinOperator.isLeftOuterJoin() || joinOperator.isInnerJoin())) {
+
+            if (!MvUtils.isSupportViewDelta(queryExpression)) {
                 logMVRewrite(mvRewriteContext, "MV is not applicable in view delta mode: " +
                         "only support inner/left outer join type for now");
                 return false;
             }
+
             List<TableScanDesc> queryTableScanDescs = MvUtils.getTableScanDescs(queryExpression);
             List<TableScanDesc> mvTableScanDescs = MvUtils.getTableScanDescs(mvExpression);
             // there should be at least one same join type in mv scan descs for every query scan desc.
@@ -243,7 +261,7 @@ public class MaterializedViewRewriter {
                 // for outer join, we should check some extra conditions
                 boolean ret = checkJoinMatch(queryJoinType, queryExpr, mvExpr);
                 if (!ret) {
-                    logMVRewrite(mvRewriteContext, "join match check failed, joinType: %s", queryJoinType);
+                    logMVRewrite(mvRewriteContext, "join match check failed, joinType: {}", queryJoinType);
                 }
                 return ret;
             }
@@ -337,7 +355,7 @@ public class MaterializedViewRewriter {
         if (!isEqual) {
             logMVRewrite(
                     mvRewriteContext,
-                    "join child predicate not matched, queryPredicates: %s, mvPredicates: %s, index: %s",
+                    "join child predicate not matched, queryPredicates: {}, mvPredicates: {}, index: {}",
                     queryPredicates, mvPredicates, index);
         }
         return isEqual;
@@ -1089,8 +1107,8 @@ public class MaterializedViewRewriter {
         final PredicateSplit compensationPredicates = getCompensationPredicatesQueryToView(columnRewriter,
                 rewriteContext, compensationJoinColumns);
         if (compensationPredicates == null) {
-            logMVRewrite(mvRewriteContext, "Rewrite query failed: cannot get compensation predicates from MV, " +
-                    "Try to use union rewrite.");
+            logMVRewrite(mvRewriteContext, "Cannot compensate predicates from mv rewrite, " +
+                    "try to use union rewrite.");
             if (!optimizerContext.getSessionVariable().isEnableMaterializedViewUnionRewrite()) {
                 return null;
             }
@@ -1901,12 +1919,11 @@ public class MaterializedViewRewriter {
 
     private MatchMode getMatchMode(List<Table> queryTables, List<Table> mvTables) {
         MatchMode matchMode = MatchMode.NOT_MATCH;
-        if (queryTables.size() == mvTables.size() && new HashSet<>(queryTables).containsAll(mvTables)) {
+        if (queryTables.size() == mvTables.size() && Sets.newHashSet(queryTables).containsAll(mvTables)) {
             matchMode = MatchMode.COMPLETE;
         } else if (queryTables.size() > mvTables.size() && queryTables.containsAll(mvTables)) {
-            // TODO: query delta
             matchMode = MatchMode.QUERY_DELTA;
-        } else if (queryTables.size() < mvTables.size() && mvTables.containsAll(queryTables)) {
+        } else if (queryTables.size() < mvTables.size() && Sets.newHashSet(mvTables).containsAll(queryTables)) {
             matchMode = MatchMode.VIEW_DELTA;
         }
         return matchMode;
@@ -2234,7 +2251,7 @@ public class MaterializedViewRewriter {
         final ScalarOperator compensationEqualPredicate =
                 getCompensationEqualPredicate(sourceEquivalenceClasses, targetEquivalenceClasses);
         if (compensationEqualPredicate == null) {
-            logMVRewrite(mvRewriteContext, "Rewrite query failed: get equal compensation predicates failed");
+            logMVRewrite(mvRewriteContext, "Compensate equal predicates failed");
             return null;
         }
 
@@ -2244,7 +2261,7 @@ public class MaterializedViewRewriter {
         ScalarOperator compensationPr =
                 getCompensationPredicate(srcPr, targetPr, columnRewriter, true, isQueryToMV);
         if (compensationPr == null) {
-            logMVRewrite(mvRewriteContext, "Rewrite query failed: get range compensation predicates failed," +
+            logMVRewrite(mvRewriteContext, "Compensate range predicates failed," +
                     "srcPr:{}, targetPr:{}", MvUtils.toString(srcPr), MvUtils.toString(targetPr));
             return null;
         }
@@ -2266,7 +2283,7 @@ public class MaterializedViewRewriter {
         ScalarOperator compensationPu =
                 getCompensationPredicate(srcPu, targetPu, columnRewriter, false, isQueryToMV);
         if (compensationPu == null) {
-            logMVRewrite(mvRewriteContext, "Rewrite query failed: get residual compensation predicates failed," +
+            logMVRewrite(mvRewriteContext, "Compensate residual predicates failed," +
                     "srcPr:{}, targetPr:{}", MvUtils.toString(srcPu), MvUtils.toString(targetPu));
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -149,7 +149,7 @@ public class MaterializedViewRewriter {
             // MV : A JOIN B JOIN C
             // To fast rewrite, only need to check `A JOIN B JOIN C` pattern rather than
             // `A JOIN B JOIN C JOIN D`.
-            if (optimizerContext.getSessionVariable().isEnableMaterializedViewRewriteFastWithDraw()) {
+            if (optimizerContext.getSessionVariable().isEnableMaterializedViewRewriteGreedyMode()) {
                 for (OptExpression child : queryExpression.getInputs()) {
                     final List<Table> childTables = MvUtils.getAllTables(child);
                     if (Sets.newHashSet(childTables).contains(mvTables)) {
@@ -185,7 +185,7 @@ public class MaterializedViewRewriter {
             // To avoid join reorder producing plan bomb, record query's max tables to be only matched.
             // But if query contains non inner/left outer joins which cannot be used to view delta join,
             // not use `intersectingTables` anymore.
-            if (optimizerContext.getSessionVariable().isEnableMaterializedViewRewriteFastWithDraw() &&
+            if (optimizerContext.getSessionVariable().isEnableMaterializedViewRewriteGreedyMode() &&
                     !queryTables.containsAll(materializationContext.getIntersectingTables())) {
                 return false;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -92,7 +92,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -484,7 +483,7 @@ public class MvUtils {
     public static ScalarOperator getCompensationPredicateForDisjunctive(ScalarOperator src, ScalarOperator target) {
         List<ScalarOperator> srcItems = Utils.extractDisjunctive(src);
         List<ScalarOperator> targetItems = Utils.extractDisjunctive(target);
-        if (!new HashSet<>(targetItems).containsAll(srcItems)) {
+        if (!Sets.newHashSet(targetItems).containsAll(srcItems)) {
             return null;
         }
         targetItems.removeAll(srcItems);
@@ -1023,6 +1022,7 @@ public class MvUtils {
         return o.toString();
     }
 
+
     /**
      * Return the max refresh timestamp of all partition infos.
      */
@@ -1061,5 +1061,13 @@ public class MvUtils {
             }
             onPredicates.addAll(Utils.extractConjuncts(joinOperator.getOnPredicate()));
         }
+    }
+
+    public static boolean isSupportViewDelta(OptExpression optExpression) {
+        return getAllJoinOperators(optExpression).stream().allMatch(x -> isSupportViewDelta(x));
+    }
+
+    public static boolean isSupportViewDelta(JoinOperator joinOperator) {
+        return  joinOperator.isLeftOuterJoin() || joinOperator.isInnerJoin();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
@@ -51,7 +51,6 @@ import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
-import org.apache.hadoop.util.ThreadUtil;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -59,6 +58,8 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Map;
+
+import static com.starrocks.sql.optimizer.MVTestUtils.waitForSchemaChangeAlterJobFinish;
 
 public class AlterJobV2Test {
     private static ConnectContext connectContext;
@@ -347,19 +348,6 @@ public class AlterJobV2Test {
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail();
-        }
-    }
-
-    private void waitForSchemaChangeAlterJobFinish() throws Exception {
-        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
-        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
-            while (!alterJobV2.getJobState().isFinalState()) {
-                System.out.println(
-                        "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
-                ThreadUtil.sleepAtLeastIgnoreInterrupts(1000);
-            }
-            System.out.println("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
-            Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1522,7 +1522,7 @@ public class CreateMaterializedViewTest {
         }
 
         MaterializedView baseInactiveMv = ((MaterializedView) testDb.getTable("base_inactive_mv"));
-        baseInactiveMv.setActive(false);
+        baseInactiveMv.setInactiveAndReason("");
 
         String sql2 = "create materialized view mv_from_base_inactive_mv " +
                 "partition by k1 " +
@@ -1556,7 +1556,7 @@ public class CreateMaterializedViewTest {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
             MaterializedView mv = ((MaterializedView) testDb.getTable("testAsHasStar"));
-            mv.setActive(false);
+            mv.setInactiveAndReason("");
             List<Column> mvColumns = mv.getFullSchema();
 
             Table baseTable = testDb.getTable("tbl1");
@@ -1649,7 +1649,7 @@ public class CreateMaterializedViewTest {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
             MaterializedView mv = ((MaterializedView) testDb.getTable("testAsSelectItemAlias1"));
-            mv.setActive(false);
+            mv.setInactiveAndReason("");
             List<Column> mvColumns = mv.getFullSchema();
 
             Assert.assertEquals("date_trunc('month', tbl1.k1)", mvColumns.get(0).getName());
@@ -1680,7 +1680,7 @@ public class CreateMaterializedViewTest {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
             MaterializedView mv = ((MaterializedView) testDb.getTable("testAsSelectItemAlias2"));
-            mv.setActive(false);
+            mv.setInactiveAndReason("");
             List<Column> mvColumns = mv.getFullSchema();
 
             Assert.assertEquals("date_trunc('month', tbl1.k1)", mvColumns.get(0).getName());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -78,6 +78,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.starrocks.sql.optimizer.MVTestUtils.waitingRollupJobV2Finish;
+
 public class CreateMaterializedViewTest {
     private static final Logger LOG = LogManager.getLogger(CreateMaterializedViewTest.class);
 
@@ -299,23 +301,6 @@ public class CreateMaterializedViewTest {
             LOG.info("waiting for TaskRunState retryCount:" + retryCount);
         }
         return taskRuns;
-    }
-
-    private void waitingRollupJobV2Finish() throws Exception {
-        // waiting alterJobV2 finish
-        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
-        //Assert.assertEquals(1, alterJobs.size());
-
-        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
-            if (alterJobV2.getType() != AlterJobV2.JobType.ROLLUP) {
-                continue;
-            }
-            while (!alterJobV2.getJobState().isFinalState()) {
-                System.out.println(
-                        "rollup job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
-                ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
-            }
-        }
     }
 
     // ========== full test ==========

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -98,7 +98,7 @@ public class MaterializedViewTest {
         mv2.setStorageMedium(TStorageMedium.SSD);
         Assert.assertEquals("SSD", mv2.getStorageMedium());
         Assert.assertEquals(true, mv2.isActive());
-        mv2.setActive(false);
+        mv2.setInactiveAndReason("");
         Assert.assertEquals(false, mv2.isActive());
 
         List<BaseTableInfo> baseTableInfos = Lists.newArrayList();
@@ -665,7 +665,7 @@ public class MaterializedViewTest {
                         "as select k1,k2,v1 from base_table;");
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView baseMv = ((MaterializedView) testDb.getTable("base_mv"));
-        baseMv.setActive(false);
+        baseMv.setInactiveAndReason("");
 
         SinglePartitionInfo singlePartitionInfo = new SinglePartitionInfo();
         MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
@@ -22,7 +22,6 @@ import com.staros.proto.FilePathInfo;
 import com.staros.proto.FileStoreInfo;
 import com.staros.proto.FileStoreType;
 import com.staros.proto.S3FileStoreInfo;
-import com.starrocks.alter.AlterJobV2;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -62,7 +61,6 @@ import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
-import org.apache.hadoop.util.ThreadUtil;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -72,7 +70,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
+
+import static com.starrocks.sql.optimizer.MVTestUtils.waitForSchemaChangeAlterJobFinish;
 
 public class LakeMaterializedViewTest {
     private static final String DB = "db_for_lake_mv";
@@ -393,19 +392,6 @@ public class LakeMaterializedViewTest {
 
         starRocksAssert.dropMaterializedView("mv3");
         Assert.assertNull(db.getTable("mv3"));
-    }
-
-    private void waitForSchemaChangeAlterJobFinish() throws Exception {
-        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
-        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
-            while (!alterJobV2.getJobState().isFinalState()) {
-                System.out.println(
-                        "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
-                ThreadUtil.sleepAtLeastIgnoreInterrupts(1000);
-            }
-            System.out.println("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
-            Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
-        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -111,9 +111,9 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery16() {
-        connectContext.getSessionVariable().setEnableMaterializedViewRewriteGreedyMode(false);
-        runFileUnitTest("materialized-view/tpch/q16");
         connectContext.getSessionVariable().setEnableMaterializedViewRewriteGreedyMode(true);
+        runFileUnitTest("materialized-view/tpch/q16");
+        connectContext.getSessionVariable().setEnableMaterializedViewRewriteGreedyMode(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -111,9 +111,9 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery16() {
-        connectContext.getSessionVariable().setEnableMaterializedViewRewriteFastWithDraw(false);
+        connectContext.getSessionVariable().setEnableMaterializedViewRewriteGreedyMode(false);
         runFileUnitTest("materialized-view/tpch/q16");
-        connectContext.getSessionVariable().setEnableMaterializedViewRewriteFastWithDraw(true);
+        connectContext.getSessionVariable().setEnableMaterializedViewRewriteGreedyMode(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -111,7 +111,9 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery16() {
+        connectContext.getSessionVariable().setEnableMaterializedViewRewriteFastWithDraw(false);
         runFileUnitTest("materialized-view/tpch/q16");
+        connectContext.getSessionVariable().setEnableMaterializedViewRewriteFastWithDraw(true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -404,7 +404,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testInactive() {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_inactive"));
-        materializedView.setActive(false);
+        materializedView.setInactiveAndReason("");
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
 
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -1825,7 +1825,6 @@ public class PartitionBasedMvRefreshProcessorTest {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            System.out.println(plan);
             Assert.assertTrue(plan.contains("partitions=2/2\n" +
                     "     rollup: list_partition_tbl1"));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -68,7 +68,7 @@ public class MaterializedViewAnalyzerTest {
         Assert.assertNotNull(table);
         Assert.assertTrue(table instanceof MaterializedView);
         MaterializedView mv = (MaterializedView) table;
-        mv.setActive(false);
+        mv.setInactiveAndReason("");
         analyzeFail("refresh materialized view mv");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -865,7 +865,6 @@ public class MVRewriteTest {
         starRocksAssert.withMaterializedView(createUserTagMVSql);
         String query = "select `" + FunctionSet.HLL_UNION + "`(" + FunctionSet.HLL_HASH + "(tag_id)) from " +
                 USER_TAG_TABLE_NAME + ";";
-        System.out.println(starRocksAssert.query(query).explainQuery());
         starRocksAssert.query(query).explainContains(USER_TAG_MV_NAME);
         query = "select hll_union_agg(" + FunctionSet.HLL_HASH + "(tag_id)) from " + USER_TAG_TABLE_NAME + ";";
         starRocksAssert.query(query).explainContains(USER_TAG_MV_NAME, FunctionSet.HLL_UNION_AGG);
@@ -907,7 +906,6 @@ public class MVRewriteTest {
         starRocksAssert.withMaterializedView(createUserTagMVSql);
         String query =
                 "select empid, percentile_approx(salary, 1), percentile_approx(commission, 1) from emps group by empid";
-        System.out.println(starRocksAssert.query(query).explainQuery());
         starRocksAssert.query(query).explainContains(QUERY_USE_EMPS_MV, "  2:AGGREGATE (update serialize)\n",
                 "output: percentile_union");
         starRocksAssert.assertMVWithoutComplexExpression(HR_DB_NAME, EMPS_TABLE_NAME);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVTestUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVTestUtils.java
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.starrocks.alter.AlterJobV2;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.hadoop.util.ThreadUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+
+import java.util.Map;
+
+public class MVTestUtils {
+    private static final Logger LOG = LogManager.getLogger(MVTestUtils.class);
+
+    public static void waitingRollupJobV2Finish() throws Exception {
+        // waiting alterJobV2 finish
+        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
+        //Assert.assertEquals(1, alterJobs.size());
+
+        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
+            if (alterJobV2.getType() != AlterJobV2.JobType.ROLLUP) {
+                continue;
+            }
+            while (!alterJobV2.getJobState().isFinalState()) {
+                System.out.println(
+                        "rollup job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
+                ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
+            }
+        }
+    }
+
+    public static void waitForSchemaChangeAlterJobFinish() throws Exception {
+        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
+        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
+            while (!alterJobV2.getJobState().isFinalState()) {
+                LOG.info(
+                        "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
+                ThreadUtil.sleepAtLeastIgnoreInterrupts(100);
+            }
+            System.out.println("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
+            Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -17,14 +17,24 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.alter.AlterJobV2;
+import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.ast.DmlStmt;
+import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
@@ -38,9 +48,12 @@ import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -82,6 +95,25 @@ public class MvRewriteTestBase {
         starRocksAssert.withDatabase("test").useDatabase("test");
 
         Config.enable_experimental_mv = true;
+
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+                if (stmt instanceof InsertStmt) {
+                    InsertStmt insertStmt = (InsertStmt) stmt;
+                    TableName tableName = insertStmt.getTableName();
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
+                    if (tbl != null) {
+                        for (Partition partition : tbl.getPartitions()) {
+                            if (insertStmt.getTargetPartitionIds().contains(partition.getId())) {
+                                setPartitionVersion(partition, partition.getVisibleVersion() + 1);
+                            }
+                        }
+                    }
+                }
+            }
+        };
 
         starRocksAssert.withTable("create table emps (\n" +
                         "    empid int not null,\n" +
@@ -264,6 +296,18 @@ public class MvRewriteTestBase {
     @AfterClass
     public static void tearDown() throws Exception {
         PseudoCluster.getInstance().shutdown(true);
+    }
+
+    private static void setPartitionVersion(Partition partition, long version) {
+        partition.setVisibleVersion(version, System.currentTimeMillis());
+        MaterializedIndex baseIndex = partition.getBaseIndex();
+        List<Tablet> tablets = baseIndex.getTablets();
+        for (Tablet tablet : tablets) {
+            List<Replica> replicas = ((LocalTablet) tablet).getImmutableReplicas();
+            for (Replica replica : replicas) {
+                replica.updateVersionInfo(version, -1, version);
+            }
+        }
     }
 
     public String getFragmentPlan(String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -16,7 +16,6 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.starrocks.alter.AlterJobV2;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.LocalTablet;
@@ -54,7 +53,6 @@ import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
-import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
@@ -63,7 +61,6 @@ import org.junit.BeforeClass;
 
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Map;
 
 public class MvRewriteTestBase {
     private static final Logger LOG = LogManager.getLogger(MvRewriteTestBase.class);
@@ -387,36 +384,6 @@ public class MvRewriteTestBase {
         }
         for (OptExpression child : root.getInputs()) {
             getScanOperators(child, name, results);
-        }
-    }
-
-    protected void waitingRollupJobV2Finish() throws Exception {
-        // waiting alterJobV2 finish
-        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
-        //Assert.assertEquals(1, alterJobs.size());
-
-        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
-            if (alterJobV2.getType() != AlterJobV2.JobType.ROLLUP) {
-                continue;
-            }
-            while (!alterJobV2.getJobState().isFinalState()) {
-                System.out.println(
-                        "rollup job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
-                ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
-            }
-        }
-    }
-
-    protected void waitForSchemaChangeAlterJobFinish() throws Exception {
-        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
-        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
-            while (!alterJobV2.getJobState().isFinalState()) {
-                LOG.info(
-                        "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
-                ThreadUtil.sleepAtLeastIgnoreInterrupts(100);
-            }
-            System.out.println("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
-            Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
@@ -100,7 +100,6 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/agg_with_having1"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains("TEST_MV_2"));
     }
 
@@ -109,7 +108,6 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/agg_with_having2"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains("TEST_MV_2"));
     }
 
@@ -118,7 +116,6 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/agg_with_having3"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains("TEST_MV_3"));
     }
 }

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv1.sql
@@ -1,4 +1,4 @@
--- partsupp_mv
+-- partsupp_mv, query2/query11/query18
 create materialized view partsupp_mv
 distributed by hash(ps_partkey, ps_suppkey) buckets 24
 refresh deferred manual
@@ -7,7 +7,7 @@ properties (
 )
 as select
               n_name,
-              p_mfgr,p_size,p_type,
+              p_mfgr,p_size,p_type,p_brand,
               ps_partkey, ps_suppkey,ps_supplycost,
               r_name,
               s_acctbal,s_address,s_comment,s_name,s_nationkey,s_phone,

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv2.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv2.sql
@@ -1,4 +1,4 @@
--- query1
+-- query1,query18
 create materialized view lineitem_agg_mv1
 distributed by hash(l_orderkey,
                l_shipdate,
@@ -52,6 +52,7 @@ as select  /*+ SET_VAR(query_timeout = 7200) */
        l_suppkey, l_shipdate, l_partkey
 ;
 
+-- query6
 create materialized view lineitem_agg_mv3
 distributed by hash(l_shipdate, l_discount, l_quantity) buckets 24
 partition by l_shipdate

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv3.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv3.sql
@@ -2,7 +2,7 @@
 create materialized view lineitem_mv_agg_mv1
  distributed by hash(p_name,
                o_orderyear,
-               n_name1) buckets 96
+               n_name2) buckets 96
  refresh deferred manual
  properties (
      "replication_num" = "1"
@@ -10,14 +10,15 @@ create materialized view lineitem_mv_agg_mv1
  as select /*+ SET_VAR(query_timeout = 7200) */
                p_name,
                o_orderyear,
-               n_name1,
+               n_name2,
                sum(l_amount) as sum_amount
     from
                lineitem_mv
+    where c_nationkey = s_nationkey
     group by
         p_name,
         o_orderyear,
-        n_name1
+        n_name2
 ;
 
 -- query7

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q16.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q16.sql
@@ -37,11 +37,8 @@ TOP-N (order by [[23: count DESC NULLS LAST, 9: p_brand ASC NULLS FIRST, 10: p_t
                 EXCHANGE SHUFFLE[9, 10, 11]
                     AGGREGATE ([LOCAL] aggregate [{}] group by [[2: ps_suppkey, 9: p_brand, 10: p_type, 11: p_size]] having [null]
                         NULL AWARE LEFT ANTI JOIN (join-predicate [2: ps_suppkey = 15: s_suppkey] post-join-predicate [null])
-                            INNER JOIN (join-predicate [6: p_partkey = 1: ps_partkey] post-join-predicate [null])
-                                SCAN (table[part] columns[6: p_partkey, 9: p_brand, 10: p_type, 11: p_size] predicate[9: p_brand != Brand#43 AND NOT 10: p_type LIKE PROMO BURNISHED% AND 11: p_size IN (31, 43, 9, 6, 18, 11, 25, 1)])
-                                EXCHANGE SHUFFLE[1]
-                                    SCAN (table[partsupp] columns[1: ps_partkey, 2: ps_suppkey] predicate[null])
+                            SCAN (mv[partsupp_mv] columns[109: p_size, 110: p_type, 111: p_brand, 113: ps_suppkey] predicate[109: p_size = 1 OR 109: p_size = 11 OR 109: p_size = 18 OR 109: p_size = 25 OR 109: p_size = 31 OR 109: p_size = 43 OR 109: p_size = 6 OR 109: p_size = 9 AND 111: p_brand < Brand#43 OR 111: p_brand > Brand#43 AND NOT 110: p_type LIKE PROMO BURNISHED%])
                             EXCHANGE BROADCAST
                                 SCAN (table[supplier] columns[21: s_comment, 15: s_suppkey] predicate[21: s_comment LIKE %Customer%Complaints%])
-[end]
+end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q17.sql
@@ -11,7 +11,6 @@ where
   and l_quantity < (
     select
             0.2 * avg(l_quantity)
---         0.2 * sum(l_quantity) / count(l_quantity)
     from
         lineitem
     where

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q9.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q9.sql
@@ -34,9 +34,9 @@ order by
 [result]
 TOP-N (order by [[48: n_name ASC NULLS FIRST, 51: year DESC NULLS LAST]])
     TOP-N (order by [[48: n_name ASC NULLS FIRST, 51: year DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{53: sum=sum(53: sum)}] group by [[48: n_name, 51: year]] having [null]
-            EXCHANGE SHUFFLE[48, 51]
-                AGGREGATE ([LOCAL] aggregate [{53: sum=sum(52: expr)}] group by [[48: n_name, 51: year]] having [null]
-                    SCAN (mv[lineitem_mv] columns[114: c_nationkey, 136: p_name, 140: s_nationkey, 143: l_amount, 145: o_orderyear, 148: n_name2] predicate[114: c_nationkey = 140: s_nationkey AND 136: p_name LIKE %peru%])
+        AGGREGATE ([GLOBAL] aggregate [{1286: sum=sum(1286: sum)}] group by [[99: n_name2, 98: o_orderyear]] having [null]
+            EXCHANGE SHUFFLE[99, 98]
+                AGGREGATE ([LOCAL] aggregate [{1286: sum=sum(100: sum_amount)}] group by [[99: n_name2, 98: o_orderyear]] having [null]
+                    SCAN (mv[lineitem_mv_agg_mv1] columns[97: p_name, 98: o_orderyear, 99: n_name2, 100: sum_amount] predicate[97: p_name LIKE %peru%])
 [end]
 

--- a/test/sql/test_materialized_view/R/test_materialized_view_status
+++ b/test/sql/test_materialized_view/R/test_materialized_view_status
@@ -34,7 +34,6 @@ CREATE MATERIALIZED VIEW mv1
 drop table t1;
 -- result:
 -- !result
-refresh materialized view mv1 with sync mode;
 CREATE TABLE `t1` (
   `k1` date NULL COMMENT "",
   `v1` int(11) NULL COMMENT "",
@@ -60,9 +59,6 @@ ALTER MATERIALIZED VIEW mv1 ACTIVE;
 -- !result
 REFRESH MATERIALIZED VIEW mv1  with sync mode;
 select * from mv1 order by k1;
--- result:
--- !result
-ALTER MATERIALIZED VIEW mv1 ACTIVE;
 -- result:
 -- !result
 insert into t1 values ("2019-01-01",1,1),("2019-01-01",1,2),("2019-01-01",2,1),("2019-01-01",2,2),

--- a/test/sql/test_materialized_view/R/test_materialized_view_status
+++ b/test/sql/test_materialized_view/R/test_materialized_view_status
@@ -31,17 +31,10 @@ CREATE MATERIALIZED VIEW mv1
                AS SELECT k1, sum(v1) as sum_v1 FROM t1 group by k1;
 -- result:
 -- !result
-select sleep(2);
--- result:
-1
--- !result
 drop table t1;
 -- result:
 -- !result
-refresh materialized view mv1;
--- result:
-E: (1064, 'Getting analyzing error at line 1, column 26. Detail message: Refresh materialized view failed because [mv1] is not active. You can try to active it with ALTER MATERIALIZED VIEW mv1 ACTIVE; .')
--- !result
+refresh materialized view mv1 with sync mode;
 CREATE TABLE `t1` (
   `k1` date NULL COMMENT "",
   `v1` int(11) NULL COMMENT "",
@@ -65,13 +58,8 @@ PROPERTIES (
 ALTER MATERIALIZED VIEW mv1 ACTIVE;
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW mv1;
--- !result
-select sleep(2);
--- result:
-1
--- !result
-select * from mv1;
+REFRESH MATERIALIZED VIEW mv1  with sync mode;
+select * from mv1 order by k1;
 -- result:
 -- !result
 ALTER MATERIALIZED VIEW mv1 ACTIVE;
@@ -82,47 +70,24 @@ insert into t1 values ("2019-01-01",1,1),("2019-01-01",1,2),("2019-01-01",2,1),(
                                          ("2023-03-11",1,1),("2023-05-11",1,2),("2023-04-11",2,1),("2023-05-01",2,2);
 -- result:
 -- !result
-select sleep(2);
--- result:
-1
--- !result
-select * from mv1;
+REFRESH MATERIALIZED VIEW mv1  with sync mode;
+select * from mv1 order by k1;
 -- result:
 2019-01-01	6
-2023-03-11	1
-2023-05-01	2
 2023-01-11	4
 2023-02-11	2
+2023-03-11	1
 2023-04-11	2
+2023-05-01	2
 2023-05-11	1
 -- !result
 ALTER MATERIALIZED VIEW mv1 INACTIVE;
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW mv1;
--- result:
-E: (1064, 'Getting analyzing error at line 1, column 26. Detail message: Refresh materialized view failed because [mv1] is not active. You can try to active it with ALTER MATERIALIZED VIEW mv1 ACTIVE; .')
--- !result
-CREATE TABLE t1 (
-    k1 INT,
-    v1 INT,
-    v2 INT)
-DUPLICATE KEY(k1)
-DISTRIBUTED BY HASH(k1)
-PROPERTIES(
-    "replication_num" = "1"
-)
-insert into t1 values (1,1,1),(1,2,2),(2,3,3),(2,3,4),(2,5,5);
--- result:
-E: (1064, "Getting syntax error at line 10, column 0. Detail message: Unexpected input 'insert', the most similar input is {<EOF>, ';'}.")
--- !result
 CREATE MATERIALIZED VIEW mv2
 DISTRIBUTED BY HASH(k1) BUCKETS 10
 REFRESH MANUAL
 AS SELECT k1,v1 FROM t1;
--- result:
--- !result
-refresh materialized view mv2;
 -- result:
 -- !result
 drop table t1;
@@ -142,10 +107,7 @@ PROPERTIES(
 alter materialized view mv2 active;
 -- result:
 -- !result
-select sleep(2);
--- result:
-1
--- !result
-select * from mv2
+refresh materialized view mv2  with sync mode;
+select * from mv2 order by k1;
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/R/test_mv_on_view
+++ b/test/sql/test_materialized_view/R/test_mv_on_view
@@ -28,9 +28,6 @@ AS select * from view1;
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW mv_on_view_1 with sync mode ;
--- result:
-662f725b-2097-11ee-85b3-f236c9537340
--- !result
 SELECT * FROM mv_on_view_1 ORDER BY event_day;
 -- result:
 2020-01-14	5
@@ -40,9 +37,6 @@ insert into ss values('2020-01-15', 3);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW mv_on_view_1 with sync mode;
--- result:
-665e238e-2097-11ee-85b3-f236c9537340
--- !result
 SELECT * FROM mv_on_view_1 ORDER BY event_day;
 -- result:
 2020-01-14	5
@@ -62,12 +56,9 @@ ALTER MATERIALIZED VIEW mv_on_view_1 ACTIVE;
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views 
     WHERE table_name = 'mv_on_view_1';
 -- result:
-true	
+true	base view view1 changed
 -- !result
 [UC]REFRESH MATERIALIZED VIEW mv_on_view_1 with sync mode;
--- result:
-66f75661-2097-11ee-85b3-f236c9537340
--- !result
 SELECT * FROM mv_on_view_1 ORDER BY event_day;
 -- result:
 -- !result
@@ -75,9 +66,6 @@ insert into jj values('2020-01-14', 2);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW mv_on_view_1 with sync mode;
--- result:
-6788c101-2097-11ee-85b3-f236c9537340
--- !result
 SELECT * FROM mv_on_view_1 ORDER BY event_day;
 -- result:
 2020-01-14	2

--- a/test/sql/test_materialized_view/R/test_mv_swap
+++ b/test/sql/test_materialized_view/R/test_mv_swap
@@ -148,11 +148,11 @@ ALTER MATERIALIZED VIEW mv_on_mv_2 ACTIVE;
 -- !result
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1';
 -- result:
-true	
+true	based table mv2 swapped
 -- !result
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2';
 -- result:
-true	
+true	base table mv_on_mv_1 inactive
 -- !result
 CREATE MATERIALIZED VIEW mv_on_table_1 REFRESH ASYNC 
 AS SELECT ss.event_day, sum(ss.pv) as ss_sum_pv, sum(jj.pv) as jj_sum_pv
@@ -173,5 +173,5 @@ ALTER MATERIALIZED VIEW mv_on_table_1 ACTIVE;
 -- !result
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_table_1';
 -- result:
-true	
+true	based table jj swapped
 -- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_status
+++ b/test/sql/test_materialized_view/T/test_materialized_view_status
@@ -25,9 +25,9 @@ CREATE MATERIALIZED VIEW mv1
                DISTRIBUTED BY HASH(k1) BUCKETS 10
                REFRESH ASYNC
                AS SELECT k1, sum(v1) as sum_v1 FROM t1 group by k1;
-select sleep(2);
 drop table t1;
-refresh materialized view mv1;
+refresh materialized view mv1 with sync mode;
+
 CREATE TABLE `t1` (
   `k1` date NULL COMMENT "",
   `v1` int(11) NULL COMMENT "",
@@ -47,32 +47,22 @@ PROPERTIES (
 "replication_num" = "1"
 );
 ALTER MATERIALIZED VIEW mv1 ACTIVE;
-REFRESH MATERIALIZED VIEW mv1;
-select sleep(2);
-select * from mv1;
+REFRESH MATERIALIZED VIEW mv1  with sync mode;
+select * from mv1 order by k1;
+
 ALTER MATERIALIZED VIEW mv1 ACTIVE;
 insert into t1 values ("2019-01-01",1,1),("2019-01-01",1,2),("2019-01-01",2,1),("2019-01-01",2,2),
                                          ("2023-01-11",1,1),("2023-01-11",1,2),("2023-02-11",2,1),("2023-01-11",2,2),
                                          ("2023-03-11",1,1),("2023-05-11",1,2),("2023-04-11",2,1),("2023-05-01",2,2);
-select sleep(2);
-select * from mv1;
+REFRESH MATERIALIZED VIEW mv1  with sync mode;
+select * from mv1 order by k1;
 ALTER MATERIALIZED VIEW mv1 INACTIVE;
-REFRESH MATERIALIZED VIEW mv1;
-CREATE TABLE t1 (
-    k1 INT,
-    v1 INT,
-    v2 INT)
-DUPLICATE KEY(k1)
-DISTRIBUTED BY HASH(k1)
-PROPERTIES(
-    "replication_num" = "1"
-)
-insert into t1 values (1,1,1),(1,2,2),(2,3,3),(2,3,4),(2,5,5);
+
 CREATE MATERIALIZED VIEW mv2
 DISTRIBUTED BY HASH(k1) BUCKETS 10
 REFRESH MANUAL
 AS SELECT k1,v1 FROM t1;
-refresh materialized view mv2;
+
 drop table t1;
 CREATE TABLE t1 (
     k1 INT,
@@ -84,5 +74,5 @@ PROPERTIES(
     "replication_num" = "1"
 );
 alter materialized view mv2 active;
-select sleep(2);
-select * from mv2
+refresh materialized view mv2  with sync mode;
+select * from mv2 order by k1;

--- a/test/sql/test_materialized_view/T/test_materialized_view_status
+++ b/test/sql/test_materialized_view/T/test_materialized_view_status
@@ -26,7 +26,6 @@ CREATE MATERIALIZED VIEW mv1
                REFRESH ASYNC
                AS SELECT k1, sum(v1) as sum_v1 FROM t1 group by k1;
 drop table t1;
-refresh materialized view mv1 with sync mode;
 
 CREATE TABLE `t1` (
   `k1` date NULL COMMENT "",
@@ -50,7 +49,6 @@ ALTER MATERIALIZED VIEW mv1 ACTIVE;
 REFRESH MATERIALIZED VIEW mv1  with sync mode;
 select * from mv1 order by k1;
 
-ALTER MATERIALIZED VIEW mv1 ACTIVE;
 insert into t1 values ("2019-01-01",1,1),("2019-01-01",1,2),("2019-01-01",2,1),("2019-01-01",2,2),
                                          ("2023-01-11",1,1),("2023-01-11",1,2),("2023-02-11",2,1),("2023-01-11",2,2),
                                          ("2023-03-11",1,1),("2023-05-11",1,2),("2023-04-11",2,1),("2023-05-01",2,2);


### PR DESCRIPTION
- Add enable_materialized_view_rewrite_greedy_mode param to control fast withdraw for mv rewrite
- Fix some logs

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
