### PR TITLE
[BugFix] fix stuck issue in agg streaming operator

### DIFF
--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -425,7 +425,7 @@ protected:
     bool _needs_finalize;
     // Indicate whether data of the hash table has been taken out or reach limit
     bool _is_ht_eos = false;
-    bool _streaming_all_states = false;
+    std::atomic<bool> _streaming_all_states = false;
     bool _is_only_group_by_columns = false;
     // At least one group by column is nullable
     bool _has_nullable_key = false;

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_source_operator.cpp
@@ -76,7 +76,9 @@ Status AggregateDistinctStreamingSourceOperator::_output_chunk_from_hash_set(Chu
     _aggregator->convert_hash_set_to_chunk(state->chunk_size(), chunk);
 
     if (_aggregator->is_streaming_all_states() && _aggregator->is_ht_eos()) {
-        RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr));
+        if (!_aggregator->is_sink_complete()) {
+            RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr));
+        }
         _aggregator->set_streaming_all_states(false);
     }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -85,7 +85,9 @@ Status AggregateStreamingSourceOperator::_output_chunk_from_hash_map(ChunkPtr* c
     RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(state->chunk_size(), chunk));
 
     if (_aggregator->is_streaming_all_states() && _aggregator->is_ht_eos()) {
-        RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr));
+        if (!_aggregator->is_sink_complete()) {
+            RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr));
+        }
         _aggregator->set_streaming_all_states(false);
     }
 

--- a/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_streaming_source_operator.cpp
@@ -16,6 +16,8 @@
 
 #include <variant>
 
