### PR TITLE
[BugFix] Fix split constant non-ASCII source and empty delimiter

### DIFF
--- a/be/src/exprs/split.cpp
+++ b/be/src/exprs/split.cpp
@@ -40,6 +40,16 @@ struct SplitState {
     const void* (*find_delimiter)(const void* big, size_t big_len, const void* little, size_t little_len);
 };
 
+static inline std::vector<std::string> split_utf8_characters(const Slice& str) {
+    std::vector<std::string> chars;
+    for (int i = 0; i < str.size;) {
+        auto char_size = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[i])];
+        chars.emplace_back(str.data + i, char_size);
+        i += char_size;
+    }
+    return chars;
+}
+
 Status StringFunctions::split_prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) {
     if (scope != FunctionContext::FRAGMENT_LOCAL) {
         return Status::OK();
@@ -51,11 +61,12 @@ Status StringFunctions::split_prepare(FunctionContext* context, FunctionContext:
     if (context->is_notnull_constant_column(0) && context->is_notnull_constant_column(1)) {
         Slice haystack = ColumnHelper::get_const_value<TYPE_VARCHAR>(context->get_constant_column(0));
         Slice delimiter = ColumnHelper::get_const_value<TYPE_VARCHAR>(context->get_constant_column(1));
-        std::vector<std::string> const_split_strings =
-                strings::Split(StringPiece(haystack.get_data(), haystack.get_size()),
-                               StringPiece(delimiter.get_data(), delimiter.get_size()));
-
-        state->const_split_strings = const_split_strings;
+        if (delimiter.empty() && !validate_ascii_fast(haystack.data, haystack.size)) {
+            state->const_split_strings = split_utf8_characters(haystack);
+        } else {
+            state->const_split_strings = strings::Split(StringPiece(haystack.get_data(), haystack.get_size()),
+                                                        StringPiece(delimiter.get_data(), delimiter.get_size()));
+        }
     } else if (context->is_notnull_constant_column(1)) {
         Slice delimiter = ColumnHelper::get_const_value<TYPE_VARCHAR>(context->get_constant_column(1));
 

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -394,53 +394,6 @@ Status StringFunctions::concat_close(FunctionContext* context, FunctionContext::
     return Status::OK();
 }
 
-// Modify from https://github.com/lemire/fastvalidate-utf-8/blob/master/include/simdasciicheck.h
-static inline bool validate_ascii_fast(const char* src, size_t len) {
-#ifdef __AVX2__
-    size_t i = 0;
-    __m256i has_error = _mm256_setzero_si256();
-    if (len >= 32) {
-        for (; i <= len - 32; i += 32) {
-            __m256i current_bytes = _mm256_loadu_si256((const __m256i*)(src + i));
-            has_error = _mm256_or_si256(has_error, current_bytes);
-        }
-    }
-    int error_mask = _mm256_movemask_epi8(has_error);
-
-    char tail_has_error = 0;
-    for (; i < len; i++) {
-        tail_has_error |= src[i];
-    }
-    error_mask |= (tail_has_error & 0x80);
-
-    return !error_mask;
-#elif defined(__SSE2__)
-    size_t i = 0;
-    __m128i has_error = _mm_setzero_si128();
-    if (len >= 16) {
-        for (; i <= len - 16; i += 16) {
-            __m128i current_bytes = _mm_loadu_si128((const __m128i*)(src + i));
-            has_error = _mm_or_si128(has_error, current_bytes);
-        }
-    }
-    int error_mask = _mm_movemask_epi8(has_error);
-
-    char tail_has_error = 0;
-    for (; i < len; i++) {
-        tail_has_error |= src[i];
-    }
-    error_mask |= (tail_has_error & 0x80);
-
-    return !error_mask;
-#else
-    char tail_has_error = 0;
-    for (size_t i = 0; i < len; i++) {
-        tail_has_error |= src[i];
-    }
-    return !(tail_has_error & 0x80);
-#endif
-}
-
 static inline void column_builder_null_op(NullableBinaryColumnBuilder* builder, size_t i) {
     builder->set_null(i);
 }

--- a/be/src/util/utf8.h
+++ b/be/src/util/utf8.h
@@ -176,4 +176,51 @@ static inline Slice utf8_char_start(const char* end) {
     return {p, count};
 }
 
+// Modify from https://github.com/lemire/fastvalidate-utf-8/blob/master/include/simdasciicheck.h
+static inline bool validate_ascii_fast(const char* src, size_t len) {
+#ifdef __AVX2__
+    size_t i = 0;
+    __m256i has_error = _mm256_setzero_si256();
+    if (len >= 32) {
+        for (; i <= len - 32; i += 32) {
+            __m256i current_bytes = _mm256_loadu_si256((const __m256i*)(src + i));
+            has_error = _mm256_or_si256(has_error, current_bytes);
+        }
+    }
+    int error_mask = _mm256_movemask_epi8(has_error);
+
+    char tail_has_error = 0;
+    for (; i < len; i++) {
+        tail_has_error |= src[i];
+    }
+    error_mask |= (tail_has_error & 0x80);
+
+    return !error_mask;
+#elif defined(__SSE2__)
+    size_t i = 0;
+    __m128i has_error = _mm_setzero_si128();
+    if (len >= 16) {
+        for (; i <= len - 16; i += 16) {
+            __m128i current_bytes = _mm_loadu_si128((const __m128i*)(src + i));
+            has_error = _mm_or_si128(has_error, current_bytes);
+        }
+    }
+    int error_mask = _mm_movemask_epi8(has_error);
+
+    char tail_has_error = 0;
+    for (; i < len; i++) {
+        tail_has_error |= src[i];
+    }
+    error_mask |= (tail_has_error & 0x80);
+
+    return !error_mask;
+#else
+    char tail_has_error = 0;
+    for (size_t i = 0; i < len; i++) {
+        tail_has_error |= src[i];
+    }
+    return !(tail_has_error & 0x80);
+#endif
+}
+
 } // namespace starrocks

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -623,7 +623,7 @@ PARALLEL_TEST(VecStringFunctionsTest, splitConst2) {
 }
 
 PARALLEL_TEST(VecStringFunctionsTest, splitChinese) {
-    /// non-const
+    /// non-constant source and delimiter.
     {
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         Columns columns;
@@ -657,7 +657,7 @@ PARALLEL_TEST(VecStringFunctionsTest, splitChinese) {
                 "['','市','区','街道']]",
                 col_array->debug_string());
     }
-    /// const
+    /// non-constant source and constant delimiter.
     {
         std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
         Columns columns;
@@ -681,6 +681,46 @@ PARALLEL_TEST(VecStringFunctionsTest, splitChinese) {
         ASSERT_TRUE(StringFunctions::split_close(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
         ASSERT_EQ("[['a','地',' ','区','b'], [], ['地','s','h','北','j',' ','京',' ','g'], [',']]",
                   result->debug_string());
+    }
+
+    /// constant source and delimiter
+    {
+        using CaseType = std::tuple<std::string, std::string, std::string>;
+        std::vector<CaseType> cases{
+                {"测隔试隔试", "", "[['测','隔','试','隔','试']]"},
+                {"测隔试隔试", "隔", "[['测','试','试']]"},
+                {"测隔试隔试", "a", "[['测隔试隔试']]"},
+                {"测abc隔试隔试", "", "[['测','a','b','c','隔','试','隔','试']]"},
+                {"测abc隔试隔试", "隔", "[['测abc','试','试']]"},
+                {"测abc隔试abc隔试", "a", "[['测','bc隔试','bc隔试']]"},
+                {"a|b|c|d", "", "[['a','|','b','|','c','|','d']]"},
+                {"a|b|c|d", "|", "[['a','b','c','d']]"},
+                {"a|b|c|d", "隔", "[['a|b|c|d']]"},
+        };
+
+        for (const auto& [src, delimiter, expected_out] : cases) {
+            std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+            Columns columns;
+
+            auto src_const = ConstColumn::create(BinaryColumn::create());
+            auto delim_const = ConstColumn::create(BinaryColumn::create());
+
+            src_const->append_datum(src);
+            delim_const->append_datum(delimiter);
+
+            columns.clear();
+            columns.push_back(src_const);
+            columns.push_back(delim_const);
+
+            ctx->set_constant_columns(columns);
+            ASSERT_TRUE(StringFunctions::split_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                                .ok());
+            ColumnPtr result = StringFunctions::split(ctx.get(), columns).value();
+            ASSERT_TRUE(
+                    StringFunctions::split_close(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL).ok());
+
+            ASSERT_EQ(expected_out, result->debug_string());
+        }
     }
 }
 

--- a/test/sql/test_function/R/test_split
+++ b/test/sql/test_function/R/test_split
@@ -1,0 +1,37 @@
+-- name: test_split_constant_source_and_delimiter
+select split('测隔试隔试', '');
+-- result:
+["测","隔","试","隔","试"]
+-- !result
+select split('测隔试隔试', '隔');
+-- result:
+["测","试","试"]
+-- !result
+select split('测隔试隔试', 'a');
+-- result:
+["测隔试隔试"]
+-- !result
+select split('测abc隔试隔试', '');
+-- result:
+["测","a","b","c","隔","试","隔","试"]
+-- !result
+select split('测abc隔试隔试', '隔');
+-- result:
+["测abc","试","试"]
+-- !result
+select split('测abc隔试abc隔试', 'a');
+-- result:
+["测","bc隔试","bc隔试"]
+-- !result
+select split('a|b|c|d', '');
+-- result:
+["a","|","b","|","c","|","d"]
+-- !result
+select split('a|b|c|d', '|');
+-- result:
+["a","b","c","d"]
+-- !result
+select split('a|b|c|d', '隔');
+-- result:
+["a|b|c|d"]
+-- !result

--- a/test/sql/test_function/T/test_split
+++ b/test/sql/test_function/T/test_split
@@ -1,0 +1,10 @@
+-- name: test_split_constant_source_and_delimiter
+select split('测隔试隔试', '');
+select split('测隔试隔试', '隔');
+select split('测隔试隔试', 'a');
+select split('测abc隔试隔试', '');
+select split('测abc隔试隔试', '隔');
+select split('测abc隔试abc隔试', 'a');
+select split('a|b|c|d', '');
+select split('a|b|c|d', '|');
+select split('a|b|c|d', '隔');


### PR DESCRIPTION
The constant source and empty delimiter doesn't consider non-ASCII source.

```sql
MySQL> select split('膨胀', '');
'utf-8' codec can't decode byte 0xe8 in position 2: invalid continuation byte
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
