### PR TITLE
[BugFix] Fix decimalv2 to string different as BE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -329,6 +329,8 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
             double val = (double) Optional.ofNullable(value).orElse((double) 0);
             BigDecimal decimal = BigDecimal.valueOf(val);
             return decimal.stripTrailingZeros().toPlainString();
+        } else if (type.isDecimalV2()) {
+            return String.valueOf(value);
         } else if (type.isDecimalOfAnyVersion()) {
             // align zero, keep same with BE
             int scale = ((ScalarType) type).getScalarScale();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -233,4 +233,23 @@ public class DecimalTypeTest extends PlanTestBase {
         }
 
     }
+
+    @Test
+    public void testDecimalV2Cast() throws Exception {
+        String sql = "select cast('12.367' as decimalv2(9,0));";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "12.367");
+
+        sql = "select cast('12.367' as decimalv2(9,1));";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "12.367");
+
+        sql = "select cast('12.367' as decimalv2(9,2));";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "12.367");
+
+        sql = "select cast(cast('12.56' as decimalv2(9,1)) as varchar);";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "'12.56'");
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/pull/27235

different behavior when decimalV2 cast to string, I can't promise the behavior is correct, but it's consistent with be at least 

```
MySQL td>  select cast('12.367' as decimalv2(9,1));
+--------------------------------+
| CAST('12.367' AS DECIMAL(9,1)) |
+--------------------------------+
| 12.367                         |
+--------------------------------+
1 row in set
Time: 0.015s
MySQL td>  select cast(cast('12.56' as decimalv2(9,1)) as varchar);
+--------------------------------------------------+
| CAST((CAST('12.56' AS DECIMAL(9,1))) AS VARCHAR) |
+--------------------------------------------------+
| 13                                               |
+--------------------------------------------------+
1 row in set
Time: 0.017s
MySQL td>
MySQL td> select * from s2;
+----+----+--------+
| v1 | v2 | v3     |
+----+----+--------+
| 1  | 1  | 12.367 |
+----+----+--------+
1 row in set
Time: 0.025s
MySQL td>    select cast(cast(v3 as decimalv2(9,1)) as varchar) from s2;
+---------------------------------------------+
| CAST((CAST(v3 AS DECIMAL(9,1))) AS VARCHAR) |
+---------------------------------------------+
| 12.367                                      |
+---------------------------------------------+
1 row in set
Time: 0.023s
MySQL td>
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
