### PR TITLE
[BugFix] Fix check sync materialized view exist bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -219,8 +219,6 @@ public class MaterializedViewHandler extends AlterHandler {
 
         olapTable.setState(OlapTableState.ROLLUP);
 
-
-
         GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(rollupJobV2);
         LOG.info("finished to create materialized view job: {}", rollupJobV2.getJobId());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -45,7 +45,6 @@ import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
-import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
@@ -446,21 +445,27 @@ public class MaterializedViewHandler extends AlterHandler {
     private List<Column> checkAndPrepareMaterializedView(CreateMaterializedViewStmt addMVClause, Database db,
                                                          OlapTable olapTable)
             throws DdlException {
-        // check if mv index already exists
-        if (olapTable.hasMaterializedIndex(addMVClause.getMVName())) {
-            throw new DdlException("Materialized view[" + addMVClause.getMVName() + "] already exists");
-        }
+        String mvName = addMVClause.getMVName();
+        // ensure mv's name is unique in the db and olap table's materialized indexes
+        {
+            // check if mv index already exists in this table
+            if (olapTable.hasMaterializedIndex(mvName)) {
+                throw new DdlException("Materialized view[" + mvName + "] already exists in the table "
+                        + olapTable.getName());
+            }
 
-        for (Table tbl : db.getTables()) {
-            if (tbl.getType() == Table.TableType.OLAP) {
-                if (addMVClause.getMVName().equals(tbl.getName())) {
-                    throw new DdlException("Table [" + addMVClause.getMVName() + "] already exists, ");
-                }
+            // check if mv index already exists in db
+            if (db.tryGetTable(mvName).isPresent()) {
+                throw new DdlException("Table [" + mvName + "] already exists in the db " + db.getFullName());
+            }
 
-                List<MaterializedIndexMeta> visibleMaterializedViews = ((OlapTable) tbl).getVisibleIndexMetas();
-                for (MaterializedIndexMeta mvMeta : visibleMaterializedViews) {
-                    if (((OlapTable) tbl).getIndexNameById(mvMeta.getIndexId()).equals(addMVClause.getMVName())) {
-                        throw new DdlException("Materialized view[" + addMVClause.getMVName() + "] already exists");
+            // check if mv index already exists in other table's materialized indexes
+            for (Table tbl : db.getTables()) {
+                if (tbl.isOlapTable()) {
+                    OlapTable otherOlapTable = (OlapTable) tbl;
+                    if (otherOlapTable.getIndexNameToId().size() > 1 && otherOlapTable.hasMaterializedIndex(mvName)) {
+                        throw new DdlException("Materialized view[" + mvName + "] already exists in table "
+                                + tbl.getName());
                     }
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -2646,6 +2646,7 @@ public class CreateMaterializedViewTest {
             Assert.assertTrue(olapTable.getIndexIdToMeta().entrySet().stream()
                     .anyMatch(x -> x.getValue().getKeysType().isAggregationFamily()));
             newStarRocksAssert.dropDatabase("test_mv_different_db");
+            starRocksAssert.dropMaterializedView("test_mv_use_different_tbl");
         } catch (Exception e) {
             Assert.fail();
         }
@@ -2692,6 +2693,7 @@ public class CreateMaterializedViewTest {
             newStarRocksAssert.dropDatabase("test_mv_different_db");
             Table mv1 = testDb.getTable("test_mv_use_different_tbl");
             Assert.assertTrue(mv1 instanceof MaterializedView);
+            starRocksAssert.dropMaterializedView("test_mv_use_different_tbl");
         } catch (Exception e) {
             Assert.fail();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -16,7 +16,6 @@ package com.starrocks.analysis;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
-import com.starrocks.alter.AlterJobV2;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
@@ -2903,6 +2902,75 @@ public class CreateMaterializedViewTest {
         Assert.assertTrue(explainString.contains("partitions=2/2\n" +
                 "     rollup: sync_mv1\n" +
                 "     tabletRatio=6/6"));
+        starRocksAssert.dropMaterializedView("sync_mv1");
+    }
+
+    // create sync mv that mv's name already existed in the db
+    @Test
+    public void testCreateSyncMV1() throws Exception {
+        try {
+            String sql = "create materialized view aggregate_table_with_null as select k1, sum(v1) from tbl1 group by k1;";
+            CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                    parseStmtWithNewParser(sql, connectContext);
+            // aggregate_table_with_null already existed in the db
+            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+            Assert.fail();
+        } catch (Throwable e) {
+            Assert.assertTrue(e.getMessage().contains("Table [aggregate_table_with_null] already exists in the db test"));
+        }
+    }
+
+    // create sync mv that mv's name already existed in the same table
+    @Test
+    public void testCreateSyncMV2() throws Exception {
+        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
+        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+
+        waitingRollupJobV2Finish();
+        OlapTable tbl1 = (OlapTable) (getTable("test", "tbl1"));
+        Assert.assertTrue(tbl1 != null);
+        Assert.assertTrue(tbl1.hasMaterializedIndex("sync_mv1"));
+
+        try {
+            // sync_mv1 already existed in the tbl1
+            sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
+            createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                    parseStmtWithNewParser(sql, connectContext);
+            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+            Assert.fail();
+        } catch (Throwable e) {
+            Assert.assertTrue(e.getMessage().contains("Materialized view[sync_mv1] already exists in " +
+                    "the table tbl1"));
+        }
+        starRocksAssert.dropMaterializedView("sync_mv1");
+    }
+
+    // create sync mv that mv's name already existed in other table
+    @Test
+    public void testCreateSyncMV3() throws Exception {
+        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
+        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+
+        waitingRollupJobV2Finish();
+        OlapTable tbl1 = (OlapTable) (getTable("test", "tbl1"));
+        Assert.assertTrue(tbl1 != null);
+        Assert.assertTrue(tbl1.hasMaterializedIndex("sync_mv1"));
+        try {
+            // sync_mv1 already existed in tbl1
+            sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl3 group by k1;";
+            createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                    parseStmtWithNewParser(sql, connectContext);
+            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+            Assert.fail();
+        } catch (Throwable e) {
+            Assert.assertTrue(e.getMessage().contains("Materialized view[sync_mv1] already exists " +
+                    "in table tbl1"));
+        }
+        starRocksAssert.dropMaterializedView("sync_mv1");
     }
 
     @Test


### PR DESCRIPTION
1. If `((OlapTable) tbl).getIndexNameById(mvMeta.getIndexId())` is null (there maybe some corrupt in the table), create sync mv will always fail

```
if (((OlapTable) tbl).getIndexNameById(mvMeta.getIndexId()).equals(addMVClause.getMVName()))
```

2. add more information to help user to check.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
