### PR TITLE
[Enhancement] Remove the OPERATE priv check on be_tablets

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -260,9 +260,6 @@ public class AuthorizerStmtVisitor extends AstVisitor<Void, ConnectContext> {
             if (table instanceof View) {
                 Authorizer.checkViewAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
                         tableName, PrivilegeType.SELECT);
-            } else if (table instanceof SystemTable && ((SystemTable) table).requireOperatePrivilege()) {
-                Authorizer.checkSystemAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
-                        PrivilegeType.OPERATE);
             } else if (table.isMaterializedView()) {
                 Authorizer.checkMaterializedViewAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
                         tableName, PrivilegeType.SELECT);


### PR DESCRIPTION
Fixes SR-19525
be_tablets contains no sensitive information,
checking `OPERATE` privilege is convenient for users, remove it.

Maybe we should check if user has any privilege
on the corresponding table, but currently query on be_tablets doesn't
need to get data from FE, so we can't do privilege checking on BE, we
may do it in the future.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
