### PR TITLE
[BugFix] forbid construct Datum from std::string

### DIFF
--- a/be/src/column/datum.h
+++ b/be/src/column/datum.h
@@ -61,6 +61,7 @@ public:
 
     template <typename T>
     Datum(T value) {
+        static_assert(!std::is_same_v<std::string, T>, "should use the Slice as parameter instead of std::string");
         set(value);
     }
 

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -705,8 +705,8 @@ PARALLEL_TEST(VecStringFunctionsTest, splitChinese) {
             auto src_const = ConstColumn::create(BinaryColumn::create());
             auto delim_const = ConstColumn::create(BinaryColumn::create());
 
-            src_const->append_datum(src);
-            delim_const->append_datum(delimiter);
+            src_const->append_datum(Slice(src));
+            delim_const->append_datum(Slice(delimiter));
 
             columns.clear();
             columns.push_back(src_const);

--- a/be/test/storage/binlog_reader_test.cpp
+++ b/be/test/storage/binlog_reader_test.cpp
@@ -145,7 +145,7 @@ void BinlogReaderTest::create_rowset(int32_t* start_key, RowsetInfo& rowset_info
             auto& cols = chunk->columns();
             cols[0]->append_datum(Datum(static_cast<int32_t>(i)));
             cols[1]->append_datum(Datum(static_cast<int32_t>(i)));
-            cols[2]->append_datum(Datum(std::to_string(i)));
+            cols[2]->append_datum(Datum(Slice(std::to_string(i))));
         }
         ASSERT_OK(rowset_writer->flush_chunk(*chunk));
         *start_key += num_rows;


### PR DESCRIPTION
Fixes #issue

`Datum` should not use the temporary `std::string` as parameter, since it's not memory-safe after it's converted into `Slice`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
