### PR TITLE
[BugFix] fix lake primary table's local persistent index load

### DIFF
--- a/be/src/storage/lake/lake_local_persistent_index.cpp
+++ b/be/src/storage/lake/lake_local_persistent_index.cpp
@@ -16,6 +16,7 @@
 
 #include "gen_cpp/persistent_index.pb.h"
 #include "storage/chunk_helper.h"
+#include "storage/lake/lake_primary_index.h"
 #include "storage/lake/meta_file.h"
 #include "storage/primary_key_encoder.h"
 #include "storage/tablet_meta_manager.h"
@@ -64,10 +65,11 @@ Status LakeLocalPersistentIndex::load_from_lake_tablet(starrocks::lake::Tablet* 
         // here just use version.major_number so that PersistentIndexMetaPB need't to be modified,
         // the minor_number is meaningless
         if (version.major_number() == base_version) {
-            // If format version is not equal to PERSISTENT_INDEX_VERSION_2, this maybe upgrade from
+            // If format version is not equal to PERSISTENT_INDEX_VERSION_3, this maybe upgrade from
             // PERSISTENT_INDEX_VERSION_2.
             // We need to rebuild persistent index because the meta structure is changed
-            if (index_meta.format_version() != PERSISTENT_INDEX_VERSION_2) {
+            if (index_meta.format_version() != PERSISTENT_INDEX_VERSION_2 &&
+                index_meta.format_version() != PERSISTENT_INDEX_VERSION_3) {
                 LOG(WARNING) << "different format version, we need to rebuild persistent index";
                 status = Status::InternalError("different format version");
             } else {
@@ -174,7 +176,7 @@ Status LakeLocalPersistentIndex::load_from_lake_tablet(starrocks::lake::Tablet* 
     index_meta.clear_l2_versions();
     index_meta.clear_l2_version_merged();
     index_meta.set_key_size(_key_size);
-    index_meta.set_format_version(PERSISTENT_INDEX_VERSION_2);
+    index_meta.set_format_version(PERSISTENT_INDEX_VERSION_3);
     _version.to_pb(index_meta.mutable_version());
     MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
     l0_meta->clear_wals();
@@ -293,6 +295,7 @@ Status LakeLocalPersistentIndex::load_from_lake_tablet(starrocks::lake::Tablet* 
                                                _l2_versions.size() > 0 ? _l2_versions[0] : EditVersion()));
     _dump_snapshot = false;
     _flushed = false;
+    _primary_index->update_data_version(base_version);
 
     LOG(INFO) << "build persistent index finish tablet: " << tablet->id() << " version:" << base_version
               << " #rowset:" << rowsets->size() << " #segment:" << total_segments << " data_size:" << total_data_size

--- a/be/src/storage/lake/lake_local_persistent_index.h
+++ b/be/src/storage/lake/lake_local_persistent_index.h
@@ -24,10 +24,14 @@
 namespace starrocks::lake {
 
 class MetaFileBuilder;
+class LakePrimaryIndex;
 
 class LakeLocalPersistentIndex : public PersistentIndex {
 public:
-    explicit LakeLocalPersistentIndex(std::string path) : PersistentIndex(path) { _path = path; }
+    explicit LakeLocalPersistentIndex(std::string path, LakePrimaryIndex* primary_index)
+            : PersistentIndex(path), _primary_index(primary_index) {
+        _path = path;
+    }
 
     ~LakeLocalPersistentIndex() override {}
 
@@ -36,6 +40,7 @@ public:
 
 private:
     std::string _path;
+    LakePrimaryIndex* _primary_index;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -80,7 +80,7 @@ Status LakePrimaryIndex::_do_lake_load(Tablet* tablet, const TabletMetadata& met
                     RETURN_IF_ERROR(
                             StorageEngine::instance()->get_persistent_index_store()->create_dir_if_path_not_exists(
                                     path));
-                    _persistent_index = std::make_unique<LakeLocalPersistentIndex>(path);
+                    _persistent_index = std::make_unique<LakeLocalPersistentIndex>(path, this);
                     return ((LakeLocalPersistentIndex*)_persistent_index.get())
                             ->load_from_lake_tablet(tablet, metadata, base_version, builder);
                 }

--- a/be/test/storage/lake/compaction_test_utils.h
+++ b/be/test/storage/lake/compaction_test_utils.h
@@ -23,12 +23,13 @@ namespace starrocks::lake {
 struct CompactionParam {
     CompactionAlgorithm algorithm = HORIZONTAL_COMPACTION;
     uint32_t vertical_compaction_max_columns_per_group = 5;
+    bool enable_persistent_index = false;
 };
 
 static std::string to_string_param_name(const testing::TestParamInfo<CompactionParam>& info) {
     std::stringstream ss;
     ss << CompactionUtils::compaction_algorithm_to_string(info.param.algorithm) << "_"
-       << info.param.vertical_compaction_max_columns_per_group;
+       << info.param.vertical_compaction_max_columns_per_group << "_" << info.param.enable_persistent_index;
     return ss.str();
 }
 

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -52,6 +52,7 @@ public:
         _tablet_metadata->set_version(1);
         _tablet_metadata->set_cumulative_point(0);
         _tablet_metadata->set_next_rowset_id(1);
+        _tablet_metadata->set_enable_persistent_index(GetParam().enable_persistent_index);
         //
         //  | column | type | KEY | NULL |
         //  +--------+------+-----+------+
@@ -620,8 +621,10 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyCompactionTest, LakePrimaryKeyCompactionTest,
-                         ::testing::Values(CompactionParam{HORIZONTAL_COMPACTION, 5},
-                                           CompactionParam{VERTICAL_COMPACTION, 1}),
+                         ::testing::Values(CompactionParam{HORIZONTAL_COMPACTION, 5, false},
+                                           CompactionParam{VERTICAL_COMPACTION, 1, false},
+                                           CompactionParam{HORIZONTAL_COMPACTION, 5, true},
+                                           CompactionParam{VERTICAL_COMPACTION, 1, true}),
                          to_string_param_name);
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -64,4 +64,8 @@ protected:
     std::unique_ptr<TabletManager> _tablet_mgr;
 };
 
+struct PrimaryKeyParam {
+    bool enable_persistent_index = false;
+};
+
 } // namespace starrocks::lake


### PR DESCRIPTION
This PR fix two problem:
1. After persistent index upgrade to `PERSISTENT_INDEX_VERSION_3`, lake persistent index also need to do upgrade.
2. update `_data_version ` after persistent index load finish. Or when publish version, check version will fail.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
