### PR TITLE
[Enhancement] Support collect external table statistics of partition level

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableColumnStats.java
@@ -33,6 +33,10 @@ public class ConnectorTableColumnStats {
         return UNKNOWN;
     }
 
+    public boolean isUnknown() {
+        return columnStatistic.isUnknown();
+    }
+
     public ColumnStatistic getColumnStatistic() {
         return columnStatistic;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1134,6 +1134,8 @@ public class StmtExecutor {
         Table table = MetaUtils.getTable(context, dropStatsStmt.getTableName());
         if (dropStatsStmt.isExternal()) {
             GlobalStateMgr.getCurrentAnalyzeMgr().dropExternalStats(table.getUUID());
+            List<String> columns = table.getBaseSchema().stream().map(Column::getName).collect(Collectors.toList());
+            GlobalStateMgr.getCurrentStatisticStorage().expireConnectorTableColumnStatistics(table, columns);
         } else {
             List<String> columns = table.getBaseSchema().stream().filter(d -> !d.isAggregated()).map(Column::getName)
                     .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -342,7 +342,9 @@ public class MetadataMgr {
             ConnectorTableColumnStats connectorTableColumnStats = columnStatisticList.get(i);
             if (connectorTableColumnStats != null) {
                 statistics.addColumnStatistic(columnRef, connectorTableColumnStats.getColumnStatistic());
-                statistics.setOutputRowCount(connectorTableColumnStats.getRowCount());
+                if (!connectorTableColumnStats.isUnknown()) {
+                    statistics.setOutputRowCount(connectorTableColumnStats.getRowCount());
+                }
             }
         }
         return statistics.build();
@@ -355,7 +357,7 @@ public class MetadataMgr {
                                          List<PartitionKey> partitionKeys,
                                          ScalarOperator predicate) {
         Statistics statistics = getTableStatisticsFromInternalStatistics(table, columns);
-        if (statistics.getColumnStatistics().values().stream().anyMatch(ColumnStatistic::isUnknown)) {
+        if (statistics.getColumnStatistics().values().stream().allMatch(ColumnStatistic::isUnknown)) {
             Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
             return connectorMetadata.map(metadata ->
                     metadata.getTableStatistics(session, table, columns, partitionKeys, predicate)).orElse(null);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticStorage.java
@@ -38,13 +38,17 @@ public interface StatisticStorage {
 
     List<ColumnStatistic> getColumnStatistics(Table table, List<String> columns);
 
+    default List<ColumnStatistic> getColumnStatisticsSync(Table table, List<String> columns) {
+        return getColumnStatistics(table, columns);
+    }
+
     default List<ConnectorTableColumnStats> getConnectorTableStatistics(Table table, List<String> columns) {
         return columns.stream().
                 map(col -> ConnectorTableColumnStats.unknown()).collect(Collectors.toList());
     }
 
-    default List<ColumnStatistic> getColumnStatisticsSync(Table table, List<String> columns) {
-        return getColumnStatistics(table, columns);
+    default List<ConnectorTableColumnStats> getConnectorTableStatisticsSync(Table table, List<String> columns) {
+        return getConnectorTableStatistics(table, columns);
     }
 
     default Map<String, Histogram> getHistogramStatistics(Table table, List<String> columns) {
@@ -59,6 +63,9 @@ public interface StatisticStorage {
     }
 
     default void expireTableAndColumnStatistics(Table table, List<String> columns) {
+    }
+
+    default void expireConnectorTableColumnStatistics(Table table, List<String> columns) {
     }
 
     void addColumnStatistic(Table table, String column, ColumnStatistic columnStatistic);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -218,6 +218,19 @@ public class AnalyzeMgr implements Writable {
         }
     }
 
+    public void refreshConnectorTableBasicStatisticsCache(Table table, List<String> columns, boolean async) {
+        if (table == null) {
+            return;
+        }
+
+        GlobalStateMgr.getCurrentStatisticStorage().expireConnectorTableColumnStatistics(table, columns);
+        if (async) {
+            GlobalStateMgr.getCurrentStatisticStorage().getConnectorTableStatistics(table, columns);
+        } else {
+            GlobalStateMgr.getCurrentStatisticStorage().getConnectorTableStatisticsSync(table, columns);
+        }
+    }
+
     public void replayRemoveBasicStatsMeta(BasicStatsMeta basicStatsMeta) {
         basicStatsMetaMap.remove(basicStatsMeta.getTableId());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -29,6 +29,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.connector.PartitionUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QueryState;
@@ -62,17 +63,19 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             ", cast($countNullFunction as BIGINT)" + // BIGINT
             ", $maxFunction" + // VARCHAR
             ", $minFunction " + // VARCHAR
-            " FROM `$catalogName`.`$dbName`.`$tableName`";
+            " FROM `$catalogName`.`$dbName`.`$tableName` where $partitionPredicate";
 
     private final String catalogName;
+    private final List<String> partitionNames;
     private final List<String> sqlBuffer = Lists.newArrayList();
     private final List<List<Expr>> rowsBuffer = Lists.newArrayList();
 
-    public ExternalFullStatisticsCollectJob(String catalogName, Database db, Table table, List<String> columns,
-                                    StatsConstants.AnalyzeType type, StatsConstants.ScheduleType scheduleType,
-                                    Map<String, String> properties) {
+    public ExternalFullStatisticsCollectJob(String catalogName, Database db, Table table, List<String> partitionNames,
+                                            List<String> columns, StatsConstants.AnalyzeType type,
+                                            StatsConstants.ScheduleType scheduleType, Map<String, String> properties) {
         super(db, table, columns, type, scheduleType, properties);
         this.catalogName = catalogName;
+        this.partitionNames = partitionNames;
     }
 
     @Override
@@ -107,16 +110,18 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
         flushInsertStatisticsData(context, true);
     }
 
-    private List<List<String>> buildCollectSQLList(int parallelism) {
+    protected List<List<String>> buildCollectSQLList(int parallelism) {
         List<String> totalQuerySQL = new ArrayList<>();
-        for (String columnName : columns) {
-            totalQuerySQL.add(buildBatchCollectFullStatisticSQL(table, columnName));
+        for (String partitionName : partitionNames) {
+            for (String columnName : columns) {
+                totalQuerySQL.add(buildBatchCollectFullStatisticSQL(table, partitionName, columnName));
+            }
         }
 
         return Lists.partition(totalQuerySQL, parallelism);
     }
 
-    private String buildBatchCollectFullStatisticSQL(Table table, String columnName) {
+    private String buildBatchCollectFullStatisticSQL(Table table, String partitionName, String columnName) {
         StringBuilder builder = new StringBuilder();
         VelocityContext context = new VelocityContext();
         Column column = table.getColumn(columnName);
@@ -126,7 +131,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
 
         context.put("version", StatsConstants.STATISTIC_EXTERNAL_VERSION);
         // all table now, partition later
-        context.put("partitionNameStr", "All");
+        context.put("partitionNameStr", partitionName);
         context.put("columnNameStr", columnNameStr);
         context.put("dataSize", fullAnalyzeGetDataSize(column));
         context.put("dbName", db.getOriginName());
@@ -143,6 +148,20 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
             context.put("countNullFunction", "COUNT(1) - COUNT(" + quoteColumnName + ")");
             context.put("maxFunction", getMinMaxFunction(column, quoteColumnName, true));
             context.put("minFunction", getMinMaxFunction(column, quoteColumnName, false));
+        }
+
+        if (table.isUnPartitioned()) {
+            context.put("partitionPredicate", "1=1");
+        } else {
+            List<String> partitionColumnNames = table.getPartitionColumnNames();
+            List<String> partitionValues = PartitionUtil.toPartitionValues(partitionName);
+            List<String> partitionPredicate = Lists.newArrayList();
+            for (int i = 0; i < partitionColumnNames.size(); i++) {
+                String partitionColumnName = partitionColumnNames.get(i);
+                String partitionValue = partitionValues.get(i);
+                partitionPredicate.add(StatisticUtils.quoting(partitionColumnName) + " = '" + partitionValue + "'");
+            }
+            context.put("partitionPredicate", Joiner.on(" AND ").join(partitionPredicate));
         }
 
         builder.append(build(context, BATCH_FULL_STATISTIC_TEMPLATE));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.statistic;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
@@ -114,7 +115,16 @@ public class StatisticsCollectJobFactory {
         if (columns == null || columns.isEmpty()) {
             columns = StatisticUtils.getCollectibleColumns(table);
         }
-        return new ExternalFullStatisticsCollectJob(catalogName, db, table, columns,
+
+        List<String> partitionNames;
+        if (!table.isUnPartitioned()) {
+            partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().
+                    listPartitionNames(catalogName, db.getFullName(), table.getName());
+        } else {
+            partitionNames = ImmutableList.of(table.getName());
+        }
+
+        return new ExternalFullStatisticsCollectJob(catalogName, db, table, partitionNames, columns,
                 analyzeType, scheduleType, properties);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeMgrTest.java
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Table;
+import com.starrocks.connector.ConnectorTableColumnStats;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.statistics.CachedStatisticStorage;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AnalyzeMgrTest {
+    public static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+    }
+
+    @Test
+    public void testRefreshConnectorTableBasicStatisticsCache(@Mocked CachedStatisticStorage cachedStatisticStorage) {
+        Table table = connectContext.getGlobalStateMgr().getMetadataMgr().getTable("hive0", "partitioned_db", "t1");
+        new Expectations() {
+            {
+                cachedStatisticStorage.getConnectorTableStatistics(table, ImmutableList.of("c1", "c2"));
+                result = ImmutableList.of(
+                        new ConnectorTableColumnStats(new ColumnStatistic(0, 10, 0, 20, 5), 5),
+                        new ConnectorTableColumnStats(new ColumnStatistic(0, 100, 0, 200, 50), 50)
+                );
+                minTimes = 1;
+            }
+        };
+
+
+        AnalyzeMgr analyzeMgr = new AnalyzeMgr();
+        analyzeMgr.refreshConnectorTableBasicStatisticsCache(table, ImmutableList.of("c1", "c2"), true);
+
+        new Expectations() {
+            {
+                cachedStatisticStorage.getConnectorTableStatisticsSync(table, ImmutableList.of("c1", "c2"));
+                result = ImmutableList.of(
+                        new ConnectorTableColumnStats(new ColumnStatistic(0, 10, 0, 20, 5), 5),
+                        new ConnectorTableColumnStats(new ColumnStatistic(0, 100, 0, 200, 50), 50)
+                );
+                minTimes = 1;
+            }
+        };
+        analyzeMgr.refreshConnectorTableBasicStatisticsCache(table, ImmutableList.of("c1", "c2"), false);
+    }
+}


### PR DESCRIPTION
#23327
1. Support collect external table statistics of partition level
2. refresh fe cache of external table statistics after execute analyze

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
