### PR TITLE
[Tool] disable release docker image workflow trigers (#29748)

### DIFF
--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -1,8 +1,9 @@
 name: 'release docker images'
 
-on:
-  release:
-    types: [published]
+# Don't trigger actions automatically
+#on:
+#  release:
+#    types: [published]
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -32,8 +33,7 @@ jobs:
 
       - name: build artifact docker image
         run: |
-          DOCKER_BUILDKIT=1 docker build --rm=true -f docker/dockerfiles/artifacts/artifact-ubuntu.Dockerfile -t artifact-ubuntu:${RELEASE_VERSION} .
-
+          DOCKER_BUILDKIT=1 docker build --rm=true --build-arg RELEASE_VERSION=${RELEASE_VERSION} -f docker/dockerfiles/artifacts/artifact.Dockerfile -t artifact-ubuntu:${RELEASE_VERSION} .
       - name: build and publish fe docker image
         run: |
           DOCKER_BUILDKIT=1 docker build --build-arg ARTIFACTIMAGE=artifact-ubuntu:${RELEASE_VERSION} -f docker/dockerfiles/fe/fe-ubuntu.Dockerfile -t ${REGISTRY}/fe-ubuntu:${RELEASE_VERSION} .


### PR DESCRIPTION
* don't trigger release-docker-image action
* let the workflow here just as an example


(cherry picked from commit d02e0541c8d22308fad79ce23cc92d0df4b2a718)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [X] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
