### PR TITLE
[Enhancement] adjust pindex major compaction thread count to twice the number of disks

### DIFF
--- a/be/src/storage/persistent_index_compaction_manager.cpp
+++ b/be/src/storage/persistent_index_compaction_manager.cpp
@@ -31,7 +31,7 @@ PersistentIndexCompactionManager::~PersistentIndexCompactionManager() {
 Status PersistentIndexCompactionManager::init() {
     int max_pk_index_compaction_thread_cnt = config::pindex_major_compaction_num_threads > 0
                                                      ? config::pindex_major_compaction_num_threads
-                                                     : CpuInfo::num_cores();
+                                                     : StorageEngine::instance()->get_store_num() * 2;
     RETURN_IF_ERROR(ThreadPoolBuilder("pk_index_compaction_worker")
                             .set_min_threads(1)
                             .set_max_threads(max_pk_index_compaction_thread_cnt)


### PR DESCRIPTION
The persistent index's major compaction thread is used for compaction l2 files of persistent index. In my performance test, when BE have many cores and less disk, it will cause disk io util too high. So it is better to adjust persistent index' major compaction thread count from cpu core number to twice the number of disks.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
