### PR TITLE
[BugFix] BE crashed when get tablet stats in shared data mode

### DIFF
--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -782,4 +782,18 @@ TEST_F(LakeServiceTest, test_publish_version_issue28244) {
     SyncPoint::GetInstance()->ClearCallBack("publish_version:delete_txn_log");
     SyncPoint::GetInstance()->DisableProcessing();
 }
+
+TEST_F(LakeServiceTest, test_get_tablet_stats) {
+    lake::TabletStatRequest request;
+    lake::TabletStatResponse response;
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(_tablet_id);
+    info->set_version(1);
+    _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(1, response.tablet_stats_size());
+    ASSERT_EQ(_tablet_id, response.tablet_stats(0).tablet_id());
+    ASSERT_EQ(0, response.tablet_stats(0).num_rows());
+    ASSERT_EQ(0, response.tablet_stats(0).data_size());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
Make sure the bthread::Mutex will not be destroyed before unlocked.

Fixes #29929

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
