### PR TITLE
[Feature] Add `hadoop-ext` package to support credential isolation

### DIFF
--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -134,7 +134,7 @@ export LIBHDFS_OPTS="$LIBHDFS_OPTS -Xrs"
 
 # HADOOP_CLASSPATH defined in $STARROCKS_HOME/conf/hadoop_env.sh
 # put $STARROCKS_HOME/conf ahead of $HADOOP_CLASSPATH so that custom config can replace the config in $HADOOP_CLASSPATH
-export CLASSPATH=$STARROCKS_HOME/conf:$STARROCKS_HOME/lib/jni-packages/*:$HADOOP_CLASSPATH:$CLASSPATH
+export CLASSPATH=${STARROCKS_HOME}/lib/jni-packages/starrocks-hadoop-ext.jar:$STARROCKS_HOME/conf:$STARROCKS_HOME/lib/jni-packages/*:$HADOOP_CLASSPATH:$CLASSPATH
 
 
 # ================= native section =====================

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -151,7 +151,7 @@ fi
 for f in $STARROCKS_HOME/lib/*.jar; do
   CLASSPATH=$f:${CLASSPATH};
 done
-export CLASSPATH=${CLASSPATH}:${STARROCKS_HOME}/lib:${STARROCKS_HOME}/conf
+export CLASSPATH=${STARROCKS_HOME}/lib/starrocks-hadoop-ext.jar:${CLASSPATH}:${STARROCKS_HOME}/lib:${STARROCKS_HOME}/conf
 
 pidfile=$PID_DIR/fe.pid
 

--- a/build.sh
+++ b/build.sh
@@ -399,6 +399,8 @@ if [ ${FE_MODULES}x != ""x ]; then
         ${MVN_CMD} clean
     fi
     ${MVN_CMD} package -am -pl ${FE_MODULES} -DskipTests
+    cd ${STARROCKS_HOME}/java-extensions
+    ${MVN_CMD} package -am -pl hadoop-ext -DskipTests
     cd ${STARROCKS_HOME}
 fi
 
@@ -423,6 +425,7 @@ if [ ${BUILD_FE} -eq 1 -o ${BUILD_SPARK_DPP} -eq 1 ]; then
         rm -rf ${STARROCKS_OUTPUT}/fe/lib/*
         cp -r -p ${STARROCKS_HOME}/fe/fe-core/target/lib/* ${STARROCKS_OUTPUT}/fe/lib/
         cp -r -p ${STARROCKS_HOME}/fe/fe-core/target/starrocks-fe.jar ${STARROCKS_OUTPUT}/fe/lib/
+        cp -r -p ${STARROCKS_HOME}/java-extensions/hadoop-ext/target/starrocks-hadoop-ext.jar ${STARROCKS_OUTPUT}/fe/lib/
         cp -r -p ${STARROCKS_HOME}/webroot/* ${STARROCKS_OUTPUT}/fe/webroot/
         cp -r -p ${STARROCKS_HOME}/fe/spark-dpp/target/spark-dpp-*-jar-with-dependencies.jar ${STARROCKS_OUTPUT}/fe/spark-dpp/
         cp -r -p ${STARROCKS_THIRDPARTY}/installed/jindosdk/* ${STARROCKS_OUTPUT}/fe/lib/
@@ -483,6 +486,7 @@ if [ ${BUILD_BE} -eq 1 ]; then
     cp -r -p ${STARROCKS_HOME}/java-extensions/paimon-reader/target/paimon-reader-lib ${STARROCKS_OUTPUT}/be/lib/
     cp -r -p ${STARROCKS_HOME}/java-extensions/paimon-reader/target/starrocks-paimon-reader.jar ${STARROCKS_OUTPUT}/be/lib/jni-packages
     cp -r -p ${STARROCKS_HOME}/java-extensions/paimon-reader/target/starrocks-paimon-reader.jar ${STARROCKS_OUTPUT}/be/lib/paimon-reader-lib
+    cp -r -p ${STARROCKS_HOME}/java-extensions/hadoop-ext/target/starrocks-hadoop-ext.jar ${STARROCKS_OUTPUT}/be/lib/jni-packages
     cp -r -p ${STARROCKS_THIRDPARTY}/installed/hadoop/share/hadoop/common ${STARROCKS_OUTPUT}/be/lib/hadoop/
     cp -r -p ${STARROCKS_THIRDPARTY}/installed/hadoop/share/hadoop/hdfs ${STARROCKS_OUTPUT}/be/lib/hadoop/
     cp -p ${STARROCKS_THIRDPARTY}/installed/hadoop/share/hadoop/tools/lib/hadoop-azure-* ${STARROCKS_OUTPUT}/be/lib/hadoop/hdfs

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfiguration.java
@@ -27,7 +27,9 @@ import org.apache.logging.log4j.Logger;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.starrocks.credential.CloudConfigurationConstants.HDFS_CLOUD_CONFIGURATION_STRING;
 import static com.starrocks.credential.CloudConfigurationConstants.HDFS_CONFIG_RESOURCES;
+import static com.starrocks.credential.CloudConfigurationConstants.HDFS_CONFIG_RESOURCES_LOADED;
 import static com.starrocks.credential.CloudConfigurationConstants.HDFS_RUNTIME_JARS;
 
 public class CloudConfiguration {
@@ -41,6 +43,7 @@ public class CloudConfiguration {
         Map<String, String> properties = new HashMap<>();
         properties.put(HDFS_CONFIG_RESOURCES, configResources);
         properties.put(HDFS_RUNTIME_JARS, runtimeJars);
+        properties.put(HDFS_CLOUD_CONFIGURATION_STRING, toConfString());
         tCloudConfiguration.setCloud_properties_v2(properties);
     }
 
@@ -54,10 +57,12 @@ public class CloudConfiguration {
             LOG.debug(String.format("Add path '%s' to configuration", path.toString()));
             conf.addResource(path);
         }
+        conf.setBoolean(HDFS_CONFIG_RESOURCES_LOADED, true);
     }
 
     public void applyToConfiguration(Configuration configuration) {
         addConfigResourcesToConfiguration(configResources, configuration);
+        configuration.set(HDFS_CLOUD_CONFIGURATION_STRING, toConfString());
     }
 
     // Hadoop FileSystem has a cache itself, it used request uri as a cache key by default,

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationConstants.java
@@ -108,6 +108,9 @@ public class CloudConfigurationConstants {
     public static final String HDFS_CONFIG_RESOURCES = "hadoop.config.resources";
     public static final String HDFS_RUNTIME_JARS = "hadoop.runtime.jars";
 
+    public static final String HDFS_CLOUD_CONFIGURATION_STRING = "hadoop.cloud.configuration.string";
+    public static final String HDFS_CONFIG_RESOURCES_LOADED = "hadoop.config.resources.loaded";
+
     // Credential for Aliyun OSS
     public static final String ALIYUN_OSS_ACCESS_KEY = "aliyun.oss.access_key";
     public static final String ALIYUN_OSS_SECRET_KEY = "aliyun.oss.secret_key";

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3726,8 +3726,8 @@ public abstract class FileSystem extends Configured
      */
     private static FileSystem createFileSystem(URI uri, Configuration conf)
             throws IOException {
-        Cache.StarRocksUtils.addConfigResourcesToConfiguration(conf);
-        LOGGER.info(String.format("%s FileSystem.createFileSystem. conf.XXX = %s", Cache.StarRocksUtils.LOG_MESSAGE_PREFIX,
+        HadoopExt.addConfigResourcesToConfiguration(conf);
+        LOGGER.info(String.format("%s FileSystem.createFileSystem. conf.XXX = %s", HadoopExt.LOGGER_MESSAGE_PREFIX,
                 conf.get("XXX", "null")));
         Tracer tracer = FsTracer.get(conf);
         try (TraceScope scope = tracer.newScope("FileSystem#createFileSystem");
@@ -3797,7 +3797,7 @@ public abstract class FileSystem extends Configured
 
         FileSystem get(URI uri, Configuration conf) throws IOException {
             Key key = new Key(uri, conf);
-            LOGGER.info(String.format("%s FileSystem.get. key = %s", StarRocksUtils.LOG_MESSAGE_PREFIX, key.toString()));
+            LOGGER.info(String.format("%s FileSystem.get. key = %s", HadoopExt.LOGGER_MESSAGE_PREFIX, key.toString()));
             return getInternal(uri, conf, key);
         }
 
@@ -4005,41 +4005,6 @@ public abstract class FileSystem extends Configured
             }
         }
 
-        static class StarRocksUtils {
-            public static final String HDFS_CONFIG_RESOURCES = "hadoop.config.resources";
-            public static final String HDFS_CONFIG_RESOURCES_LOADED = "hadoop.config.resources.loaded";
-            public static final String HDFS_RUNTIME_JARS = "hadoop.runtime.jars";
-            public static final String HDFS_CLOUD_CONFIGURATION_STRING = "hadoop.cloud.configuration.string";
-            public static final String STARROCKS_HOME_ENV = "STARROCKS_HOME";
-            public static final String LOG_MESSAGE_PREFIX = "[hadoop-ext]";
-
-            public static void addConfigResourcesToConfiguration(Configuration conf) {
-                if (conf.getBoolean(HDFS_CONFIG_RESOURCES_LOADED, false)) {
-                    return;
-                }
-                String configResources = conf.get(HDFS_CONFIG_RESOURCES);
-                if (configResources == null || configResources.isEmpty()) {
-                    return;
-                }
-                final String STARROCKS_HOME_DIR = System.getenv(STARROCKS_HOME_ENV);
-                if (STARROCKS_HOME_DIR == null) {
-                    LOGGER.info(String.format("%s env '%s' is not defined", LOG_MESSAGE_PREFIX, STARROCKS_HOME_ENV));
-                    return;
-                }
-                String[] parts = configResources.split(",");
-                for (String p : parts) {
-                    Path path = new Path(STARROCKS_HOME_DIR + "/conf/", p);
-                    LOGGER.info(String.format("%s Add path '%s' to configuration", LOG_MESSAGE_PREFIX, path.toString()));
-                    conf.addResource(path);
-                }
-                conf.setBoolean(HDFS_CONFIG_RESOURCES_LOADED, true);
-            }
-
-            public static String getCloudConfString(Configuration conf) {
-                return conf.get(HDFS_CLOUD_CONFIGURATION_STRING, "");
-            }
-        }
-
         /**
          * FileSystem.Cache.Key
          */
@@ -4065,7 +4030,7 @@ public abstract class FileSystem extends Configured
 
                 this.ugi = UserGroupInformation.getCurrentUser();
 
-                this.cloudConf = StarRocksUtils.getCloudConfString(conf);
+                this.cloudConf = HadoopExt.getCloudConfString(conf);
             }
 
             @Override

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -598,6 +598,7 @@ public abstract class FileSystem extends Configured
             return createFileSystem(uri, conf);
         }
 
