### PR TITLE
[BugFix] Fix compling EncodedUtf8Char with -fprofile-arcs

### DIFF
--- a/be/src/util/utf8_encoding.h
+++ b/be/src/util/utf8_encoding.h
@@ -35,7 +35,8 @@ struct EncodedUtf8Char {
     EncodedUtf8Char() { u.value = ABSENT_ENCODED; }
     explicit EncodedUtf8Char(const char* p, size_t size) {
         u.value = ABSENT_ENCODED;
-        strings::memcpy_inlined(u.bytes, p, std::min(sizeof(u.bytes), size));
+        size_t copy_size = size < sizeof(u.bytes) ? size : sizeof(u.bytes);
+        strings::memcpy_inlined(u.bytes, p, copy_size);
     }
     EncodedUtf8Char(const EncodedUtf8Char& x) { u.value = x.u.value; }
     EncodedUtf8Char(EncodedUtf8Char&& x) noexcept { u.value = x.u.value; }


### PR DESCRIPTION
When the following codes compiling with the option `-fprofile-arcs`, an compile warning occurs:
```
In function ‘void memcpy_inlined(void*, const void*, size_t)’,
    inlined from ‘EncodedUtf8Char::EncodedUtf8Char(const char*, size_t)’ at test.cpp:57:23:
test.cpp:19:29: error: writing 8 bytes into a region of size 4 [-Werror=stringop-overflow=]
   19 |             __builtin_memcpy(dst + size - 8, src + size - 8, 8);
      |             ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test.cpp: In constructor ‘EncodedUtf8Char::EncodedUtf8Char(const char*, size_t)’:
test.cpp:48:18: note: at offset 0 to object ‘EncodedUtf8Char::U::<unnamed struct>::bytes’ with size 4 declared here
   48 |             char bytes[4];
```

It seems that `const size_t& min(size_t, size_t)` with `-fprofile-arcs`, GCC cannot infer that `min(4UL, size)` is always not greater than 4.
- GCC 10.5 `const size_t& min`: error https://godbolt.org/z/ver8TG5bd
- GCC 10.5 `size_t min`: OK https://godbolt.org/z/c4GenGax4
- GCC 12.1 `const size_t& min`: OK https://godbolt.org/z/qnxG6GxTj

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
