### PR TITLE
[BugFix] Return error if get_stub failed

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -556,7 +556,7 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chu
         {
             SCOPED_TIMER(_shuffle_hash_timer);
             for (size_t i = 0; i < _partitions_columns.size(); ++i) {
-                ASSIGN_OR_RETURN(_partitions_columns[i], _partition_expr_ctxs[i]->evaluate(chunk.get()));
+                ASSIGN_OR_RETURN(_partitions_columns[i], _partition_expr_ctxs[i]->evaluate(chunk.get()))
                 DCHECK(_partitions_columns[i] != nullptr);
             }
 

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -199,7 +199,7 @@ Status DataStreamSender::Channel::init(RuntimeState* state) {
         return Status::InternalError("no brpc destination");
     }
     _brpc_stub = state->exec_env()->brpc_stub_cache()->get_stub(_brpc_dest_addr);
-    if (_brpc_stub == nullptr) {
+    if (UNLIKELY(_brpc_stub == nullptr)) {
         auto msg = fmt::format("The brpc stub of {}:{} is null.", _brpc_dest_addr.hostname, _brpc_dest_addr.port);
         LOG(WARNING) << msg;
         return Status::InternalError(msg);

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -198,6 +198,12 @@ Status DataStreamSender::Channel::init(RuntimeState* state) {
                         ", maybe version is not compatible.";
         return Status::InternalError("no brpc destination");
     }
+    _brpc_stub = state->exec_env()->brpc_stub_cache()->get_stub(_brpc_dest_addr);
+    if (_brpc_stub == nullptr) {
+        auto msg = fmt::format("The brpc stub of {}:{} is null.", _brpc_dest_addr.hostname, _brpc_dest_addr.port);
+        LOG(WARNING) << msg;
+        return Status::InternalError(msg);
+    }
 
     // initialize brpc request
     _finst_id.set_hi(_fragment_instance_id.hi);
@@ -221,7 +227,6 @@ Status DataStreamSender::Channel::init(RuntimeState* state) {
         _is_inited = true;
         return Status::OK();
     }
-    _brpc_stub = state->exec_env()->brpc_stub_cache()->get_stub(_brpc_dest_addr);
 
     _need_close = true;
     _is_inited = true;

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -401,7 +401,7 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int rf_version, int32_t fil
         auto& t = targets[index];
         bool is_local = (local == t.first);
         auto* stub = _exec_env->brpc_stub_cache()->get_stub(t.first);
-        if (stub == nullptr) {
+        if (UNLIKELY(stub == nullptr)) {
             LOG(WARNING) << strings::Substitute("The brpc stub of {}:{} is null.", t.first.hostname, t.first.port);
             return;
         }
@@ -655,7 +655,7 @@ void RuntimeFilterWorker::_receive_total_runtime_filter(PTransmitRuntimeFilterPa
         addr.hostname = t.host();
         addr.port = t.port();
         auto* stub = _exec_env->brpc_stub_cache()->get_stub(addr);
-        if (stub == nullptr) {
+        if (UNLIKELY(stub == nullptr)) {
             LOG(WARNING) << strings::Substitute("The brpc stub of {}:{} is null.", addr.hostname, addr.port);
             return;
         }
@@ -755,7 +755,7 @@ void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_relay(PTransmitRunti
     auto* rpc_closure = new RuntimeFilterRpcClosure();
     SingleClosureJoinAndClean join_and_join(rpc_closure);
     auto* stub = _exec_env->brpc_stub_cache()->get_stub(first_dest.address);
-    if (stub == nullptr) {
+    if (UNLIKELY(stub == nullptr)) {
         LOG(WARNING) << strings::Substitute("The brpc stub of $0:$1 is null.", first_dest.address.hostname,
                                             first_dest.address.port);
         return;
@@ -783,7 +783,7 @@ void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_passthrough(
             auto request = params;
             auto& dest = destinations[start_idx + i];
             auto* stub = _exec_env->brpc_stub_cache()->get_stub(dest.address);
-            if (stub == nullptr) {
+            if (UNLIKELY(stub == nullptr)) {
                 LOG(WARNING) << strings::Substitute("The brpc stub of $0:$1 is null.", dest.address.hostname,
                                                     dest.address.port);
                 return;
@@ -826,7 +826,7 @@ void RuntimeFilterWorker::_deliver_part_runtime_filter(std::vector<TNetworkAddre
     BatchClosuresJoinAndClean join_and_clean(rpc_closures);
     for (const auto& addr : transmit_addrs) {
         auto* stub = _exec_env->brpc_stub_cache()->get_stub(addr);
-        if (stub == nullptr) {
+        if (UNLIKELY(stub == nullptr)) {
             LOG(WARNING) << strings::Substitute("The brpc stub of {}:{} is null.", addr.hostname, addr.port);
             return;
         }

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -400,7 +400,11 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int rf_version, int32_t fil
     while (index < size) {
         auto& t = targets[index];
         bool is_local = (local == t.first);
-        doris::PBackendService_Stub* stub = _exec_env->brpc_stub_cache()->get_stub(t.first);
+        auto* stub = _exec_env->brpc_stub_cache()->get_stub(t.first);
+        if (stub == nullptr) {
+            LOG(WARNING) << strings::Substitute("The brpc stub of {}:{} is null.", t.first.hostname, t.first.port);
+            return;
+        }
         request.clear_probe_finst_ids();
         request.clear_forward_targets();
         for (const auto& inst : t.second) {
@@ -650,7 +654,11 @@ void RuntimeFilterWorker::_receive_total_runtime_filter(PTransmitRuntimeFilterPa
         TNetworkAddress addr;
         addr.hostname = t.host();
         addr.port = t.port();
-        doris::PBackendService_Stub* stub = _exec_env->brpc_stub_cache()->get_stub(addr);
+        auto* stub = _exec_env->brpc_stub_cache()->get_stub(addr);
+        if (stub == nullptr) {
+            LOG(WARNING) << strings::Substitute("The brpc stub of {}:{} is null.", addr.hostname, addr.port);
+            return;
+        }
 
         request.clear_probe_finst_ids();
         request.clear_forward_targets();
@@ -746,7 +754,12 @@ void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_relay(PTransmitRunti
 
     auto* rpc_closure = new RuntimeFilterRpcClosure();
     SingleClosureJoinAndClean join_and_join(rpc_closure);
-    doris::PBackendService_Stub* stub = _exec_env->brpc_stub_cache()->get_stub(first_dest.address);
+    auto* stub = _exec_env->brpc_stub_cache()->get_stub(first_dest.address);
+    if (stub == nullptr) {
+        LOG(WARNING) << strings::Substitute("The brpc stub of $0:$1 is null.", first_dest.address.hostname,
+                                            first_dest.address.port);
+        return;
+    }
     _exec_env->add_rf_event(
             {request.query_id(), request.filter_id(), first_dest.address.hostname, "DELIVER_BROADCAST_RF_RELAY"});
     rpc_closure->ref();
@@ -769,7 +782,12 @@ void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_passthrough(
         for (auto i = 0; i < num_inflight; ++i) {
             auto request = params;
             auto& dest = destinations[start_idx + i];
-            doris::PBackendService_Stub* stub = _exec_env->brpc_stub_cache()->get_stub(dest.address);
+            auto* stub = _exec_env->brpc_stub_cache()->get_stub(dest.address);
+            if (stub == nullptr) {
+                LOG(WARNING) << strings::Substitute("The brpc stub of $0:$1 is null.", dest.address.hostname,
+                                                    dest.address.port);
+                return;
+            }
             request.clear_probe_finst_ids();
             request.clear_forward_targets();
             for (const auto& id : dest.finstance_ids) {
@@ -807,7 +825,11 @@ void RuntimeFilterWorker::_deliver_part_runtime_filter(std::vector<TNetworkAddre
     rpc_closures.reserve(transmit_addrs.size());
     BatchClosuresJoinAndClean join_and_clean(rpc_closures);
     for (const auto& addr : transmit_addrs) {
-        doris::PBackendService_Stub* stub = _exec_env->brpc_stub_cache()->get_stub(addr);
+        auto* stub = _exec_env->brpc_stub_cache()->get_stub(addr);
+        if (stub == nullptr) {
+            LOG(WARNING) << strings::Substitute("The brpc stub of {}:{} is null.", addr.hostname, addr.port);
+            return;
+        }
         _exec_env->add_rf_event({params.query_id(), params.filter_id(), addr.hostname, "SEND_PART_RF_RPC"});
         rpc_closures.push_back(new RuntimeFilterRpcClosure());
         auto* closure = rpc_closures.back();

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -124,12 +124,12 @@ public:
         if (!is_valid_ip(host)) {
             realhost = hostname_to_ip(host);
             if (realhost == "") {
-                LOG(WARNING) << "failed to get ip from host";
+                LOG(WARNING) << "failed to get ip from host, host=" << host;
                 return nullptr;
             }
         }
         if (str2endpoint(realhost.c_str(), port, &endpoint)) {
-            LOG(WARNING) << "unknown endpoint, host = " << host;
+            LOG(WARNING) << "unknown endpoint, host=" << host;
             return nullptr;
         }
         return get_stub(endpoint);


### PR DESCRIPTION
Fixes #issue

We should check the return ptr of get_stub, otherwise it will crash.

```
*** Aborted at 1693311284 (unix time) try "date -d @1693311284" if you are using GNU date ***
PC: @          0x524347d starrocks::DataStreamSender::Channel::_do_send_chunk_rpc()
*** SIGSEGV (@0x0) received by PID 78 (TID 0x7fb93d1c7700) from PID 0; stack trace: ***
    @          0x59cf382 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fb98e242630 (unknown)
    @          0x524347d starrocks::DataStreamSender::Channel::_do_send_chunk_rpc()
    @          0x52479b9 starrocks::DataStreamSender::Channel::send_one_chunk()
    @          0x5248182 starrocks::DataStreamSender::Channel::close_internal()
    @          0x5248390 starrocks::DataStreamSender::Channel::close()
    @          0x524858b starrocks::DataStreamSender::close()
    @          0x48d716c starrocks::PlanFragmentExecutor::_open_internal_vectorized()
    @          0x48d8c1d starrocks::PlanFragmentExecutor::open()
    @          0x48244cb starrocks::FragmentExecState::execute()
    @          0x482a883 starrocks::FragmentMgr::exec_actual()
    @          0x49ce652 starrocks::ThreadPool::dispatch_thread()
    @          0x49c914a starrocks::Thread::supervise_thread()
    @     0x7fb98e23aea5 start_thread
    @     0x7fb98d85596d __clone
    @                0x0 (unknown)
```

```
W0829 20:14:43.967415  1135 network_util.cpp:114] status of hostname_to_ip_addrs was not ok, err is Could not find IPv4 address for: backend-3
W0829 20:14:43.967471  1135 brpc_stub_cache.h:114] failed to get ip from host
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
