### PR TITLE
[Enhancement] unify string to int behavior between FE and BE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -457,15 +457,15 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
                 return ConstantOperator.createBoolean(true);
             }
         } else if (desc.isTinyint()) {
-            return ConstantOperator.createTinyInt(Byte.parseByte(childString));
+            return ConstantOperator.createTinyInt(Byte.parseByte(childString.trim()));
         } else if (desc.isSmallint()) {
-            return ConstantOperator.createSmallInt(Short.parseShort(childString));
+            return ConstantOperator.createSmallInt(Short.parseShort(childString.trim()));
         } else if (desc.isInt()) {
-            return ConstantOperator.createInt(Integer.parseInt(childString));
+            return ConstantOperator.createInt(Integer.parseInt(childString.trim()));
         } else if (desc.isBigint()) {
-            return ConstantOperator.createBigint(Long.parseLong(childString));
+            return ConstantOperator.createBigint(Long.parseLong(childString.trim()));
         } else if (desc.isLargeint()) {
-            return ConstantOperator.createLargeInt(new BigInteger(childString));
+            return ConstantOperator.createLargeInt(new BigInteger(childString.trim()));
         } else if (desc.isFloat()) {
             return ConstantOperator.createFloat(Double.parseDouble(childString));
         } else if (desc.isDouble()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -146,5 +146,9 @@ public class PartitionPruneTest extends PlanTestBase {
         sql = "select * from ptest where cast('  -111.12  ' as double) = k1";
         plan = getFragmentPlan(sql);
         assertContains(plan, "PREDICATES: CAST(1: k1 AS DOUBLE) = -111.12");
+
+        sql = "select * from ptest where cast('  -111 2  ' as int) = k1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: 1: k1 = CAST('  -111 2  ' AS INT)");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -136,4 +136,15 @@ public class PartitionPruneTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "partitions=3/4");
     }
+
+    @Test
+    public void testCastStringWithWhitSpace() throws Exception {
+        String sql = "select * from ptest where cast('  111  ' as bigint) = k1";
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "tabletRatio=4/40", "PREDICATES: 1: k1 = 111");
+
+        sql = "select * from ptest where cast('  -111.12  ' as double) = k1";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: CAST(1: k1 AS DOUBLE) = -111.12");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
@@ -198,4 +198,14 @@ public class StructTypePlanTest extends PlanTestBase {
                 "result: struct<col1 boolean, col2 boolean, col3 boolean>; args nullable: true; result nullable: true] " +
                 "as struct<a int(11), b map<int(11),int(11)>, c array<int(11)>>)");
     }
+
+    @Test
+    public void testCastArrayIndex() throws Exception {
+        String sql = "select c1.b[cast('  111   ' as bigint)] from test";
+        String plan = getVerboseExplain(sql);
+        assertCContains(plan, "1:Project\n" +
+                "  |  output columns:\n" +
+                "  |  5 <-> 2: c1.b[111]",
+                "Pruned type: 2 <-> [struct<a int(11), b array<struct<a int(11), b int(11)>>>]");
+    }
 }


### PR DESCRIPTION
Fixes #issue
For sql like
```
select cast(' 111 ' to int);
```
we cannot fold this cast in FE because  `Integer.parseInt(' 111 ')` throws NumberFormatException, while BE will firstly remove these leading and trailing whitespaces then cast '111' to int.
So we can unify this behavior between FE and BE to do more constant folding in FE.
BTW, `Double.parseDouble()` has already considered it.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
