### PR TITLE
[BugFix] Fix single replica lost after consecutive balance (#29530)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -100,6 +100,8 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     // no need to persist
     private long lastStatusCheckTime = -1;
 
+    private long lastFullCloneFinishedTimeMs = -1;
+
     public LocalTablet() {
         this(0L, new ArrayList<>());
     }
@@ -822,5 +824,13 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
                 sb.append("}");
             }
         }
+    }
+
+    public long getLastFullCloneFinishedTimeMs() {
+        return lastFullCloneFinishedTimeMs;
+    }
+
+    public void setLastFullCloneFinishedTimeMs(long lastFullCloneFinishedTimeMs) {
+        this.lastFullCloneFinishedTimeMs = lastFullCloneFinishedTimeMs;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -803,7 +803,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         cloneTask.setPathHash(srcPathHash, destPathHash);
         cloneTask.setIsLocal(srcReplica.getBackendId() == destBackendId);
 
-        // if this is a balance task, or this is a repair task with REPLICA_MISSING/REPLICA_RELOCATING or REPLICA_MISSING_IN_CLUSTER,
+        // if this is a balance task, or this is a repair task with REPLICA_MISSING/REPLICA_RELOCATING,
         // we create a new replica with state CLONE
         Database db = GlobalStateMgr.getCurrentState().getDbIncludeRecycleBin(dbId);
         if (db == null) {
@@ -815,6 +815,27 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     || tabletStatus == TabletStatus.REPLICA_RELOCATING
                     || tabletStatus == TabletStatus.COLOCATE_MISMATCH
                     || (type == Type.BALANCE && !cloneTask.isLocal())) {
+                // We should avoid full clone task to run concurrently with replica drop task,
+                // otherwise it may cause replica lost in the following scenario:
+                // we have a tablet T with only one replica,
+                // t1: balancer move T from backend 10001 to backend 10002
+                // t2: after clone finished, redundant replica on 10001 will be dropped,
+                //     but this will only clean the meta from FE, replica is physically
+                //     dropped until next tablet report from BE
+                // t3: balancer schedule a task to move back T from backend 10002 to backend 10001
+                // t4: tablet report from 10001 received, and a replica drop task is sent to backend 10001
+                // t5: clone on backend 10001 finished, and a new replica of T is created on FE
+                // t6: replica drop task has been executed on backend 10001
+                // t7: after the second clone finished, redundant replica on 10002 will be dropped
+                // t8: replica of T is physically lost with only meta of replica on 10001 is left on FE
+                //
+                // If the timing of consecutive full clones is too close, we will delay the next full clone
+                // so that report handler will delete the src replica physically in time.
+                if (System.currentTimeMillis() - tablet.getLastFullCloneFinishedTimeMs() <
+                        Config.tablet_sched_consecutive_full_clone_delay_sec * 1000) {
+                    throw new SchedException(Status.SCHEDULE_RETRY, "consecutive full clone needs to delay");
+                }
+
                 Replica cloneReplica = new Replica(
                         GlobalStateMgr.getCurrentState().getNextId(), destBackendId,
                         -1 /* version */, schemaHash,
@@ -1089,6 +1110,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
         if (replica.getState() == ReplicaState.CLONE) {
             replica.setState(ReplicaState.NORMAL);
+            tablet.setLastFullCloneFinishedTimeMs(System.currentTimeMillis());
             GlobalStateMgr.getCurrentState().getEditLog().logAddReplica(info);
         } else {
             // if in VERSION_INCOMPLETE, replica is not newly created, thus the state is not CLONE

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1306,6 +1306,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int tablet_sched_max_migration_task_sent_once = 1000;
 
+    @ConfField(mutable = true)
+    public static long tablet_sched_consecutive_full_clone_delay_sec = 180; // 3min
+
     /**
      * After checked tablet_checker_partition_batch_num partitions, db lock will be released,
      * so that other threads can get the lock.

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -956,6 +956,7 @@ public class ReportHandler extends Daemon {
                 --maxTaskSendPerBe;
             }
         } // end for backendTabletIds
+
         AgentTaskExecutor.submit(batchTask);
 
         if (deleteFromBackendCounter != 0 || addToMetaCounter != 0) {


### PR DESCRIPTION
Fixes SSU-895

We should avoid full clone task to run concurrently with replica drop task, otherwise it may cause replica lost in the following scenario: we have a tablet T with only one replica,
t1: balancer move T from backend 10001 to backend 10002 t2: after clone finished, redundant replica on 10001 will be dropped, but this will only clean the meta from FE, replica is physically dropped until next tablet report from BE
t3: balancer schedule a task to move back T from backend 10002 to backend 10001 t4: tablet report from 10001 received, and a replica drop task is sent to backend 10001 t5: clone on backend 10001 finished, and a new replica of T is created on FE t6: replica drop task has been executed on backend 10001 t7: after the second clone finished, redundant replica on 10002 will be dropped t8: replica of T is physically lost with only meta of replica on 10001 is left on FE

If the timing of consecutive full clones is too close, we will delay the next full clone so that report handler will delete the src replica physically in time.
