### PR TITLE
[BugFix] Only query synchronized materialized views for _SYNC_MV_ hint

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -491,7 +491,12 @@ public class Database extends MetaObject implements Writable {
             if (table instanceof OlapTable) {
                 OlapTable olapTable = (OlapTable) table;
                 for (MaterializedIndexMeta mvMeta : olapTable.getVisibleIndexMetas()) {
-                    String indexName = olapTable.getIndexNameById(mvMeta.getIndexId());
+                    Long mvIndexId = mvMeta.getIndexId();
+                    // materialized view index should not consider the base index id.
+                    if (mvIndexId == olapTable.getBaseIndexId()) {
+                        continue;
+                    }
+                    String indexName = olapTable.getIndexNameById(mvIndexId);
                     if (indexName == null) {
                         continue;
                     }


### PR DESCRIPTION
- Little bugfix: Only query synchronized materialized views for _SYNC_MV_ hint

Fixes #26970


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
