### PR TITLE
[BugFix] Update maximumPoolSize same as corePoolSize in task executor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -785,7 +785,7 @@ public class GlobalStateMgr {
         getConfigRefreshDaemon().registerListener(() -> {
             try {
                 if (Config.max_broker_load_job_concurrency != loadingLoadTaskScheduler.getCorePoolSize()) {
-                    loadingLoadTaskScheduler.setCorePoolSize(Config.max_broker_load_job_concurrency);
+                    loadingLoadTaskScheduler.setPoolSize(Config.max_broker_load_job_concurrency);
                 }
             } catch (Exception e) {
                 LOG.warn("check config failed", e);

--- a/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
@@ -110,8 +110,10 @@ public class PriorityLeaderTaskExecutor {
         return executor.getCorePoolSize();
     }
 
-    public void setCorePoolSize(int corePoolSize) {
-        executor.setCorePoolSize(corePoolSize);
+    public void setPoolSize(int poolSize) {
+        // corePoolSize and maximumPoolSize are same
+        executor.setMaximumPoolSize(poolSize);
+        executor.setCorePoolSize(poolSize);
     }
 
     private class TaskChecker implements Runnable {

--- a/fe/fe-core/src/test/java/com/starrocks/task/PriorityLeaderTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/PriorityLeaderTaskExecutorTest.java
@@ -15,6 +15,8 @@
 
 package com.starrocks.task;
 
+import com.starrocks.common.PriorityThreadPoolExecutor;
+import com.starrocks.common.jmockit.Deencapsulation;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -87,6 +89,18 @@ public class PriorityLeaderTaskExecutorTest {
         Assert.assertEquals(4L, SEQ.get(1).longValue());
         Assert.assertEquals(3L, SEQ.get(2).longValue());
         Assert.assertEquals(2L, SEQ.get(3).longValue());
+    }
+
+    @Test
+    public void testUpdatePoolSize() {
+        PriorityThreadPoolExecutor priorityExecutor = Deencapsulation.getField(executor, "executor");
+        Assert.assertEquals(THREAD_NUM, executor.getCorePoolSize());
+        Assert.assertEquals(THREAD_NUM, priorityExecutor.getMaximumPoolSize());
+
+        int newThreadNum = THREAD_NUM + 1;
+        executor.setPoolSize(newThreadNum);
+        Assert.assertEquals(newThreadNum, executor.getCorePoolSize());
+        Assert.assertEquals(newThreadNum, priorityExecutor.getMaximumPoolSize());
     }
 
     private class TestLeaderTask extends PriorityLeaderTask {


### PR DESCRIPTION
When user increases max_broker_load_job_concurrency online, the loading jobs concurrency does not increase. The reason is that maximumPoolSize is not modified.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
