### PR TITLE
[BugFix] Restore primary key table cause meta inconsistent when restart BE(#30129)

### DIFF
--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -205,7 +205,7 @@ Status TabletMeta::deserialize(std::string_view data) {
     return Status::OK();
 }
 
-void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb, const TabletSchemaPB* ptablet_schema_pb) {
+void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb) {
     auto& tablet_meta_pb = *ptablet_meta_pb;
     _table_id = tablet_meta_pb.table_id();
     _partition_id = tablet_meta_pb.partition_id();
@@ -251,20 +251,11 @@ void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb, const TabletSchemaP
     }
 
     // init _schema
-    if (ptablet_schema_pb == nullptr) {
-        if (tablet_meta_pb.schema().has_id() && tablet_meta_pb.schema().id() != TabletSchema::invalid_id()) {
-            // Does not collect the memory usage of |_schema|.
-            _schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_meta_pb.schema()).first;
-        } else {
-            _schema = std::make_shared<const TabletSchema>(tablet_meta_pb.schema());
-        }
+    if (tablet_meta_pb.schema().has_id() && tablet_meta_pb.schema().id() != TabletSchema::invalid_id()) {
+        // Does not collect the memory usage of |_schema|.
+        _schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_meta_pb.schema()).first;
     } else {
-        if (ptablet_schema_pb->has_id() && ptablet_schema_pb->id() != TabletSchema::invalid_id()) {
-            // Does not collect the memory usage of |_schema|.
-            _schema = GlobalTabletSchemaMap::Instance()->emplace(*ptablet_schema_pb).first;
-        } else {
-            _schema = std::make_shared<const TabletSchema>(*ptablet_schema_pb);
-        }
+        _schema = std::make_shared<const TabletSchema>(tablet_meta_pb.schema());
     }
 
     // init _rs_metas
@@ -546,6 +537,16 @@ void TabletMeta::create_inital_updates_meta() {
     _updatesPB->mutable_apply_version()->set_minor_number(edit_version_pb->minor_number());
     _updatesPB->set_next_log_id(0);
     _updatesPB->set_next_rowset_id(0);
+}
+
+void TabletMeta::reset_tablet_schema_for_restore(const TabletSchemaPB& schema_pb) {
+    _schema.reset();
+    if (schema_pb.has_id() && schema_pb.id() != TabletSchema::invalid_id()) {
+        // Does not collect the memory usage of |_schema|.
+        _schema = GlobalTabletSchemaMap::Instance()->emplace(schema_pb).first;
+    } else {
+        _schema = std::make_shared<const TabletSchema>(schema_pb);
+    }
 }
 
 bool operator==(const TabletMeta& a, const TabletMeta& b) {

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -120,7 +120,7 @@ public:
 
     [[nodiscard]] Status serialize(std::string* meta_binary);
     [[nodiscard]] Status deserialize(std::string_view data);
-    void init_from_pb(TabletMetaPB* ptablet_meta_pb, const TabletSchemaPB* ptablet_schema_pb = nullptr);
+    void init_from_pb(TabletMetaPB* ptablet_meta_pb);
 
     void to_meta_pb(TabletMetaPB* tablet_meta_pb);
     void to_json(std::string* json_string, json2pb::Pb2JsonOptions& options);
@@ -173,6 +173,8 @@ public:
     void delete_inc_rs_meta_by_version(const Version& version);
     RowsetMetaSharedPtr acquire_inc_rs_meta_by_version(const Version& version) const;
     void delete_stale_rs_meta_by_version(const Version& version);
+
+    void reset_tablet_schema_for_restore(const TabletSchemaPB& schema_pb);
 
     void add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version);
     void remove_delete_predicate_by_version(const Version& version);


### PR DESCRIPTION
Problem:
This problem is introduced by commit cfba8973f4718c0a4f2d6846d2bdaa473ba0be49 In this pr, we create a new tablet meta with snapshot tablet_schema to avoid the crash if the backup table has been done schema change.

But the problem is that, the _updates in new tablet meta is nullptr. It forget to reset it to tablet->updates(). So when remove expired versions for primary key table, tablet_meta.save_meta() will save the wrong meta data for this tablet. When we restart be, it will cause the meta inconsistent problem.

Solution:
Call release_updates to reset the _updates in tablet_meta to tablet->updates()

Fixes #30129

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