+        LOGGER.warn("[XXX] FileSystem.Cache from hadoop-ext package");
         return CACHE.get(uri, conf);
     }
 

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4026,6 +4026,7 @@ public abstract class FileSystem extends Configured
                     LOGGER.debug(String.format("[hadoop-ext] Add path '%s' to configuration", path.toString()));
                     conf.addResource(path);
                 }
+                conf.setBoolean(HDFS_CONFIG_RESOURCES_LOADED, true);
             }
 
             public static String getFSCredential(Configuration conf) {

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3727,8 +3727,7 @@ public abstract class FileSystem extends Configured
     private static FileSystem createFileSystem(URI uri, Configuration conf)
             throws IOException {
         HadoopExt.addConfigResourcesToConfiguration(conf);
-        LOGGER.info(String.format("%s FileSystem.createFileSystem. conf.XXX = %s", HadoopExt.LOGGER_MESSAGE_PREFIX,
-                conf.get("XXX", "null")));
+        LOGGER.info(String.format("%s FileSystem.createFileSystem", HadoopExt.LOGGER_MESSAGE_PREFIX));
         Tracer tracer = FsTracer.get(conf);
         try (TraceScope scope = tracer.newScope("FileSystem#createFileSystem");
                 DurationInfo ignored =

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3729,6 +3729,7 @@ public abstract class FileSystem extends Configured
     private static FileSystem createFileSystem(URI uri, Configuration conf)
             throws IOException {
         Cache.StarRocksUtils.addConfigResourcesToConfiguration(conf);
+        LOGGER.info("[hadoop-ext] FileSystem.createFileSystem. conf.XXX = " + conf.get("XXX", "null"));
         Tracer tracer = FsTracer.get(conf);
         try (TraceScope scope = tracer.newScope("FileSystem#createFileSystem");
                 DurationInfo ignored =

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4009,12 +4009,10 @@ public abstract class FileSystem extends Configured
          * FileSystem.Cache.Key
          */
         static class Key {
-
             final String scheme;
             final String authority;
             final UserGroupInformation ugi;
             final long unique;   // an artificial way to make a key unique
-
             final String cloudConf;
 
             Key(URI uri, Configuration conf) throws IOException {
@@ -4062,7 +4060,6 @@ public abstract class FileSystem extends Configured
             public String toString() {
                 return "(ugi = " + ugi.toString() + ", cloudConf = " + cloudConf + ")@" + scheme + "://" + authority;
             }
-
         }
     }
 

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -83,6 +83,7 @@ import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.FileAlreadyExistsException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -3797,6 +3797,7 @@ public abstract class FileSystem extends Configured
 
         FileSystem get(URI uri, Configuration conf) throws IOException {
             Key key = new Key(uri, conf);
+            LOGGER.info("[hadoop-ext] FileSystem.get. key = " + key.toString());
             return getInternal(uri, conf, key);
         }
 
@@ -4021,13 +4022,13 @@ public abstract class FileSystem extends Configured
                 }
                 final String STARROCKS_HOME_DIR = System.getenv(STARROCKS_HOME_ENV);
                 if (STARROCKS_HOME_DIR == null) {
-                    LOGGER.warn(String.format("[hadoop-ext] env '%s' is not defined", STARROCKS_HOME_ENV));
+                    LOGGER.info(String.format("[hadoop-ext] env '%s' is not defined", STARROCKS_HOME_ENV));
                     return;
                 }
                 String[] parts = configResources.split(",");
                 for (String p : parts) {
                     Path path = new Path(STARROCKS_HOME_DIR + "/conf/", p);
-                    LOGGER.debug(String.format("[hadoop-ext] Add path '%s' to configuration", path.toString()));
+                    LOGGER.info(String.format("[hadoop-ext] Add path '%s' to configuration", path.toString()));
                     conf.addResource(path);
                 }
                 conf.setBoolean(HDFS_CONFIG_RESOURCES_LOADED, true);

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -598,7 +598,7 @@ public abstract class FileSystem extends Configured
             return createFileSystem(uri, conf);
         }
 
-        LOGGER.warn("[XXX] FileSystem.Cache from hadoop-ext package");
+        LOGGER.warn("[hadoop-ext] FileSystem.Cache from hadoop-ext package");
         return CACHE.get(uri, conf);
     }
 
@@ -3728,6 +3728,7 @@ public abstract class FileSystem extends Configured
      */
     private static FileSystem createFileSystem(URI uri, Configuration conf)
             throws IOException {
+        Cache.StarRocksUtils.addConfigResourcesToConfiguration(conf);
         Tracer tracer = FsTracer.get(conf);
         try (TraceScope scope = tracer.newScope("FileSystem#createFileSystem");
                 DurationInfo ignored =
@@ -4003,14 +4004,46 @@ public abstract class FileSystem extends Configured
             }
         }
 
+        static class StarRocksUtils {
+            public static final String HDFS_CONFIG_RESOURCES = "hadoop.config.resources";
+            public static final String HDFS_CONFIG_RESOURCES_LOADED = "hadoop.config.resources.loaded";
+            public static final String HDFS_RUNTIME_JARS = "hadoop.runtime.jars";
+            public static final String HDFS_FS_CACHE_KEY = "hadoop.fs.cache.key";
+            public static final String STARROCKS_HOME_ENV_KEY = "STARROCKS_HOME";
+
+            public static void addConfigResourcesToConfiguration(Configuration conf) {
+                if (conf.getBoolean(HDFS_CONFIG_RESOURCES_LOADED, false)) {
+                    return;
+                }
+                String configResources = conf.get(HDFS_CONFIG_RESOURCES);
+                if (configResources.isEmpty()) {
+                    return;
+                }
+                final String STARROCKS_HOME_DIR = System.getenv(STARROCKS_HOME_ENV_KEY);
+                String[] parts = configResources.split(",");
+                for (String p : parts) {
+                    Path path = new Path(STARROCKS_HOME_DIR + "/conf/", p);
+                    LOGGER.debug(String.format("[hadoop-ext] Add path '%s' to configuration", path.toString()));
+                    conf.addResource(path);
+                }
+            }
+
+            public static String getFSCredential(Configuration conf) {
+                return conf.get(HDFS_FS_CACHE_KEY, "");
+            }
+        }
+
         /**
          * FileSystem.Cache.Key
          */
         static class Key {
+
             final String scheme;
             final String authority;
             final UserGroupInformation ugi;
             final long unique;   // an artificial way to make a key unique
+
+            final String cred;
 
             Key(URI uri, Configuration conf) throws IOException {
                 this(uri, conf, 0);
@@ -4024,11 +4057,13 @@ public abstract class FileSystem extends Configured
                 this.unique = unique;
 
                 this.ugi = UserGroupInformation.getCurrentUser();
+
+                this.cred = StarRocksUtils.getFSCredential(conf);
             }
 
             @Override
             public int hashCode() {
-                return (scheme + authority).hashCode() + ugi.hashCode() + (int) unique;
+                return (scheme + authority + cred).hashCode() + ugi.hashCode() + (int) unique;
             }
 
             static boolean isEqual(Object a, Object b) {
@@ -4044,6 +4079,7 @@ public abstract class FileSystem extends Configured
                     Key that = (Key) obj;
                     return isEqual(this.scheme, that.scheme)
                             && isEqual(this.authority, that.authority)
+                            && isEqual(this.cred, that.cred)
                             && isEqual(this.ugi, that.ugi)
                             && (this.unique == that.unique);
                 }
@@ -4052,8 +4088,9 @@ public abstract class FileSystem extends Configured
 
             @Override
             public String toString() {
-                return "(" + ugi.toString() + ")@" + scheme + "://" + authority;
+                return "(ugi = " + ugi.toString() + ", cred = " + cred + ")@" + scheme + "://" + authority;
             }
+
         }
     }
 

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4009,17 +4009,21 @@ public abstract class FileSystem extends Configured
             public static final String HDFS_CONFIG_RESOURCES_LOADED = "hadoop.config.resources.loaded";
             public static final String HDFS_RUNTIME_JARS = "hadoop.runtime.jars";
             public static final String HDFS_FS_CACHE_KEY = "hadoop.fs.cache.key";
-            public static final String STARROCKS_HOME_ENV_KEY = "STARROCKS_HOME";
+            public static final String STARROCKS_HOME_ENV = "STARROCKS_HOME";
 
             public static void addConfigResourcesToConfiguration(Configuration conf) {
                 if (conf.getBoolean(HDFS_CONFIG_RESOURCES_LOADED, false)) {
                     return;
                 }
                 String configResources = conf.get(HDFS_CONFIG_RESOURCES);
-                if (configResources.isEmpty()) {
+                if (configResources == null || configResources.isEmpty()) {
                     return;
                 }
-                final String STARROCKS_HOME_DIR = System.getenv(STARROCKS_HOME_ENV_KEY);
+                final String STARROCKS_HOME_DIR = System.getenv(STARROCKS_HOME_ENV);
+                if (STARROCKS_HOME_DIR == null) {
+                    LOGGER.warn(String.format("[hadoop-ext] env '%s' is not defined", STARROCKS_HOME_ENV));
+                    return;
+                }
                 String[] parts = configResources.split(",");
                 for (String p : parts) {
                     Path path = new Path(STARROCKS_HOME_DIR + "/conf/", p);

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -597,8 +597,6 @@ public abstract class FileSystem extends Configured
             LOGGER.debug("Bypassing cache to create filesystem {}", uri);
             return createFileSystem(uri, conf);
         }
-
-        LOGGER.warn("[hadoop-ext] FileSystem.Cache from hadoop-ext package");
         return CACHE.get(uri, conf);
     }
 
@@ -3729,7 +3727,8 @@ public abstract class FileSystem extends Configured
     private static FileSystem createFileSystem(URI uri, Configuration conf)
             throws IOException {
         Cache.StarRocksUtils.addConfigResourcesToConfiguration(conf);
-        LOGGER.info("[hadoop-ext] FileSystem.createFileSystem. conf.XXX = " + conf.get("XXX", "null"));
+        LOGGER.info(String.format("%s FileSystem.createFileSystem. conf.XXX = %s", Cache.StarRocksUtils.LOG_MESSAGE_PREFIX,
+                conf.get("XXX", "null")));
         Tracer tracer = FsTracer.get(conf);
         try (TraceScope scope = tracer.newScope("FileSystem#createFileSystem");
                 DurationInfo ignored =
@@ -3798,7 +3797,7 @@ public abstract class FileSystem extends Configured
 
         FileSystem get(URI uri, Configuration conf) throws IOException {
             Key key = new Key(uri, conf);
-            LOGGER.info("[hadoop-ext] FileSystem.get. key = " + key.toString());
+            LOGGER.info(String.format("%s FileSystem.get. key = %s", StarRocksUtils.LOG_MESSAGE_PREFIX, key.toString()));
             return getInternal(uri, conf, key);
         }
 
@@ -4012,6 +4011,7 @@ public abstract class FileSystem extends Configured
             public static final String HDFS_RUNTIME_JARS = "hadoop.runtime.jars";
             public static final String HDFS_CLOUD_CONFIGURATION_STRING = "hadoop.cloud.configuration.string";
             public static final String STARROCKS_HOME_ENV = "STARROCKS_HOME";
+            public static final String LOG_MESSAGE_PREFIX = "[hadoop-ext]";
 
             public static void addConfigResourcesToConfiguration(Configuration conf) {
                 if (conf.getBoolean(HDFS_CONFIG_RESOURCES_LOADED, false)) {
@@ -4023,13 +4023,13 @@ public abstract class FileSystem extends Configured
                 }
                 final String STARROCKS_HOME_DIR = System.getenv(STARROCKS_HOME_ENV);
                 if (STARROCKS_HOME_DIR == null) {
-                    LOGGER.info(String.format("[hadoop-ext] env '%s' is not defined", STARROCKS_HOME_ENV));
+                    LOGGER.info(String.format("%s env '%s' is not defined", LOG_MESSAGE_PREFIX, STARROCKS_HOME_ENV));
                     return;
                 }
                 String[] parts = configResources.split(",");
                 for (String p : parts) {
                     Path path = new Path(STARROCKS_HOME_DIR + "/conf/", p);
-                    LOGGER.info(String.format("[hadoop-ext] Add path '%s' to configuration", path.toString()));
+                    LOGGER.info(String.format("%s Add path '%s' to configuration", LOG_MESSAGE_PREFIX, path.toString()));
                     conf.addResource(path);
                 }
                 conf.setBoolean(HDFS_CONFIG_RESOURCES_LOADED, true);

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -4008,7 +4008,7 @@ public abstract class FileSystem extends Configured
             public static final String HDFS_CONFIG_RESOURCES = "hadoop.config.resources";
             public static final String HDFS_CONFIG_RESOURCES_LOADED = "hadoop.config.resources.loaded";
             public static final String HDFS_RUNTIME_JARS = "hadoop.runtime.jars";
-            public static final String HDFS_FS_CACHE_KEY = "hadoop.fs.cache.key";
+            public static final String HDFS_CLOUD_CONFIGURATION_STRING = "hadoop.cloud.configuration.string";
             public static final String STARROCKS_HOME_ENV = "STARROCKS_HOME";
 
             public static void addConfigResourcesToConfiguration(Configuration conf) {
@@ -4033,8 +4033,8 @@ public abstract class FileSystem extends Configured
                 conf.setBoolean(HDFS_CONFIG_RESOURCES_LOADED, true);
             }
 
-            public static String getFSCredential(Configuration conf) {
-                return conf.get(HDFS_FS_CACHE_KEY, "");
+            public static String getCloudConfString(Configuration conf) {
+                return conf.get(HDFS_CLOUD_CONFIGURATION_STRING, "");
             }
         }
 
@@ -4048,7 +4048,7 @@ public abstract class FileSystem extends Configured
             final UserGroupInformation ugi;
             final long unique;   // an artificial way to make a key unique
 
-            final String cred;
+            final String cloudConf;
 
             Key(URI uri, Configuration conf) throws IOException {
                 this(uri, conf, 0);
@@ -4063,12 +4063,12 @@ public abstract class FileSystem extends Configured
 
                 this.ugi = UserGroupInformation.getCurrentUser();
 
-                this.cred = StarRocksUtils.getFSCredential(conf);
+                this.cloudConf = StarRocksUtils.getCloudConfString(conf);
             }
 
             @Override
             public int hashCode() {
-                return (scheme + authority + cred).hashCode() + ugi.hashCode() + (int) unique;
+                return (scheme + authority + cloudConf).hashCode() + ugi.hashCode() + (int) unique;
             }
 
             static boolean isEqual(Object a, Object b) {
@@ -4084,7 +4084,7 @@ public abstract class FileSystem extends Configured
                     Key that = (Key) obj;
                     return isEqual(this.scheme, that.scheme)
                             && isEqual(this.authority, that.authority)
-                            && isEqual(this.cred, that.cred)
+                            && isEqual(this.cloudConf, that.cloudConf)
                             && isEqual(this.ugi, that.ugi)
                             && (this.unique == that.unique);
                 }
@@ -4093,7 +4093,7 @@ public abstract class FileSystem extends Configured
 
             @Override
             public String toString() {
-                return "(ugi = " + ugi.toString() + ", cred = " + cred + ")@" + scheme + "://" + authority;
+                return "(ugi = " + ugi.toString() + ", cloudConf = " + cloudConf + ")@" + scheme + "://" + authority;
             }
 
         }

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -83,7 +83,6 @@ import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.FileAlreadyExistsException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -597,6 +596,7 @@ public abstract class FileSystem extends Configured
             LOGGER.debug("Bypassing cache to create filesystem {}", uri);
             return createFileSystem(uri, conf);
         }
+
         return CACHE.get(uri, conf);
     }
 
@@ -3796,7 +3796,6 @@ public abstract class FileSystem extends Configured
 
         FileSystem get(URI uri, Configuration conf) throws IOException {
             Key key = new Key(uri, conf);
-            LOGGER.info(String.format("%s FileSystem.get. key = %s", HadoopExt.LOGGER_MESSAGE_PREFIX, key.toString()));
             return getInternal(uri, conf, key);
         }
 

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/HadoopExt.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/HadoopExt.java
@@ -25,7 +25,7 @@ class HadoopExt {
         }
         final String STARROCKS_HOME_DIR = System.getenv(STARROCKS_HOME_ENV);
         if (STARROCKS_HOME_DIR == null) {
-            LOGGER.info(String.format("%s env '%s' is not defined", LOGGER_MESSAGE_PREFIX, STARROCKS_HOME_ENV));
+            LOGGER.warn(String.format("%s env '%s' is not defined", LOGGER_MESSAGE_PREFIX, STARROCKS_HOME_ENV));
             return;
         }
         String[] parts = configResources.split(",");

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/HadoopExt.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/HadoopExt.java
@@ -1,0 +1,43 @@
+package org.apache.hadoop.fs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class HadoopExt {
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(HadoopExt.class);
+
+    public static final String HDFS_CONFIG_RESOURCES = "hadoop.config.resources";
+    public static final String HDFS_CONFIG_RESOURCES_LOADED = "hadoop.config.resources.loaded";
+    public static final String HDFS_RUNTIME_JARS = "hadoop.runtime.jars";
+    public static final String HDFS_CLOUD_CONFIGURATION_STRING = "hadoop.cloud.configuration.string";
+    public static final String STARROCKS_HOME_ENV = "STARROCKS_HOME";
+    public static final String LOGGER_MESSAGE_PREFIX = "[hadoop-ext]";
+
+    public static void addConfigResourcesToConfiguration(Configuration conf) {
+        if (conf.getBoolean(HDFS_CONFIG_RESOURCES_LOADED, false)) {
+            return;
+        }
+        String configResources = conf.get(HDFS_CONFIG_RESOURCES);
+        if (configResources == null || configResources.isEmpty()) {
+            return;
+        }
+        final String STARROCKS_HOME_DIR = System.getenv(STARROCKS_HOME_ENV);
+        if (STARROCKS_HOME_DIR == null) {
+            LOGGER.info(String.format("%s env '%s' is not defined", LOGGER_MESSAGE_PREFIX, STARROCKS_HOME_ENV));
+            return;
+        }
+        String[] parts = configResources.split(",");
+        for (String p : parts) {
+            Path path = new Path(STARROCKS_HOME_DIR + "/conf/", p);
+            LOGGER.info(String.format("%s Add path '%s' to configuration", LOGGER_MESSAGE_PREFIX, path.toString()));
+            conf.addResource(path);
+        }
+        conf.setBoolean(HDFS_CONFIG_RESOURCES_LOADED, true);
+    }
+
+    public static String getCloudConfString(Configuration conf) {
+        return conf.get(HDFS_CLOUD_CONFIGURATION_STRING, "");
+    }
+}


### PR DESCRIPTION
Fixes #issue

`FileSystem.java` is copied from hadoop source code with two fixes

```java
private static FileSystem createFileSystem(URI uri, Configuration conf)
        throws IOException {
    HadoopExt.addConfigResourcesToConfiguration(conf);
```

And 

```java
Key(URI uri, Configuration conf, long unique) throws IOException {
    scheme = uri.getScheme() == null ?
            "" : StringUtils.toLowerCase(uri.getScheme());
    authority = uri.getAuthority() == null ?
            "" : StringUtils.toLowerCase(uri.getAuthority());
    this.unique = unique;

    this.ugi = UserGroupInformation.getCurrentUser();

    this.cloudConf = HadoopExt.getCloudConfString(conf);
}
```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
