### PR TITLE
[BugFix] Fix mv refresh bug when mv's original query has extra predicates (#29808)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -403,7 +403,7 @@ public class AlterJobMgr {
             materializedView.getRefreshScheme().getAsyncRefreshContext().clearVisibleVersionMap();
             GlobalStateMgr.getCurrentState().updateBaseTableRelatedMv(materializedView.getDbId(),
                     materializedView, baseTableInfos);
-            materializedView.setActive(true);
+            materializedView.setActive();
         } else if (AlterMaterializedViewStmt.INACTIVE.equalsIgnoreCase(status)) {
             materializedView.setInactiveAndReason("user use alter materialized view set status to inactive");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -300,9 +300,11 @@ public class Log4jConfig extends XmlConfiguration {
         strSub = new StrSubstitutor(new Interpolator(properties));
         newXmlConfTemplate = strSub.replace(newXmlConfTemplate);
 
-        System.out.println("=====");
-        System.out.println(newXmlConfTemplate);
-        System.out.println("=====");
+        if (!FeConstants.runningUnitTest && !FeConstants.isReplayFromQueryDump) {
+            System.out.println("=====");
+            System.out.println(newXmlConfTemplate);
+            System.out.println("=====");
+        }
 
         // new SimpleLog4jConfiguration with xmlConfTemplate
         ByteArrayInputStream bis = new ByteArrayInputStream(newXmlConfTemplate.getBytes("UTF-8"));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -418,6 +418,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ANALYZE_FOR_MV = "analyze_mv";
     public static final String QUERY_EXCLUDING_MV_NAMES = "query_excluding_mv_names";
     public static final String QUERY_INCLUDING_MV_NAMES = "query_including_mv_names";
+    public static final String ENABLE_MATERIALIZED_VIEW_REWRITE_GREEDY_MODE =
+            "enable_materialized_view_rewrite_greedy_mode";
 
     public static final String ENABLE_BIG_QUERY_LOG = "enable_big_query_log";
     public static final String BIG_QUERY_LOG_CPU_SECOND_THRESHOLD = "big_query_log_cpu_second_threshold";
@@ -1146,6 +1148,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     //      try to rewrite by single table mvs and is determined by rule rather than by cost.
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_SINGLE_TABLE_VIEW_DELTA_REWRITE, flag = VariableMgr.INVISIBLE)
     private boolean enableMaterializedViewSingleTableViewDeltaRewrite = false;
+
+    // Enable greedy mode in mv rewrite to cut down optimizer time for mv rewrite:
+    // - Use plan cache if possible to avoid regenerating plan tree.
+    // - Use the max plan tree to rewrite in view-delta mode to avoid too many rewrites.
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_REWRITE_GREEDY_MODE)
+    private boolean enableMaterializedViewRewriteGreedyMode = false;
 
     @VarAttr(name = QUERY_EXCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
     private String queryExcludingMVNames = "";
@@ -2218,6 +2226,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setEnableMaterializedViewSingleTableViewDeltaRewrite(
             boolean enableMaterializedViewSingleTableViewDeltaRewrite) {
         this.enableMaterializedViewSingleTableViewDeltaRewrite = enableMaterializedViewSingleTableViewDeltaRewrite;
+    }
+
+    public void setEnableMaterializedViewRewriteGreedyMode(boolean enableMaterializedViewRewriteGreedyMode) {
+        this.enableMaterializedViewRewriteGreedyMode = enableMaterializedViewRewriteGreedyMode;
+    }
+
+    public boolean isEnableMaterializedViewRewriteGreedyMode() {
+        return this.enableMaterializedViewRewriteGreedyMode;
     }
 
     public String getQueryExcludingMVNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -959,7 +959,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     QueryRelation queryRelation = queryStatement.getQueryRelation();
                     if (queryRelation instanceof SelectRelation) {
                         SelectRelation selectRelation = ((SelectRelation) queryStatement.getQueryRelation());
-                        selectRelation.setWhereClause(Expr.compoundOr(Lists.newArrayList(selectRelation.getWhereClause(),
+                        selectRelation.setWhereClause(Expr.compoundAnd(Lists.newArrayList(selectRelation.getWhereClause(),
                                 partitionPredicates)));
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -92,7 +92,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -483,7 +482,7 @@ public class MvUtils {
     public static ScalarOperator getCompensationPredicateForDisjunctive(ScalarOperator src, ScalarOperator target) {
         List<ScalarOperator> srcItems = Utils.extractDisjunctive(src);
         List<ScalarOperator> targetItems = Utils.extractDisjunctive(target);
-        if (!new HashSet<>(targetItems).containsAll(srcItems)) {
+        if (!Sets.newHashSet(targetItems).containsAll(srcItems)) {
             return null;
         }
         targetItems.removeAll(srcItems);
@@ -1040,6 +1039,7 @@ public class MvUtils {
         }
     }
 
+<<<<<<< HEAD
     /**
      * Return the max refresh timestamp of all partition infos.
      */
@@ -1051,5 +1051,13 @@ public class MvUtils {
                 .max(Long::compareTo)
                 .filter(Objects::nonNull)
                 .orElse(System.currentTimeMillis());
+    }
+
+    public static boolean isSupportViewDelta(OptExpression optExpression) {
+        return getAllJoinOperators(optExpression).stream().allMatch(x -> isSupportViewDelta(x));
+    }
+
+    public static boolean isSupportViewDelta(JoinOperator joinOperator) {
+        return  joinOperator.isLeftOuterJoin() || joinOperator.isInnerJoin();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1039,7 +1039,6 @@ public class MvUtils {
         }
     }
 
-<<<<<<< HEAD
     /**
      * Return the max refresh timestamp of all partition infos.
      */

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
@@ -51,7 +51,6 @@ import com.starrocks.sql.ast.ShowCreateTableStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
-import org.apache.hadoop.util.ThreadUtil;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -59,6 +58,8 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Map;
+
+import static com.starrocks.sql.optimizer.MVTestUtils.waitForSchemaChangeAlterJobFinish;
 
 public class AlterJobV2Test {
     private static ConnectContext connectContext;
@@ -347,19 +348,6 @@ public class AlterJobV2Test {
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail();
-        }
-    }
-
-    private void waitForSchemaChangeAlterJobFinish() throws Exception {
-        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
-        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
-            while (!alterJobV2.getJobState().isFinalState()) {
-                System.out.println(
-                        "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
-                ThreadUtil.sleepAtLeastIgnoreInterrupts(1000);
-            }
-            System.out.println("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
-            Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -76,6 +76,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.starrocks.sql.optimizer.MVTestUtils.waitingRollupJobV2Finish;
+
 public class CreateMaterializedViewTest {
     private static final Logger LOG = LogManager.getLogger(CreateMaterializedViewTest.class);
 
@@ -297,23 +299,6 @@ public class CreateMaterializedViewTest {
             LOG.info("waiting for TaskRunState retryCount:" + retryCount);
         }
         return taskRuns;
-    }
-
-    private void waitingRollupJobV2Finish() throws Exception {
-        // waiting alterJobV2 finish
-        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
-        //Assert.assertEquals(1, alterJobs.size());
-
-        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
-            if (alterJobV2.getType() != AlterJobV2.JobType.ROLLUP) {
-                continue;
-            }
-            while (!alterJobV2.getJobState().isFinalState()) {
-                System.out.println(
-                        "rollup job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
-                ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
-            }
-        }
     }
 
     // ========== full test ==========
@@ -1520,7 +1505,7 @@ public class CreateMaterializedViewTest {
         }
 
         MaterializedView baseInactiveMv = ((MaterializedView) testDb.getTable("base_inactive_mv"));
-        baseInactiveMv.setActive(false);
+        baseInactiveMv.setInactiveAndReason("");
 
         String sql2 = "create materialized view mv_from_base_inactive_mv " +
                 "partition by k1 " +
@@ -1554,7 +1539,7 @@ public class CreateMaterializedViewTest {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
             MaterializedView mv = ((MaterializedView) testDb.getTable("testAsHasStar"));
-            mv.setActive(false);
+            mv.setInactiveAndReason("");
             List<Column> mvColumns = mv.getFullSchema();
 
             Table baseTable = testDb.getTable("tbl1");
@@ -1647,7 +1632,7 @@ public class CreateMaterializedViewTest {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
             MaterializedView mv = ((MaterializedView) testDb.getTable("testAsSelectItemAlias1"));
-            mv.setActive(false);
+            mv.setInactiveAndReason("");
             List<Column> mvColumns = mv.getFullSchema();
 
             Assert.assertEquals("date_trunc('month', tbl1.k1)", mvColumns.get(0).getName());
@@ -1678,7 +1663,7 @@ public class CreateMaterializedViewTest {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
             MaterializedView mv = ((MaterializedView) testDb.getTable("testAsSelectItemAlias2"));
-            mv.setActive(false);
+            mv.setInactiveAndReason("");
             List<Column> mvColumns = mv.getFullSchema();
 
             Assert.assertEquals("date_trunc('month', tbl1.k1)", mvColumns.get(0).getName());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -98,7 +98,7 @@ public class MaterializedViewTest {
         mv2.setStorageMedium(TStorageMedium.SSD);
         Assert.assertEquals("SSD", mv2.getStorageMedium());
         Assert.assertEquals(true, mv2.isActive());
-        mv2.setActive(false);
+        mv2.setInactiveAndReason("");
         Assert.assertEquals(false, mv2.isActive());
 
         List<BaseTableInfo> baseTableInfos = Lists.newArrayList();
@@ -665,7 +665,7 @@ public class MaterializedViewTest {
                         "as select k1,k2,v1 from base_table;");
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView baseMv = ((MaterializedView) testDb.getTable("base_mv"));
-        baseMv.setActive(false);
+        baseMv.setInactiveAndReason("");
 
         SinglePartitionInfo singlePartitionInfo = new SinglePartitionInfo();
         MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
@@ -22,7 +22,6 @@ import com.staros.proto.FilePathInfo;
 import com.staros.proto.FileStoreInfo;
 import com.staros.proto.FileStoreType;
 import com.staros.proto.S3FileStoreInfo;
-import com.starrocks.alter.AlterJobV2;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -62,7 +61,6 @@ import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
-import org.apache.hadoop.util.ThreadUtil;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -72,7 +70,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
+
+import static com.starrocks.sql.optimizer.MVTestUtils.waitForSchemaChangeAlterJobFinish;
 
 public class LakeMaterializedViewTest {
     private static final String DB = "db_for_lake_mv";
@@ -393,19 +392,6 @@ public class LakeMaterializedViewTest {
 
         starRocksAssert.dropMaterializedView("mv3");
         Assert.assertNull(db.getTable("mv3"));
-    }
-
-    private void waitForSchemaChangeAlterJobFinish() throws Exception {
-        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
-        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
-            while (!alterJobV2.getJobState().isFinalState()) {
-                System.out.println(
-                        "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
-                ThreadUtil.sleepAtLeastIgnoreInterrupts(1000);
-            }
-            System.out.println("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
-            Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
-        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -111,7 +111,9 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery16() {
+        connectContext.getSessionVariable().setEnableMaterializedViewRewriteGreedyMode(true);
         runFileUnitTest("materialized-view/tpch/q16");
+        connectContext.getSessionVariable().setEnableMaterializedViewRewriteGreedyMode(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -1723,7 +1723,7 @@ public class PartitionBasedMvRefreshProcessorTest {
         }
     }
 
-   @Test
+    @Test
     public void testPartitionPruneNonRefBaseTable1() throws Exception {
         starRocksAssert.useDatabase("test")
                 .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`partition_prune_non_ref_tables1`\n" +
@@ -1852,6 +1852,77 @@ public class PartitionBasedMvRefreshProcessorTest {
                     "     rollup: tbl4"));
         }
         starRocksAssert.dropMaterializedView("partition_prune_non_ref_tables2");
+    }
+
+    @Test
+    public void testPartitionPruneNonRefBaseTable3() throws Exception {
+        // mv with predicates
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`partition_prune_non_ref_tables1`\n" +
+                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                        "PARTITION BY (`k1`)\n" +
+                        "DISTRIBUTED BY HASH(`k1`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT t1.k1, sum(t1.k2) as sum1, avg(t2.k2) as avg1 FROM tbl4 as t1 join " +
+                        "tbl5 t2 on t1.k1=t2.dt where t1.k1>'2022-01-01' and t1.k2>0 group by t1.k1");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("partition_prune_non_ref_tables1"));
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        // run 1
+        {
+            // just refresh to avoid dirty data
+            taskRun.executeTaskRun();
+        }
+
+        // run 2
+        {
+            // base table partition insert data
+            String insertSql = "insert into tbl4 partition(p4) values('2022-04-01', 3, 10);";
+            new StmtExecutor(connectContext, insertSql).execute();
+
+            taskRun.executeTaskRun();
+            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                    taskRun.getProcessor();
+            MvTaskRunContext mvContext = processor.getMvContext();
+            ExecPlan execPlan = mvContext.getExecPlan();
+            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+            System.out.println(plan);
+            Assert.assertFalse(plan.contains("partitions=5/5"));
+            Assert.assertTrue(plan.contains("PREDICATES: 2: k2 > 0\n" +
+                    "     partitions=1/5\n" +
+                    "     rollup: tbl4"));
+            Assert.assertTrue(plan.contains("partitions=1/5\n" +
+                    "     rollup: tbl5"));
+        }
+
+        // run 3
+        {
+            // TODO: non-ref base table partition's updated will cause the materialized view's refresh all partitions
+            String insertSql = "insert into tbl5 partition(p4) values('2022-04-01', '2021-04-01 00:02:11', 3, 10);";
+            new StmtExecutor(connectContext, insertSql).execute();
+
+            taskRun.executeTaskRun();
+            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                    taskRun.getProcessor();
+            MvTaskRunContext mvContext = processor.getMvContext();
+            ExecPlan execPlan = mvContext.getExecPlan();
+            String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+            System.out.println(plan);
+            Assert.assertTrue(plan.contains("k1 > '2022-01-01', 2: k2 > 0\n" +
+                    "     partitions=4/5\n" +
+                    "     rollup: tbl4"));
+            Assert.assertTrue(plan.contains("4: dt > '2022-01-01'\n" +
+                    "     partitions=4/5\n" +
+                    "     rollup: tbl5"));
+        }
+        starRocksAssert.dropMaterializedView("partition_prune_non_ref_tables1");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -393,7 +393,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     public void testInactive() {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_inactive"));
-        materializedView.setActive(false);
+        materializedView.setInactiveAndReason("");
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
 
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -1723,7 +1723,7 @@ public class PartitionBasedMvRefreshProcessorTest {
         }
     }
 
-    @Test
+   @Test
     public void testPartitionPruneNonRefBaseTable1() throws Exception {
         starRocksAssert.useDatabase("test")
                 .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`partition_prune_non_ref_tables1`\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -68,7 +68,7 @@ public class MaterializedViewAnalyzerTest {
         Assert.assertNotNull(table);
         Assert.assertTrue(table instanceof MaterializedView);
         MaterializedView mv = (MaterializedView) table;
-        mv.setActive(false);
+        mv.setInactiveAndReason("");
         analyzeFail("refresh materialized view mv");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -865,7 +865,6 @@ public class MVRewriteTest {
         starRocksAssert.withMaterializedView(createUserTagMVSql);
         String query = "select `" + FunctionSet.HLL_UNION + "`(" + FunctionSet.HLL_HASH + "(tag_id)) from " +
                 USER_TAG_TABLE_NAME + ";";
-        System.out.println(starRocksAssert.query(query).explainQuery());
         starRocksAssert.query(query).explainContains(USER_TAG_MV_NAME);
         query = "select hll_union_agg(" + FunctionSet.HLL_HASH + "(tag_id)) from " + USER_TAG_TABLE_NAME + ";";
         starRocksAssert.query(query).explainContains(USER_TAG_MV_NAME, FunctionSet.HLL_UNION_AGG);
@@ -907,7 +906,6 @@ public class MVRewriteTest {
         starRocksAssert.withMaterializedView(createUserTagMVSql);
         String query =
                 "select empid, percentile_approx(salary, 1), percentile_approx(commission, 1) from emps group by empid";
-        System.out.println(starRocksAssert.query(query).explainQuery());
         starRocksAssert.query(query).explainContains(QUERY_USE_EMPS_MV, "  2:AGGREGATE (update serialize)\n",
                 "output: percentile_union");
         starRocksAssert.assertMVWithoutComplexExpression(HR_DB_NAME, EMPS_TABLE_NAME);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVTestUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVTestUtils.java
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.starrocks.alter.AlterJobV2;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.hadoop.util.ThreadUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+
+import java.util.Map;
+
+public class MVTestUtils {
+    private static final Logger LOG = LogManager.getLogger(MVTestUtils.class);
+
+    public static void waitingRollupJobV2Finish() throws Exception {
+        // waiting alterJobV2 finish
+        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getRollupHandler().getAlterJobsV2();
+        //Assert.assertEquals(1, alterJobs.size());
+
+        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
+            if (alterJobV2.getType() != AlterJobV2.JobType.ROLLUP) {
+                continue;
+            }
+            while (!alterJobV2.getJobState().isFinalState()) {
+                System.out.println(
+                        "rollup job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
+                ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
+            }
+        }
+    }
+
+    public static void waitForSchemaChangeAlterJobFinish() throws Exception {
+        Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
+        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
+            while (!alterJobV2.getJobState().isFinalState()) {
+                LOG.info(
+                        "alter job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
+                ThreadUtil.sleepAtLeastIgnoreInterrupts(100);
+            }
+            System.out.println("alter job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
+            Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -933,7 +933,6 @@ public class MvRewriteTest extends MvRewriteTestBase {
     }
 
     @Test
-<<<<<<< HEAD
     public void testHiveAggregateMvRewrite() throws Exception {
         createAndRefreshMv("test", "hive_agg_join_mv_1", "create materialized view hive_agg_join_mv_1" +
                 " distributed by hash(s_nationkey)" +
@@ -990,7 +989,9 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 "     NON-PARTITION PREDICATES: 13: s_suppkey < 10, 13: s_suppkey > 4");
 
         dropMv("test", "hive_union_mv_1");
-=======
+    }
+
+    @Test
     public void testMVCacheInvalidAndReValid() throws Exception {
         starRocksAssert.withTable("\n" +
                 "CREATE TABLE test_base_tbl(\n" +
@@ -1067,7 +1068,6 @@ public class MvRewriteTest extends MvRewriteTestBase {
             plan = getFragmentPlan(sql);
             PlanTestBase.assertContains(plan, "test_cache_mv1");
         }
->>>>>>> 30d68c3d20 ([BugFix] Add enable_materialized_view_rewrite_greedy_mode param to control fast withdraw for mv rewrite (#29645))
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ForeignKeyConstraint;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
@@ -24,9 +25,13 @@ import com.starrocks.catalog.UniqueConstraint;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -34,6 +39,9 @@ import org.junit.Test;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.starrocks.sql.optimizer.MVTestUtils.waitForSchemaChangeAlterJobFinish;
+import static com.starrocks.sql.optimizer.MVTestUtils.waitingRollupJobV2Finish;
 
 public class MvRewriteTest extends MvRewriteTestBase {
     @Test
@@ -925,6 +933,7 @@ public class MvRewriteTest extends MvRewriteTestBase {
     }
 
     @Test
+<<<<<<< HEAD
     public void testHiveAggregateMvRewrite() throws Exception {
         createAndRefreshMv("test", "hive_agg_join_mv_1", "create materialized view hive_agg_join_mv_1" +
                 " distributed by hash(s_nationkey)" +
@@ -981,6 +990,84 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 "     NON-PARTITION PREDICATES: 13: s_suppkey < 10, 13: s_suppkey > 4");
 
         dropMv("test", "hive_union_mv_1");
+=======
+    public void testMVCacheInvalidAndReValid() throws Exception {
+        starRocksAssert.withTable("\n" +
+                "CREATE TABLE test_base_tbl(\n" +
+                "  `dt` datetime DEFAULT NULL,\n" +
+                "  `col1` bigint(20) DEFAULT NULL,\n" +
+                "  `col2` bigint(20) DEFAULT NULL,\n" +
+                "  `col3` bigint(20) DEFAULT NULL,\n" +
+                "  `error_code` varchar(1048576) DEFAULT NULL\n" +
+                ")\n" +
+                "DUPLICATE KEY (dt)\n" +
+                "PARTITION BY date_trunc('day', dt)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW  test_cache_mv1 \n" +
+                "DISTRIBUTED BY HASH(col1, dt) BUCKETS 32\n" +
+                "--DISTRIBUTED BY RANDOM BUCKETS 32\n" +
+                "partition by date_trunc('day', dt)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS select\n" +
+                "      col1,\n" +
+                "        dt,\n" +
+                "        sum(col2) AS sum_col2,\n" +
+                "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
+                "    FROM\n" +
+                "        test_base_tbl AS f\n" +
+                "    GROUP BY\n" +
+                "        col1,\n" +
+                "        dt;");
+        refreshMaterializedView("test", "test_cache_mv1");
+
+        {
+            String sql = "select\n" +
+                    "      col1,\n" +
+                    "        sum(col2) AS sum_col2,\n" +
+                    "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
+                    "    FROM\n" +
+                    "        test_base_tbl AS f\n" +
+                    "    WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
+                    "        AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
+                    "    GROUP BY col1;";
+            String plan = getFragmentPlan(sql);
+            PlanTestBase.assertContains(plan, "test_cache_mv1");
+        }
+
+        {
+            // invalid base table
+            String alterSql = "alter table test_base_tbl modify column col1  varchar(30);";
+            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSql,
+                    connectContext);
+            GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(alterTableStmt);
+            waitForSchemaChangeAlterJobFinish();
+
+            // check mv invalid
+            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+            MaterializedView mv1 = ((MaterializedView) testDb.getTable("test_cache_mv1"));
+            Assert.assertFalse(mv1.isActive());
+
+            String sql = "select\n" +
+                    "      col1,\n" +
+                    "        sum(col2) AS sum_col2,\n" +
+                    "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
+                    "    FROM\n" +
+                    "        test_base_tbl AS f\n" +
+                    "    WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
+                    "        AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
+                    "    GROUP BY col1;";
+            String plan = getFragmentPlan(sql);
+            PlanTestBase.assertNotContains(plan, "test_cache_mv1");
+
+            cluster.runSql("test", "alter materialized view test_cache_mv1 active;");
+            plan = getFragmentPlan(sql);
+            PlanTestBase.assertContains(plan, "test_cache_mv1");
+        }
+>>>>>>> 30d68c3d20 ([BugFix] Add enable_materialized_view_rewrite_greedy_mode param to control fast withdraw for mv rewrite (#29645))
     }
 
     @Test
@@ -2009,10 +2096,9 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 "                \"storage_format\" = \"DEFAULT\",\n" +
                 "                \"enable_persistent_index\" = \"false\"\n" +
                 "                );");
-        cluster.runSql("test", "insert into sync_tbl_t1 values ('2022-05-01',1,2,3), " +
-                "('2022-05-01',2,2,2), ('2022-05-01',3,2,3);");
-        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW sync_mv1 AS " +
-                "select a, b*10 as col2, c+1 as col3 from sync_tbl_t1;");
+        String sql = "CREATE MATERIALIZED VIEW sync_mv1 AS select a, b*10 as col2, c+1 as col3 from sync_tbl_t1;";
+        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().createMaterializedView((CreateMaterializedViewStmt) statementBase);
         waitingRollupJobV2Finish();
         String query = "select a, b*10 as col2, c+1 as col3 from sync_tbl_t1 order by a;";
         String plan = getFragmentPlan(query);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
@@ -100,7 +100,6 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/agg_with_having1"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains("TEST_MV_2"));
     }
 
@@ -109,7 +108,6 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/agg_with_having2"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains("TEST_MV_2"));
     }
 
@@ -118,7 +116,6 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/agg_with_having3"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
-        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second.contains("TEST_MV_3"));
     }
 }

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv1.sql
@@ -1,4 +1,4 @@
--- partsupp_mv
+-- partsupp_mv, query2/query11/query18
 create materialized view partsupp_mv
 distributed by hash(ps_partkey, ps_suppkey) buckets 24
 refresh deferred manual
@@ -7,7 +7,7 @@ properties (
 )
 as select
               n_name,
-              p_mfgr,p_size,p_type,
+              p_mfgr,p_size,p_type,p_brand,
               ps_partkey, ps_suppkey,ps_supplycost,
               r_name,
               s_acctbal,s_address,s_comment,s_name,s_nationkey,s_phone,

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv2.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv2.sql
@@ -1,4 +1,4 @@
--- query1
+-- query1,query18
 create materialized view lineitem_agg_mv1
 distributed by hash(l_orderkey,
                l_shipdate,
@@ -52,6 +52,7 @@ as select  /*+ SET_VAR(query_timeout = 7200) */
        l_suppkey, l_shipdate, l_partkey
 ;
 
+-- query6
 create materialized view lineitem_agg_mv3
 distributed by hash(l_shipdate, l_discount, l_quantity) buckets 24
 partition by l_shipdate

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv3.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/ddl_tpch_mv3.sql
@@ -2,7 +2,7 @@
 create materialized view lineitem_mv_agg_mv1
  distributed by hash(p_name,
                o_orderyear,
-               n_name1) buckets 96
+               n_name2) buckets 96
  refresh deferred manual
  properties (
      "replication_num" = "1"
@@ -10,14 +10,15 @@ create materialized view lineitem_mv_agg_mv1
  as select /*+ SET_VAR(query_timeout = 7200) */
                p_name,
                o_orderyear,
-               n_name1,
+               n_name2,
                sum(l_amount) as sum_amount
     from
                lineitem_mv
+    where c_nationkey = s_nationkey
     group by
         p_name,
         o_orderyear,
-        n_name1
+        n_name2
 ;
 
 -- query7

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q16.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q16.sql
@@ -37,11 +37,8 @@ TOP-N (order by [[23: count DESC NULLS LAST, 9: p_brand ASC NULLS FIRST, 10: p_t
                 EXCHANGE SHUFFLE[9, 10, 11]
                     AGGREGATE ([LOCAL] aggregate [{}] group by [[2: ps_suppkey, 9: p_brand, 10: p_type, 11: p_size]] having [null]
                         NULL AWARE LEFT ANTI JOIN (join-predicate [2: ps_suppkey = 15: s_suppkey] post-join-predicate [null])
-                            INNER JOIN (join-predicate [6: p_partkey = 1: ps_partkey] post-join-predicate [null])
-                                SCAN (table[part] columns[6: p_partkey, 9: p_brand, 10: p_type, 11: p_size] predicate[9: p_brand != Brand#43 AND NOT 10: p_type LIKE PROMO BURNISHED% AND 11: p_size IN (31, 43, 9, 6, 18, 11, 25, 1)])
-                                EXCHANGE SHUFFLE[1]
-                                    SCAN (table[partsupp] columns[1: ps_partkey, 2: ps_suppkey] predicate[null])
+                            SCAN (mv[partsupp_mv] columns[109: p_size, 110: p_type, 111: p_brand, 113: ps_suppkey] predicate[109: p_size = 1 OR 109: p_size = 11 OR 109: p_size = 18 OR 109: p_size = 25 OR 109: p_size = 31 OR 109: p_size = 43 OR 109: p_size = 6 OR 109: p_size = 9 AND 111: p_brand < Brand#43 OR 111: p_brand > Brand#43 AND NOT 110: p_type LIKE PROMO BURNISHED%])
                             EXCHANGE BROADCAST
                                 SCAN (table[supplier] columns[21: s_comment, 15: s_suppkey] predicate[21: s_comment LIKE %Customer%Complaints%])
-[end]
+end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q17.sql
@@ -11,7 +11,6 @@ where
   and l_quantity < (
     select
             0.2 * avg(l_quantity)
---         0.2 * sum(l_quantity) / count(l_quantity)
     from
         lineitem
     where

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q9.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q9.sql
@@ -32,11 +32,11 @@ order by
     nation,
     o_year desc ;
 [result]
-TOP-N (order by [[: n_name ASC NULLS FIRST, : year DESC NULLS LAST]])
-    TOP-N (order by [[: n_name ASC NULLS FIRST, : year DESC NULLS LAST]])
-        AGGREGATE ([GLOBAL] aggregate [{: sum=sum(: sum)}] group by [[: n_name, : year]] having [null]
-            EXCHANGE SHUFFLE[, ]
-                AGGREGATE ([LOCAL] aggregate [{: sum=sum(: expr)}] group by [[: n_name, : year]] having [null]
-                    SCAN (mv[lineitem_mv] columns[: c_nationkey, : p_name, : s_nationkey, : l_amount, : o_orderyear, : n_name] predicate[: c_nationkey = : s_nationkey AND : p_name LIKE %peru%])
+TOP-N (order by [[48: n_name ASC NULLS FIRST, 51: year DESC NULLS LAST]])
+    TOP-N (order by [[48: n_name ASC NULLS FIRST, 51: year DESC NULLS LAST]])
+        AGGREGATE ([GLOBAL] aggregate [{1286: sum=sum(1286: sum)}] group by [[99: n_name2, 98: o_orderyear]] having [null]
+            EXCHANGE SHUFFLE[99, 98]
+                AGGREGATE ([LOCAL] aggregate [{1286: sum=sum(100: sum_amount)}] group by [[99: n_name2, 98: o_orderyear]] having [null]
+                    SCAN (mv[lineitem_mv_agg_mv1] columns[97: p_name, 98: o_orderyear, 99: n_name2, 100: sum_amount] predicate[97: p_name LIKE %peru%])
 [end]
 

--- a/test/sql/test_materialized_view/R/test_materialized_view_status
+++ b/test/sql/test_materialized_view/R/test_materialized_view_status
@@ -31,16 +31,8 @@ CREATE MATERIALIZED VIEW mv1
                AS SELECT k1, sum(v1) as sum_v1 FROM t1 group by k1;
 -- result:
 -- !result
-select sleep(2);
--- result:
-1
--- !result
 drop table t1;
 -- result:
--- !result
-refresh materialized view mv1;
--- result:
-E: (1064, 'Getting analyzing error at line 1, column 26. Detail message: Refresh materialized view failed because [mv1] is not active. You can try to active it with ALTER MATERIALIZED VIEW mv1 ACTIVE; .')
 -- !result
 CREATE TABLE `t1` (
   `k1` date NULL COMMENT "",
@@ -65,16 +57,8 @@ PROPERTIES (
 ALTER MATERIALIZED VIEW mv1 ACTIVE;
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW mv1;
--- !result
-select sleep(2);
--- result:
-1
--- !result
-select * from mv1;
--- result:
--- !result
-ALTER MATERIALIZED VIEW mv1 ACTIVE;
+REFRESH MATERIALIZED VIEW mv1  with sync mode;
+select * from mv1 order by k1;
 -- result:
 -- !result
 insert into t1 values ("2019-01-01",1,1),("2019-01-01",1,2),("2019-01-01",2,1),("2019-01-01",2,2),
@@ -82,47 +66,24 @@ insert into t1 values ("2019-01-01",1,1),("2019-01-01",1,2),("2019-01-01",2,1),(
                                          ("2023-03-11",1,1),("2023-05-11",1,2),("2023-04-11",2,1),("2023-05-01",2,2);
 -- result:
 -- !result
-select sleep(2);
--- result:
-1
--- !result
-select * from mv1;
+REFRESH MATERIALIZED VIEW mv1  with sync mode;
+select * from mv1 order by k1;
 -- result:
 2019-01-01	6
-2023-03-11	1
-2023-05-01	2
 2023-01-11	4
 2023-02-11	2
+2023-03-11	1
 2023-04-11	2
+2023-05-01	2
 2023-05-11	1
 -- !result
 ALTER MATERIALIZED VIEW mv1 INACTIVE;
 -- result:
 -- !result
-REFRESH MATERIALIZED VIEW mv1;
--- result:
-E: (1064, 'Getting analyzing error at line 1, column 26. Detail message: Refresh materialized view failed because [mv1] is not active. You can try to active it with ALTER MATERIALIZED VIEW mv1 ACTIVE; .')
--- !result
-CREATE TABLE t1 (
-    k1 INT,
-    v1 INT,
-    v2 INT)
-DUPLICATE KEY(k1)
-DISTRIBUTED BY HASH(k1)
-PROPERTIES(
-    "replication_num" = "1"
-)
-insert into t1 values (1,1,1),(1,2,2),(2,3,3),(2,3,4),(2,5,5);
--- result:
-E: (1064, "Getting syntax error at line 10, column 0. Detail message: Unexpected input 'insert', the most similar input is {<EOF>, ';'}.")
--- !result
 CREATE MATERIALIZED VIEW mv2
 DISTRIBUTED BY HASH(k1) BUCKETS 10
 REFRESH MANUAL
 AS SELECT k1,v1 FROM t1;
--- result:
--- !result
-refresh materialized view mv2;
 -- result:
 -- !result
 drop table t1;
@@ -142,10 +103,7 @@ PROPERTIES(
 alter materialized view mv2 active;
 -- result:
 -- !result
-select sleep(2);
--- result:
-1
--- !result
-select * from mv2
+refresh materialized view mv2  with sync mode;
+select * from mv2 order by k1;
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/R/test_mv_on_view
+++ b/test/sql/test_materialized_view/R/test_mv_on_view
@@ -28,9 +28,6 @@ AS select * from view1;
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW mv_on_view_1 with sync mode ;
--- result:
-662f725b-2097-11ee-85b3-f236c9537340
--- !result
 SELECT * FROM mv_on_view_1 ORDER BY event_day;
 -- result:
 2020-01-14	5
@@ -40,9 +37,6 @@ insert into ss values('2020-01-15', 3);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW mv_on_view_1 with sync mode;
--- result:
-665e238e-2097-11ee-85b3-f236c9537340
--- !result
 SELECT * FROM mv_on_view_1 ORDER BY event_day;
 -- result:
 2020-01-14	5
@@ -62,12 +56,9 @@ ALTER MATERIALIZED VIEW mv_on_view_1 ACTIVE;
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views 
     WHERE table_name = 'mv_on_view_1';
 -- result:
-true	
+true	base view view1 changed
 -- !result
 [UC]REFRESH MATERIALIZED VIEW mv_on_view_1 with sync mode;
--- result:
-66f75661-2097-11ee-85b3-f236c9537340
--- !result
 SELECT * FROM mv_on_view_1 ORDER BY event_day;
 -- result:
 -- !result
@@ -75,9 +66,6 @@ insert into jj values('2020-01-14', 2);
 -- result:
 -- !result
 [UC]REFRESH MATERIALIZED VIEW mv_on_view_1 with sync mode;
--- result:
-6788c101-2097-11ee-85b3-f236c9537340
--- !result
 SELECT * FROM mv_on_view_1 ORDER BY event_day;
 -- result:
 2020-01-14	2

--- a/test/sql/test_materialized_view/R/test_mv_swap
+++ b/test/sql/test_materialized_view/R/test_mv_swap
@@ -148,11 +148,11 @@ ALTER MATERIALIZED VIEW mv_on_mv_2 ACTIVE;
 -- !result
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_1';
 -- result:
-true	
+true	based table mv2 swapped
 -- !result
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_mv_2';
 -- result:
-true	
+true	base table mv_on_mv_1 inactive
 -- !result
 CREATE MATERIALIZED VIEW mv_on_table_1 REFRESH ASYNC 
 AS SELECT ss.event_day, sum(ss.pv) as ss_sum_pv, sum(jj.pv) as jj_sum_pv
@@ -173,5 +173,5 @@ ALTER MATERIALIZED VIEW mv_on_table_1 ACTIVE;
 -- !result
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views WHERE table_name = 'mv_on_table_1';
 -- result:
-true	
+true	based table jj swapped
 -- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_status
+++ b/test/sql/test_materialized_view/T/test_materialized_view_status
@@ -25,9 +25,8 @@ CREATE MATERIALIZED VIEW mv1
                DISTRIBUTED BY HASH(k1) BUCKETS 10
                REFRESH ASYNC
                AS SELECT k1, sum(v1) as sum_v1 FROM t1 group by k1;
-select sleep(2);
 drop table t1;
-refresh materialized view mv1;
+
 CREATE TABLE `t1` (
   `k1` date NULL COMMENT "",
   `v1` int(11) NULL COMMENT "",
@@ -47,32 +46,21 @@ PROPERTIES (
 "replication_num" = "1"
 );
 ALTER MATERIALIZED VIEW mv1 ACTIVE;
-REFRESH MATERIALIZED VIEW mv1;
-select sleep(2);
-select * from mv1;
-ALTER MATERIALIZED VIEW mv1 ACTIVE;
+REFRESH MATERIALIZED VIEW mv1  with sync mode;
+select * from mv1 order by k1;
+
 insert into t1 values ("2019-01-01",1,1),("2019-01-01",1,2),("2019-01-01",2,1),("2019-01-01",2,2),
                                          ("2023-01-11",1,1),("2023-01-11",1,2),("2023-02-11",2,1),("2023-01-11",2,2),
                                          ("2023-03-11",1,1),("2023-05-11",1,2),("2023-04-11",2,1),("2023-05-01",2,2);
-select sleep(2);
-select * from mv1;
+REFRESH MATERIALIZED VIEW mv1  with sync mode;
+select * from mv1 order by k1;
 ALTER MATERIALIZED VIEW mv1 INACTIVE;
-REFRESH MATERIALIZED VIEW mv1;
-CREATE TABLE t1 (
-    k1 INT,
-    v1 INT,
-    v2 INT)
-DUPLICATE KEY(k1)
-DISTRIBUTED BY HASH(k1)
-PROPERTIES(
-    "replication_num" = "1"
-)
-insert into t1 values (1,1,1),(1,2,2),(2,3,3),(2,3,4),(2,5,5);
+
 CREATE MATERIALIZED VIEW mv2
 DISTRIBUTED BY HASH(k1) BUCKETS 10
 REFRESH MANUAL
 AS SELECT k1,v1 FROM t1;
-refresh materialized view mv2;
+
 drop table t1;
 CREATE TABLE t1 (
     k1 INT,
@@ -84,5 +72,5 @@ PROPERTIES(
     "replication_num" = "1"
 );
 alter materialized view mv2 active;
-select sleep(2);
-select * from mv2
+refresh materialized view mv2  with sync mode;
+select * from mv2 order by k1;


### PR DESCRIPTION
[[BugFix] Add enable_materialized_view_rewrite_greedy_mode param to co](https://github.com/StarRocks/starrocks/commit/68e0aaf9d931b4891c7b0e74d98bdf1d06d76941)

[Fix mv refresh bug when mv's original query has extra predicates (](https://github.com/StarRocks/starrocks/commit/d2208ba78ee6f165fd814285aff2455ce2569a0b)https://github.com/StarRocks/starrocks/pull/29808
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
