### PR TITLE
[Enhancement] Support compact thrift protocol

### DIFF
--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -195,7 +195,7 @@ private:
     void _get_file_schema(google::protobuf::RpcController* controller, const PGetFileSchemaRequest* request,
                           PGetFileSchemaResult* response, google::protobuf::Closure* done);
 
-    Status _exec_plan_fragment(brpc::Controller* cntl);
+    Status _exec_plan_fragment(brpc::Controller* cntl, const PExecPlanFragmentRequest* request);
     Status _exec_plan_fragment_by_pipeline(const TExecPlanFragmentParams& t_common_request,
                                            const TExecPlanFragmentParams& t_unique_request);
     Status _exec_plan_fragment_by_non_pipeline(const TExecPlanFragmentParams& t_request);

--- a/be/src/util/thrift_util.h
+++ b/be/src/util/thrift_util.h
@@ -168,6 +168,17 @@ Status deserialize_thrift_msg(const uint8_t* buf, uint32_t* len, TProtocolType t
     return Status::OK();
 }
 
+template <class T>
+Status deserialize_thrift_msg(const uint8_t* buf, uint32_t* len, const std::string& protocol, T* deserialized_msg) {
+    if (protocol == "json") {
+        return deserialize_thrift_msg<T>(buf, len, TProtocolType::JSON, deserialized_msg);
+    } else if (protocol == "compact") {
+        return deserialize_thrift_msg<T>(buf, len, TProtocolType::COMPACT, deserialized_msg);
+    } else {
+        return deserialize_thrift_msg<T>(buf, len, TProtocolType::BINARY, deserialized_msg);
+    }
+}
+
 // Redirects all Thrift logging to VLOG(1)
 void init_thrift_logging();
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -526,7 +526,6 @@ public class Function implements Writable {
 
     public TFunction toThrift() {
         TFunction fn = new TFunction();
-        fn.setSignature(signatureString());
         fn.setName(name.toThrift());
         fn.setBinary_type(binaryType);
         if (location != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -508,7 +508,6 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         msg.node_id = id.asInt();
         msg.num_children = children.size();
         msg.limit = limit;
-        msg.setUse_vectorized(true);
         for (TupleId tid : tupleIds) {
             msg.addToRow_tuples(tid.asInt());
             msg.addToNullable_tuples(nullableTupleIds.contains(tid));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -491,6 +491,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String HIVE_TEMP_STAGING_DIR = "hive_temp_staging_dir";
 
+    // binary, json, compact
+    public static final String THRIFT_PLAN_PROTOCOL = "thrift_plan_protocol";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1033,6 +1036,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = CONSISTENT_HASH_VIRTUAL_NUMBER, flag = VariableMgr.INVISIBLE)
     private int consistentHashVirtualNodeNum = 32;
+
+    // binary, json, compact,
+    @VarAttr(name = THRIFT_PLAN_PROTOCOL)
+    private String thriftPlanProtocol = "binary";
+
+    public String getThriftPlanProtocol() {
+        return thriftPlanProtocol;
+    }
 
     public void setPartialUpdateMode(String mode) {
         this.partialUpdateMode = mode;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -157,7 +157,8 @@ public class FragmentInstanceExecState {
 
         TNetworkAddress brpcAddress = worker.getBrpcAddress();
         try {
-            deployFuture = BackendServiceClient.getInstance().execPlanFragmentAsync(brpcAddress, requestToDeploy);
+            deployFuture = BackendServiceClient.getInstance().execPlanFragmentAsync(brpcAddress, requestToDeploy,
+                    jobSpec.getPlanProtocol());
         } catch (RpcException | TException e) {
             // DO NOT throw exception here, return a complete future with error code,
             // so that the following logic will cancel the fragment.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -35,6 +35,7 @@ import com.starrocks.thrift.TQueryOptions;
 import com.starrocks.thrift.TQueryType;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWorkGroup;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -74,6 +75,8 @@ public class JobSpec {
     private final TQueryOptions queryOptions;
     private final TWorkGroup resourceGroup;
 
+    private final String planProtocol;
+
     public static class Factory {
         private Factory() {
         }
@@ -103,6 +106,7 @@ public class JobSpec {
                     .queryGlobals(queryGlobals)
                     .queryOptions(queryOptions)
                     .commonProperties(context)
+                    .setPlanProtocol(context.getSessionVariable().getThriftPlanProtocol())
                     .build();
         }
 
@@ -336,6 +340,7 @@ public class JobSpec {
         this.queryGlobals = builder.queryGlobals;
         this.queryOptions = builder.queryOptions;
         this.resourceGroup = builder.resourceGroup;
+        this.planProtocol = builder.planProtocol;
     }
 
     @Override
@@ -438,6 +443,10 @@ public class JobSpec {
         return queryOptions.getLoad_job_type() == TLoadJobType.STREAM_LOAD;
     }
 
+    public String getPlanProtocol() {
+        return planProtocol;
+    }
+
     public void reset() {
         fragments.forEach(PlanFragment::reset);
     }
@@ -459,6 +468,7 @@ public class JobSpec {
         private TQueryGlobals queryGlobals;
         private TQueryOptions queryOptions;
         private TWorkGroup resourceGroup;
+        private String planProtocol;
 
         public JobSpec build() {
             return new JobSpec(this);
@@ -535,6 +545,11 @@ public class JobSpec {
 
         private Builder needReport(boolean needReport) {
             this.needReport = needReport;
+            return this;
+        }
+
+        private Builder setPlanProtocol(String planProtocol) {
+            this.planProtocol = StringUtils.lowerCase(planProtocol);
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/AttachmentRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/AttachmentRequest.java
@@ -17,24 +17,41 @@
 
 package com.starrocks.rpc;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
 import org.apache.thrift.TFieldIdEnum;
 import org.apache.thrift.TSerializer;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TCompactProtocol;
+import org.apache.thrift.protocol.TJSONProtocol;
 
 // used to compatible with our older thrift protocol
 public class AttachmentRequest {
     protected byte[] serializedRequest;
     protected byte[] serializedResult;
 
-    public <T extends TBase<T, F>, F extends TFieldIdEnum> void setRequest(TBase<T, F> request) throws TException {
-        TSerializer serializer = new TSerializer();
+    public <T extends TBase<T, F>, F extends TFieldIdEnum> void setRequest(TBase<T, F> request, String protocol)
+            throws TException {
+        TSerializer serializer;
+        if (StringUtils.equalsIgnoreCase(protocol, "compact")) {
+            serializer = new TSerializer(TCompactProtocol::new);
+        } else if (StringUtils.equalsIgnoreCase(protocol, "json")) {
+            serializer = new TSerializer(TJSONProtocol::new);
+        } else {
+            // default bianry
+            serializer = new TSerializer(TBinaryProtocol::new);
+        }
+
         serializedRequest = serializer.serialize(request);
     }
 
-    public void setSerializedRequest(byte[] request) {
-        this.serializedRequest = request;
+    public <T extends TBase<T, F>, F extends TFieldIdEnum> void setRequest(TBase<T, F> request)
+            throws TException {
+        TSerializer serializer = new TSerializer(TBinaryProtocol::new);
+
+        serializedRequest = serializer.serialize(request);
     }
 
     public byte[] getSerializedRequest() {

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PExecPlanFragmentRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PExecPlanFragmentRequest.java
@@ -17,8 +17,15 @@
 
 package com.starrocks.rpc;
 
+import com.baidu.bjf.remoting.protobuf.annotation.Protobuf;
 import com.baidu.bjf.remoting.protobuf.annotation.ProtobufClass;
 
 @ProtobufClass
 public class PExecPlanFragmentRequest extends AttachmentRequest {
+    @Protobuf(order = 1, required = false)
+    String attachmentProtocol;
+
+    public void setAttachmentProtocol(String attachmentProtocol) {
+        this.attachmentProtocol = attachmentProtocol;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PushTask.java
@@ -194,12 +194,10 @@ public class PushTask extends AgentTask {
                     tConditions.add(tCondition);
                 }
                 request.setDelete_conditions(tConditions);
-                request.setUse_vectorized(useVectorized);
                 break;
             case LOAD_V2:
                 request.setBroker_scan_range(tBrokerScanRange);
                 request.setDesc_tbl(tDescriptorTable);
-                request.setUse_vectorized(useVectorized);
                 request.setTablet_type(tabletType);
                 break;
             case CANCEL_DELETE:

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -93,7 +93,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
                 "arg_types:[TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DOUBLE))]), " +
                 "TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DOUBLE))])], " +
                 "ret_type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DOUBLE))]), " +
-                "has_var_args:false, signature:nullif(DOUBLE, DOUBLE), scalar_fn:TScalarFunction(symbol:), " +
+                "has_var_args:false, scalar_fn:TScalarFunction(symbol:), " +
                 "id:70307, fid:70307";
         String thrift = UtFrameUtils.getPlanThriftString(ctx, sql);
         Assert.assertTrue(thrift, thrift.contains(expectString));
@@ -105,7 +105,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         String expectString = "fn:TFunction(name:TFunctionName(function_name:coalesce), binary_type:BUILTIN, " +
                 "arg_types:[TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DOUBLE))])], " +
                 "ret_type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DOUBLE))]), " +
-                "has_var_args:true, signature:coalesce(DOUBLE...), scalar_fn:TScalarFunction(symbol:), " +
+                "has_var_args:true, scalar_fn:TScalarFunction(symbol:), " +
                 "id:70407, fid:70407";
         String thrift = UtFrameUtils.getPlanThriftString(ctx, sql);
         Assert.assertTrue(thrift, thrift.contains(expectString));
@@ -127,8 +127,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
         String expectString =
                 "fn:TFunction(name:TFunctionName(function_name:money_format), binary_type:BUILTIN, arg_types:[TTypeDesc" +
                         "(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DECIMAL128, precision:20, scale:3))])], ret_type:TTypeDesc" +
-                        "(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:VARCHAR, len:-1))]), has_var_args:false, signature:" +
-                        "money_format(DECIMAL128(20,3)), scalar_fn:" +
+                        "(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:VARCHAR, len:-1))]), has_var_args:false, scalar_fn:" +
                         "TScalarFunction(symbol:)" +
                         ", id:304022, fid:304022";
         String thrift = UtFrameUtils.getPlanThriftString(ctx, sql);
@@ -138,7 +137,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
                 "fn:TFunction(name:TFunctionName(function_name:money_format), binary_type:BUILTIN, arg_types:[TTypeDesc(types:" +
                         "[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DECIMAL128, precision:20, scale:3))])], ret_type:TTypeDesc" +
                         "(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:VARCHAR, len:-1))]), has_var_args:false, " +
-                        "signature:money_format(DECIMAL128(20,3)), scalar_fn:TScalarFunction(symbol:), id:304022, fid:304022";
+                        "scalar_fn:TScalarFunction(symbol:), id:304022, fid:304022";
         thrift = UtFrameUtils.getPlanThriftString(ctx, sql);
         Assert.assertTrue(thrift.contains(expectString));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -456,11 +456,9 @@ public class ExpressionTest extends PlanTestBase {
     public void testFunctionNullable() throws Exception {
         String sql = "select UNIX_TIMESTAMP(\"2015-07-28 19:41:12\", \"22\");";
         String plan = getThriftPlan(sql);
-        Assert.assertTrue(plan, plan.contains(
-                "signature:unix_timestamp(VARCHAR, VARCHAR), scalar_fn:TScalarFunction(symbol:), "
-                        +
-                        "id:50287, fid:50287, could_apply_dict_optimize:false, ignore_nulls:false), has_nullable_child:false, "
-                        + "is_nullable:true"));
+        Assert.assertTrue(plan, plan.contains("scalar_fn:TScalarFunction(symbol:), " +
+                "id:50287, fid:50287, could_apply_dict_optimize:false, ignore_nulls:false), " +
+                "has_nullable_child:false, is_nullable:true"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -25,7 +25,7 @@ public class WindowTest extends PlanTestBase {
     public void testLagWindowFunction() throws Exception {
         String sql = "select lag(id_datetime, 1, '2020-01-01') over(partition by t1c) from test_all_type;";
         String plan = getThriftPlan(sql);
-        assertContains(plan, "signature:lag(DATETIME, BIGINT, DATETIME)");
+        assertContains(plan, "lag");
 
         sql = "select lag(id_decimal, 1, 10000) over(partition by t1c) from test_all_type;";
         plan = getThriftPlan(sql);
@@ -36,7 +36,7 @@ public class WindowTest extends PlanTestBase {
                 "TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:DECIMAL64, precision:10, scale:2))])], " +
                 "ret_type:TTypeDesc(types:[TTypeNode(type:SCALAR, " +
                 "scalar_type:TScalarType(type:DECIMAL64, precision:10, scale:2))]), " +
-                "has_var_args:false, signature:lag(DECIMAL64(10,2), BIGINT, DECIMAL64(10,2))";
+                "has_var_args:false";
         System.out.println(expectSlice);
         Assert.assertTrue(plan, plan.contains(expectSlice));
 

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -274,6 +274,8 @@ message PTabletWriterCancelResult {
 };
 
 message PExecPlanFragmentRequest {
+    // describe attachment protocol: binary, compact, json
+    optional string attachment_protocol = 1;
 };
 
 message PTabletReaderOpenRequest {

--- a/gensrc/thrift/Exprs.thrift
+++ b/gensrc/thrift/Exprs.thrift
@@ -84,23 +84,6 @@ enum TExprNodeType {
   MAP_EXPR,
 }
 
-//enum TAggregationOp {
-//  INVALID,
-//  COUNT,
-//  MAX,
-//  DISTINCT_PC,
-//  MERGE_PC,
-//  DISTINCT_PCSA,
-//  MERGE_PCSA,
-//  MIN,
-//  SUM,
-//}
-//
-//struct TAggregateExpr {
-//  1: required bool is_star
-//  2: required bool is_distinct
-//  3: required TAggregationOp op
-//}
 struct TAggregateExpr {
   // Indicates whether this expr is the merge() of an aggregation.
   1: required bool is_merge_agg
@@ -231,7 +214,7 @@ struct TExprNode {
   31: optional TBinaryLiteral binary_literal;
 
   // For vector query engine
-  50: optional bool use_vectorized
+  50: optional bool use_vectorized  // Deprecated
   51: optional bool has_nullable_child
   52: optional bool is_nullable
   53: optional Types.TTypeDesc child_type_desc

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -337,7 +337,7 @@ struct TFunction {
   // Optional comment to attach to the function
   6: optional string comment
 
-  7: optional string signature
+  7: optional string signature // Deprecated
 
   // HDFS path for the function binary. This binary must exist at the time the
   // function is created.


### PR DESCRIPTION
Fixes #issue

* support thrift serialized protocol, for a complex sql, fragment plan size:

| binary(default) | compact | json |
| ---- | ---- | ---- |
| 901347 bytes | 336452 bytes | 2171040 bytes |


and support `thrift_plan_protocol` in session variables  to control it

* remove unused thrift parameters: `signature` and `useVectorized`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
