### PR TITLE
[BugFix] Fix iceberg aws "Multiple HTTP implementations were found on the classpath" exception

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
+++ b/fe/fe-core/src/main/java/com/starrocks/StarRocksFE.java
@@ -180,6 +180,17 @@ public class StarRocksFE {
 
             addShutdownHook();
 
+            // To resolve: "Multiple HTTP implementations were found on the classpath. To avoid non-deterministic
+            // loading implementations, please explicitly provide an HTTP client via the client builders, set
+            // the software.amazon.awssdk.http.service.impl system property with the FQCN of the HTTP service to
+            // use as the default, or remove all but one HTTP implementation from the classpath"
+            // Currently, there are 2 implements of HTTP client: ApacheHttpClient and UrlConnectionHttpClient
+            // The UrlConnectionHttpClient is introduced by #16602, and it causes the exception.
+            // So we set the default HTTP client to UrlConnectionHttpClient.
+            // TODO: remove this after we remove ApacheHttpClient
+            System.setProperty("software.amazon.awssdk.http.service.impl",
+                    "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+
             LOG.info("FE started successfully");
 
             while (!stopped) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.starrocks.connector.iceberg.glue;
+package com.starrocks.connector.iceberg;
 
 import com.google.common.base.Preconditions;
 import org.apache.iceberg.aws.AwsClientFactory;
@@ -116,7 +116,6 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
                                                                               String region) {
         // Build sts client
         StsClientBuilder stsClientBuilder = StsClient.builder().credentialsProvider(baseCredentials);
-        stsClientBuilder.applyMutation(awsProperties::applyHttpClientConfigurations);
         if (!region.isEmpty()) {
             stsClientBuilder.region(Region.of(region));
         }
@@ -159,8 +158,6 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
             s3ClientBuilder.endpointOverride(URI.create(s3Endpoint));
         }
 
-        s3ClientBuilder.applyMutation(awsProperties::applyHttpClientConfigurations);
-
         return s3ClientBuilder.build();
     }
 
@@ -185,7 +182,6 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
             glueClientBuilder.endpointOverride(URI.create(glueEndpoint));
         }
 
-        glueClientBuilder.applyMutation(awsProperties::applyHttpClientConfigurations);
         return glueClientBuilder.build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergAwsClientFactory;
 import com.starrocks.connector.iceberg.IcebergCatalog;
 import com.starrocks.connector.iceberg.IcebergCatalogType;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;


### PR DESCRIPTION
After branch 3.1, we refactor the Iceberg catalog and introduce AWS SDK v2, in the Iceberg catalog, if we access AWS resources, FE will throw the below exception. 
```sql
mysql> show tables from iceberg_glue_no_assume.smith;
ERROR 1064 (HY000): Multiple HTTP implementations were found on the classpath. To avoid non-deterministic loading implementations, please explicitly provide an HTTP client via the client builders, set the software.amazon.awssdk.http.service.impl system property with the FQCN of the HTTP service to use as the default, or remove all but one HTTP implementation from the classpath
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
