### PR TITLE
[BugFix] Fix TableAndViewCollector when creating mv with agg or subquery

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -2228,8 +2228,25 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testCollectAllTableAndView() {
+    public void testCollectAllTableAndView1() {
         String sql = "select k2,v1 from test.tbl1 where k2 > 0 and v1 not in (select v1 from test.tbl2 where k2 > 0);";
+        try {
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            Map<TableName, Table> result = AnalyzerUtils.collectAllTableAndView(statementBase);
+            Assert.assertEquals(result.size(), 2);
+        } catch (Exception e) {
+            LOG.error("Test CollectAllTableAndView failed", e);
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testCollectAllTableAndView2() {
+        String sql = "select * from test.tbl2 " +
+                "inner join (select k2,v1 from test.tbl1 where k2 > 0 and v1 in " +
+                "(select distinct v1 from test.tbl2 where k2 > 0)) t on t.v1 = tbl2.v1 " +
+                "inner join (select k2, v1 from test.tbl1 where k2 > 20 and " +
+                " v1 in (select distinct v1 from test.tbl1 where k2 < 0)) t2 on t2.v1=tbl2.v1;";
         try {
             StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             Map<TableName, Table> result = AnalyzerUtils.collectAllTableAndView(statementBase);


### PR DESCRIPTION
Fixes #30231

- When creating mv with subquery predicate expression, original codes cannot collect the base tables of QueryStatement, which will cause the materialized view's base table infos are not correct .
- 3.0/3.1 version is fixed by this pr: [BugFix] Fix bug grant DML privilege miss check table in query by HangyuanLiu · Pull Request #18808 

```
        @Override
        public Void visitExpression(Expr node, Void context) {
            node.getChildren().forEach(this::visit);
            return null;
        }
```
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
