### PR TITLE
[fix]regexp_extract fix the problem that the first match is empty

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -2884,7 +2884,7 @@ static ColumnPtr regexp_extract_general(FunctionContext* context, re2::RE2::Opti
         re2::StringPiece str_sp(str_value.get_data(), str_value.get_size());
         std::vector<re2::StringPiece> matches(max_matches);
         bool success = local_re.Match(str_sp, 0, str_value.get_size(), re2::RE2::UNANCHORED, &matches[0], max_matches);
-        if (!success) {
+        if (!success || matches[0].empty) {
             result.append(Slice("", 0));
             continue;
         }


### PR DESCRIPTION
Fixes #29668

## What type of PR is this:

- [ x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
