### PR TITLE
[BugFix] Update corePoolSize before maximumPoolSize in task executor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
@@ -111,9 +111,11 @@ public class PriorityLeaderTaskExecutor {
     }
 
     public void setPoolSize(int poolSize) {
-        // corePoolSize and maximumPoolSize are same
-        executor.setMaximumPoolSize(poolSize);
+        // corePoolSize and maximumPoolSize are same.
+        // Must set corePoolSize first, because setMaximumPoolSize() will throw IllegalArgumentException
+        // if maximumPoolSize < corePoolSize.
         executor.setCorePoolSize(poolSize);
+        executor.setMaximumPoolSize(poolSize);
     }
 
     private class TaskChecker implements Runnable {

--- a/fe/fe-core/src/test/java/com/starrocks/task/PriorityLeaderTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/PriorityLeaderTaskExecutorTest.java
@@ -97,10 +97,16 @@ public class PriorityLeaderTaskExecutorTest {
         Assert.assertEquals(THREAD_NUM, executor.getCorePoolSize());
         Assert.assertEquals(THREAD_NUM, priorityExecutor.getMaximumPoolSize());
 
+        // set from 1 to 2
         int newThreadNum = THREAD_NUM + 1;
         executor.setPoolSize(newThreadNum);
         Assert.assertEquals(newThreadNum, executor.getCorePoolSize());
         Assert.assertEquals(newThreadNum, priorityExecutor.getMaximumPoolSize());
+
+        // set from 2 to 1
+        executor.setPoolSize(THREAD_NUM);
+        Assert.assertEquals(THREAD_NUM, executor.getCorePoolSize());
+        Assert.assertEquals(THREAD_NUM, priorityExecutor.getMaximumPoolSize());
     }
 
     private class TestLeaderTask extends PriorityLeaderTask {


### PR DESCRIPTION
Must set corePoolSize first, because setMaximumPoolSize() will throw IllegalArgumentException if maximumPoolSize < corePoolSize.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
