### PR TITLE
[Tool] set default jdk11 options if not provided in fe.conf

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -119,8 +119,12 @@ if [[ "$JAVA_VERSION" -gt 8 ]]; then
     elif [ -n "$JAVA_OPTS_FOR_JDK_9" ]; then 
         final_java_opt=$JAVA_OPTS_FOR_JDK_9
     else
-        echo "JAVA_OPTS_FOR_JDK_11 is not set in fe.conf"       
-        exit -1
+        if [ -z "$DATE" ] ; then
+            DATE=`date +%Y%m%d-%H%M%S`
+        fi
+        default_java_opts_for_jdk11="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xlog:gc*:${LOG_DIR}/fe.gc.log.$DATE:time"
+        echo "JAVA_OPTS_FOR_JDK_11 is not set in fe.conf, use default java options for jdk11 to start fe process: $default_java_opts_for_jdk11"
+        final_java_opt=$default_java_opts_for_jdk11
     fi
 fi
 


### PR DESCRIPTION
* Fixes #29734

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [X] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
