### PR TITLE
[BugFix] Fix be crash when broker load with conjunct

### DIFF
--- a/be/src/exec/file_scanner.cpp
+++ b/be/src/exec/file_scanner.cpp
@@ -200,7 +200,7 @@ StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::ChunkPtr& src, star
 
         // The column builder in ctx->evaluate may build column as non-nullable.
         // See be/src/column/column_builder.h#L79.
-        if (!col->is_nullable() && slot->is_nullable()) {
+        if (!col->is_nullable()) {
             col = ColumnHelper::cast_to_nullable_column(col);
         }
 

--- a/be/test/exec/parquet_scanner_test.cpp
+++ b/be/test/exec/parquet_scanner_test.cpp
@@ -459,7 +459,7 @@ TEST_F(ParquetScannerTest, test_parquet_data) {
     auto check = [](const ChunkPtr& chunk) {
         auto& columns = chunk->columns();
         for (auto& col : columns) {
-            ASSERT_TRUE(!col->is_nullable() && !col->is_constant());
+            ASSERT_TRUE(col->is_nullable() && !col->is_constant());
         }
     };
     validate(scanner, 36865, check);
@@ -625,7 +625,7 @@ TEST_F(ParquetScannerTest, test_selected_parquet_data) {
     auto check = [](const ChunkPtr& chunk) {
         auto& columns = chunk->columns();
         for (auto& col : columns) {
-            ASSERT_TRUE(!col->is_nullable() && !col->is_constant());
+            ASSERT_TRUE(col->is_nullable() && !col->is_constant());
         }
     };
     validate(scanner, 36865, check);


### PR DESCRIPTION
Fixes #29846

After FileScanner materialize, some column of chunk will convert from nullable to not null.
So in ChunkPipelineAccumulator `_in_chunk->append(*chunk)`, _in_chunk schema may different with chunk, it lead to crash.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
