### PR TITLE
[BugFix] fix agg in order by not being analyzed correctly

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -231,7 +231,7 @@ public class AggregationAnalyzer {
                             arg.getFn() instanceof AggregateFunction, aggFunc);
                     return !aggFunc.isEmpty();
                 })) {
-                    throw new SemanticException(PARSER_ERROR_MSG.unsupportedNestAgg("window function"), expr.getPos());
+                    throw new SemanticException(PARSER_ERROR_MSG.unsupportedNestAgg("aggregation function"), expr.getPos());
                 }
 
                 if (expr.getChildren().stream().anyMatch(childExpr -> {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -127,6 +127,16 @@ public class ExpressionAnalyzer {
         bottomUpAnalyze(visitor, expression, scope);
     }
 
+    public void analyzeWithoutUpdateState(Expr expression, AnalyzeState analyzeState, Scope scope) {
+        Visitor visitor = new Visitor(analyzeState, session) {
+            @Override
+            protected void handleResolvedField(SlotRef slot, ResolvedField resolvedField) {
+                // do not put the slotRef in analyzeState
+            }
+        };
+        bottomUpAnalyze(visitor, expression, scope);
+    }
+
     private boolean isArrayHighOrderFunction(Expr expr) {
         if (expr instanceof FunctionCallExpr) {
             if (((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.ARRAY_MAP) ||
@@ -352,7 +362,7 @@ public class ExpressionAnalyzer {
                     node.getPos());
         }
 
-        private void handleResolvedField(SlotRef slot, ResolvedField resolvedField) {
+        protected void handleResolvedField(SlotRef slot, ResolvedField resolvedField) {
             analyzeState.addColumnReference(slot, FieldId.from(resolvedField));
         }
 
@@ -407,7 +417,6 @@ public class ExpressionAnalyzer {
                     node.resetStructInfo();
                 }
             }
-
             handleResolvedField(node, resolvedField);
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -418,8 +418,8 @@ public class SelectAnalyzer {
 
     private List<FunctionCallExpr> analyzeAggregations(AnalyzeState analyzeState, Scope sourceScope,
                                                        List<Expr> outputAndOrderByExpressions) {
-        List<FunctionCallExpr> aggregations = Lists.newArrayList();
-        TreeNode.collect(outputAndOrderByExpressions, Expr.isAggregatePredicate()::apply, aggregations);
+        final List<FunctionCallExpr> aggregations = Lists.newArrayList();
+        outputAndOrderByExpressions.stream().forEach(e -> e.collectAll(Expr.isAggregatePredicate(), aggregations));
         aggregations.forEach(e -> analyzeExpression(e, analyzeState, sourceScope));
 
         long distinctNum = aggregations.stream().filter(FunctionCallExpr::isDistinct).count();
@@ -437,7 +437,7 @@ public class SelectAnalyzer {
             }
         }
 
-        analyzeState.setAggregate(aggregations);
+        analyzeState.setAggregate(aggregations.stream().distinct().collect(Collectors.toList()));
 
         return aggregations;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -100,7 +100,7 @@ public class SelectAnalyzer {
             sourceExpressions.add(analyzeState.getHaving());
         }
 
-        List<FunctionCallExpr> aggregates = analyzeAggregations(analyzeState,
+        List<FunctionCallExpr> aggregates = analyzeAggregations(analyzeState, sourceScope,
                 Stream.concat(sourceExpressions.stream(), orderByExpressions.stream()).collect(Collectors.toList()));
         if (AnalyzerUtils.isAggregate(aggregates, groupByExpressions)) {
             if (!groupByExpressions.isEmpty() &&
@@ -421,10 +421,12 @@ public class SelectAnalyzer {
         analyzeState.setGroupingFunctionCallExprs(groupingFunctionCallExprs);
     }
 
-    private List<FunctionCallExpr> analyzeAggregations(AnalyzeState analyzeState,
+    private List<FunctionCallExpr> analyzeAggregations(AnalyzeState analyzeState, Scope sourceScope,
                                                           List<Expr> outputAndOrderByExpressions) {
         List<FunctionCallExpr> aggregations = Lists.newArrayList();
         TreeNode.collect(outputAndOrderByExpressions, Expr.isAggregatePredicate()::apply, aggregations);
+        aggregations.forEach(e -> analyzeExpression(e, analyzeState, sourceScope));
+
 
         long distinctNum = aggregations.stream().filter(FunctionCallExpr::isDistinct).count();
         for (FunctionCallExpr agg : aggregations) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleExpressionAnalyzer.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/analyzer/SimpleExpressionAnalyzer.java
@@ -189,7 +189,7 @@ public class SimpleExpressionAnalyzer {
             throw unsupportedException("not yet implemented: expression analyzer for " + node.getClass().getName());
         }
 
-        private void handleResolvedField(SlotRef slot, ResolvedField resolvedField) {
+        protected void handleResolvedField(SlotRef slot, ResolvedField resolvedField) {
             analyzeState.addColumnReference(slot, FieldId.from(resolvedField));
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -40,13 +40,15 @@ public class AnalyzeAggregateTest {
         analyzeFail("select sum(v1) from t0 order by sum(abs(max(v2) over ()))",
                 "Unsupported nest window function inside aggregation.");
         analyzeFail("select sum(v1) from t0 order by sum(max(v2))",
-                "Unsupported nest window function inside aggregation.");
+                "Unsupported nest aggregation function inside aggregation.");
         analyzeFail("select sum(v1) from t0 order by sum(abs(max(v2)))",
-                "Unsupported nest window function inside aggregation.");
+                "Unsupported nest aggregation function inside aggregation.");
         analyzeFail("select sum(max(v2)) from t0",
-                "Unsupported nest window function inside aggregation.");
+                "Unsupported nest aggregation function inside aggregation.");
         analyzeFail("select sum(1 + max(v2)) from t0",
-                "Unsupported nest window function inside aggregation.");
+                "Unsupported nest aggregation function inside aggregation.");
+        analyzeFail("select min(v1) col from t0 order by min(col) + 1,  min(col)",
+                "Column 'col' cannot be resolved");
 
         analyzeFail("select v1 from t0 group by v1,cast(v2 as int) having cast(v2 as boolean)",
                 "must be an aggregate expression or appear in GROUP BY clause");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -192,6 +192,8 @@ public class AnalyzeAggregateTest {
                 "No matching function with signature: multi_distinct_count(json");
         analyzeFail("select count(distinct va),count(distinct vm) from ttypes group by v1",
                 "No matching function with signature: multi_distinct_count(array");
+        analyzeFail("select count(distinct va) vj from ttypes group by v1 order by count(distinct vj)",
+                "No matching function with signature: multi_distinct_count(array");
 
         // group by complex types
         analyzeSuccess("select count(*) from ttypes group by vm");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2428,13 +2428,15 @@ public class AggregateTest extends PlanTestBase {
     @Test
     public void testOrderByWithAgg() throws Exception {
         String sql = "select round(count(t1e) * 100.0 / min(t1f), 4) as potential_customer_rate, " +
-                "min(t1f) as t1f from test_all_type_not_null " +
+                "min(t1f) as t1f, min(t1f) as t1f from test_all_type_not_null " +
                 "group by t1a, t1b " +
-                "order by round(count(t1e) * 100.0 / min(t1f) / min(t1f), 4), min(t1f)";
+                "order by round(count(t1e) * 100.0 / min(t1f) / min(t1f), 4), min(t1f), abs(t1f)";
 
         String plan = getFragmentPlan(sql);
+        System.out.println(plan);
         assertCContains(plan, "1:AGGREGATE (update finalize)\n" +
                 "  |  output: count(5: t1e), min(6: t1f)\n" +
-                "  |  group by: 1: t1a, 2: t1b");
+                "  |  group by: 1: t1a, 2: t1b",
+                "order by: <slot 14> 14: round ASC, <slot 12> 12: min ASC, <slot 15> 15: abs ASC");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2424,4 +2424,17 @@ public class AggregateTest extends PlanTestBase {
                 "  |  equal join conjunct: 7: v3 <=> 9: v3\n" +
                 "  |  limit: 10");
     }
+
+    @Test
+    public void testOrderByWithAgg() throws Exception {
+        String sql = "select round(count(t1e) * 100.0 / min(t1f), 4) as potential_customer_rate, " +
+                "min(t1f) as t1f from test_all_type_not_null " +
+                "group by t1a, t1b " +
+                "order by round(count(t1e) * 100.0 / min(t1f) / min(t1f), 4), min(t1f)";
+
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "1:AGGREGATE (update finalize)\n" +
+                "  |  output: count(5: t1e), min(6: t1f)\n" +
+                "  |  group by: 1: t1a, 2: t1b");
+    }
 }

--- a/test/sql/test_agg/R/test_orderby_agg
+++ b/test/sql/test_agg/R/test_orderby_agg
@@ -1,5 +1,4 @@
 -- name: test_orderby_agg
-
 CREATE TABLE `t0` (
   `v1` bigint(20) NULL COMMENT "",
   `v2` bigint(20) NULL COMMENT "",
@@ -15,13 +14,55 @@ PROPERTIES (
 "replicated_storage" = "true",
 "compression" = "LZ4"
 );
-
+-- result:
+-- !result
 insert into t0 values(1, 2, 3, 'a'), (1, 3, 4, 'b'), (2, 3, 4, 'a'), (null, 1, null, 'c'), (4, null, 1 , null),
 (5, 1 , 3, 'c'), (2, 2, null, 'a'), (4, null, 4, 'c'), (null, null, 2, null);
-
+-- result:
+-- !result
 select min(v1) v1 from t0 group by v3 order by round(count(v2) / min(v1)), min(v1);
+-- result:
+None
+4
+2
+1
+1
+-- !result
 select min(v1) v1 from t0 group by v3 order by round(count(v2) / min(v1)), abs(v1);
+-- result:
+None
+4
+2
+1
+1
+-- !result
 select min(v1) v11 from t0 group by v3 order by round(count(v2) / min(v1)), abs(v11);
+-- result:
+None
+4
+2
+1
+1
+-- !result
 select min(v1) v11, min(v1) v1 from t0 group by v3 order by round(count(v2) / min(v1)), abs(v11), abs(v1);
+-- result:
+None	None
+4	4
+2	2
+1	1
+1	1
+-- !result
 select round(count(v1) * 100.0 / min(v2), 4) as potential_customer_rate, min(v2) v2 from t0 group by v4 order by round(count(v1) * 100.0 / min(v2), 4), min(v2);
+-- result:
+None	None
+33.3333	3
+150.0000	2
+200.0000	1
+-- !result
 select round(count(v1) * 100.0 / min(v2), 4) as potential_customer_rate, min(v2) v2 from t0 group by v4 order by round(count(v1) * 100.0 / min(v2), 4), abs(v2);
+-- result:
+None	None
+33.3333	3
+150.0000	2
+200.0000	1
+-- !result

--- a/test/sql/test_agg/R/test_orderby_agg
+++ b/test/sql/test_agg/R/test_orderby_agg
@@ -28,6 +28,14 @@ None
 1
 1
 -- !result
+select min(v1) v1, round(count(v2) / min(v1)) round_col from t0 group by v3 order by abs(min(v1)) + abs(v1) asc;
+-- result:
+None	None
+1	2
+1	2
+2	1
+4	0
+-- !result
 select min(v1) v1 from t0 group by v3 order by round(count(v2) / min(v1)), abs(v1);
 -- result:
 None

--- a/test/sql/test_agg/T/test_orderby_agg
+++ b/test/sql/test_agg/T/test_orderby_agg
@@ -1,0 +1,25 @@
+CREATE TABLE `t0` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT "",
+  `v4` varchar NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`, `v2`, `v3`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+insert into t0 values(1, 2, 3, 'a'), (1, 3, 4, 'b'), (2, 3, 4, 'a'), (null, 1, null, 'c'), (4, null, 1 , null),
+(5, 1 , 3, 'c'), (2, 2, null, 'a'), (4, null, 4, 'c'), (null, null, 2, null);
+
+select min(v1) v1 from t0 group by v3 order by round(count(v2) / min(v1)), min(v1);
+select min(v1) v1 from t0 group by v3 order by round(count(v2) / min(v1)), abs(v1);
+select min(v1) v11 from t0 group by v3 order by round(count(v2) / min(v1)), abs(v11);
+select min(v1) v11, min(v1) v1 from t0 group by v3 order by round(count(v2) / min(v1)), abs(v11), abs(v1);
+select round(count(v1) * 100.0 / min(v2), 4) as potential_customer_rate, min(v2) v2 from t0 group by v4 order by round(count(v1) * 100.0 / min(v2), 4), min(v2);
+select round(count(v1) * 100.0 / min(v2), 4) as potential_customer_rate, min(v2) v2 from t0 group by v4 order by round(count(v1) * 100.0 / min(v2), 4), abs(v2);

--- a/test/sql/test_agg/T/test_orderby_agg
+++ b/test/sql/test_agg/T/test_orderby_agg
@@ -20,6 +20,8 @@ insert into t0 values(1, 2, 3, 'a'), (1, 3, 4, 'b'), (2, 3, 4, 'a'), (null, 1, n
 (5, 1 , 3, 'c'), (2, 2, null, 'a'), (4, null, 4, 'c'), (null, null, 2, null);
 
 select min(v1) v1 from t0 group by v3 order by round(count(v2) / min(v1)), min(v1);
+select min(v1) v1, round(count(v2) / min(v1)) round_col from t0 group by v3 order by abs(min(v1)) + abs(v1) asc;
+
 select min(v1) v1 from t0 group by v3 order by round(count(v2) / min(v1)), abs(v1);
 select min(v1) v11 from t0 group by v3 order by round(count(v2) / min(v1)), abs(v11);
 select min(v1) v11, min(v1) v1 from t0 group by v3 order by round(count(v2) / min(v1)), abs(v11), abs(v1);


### PR DESCRIPTION
Fixes #issue
For sql like 
```
select min(v1) v1 from t0 group by v3 order by round(count(v2) / min(v1)), min(v1), abs(v1);
```
The statement had been transformed to a wrong plan fragment like:
```
LogicalProjectOperator {projection=[3: v3, 5: count, 6: min, min(1: v1)]}
            ->  LogicalAggregation {type=GLOBAL ,aggregations={4: min=min(1: v1), 5: count=count(2: v2), 6: min=min(1: v1)} ,groupKeys=[3: v3]}
```
This reason is the scope for analyzing order by is combined querySource scope and output scope. For the order by elements in the sql, its scope is like `output scope: v1(tblName null), source scope: v1(tblName t0), v2(tblName t0), v3(tblName t0)`.  When analyze `min(v1)`, the v1 matched with `v1(tblName null)` firstly, while it should be `v1(tblName t0)`.  Even the old code would analyze the aggregations using source scope in the later step, the fisrt analyzed process has put the `slotRef` in a map. The second analyzed process may change the `slotRef` already in the map, leading to unexpect behavior when get obejct from the map. 
So, the better way is to distinguish the aggregation func from the normal func in the analyze orderby stage, and use the corresponding scope to process them respectively.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
