### PR TITLE
[BugFix] fix scalarOperator not being negated correctly (backport #29695)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FilterSelectivityEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FilterSelectivityEvaluator.java
@@ -156,7 +156,7 @@ public class FilterSelectivityEvaluator {
             } else {
                 Set<ScalarOperator> inSet = predicate.getChildren().stream().skip(1).collect(Collectors.toSet());
                 List<ColumnRefOperator> usedCols = predicate.getChild(0).getColumnRefs();
-                if (isOnlyRefOneCol(usedCols) && inSet.stream().allMatch(ScalarOperator::isConstantRef)) {
+                if (isOnlyRefOneCol(usedCols) && inSet.stream().allMatch(e -> e.isConstantRef() && !e.isNullable())) {
                     ColumnRefOperator column = usedCols.get(0);
                     ColumnStatistic columnStatistic = statistics.getColumnStatistic(column);
                     double selectRatio;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/InvertedCaseWhen.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/InvertedCaseWhen.java
@@ -276,16 +276,17 @@ public class InvertedCaseWhen {
         @Override
         public Optional<ScalarOperator> visitInPredicate(InPredicateOperator predicate, Void context) {
             Set<ScalarOperator> inSet = predicate.getChildren().stream().skip(1).collect(Collectors.toSet());
-            if (!inSet.stream().allMatch(ScalarOperator::isConstantRef)) {
+            // col in (1, 2, 3) is not equal with col in (1, 2, 3, null). For col = 4, the first return false
+            // while the second return null.
+            // If there exists null value, we forbid rewriting the predicate.
+            if (!inSet.stream().allMatch(e -> e.isConstantRef() && !e.isNullable())) {
                 return Optional.empty();
             }
             Optional<InvertedCaseWhen> maybeInvertedCaseWhen = from(predicate.getChild(0));
             if (!maybeInvertedCaseWhen.isPresent()) {
                 return Optional.empty();
             }
-            // case when ... in (NULL, NULL) is equivalent to NULL
-            // case when ... in (NULL, c1) is equivalent to case when ... in (c1)
-            inSet.removeIf(ScalarOperator::isConstantNull);
+
             if (inSet.isEmpty()) {
                 return Optional.of(ConstantOperator.NULL);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/NegateFilterShuttle.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/NegateFilterShuttle.java
@@ -17,14 +17,15 @@ package com.starrocks.sql.optimizer.rewrite.scalar;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.CompoundType;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 
 import static com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator.BinaryType.EQ_FOR_NULL;
 
-public class NegateFilterShuttle extends BaseScalarOperatorShuttle {
+public class NegateFilterShuttle extends ScalarOperatorVisitor<ScalarOperator, Void> {
 
     private static NegateFilterShuttle INSTANCE = new NegateFilterShuttle();
 
@@ -91,18 +92,34 @@ public class NegateFilterShuttle extends BaseScalarOperatorShuttle {
 
     @Override
     public ScalarOperator visitInPredicate(InPredicateOperator predicate, Void context) {
+        boolean containsNullValue = predicate.getChildren().stream().skip(1).anyMatch(ScalarOperator::isNullable);
         ScalarOperator negation = new InPredicateOperator(!predicate.isNotIn(), predicate.getChildren());
-        if (predicate.getChild(0).isNullable()) {
-            ScalarOperator isNull = new IsNullPredicateOperator(predicate.getChild(0));
-            return new CompoundPredicateOperator(CompoundType.OR, negation, isNull);
+        if (containsNullValue) {
+            return new CompoundPredicateOperator(CompoundType.OR, negation, new IsNullPredicateOperator(predicate));
         } else {
-            return negation;
+            if (predicate.getChild(0).isNullable()) {
+                ScalarOperator isNull = new IsNullPredicateOperator(predicate.getChild(0));
+                return new CompoundPredicateOperator(CompoundType.OR, negation, isNull);
+            } else {
+                return negation;
+            }
         }
     }
 
     @Override
     public ScalarOperator visitIsNullPredicate(IsNullPredicateOperator predicate, Void context) {
         return new IsNullPredicateOperator(!predicate.isNotNull(), predicate.getChild(0));
+    }
+
+    @Override
+    public ScalarOperator visitConstant(ConstantOperator literal, Void context) {
+        if (literal.isTrue()) {
+            return ConstantOperator.FALSE;
+        } else if (literal.isFalse()) {
+            return ConstantOperator.TRUE;
+        } else {
+            return new CompoundPredicateOperator(CompoundType.NOT, literal);
+        }
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/BaseScalarOperatorShuttleTest.java
@@ -3,6 +3,7 @@
 package com.starrocks.sql.optimizer.rewrite;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.operator.scalar.ArrayOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ArraySliceOperator;
@@ -18,7 +19,14 @@ import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.scalar.NegateFilterShuttle;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 import static com.starrocks.catalog.Type.ARRAY_TINYINT;
 import static com.starrocks.catalog.Type.INT;
@@ -140,4 +148,97 @@ class BaseScalarOperatorShuttleTest {
         assertNotEquals(otherOperator, newOperator);
 
     }
+
+    @ParameterizedTest(name = "{index}: {0}.")
+    @MethodSource("inPredicateCases")
+    void testNegateInPredicate(ScalarOperator operator, String expected) {
+        NegateFilterShuttle shuttle1 = NegateFilterShuttle.getInstance();
+        ScalarOperator reuslt = shuttle1.negateFilter(operator);
+        assertEquals(expected, reuslt.toString());
+    }
+
+    private static Stream<Arguments> inPredicateCases() {
+        List<Arguments> argumentsList = Lists.newArrayList();
+        // not in constant values without null
+        InPredicateOperator operator = new InPredicateOperator(true, ImmutableList.of(
+                new ColumnRefOperator(1, INT, "id", false),
+                ConstantOperator.createInt(1),
+                ConstantOperator.createInt(2)));
+
+        argumentsList.add(Arguments.of(operator, "1: id IN (1, 2)"));
+
+        operator = new InPredicateOperator(true, ImmutableList.of(
+                new ColumnRefOperator(1, INT, "id", true),
+                ConstantOperator.createInt(1),
+                ConstantOperator.createInt(2)));
+
+        argumentsList.add(Arguments.of(operator, "1: id IN (1, 2) OR 1: id IS NULL"));
+
+        // not in constant values with null
+        operator = new InPredicateOperator(true, ImmutableList.of(
+                new ColumnRefOperator(1, INT, "id", false),
+                ConstantOperator.createInt(1),
+                ConstantOperator.createInt(2),
+                ConstantOperator.NULL));
+        argumentsList.add(Arguments.of(operator, "1: id IN (1, 2, null) OR 1: id NOT IN (1, 2, null) IS NULL"));
+
+        operator = new InPredicateOperator(true, ImmutableList.of(
+                new ColumnRefOperator(1, INT, "id", true),
+                ConstantOperator.createInt(1),
+                ConstantOperator.createInt(2),
+                ConstantOperator.NULL));
+        argumentsList.add(Arguments.of(operator, "1: id IN (1, 2, null) OR 1: id NOT IN (1, 2, null) IS NULL"));
+
+        // not in values contains expr
+        operator = new InPredicateOperator(true, ImmutableList.of(
+                new ColumnRefOperator(1, INT, "id", true),
+                ConstantOperator.createInt(1),
+                ConstantOperator.createInt(2),
+                new CastOperator(INT, ConstantOperator.createChar("a"))));
+
+        argumentsList.add(Arguments.of(operator, "1: id IN (1, 2, cast(a as int(11))) " +
+                "OR 1: id NOT IN (1, 2, cast(a as int(11))) IS NULL"));
+
+        // in constant values without null
+        operator = new InPredicateOperator(false, ImmutableList.of(
+                new ColumnRefOperator(1, INT, "id", false),
+                ConstantOperator.createInt(1),
+                ConstantOperator.createInt(2)));
+
+        argumentsList.add(Arguments.of(operator, "1: id NOT IN (1, 2)"));
+
+        operator = new InPredicateOperator(false, ImmutableList.of(
+                new ColumnRefOperator(1, INT, "id", true),
+                ConstantOperator.createInt(1),
+                ConstantOperator.createInt(2)));
+
+        argumentsList.add(Arguments.of(operator, "1: id NOT IN (1, 2) OR 1: id IS NULL"));
+
+        // in constant values with null
+        operator = new InPredicateOperator(false, ImmutableList.of(
+                new ColumnRefOperator(1, INT, "id", false),
+                ConstantOperator.createInt(1),
+                ConstantOperator.createInt(2),
+                ConstantOperator.NULL));
+        argumentsList.add(Arguments.of(operator, "1: id NOT IN (1, 2, null) OR 1: id IN (1, 2, null) IS NULL"));
+
+        operator = new InPredicateOperator(false, ImmutableList.of(
+                new ColumnRefOperator(1, INT, "id", true),
+                ConstantOperator.createInt(1),
+                ConstantOperator.createInt(2),
+                ConstantOperator.NULL));
+        argumentsList.add(Arguments.of(operator, "1: id NOT IN (1, 2, null) OR 1: id IN (1, 2, null) IS NULL"));
+
+        // in values contains expr
+        operator = new InPredicateOperator(false, ImmutableList.of(
+                new ColumnRefOperator(1, INT, "id", true),
+                ConstantOperator.createInt(1),
+                ConstantOperator.createInt(2),
+                new CastOperator(INT, ConstantOperator.createChar("a"))));
+
+        argumentsList.add(Arguments.of(operator, "1: id NOT IN (1, 2, cast(a as int(11))) " +
+                "OR 1: id IN (1, 2, cast(a as int(11))) IS NULL"));
+        return argumentsList.stream();
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriterTest.java
@@ -13,6 +13,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.NegateFilterShuttle;
 import com.starrocks.sql.optimizer.rewrite.scalar.NormalizePredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ReduceCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
@@ -92,5 +93,16 @@ public class ScalarOperatorRewriterTest {
 
         assertEquals(OperatorType.CALL, result.getChild(1).getChild(1).getOpType());
         assertEquals(Type.BOOLEAN, result.getChild(1).getChild(1).getType());
+    }
+
+    @Test
+    public void testRewrite3() {
+        ConstantOperator constFalse = ConstantOperator.FALSE;
+        assertEquals(ConstantOperator.TRUE, NegateFilterShuttle.getInstance().negateFilter(constFalse));
+        constFalse = ConstantOperator.TRUE;
+        assertEquals(ConstantOperator.FALSE, NegateFilterShuttle.getInstance().negateFilter(constFalse));
+        constFalse = ConstantOperator.NULL;
+        assertEquals(new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.NOT, constFalse),
+                NegateFilterShuttle.getInstance().negateFilter(constFalse));
     }
 }


### PR DESCRIPTION
backport #29695

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
