### PR TITLE
[Enhancement] prune subfields in unnested array

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -444,6 +444,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_REWRITE_SIMPLE_AGG_TO_META_SCAN = "enable_rewrite_simple_agg_to_meta_scan";
 
     public static final String ENABLE_PRUNE_COMPLEX_TYPES = "enable_prune_complex_types";
+    public static final String ENABLE_PRUNE_COMPLEX_TYPES_IN_UNNEST = "enable_prune_complex_types_in_unnest";
     public static final String RANGE_PRUNER_PREDICATES_MAX_LEN = "range_pruner_max_predicate";
 
     public static final String GROUP_CONCAT_MAX_LEN = "group_concat_max_len";
@@ -1271,6 +1272,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_PRUNE_COMPLEX_TYPES)
     private boolean enablePruneComplexTypes = true;
+
+    @VarAttr(name = ENABLE_PRUNE_COMPLEX_TYPES_IN_UNNEST)
+    private boolean enablePruneComplexTypesInUnnest = true;
 
     @VarAttr(name = RANGE_PRUNER_PREDICATES_MAX_LEN)
     public int rangePrunerPredicateMaxLen = 100;
@@ -2468,6 +2472,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnablePruneComplexTypes(boolean enablePruneComplexTypes) {
         this.enablePruneComplexTypes = enablePruneComplexTypes;
+    }
+
+    public boolean getEnablePruneComplexTypesInUnnest() {
+        return this.enablePruneComplexTypesInUnnest;
+    }
+
+    public void setEnablePruneComplexTypesInUnnest(boolean enablePruneComplexTypesInUnnest) {
+        this.enablePruneComplexTypesInUnnest = enablePruneComplexTypesInUnnest;
     }
 
     public int getRangePrunerPredicateMaxLen() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/pattern/Pattern.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/pattern/Pattern.java
