### PR TITLE
[Refactor] separate `RecyclableClient` class from `HiveMetaClient`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -86,6 +86,9 @@ public class HiveMetaClient {
             client = getClient();
             argClasses = argClasses == null ? ClassUtils.getCompatibleParamClasses(args) : argClasses;
             Method method = client.getHiveClient().getClass().getDeclaredMethod(methodName, argClasses);
+            if (client == null || client.getHiveClient() == null) {
+                System.out.println("client is null or client is null");
+            }
             return (T) method.invoke(client.getHiveClient(), args);
         } catch (Throwable e) {
             LOG.error(messageIfError, e);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -90,8 +90,8 @@ public class HiveMetaClient {
         try {
             client = getClient();
             argClasses = argClasses == null ? ClassUtils.getCompatibleParamClasses(args) : argClasses;
-            Method method = client.hiveClient.getClass().getDeclaredMethod(methodName, argClasses);
-            return (T) method.invoke(client.hiveClient, args);
+            Method method = client.getHiveClient().getClass().getDeclaredMethod(methodName, argClasses);
+            return (T) method.invoke(client.getHiveClient(), args);
         } catch (Throwable e) {
             LOG.error(messageIfError, e);
             connectionException = new StarRocksConnectorException(messageIfError + ", msg: " + e.getMessage(), e);
@@ -232,7 +232,7 @@ public class HiveMetaClient {
             StarRocksConnectorException connectionException = null;
             try {
                 client = getClient();
-                partitions = client.hiveClient.getPartitionsByNames(dbName, tblName, partitionNames);
+                partitions = client.getHiveClient().getPartitionsByNames(dbName, tblName, partitionNames);
                 if (partitions.size() != partitionNames.size()) {
                     LOG.warn("Expect to fetch {} partition on [{}.{}], but actually fetched {} partition",
                             partitionNames.size(), dbName, tblName, partitions.size());
@@ -306,7 +306,7 @@ public class HiveMetaClient {
         try {
             client = getClient();
             for (List<String> parts : partNamesList) {
-                partitions.addAll(client.hiveClient.getPartitionsByNames(dbName, tableName, parts));
+                partitions.addAll(client.getHiveClient().getPartitionsByNames(dbName, tableName, parts));
             }
             LOG.info("Succeed to getPartitionByName on [{}.{}] with {} times retry, slice size is {}, partName size is {}",
                     dbName, tableName, retryNum, subListSize, partNames.size());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -19,13 +19,10 @@ import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.events.MetastoreNotificationFetchException;
-import com.starrocks.connector.hive.glue.AWSCatalogMetastoreClient;
 import com.starrocks.sql.PlannerProfile;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
-import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -40,11 +37,9 @@ import org.apache.thrift.transport.TTransportException;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
 import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_URIS;
 
 public class HiveMetaClient {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/RecyclableClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/RecyclableClient.java
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive;
+
+import com.starrocks.connector.hive.glue.AWSCatalogMetastoreClient;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.LinkedList;
+
+import static com.starrocks.connector.hive.HiveConnector.HIVE_METASTORE_TYPE;
+
+public class RecyclableClient {
+    private static final Logger LOG = LogManager.getLogger(RecyclableClient.class);
+    private static final LinkedList<RecyclableClient> CLIENT_POOL = new LinkedList<>();
+    private static final Object CLIENT_POOL_LOCK = new Object();
+
+    public final IMetaStoreClient hiveClient;
+
+    // Maximum number of idle metastore connections in the connection pool at any point.
+    private static final int MAX_HMS_CONNECTION_POOL_SIZE = 32;
+    private static final String DLF_HIVE_METASTORE = "dlf";
+    private static final String GLUE_HIVE_METASTORE = "glue";
+
+    private static final HiveMetaHookLoader DUMMY_HOOK_LOADER = tbl -> null;
+
+    private RecyclableClient(HiveConf conf) throws MetaException {
+        if (DLF_HIVE_METASTORE.equalsIgnoreCase(conf.get(HIVE_METASTORE_TYPE))) {
+            hiveClient = RetryingMetaStoreClient.getProxy(conf, DUMMY_HOOK_LOADER,
+                    DLFProxyMetaStoreClient.class.getName());
+        } else if (GLUE_HIVE_METASTORE.equalsIgnoreCase(conf.get(HIVE_METASTORE_TYPE))) {
+            hiveClient = RetryingMetaStoreClient.getProxy(conf, DUMMY_HOOK_LOADER,
+                    AWSCatalogMetastoreClient.class.getName());
+        } else {
+            hiveClient = RetryingMetaStoreClient.getProxy(conf, DUMMY_HOOK_LOADER,
+                    HiveMetaStoreClient.class.getName());
+        }
+    }
+
+    // When the number of currently used clients is less than MAX_HMS_CONNECTION_POOL_SIZE,
+    // the client will be recycled and reused. If it does, we close the client.
+    public void finish() {
+        synchronized (CLIENT_POOL_LOCK) {
+            if (CLIENT_POOL.size() >= MAX_HMS_CONNECTION_POOL_SIZE) {
+                LOG.warn("There are more than {} connections currently accessing the metastore",
+                        MAX_HMS_CONNECTION_POOL_SIZE);
+                close();
+            } else {
+                CLIENT_POOL.offer(this);
+            }
+        }
+    }
+
+    public void close() {
+        hiveClient.close();
+    }
+
+    public IMetaStoreClient getHiveClient() {
+        return hiveClient;
+    }
+
+    public static RecyclableClient getInstance(HiveConf conf) throws MetaException {
+        // The MetaStoreClient c'tor relies on knowing the Hadoop version by asking
+        // org.apache.hadoop.util.VersionInfo. The VersionInfo class relies on opening
+        // the 'common-version-info.properties' file as a resource from hadoop-common*.jar
+        // using the Thread's context classloader. If necessary, set the Thread's context
+        // classloader, otherwise VersionInfo will fail in it's c'tor.
+        if (Thread.currentThread().getContextClassLoader() == null) {
+            Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
+        }
+
+        synchronized (CLIENT_POOL_LOCK) {
+            RecyclableClient client = CLIENT_POOL.poll();
+            // The pool was empty so create a new client and return that.
+            // Serialize client creation to defend against possible race conditions accessing
+            // local Kerberos state
+            if (client == null) {
+                return new RecyclableClient(conf);
+            } else {
+                return client;
+            }
+        }
+    }
+
+    public static int size() {
+        synchronized (CLIENT_POOL_LOCK) {
+            return CLIENT_POOL.size();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/RecyclableClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/RecyclableClient.java
@@ -33,7 +33,7 @@ public class RecyclableClient {
     private static final LinkedList<RecyclableClient> CLIENT_POOL = new LinkedList<>();
     private static final Object CLIENT_POOL_LOCK = new Object();
 
-    public final IMetaStoreClient hiveClient;
+    private final IMetaStoreClient hiveClient;
 
     // Maximum number of idle metastore connections in the connection pool at any point.
     private static final int MAX_HMS_CONNECTION_POOL_SIZE = 32;


### PR DESCRIPTION
Fixes #issue

This PR is to separate `RecyclableClient` class from `HiveMetaClient`.

So in future, we can replace `RecyclableClient` class independently, without changing main codebase.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
