### PR TITLE
[Enhancement] add nap_sleep() to handle sleep a large portion of time (#29689)

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -71,6 +71,7 @@
 #include "storage/task/engine_storage_migration_task.h"
 #include "storage/update_manager.h"
 #include "storage/utils.h"
+#include "util/misc.h"
 #include "util/starrocks_metrics.h"
 #include "util/stopwatch.hpp"
 #include "util/thread.h"
@@ -600,7 +601,8 @@ void* ReportTaskWorkerPool::_worker_thread_callback(void* arg_this) {
                          << ", err=" << status;
         }
 
-        sleep(config::report_task_interval_seconds);
+        nap_sleep(config::report_task_interval_seconds,
+                  [worker_pool_this] { return worker_pool_this->_stopped.load(); });
     }
 
     return nullptr;
@@ -740,7 +742,8 @@ void* ReportWorkgroupTaskWorkerPool::_worker_thread_callback(void* arg_this) {
         if (result.__isset.workgroup_ops) {
             workgroup::WorkGroupManager::instance()->apply(result.workgroup_ops);
         }
-        sleep(config::report_workgroup_interval_seconds);
+        nap_sleep(config::report_workgroup_interval_seconds,
+                  [worker_pool_this] { return worker_pool_this->_stopped.load(); });
     }
 
     return nullptr;

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -58,6 +58,7 @@
 #include "util/gc_helper.h"
 #include "util/logging.h"
 #include "util/mem_info.h"
+#include "util/misc.h"
 #include "util/monotime.h"
 #include "util/network_util.h"
 #include "util/starrocks_metrics.h"
@@ -97,7 +98,7 @@ void gc_memory(void* arg_this) {
 
     auto* daemon = static_cast<Daemon*>(arg_this);
     while (!daemon->stopped()) {
-        sleep(static_cast<unsigned int>(config::memory_maintenance_sleep_time_s));
+        nap_sleep(config::memory_maintenance_sleep_time_s, [daemon] { return daemon->stopped(); });
 #if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)
         MallocExtension::instance()->MarkThreadBusy();
 #endif
@@ -210,7 +211,7 @@ void calculate_metrics(void* arg_this) {
                 mem_metrics->update_mem_bytes.value(), mem_metrics->chunk_allocator_mem_bytes.value(),
                 mem_metrics->clone_mem_bytes.value(), mem_metrics->consistency_mem_bytes.value());
 
-        sleep(15); // 15 seconds
+        nap_sleep(15, [daemon] { return daemon->stopped(); });
     }
 }
 

--- a/be/src/runtime/broker_mgr.cpp
+++ b/be/src/runtime/broker_mgr.cpp
@@ -42,7 +42,7 @@
 #include "runtime/client_cache.h"
 #include "runtime/exec_env.h"
 #include "service/backend_options.h"
-#include "util/await.h"
+#include "util/misc.h"
 #include "util/starrocks_metrics.h"
 #include "util/thread.h"
 
@@ -106,9 +106,6 @@ void BrokerMgr::ping(const TNetworkAddress& addr) {
 }
 
 void BrokerMgr::ping_worker() {
-    Awaitility await;
-    // timeout in 5 seconds with 200ms check interval
-    await.timeout(5 * 1000L * 1000).interval(200 * 1000L);
     while (!_thread_stop) {
         std::vector<TNetworkAddress> addresses;
         {
@@ -120,8 +117,7 @@ void BrokerMgr::ping_worker() {
         for (auto& addr : addresses) {
             ping(addr);
         }
-        // block until _thread_stop is true or timeout
-        await.until([this] { return _thread_stop; });
+        nap_sleep(5, [this] { return _thread_stop; });
     }
 }
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -59,7 +59,7 @@
 #include "runtime/runtime_filter_cache.h"
 #include "runtime/runtime_filter_worker.h"
 #include "service/backend_options.h"
-#include "util/await.h"
+#include "util/misc.h"
 #include "util/starrocks_metrics.h"
 #include "util/stopwatch.hpp"
 #include "util/thread.h"
@@ -528,9 +528,6 @@ void FragmentMgr::receive_runtime_filter(const PTransmitRuntimeFilterParams& par
 
 void FragmentMgr::cancel_worker() {
     LOG(INFO) << "FragmentMgr cancel worker start working.";
-    Awaitility await;
-    // timeout in 1 second and check every 200ms
-    await.timeout(1000 * 1000).interval(200 * 1000);
     while (!_stop) {
         std::vector<TUniqueId> to_delete;
         DateTimeValue now = DateTimeValue::local_time();
@@ -546,9 +543,7 @@ void FragmentMgr::cancel_worker() {
             cancel(id, PPlanFragmentCancelReason::TIMEOUT);
             LOG(INFO) << "FragmentMgr cancel worker going to cancel timeout fragment " << print_id(id);
         }
-
-        // block until timeout or _stop is true
-        await.until([this] { return _stop; });
+        nap_sleep(1, [this] { return _stop; });
     }
     LOG(INFO) << "FragmentMgr cancel worker is going to exit.";
 }

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -77,7 +77,7 @@ void start_be() {
     }
 
     while (!starrocks::k_starrocks_exit.load()) {
-        sleep(10);
+        sleep(1);
     }
 
     starrocks::wait_for_fragments_finish(exec_env, starrocks::config::loop_count_wait_fragments_finish);

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -44,6 +44,7 @@ set(UTIL_FILES
   starrocks_metrics.cpp
   mem_info.cpp
   metrics.cpp
+  misc.cpp
   murmur_hash3.cpp
   network_util.cpp
   parse_util.cpp

--- a/be/src/util/misc.cpp
+++ b/be/src/util/misc.cpp
@@ -1,0 +1,33 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/misc.h"
+
+#include "util/await.h"
+
+namespace starrocks {
+
+#ifdef BE_TEST
+static constexpr int sleep_interval = 100 * 1000; // 100ms
+#else
+static constexpr int sleep_interval = 1 * 1000 * 1000; // 1 seconds
+#endif
+
+void nap_sleep(int32_t sleep_secs, std::function<bool()> stop_condition) {
+    Awaitility await;
+    await.timeout(sleep_secs * 1000LL * 1000LL).interval(sleep_interval);
+    await.until(stop_condition);
+}
+
+} // namespace starrocks

--- a/be/src/util/misc.h
+++ b/be/src/util/misc.h
@@ -1,0 +1,24 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+
+namespace starrocks {
+
+// take a sleep with small intervals until time out by `sleep_secs` or the `stop_condition()` is true
+void nap_sleep(int32_t sleep_secs, std::function<bool()> stop_condition);
+
+} // namespace starrocks

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -161,7 +161,7 @@ export_shared_envvars() {
 
     # https://github.com/aws/aws-cli/issues/5623
     # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-    export AWS_EC2_METADATA_DISABLED=false
+    export AWS_EC2_METADATA_DISABLED=${AWS_EC2_METADATA_DISABLED:-false}
     # ===================================================================================
 }
 


### PR DESCRIPTION
* respect AWS_EC2_METADATA_DISABLED if already set in env
* BE binary can stop with 10 seconds with this change nap_sleep() change and also AWS_EC2_METADATA_DISABLED=true in non-ec2 env


(cherry picked from commit ef6c33877b8198faf1756260a240a58dbcdfb02c)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
