### PR TITLE
[Enhancement] Show_meta_info api supports cloud native table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -226,9 +226,13 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     }
 
     public long getDataSize() {
+        return getDataSize(false);
+    }
+
+    public long getDataSize(boolean singleReplica) {
         long dataSize = 0;
         for (Tablet tablet : getTablets()) {
-            dataSize += tablet.getDataSize(false);
+            dataSize += tablet.getDataSize(singleReplica);
         }
         return dataSize;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/http/ShowMetaInfoActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/ShowMetaInfoActionTest.java
@@ -40,7 +40,7 @@ public class ShowMetaInfoActionTest extends StarRocksHttpTestCase {
     private static final String DB_NAME = "TEST_DB";
     private static final String TABLE_NAME = "TEST_TABLE";
     private static final long EXPECTED_SINGLE_REPLICA_SIZE = 1024L;
-    private static final int httpSlowRequestThresholdMs = Config.http_slow_request_threshold_ms;
+    private static final int HTTP_SLOW_REQUEST_THRESHOLD_MS = Config.http_slow_request_threshold_ms;
 
     @Override
     public void doSetUp() {
@@ -59,7 +59,7 @@ public class ShowMetaInfoActionTest extends StarRocksHttpTestCase {
 
     @After
     public void tearDown() {
-        Config.http_slow_request_threshold_ms = httpSlowRequestThresholdMs;
+        Config.http_slow_request_threshold_ms = HTTP_SLOW_REQUEST_THRESHOLD_MS;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/http/ShowMetaInfoActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/ShowMetaInfoActionTest.java
@@ -1,0 +1,105 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
+import com.starrocks.server.GlobalStateMgr;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.Assert.assertTrue;
+
+public class ShowMetaInfoActionTest extends StarRocksHttpTestCase {
+
+    private static final long DB_ID = 1000 + testDbId;
+    private static final String DB_NAME = "TEST_DB";
+    private static final String TABLE_NAME = "TEST_TABLE";
+    private static final long EXPECTED_SINGLE_REPLICA_SIZE = 1024L;
+    private static final int httpSlowRequestThresholdMs = Config.http_slow_request_threshold_ms;
+
+    @Override
+    public void doSetUp() {
+        Database db = new Database(DB_ID, DB_NAME);
+        OlapTable table = newTable(TABLE_NAME, EXPECTED_SINGLE_REPLICA_SIZE);
+        db.registerTableUnlocked(table);
+
+        // inject our test db
+        ConcurrentHashMap<String, Database> fullNameToDb = GlobalStateMgr.getCurrentState()
+                .getLocalMetastore().getFullNameToDb();
+        fullNameToDb.put(DB_NAME, db);
+
+        ConcurrentHashMap<Long, Database> idToDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getIdToDb();
+        idToDb.put(DB_ID, db);
+    }
+
+    @After
+    public void tearDown() {
+        Config.http_slow_request_threshold_ms = httpSlowRequestThresholdMs;
+    }
+
+    @Test
+    public void testShowDBSize() throws IOException {
+
+        Config.http_slow_request_threshold_ms = 0;
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url(BASE_URL + "/api/show_meta_info?action=SHOW_DB_SIZE")
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        assertTrue(response.isSuccessful());
+        Assert.assertNotNull(response.body());
+        String respStr = response.body().string();
+        Assert.assertNotNull(respStr);
+        Gson gson = new Gson();
+        Map<String, Long> dbSizeResult = gson.fromJson(respStr, new TypeToken<HashMap<String, Long>>() {
+        }.getType());
+        // SHOW_DB_SIZE only considers table size with one single replica
+        Assert.assertEquals(Optional.of(EXPECTED_SINGLE_REPLICA_SIZE).get(), dbSizeResult.get(DB_NAME));
+    }
+
+    @Test
+    public void testShowFullDBSize() throws IOException {
+        Config.http_slow_request_threshold_ms = 0;
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url(BASE_URL + "/api/show_meta_info?action=SHOW_FULL_DB_SIZE")
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        assertTrue(response.isSuccessful());
+        Assert.assertNotNull(response.body());
+        String respStr = response.body().string();
+        Assert.assertNotNull(respStr);
+        Gson gson = new Gson();
+        Map<String, Long> dbSizeResult = gson.fromJson(respStr, new TypeToken<HashMap<String, Long>>() {
+        }.getType());
+        // SHOW_FULL_DB_SIZE considers table size with all replicas
+        Assert.assertEquals(Optional.of(EXPECTED_SINGLE_REPLICA_SIZE * 3).get(), dbSizeResult.get(DB_NAME));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -189,6 +189,10 @@ public abstract class StarRocksHttpTestCase {
     }
 
     public static OlapTable newTable(String name) {
+        return newTable(name, 1024000L);
+    }
+
+    public static OlapTable newTable(String name, long replicaDataSize) {
         GlobalStateMgr.getCurrentState().getTabletInvertedIndex().clear();
         Column k1 = new Column("k1", Type.BIGINT);
         Column k2 = new Column("k2", Type.DOUBLE);
@@ -198,15 +202,15 @@ public abstract class StarRocksHttpTestCase {
 
         Replica replica1 =
                 new Replica(testReplicaId1, testBackendId1, testStartVersion, testSchemaHash,
-                        1024000L, 2000L,
+                        replicaDataSize, 2000L,
                         Replica.ReplicaState.NORMAL, -1, 0);
         Replica replica2 =
                 new Replica(testReplicaId2, testBackendId2, testStartVersion, testSchemaHash,
-                        1024000L, 2000L,
+                        replicaDataSize, 2000L,
                         Replica.ReplicaState.NORMAL, -1, 0);
         Replica replica3 =
                 new Replica(testReplicaId3, testBackendId3, testStartVersion, testSchemaHash,
-                        1024000L, 2000L,
+                        replicaDataSize, 2000L,
                         Replica.ReplicaState.NORMAL, -1, 0);
 
         // tablet


### PR DESCRIPTION
In this pr, we add
1. `/api/show_meta_info?action=SHOW_DB_SIZE` api supports cloud native table
2.  A new SHOW_FULL_DB_SIZE action to support showing db size with all replicas included


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