+#include "util/failpoint/fail_point.h"
+
 namespace starrocks::pipeline {
 
 bool AggregateStreamingSourceOperator::has_output() const {
@@ -75,6 +77,9 @@ StatusOr<ChunkPtr> AggregateStreamingSourceOperator::pull_chunk(RuntimeState* st
     return std::move(chunk);
 }
 
+// used to verify https://github.com/StarRocks/starrocks/issues/30078
+DEFINE_FAIL_POINT(force_reset_aggregator_after_agg_streaming_sink_finish);
+
 Status AggregateStreamingSourceOperator::_output_chunk_from_hash_map(ChunkPtr* chunk, RuntimeState* state) {
     if (!_aggregator->it_hash().has_value()) {
         _aggregator->hash_map_variant().visit(
@@ -84,7 +89,14 @@ Status AggregateStreamingSourceOperator::_output_chunk_from_hash_map(ChunkPtr* c
 
     RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(state->chunk_size(), chunk));
 
-    if (_aggregator->is_streaming_all_states() && _aggregator->is_ht_eos()) {
+    bool need_reset_aggregator = _aggregator->is_streaming_all_states() && _aggregator->is_ht_eos();
+    FAIL_POINT_TRIGGER_EXECUTE(force_reset_aggregator_after_agg_streaming_sink_finish, {
+        if (_aggregator->is_sink_complete()) {
+            need_reset_aggregator = true;
+        }
+    });
+
+    if (need_reset_aggregator) {
         if (!_aggregator->is_sink_complete()) {
             RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr));
         }

--- a/test/sql/test_streaming_agg/R/test_pr_30076
+++ b/test/sql/test_streaming_agg/R/test_pr_30076
@@ -1,4 +1,4 @@
--- name: test_pr_30076
+-- name: test_pr_30076 @sequential
 create table t0(
     c0 INT,
     c1 BIGINT

--- a/test/sql/test_streaming_agg/R/test_pr_30076
+++ b/test/sql/test_streaming_agg/R/test_pr_30076
@@ -1,0 +1,38 @@
+-- name: test_pr_30076
+create table t0(
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 values (1,1),(2,2),(3,3),(4,4),(5,5);
+-- result:
+-- !result
+set pipeline_dop=1;
+-- result:
+-- !result
+set new_planner_agg_stage=2;
+-- result:
+-- !result
+select c0, sum(c1) from t0 group by c0 order by c0;
+-- result:
+1	1
+2	2
+3	3
+4	4
+5	5
+-- !result
+admin enable failpoint 'force_reset_aggregator_after_agg_streaming_sink_finish';
+-- result:
+-- !result
+select c0, sum(c1) from t0 group by c0 order by c0;
+-- result:
+1	1
+2	2
+3	3
+4	4
+5	5
+-- !result
+admin disable failpoint 'force_reset_aggregator_after_agg_streaming_sink_finish';
+-- result:
+-- !result

--- a/test/sql/test_streaming_agg/T/test_pr_30076
+++ b/test/sql/test_streaming_agg/T/test_pr_30076
@@ -1,4 +1,4 @@
--- name: test_pr_30076
+-- name: test_pr_30076 @sequential
 
 create table t0(
     c0 INT,

--- a/test/sql/test_streaming_agg/T/test_pr_30076
+++ b/test/sql/test_streaming_agg/T/test_pr_30076
@@ -1,0 +1,16 @@
+-- name: test_pr_30076
+
+create table t0(
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+
+insert into t0 values (1,1),(2,2),(3,3),(4,4),(5,5);
+
+set pipeline_dop=1;
+set new_planner_agg_stage=2;
+select c0, sum(c1) from t0 group by c0 order by c0;
+
+admin enable failpoint 'force_reset_aggregator_after_agg_streaming_sink_finish';
+select c0, sum(c1) from t0 group by c0 order by c0;
+admin disable failpoint 'force_reset_aggregator_after_agg_streaming_sink_finish';


### PR DESCRIPTION
Fixes #30078
introduced by #28402

### root cause
1. AggregateStreamingSourceOperator::is_finished need check Aggregator::is_sink_complete
```cpp
bool AggregateStreamingSourceOperator::is_finished() const {
    return _aggregator->is_sink_complete() && !has_output();
}
```
2. Normally, Aggregator::_is_sink_complete will be set to true in AggregateStreamingSinkOperator::set_finishing
```cpp
Status AggregateStreamingSinkOperator::set_finishing(RuntimeState* state) {
    _is_finished = true;

    // skip processing if cancelled
    if (state->is_cancelled()) {
        return Status::OK();
    }

    if (_aggregator->hash_map_variant().size() == 0) {
        _aggregator->set_ht_eos();
    }

    _aggregator->sink_complete();
    return Status::OK();
}
```

3. but when pulling chunk from AggregateStreamingSourceOperator, Aggregator::reset_state may be invoked, after reset_state, Aggregator::_is_sink_complete will be set to false.

```cpp
Status AggregateStreamingSourceOperator::_output_chunk_from_hash_map(ChunkPtr* chunk, RuntimeState* state) {
    if (!_aggregator->it_hash().has_value()) {
        _aggregator->hash_map_variant().visit(
                [&](auto& hash_map_with_key) { _aggregator->it_hash() = _aggregator->_state_allocator.begin(); });
        COUNTER_SET(_aggregator->hash_table_size(), (int64_t)_aggregator->hash_map_variant().size());
    }

    RETURN_IF_ERROR(_aggregator->convert_hash_map_to_chunk(state->chunk_size(), chunk));

    if (_aggregator->is_streaming_all_states() && _aggregator->is_ht_eos()) {
        RETURN_IF_ERROR(_aggregator->reset_state(state, {}, nullptr));
        _aggregator->set_streaming_all_states(false);
    }

    return Status::OK();
}
```

4. so if the following sequence of calls occurs, the query will never end
```shell
T0:  AggregateStreamingSinkOperator::set_finishing, _aggregator->is_sink_complete() will return true
T1:  AggregateStreamingSourceOperator::_output_chunk_from_hash_map -> Aggregator::reset_state, _aggregator->is_sink_complete() will return false.

after T1, AggregateStreamingSourceOperator::is_finished will never return true
```
### an easy way to reproduce

I have added a fail point and  an related test case in this PR, without my fix, the query will never end after enabling failpoint force_reset_aggregator_after_agg_streaming_sink_finish


### fix solutions
1. change  the type of Aggregator::_streaming_all_states to std::atomic<bool> because It will be accessed concurrently by AggregateStreamingSinkOperator and AggregateStreamingSourceOperator
2. if AggregateStreamingSinkOperator::set_finishing has been invoked, we should avoid to reset_state in source side

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
