### PR TITLE
[Enhancement] primary key using persistent index by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
@@ -68,7 +68,8 @@ public class LogUtil {
                 .collect(Collectors.joining(System.lineSeparator(), System.lineSeparator(), ""));
     }
 
-    public static String removeCommentAndLineSeparator(String origStmt) {
+    // just remove redundant spaces, tabs and line separators
+    public static String removeLineSeparator(String origStmt) {
         char inStringStart = '-';
 
         StringBuilder sb = new StringBuilder();
@@ -92,20 +93,12 @@ public class LogUtil {
                     character == '#') {
                 // process comment style like '-- comment' or '# comment'
                 while (idx < length - 1 && origStmt.charAt(idx) != '\n') {
+                    appendChar(sb, origStmt.charAt(idx));
                     ++idx;
                 }
-                appendChar(sb, ' ');
-            } else if (character == '/' && idx != length - 2 &&
-                    origStmt.charAt(idx + 1) == '*' && origStmt.charAt(idx + 2) != '+') {
-                //  process comment style like '/* comment */'
-                while (idx < length - 1 && (origStmt.charAt(idx) != '*' || origStmt.charAt(idx + 1) != '/')) {
-                    ++idx;
-                }
-                ++idx;
-                appendChar(sb, ' ');
-            } else if (character == '/' && idx != origStmt.length() - 2 &&
-                    origStmt.charAt(idx + 1) == '*' && origStmt.charAt(idx + 2) == '+') {
-                //  process hint
+                appendChar(sb, '\n');
+            } else if (character == '/' && idx != origStmt.length() - 1 && origStmt.charAt(idx + 1) == '*') {
+                //  process comment style like '/* comment */' or hint
                 while (idx < length - 1 && (origStmt.charAt(idx) != '*' || origStmt.charAt(idx + 1) != '/')) {
                     appendChar(sb, origStmt.charAt(idx));
                     idx++;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -216,7 +216,7 @@ public class ConnectProcessor {
             // invalid sql, record the original statement to avoid audit log can't replay
             ctx.getAuditEventBuilder().setStmt(origStmt);
         } else {
-            ctx.getAuditEventBuilder().setStmt(LogUtil.removeCommentAndLineSeparator(origStmt));
+            ctx.getAuditEventBuilder().setStmt(LogUtil.removeLineSeparator(origStmt));
         }
 
         GlobalStateMgr.getCurrentAuditEventProcessor().handleAuditEvent(ctx.getAuditEventBuilder().build());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -699,8 +699,9 @@ public class AnalyzeSingleTest {
     }
 
     @Test
-    public void testRemoveCommentAndLineSeparator1() {
-        String sql = "#comment\nselect /* comment */ /*+SET_VAR(disable_join_reorder=true)*/* from    " +
+    public void testRemoveLineSeparator1() {
+        String sql = "#comment\nselect /* comment */ /*+SET_VAR(disable_join_reorder=true)*/* \n" +
+                "from    \n" +
                 "tbl where-- comment\n" +
                 "col = 1 #comment\r\n" +
                 "\tand /*\n" +
@@ -708,15 +709,22 @@ public class AnalyzeSingleTest {
                 "comment\n" +
                 "*/ col = \"con   tent\n" +
                 "contend\" and col = \"''```中\t文  \\\"\r\n\\r\\n\\t\\\"英  文\" and `col`= 'abc\"bcd\\\'';";
-        String res = LogUtil.removeCommentAndLineSeparator(sql);
-        Assert.assertEquals("select /*+SET_VAR(disable_join_reorder=true)*/* from tbl where col = 1 " +
-                "and col = \"con   tent\n" +
-                "contend\" and col = \"''```中\t文  \\\"\r\n\\r\\n\\t\\\"英  文\" and `col`= 'abc\"bcd\\'';", res);
+        String res = LogUtil.removeLineSeparator(sql);
+        String expect = "#comment\n" +
+                "select /* comment */ /*+SET_VAR(disable_join_reorder=true)*/* from tbl where-- comment\n" +
+                "col = 1 #comment\r\n" +
+                " and /*\n" +
+                "comment\n" +
+                "comment\n" +
+                "*/ col = \"con   tent\n" +
+                "contend\" and col = \"''```中\t文  \\\"\r\n" +
+                "\\r\\n\\t\\\"英  文\" and `col`= 'abc\"bcd\\'';";
+        Assert.assertEquals(expect, res);
     }
 
     @Test
-    public void testRemoveCommentAndLineSeparator2() {
-        String invalidSql = "#comment\nselect /* comment */ /*+SET_VAR(disable_join_reorder=true)*/* from    " +
+    public void testRemoveLineSeparator2() {
+        String invalidSql = "#comment\nselect /* comment */ /*+SET_VAR(disable_join_reorder=true)*/* from    \n" +
                 "tbl where-- comment\n" +
                 "col = 1 #comment\r\n" +
                 "\tand /*\n" +
@@ -724,9 +732,15 @@ public class AnalyzeSingleTest {
                 "comment\n" +
                 "*/ col = \"con   tent\n" +
                 "contend and col = \"''```中\t文  \\\"\r\n\\r\\n\\t\\\"英  文\" and `col`= 'abc\"bcd\\\'';";
-        String res = LogUtil.removeCommentAndLineSeparator(invalidSql);
-        Assert.assertEquals("select /*+SET_VAR(disable_join_reorder=true)*/* from tbl where col = 1 " +
-                "and col = \"con   tent\n" +
-                "contend and col = \"''```中\t文  \\\"\r\n\\r\\n\\t\\\"英  文\" and `col`= 'abc\"bcd\\'';`", res);
+        String res = LogUtil.removeLineSeparator(invalidSql);
+        Assert.assertEquals("#comment\n" +
+                "select /* comment */ /*+SET_VAR(disable_join_reorder=true)*/* from tbl where-- comment\n" +
+                "col = 1 #comment\r\n" +
+                " and /*\n" +
+                "comment\n" +
+                "comment\n" +
+                "*/ col = \"con   tent\n" +
+                "contend and col = \"''```中\t文  \\\"\r\n" +
+                "\\r\\n\\t\\\"英  文\" and `col`= 'abc\"bcd\\'';`", res);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -410,7 +410,7 @@ public class UtFrameUtils {
     private static <R> R buildPlan(ConnectContext connectContext, String originStmt,
                                    GetPlanHook<R> returnedSupplier) throws Exception {
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
-        originStmt = LogUtil.removeCommentAndLineSeparator(originStmt);
+        originStmt = LogUtil.removeLineSeparator(originStmt);
 
         List<StatementBase> statements;
         try (PlannerProfile.ScopedTimer ignored = PlannerProfile.getScopedTimer("Parser")) {
@@ -737,7 +737,7 @@ public class UtFrameUtils {
     public static Pair<String, ExecPlan> getNewPlanAndFragmentFromDump(ConnectContext connectContext,
                                                                        QueryDumpInfo replayDumpInfo) throws Exception {
         String replaySql = initMockEnv(connectContext, replayDumpInfo);
-        replaySql = LogUtil.removeCommentAndLineSeparator(replaySql);
+        replaySql = LogUtil.removeLineSeparator(replaySql);
         Map<String, Database> dbs = null;
         try {
             StatementBase statementBase;


### PR DESCRIPTION
Primary key table use persistent index by default. Add config `enable_persistent_index_default` to control this.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
