### PR TITLE
[BugFix] fix comments not being discarded when to AST

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocksLex.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocksLex.g4
@@ -546,7 +546,7 @@ SIMPLE_COMMENT
     ;
 
 BRACKETED_COMMENT
-    : '/*' ~'+' .*? '*/' -> channel(HIDDEN)
+    : '/*' ('+'? [ \r\n\t\u3000]* | ~'+' .*?) '*/' -> channel(HIDDEN)
     ;
 
 SEMICOLON: ';';

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -759,6 +759,5 @@ public class AnalyzeSingleTest {
         analyzeSuccess("select v1 /*    a*/ from t0");
         analyzeSuccess("select v1 /*abc    '中文\n'*/ from t0");
         analyzeSuccess("select /*+ SET_VAR ('abc' = 'abc')*/ v1  from t0");
-
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -743,4 +743,22 @@ public class AnalyzeSingleTest {
                 "contend and col = \"''```中\t文  \\\"\r\n" +
                 "\\r\\n\\t\\\"英  文\" and `col`= 'abc\"bcd\\'';`", res);
     }
+
+    @Test
+    public void test() {
+        analyzeFail("select /*+ SET */ v1 from t0",
+                "Unexpected input 'SET', the most similar input is {'SET_VAR'}");
+        analyzeFail("select /*+   abc*/ v1 from t0",
+                "Unexpected input 'abc', the most similar input is {'SET_VAR'}");
+
+        analyzeSuccess("select v1 /*+*/ from t0");
+        analyzeSuccess("select v1 /*+\n*/ from t0");
+        analyzeSuccess("select v1 /*+   \n\n*/ from t0");
+        analyzeSuccess("select v1 /**/ from t0");
+        analyzeSuccess("select v1 /*    */ from t0");
+        analyzeSuccess("select v1 /*    a*/ from t0");
+        analyzeSuccess("select v1 /*abc    '中文\n'*/ from t0");
+        analyzeSuccess("select /*+ SET_VAR ('abc' = 'abc')*/ v1  from t0");
+
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -745,7 +745,7 @@ public class AnalyzeSingleTest {
     }
 
     @Test
-    public void test() {
+    public void testRemoveComments() {
         analyzeFail("select /*+ SET */ v1 from t0",
                 "Unexpected input 'SET', the most similar input is {'SET_VAR'}");
         analyzeFail("select /*+   abc*/ v1 from t0",


### PR DESCRIPTION
Fixes #issue
```
/**/

/*+*/

/*+
*/
```
These above comments are not being discarded when extracting token streams.
This pr just fix the speicial scenes, while it cannot discard comments like `/*+ abc */`. We will redirect these `/*+ string*/ ` style comments to another channel and process them to extract hint message later.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
