### PR TITLE
[Enhancement] Improve data lake csv reader performance further

### DIFF
--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -244,6 +244,7 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
 
     size_t rows_read = 0;
 
+    CSVReader::Fields fields{};
     for (; rows_read < chunk_size; rows_read++) {
         CSVReader::Record record{};
         Status status = down_cast<HdfsScannerCSVReader*>(_reader.get())->next_record(&record);
@@ -272,7 +273,7 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
             return Status::InternalError("Face csv invalidate UTF-8 character line.");
         }
 
-        CSVReader::Fields fields{};
+        fields.resize(0);
         _reader->split_record(record, &fields);
 
         size_t num_materialize_columns = _scanner_params.materialize_slots.size();

--- a/be/src/formats/csv/array_converter.cpp
+++ b/be/src/formats/csv/array_converter.cpp
@@ -43,7 +43,7 @@ Status ArrayConverter::write_quoted_string(OutputStream* os, const Column& colum
     return write_string(os, column, row_num, options);
 }
 
-bool ArrayConverter::read_string(Column* column, Slice s, const Options& options) const {
+bool ArrayConverter::read_string(Column* column, const Slice& s, const Options& options) const {
     if (_array_reader == nullptr) {
         _array_reader = ArrayReader::create_array_reader(options);
     }
@@ -78,7 +78,7 @@ bool ArrayConverter::read_string(Column* column, Slice s, const Options& options
     return true;
 }
 
-bool ArrayConverter::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool ArrayConverter::read_quoted_string(Column* column, const Slice& s, const Options& options) const {
     return read_string(column, s, options);
 }
 

--- a/be/src/formats/csv/array_converter.cpp
+++ b/be/src/formats/csv/array_converter.cpp
@@ -57,7 +57,7 @@ bool ArrayConverter::read_string(Column* column, const Slice& s, const Options& 
     auto* elements = array->elements_column().get();
 
     std::vector<Slice> fields;
-    if (!s.empty() && !_array_reader->split_array_elements(s, &fields)) {
+    if (!s.empty() && !_array_reader->split_array_elements(s, fields)) {
         return false;
     }
     size_t old_size = elements->size();

--- a/be/src/formats/csv/array_converter.h
+++ b/be/src/formats/csv/array_converter.h
@@ -27,8 +27,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 
 private:
     mutable std::unique_ptr<ArrayReader> _array_reader;

--- a/be/src/formats/csv/array_reader.cpp
+++ b/be/src/formats/csv/array_reader.cpp
@@ -58,7 +58,7 @@ bool DefaultArrayReader::split_array_elements(Slice s, std::vector<Slice>* eleme
             array_nest_level--;
         } else if (!in_quote && array_nest_level == 0 && c == _array_delimiter) {
             elements->back().remove_suffix(s.size - i);
-            elements->push_back(Slice(s.data + i + 1, s.size - i - 1));
+            elements->emplace_back(s.data + i + 1, s.size - i - 1);
         }
     }
     if (array_nest_level != 0 || in_quote) {
@@ -88,12 +88,12 @@ bool HiveTextArrayReader::split_array_elements(Slice s, std::vector<Slice>* elem
     for (/**/; right < s.size; right++) {
         char c = s[right];
         if (c == _array_delimiter) {
-            elements->push_back(Slice(s.data + left, right - left));
+            elements->emplace_back(s.data + left, right - left);
             left = right + 1;
         }
     }
     if (right > left) {
-        elements->push_back(Slice(s.data + left, right - left));
+        elements->emplace_back(s.data + left, right - left);
     }
 
     return true;

--- a/be/src/formats/csv/array_reader.cpp
+++ b/be/src/formats/csv/array_reader.cpp
@@ -36,7 +36,8 @@ bool DefaultArrayReader::validate(const Slice& s) const {
     return true;
 }
 
-bool DefaultArrayReader::split_array_elements(Slice s, std::vector<Slice>* elements) const {
+bool DefaultArrayReader::split_array_elements(const Slice& tmp_s, std::vector<Slice>& elements) const {
+    Slice s = tmp_s;
     s.remove_prefix(1);
     s.remove_suffix(1);
     if (s.empty()) {
@@ -46,7 +47,7 @@ bool DefaultArrayReader::split_array_elements(Slice s, std::vector<Slice>* eleme
 
     bool in_quote = false;
     int array_nest_level = 0;
-    elements->push_back(s);
+    elements.push_back(s);
     for (size_t i = 0; i < s.size; i++) {
         char c = s[i];
         // TODO(zhuming): handle escaped double quotes
@@ -57,8 +58,8 @@ bool DefaultArrayReader::split_array_elements(Slice s, std::vector<Slice>* eleme
         } else if (!in_quote && c == ']') {
             array_nest_level--;
         } else if (!in_quote && array_nest_level == 0 && c == _array_delimiter) {
-            elements->back().remove_suffix(s.size - i);
-            elements->emplace_back(s.data + i + 1, s.size - i - 1);
+            elements.back().remove_suffix(s.size - i);
+            elements.emplace_back(s.data + i + 1, s.size - i - 1);
         }
     }
     if (array_nest_level != 0 || in_quote) {
@@ -77,7 +78,7 @@ bool HiveTextArrayReader::validate(const Slice& s) const {
     return true;
 }
 
-bool HiveTextArrayReader::split_array_elements(Slice s, std::vector<Slice>* elements) const {
+bool HiveTextArrayReader::split_array_elements(const Slice& s, std::vector<Slice>& elements) const {
     if (s.size == 0) {
         // consider empty array
         return true;
@@ -88,12 +89,12 @@ bool HiveTextArrayReader::split_array_elements(Slice s, std::vector<Slice>* elem
     for (/**/; right < s.size; right++) {
         char c = s[right];
         if (c == _array_delimiter) {
-            elements->emplace_back(s.data + left, right - left);
+            elements.emplace_back(s.data + left, right - left);
             left = right + 1;
         }
     }
     if (right > left) {
-        elements->emplace_back(s.data + left, right - left);
+        elements.emplace_back(s.data + left, right - left);
     }
 
     return true;

--- a/be/src/formats/csv/array_reader.h
+++ b/be/src/formats/csv/array_reader.h
@@ -22,7 +22,7 @@ public:
     explicit ArrayReader(char array_delimiter) : _array_delimiter(array_delimiter) {}
     virtual ~ArrayReader() = default;
     [[nodiscard]] virtual bool validate(const Slice& s) const = 0;
-    [[nodiscard]] virtual bool split_array_elements(Slice s, std::vector<Slice>* elements) const = 0;
+    [[nodiscard]] virtual bool split_array_elements(const Slice& s, std::vector<Slice>& elements) const = 0;
 
     // In Hive nested array, string is not quoted, you should set false here if you want
     // to parse Hive array format.
@@ -39,7 +39,7 @@ class DefaultArrayReader final : public ArrayReader {
 public:
     explicit DefaultArrayReader() : ArrayReader(',') {}
     [[nodiscard]] bool validate(const Slice& s) const override;
-    [[nodiscard]] bool split_array_elements(Slice s, std::vector<Slice>* elements) const override;
+    [[nodiscard]] bool split_array_elements(const Slice& s, std::vector<Slice>& elements) const override;
     [[nodiscard]] bool read_quoted_string(const std::unique_ptr<Converter>& elem_converter, Column* column,
                                           const Slice& s, const Converter::Options& options) const override;
 };
@@ -57,7 +57,7 @@ public:
                                                    options.array_hive_mapkey_delimiter,
                                                    options.array_hive_nested_level)) {}
     [[nodiscard]] bool validate(const Slice& s) const override;
-    [[nodiscard]] bool split_array_elements(Slice s, std::vector<Slice>* elements) const override;
+    [[nodiscard]] bool split_array_elements(const Slice& s, std::vector<Slice>& elements) const override;
     [[nodiscard]] bool read_quoted_string(const std::unique_ptr<Converter>& elem_converter, Column* column,
                                           const Slice& s, const Converter::Options& options) const override;
 

--- a/be/src/formats/csv/boolean_converter.cpp
+++ b/be/src/formats/csv/boolean_converter.cpp
@@ -37,7 +37,7 @@ Status BooleanConverter::write_quoted_string(OutputStream* os, const Column& col
     return write_string(os, column, row_num, options);
 }
 
-bool BooleanConverter::read_string(Column* column, Slice s, const Options& options) const {
+bool BooleanConverter::read_string(Column* column, const Slice& s, const Options& options) const {
     StringParser::ParseResult r;
     bool v = StringParser::string_to_bool(s.data, s.size, &r);
     if (r == StringParser::PARSE_SUCCESS) {
@@ -60,7 +60,7 @@ bool BooleanConverter::read_string(Column* column, Slice s, const Options& optio
     }
 }
 
-bool BooleanConverter::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool BooleanConverter::read_quoted_string(Column* column, const Slice& s, const Options& options) const {
     return read_string(column, s, options);
 }
 

--- a/be/src/formats/csv/boolean_converter.h
+++ b/be/src/formats/csv/boolean_converter.h
@@ -23,8 +23,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 };
 
 } // namespace starrocks::csv

--- a/be/src/formats/csv/converter.h
+++ b/be/src/formats/csv/converter.h
@@ -97,9 +97,9 @@ public:
         return true;
     }
 
-    virtual bool read_string(Column* column, Slice s, const Options& options) const = 0;
+    virtual bool read_string(Column* column, const Slice& s, const Options& options) const = 0;
 
-    virtual bool read_quoted_string(Column* column, Slice s, const Options& options) const = 0;
+    virtual bool read_quoted_string(Column* column, const Slice& s, const Options& options) const = 0;
 
 protected:
     template <char quote>

--- a/be/src/formats/csv/date_converter.cpp
+++ b/be/src/formats/csv/date_converter.cpp
@@ -34,7 +34,7 @@ Status DateConverter::write_quoted_string(OutputStream* os, const Column& column
     return os->write('"');
 }
 
-bool DateConverter::read_string(Column* column, Slice s, const Options& options) const {
+bool DateConverter::read_string(Column* column, const Slice& s, const Options& options) const {
     DateValue v{};
     bool r = v.from_string(s.data, s.size);
     if (r) {
@@ -43,7 +43,8 @@ bool DateConverter::read_string(Column* column, Slice s, const Options& options)
     return r;
 }
 
-bool DateConverter::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool DateConverter::read_quoted_string(Column* column, const Slice& tmp_s, const Options& options) const {
+    Slice s = tmp_s;
     if (!remove_enclosing_quotes<'"'>(&s)) {
         return false;
     }

--- a/be/src/formats/csv/date_converter.h
+++ b/be/src/formats/csv/date_converter.h
@@ -23,8 +23,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 };
 
 } // namespace starrocks::csv

--- a/be/src/formats/csv/datetime_converter.cpp
+++ b/be/src/formats/csv/datetime_converter.cpp
@@ -34,7 +34,7 @@ Status DatetimeConverter::write_quoted_string(OutputStream* os, const Column& co
     return os->write('"');
 }
 
-bool DatetimeConverter::read_string(Column* column, Slice s, const Options& options) const {
+bool DatetimeConverter::read_string(Column* column, const Slice& s, const Options& options) const {
     TimestampValue v{};
     bool r = v.from_string(s.data, s.size);
     if (r) {
@@ -43,7 +43,8 @@ bool DatetimeConverter::read_string(Column* column, Slice s, const Options& opti
     return r;
 }
 
-bool DatetimeConverter::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool DatetimeConverter::read_quoted_string(Column* column, const Slice& tmp_s, const Options& options) const {
+    Slice s = tmp_s;
     if (!remove_enclosing_quotes<'"'>(&s)) {
         return false;
     }

--- a/be/src/formats/csv/datetime_converter.h
+++ b/be/src/formats/csv/datetime_converter.h
@@ -23,8 +23,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 };
 
 } // namespace starrocks::csv

--- a/be/src/formats/csv/decimalv2_converter.cpp
+++ b/be/src/formats/csv/decimalv2_converter.cpp
@@ -32,7 +32,7 @@ Status DecimalV2Converter::write_quoted_string(OutputStream* os, const Column& c
     return write_string(os, column, row_num, options);
 }
 
-bool DecimalV2Converter::read_string(Column* column, Slice s, const Options& options) const {
+bool DecimalV2Converter::read_string(Column* column, const Slice& s, const Options& options) const {
     DecimalV2Value v;
     int err = v.parse_from_str(s.data, s.size);
     if (err == 0) {
@@ -41,7 +41,7 @@ bool DecimalV2Converter::read_string(Column* column, Slice s, const Options& opt
     return err == 0;
 }
 
-bool DecimalV2Converter::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool DecimalV2Converter::read_quoted_string(Column* column, const Slice& s, const Options& options) const {
     return read_string(column, s, options);
 }
 

--- a/be/src/formats/csv/decimalv2_converter.h
+++ b/be/src/formats/csv/decimalv2_converter.h
@@ -23,8 +23,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 };
 
 } // namespace starrocks::csv

--- a/be/src/formats/csv/decimalv3_converter.cpp
+++ b/be/src/formats/csv/decimalv3_converter.cpp
@@ -36,7 +36,7 @@ Status DecimalV3Converter<T>::write_quoted_string(OutputStream* os, const Column
 }
 
 template <typename T>
-bool DecimalV3Converter<T>::read_string(Column* column, Slice s, const Options& options) const {
+bool DecimalV3Converter<T>::read_string(Column* column, const Slice& s, const Options& options) const {
     auto decimalv3_column = down_cast<DecimalV3Column<T>*>(column);
     T v;
     bool fail = DecimalV3Cast::from_string<T>(&v, _precision, _scale, s.data, s.size);
@@ -48,7 +48,7 @@ bool DecimalV3Converter<T>::read_string(Column* column, Slice s, const Options& 
 }
 
 template <typename T>
-bool DecimalV3Converter<T>::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool DecimalV3Converter<T>::read_quoted_string(Column* column, const Slice& s, const Options& options) const {
     return read_string(column, s, options);
 }
 

--- a/be/src/formats/csv/decimalv3_converter.h
+++ b/be/src/formats/csv/decimalv3_converter.h
@@ -29,8 +29,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 
 private:
     int _precision;

--- a/be/src/formats/csv/default_value_converter.cpp
+++ b/be/src/formats/csv/default_value_converter.cpp
@@ -18,7 +18,7 @@
 
 namespace starrocks::csv {
 
-bool DefaultValueConverter::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool DefaultValueConverter::read_quoted_string(Column* column, const Slice& s, const Options& options) const {
     if (options.invalid_field_as_null) {
         column->append_default();
         return true;
@@ -27,7 +27,7 @@ bool DefaultValueConverter::read_quoted_string(Column* column, Slice s, const Op
     }
 }
 
-bool DefaultValueConverter::read_string(Column* column, Slice s, const Options& options) const {
+bool DefaultValueConverter::read_string(Column* column, const Slice& s, const Options& options) const {
     return read_quoted_string(column, s, options);
 }
 

--- a/be/src/formats/csv/default_value_converter.h
+++ b/be/src/formats/csv/default_value_converter.h
@@ -23,8 +23,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 };
 
 } // namespace starrocks::csv

--- a/be/src/formats/csv/float_converter.cpp
+++ b/be/src/formats/csv/float_converter.cpp
@@ -34,7 +34,7 @@ Status FloatConverter<T>::write_quoted_string(OutputStream* os, const Column& co
 }
 
 template <typename T>
-bool FloatConverter<T>::read_string(Column* column, Slice s, const Options& options) const {
+bool FloatConverter<T>::read_string(Column* column, const Slice& s, const Options& options) const {
     StringParser::ParseResult r;
     auto v = StringParser::string_to_float<DataType>(s.data, s.size, &r);
     if (r == StringParser::PARSE_SUCCESS) {
@@ -44,7 +44,7 @@ bool FloatConverter<T>::read_string(Column* column, Slice s, const Options& opti
 }
 
 template <typename T>
-bool FloatConverter<T>::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool FloatConverter<T>::read_quoted_string(Column* column, const Slice& s, const Options& options) const {
     return read_string(column, s, options);
 }
 

--- a/be/src/formats/csv/float_converter.h
+++ b/be/src/formats/csv/float_converter.h
@@ -28,8 +28,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 };
 
 } // namespace starrocks::csv

--- a/be/src/formats/csv/json_converter.cpp
+++ b/be/src/formats/csv/json_converter.cpp
@@ -36,7 +36,7 @@ Status JsonConverter::write_quoted_string(OutputStream* os, const Column& column
     return os->write('"');
 }
 
-bool JsonConverter::read_string(Column* column, Slice s, const Options& options) const {
+bool JsonConverter::read_string(Column* column, const Slice& s, const Options& options) const {
     auto json = JsonValue::parse(s);
     if (json.ok()) {
         auto json_column = down_cast<JsonColumn*>(column);
@@ -46,7 +46,8 @@ bool JsonConverter::read_string(Column* column, Slice s, const Options& options)
     return false;
 }
 
-bool JsonConverter::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool JsonConverter::read_quoted_string(Column* column, const Slice& tmp_s, const Options& options) const {
+    Slice s = tmp_s;
     if (!remove_enclosing_quotes<'"'>(&s)) {
         return false;
     }

--- a/be/src/formats/csv/json_converter.h
+++ b/be/src/formats/csv/json_converter.h
@@ -23,8 +23,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 };
 
 } // namespace starrocks::csv

--- a/be/src/formats/csv/map_converter.cpp
+++ b/be/src/formats/csv/map_converter.cpp
@@ -103,7 +103,7 @@ bool MapConverter::split_map_key_value(Slice s, std::vector<Slice>& keys, std::v
     return true;
 }
 
-bool MapConverter::read_string(Column* column, Slice s, const Options& options) const {
+bool MapConverter::read_string(Column* column, const Slice& s, const Options& options) const {
     if (!validate(s)) {
         return false;
     }
@@ -149,7 +149,7 @@ bool MapConverter::read_string(Column* column, Slice s, const Options& options) 
     return true;
 }
 
-bool MapConverter::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool MapConverter::read_quoted_string(Column* column, const Slice& s, const Options& options) const {
     return read_string(column, s, options);
 }
 

--- a/be/src/formats/csv/map_converter.h
+++ b/be/src/formats/csv/map_converter.h
@@ -29,8 +29,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 
 private:
     bool validate(const Slice& s) const;

--- a/be/src/formats/csv/nullable_converter.cpp
+++ b/be/src/formats/csv/nullable_converter.cpp
@@ -61,7 +61,7 @@ bool NullableConverter::read_string_for_adaptive_null_column(Column* column, Sli
     }
 }
 
-bool NullableConverter::read_string(Column* column, Slice s, const Options& options) const {
+bool NullableConverter::read_string(Column* column, const Slice& s, const Options& options) const {
     auto* nullable = down_cast<NullableColumn*>(column);
     auto* data = nullable->data_column().get();
 
@@ -77,7 +77,7 @@ bool NullableConverter::read_string(Column* column, Slice s, const Options& opti
     }
 }
 
-bool NullableConverter::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool NullableConverter::read_quoted_string(Column* column, const Slice& s, const Options& options) const {
     auto* nullable = down_cast<NullableColumn*>(column);
     auto* data = nullable->data_column().get();
 

--- a/be/src/formats/csv/nullable_converter.h
+++ b/be/src/formats/csv/nullable_converter.h
@@ -27,8 +27,8 @@ public:
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
     bool read_string_for_adaptive_null_column(Column* column, Slice s, const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 
 private:
     std::unique_ptr<Converter> _base_converter;

--- a/be/src/formats/csv/numeric_converter.cpp
+++ b/be/src/formats/csv/numeric_converter.cpp
@@ -15,7 +15,6 @@
 #include "formats/csv/numeric_converter.h"
 
 #include "column/fixed_length_column.h"
-#include "common/logging.h"
 #include "util/string_parser.hpp"
 
 namespace starrocks::csv {
@@ -38,7 +37,7 @@ Status NumericConverter<T>::write_quoted_string(OutputStream* os, const Column& 
 }
 
 template <typename T>
-bool NumericConverter<T>::read_string(Column* column, Slice s, const Options& options) const {
+bool NumericConverter<T>::read_string(Column* column, const Slice& s, const Options& options) const {
     StringParser::ParseResult r;
     auto v = StringParser::string_to_int<DataType>(s.data, s.size, &r);
     if (r == StringParser::PARSE_SUCCESS) {
@@ -79,7 +78,7 @@ bool NumericConverter<T>::read_string(Column* column, Slice s, const Options& op
 }
 
 template <typename T>
-bool NumericConverter<T>::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool NumericConverter<T>::read_quoted_string(Column* column, const Slice& s, const Options& options) const {
     return read_string(column, s, options);
 }
 

--- a/be/src/formats/csv/numeric_converter.h
+++ b/be/src/formats/csv/numeric_converter.h
@@ -28,8 +28,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 };
 
 } // namespace starrocks::csv

--- a/be/src/formats/csv/string_converter.cpp
+++ b/be/src/formats/csv/string_converter.cpp
@@ -54,7 +54,7 @@ Status StringConverter::write_quoted_string(OutputStream* os, const Column& colu
     return os->write('"');
 }
 
-bool StringConverter::read_string(Column* column, Slice s, const Options& options) const {
+bool StringConverter::read_string(Column* column, const Slice& s, const Options& options) const {
     int max_size = 0;
     if (options.type_desc != nullptr) {
         max_size = options.type_desc->len;
@@ -70,7 +70,8 @@ bool StringConverter::read_string(Column* column, Slice s, const Options& option
     return true;
 }
 
-bool StringConverter::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool StringConverter::read_quoted_string(Column* column, const Slice& tmp_s, const Options& options) const {
+    Slice s = tmp_s;
     if (!remove_enclosing_quotes<'"'>(&s)) {
         return false;
     }

--- a/be/src/formats/csv/string_converter.cpp
+++ b/be/src/formats/csv/string_converter.cpp
@@ -60,11 +60,12 @@ bool StringConverter::read_string(Column* column, const Slice& s, const Options&
         max_size = options.type_desc->len;
     }
 
-    if (config::enable_check_string_lengths &&
-        ((s.size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && s.size > max_size))) {
-        VLOG(3) << strings::Substitute("Column [$0]'s length exceed max varchar length. str_size($1), max_size($2)",
-                                       column->get_name(), s.size, max_size);
-        return false;
+    if (config::enable_check_string_lengths) {
+        if (UNLIKELY(s.size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && s.size > max_size)) {
+            VLOG(3) << strings::Substitute("Column [$0]'s length exceed max varchar length. str_size($1), max_size($2)",
+                                           column->get_name(), s.size, max_size);
+            return false;
+        }
     }
     down_cast<BinaryColumn*>(column)->append(s);
     return true;
@@ -107,15 +108,17 @@ bool StringConverter::read_quoted_string(Column* column, const Slice& tmp_s, con
         max_size = options.type_desc->len;
     }
     size_t ext_size = new_size - old_size;
-    if (config::enable_check_string_lengths &&
-        ((ext_size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && ext_size > max_size))) {
-        bytes.resize(old_size);
-        VLOG(3) << strings::Substitute(
-                "Column [$0]'s length exceed max varchar length. old_size($1), new_size($2), ext_size($3), "
-                "max_size($4)",
-                column->get_name(), old_size, new_size, ext_size, max_size);
-        return false;
+    if (config::enable_check_string_lengths) {
+        if (UNLIKELY((ext_size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && ext_size > max_size))) {
+            bytes.resize(old_size);
+            VLOG(3) << strings::Substitute(
+                    "Column [$0]'s length exceed max varchar length. old_size($1), new_size($2), ext_size($3), "
+                    "max_size($4)",
+                    column->get_name(), old_size, new_size, ext_size, max_size);
+            return false;
+        }
     }
+
     offsets.push_back(bytes.size());
     return true;
 }

--- a/be/src/formats/csv/string_converter.cpp
+++ b/be/src/formats/csv/string_converter.cpp
@@ -116,7 +116,6 @@ bool StringConverter::read_quoted_string(Column* column, const Slice& tmp_s, con
                 column->get_name(), old_size, new_size, ext_size, max_size);
         return false;
     }
-
     offsets.push_back(bytes.size());
     return true;
 }

--- a/be/src/formats/csv/string_converter.cpp
+++ b/be/src/formats/csv/string_converter.cpp
@@ -60,12 +60,11 @@ bool StringConverter::read_string(Column* column, const Slice& s, const Options&
         max_size = options.type_desc->len;
     }
 
-    if (config::enable_check_string_lengths) {
-        if (UNLIKELY(s.size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && s.size > max_size)) {
-            VLOG(3) << strings::Substitute("Column [$0]'s length exceed max varchar length. str_size($1), max_size($2)",
-                                           column->get_name(), s.size, max_size);
-            return false;
-        }
+    if (config::enable_check_string_lengths &&
+        ((s.size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && s.size > max_size))) {
+        VLOG(3) << strings::Substitute("Column [$0]'s length exceed max varchar length. str_size($1), max_size($2)",
+                                       column->get_name(), s.size, max_size);
+        return false;
     }
     down_cast<BinaryColumn*>(column)->append(s);
     return true;
@@ -108,15 +107,14 @@ bool StringConverter::read_quoted_string(Column* column, const Slice& tmp_s, con
         max_size = options.type_desc->len;
     }
     size_t ext_size = new_size - old_size;
-    if (config::enable_check_string_lengths) {
-        if (UNLIKELY((ext_size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && ext_size > max_size))) {
-            bytes.resize(old_size);
-            VLOG(3) << strings::Substitute(
-                    "Column [$0]'s length exceed max varchar length. old_size($1), new_size($2), ext_size($3), "
-                    "max_size($4)",
-                    column->get_name(), old_size, new_size, ext_size, max_size);
-            return false;
-        }
+    if (config::enable_check_string_lengths &&
+        ((ext_size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && ext_size > max_size))) {
+        bytes.resize(old_size);
+        VLOG(3) << strings::Substitute(
+                "Column [$0]'s length exceed max varchar length. old_size($1), new_size($2), ext_size($3), "
+                "max_size($4)",
+                column->get_name(), old_size, new_size, ext_size, max_size);
+        return false;
     }
 
     offsets.push_back(bytes.size());

--- a/be/src/formats/csv/string_converter.h
+++ b/be/src/formats/csv/string_converter.h
@@ -23,8 +23,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 };
 
 } // namespace starrocks::csv

--- a/be/src/formats/csv/varbinary_converter.cpp
+++ b/be/src/formats/csv/varbinary_converter.cpp
@@ -53,7 +53,7 @@ Status VarBinaryConverter::write_quoted_string(OutputStream* os, const Column& c
     return os->write('"');
 }
 
-bool VarBinaryConverter::read_string(Column* column, Slice s, const Options& options) const {
+bool VarBinaryConverter::read_string(Column* column, const Slice& s, const Options& options) const {
     int max_size = 0;
     if (options.type_desc != nullptr) {
         max_size = options.type_desc->len;
@@ -95,7 +95,8 @@ bool VarBinaryConverter::read_string(Column* column, Slice s, const Options& opt
     return true;
 }
 
-bool VarBinaryConverter::read_quoted_string(Column* column, Slice s, const Options& options) const {
+bool VarBinaryConverter::read_quoted_string(Column* column, const Slice& tmp_s, const Options& options) const {
+    Slice s = tmp_s;
     // TODO: need write quote for binary?
     if (!remove_enclosing_quotes<'"'>(&s)) {
         return false;

--- a/be/src/formats/csv/varbinary_converter.h
+++ b/be/src/formats/csv/varbinary_converter.h
@@ -23,8 +23,8 @@ public:
     Status write_string(OutputStream* os, const Column& column, size_t row_num, const Options& options) const override;
     Status write_quoted_string(OutputStream* os, const Column& column, size_t row_num,
                                const Options& options) const override;
-    bool read_string(Column* column, Slice s, const Options& options) const override;
-    bool read_quoted_string(Column* column, Slice s, const Options& options) const override;
+    bool read_string(Column* column, const Slice& s, const Options& options) const override;
+    bool read_quoted_string(Column* column, const Slice& s, const Options& options) const override;
 };
 
 } // namespace starrocks::csv


### PR DESCRIPTION
Based on the previous PR #30028, further optimization.

In my test case
ClickHouse + cache 15.057 sec
Previous sr + cache(all go through memory) 17.303 sec
In this pr, sr + cache(all go through memory) 15.009 sec

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
