### PR TITLE
[Enhancement] Add metrics for group-level query queue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -46,6 +46,7 @@ public class ResourceGroup implements Writable {
     public static final String BIG_QUERY_CPU_SECOND_LIMIT = "big_query_cpu_second_limit";
     public static final String CONCURRENCY_LIMIT = "concurrency_limit";
     public static final String DEFAULT_RESOURCE_GROUP_NAME = "default_wg";
+    public static final String DISABLE_RESOURCE_GROUP_NAME = "disable_resource_group";
     public static final String DEFAULT_MV_RESOURCE_GROUP_NAME = "default_mv_wg";
     public static final long DEFAULT_MV_WG_ID = 1;
     public static final long DEFAULT_MV_VERSION = 1;

--- a/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
@@ -91,7 +91,7 @@ public class ResourceGroupMetricMgr {
     public static void increaseTimeoutQueuedQuery(ConnectContext ctx, long delta) {
         LongCounterMetric metrics = createQueryResourceGroupMetrics(
                 RESOURCE_GROUP_QUERY_QUEUE_TIMEOUT_MAP, RESOURCE_GROUP_QUERY_QUEUE_TIMEOUT,
-                "the number of pending queries of this resource group", ctx);
+                "the number of pending timeout queries of this resource group", ctx);
         metrics.increase(delta);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.metric;
 
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Snapshot;
+import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.thrift.TWorkGroup;
@@ -28,39 +28,71 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 
 public class ResourceGroupMetricMgr {
     private static final Logger LOG = LogManager.getLogger(ResourceGroupMetricMgr.class);
 
     private static final String QUERY_RESOURCE_GROUP = "query_resource_group";
-    private static final String QUERY_RESOURCE_GROUP_LATENCY = "query_resource_group_latency";
     private static final String QUERY_RESOURCE_GROUP_ERR = "query_resource_group_err";
+    private static final String QUERY_RESOURCE_GROUP_LATENCY = "query_resource_group_latency";
+
+    private static final String RESOURCE_GROUP_QUERY_QUEUE_TOTAL = "resource_group_query_queue_total";
+    private static final String RESOURCE_GROUP_QUERY_QUEUE_PENDING = "resource_group_query_queue_pending";
+    private static final String RESOURCE_GROUP_QUERY_QUEUE_TIMEOUT = "resource_group_query_queue_timeout";
+
     private static final ConcurrentHashMap<String, LongCounterMetric> RESOURCE_GROUP_QUERY_COUNTER_MAP
-            = new ConcurrentHashMap<>();
-    private static final ConcurrentHashMap<String, QueryResourceGroupLatencyMetrics> RESOURCE_GROUP_QUERY_LATENCY_MAP
             = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, LongCounterMetric> RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP
             = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, QueryResourceGroupLatencyMetrics> RESOURCE_GROUP_QUERY_LATENCY_MAP
+            = new ConcurrentHashMap<>();
 
-    //starrocks_fe_query_resource_group
-    public static void increaseQuery(ConnectContext ctx, Long num) {
-        LongCounterMetric metrics =
-                createQeuryResourceGroupMetrics(RESOURCE_GROUP_QUERY_COUNTER_MAP, QUERY_RESOURCE_GROUP,
-                        "query resource group", ctx);
-        if (metrics != null) {
-            metrics.increase(num);
-        }
+    private static final ConcurrentHashMap<String, LongCounterMetric> RESOURCE_GROUP_QUERY_QUEUE_TOTAL_MAP
+            = new ConcurrentHashMap<>();
+
+    private static final ConcurrentHashMap<String, LongCounterMetric> RESOURCE_GROUP_QUERY_QUEUE_PENDING_MAP
+            = new ConcurrentHashMap<>();
+
+    private static final ConcurrentHashMap<String, LongCounterMetric> RESOURCE_GROUP_QUERY_QUEUE_TIMEOUT_MAP
+            = new ConcurrentHashMap<>();
+
+    /**
+     * For the metric {@code starrocks_fe_query_resource_group}.
+     */
+    public static void increaseQuery(ConnectContext ctx, long delta) {
+        LongCounterMetric metrics = createQueryResourceGroupMetrics(
+                RESOURCE_GROUP_QUERY_COUNTER_MAP, QUERY_RESOURCE_GROUP, "query resource group", ctx);
+        metrics.increase(delta);
     }
 
-    //starrocks_fe_query_resource_group_err
-    public static void increaseQueryErr(ConnectContext ctx, Long num) {
-        LongCounterMetric metrics =
-                createQeuryResourceGroupMetrics(RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP, QUERY_RESOURCE_GROUP_ERR,
-                        "query err resource group", ctx);
-        if (metrics != null) {
-            metrics.increase(num);
+    /**
+     * For the metric {@code starrocks_fe_query_resource_group_err}.
+     */
+    public static void increaseQueryErr(ConnectContext ctx, long delta) {
+        LongCounterMetric metrics = createQueryResourceGroupMetrics(
+                RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP, QUERY_RESOURCE_GROUP_ERR, "query err resource group", ctx);
+        metrics.increase(delta);
+    }
+
+    public static void increaseQueuedQuery(ConnectContext ctx, long delta) {
+        if (delta > 0) {
+            LongCounterMetric metrics = createQueryResourceGroupMetrics(
+                    RESOURCE_GROUP_QUERY_QUEUE_TOTAL_MAP, RESOURCE_GROUP_QUERY_QUEUE_TOTAL,
+                    "the number of total history queued queries of this resource group", ctx);
+            metrics.increase(delta);
         }
+
+        LongCounterMetric metrics = createQueryResourceGroupMetrics(
+                RESOURCE_GROUP_QUERY_QUEUE_PENDING_MAP, RESOURCE_GROUP_QUERY_QUEUE_PENDING,
+                "the number of pending queries of this resource group", ctx);
+        metrics.increase(delta);
+    }
+
+    public static void increaseTimeoutQueuedQuery(ConnectContext ctx, long delta) {
+        LongCounterMetric metrics = createQueryResourceGroupMetrics(
+                RESOURCE_GROUP_QUERY_QUEUE_TIMEOUT_MAP, RESOURCE_GROUP_QUERY_QUEUE_TIMEOUT,
+                "the number of pending queries of this resource group", ctx);
+        metrics.increase(delta);
     }
 
     public static void visitQueryLatency() {
@@ -70,79 +102,65 @@ public class ResourceGroupMetricMgr {
         }
     }
 
-    //starrocks_fe_query_resource_group_latency
+    /**
+     * For the metric {@code starrocks_fe_query_resource_group_latency}.
+     */
     public static void updateQueryLatency(ConnectContext ctx, Long elapseMs) {
         QueryResourceGroupLatencyMetrics metrics = createQueryResourceGroupLatencyMetrics(ctx);
-        if (metrics != null) {
-            metrics.histogram.update(elapseMs);
-        }
+        metrics.histogram.update(elapseMs);
     }
 
-    private static LongCounterMetric createQeuryResourceGroupMetrics(Map cacheMap, String metricsName,
+    private static LongCounterMetric createQueryResourceGroupMetrics(Map<String, LongCounterMetric> cacheMap, String metricsName,
                                                                      String metricsMsg, ConnectContext ctx) {
-        String resourceGroupName = checkAndGetWorkGroupName(ctx);
-        if (resourceGroupName == null || resourceGroupName.isEmpty()) {
-            return null;
-        }
-        if (!cacheMap.containsKey(resourceGroupName)) {
+        String groupName = getGroupName(ctx);
+        if (!cacheMap.containsKey(groupName)) {
             synchronized (ResourceGroupMetricMgr.class) {
-                if (!cacheMap.containsKey(resourceGroupName)) {
-                    LongCounterMetric metric = new LongCounterMetric(metricsName, Metric.MetricUnit.REQUESTS,
-                            metricsMsg);
-                    metric.addLabel(new MetricLabel("name", resourceGroupName));
-                    cacheMap.put(resourceGroupName, metric);
+                if (!cacheMap.containsKey(groupName)) {
+                    LongCounterMetric metric = new LongCounterMetric(metricsName, Metric.MetricUnit.REQUESTS, metricsMsg);
+                    metric.addLabel(new MetricLabel("name", groupName));
+                    cacheMap.put(groupName, metric);
                     MetricRepo.addMetric(metric);
-                    LOG.info("Add {} metric, resource group name is {}", metricsName, resourceGroupName);
+                    LOG.info("Add {} metric, resource group name is {}", metricsName, groupName);
                 }
             }
         }
-        return (LongCounterMetric) cacheMap.get(resourceGroupName);
+
+        return cacheMap.get(groupName);
     }
 
-    private static String checkAndGetWorkGroupName(ConnectContext ctx) {
+    private static String getGroupName(ConnectContext ctx) {
         SessionVariable sessionVariable = ctx.getSessionVariable();
         if (!sessionVariable.isEnableResourceGroup() || !sessionVariable.isEnablePipelineEngine()) {
-            return null;
+            return ResourceGroup.DISABLE_RESOURCE_GROUP_NAME;
         }
+
         TWorkGroup resourceGroup = ctx.getResourceGroup();
-        return resourceGroup == null ? "default_wg" : resourceGroup.getName();
+        return resourceGroup == null ? ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME : resourceGroup.getName();
     }
 
     private static QueryResourceGroupLatencyMetrics createQueryResourceGroupLatencyMetrics(ConnectContext ctx) {
-        String resourceGroupName = checkAndGetWorkGroupName(ctx);
-        if (resourceGroupName == null || resourceGroupName.isEmpty()) {
-            return null;
-        }
-        RESOURCE_GROUP_QUERY_LATENCY_MAP.computeIfAbsent(resourceGroupName, RESOURCE_GROUP_LATENCY_METRICS_FUNCTION);
-        return RESOURCE_GROUP_QUERY_LATENCY_MAP.get(resourceGroupName);
+        String groupName = getGroupName(ctx);
+        return RESOURCE_GROUP_QUERY_LATENCY_MAP.computeIfAbsent(groupName,
+                currGroupName -> new QueryResourceGroupLatencyMetrics(QUERY_RESOURCE_GROUP_LATENCY, currGroupName));
     }
 
-    private static final Function<String, QueryResourceGroupLatencyMetrics> RESOURCE_GROUP_LATENCY_METRICS_FUNCTION =
-            new Function<String, QueryResourceGroupLatencyMetrics>() {
-                @Override
-                public QueryResourceGroupLatencyMetrics apply(String resourceGroupName) {
-                    return new QueryResourceGroupLatencyMetrics(QUERY_RESOURCE_GROUP_LATENCY, resourceGroupName);
-                }
-            };
-
     private static final class QueryResourceGroupLatencyMetrics {
-        private static final String[] QUERY_LATENCY_LABLE =
+        private static final String[] QUERY_LATENCY_LABELS =
                 {"mean", "75_quantile", "95_quantile", "98_quantile", "99_quantile", "999_quantile"};
 
-        private MetricRegistry metricRegistry;
+        private final MetricRegistry metricRegistry;
         private Histogram histogram;
-        private List<GaugeMetricImpl> metricsList;
-        private String metricsName;
+        private final List<GaugeMetricImpl<Double>> metricsList;
+        private final String metricName;
 
-        private QueryResourceGroupLatencyMetrics(String metricsName, String resourceGroupName) {
-            this.metricsName = metricsName;
+        private QueryResourceGroupLatencyMetrics(String metricName, String resourceGroupName) {
+            this.metricName = metricName;
             this.metricRegistry = new MetricRegistry();
-            initHistogram(metricsName);
+            initHistogram(metricName);
             this.metricsList = new ArrayList<>();
-            for (String label : QUERY_LATENCY_LABLE) {
-                GaugeMetricImpl<Double> metrics =
-                        new GaugeMetricImpl<>(metricsName, Metric.MetricUnit.MILLISECONDS,
-                                label + " of resource group query latency");
+            for (String label : QUERY_LATENCY_LABELS) {
+                GaugeMetricImpl<Double> metrics = new GaugeMetricImpl<>(
+                        metricName, Metric.MetricUnit.MILLISECONDS, label + " of resource group query latency");
                 metrics.addLabel(new MetricLabel("type", label));
                 metrics.addLabel(new MetricLabel("name", resourceGroupName));
                 metrics.setValue(0.0);
@@ -158,8 +176,8 @@ public class ResourceGroupMetricMgr {
 
         private void update() {
             Histogram oldHistogram = this.histogram;
-            this.metricRegistry.remove(this.metricsName);
-            initHistogram(metricsName);
+            this.metricRegistry.remove(this.metricName);
+            initHistogram(metricName);
 
             Snapshot snapshot = oldHistogram.getSnapshot();
             metricsList.get(0).setValue(snapshot.getMedian());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -17,6 +17,7 @@ package com.starrocks.qe;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.metric.ResourceGroupMetricMgr;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.planner.SchemaScanNode;
 import com.starrocks.qe.scheduler.RecoverableException;
@@ -64,6 +65,7 @@ public class QueryQueueManager {
             context.setPending(true);
             MetricRepo.COUNTER_QUERY_QUEUE_PENDING.increase(1L);
             MetricRepo.COUNTER_QUERY_QUEUE_TOTAL.increase(1L);
+            ResourceGroupMetricMgr.increaseQueuedQuery(context, 1L);
 
             long timeoutMs = slotRequirement.getExpiredPendingTimeMs();
             LogicalSlot allocatedSlot = null;
@@ -76,6 +78,7 @@ public class QueryQueueManager {
                     String errMsg = String.format(PENDING_TIMEOUT_ERROR_MSG_FORMAT,
                             GlobalVariable.getQueryQueuePendingTimeoutSecond(),
                             GlobalVariable.QUERY_QUEUE_PENDING_TIMEOUT_SECOND);
+                    ResourceGroupMetricMgr.increaseTimeoutQueuedQuery(context, 1L);
                     throw new UserException(errMsg);
                 }
 
@@ -100,6 +103,7 @@ public class QueryQueueManager {
             if (isPending) {
                 context.auditEventBuilder.setPendingTimeMs(System.currentTimeMillis() - startMs);
                 MetricRepo.COUNTER_QUERY_QUEUE_PENDING.increase(-1L);
+                ResourceGroupMetricMgr.increaseQueuedQuery(context, -1L);
                 context.setPending(false);
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/metric/ResourceGroupMetricTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/ResourceGroupMetricTest.java
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.metric;
 
+import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
@@ -24,6 +24,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ResourceGroupMetricTest {
 
@@ -31,6 +35,114 @@ public class ResourceGroupMetricTest {
     public static void setUp() {
         FeConstants.runningUnitTest = true;
         MetricRepo.init();
+    }
+
+    @Test
+    public void testResourceGroupQueryQueueMetrics() {
+        ConnectContext ctx = new ConnectContext();
+        SessionVariable sessionVariable = new SessionVariable();
+        ctx.setSessionVariable(sessionVariable);
+
+        ResourceGroup wg1 = new ResourceGroup();
+        wg1.setName("wg1");
+        ResourceGroup wg2 = new ResourceGroup();
+        wg2.setName("wg2");
+
+        // Increase.
+        ctx.setResourceGroup(wg1.toThrift());
+        ResourceGroupMetricMgr.increaseQueuedQuery(ctx, 10L);
+        ResourceGroupMetricMgr.increaseTimeoutQueuedQuery(ctx, 1L);
+
+        ctx.setResourceGroup(wg2.toThrift());
+        ResourceGroupMetricMgr.increaseQueuedQuery(ctx, 20L);
+        ResourceGroupMetricMgr.increaseTimeoutQueuedQuery(ctx, 2L);
+
+        ctx.setResourceGroup(null);
+        ResourceGroupMetricMgr.increaseQueuedQuery(ctx, 30L);
+        ResourceGroupMetricMgr.increaseTimeoutQueuedQuery(ctx, 3L);
+
+        ctx.getSessionVariable().setEnablePipelineEngine(false);
+        ResourceGroupMetricMgr.increaseQueuedQuery(ctx, 40L);
+        ResourceGroupMetricMgr.increaseTimeoutQueuedQuery(ctx, 4L);
+        ctx.getSessionVariable().setEnablePipelineEngine(true);
+
+        List<Metric> metricTotal = MetricRepo.getMetricsByName("resource_group_query_queue_total");
+        List<Metric> metricPending = MetricRepo.getMetricsByName("resource_group_query_queue_pending");
+        List<Metric> metricTimeout = MetricRepo.getMetricsByName("resource_group_query_queue_timeout");
+
+        Assert.assertEquals(4, metricTotal.size());
+        Assert.assertEquals(4, metricPending.size());
+        Assert.assertEquals(4, metricTimeout.size());
+
+        // Check.
+        Map<String, Long> groupToTotal = metricTotal.stream().map(m -> (LongCounterMetric) m).collect(Collectors.toMap(
+                m -> m.getLabels().get(0).getValue(),
+                LongCounterMetric::getValue
+        ));
+        Map<String, Long> expectedGroupToTotal = ImmutableMap.of(
+                wg1.getName(), 10L,
+                wg2.getName(), 20L,
+                ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME, 30L,
+                ResourceGroup.DISABLE_RESOURCE_GROUP_NAME, 40L
+        );
+        assertThat(groupToTotal).containsExactlyInAnyOrderEntriesOf(expectedGroupToTotal);
+
+        Map<String, Long> groupToPending = metricPending.stream().map(m -> (LongCounterMetric) m).collect(Collectors.toMap(
+                m -> m.getLabels().get(0).getValue(),
+                LongCounterMetric::getValue
+        ));
+        assertThat(groupToPending).containsExactlyInAnyOrderEntriesOf(expectedGroupToTotal);
+
+        Map<String, Long> groupToTimeout = metricTimeout.stream().map(m -> (LongCounterMetric) m).collect(Collectors.toMap(
+                m -> m.getLabels().get(0).getValue(),
+                LongCounterMetric::getValue
+        ));
+        Map<String, Long> expectedGroupToTimeout = ImmutableMap.of(
+                wg1.getName(), 1L,
+                wg2.getName(), 2L,
+                ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME, 3L,
+                ResourceGroup.DISABLE_RESOURCE_GROUP_NAME, 4L
+        );
+        assertThat(groupToTimeout).containsExactlyInAnyOrderEntriesOf(expectedGroupToTimeout);
+
+        // Decrease.
+        ctx.setResourceGroup(wg1.toThrift());
+        ResourceGroupMetricMgr.increaseQueuedQuery(ctx, -1L);
+
+        ctx.setResourceGroup(wg2.toThrift());
+        ResourceGroupMetricMgr.increaseQueuedQuery(ctx, -2L);
+
+        ctx.setResourceGroup(null);
+        ResourceGroupMetricMgr.increaseQueuedQuery(ctx, -3L);
+
+        ctx.getSessionVariable().setEnablePipelineEngine(false);
+        ResourceGroupMetricMgr.increaseQueuedQuery(ctx, -4L);
+        ctx.getSessionVariable().setEnablePipelineEngine(true);
+
+        // Check.
+        groupToTotal = metricTotal.stream().map(m -> (LongCounterMetric) m).collect(Collectors.toMap(
+                m -> m.getLabels().get(0).getValue(),
+                LongCounterMetric::getValue
+        ));
+        assertThat(groupToTotal).containsExactlyInAnyOrderEntriesOf(expectedGroupToTotal);
+
+        groupToPending = metricPending.stream().map(m -> (LongCounterMetric) m).collect(Collectors.toMap(
+                m -> m.getLabels().get(0).getValue(),
+                LongCounterMetric::getValue
+        ));
+        Map<String, Long> expectedGroupToPending = ImmutableMap.of(
+                wg1.getName(), 10L - 1L,
+                wg2.getName(), 20L - 2L,
+                ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME, 30L - 3L,
+                ResourceGroup.DISABLE_RESOURCE_GROUP_NAME, 40L - 4L
+        );
+        assertThat(groupToPending).containsExactlyInAnyOrderEntriesOf(expectedGroupToPending);
+
+        groupToTimeout = metricTimeout.stream().map(m -> (LongCounterMetric) m).collect(Collectors.toMap(
+                m -> m.getLabels().get(0).getValue(),
+                LongCounterMetric::getValue
+        ));
+        assertThat(groupToTimeout).containsExactlyInAnyOrderEntriesOf(expectedGroupToTimeout);
     }
 
     @Test
@@ -56,13 +168,25 @@ public class ResourceGroupMetricTest {
         ResourceGroupMetricMgr.increaseQueryErr(ctx, 1L);
         ResourceGroupMetricMgr.updateQueryLatency(ctx, 10L);
 
+        ctx.setResourceGroup(null);
+        ctx.getAuditEventBuilder().setResourceGroup(ResourceGroup.DISABLE_RESOURCE_GROUP_NAME);
+        ResourceGroupMetricMgr.increaseQuery(ctx, 2L);
+        ResourceGroupMetricMgr.increaseQueryErr(ctx, 2L);
+        ResourceGroupMetricMgr.updateQueryLatency(ctx, 20L);
+
+        ctx.getSessionVariable().setEnablePipelineEngine(false);
+        ctx.getAuditEventBuilder().setResourceGroup("");
+        ResourceGroupMetricMgr.increaseQuery(ctx, 3L);
+        ResourceGroupMetricMgr.increaseQueryErr(ctx, 3L);
+        ResourceGroupMetricMgr.updateQueryLatency(ctx, 30L);
+
         List<Metric> metricsResourceGroup = MetricRepo.getMetricsByName("query_resource_group");
         List<Metric> metricsResourceGroupErr = MetricRepo.getMetricsByName("query_resource_group_err");
         List<Metric> metricsResourceGroupLatency = MetricRepo.getMetricsByName("query_resource_group_latency");
 
-        Assert.assertEquals(2, metricsResourceGroup.size());
-        Assert.assertEquals(2, metricsResourceGroupErr.size());
-        Assert.assertEquals(2 * 6, metricsResourceGroupLatency.size());
+        Assert.assertEquals(4, metricsResourceGroup.size());
+        Assert.assertEquals(4, metricsResourceGroupErr.size());
+        Assert.assertEquals(4 * 6, metricsResourceGroupLatency.size());
 
         for (Metric resourceGroupMetric : metricsResourceGroup) {
             LongCounterMetric metric = (LongCounterMetric) resourceGroupMetric;
@@ -70,6 +194,10 @@ public class ResourceGroupMetricTest {
                 Assert.assertEquals(Long.valueOf(1L), metric.getValue());
             } else if (wg2.getName().equals(metric.getLabels().get(0).getValue())) {
                 Assert.assertEquals(Long.valueOf(1L), metric.getValue());
+            } else if (ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME.equals(metric.getLabels().get(0).getValue())) {
+                Assert.assertEquals(Long.valueOf(2L), metric.getValue());
+            } else if (ResourceGroup.DISABLE_RESOURCE_GROUP_NAME.equals(metric.getLabels().get(0).getValue())) {
+                Assert.assertEquals(Long.valueOf(3L), metric.getValue());
             } else {
                 Assert.fail();
             }
@@ -81,6 +209,10 @@ public class ResourceGroupMetricTest {
                 Assert.assertEquals(Long.valueOf(1L), metric.getValue());
             } else if (wg2.getName().equals(metric.getLabels().get(0).getValue())) {
                 Assert.assertEquals(Long.valueOf(1L), metric.getValue());
+            } else if (ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME.equals(metric.getLabels().get(0).getValue())) {
+                Assert.assertEquals(Long.valueOf(2L), metric.getValue());
+            } else if (ResourceGroup.DISABLE_RESOURCE_GROUP_NAME.equals(metric.getLabels().get(0).getValue())) {
+                Assert.assertEquals(Long.valueOf(3L), metric.getValue());
             } else {
                 Assert.fail();
             }
@@ -94,6 +226,10 @@ public class ResourceGroupMetricTest {
                 Assert.assertEquals(Double.valueOf(10d), Double.valueOf(String.valueOf(metric.getValue())));
             } else if (wg2.getName().equals(metric.getLabels().get(1).getValue())) {
                 Assert.assertEquals(Double.valueOf(10d), Double.valueOf(String.valueOf(metric.getValue())));
+            } else if (ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME.equals(metric.getLabels().get(1).getValue())) {
+                Assert.assertEquals(Double.valueOf(20d), Double.valueOf(String.valueOf(metric.getValue())));
+            } else if (ResourceGroup.DISABLE_RESOURCE_GROUP_NAME.equals(metric.getLabels().get(1).getValue())) {
+                Assert.assertEquals(Double.valueOf(30d), Double.valueOf(String.valueOf(metric.getValue())));
             } else {
                 Assert.fail();
             }


### PR DESCRIPTION
Add three metrics for the group-level query queue:
- `resource_group_query_queue_total` label by the group name.
    the number of total history queued queries of this resource group
- `resource_group_query_queue_pending` label by the group name.
    the number of pending queries of this resource group
- `resource_group_query_queue_timeout` label by the group name.
    the number of pending timeout queries of this resource group

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
