### PR TITLE
[BugFix] Fix pending queryeis when group.concurrency_limit is null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotRequestQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotRequestQueue.java
@@ -142,8 +142,8 @@ public class SlotRequestQueue {
             return true;
         }
 
-        int numTotalSlots = group.getConcurrencyLimit();
-        return numTotalSlots <= 0 || numAllocatedSlotsOfGroup < numTotalSlots;
+        Integer numTotalSlots = group.getConcurrencyLimit();
+        return numTotalSlots == null || numTotalSlots <= 0 || numAllocatedSlotsOfGroup < numTotalSlots;
     }
 
     private int peakSlotsToAllocateFromSubQueue(LinkedHashMap<TUniqueId, LogicalSlot> subQueue,


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
