### PR TITLE
[BugFix][Cherry-Pick][Branch-2.5] Primary key table data separated by primary key and sort key  may be disordered after compaction (#25188)

### DIFF
--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -9,7 +9,9 @@ namespace starrocks::vectorized {
 
 #ifdef BE_TEST
 
-Schema::Schema(Fields fields) : Schema(fields, KeysType::DUP_KEYS, {}) {}
+Schema::Schema(Fields fields) : Schema(fields, KeysType::DUP_KEYS, {}) {
+    _init_sort_key_idxes();
+}
 
 #endif
 
@@ -22,6 +24,7 @@ Schema::Schema(Fields fields, KeysType keys_type, std::vector<ColumnId> sort_key
     auto is_key = [](const FieldPtr& f) { return f->is_key(); };
     _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);
     _build_index_map(_fields);
+    _init_sort_key_idxes();
 }
 
 Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids)
@@ -34,6 +37,7 @@ Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids)
     auto is_key = [](const FieldPtr& f) { return f->is_key(); };
     _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);
     _build_index_map(_fields);
+    _init_sort_key_idxes();
 }
 
 Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids, const std::vector<ColumnId>& scids)
@@ -48,6 +52,7 @@ Schema::Schema(Schema* schema, const std::vector<ColumnId>& cids, const std::vec
     auto is_key = [](const FieldPtr& f) { return f->is_key(); };
     _num_keys = std::count_if(_fields.begin(), _fields.end(), is_key);
     _build_index_map(_fields);
+    _init_sort_key_idxes();
 }
 
 // if we use this constructor and share the name_to_index with another schema,
@@ -69,6 +74,7 @@ Schema::Schema(Schema* schema)
         _share_name_to_index = false;
         _build_index_map(_fields);
     }
+    _init_sort_key_idxes();
 }
 
 // if we use this constructor and share the name_to_index with another schema,
@@ -89,6 +95,7 @@ Schema::Schema(const Schema& schema)
         _share_name_to_index = false;
         _build_index_map(_fields);
     }
+    _init_sort_key_idxes();
 }
 
 // if we use this constructor and share the name_to_index with another schema,

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <numeric>
 #include <string_view>
 #include <utility>
 
@@ -77,6 +78,12 @@ public:
 
 private:
     void _build_index_map(const Fields& fields);
+    void _init_sort_key_idxes() {
+        if (_sort_key_idxes.empty()) {
+            _sort_key_idxes.resize(num_key_fields());
+            std::iota(_sort_key_idxes.begin(), _sort_key_idxes.end(), 0);
+        }
+    }
 
     Fields _fields;
     size_t _num_keys = 0;


### PR DESCRIPTION
If we create a primary key table that separates the primary key and the sort key, we should order segment data by the sort key but not the primary key. But when compaction is finished, the segment data may be out of order because in the heap merge of segment data, the `HeapMergeIterator` use the primary key as the basis for sorting data.