@@ -32,6 +32,7 @@ public class Pattern {
             .add(OperatorType.LOGICAL_HIVE_SCAN)
             .add(OperatorType.LOGICAL_ICEBERG_SCAN)
             .add(OperatorType.LOGICAL_HUDI_SCAN)
+            .add(OperatorType.LOGICAL_FILE_SCAN)
             .add(OperatorType.LOGICAL_SCHEMA_SCAN)
             .add(OperatorType.LOGICAL_MYSQL_SCAN)
             .add(OperatorType.LOGICAL_ES_SCAN)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneComplexTypeUtil.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.MapType;
 import com.starrocks.catalog.StructType;
 import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -60,12 +61,15 @@ public class PruneComplexTypeUtil {
     protected static class Context {
         // The same ColumnRefOperator may have multiple access paths for complex type
         private final Map<ColumnRefOperator, ComplexTypeAccessGroup> accessGroups;
-
+        private final Map<ColumnRefOperator, ColumnRefOperator> unnestColRefMap;
+        private boolean enablePruneComplexTypesInUnnest;
         private boolean enablePruneComplexTypes;
 
-        public Context() {
+        public Context(boolean enablePruneComplexTypesInUnnest) {
             this.accessGroups = new HashMap<>();
             this.enablePruneComplexTypes = true;
+            this.unnestColRefMap = new HashMap<>();
+            this.enablePruneComplexTypesInUnnest = enablePruneComplexTypesInUnnest;
         }
 
         public void setEnablePruneComplexTypes(boolean enablePruneComplexTypes) {
@@ -79,6 +83,12 @@ public class PruneComplexTypeUtil {
         public void addAccessPaths(ColumnRefOperator columnRefOperator, ComplexTypeAccessPaths accessPaths) {
             accessGroups.putIfAbsent(columnRefOperator, new ComplexTypeAccessGroup());
             accessGroups.get(columnRefOperator).addAccessPaths(accessPaths);
+
+            ColumnRefOperator oriColRefOperator = getOriginalColRef(columnRefOperator);
+            if (oriColRefOperator != columnRefOperator) {
+                accessGroups.putIfAbsent(oriColRefOperator, new ComplexTypeAccessGroup());
+                accessGroups.get(oriColRefOperator).addAccessPaths(accessPaths);
+            }
         }
 
         public void addAccessPaths(ColumnRefOperator columnRefOperator,
@@ -110,8 +120,41 @@ public class PruneComplexTypeUtil {
             scalarOperator.accept(markSubfieldsVisitor, this);
         }
 
+        public void setUnnest(PhysicalTableFunctionOperator operator) {
+            for (int i = 0; i < operator.getFnResultColRefs().size(); i++) {
+                ColumnRefOperator output = operator.getFnResultColRefs().get(i);
+                ColumnRefOperator input = operator.getFnParamColumnRefs().get(i);
+                unnestColRefMap.put(output, input);
+                if (getVisitedAccessGroup(output) != null) {
+                    accessGroups.put(input, getVisitedAccessGroup(output));
+                    if (operator.getProjection() == null && operator.getOutputColRefs().contains(output)) {
+                        add(input, input);
+                    }
+                }
+            }
+        }
+
+        public boolean isEnablePruneComplexTypesInUnnest() {
+            return enablePruneComplexTypesInUnnest;
+        }
+
+        public boolean hasUnnestColRefMapValue(ColumnRefOperator columnRefOperator) {
+            return unnestColRefMap.containsValue(columnRefOperator);
+        }
+
+        public boolean hasUnnestColRefMapKey(ColumnRefOperator columnRefOperator) {
+            return unnestColRefMap.containsKey(columnRefOperator);
+        }
+
         public ComplexTypeAccessGroup getVisitedAccessGroup(ColumnRefOperator columnRefOperator) {
             return accessGroups.get(columnRefOperator);
+        }
+
+        private ColumnRefOperator getOriginalColRef(ColumnRefOperator col) {
+            if (unnestColRefMap.containsKey(col)) {
+                return unnestColRefMap.get(col);
+            }
+            return col;
         }
 
         private boolean checkCanPrune(ColumnRefOperator columnRefOperator, ScalarOperator scalarOperator) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rule.tree;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ComplexTypeAccessGroup;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.FeConstants;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -24,6 +25,7 @@ import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalTableFunctionOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -47,7 +49,8 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
         }
         // Store all operator's context, used for PRUNE_SUBFIELDS_OPT_VISITOR.
         // globalContext contains all physical operators' context
-        PruneComplexTypeUtil.Context context = new PruneComplexTypeUtil.Context();
+        PruneComplexTypeUtil.Context context = new PruneComplexTypeUtil.Context(
+                taskContext.getOptimizerContext().getSessionVariable().getEnablePruneComplexTypesInUnnest());
         root.getOp().accept(MARK_SUBFIELDS_OPT_VISITOR, root, context);
         if (context.getEnablePruneComplexTypes()) {
             // Still do prune
@@ -82,6 +85,19 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
                 opt.getOp().accept(this, opt, context);
             }
             return null;
+        }
+
+        @Override
+        public Void visitPhysicalTableFunction(OptExpression optExpression,
+                                               PruneComplexTypeUtil.Context context) {
+            PhysicalTableFunctionOperator tableFunctionOperator = (PhysicalTableFunctionOperator) optExpression.getOp();
+            // only prune type in unnest()
+            if (context.isEnablePruneComplexTypesInUnnest() &&
+                    tableFunctionOperator.getFn().functionName().equalsIgnoreCase("unnest") &&
+                    tableFunctionOperator.getFnParamColumnRefs().size() == tableFunctionOperator.getFnResultColRefs().size()) {
+                context.setUnnest(tableFunctionOperator);
+            }
+            return visit(optExpression, context);
         }
 
         @Override
@@ -124,7 +140,8 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
             Projection projection = optExpression.getOp().getProjection();
             if (projection == null) {
                 for (ColumnRefOperator columnRefOperator : physicalScanOperator.getOutputColumns()) {
-                    if (columnRefOperator.getType().isMapType() || columnRefOperator.getType().isStructType()) {
+                    if ((columnRefOperator.getType().isMapType() || columnRefOperator.getType().isStructType()) &&
+                            !context.hasUnnestColRefMapValue(columnRefOperator)) {
                         context.add(columnRefOperator, columnRefOperator);
                     }
                 }
@@ -153,7 +170,7 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
         public Void visitPhysicalScan(OptExpression optExpression, PruneComplexTypeUtil.Context context) {
             PhysicalScanOperator physicalScanOperator = (PhysicalScanOperator) optExpression.getOp();
 
-            if (OperatorType.PHYSICAL_OLAP_SCAN.equals(physicalScanOperator.getOpType())) {
+            if (OperatorType.PHYSICAL_OLAP_SCAN.equals(physicalScanOperator.getOpType()) && !FeConstants.runningUnitTest) {
                 // olap scan operator prune column not in this rule
                 return null;
             }
@@ -162,6 +179,19 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
                     .entrySet()) {
                 if (entry.getKey().getType().isComplexType()) {
                     pruneForComplexType(entry.getKey(), context);
+                }
+            }
+            return visit(optExpression, context);
+        }
+
+        @Override
+        public Void visitPhysicalTableFunction(OptExpression optExpression, PruneComplexTypeUtil.Context context) {
+            PhysicalTableFunctionOperator operator = (PhysicalTableFunctionOperator) optExpression.getOp();
+            for (int i = 0; i < operator.getFnResultColRefs().size(); i++) {
+                ColumnRefOperator output = operator.getFnResultColRefs().get(i);
+                if (output.getType().isComplexType() && context.hasUnnestColRefMapKey(output)) {
+                    pruneForComplexType(output, context);
+                    operator.getFn().getTableFnReturnTypes().set(i, output.getType());
                 }
             }
             return visit(optExpression, context);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/StructTypePlanTest.java
@@ -40,12 +40,18 @@ public class StructTypePlanTest extends PlanTestBase {
                 "c3 struct<a int, b int, c struct<a int, b int>, d array<int>>) " +
                 "duplicate key(c0) distributed by hash(c0) buckets 1 " +
                 "properties('replication_num'='1');");
+        starRocksAssert.withTable("create table array_struct_nest(c1 int, " +
+                "c2 array<struct<c2_sub1 int, c2_sub2 int>>, " +
+                "c3 struct<c3_sub1 array<struct<c3_sub1_sub1 int, c3_sub1_sub2 int>>, c3_sub2 int>) " +
+                "duplicate key(c1) distributed by hash(c1) buckets 1 " +
+                "properties('replication_num'='1');");
         FeConstants.runningUnitTest = false;
     }
 
     @Before
     public void setup() throws Exception {
         connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
+        connectContext.getSessionVariable().setEnablePruneComplexTypesInUnnest(true);
         connectContext.getSessionVariable().setCboPruneSubfield(true);
     }
 
@@ -207,5 +213,79 @@ public class StructTypePlanTest extends PlanTestBase {
                 "  |  output columns:\n" +
                 "  |  5 <-> 2: c1.b[111]",
                 "Pruned type: 2 <-> [struct<a int(11), b array<struct<a int(11), b int(11)>>>]");
+    }
+
+    @Test
+    public void testNoProjectOnTF() throws Exception {
+        FeConstants.runningUnitTest = true;
+        // no project on input, and no project on tf, no prune
+        String sql = "select c2_struct from array_struct_nest, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        sql = "select c2 from array_struct_nest, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        sql = "select c2, c2_struct from array_struct_nest, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        // project on input, no project on tf, prune
+        sql = "select c3_struct from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), c3_sub1_sub2 int(11)>>>]");
+        // output contains the complete column, no prune
+        sql = "select c3 from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), " +
+                "c3_sub1_sub2 int(11)>>, c3_sub2 int(11)>]");
+        sql = "select c3, c3_struct from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), " +
+                "c3_sub1_sub2 int(11)>>, c3_sub2 int(11)>]");
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testProjectOnTF() throws Exception {
+        FeConstants.runningUnitTest = true;
+        // no project on input, and project on tf, prune
+        String sql = "select c2_struct.c2_sub1 from array_struct_nest, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11)>>]");
+        // no project on input, and project on tf all subfiled, no prune
+        sql = "select c2_struct.c2_sub1, c2_struct.c2_sub2 from array_struct_nest, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        sql = "select c2_struct, c2_struct.c2_sub2 from array_struct_nest, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        // project on input, project on tf, prune
+        sql = "select c3_struct.c3_sub1_sub1 from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11)>>>]");
+        // project on input, project on tf but all subfiled, prune
+        sql = "select c3_struct.c3_sub1_sub1, c3_struct.c3_sub1_sub2 from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), c3_sub1_sub2 int(11)>>>]");
+        sql = "select c3_struct.c3_sub1_sub1, c3_struct from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), c3_sub1_sub2 int(11)>>>]");
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testNoOutputOnTF() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String sql = "select c1 from array_struct_nest, unnest(c2) as t(c2_struct) where c2_struct.c2_sub1 > 0;";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11)>>]");
+        sql = "select c1 from array_struct_nest, unnest(c3.c3_sub1) as t(c3_struct) where c3_struct.c3_sub1_sub1 > 0;";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11)>>>]");
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testUnnestComplex() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String sql = "select c3_struct.c3_sub1_sub1 from array_struct_nest, unnest(c2) as t(c_struct), " +
+                "unnest(c3.c3_sub1) as tt(c3_struct) where c_struct.c2_sub1 > 10";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11)>>]");
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11)>>>]");
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testUnnestCrossJoin() throws Exception {
+        FeConstants.runningUnitTest = true;
+        String sql = "select c3_struct.c3_sub1_sub1 from array_struct_nest cross join " +
+                "unnest(c3.c3_sub1) as t(c3_struct) where c1 > 0;";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11)>>>]");
+        FeConstants.runningUnitTest = false;
     }
 }


### PR DESCRIPTION
for array column of struct type like array_column array<struct<c1, c2, c3>>, 
when use unnest like `select a.c1 from table, unnest(array_col) as t (a)`,
the sql only use c1 subfiled of the unnested array column a,  but for physical 
scan node can't get the information of subfiled usage of array_column, 
so we need a map, storage the subfiled usage of column a and then map it to 
the original column array_column, so that the useless subfiled can be pruned.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
