### PR TITLE
[BugFix] Fix bug with missing auto_increment attribute

### DIFF
--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -165,6 +165,7 @@ Status t_column_to_pb_column(int32_t unique_id, const TColumn& t_column, ColumnP
     column_pb->set_is_key(t_column.is_key);
     column_pb->set_is_nullable(t_column.is_allow_null);
     column_pb->set_has_bitmap_index(t_column.has_bitmap_index);
+    column_pb->set_is_auto_increment(t_column.is_auto_increment);
     if (t_column.is_key) {
         auto agg_method = STORAGE_AGGREGATE_NONE;
         column_pb->set_aggregation(get_string_by_aggregation_type(agg_method));


### PR DESCRIPTION
This bug is introduced by https://github.com/StarRocks/starrocks/pull/26246. We support light schema change in the pr, and we maybe need to build the tablet schema according column description from FE. However, in the conversion from thrift column to protobuf column, the `auto_increment` attribute is lost. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
