### PR TITLE
[Feature] Turn on query cache in default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -104,6 +104,8 @@ public class FragmentNormalizer {
 
     private Set<Integer> cachedPlanNodeIds = Sets.newHashSet();
     private boolean assignScanRangesAcrossDrivers = false;
+    private int numTablets = 0;
+    private long rowCountPerTablet = 0;
     public FragmentNormalizer(ExecPlan execPlan, PlanFragment fragment) {
         this.execPlan = execPlan;
         this.fragment = fragment;
@@ -152,6 +154,22 @@ public class FragmentNormalizer {
 
     void endNotRemappingSlotId() {
         this.notRemappingSlotId = false;
+    }
+
+    public void setNumTablets(int numTablets) {
+        this.numTablets = numTablets;
+    }
+
+    public int getNumTablets() {
+        return this.numTablets;
+    }
+
+    public void setRowCountPerTablet(long rowCountPerTablet) {
+        this.rowCountPerTablet = rowCountPerTablet;
+    }
+
+    public long getRowCountPerTablet(){
+        return rowCountPerTablet;
     }
 
     public boolean isNotRemappingSlotId() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1136,6 +1136,9 @@ public class OlapScanNode extends ScanNode {
                     normalizer.getExecPlan().getDescTbl().getTupleDesc(tupleIds.get(0)).getSlots().stream()
                             .filter(s -> aggColumnNames.contains(s.getColumn().getName())).map(s -> s.getId())
                             .collect(Collectors.toSet());
+            int numTablets = Math.max(1, this.getScanTabletIds().size());
+            normalizer.setNumTablets(numTablets);
+            normalizer.setRowCountPerTablet(Math.max(1L, this.getCardinality() / numTablets));
             normalizer.setSlotsUseAggColumns(aggColumnSlotIds);
         } else {
             List<Long> partitionIds = getSelectedPartitionIds();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -371,7 +371,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CONNECTOR_IO_TASKS_SLOW_IO_LATENCY_MS = "connector_io_tasks_slow_io_latency_ms";
     public static final String SCAN_USE_QUERY_MEM_RATIO = "scan_use_query_mem_ratio";
     public static final String CONNECTOR_SCAN_USE_QUERY_MEM_RATIO = "connector_scan_use_query_mem_ratio";
+
+    public static final String ENABLE_QUERY_CACHE_V2 = "enable_query_cache_v2";
     public static final String ENABLE_QUERY_CACHE = "enable_query_cache";
+
+    public static final String QUERY_CACHE_DENY_OVERSIZE_RESULT = "query_cache_deny_oversize_result";
     public static final String QUERY_CACHE_FORCE_POPULATE = "query_cache_force_populate";
     public static final String QUERY_CACHE_ENTRY_MAX_BYTES = "query_cache_entry_max_bytes";
     public static final String QUERY_CACHE_ENTRY_MAX_ROWS = "query_cache_entry_max_rows";
@@ -1162,8 +1166,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = HUDI_MOR_FORCE_JNI_READER)
     private boolean hudiMORForceJNIReader = false;
 
-    @VarAttr(name = ENABLE_QUERY_CACHE)
-    private boolean enableQueryCache = false;
+    @VarAttr(name = ENABLE_QUERY_CACHE_V2, alias = ENABLE_QUERY_CACHE, show = ENABLE_QUERY_CACHE)
+    private boolean enableQueryCache = true;
+
+    @VarAttr(name = QUERY_CACHE_DENY_OVERSIZE_RESULT, flag = VariableMgr.INVISIBLE)
+    private boolean queryCacheDenyOversizeResult = true;
 
     @VarAttr(name = QUERY_CACHE_FORCE_POPULATE)
     private boolean queryCacheForcePopulate = false;
@@ -2258,6 +2265,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableQueryCache(boolean on) {
         enableQueryCache = on;
+    }
+
+    public void setQueryCacheDenyOversizeResult(boolean on) {
+        queryCacheDenyOversizeResult = on;
+    }
+
+    public boolean isQueryCacheDenyOversizeResult() {
+        return queryCacheDenyOversizeResult;
     }
 
     public boolean isQueryCacheForcePopulate() {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
@@ -414,6 +414,7 @@ public class QueryCacheTest {
                 throw new RuntimeException(e);
             }
         });
+        ctx.getSessionVariable().setQueryCacheDenyOversizeResult(false);
     }
 
     public static List<String> getSsbCreateTableSqlList() {

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/plan/AggregateTest.java
@@ -35,6 +35,6 @@ public class AggregateTest extends SchedulerTestBase {
      */
     @Test
     public void testLocalOnePhaseAggregateWithExchangeInstanceParallel() {
-        runFileUnitTest("scheduler/aggregate/agg_local_one_phase_non_partition_one_exchange");
+        runFileUnitTest("scheduler/aggregate/agg_local_one_phase_non_partition_one_exchange", true);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1653,6 +1653,7 @@ public class AggregateTest extends PlanTestBase {
     @Test
     public void testSortedStreamingAggregate() throws Exception {
         connectContext.getSessionVariable().setEnableSortAggregate(true);
+        connectContext.getSessionVariable().setEnableQueryCache(false);
         String sql;
         String plan;
         {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1101,6 +1101,7 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
 
         // For the none-local one-phase aggregation, disable AssignScanRangesPerDriverSeq and enable SharedScan.
         ConnectContext.get().getSessionVariable().setNewPlanerAggStage(1);
+        ConnectContext.get().getSessionVariable().setEnableQueryCache(false);
         sql = "select count(1) from customer group by C_NAME";
         plan = getExecPlan(sql);
         fragment = plan.getFragments().get(2);

--- a/fe/fe-core/src/test/resources/sql/scheduler/aggregate/agg_local_one_phase_non_partition_one_exchange.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/aggregate/agg_local_one_phase_non_partition_one_exchange.sql
@@ -20,38 +20,61 @@ PLAN FRAGMENT 2(F00)
     INSTANCE(2-F00#0)
       DESTINATIONS: 1-F01#0
       BE: 10001
-      SCAN RANGES
+      DOP: 7
+      SCAN RANGES (per driver sequence)
         0:OlapScanNode
-          1. partitionID=1001,tabletID=1004
-          2. partitionID=1001,tabletID=1010
-          3. partitionID=1001,tabletID=1016
-          4. partitionID=1001,tabletID=1022
-          5. partitionID=1001,tabletID=1028
-          6. partitionID=1001,tabletID=1034
-          7. partitionID=1001,tabletID=1040
+          DriverSequence#0
+            1. partitionID=1001,tabletID=1004
+          DriverSequence#1
+            2. partitionID=1001,tabletID=1010
+          DriverSequence#2
+            3. partitionID=1001,tabletID=1016
+          DriverSequence#3
+            4. partitionID=1001,tabletID=1022
+          DriverSequence#4
+            5. partitionID=1001,tabletID=1028
+          DriverSequence#5
+            6. partitionID=1001,tabletID=1034
+          DriverSequence#6
+            7. partitionID=1001,tabletID=1040
     INSTANCE(3-F00#1)
       DESTINATIONS: 1-F01#0
       BE: 10002
-      SCAN RANGES
+      DOP: 7
+      SCAN RANGES (per driver sequence)
         0:OlapScanNode
-          1. partitionID=1001,tabletID=1006
-          2. partitionID=1001,tabletID=1012
-          3. partitionID=1001,tabletID=1018
-          4. partitionID=1001,tabletID=1024
-          5. partitionID=1001,tabletID=1030
-          6. partitionID=1001,tabletID=1036
-          7. partitionID=1001,tabletID=1042
+          DriverSequence#0
+            1. partitionID=1001,tabletID=1006
+          DriverSequence#1
+            2. partitionID=1001,tabletID=1012
+          DriverSequence#2
+            3. partitionID=1001,tabletID=1018
+          DriverSequence#3
+            4. partitionID=1001,tabletID=1024
+          DriverSequence#4
+            5. partitionID=1001,tabletID=1030
+          DriverSequence#5
+            6. partitionID=1001,tabletID=1036
+          DriverSequence#6
+            7. partitionID=1001,tabletID=1042
     INSTANCE(4-F00#2)
       DESTINATIONS: 1-F01#0
       BE: 10003
-      SCAN RANGES
+      DOP: 6
+      SCAN RANGES (per driver sequence)
         0:OlapScanNode
-          1. partitionID=1001,tabletID=1008
-          2. partitionID=1001,tabletID=1014
-          3. partitionID=1001,tabletID=1020
-          4. partitionID=1001,tabletID=1026
-          5. partitionID=1001,tabletID=1032
-          6. partitionID=1001,tabletID=1038
+          DriverSequence#0
+            1. partitionID=1001,tabletID=1008
+          DriverSequence#1
+            2. partitionID=1001,tabletID=1014
+          DriverSequence#2
+            3. partitionID=1001,tabletID=1020
+          DriverSequence#3
+            4. partitionID=1001,tabletID=1026
+          DriverSequence#4
+            5. partitionID=1001,tabletID=1032
+          DriverSequence#5
+            6. partitionID=1001,tabletID=1038
 
 [fragment]
 PLAN FRAGMENT 0
@@ -128,38 +151,61 @@ PLAN FRAGMENT 2(F00)
     INSTANCE(4-F00#0)
       DESTINATIONS: 1-F01#0,2-F01#1,3-F01#2
       BE: 10001
-      SCAN RANGES
+      DOP: 7
+      SCAN RANGES (per driver sequence)
         0:OlapScanNode
-          1. partitionID=1001,tabletID=1004
-          2. partitionID=1001,tabletID=1010
-          3. partitionID=1001,tabletID=1016
-          4. partitionID=1001,tabletID=1022
-          5. partitionID=1001,tabletID=1028
-          6. partitionID=1001,tabletID=1034
-          7. partitionID=1001,tabletID=1040
+          DriverSequence#0
+            1. partitionID=1001,tabletID=1004
+          DriverSequence#1
+            2. partitionID=1001,tabletID=1010
+          DriverSequence#2
+            3. partitionID=1001,tabletID=1016
+          DriverSequence#3
+            4. partitionID=1001,tabletID=1022
+          DriverSequence#4
+            5. partitionID=1001,tabletID=1028
+          DriverSequence#5
+            6. partitionID=1001,tabletID=1034
+          DriverSequence#6
+            7. partitionID=1001,tabletID=1040
     INSTANCE(5-F00#1)
       DESTINATIONS: 1-F01#0,2-F01#1,3-F01#2
       BE: 10002
-      SCAN RANGES
+      DOP: 7
+      SCAN RANGES (per driver sequence)
         0:OlapScanNode
-          1. partitionID=1001,tabletID=1006
-          2. partitionID=1001,tabletID=1012
-          3. partitionID=1001,tabletID=1018
-          4. partitionID=1001,tabletID=1024
-          5. partitionID=1001,tabletID=1030
-          6. partitionID=1001,tabletID=1036
-          7. partitionID=1001,tabletID=1042
+          DriverSequence#0
+            1. partitionID=1001,tabletID=1006
+          DriverSequence#1
+            2. partitionID=1001,tabletID=1012
+          DriverSequence#2
+            3. partitionID=1001,tabletID=1018
+          DriverSequence#3
+            4. partitionID=1001,tabletID=1024
+          DriverSequence#4
+            5. partitionID=1001,tabletID=1030
+          DriverSequence#5
+            6. partitionID=1001,tabletID=1036
+          DriverSequence#6
+            7. partitionID=1001,tabletID=1042
     INSTANCE(6-F00#2)
       DESTINATIONS: 1-F01#0,2-F01#1,3-F01#2
       BE: 10003
-      SCAN RANGES
+      DOP: 6
+      SCAN RANGES (per driver sequence)
         0:OlapScanNode
-          1. partitionID=1001,tabletID=1008
-          2. partitionID=1001,tabletID=1014
-          3. partitionID=1001,tabletID=1020
-          4. partitionID=1001,tabletID=1026
-          5. partitionID=1001,tabletID=1032
-          6. partitionID=1001,tabletID=1038
+          DriverSequence#0
+            1. partitionID=1001,tabletID=1008
+          DriverSequence#1
+            2. partitionID=1001,tabletID=1014
+          DriverSequence#2
+            3. partitionID=1001,tabletID=1020
+          DriverSequence#3
+            4. partitionID=1001,tabletID=1026
+          DriverSequence#4
+            5. partitionID=1001,tabletID=1032
+          DriverSequence#5
+            6. partitionID=1001,tabletID=1038
 
 [fragment]
 PLAN FRAGMENT 0


### PR DESCRIPTION
Benchmark Test result as follows
http://47.92.23.11:8001/cluster/regression/report/55

Slow queries(performance degradation is greater than 10%) in above list is badcases, so forbidden query cache for these queries. badcases includes:
1. multi_distinct_count, multi_distinct_sum, aggregation functions generates bitmap or complex types as intermediate result(Aggregation needs not  finalization) or result type (Aggregation needs finalization).
2. for 1st-agg, evaluated row count of per-tablet aggregation would be aggregation's cardinality/numTablets.
3. for {2nd,3rd,4th}-agg, evaluated row count of per-tablet aggregation would be min(OlapScanNode's cardinality/OlapScanNode's numTablets,  Aggregation's cardinality*0.5);
4. if evaluated row count  of per-tablet aggragation exceeds exceed query_cache_entry_max_rows or evaluated bytes of per-tablet aggregation exceeds query_cache_entry_max_bytes, the query are badcase, so should not use query cache.

Slow query performance tests after automatically turning off query cache according to above policies as follows:
```
+=====+=====================+=====+=============+========================+=========================+========================================+
| NO. | query               | dop | concurrency | enable_query_cache(ms) | disable_query_cache(ms) | enable_query_cache/disable_query_cache |
+=====+=====================+=====+=============+========================+=========================+========================================+
| 1   | click_bench.q07.sql | 8   | 1           | 38                     | 56                      | 0.68                                   |
| 2   | click_bench.q06.sql | 8   | 1           | 407                    | 396                     | 1.03                                   |
| 3   | test_ssb.q176.sql   | 8   | 1           | 2883                   | 2793                    | 1.03                                   |
| 4   | click_bench.q09.sql | 8   | 1           | 216                    | 190                     | 1.14                                   |
| 5   | click_bench.q20.sql | 8   | 32          | 173                    | 212                     | 0.82                                   |
| 6   | click_bench.q19.sql | 8   | 1           | 1510                   | 1480                    | 1.02                                   |
| 7   | tpcds.query94.sql   | 8   | 1           | 516                    | 544                     | 0.95                                   |
| 8   | click_bench.q09.sql | 8   | 8           | 1137                   | 1052                    | 1.08                                   |
| 9   | click_bench.q09.sql | 8   | 16          | 2334                   | 2191                    | 1.07                                   |
| 10  | tpcds.query83.sql   | 8   | 1           | 347                    | 373                     | 0.93                                   |
| 11  | tpcds.query85.sql   | 8   | 1           | 564                    | 532                     | 1.06                                   |
| 12  | click_bench.q09.sql | 8   | 32          | 4768                   | 4417                    | 1.08                                   |
| 13  | click_bench.q08.sql | 8   | 16          | 450                    | 674                     | 0.67                                   |
| 14  | click_bench.q12.sql | 8   | 1           | 79                     | 93                      | 0.85                                   |
| 15  | click_bench.q17.sql | 8   | 1           | 831                    | 699                     | 1.19                                   |
| 16  | click_bench.q19.sql | 8   | 8           | 8195                   | 7642                    | 1.07                                   |
| 17  | click_bench.q17.sql | 8   | 8           | 4249                   | 3578                    | 1.19                                   |
| 18  | click_bench.q08.sql | 8   | 8           | 223                    | 279                     | 0.80                                   |
| 19  | click_bench.q17.sql | 8   | 16          | 8307                   | 7225                    | 1.15                                   |
| 20  | click_bench.q39.sql | 8   | 32          | 1010                   | 966                     | 1.05                                   |
| 21  | test_ssb.q157.sql   | 8   | 1           | 4769                   | 4215                    | 1.13                                   |
| 22  | click_bench.q16.sql | 8   | 32          | 4053                   | 3971                    | 1.02                                   |
| 23  | click_bench.q25.sql | 8   | 16          | 477                    | 509                     | 0.94                                   |
| 24  | click_bench.q38.sql | 8   | 32          | 1226                   | 1288                    | 0.95                                   |
| 25  | click_bench.q30.sql | 8   | 1           | 100                    | 134                     | 0.75                                   |
| 26  | click_bench.q27.sql | 8   | 32          | 770                    | 868                     | 0.89                                   |
| 27  | click_bench.q14.sql | 8   | 1           | 503                    | 511                     | 0.98                                   |
| 28  | click_bench.q16.sql | 8   | 16          | 2006                   | 1878                    | 1.07                                   |
| 29  | ssb.q10.sql         | 8   | 16          | 1485                   | 1539                    | 0.96                                   |
| 30  | test_ssb.q173.sql   | 8   | 1           | 1258                   | 1227                    | 1.03                                   |
| 31  | click_bench.q16.sql | 8   | 8           | 983                    | 942                     | 1.04                                   |
| 32  | click_bench.q02.sql | 8   | 32          | 557                    | 621                     | 0.90                                   |
| 33  | tpcds.query91.sql   | 8   | 1           | 213                    | 235                     | 0.91                                   |
| 34  | click_bench.q23.sql | 8   | 1           | 738                    | 1025                    | 0.72                                   |
| 35  | click_bench.q39.sql | 8   | 16          | 485                    | 482                     | 1.01                                   |
| 36  | click_bench.q08.sql | 8   | 32          | 1022                   | 1272                    | 0.80                                   |
| 37  | click_bench.q39.sql | 8   | 8           | 354                    | 285                     | 1.24                                   |
| 38  | click_bench.q43.sql | 8   | 32          | 1217                   | 1304                    | 0.93                                   |
| 39  | click_bench.q14.sql | 8   | 8           | 3417                   | 3549                    | 0.96                                   |
| 40  | click_bench.q38.sql | 8   | 8           | 250                    | 259                     | 0.97                                   |
| 41  | click_bench.q38.sql | 8   | 16          | 565                    | 549                     | 1.03                                   |
| 42  | tpcds.query90.sql   | 8   | 1           | 159                    | 188                     | 0.85                                   |
| 43  | click_bench.q01.sql | 8   | 16          | 238                    | 387                     | 0.61                                   |
| 44  | click_bench.q02.sql | 8   | 16          | 255                    | 282                     | 0.90                                   |
| 45  | click_bench.q03.sql | 8   | 1           | 26                     | 38                      | 0.68                                   |
| 46  | tpcds.query80.sql   | 8   | 1           | 1404                   | 1377                    | 1.02                                   |
| 47  | click_bench.q27.sql | 8   | 16          | 407                    | 595                     | 0.68                                   |
| 48  | click_bench.q37.sql | 8   | 32          | 1447                   | 1532                    | 0.94                                   |
| 49  | click_bench.q05.sql | 8   | 1           | 148                    | 146                     | 1.01                                   |
| 50  | click_bench.q14.sql | 8   | 16          | 7140                   | 7250                    | 0.98                                   |
| 52  | tpcds.query40.sql   | 8   | 1           | 281                    | 287                     | 0.98                                   |
| 53  | click_bench.q27.sql | 8   | 8           | 203                    | 196                     | 1.04                                   |
| 54  | tpcds.query76.sql   | 8   | 1           | 361                    | 423                     | 0.85                                   |
| 55  | click_bench.q16.sql | 8   | 1           | 203                    | 188                     | 1.08                                   |
| 56  | click_bench.q25.sql | 8   | 8           | 234                    | 185                     | 1.26                                   |
| 57  | tpcds.query30.sql   | 8   | 1           | 239                    | 281                     | 0.85                                   |
| 58  | click_bench.q37.sql | 8   | 16          | 663                    | 684                     | 0.97                                   |
| 59  | ssb.q10.sql         | 8   | 8           | 851                    | 880                     | 0.97                                   |
| 60  | ssb.q10.sql         | 8   | 32          | 3115                   | 3394                    | 0.92                                   |
| 61  | click_bench.q01.sql | 8   | 32          | 597                    | 910                     | 0.66                                   |
| 62  | click_bench.q11.sql | 8   | 16          | 816                    | 1037                    | 0.79                                   |
| 63  | click_bench.q25.sql | 8   | 32          | 771                    | 834                     | 0.92                                   |
| 64  | click_bench.q42.sql | 8   | 16          | 560                    | 579                     | 0.97                                   |
| 65  | tpcds.query49.sql   | 8   | 1           | 704                    | 753                     | 0.93                                   |
| 66  | click_bench.q37.sql | 8   | 8           | 322                    | 311                     | 1.04                                   |
| 67  | click_bench.q41.sql | 8   | 16          | 546                    | 664                     | 0.82                                   |
| 68  | click_bench.q06.sql | 8   | 8           | 2367                   | 2314                    | 1.02                                   |
| 69  | ssb.q13.sql         | 8   | 8           | 1891                   | 1885                    | 1.00                                   |
| 70  | test_ssb.q209.sql   | 8   | 1           | 1534                   | 1420                    | 1.08                                   |
| 71  | tpcds.query41.sql   | 8   | 1           | 78                     | 72                      | 1.08                                   |
| 73  | test_ssb.q210.sql   | 8   | 1           | 1024                   | 1011                    | 1.01                                   |
| 74  | click_bench.q06.sql | 8   | 16          | 4731                   | 4720                    | 1.00                                   |
| 75  | tpcds.query06.sql   | 8   | 1           | 366                    | 397                     | 0.92                                   |
| 76  | tpcds.query45.sql   | 8   | 1           | 379                    | 331                     | 1.15                                   |
| 77  | click_bench.q20.sql | 8   | 16          | 89                     | 88                      | 1.01                                   |
| 78  | tpcds.query56.sql   | 8   | 1           | 532                    | 767                     | 0.69                                   |
| 79  | tpcds.query58.sql   | 8   | 1           | 531                    | 544                     | 0.98                                   |
| 80  | click_bench.q02.sql | 8   | 8           | 128                    | 146                     | 0.88                                   |
| 81  | click_bench.q24.sql | 8   | 32          | 2919                   | 2749                    | 1.06                                   |
| 82  | ssb-flat.q02.sql    | 8   | 32          | 579                    | 655                     | 0.88                                   |
| 83  | ssb.q13.sql         | 8   | 16          | 3751                   | 3819                    | 0.98                                   |
| 84  | test_ssb.q178.sql   | 8   | 1           | 5472                   | 5568                    | 0.98                                   |
| 85  | tpcds.query16.sql   | 8   | 1           | 618                    | 644                     | 0.96                                   |
| 86  | click_bench.q24.sql | 8   | 16          | 1105                   | 1174                    | 0.94                                   |
| 87  | tpcds.query60.sql   | 8   | 1           | 456                    | 693                     | 0.66                                   |
| 88  | tpch.q15.sql        | 8   | 1           | 195                    | 196                     | 0.99                                   |
| 89  | click_bench.q06.sql | 8   | 32          | OOM                    | OOM                     | n/a                                    |
| 90  | ssb-flat.q10.sql    | 8   | 16          | 504                    | 576                     | 0.88                                   |
| 91  | tpcds.query19.sql   | 8   | 1           | 656                    | 476                     | 1.38                                   |
| 92  | tpcds.query24.sql   | 8   | 1           | 1107                   | 1143                    | 0.97                                   |
| 93  | click_bench.q11.sql | 8   | 1           | 115                    | 106                     | 1.08                                   |
| 94  | click_bench.q11.sql | 8   | 32          | 1504                   | 1900                    | 0.79                                   |
| 95  | ssb-flat.q02.sql    | 8   | 16          | 257                    | 278                     | 0.92                                   |
| 96  | ssb.q13.sql         | 8   | 1           | 298                    | 320                     | 0.93                                   |
| 97  | tpcds.query29.sql   | 8   | 1           | 781                    | 786                     | 0.99                                   |
| 98  | tpcds.query69.sql   | 8   | 1           | 469                    | 444                     | 1.06                                   |
| 99  | click_bench.q41.sql | 8   | 8           | 245                    | 296                     | 0.83                                   |
| 100 | click_bench.q43.sql | 8   | 16          | 481                    | 572                     | 0.84                                   |
| 101 | ssb.q13.sql         | 8   | 32          | 7232                   | 7352                    | 0.98                                   |
| 102 | tpcds.query61.sql   | 8   | 1           | 856                    | 843                     | 1.02                                   |
| 103 | tpcds.query84.sql   | 8   | 1           | 154                    | 179                     | 0.86                                   |
| 104 | tpcds.query46.sql   | 8   | 1           | 567                    | 555                     | 1.02                                   |
| 105 | tpcds.query95.sql   | 8   | 1           | 839                    | 793                     | 1.06                                   |
| 106 | click_bench.q26.sql | 8   | 16          | 852                    | 812                     | 1.05                                   |
| 107 | click_bench.q42.sql | 8   | 32          | 1020                   | 1263                    | 0.81                                   |
| 108 | click_bench.q43.sql | 8   | 8           | 286                    | 351                     | 0.81                                   |
| 109 | test_ssb.q215.sql   | 8   | 1           | 1869                   | 1541                    | 1.21                                   |
| 110 | click_bench.q26.sql | 8   | 32          | 1655                   | 1716                    | 0.96                                   |
| 111 | click_bench.q41.sql | 8   | 32          | 1088                   | 1174                    | 0.93                                   |
| 112 | ssb-flat.q10.sql    | 8   | 32          | 1257                   | 1124                    | 1.12                                   |
| 113 | test_ssb.q136.sql   | 8   | 1           | 1503                   | 1413                    | 1.06                                   |
| 114 | test_ssb.q139.sql   | 8   | 1           | 1016                   | 954                     | 1.06                                   |
| 115 | test_ssb.q32.sql    | 8   | 1           | 284                    | 290                     | 0.98                                   |
| 116 | tpcds.query37.sql   | 8   | 1           | 105                    | 100                     | 1.05                                   |
| 117 | tpch.q08.sql        | 8   | 1           | 891                    | 970                     | 0.92                                   |
| 118 | test_ssb.q155.sql   | 8   | 1           | 5292                   | 5532                    | 0.96                                   |
| 119 | tpcds.query12.sql   | 8   | 1           | 169                    | 163                     | 1.04                                   |
| 120 | tpcds.query17.sql   | 8   | 1           | 983                    | 927                     | 1.06                                   |
| 121 | tpcds.query35.sql   | 8   | 1           | 631                    | 632                     | 1.00                                   |
| 122 | tpcds.query92.sql   | 8   | 1           | 136                    | 194                     | 0.70                                   |
| 123 | click_bench.q13.sql | 8   | 8           | 2202                   | 2254                    | 0.98                                   |
| 124 | click_bench.q15.sql | 8   | 16          | 5913                   | 6136                    | 0.96                                   |
| 125 | click_bench.q26.sql | 8   | 8           | 475                    | 414                     | 1.15                                   |
| 126 | click_bench.q30.sql | 8   | 32          | 1844                   | 1772                    | 1.04                                   |
| 127 | ssb.q03.sql         | 8   | 1           | 51                     | 103                     | 0.50                                   |
| 128 | tpcds.query54.sql   | 8   | 1           | 396                    | 541                     | 0.73                                   |
| 129 | tpcds.query71.sql   | 8   | 1           | 533                    | 483                     | 1.10                                   |
| 130 | test_ssb.q29.sql    | 8   | 1           | 196                    | 160                     | 1.23                                   |
| 131 | tpcds.query81.sql   | 8   | 1           | 273                    | 269                     | 1.01                                   |
| 132 | click_bench.q31.sql | 8   | 32          | 5422                   | 5574                    | 0.97                                   |
| 133 | test_ssb.q212.sql   | 8   | 1           | 1193                   | 1067                    | 1.12                                   |
| 134 | test_ssb.q36.sql    | 8   | 1           | 55                     | 92                      | 0.60                                   |
| 136 | tpcds.query33.sql   | 8   | 1           | 420                    | 660                     | 0.64                                   |
| 137 | click_bench.q41.sql | 8   | 1           | 47                     | 56                      | 0.84                                   |
| 138 | click_bench.q42.sql | 8   | 1           | 45                     | 50                      | 0.90                                   |
| 139 | test_ssb.q162.sql   | 8   | 1           | 12534                  | 12359                   | 1.01                                   |
| 140 | test_ssb.q207.sql   | 8   | 1           | 3961                   | 3411                    | 1.16                                   |
| 141 | test_ssb.q217.sql   | 8   | 1           | 1886                   | 1608                    | 1.17                                   |
| 142 | test_ssb.q234.sql   | 8   | 1           | 4034                   | 3431                    | 1.18                                   |
| 143 | tpcds.query66.sql   | 8   | 1           | 648                    | 669                     | 0.97                                   |
| 144 | click_bench.q13.sql | 8   | 32          | 10150                  | 10071                   | 1.01                                   |
| 145 | click_bench.q15.sql | 8   | 8           | 2853                   | 2888                    | 0.99                                   |
| 146 | click_bench.q31.sql | 8   | 16          | 2591                   | 2646                    | 0.98                                   |
| 147 | ssb-flat.q03.sql    | 8   | 1           | 31                     | 66                      | 0.47                                   |
| 148 | test_ssb.q158.sql   | 8   | 1           | 13017                  | 13037                   | 1.00                                   |
+-----+---------------------+-----+-------------+------------------------+-------------------------+----------------------------------------+
```


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
