### PR TITLE
[BugFix] Restore primary key table cause meta inconsistent when restart BE(#30129)

### DIFF
--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -535,17 +535,17 @@ Status SnapshotLoader::primary_key_move(const std::string& snapshot_path, const 
         LOG(FATAL) << "only support overwrite now";
     }
 
-    // We just replace the table_schema in tabletMeta using the schema
-    // in snapshot_meta.
-    TabletMetaSharedPtr new_tablet_meta = std::make_shared<TabletMeta>();
-    std::shared_lock rdlock(tablet->get_header_lock());
-    tablet->generate_tablet_meta_copy_unlocked(new_tablet_meta);
-    rdlock.unlock();
-
-    TabletMetaPB metapb;
-    new_tablet_meta->to_meta_pb(&metapb);
-    new_tablet_meta->init_from_pb(&metapb, &snapshot_meta.tablet_meta().schema());
-    tablet->set_tablet_meta(new_tablet_meta);
+    /*
+     * just reset the tablet_schema using the schema in snapshot_meta
+     * 
+     * we do not use tablet_meta copy to avoid the TabletUpdates
+     * inconsistent problem.
+     * 
+     * we also do not use the snapshot_meta to construct a new
+     * tablet to replace the old one here, because it may easy
+     * to forget reset some variable in the snapshot_meta.
+    */
+    tablet->tablet_meta()->reset_tablet_schema_for_restore(snapshot_meta.tablet_meta().schema());
     tablet->save_meta();
 
     RETURN_IF_ERROR(tablet->updates()->load_snapshot(snapshot_meta, true));

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -176,7 +176,7 @@ Status TabletMeta::deserialize(std::string_view data) {
     return Status::OK();
 }
 
-void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb, const TabletSchemaPB* ptablet_schema_pb) {
+void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb) {
     auto& tablet_meta_pb = *ptablet_meta_pb;
     _table_id = tablet_meta_pb.table_id();
     _partition_id = tablet_meta_pb.partition_id();
@@ -222,20 +222,11 @@ void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb, const TabletSchemaP
     }
 
     // init _schema
-    if (ptablet_schema_pb == nullptr) {
-        if (tablet_meta_pb.schema().has_id() && tablet_meta_pb.schema().id() != TabletSchema::invalid_id()) {
-            // Does not collect the memory usage of |_schema|.
-            _schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_meta_pb.schema()).first;
-        } else {
-            _schema = std::make_shared<const TabletSchema>(tablet_meta_pb.schema());
-        }
+    if (tablet_meta_pb.schema().has_id() && tablet_meta_pb.schema().id() != TabletSchema::invalid_id()) {
+        // Does not collect the memory usage of |_schema|.
+        _schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_meta_pb.schema()).first;
     } else {
-        if (ptablet_schema_pb->has_id() && ptablet_schema_pb->id() != TabletSchema::invalid_id()) {
-            // Does not collect the memory usage of |_schema|.
-            _schema = GlobalTabletSchemaMap::Instance()->emplace(*ptablet_schema_pb).first;
-        } else {
-            _schema = std::make_shared<const TabletSchema>(*ptablet_schema_pb);
-        }
+        _schema = std::make_shared<const TabletSchema>(tablet_meta_pb.schema());
     }
 
     // init _rs_metas
@@ -499,6 +490,16 @@ void TabletMeta::create_inital_updates_meta() {
     _updatesPB->mutable_apply_version()->set_minor(edit_version_pb->minor());
     _updatesPB->set_next_log_id(0);
     _updatesPB->set_next_rowset_id(0);
+}
+
+void TabletMeta::reset_tablet_schema_for_restore(const TabletSchemaPB& schema_pb) {
+    _schema.reset();
+    if (schema_pb.has_id() && schema_pb.id() != TabletSchema::invalid_id()) {
+        // Does not collect the memory usage of |_schema|.
+        _schema = GlobalTabletSchemaMap::Instance()->emplace(schema_pb).first;
+    } else {
+        _schema = std::make_shared<const TabletSchema>(schema_pb);
+    }
 }
 
 bool operator==(const TabletMeta& a, const TabletMeta& b) {

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -104,7 +104,7 @@ public:
 
     Status serialize(std::string* meta_binary);
     Status deserialize(std::string_view data);
-    void init_from_pb(TabletMetaPB* ptablet_meta_pb, const TabletSchemaPB* ptablet_schema_pb = nullptr);
+    void init_from_pb(TabletMetaPB* ptablet_meta_pb);
 
     void to_meta_pb(TabletMetaPB* tablet_meta_pb);
     void to_json(std::string* json_string, json2pb::Pb2JsonOptions& options);
@@ -157,6 +157,8 @@ public:
     void delete_inc_rs_meta_by_version(const Version& version);
     RowsetMetaSharedPtr acquire_inc_rs_meta_by_version(const Version& version) const;
     void delete_stale_rs_meta_by_version(const Version& version);
+
+    void reset_tablet_schema_for_restore(const TabletSchemaPB& schema_pb);
 
     void add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version);
     void remove_delete_predicate_by_version(const Version& version);


### PR DESCRIPTION
Problem:
This problem is introduced by commit cfba8973f4718c0a4f2d6846d2bdaa473ba0be49 In this pr, we create a new tablet meta with snapshot tablet_schema to avoid the crash if the backup table has been done schema change.

But the problem is that, the _updates in new tablet meta is nullptr. It forget to reset it to tablet->updates(). So when remove expired versions for primary key table, tablet_meta.save_meta() will save the wrong meta data for this tablet. When we restart be, it will cause the meta inconsistent problem.

Solution:
reset the tablet_schema directly for the tablet_meta

Fixes #30129

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
