### PR TITLE
[Enhancement] Improve the profile serialization performance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -770,6 +770,17 @@ public class RuntimeProfile {
 
         @Override
         public String format(RuntimeProfile profile, String prefix) {
+            this.doFormat(profile, prefix);
+            return builder.toString();
+        }
+
+        @Override
+        public String format(RuntimeProfile profile) {
+            this.doFormat(profile, "");
+            return builder.toString();
+        }
+
+        private void doFormat(RuntimeProfile profile, String prefix) {
             Counter totalTimeCounter = profile.getCounterMap().get(TOTAL_TIME_COUNTER);
             Preconditions.checkState(totalTimeCounter != null);
             // 1. profile name
@@ -803,14 +814,8 @@ public class RuntimeProfile {
             for (Pair<RuntimeProfile, Boolean> childPair : profile.getChildList()) {
                 boolean indent = childPair.second;
                 RuntimeProfile childProfile = childPair.first;
-                format(childProfile, prefix + (indent ? "  " : ""));
+                doFormat(childProfile, prefix + (indent ? "  " : ""));
             }
-            return builder.toString();
-        }
-
-        @Override
-        public String format(RuntimeProfile profile) {
-            return this.format(profile, "");
         }
 
         private void printChildCounters(RuntimeProfile profile, String prefix, String counterName) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -317,10 +317,14 @@ public class StmtExecutor {
             if (coord.getQueryProfile() != null) {
                 coord.getQueryProfile().getCounterTotalTime()
                         .setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
+                long profileCollectStartTime = System.currentTimeMillis();
                 coord.endProfile();
+                profile.getChild("Summary").addInfoString(ProfileManager.PROFILE_TIME,
+                        DebugUtil.getPrettyStringMs(System.currentTimeMillis() - profileCollectStartTime));
                 profile.addChild(coord.buildMergedQueryProfile());
             }
         }
+        profile.computeTimeInChildProfile();
     }
 
     public boolean isForwardToLeader() {
@@ -746,15 +750,7 @@ public class StmtExecutor {
     }
 
     private void writeProfile(ExecPlan plan, long beginTimeInNanoSecond) {
-        long profileBeginTime = System.currentTimeMillis();
         initProfile(beginTimeInNanoSecond);
-        profile.computeTimeInChildProfile();
-        long profileEndTime = System.currentTimeMillis();
-        profile.getChild("Summary")
-                .addInfoString(ProfileManager.PROFILE_TIME,
-                        DebugUtil.getPrettyStringMs(profileEndTime - profileBeginTime));
-        StringBuilder builder = new StringBuilder();
-        profile.prettyPrint(builder, "");
         ProfilingExecPlan profilingPlan = plan == null ? null : plan.getProfilingPlan();
         String profileContent = ProfileManager.getInstance().pushProfile(profilingPlan, profile);
         if (context.getQueryDetail() != null) {


### PR DESCRIPTION
## Root cause

When serializing a `RuntimeProfile` instance to String, the `StringBuilder::toString()` has been invoked too many times, which is time-consumed.

And the solution is simple, remove the unnecessary calls.

## Test

For query like this: [union_query.txt](https://github.com/StarRocks/starrocks/files/12483428/union_query.txt)

Time usage before this pr(with profile enabled): 
* non-pipeline: 2.5s
* pipeline: 16s

Time usage after this pr(with profile enable): 
* non-pipeline: 0.8s
* pipeline: 2s

The profile of the pipeline is more intricate than that of the non-pipeline. While the pipeline offers a significant performance improvement, its profile size remains larger than the non-pipeline's, resulting in greater overall time consumption.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
