### PR TITLE
[BugFix][CherryPick] fix to_bitmap statistics calculator for 3.1 (#29961)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -444,13 +444,17 @@ public class ExpressionStatisticCalculator {
                 case FunctionSet.TRUNCATE:
                     // Just use the input's statistics as output's statistics
                     break;
+                case FunctionSet.TO_BITMAP:
+                    minValue = Double.NEGATIVE_INFINITY;
+                    maxValue = Double.POSITIVE_INFINITY;
+                    break;
                 default:
                     return ColumnStatistic.unknown();
             }
 
             final double averageRowSize;
             if (callOperator.getType().isIntegerType() || callOperator.getType().isFloatingPointType()
-                    || callOperator.getType().isDateType()) {
+                    || callOperator.getType().isDateType() || callOperator.getType().isBitmapType()) {
                 averageRowSize = callOperator.getType().getTypeSize();
             } else {
                 averageRowSize = columnStatistic.getAverageRowSize();

--- a/test/sql/test_materialized_view/R/test_materialized_view_force_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_force_rewrite
@@ -122,10 +122,6 @@ function: check_hit_materialized_view("SELECT t1.t1_id, bitmap_union(to_bitmap(t
 -- result:
 None
 -- !result
-SELECT t1.t1_id, bitmap_union_count(to_bitmap(t1.t1_age)) FROM t1 INNER JOIN t2 ON t1.t1_t2_id=t2.t2_id INNER JOIN t3 ON t1.t1_t3_id=t3.t3_id group by t1.t1_id order by t1.t1_id;
--- result:
-E: (1064, 'no executable plan with materialized view for this sql in default_or_error mode because ofcost.')
--- !result
 SELECT t1.t1_id, count(distinct t1.t1_age) FROM t1 INNER JOIN t2 ON t1.t1_t2_id=t2.t2_id INNER JOIN t3 ON t1.t1_t3_id=t3.t3_id group by t1.t1_id order by t1.t1_id;
 -- result:
 E: (1064, 'no executable plan with materialized view for this sql in default_or_error mode because ofcost.')

--- a/test/sql/test_materialized_view/T/test_materialized_view_force_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_force_rewrite
@@ -78,8 +78,6 @@ set materialized_view_rewrite_mode="default_or_error";
 -- hit
 function: check_hit_materialized_view("SELECT t1.t1_id, bitmap_union(to_bitmap(t1.t1_age)) FROM t1 INNER JOIN t2 ON t1.t1_t2_id=t2.t2_id INNER JOIN t3 ON t1.t1_t3_id=t3.t3_id group by t1.t1_id", "mv1")
 -- hit
-SELECT t1.t1_id, bitmap_union_count(to_bitmap(t1.t1_age)) FROM t1 INNER JOIN t2 ON t1.t1_t2_id=t2.t2_id INNER JOIN t3 ON t1.t1_t3_id=t3.t3_id group by t1.t1_id order by t1.t1_id;
--- hit
 SELECT t1.t1_id, count(distinct t1.t1_age) FROM t1 INNER JOIN t2 ON t1.t1_t2_id=t2.t2_id INNER JOIN t3 ON t1.t1_t3_id=t3.t3_id group by t1.t1_id order by t1.t1_id;
 -- no hit
 SELECT t1.t1_id, bitmap_union_count(to_bitmap(t1.t1_age + 1)) FROM t1 INNER JOIN t2 ON t1.t1_t2_id=t2.t2_id INNER JOIN t3 ON t1.t1_t3_id=t3.t3_id group by t1.t1_id order by t1.t1_id;


### PR DESCRIPTION
* fix to_bitmap statistics calculator

Fixes #29961 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
