### PR TITLE
[BugFix] fix leak of ConnectorMetadata when refreshing MV

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorColumnStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorColumnStatsCacheLoader.java
@@ -52,8 +52,7 @@ public class ConnectorColumnStatsCacheLoader implements
     public @NonNull CompletableFuture<Optional<ConnectorTableColumnStats>> asyncLoad(@NonNull ConnectorTableColumnKey cacheKey,
                                                                                      @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
-            try {
-                ConnectContext connectContext = StatisticUtils.buildConnectContext();
+            try (ConnectContext connectContext = StatisticUtils.buildConnectContext()) {
                 connectContext.setThreadLocalInfo();
                 List<TStatisticData> statisticData = queryStatisticsData(connectContext, cacheKey.tableUUID, cacheKey.column);
                 // check TStatisticData is not empty, There may be no such column Statistics in BE
@@ -75,7 +74,7 @@ public class ConnectorColumnStatsCacheLoader implements
             @NonNull Iterable<? extends @NonNull ConnectorTableColumnKey> keys, @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
 
-            try {
+            try (ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext()) {
                 String tableUUID = null;
                 List<String> columns = new ArrayList<>();
                 for (ConnectorTableColumnKey key : keys) {
@@ -83,7 +82,6 @@ public class ConnectorColumnStatsCacheLoader implements
                     columns.add(key.column);
                 }
 
-                ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
                 statsConnectCtx.setThreadLocalInfo();
                 List<TStatisticData> statisticData = queryStatisticsData(statsConnectCtx, tableUUID, columns);
                 Map<ConnectorTableColumnKey, Optional<ConnectorTableColumnStats>> result = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoExecutor.java
@@ -55,8 +55,7 @@ public class RepoExecutor {
     }
 
     public void executeDML(String sql) {
-        try {
-            ConnectContext context = createConnectContext();
+        try (ConnectContext context = createConnectContext()) {
 
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             Preconditions.checkState(parsedStmt instanceof DmlStmt, "the statement should be dml");
@@ -69,14 +68,11 @@ public class RepoExecutor {
         } catch (Exception e) {
             LOG.error("RepoExecutor execute SQL {} failed: {}", sql, e.getMessage(), e);
             throw new SemanticException(String.format("execute sql failed: %s", e.getMessage()), e);
-        } finally {
-            ConnectContext.remove();
         }
     }
 
     public List<TResultBatch> executeDQL(String sql) {
-        try {
-            ConnectContext context = createConnectContext();
+        try (ConnectContext context = createConnectContext()) {
 
             // TODO: use json sink protocol, instead of statistic protocol
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
@@ -92,14 +88,11 @@ public class RepoExecutor {
         } catch (Exception e) {
             LOG.error("Repo execute SQL failed {}", sql, e);
             throw new SemanticException("execute sql failed: " + sql, e);
-        } finally {
-            ConnectContext.remove();
         }
     }
 
     public void executeDDL(String sql) {
-        try {
-            ConnectContext context = createConnectContext();
+        try (ConnectContext context = createConnectContext()) {
 
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             Analyzer.analyze(parsedStmt, context);
@@ -107,8 +100,6 @@ public class RepoExecutor {
         } catch (Exception e) {
             LOG.error("execute DDL error: {}", sql, e);
             throw new RuntimeException(e);
-        } finally {
-            ConnectContext.remove();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -296,6 +296,10 @@ public class ConnectContext implements AutoCloseable {
         threadLocalInfo.set(this);
     }
 
+    public void removeThreadLocalInfo() {
+        threadLocalInfo.remove();
+    }
+
     public void setGlobalStateMgr(GlobalStateMgr globalStateMgr) {
         this.globalStateMgr = globalStateMgr;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -772,16 +772,16 @@ public class DDLStmtExecutor {
 
                 context.getGlobalStateMgr().getAnalyzeMgr().addAnalyzeJob(analyzeJob);
 
-                ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
-                // from current session, may execute analyze stmt
-                statsConnectCtx.getSessionVariable().setStatisticCollectParallelism(
-                        context.getSessionVariable().getStatisticCollectParallelism());
-                statsConnectCtx.setStatisticsConnection(true);
                 Thread thread = new Thread(() -> {
-                    statsConnectCtx.setThreadLocalInfo();
-                    StatisticExecutor statisticExecutor = new StatisticExecutor();
-                    analyzeJob.run(statsConnectCtx, statisticExecutor);
-                    statsConnectCtx.close();
+                    try (ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext()) {
+                        // from current session, may execute analyze stmt
+                        statsConnectCtx.getSessionVariable().setStatisticCollectParallelism(
+                                context.getSessionVariable().getStatisticCollectParallelism());
+                        statsConnectCtx.setStatisticsConnection(true);
+                        statsConnectCtx.setThreadLocalInfo();
+                        StatisticExecutor statisticExecutor = new StatisticExecutor();
+                        analyzeJob.run(statsConnectCtx, statisticExecutor);
+                    }
                 });
                 thread.start();
             });

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -781,6 +781,7 @@ public class DDLStmtExecutor {
                     statsConnectCtx.setThreadLocalInfo();
                     StatisticExecutor statisticExecutor = new StatisticExecutor();
                     analyzeJob.run(statsConnectCtx, statisticExecutor);
+                    statsConnectCtx.close();
                 });
                 thread.start();
             });

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -39,6 +39,7 @@ import com.starrocks.catalog.MvId;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.qe.scheduler.Coordinator;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TBatchReportExecStatusParams;
 import com.starrocks.thrift.TBatchReportExecStatusResult;
 import com.starrocks.thrift.TNetworkAddress;
@@ -106,6 +107,7 @@ public final class QeProcessorImpl implements QeProcessor {
     public void unregisterQuery(TUniqueId queryId) {
         QueryInfo info = coordinatorMap.remove(queryId);
         if (info != null) {
+            GlobalStateMgr.getCurrentState().getMetadataMgr().removeQueryMetadata();
             if (info.getCoord() != null) {
                 info.getCoord().onFinished();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1066,13 +1066,14 @@ public class StmtExecutor {
     }
 
     private void executeAnalyze(AnalyzeStmt analyzeStmt, AnalyzeStatus analyzeStatus, Database db, Table table) {
-        ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
-        // from current session, may execute analyze stmt
-        statsConnectCtx.getSessionVariable().setStatisticCollectParallelism(
-                context.getSessionVariable().getStatisticCollectParallelism());
-        statsConnectCtx.setThreadLocalInfo();
-        statsConnectCtx.setStatisticsConnection(true);
-        executeAnalyze(statsConnectCtx, analyzeStmt, analyzeStatus, db, table);
+        try (ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext()) {
+            // from current session, may execute analyze stmt
+            statsConnectCtx.getSessionVariable().setStatisticCollectParallelism(
+                    context.getSessionVariable().getStatisticCollectParallelism());
+            statsConnectCtx.setThreadLocalInfo();
+            statsConnectCtx.setStatisticsConnection(true);
+            executeAnalyze(statsConnectCtx, analyzeStmt, analyzeStatus, db, table);
+        }
     }
 
     private void executeAnalyze(ConnectContext statsConnectCtx, AnalyzeStmt analyzeStmt, AnalyzeStatus analyzeStatus,

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -170,6 +170,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             doMvRefresh(context);
         } finally {
             postProcess();
+            GlobalStateMgr.getCurrentState().getMetadataMgr().removeQueryMetadata();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -170,7 +170,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             doMvRefresh(context);
         } finally {
             postProcess();
-            GlobalStateMgr.getCurrentState().getMetadataMgr().removeQueryMetadata();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/SqlTaskRunProcessor.java
@@ -38,7 +38,7 @@ public class SqlTaskRunProcessor extends BaseTaskRunProcessor {
                     .setCatalog(ctx.getCurrentCatalog());
             ctx.getPlannerProfile().reset();
 
-            executor = ctx.executeSql(context.getDefinition());
+            executor = executeSql(ctx, context.getDefinition());
         } finally {
             if (executor != null) {
                 auditAfterExec(context, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -263,6 +263,12 @@ public class TaskRun implements Comparable<TaskRun> {
         return status;
     }
 
+    public void close() {
+        if (runCtx != null) {
+            runCtx.close();
+        }
+    }
+
     @Override
     public int compareTo(@NotNull TaskRun taskRun) {
         if (this.getStatus().getPriority() != taskRun.getStatus().getPriority()) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -56,6 +56,7 @@ public class TaskRunExecutor {
                 status.setErrorCode(-1);
                 status.setErrorMessage(ex.toString());
             } finally {
+                taskRun.close();
                 status.setFinishTime(System.currentTimeMillis());
             }
             return status.getState();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnBasicStatsCacheLoader.java
@@ -55,8 +55,7 @@ public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStats
     public @NonNull CompletableFuture<Optional<ColumnStatistic>> asyncLoad(@NonNull ColumnStatsCacheKey cacheKey,
                                                                            @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
-            try {
-                ConnectContext connectContext = StatisticUtils.buildConnectContext();
+            try (ConnectContext connectContext = StatisticUtils.buildConnectContext()) {
                 connectContext.setThreadLocalInfo();
                 List<TStatisticData> statisticData = queryStatisticsData(connectContext, cacheKey.tableId, cacheKey.column);
                 // check TStatisticData is not empty, There may be no such column Statistics in BE
@@ -78,7 +77,7 @@ public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStats
             @NonNull Iterable<? extends @NonNull ColumnStatsCacheKey> keys, @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
 
-            try {
+            try (ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext()) {
                 long tableId = -1;
                 List<String> columns = new ArrayList<>();
                 for (ColumnStatsCacheKey key : keys) {
@@ -86,7 +85,6 @@ public class ColumnBasicStatsCacheLoader implements AsyncCacheLoader<ColumnStats
                     columns.add(key.column);
                 }
 
-                ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
                 statsConnectCtx.setThreadLocalInfo();
                 List<TStatisticData> statisticData = queryStatisticsData(statsConnectCtx, tableId, columns);
                 Map<ColumnStatsCacheKey, Optional<ColumnStatistic>> result = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnHistogramStatsCacheLoader.java
@@ -60,8 +60,7 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
     CompletableFuture<Optional<Histogram>> asyncLoad(@NonNull ColumnStatsCacheKey cacheKey,
                                                      @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
-            try {
-                ConnectContext connectContext = StatisticUtils.buildConnectContext();
+            try (ConnectContext connectContext = StatisticUtils.buildConnectContext()) {
                 connectContext.setThreadLocalInfo();
                 List<TStatisticData> statisticData =
                         queryHistogramStatistics(connectContext, cacheKey.tableId, Lists.newArrayList(cacheKey.column));
@@ -84,7 +83,7 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
             @NonNull Iterable<? extends @NonNull ColumnStatsCacheKey> keys, @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
             Map<ColumnStatsCacheKey, Optional<Histogram>> result = new HashMap<>();
-            try {
+            try (ConnectContext connectContext = StatisticUtils.buildConnectContext()) {
                 long tableId = -1;
                 List<String> columns = new ArrayList<>();
                 for (ColumnStatsCacheKey key : keys) {
@@ -92,7 +91,6 @@ public class ColumnHistogramStatsCacheLoader implements AsyncCacheLoader<ColumnS
                     columns.add(key.column);
                     result.put(key, Optional.empty());
                 }
-                ConnectContext connectContext = StatisticUtils.buildConnectContext();
                 connectContext.setThreadLocalInfo();
 
                 List<TStatisticData> histogramStatsDataList = queryHistogramStatistics(connectContext, tableId, columns);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/TableStatsCacheLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/TableStatsCacheLoader.java
@@ -36,8 +36,7 @@ public class TableStatsCacheLoader implements AsyncCacheLoader<TableStatsCacheKe
     public @NonNull CompletableFuture<Optional<TableStatistic>> asyncLoad(@NonNull TableStatsCacheKey cacheKey, @
             NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
-            try {
-                ConnectContext connectContext = StatisticUtils.buildConnectContext();
+            try (ConnectContext connectContext = StatisticUtils.buildConnectContext()) {
                 connectContext.setThreadLocalInfo();
                 List<TStatisticData> statisticData = queryStatisticsData(connectContext, cacheKey.tableId, cacheKey.partitionId);
                 if (statisticData.size() == 0) {
@@ -59,11 +58,10 @@ public class TableStatsCacheLoader implements AsyncCacheLoader<TableStatsCacheKe
             @NonNull Iterable<? extends @NonNull TableStatsCacheKey> cacheKey,
             @NonNull Executor executor) {
         return CompletableFuture.supplyAsync(() -> {
-            try {
+            try (ConnectContext connectContext = StatisticUtils.buildConnectContext()) {
                 TableStatsCacheKey tableStatsCacheKey = cacheKey.iterator().next();
                 long tableId = tableStatsCacheKey.getTableId();
 
-                ConnectContext connectContext = StatisticUtils.buildConnectContext();
                 connectContext.setThreadLocalInfo();
                 List<TStatisticData> statisticData = queryStatisticsData(connectContext, tableStatsCacheKey.getTableId());
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
@@ -81,10 +81,11 @@ public class StatisticAutoCollector extends FrontendDaemon {
                 analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
                 GlobalStateMgr.getCurrentAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
 
-                ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
-                statsConnectCtx.setStatisticsConnection(true);
-                statsConnectCtx.setThreadLocalInfo();
-                STATISTIC_EXECUTOR.collectStatistics(statsConnectCtx, statsJob, analyzeStatus, true);
+                try (ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext()) {
+                    statsConnectCtx.setStatisticsConnection(true);
+                    statsConnectCtx.setThreadLocalInfo();
+                    STATISTIC_EXECUTOR.collectStatistics(statsConnectCtx, statsJob, analyzeStatus, true);
+                }
             }
             LOG.info("auto collect full statistic on all databases end");
         } else {
@@ -94,10 +95,11 @@ public class StatisticAutoCollector extends FrontendDaemon {
                     .collect(Collectors.joining(", "));
             LOG.info("auto collect statistic on analyze job[{}] start", jobIds);
             for (AnalyzeJob analyzeJob : allAnalyzeJobs) {
-                ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
-                statsConnectCtx.setStatisticsConnection(true);
-                statsConnectCtx.setThreadLocalInfo();
-                analyzeJob.run(statsConnectCtx, STATISTIC_EXECUTOR);
+                try (ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext()) {
+                    statsConnectCtx.setStatisticsConnection(true);
+                    statsConnectCtx.setThreadLocalInfo();
+                    analyzeJob.run(statsConnectCtx, STATISTIC_EXECUTOR);
+                }
             }
             LOG.info("auto collect statistic on analyze job[{}] end", jobIds);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -190,17 +190,18 @@ public class StatisticExecutor {
                 "dict_merge(" + StatisticUtils.quoting(column) + ") as _dict_merge_" + column +
                 " from " + StatisticUtils.quoting(catalogName, db.getOriginName(), table.getName()) + " [_META_]";
 
-        ConnectContext context = StatisticUtils.buildConnectContext();
-        context.setThreadLocalInfo();
-        StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
+        try (ConnectContext context = StatisticUtils.buildConnectContext()) {
+            context.setThreadLocalInfo();
+            StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
 
-        ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, TResultSinkType.STATISTIC);
-        StmtExecutor executor = new StmtExecutor(context, parsedStmt);
-        Pair<List<TResultBatch>, Status> sqlResult = executor.executeStmtWithExecPlan(context, execPlan);
-        if (!sqlResult.second.ok()) {
-            return Pair.create(Collections.emptyList(), sqlResult.second);
-        } else {
-            return Pair.create(deserializerStatisticData(sqlResult.first), sqlResult.second);
+            ExecPlan execPlan = StatementPlanner.plan(parsedStmt, context, TResultSinkType.STATISTIC);
+            StmtExecutor executor = new StmtExecutor(context, parsedStmt);
+            Pair<List<TResultBatch>, Status> sqlResult = executor.executeStmtWithExecPlan(context, execPlan);
+            if (!sqlResult.second.ok()) {
+                return Pair.create(Collections.emptyList(), sqlResult.second);
+            } else {
+                return Pair.create(deserializerStatisticData(sqlResult.first), sqlResult.second);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -152,15 +152,16 @@ public class StatisticUtils {
             future = GlobalStateMgr.getCurrentAnalyzeMgr().getAnalyzeTaskThreadPool()
                     .submit(() -> {
                         StatisticExecutor statisticExecutor = new StatisticExecutor();
-                        ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext();
-                        statsConnectCtx.setThreadLocalInfo();
-                        statsConnectCtx.setStatisticsConnection(true);
+                        try (ConnectContext statsConnectCtx = StatisticUtils.buildConnectContext()) {
+                            statsConnectCtx.setThreadLocalInfo();
+                            statsConnectCtx.setStatisticsConnection(true);
 
-                        statisticExecutor.collectStatistics(statsConnectCtx,
-                                StatisticsCollectJobFactory.buildStatisticsCollectJob(db, table,
-                                        collectPartitionIds, null, analyzeType,
-                                        StatsConstants.ScheduleType.ONCE,
-                                        analyzeStatus.getProperties()), analyzeStatus, false);
+                            statisticExecutor.collectStatistics(statsConnectCtx,
+                                    StatisticsCollectJobFactory.buildStatisticsCollectJob(db, table,
+                                            collectPartitionIds, null, analyzeType,
+                                            StatsConstants.ScheduleType.ONCE,
+                                            analyzeStatus.getProperties()), analyzeStatus, false);
+                        }
                     });
         } catch (Throwable e) {
             LOG.error("failed to submit statistic collect job", e);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -302,19 +302,20 @@ public class StatisticsMetaManager extends FrontendDaemon {
     }
 
     private boolean createTable(String tableName) {
-        ConnectContext context = StatisticUtils.buildConnectContext();
-        context.setThreadLocalInfo();
+        try (ConnectContext context = StatisticUtils.buildConnectContext()) {
+            context.setThreadLocalInfo();
 
-        if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {
-            return createSampleStatisticsTable(context);
-        } else if (tableName.equals(StatsConstants.FULL_STATISTICS_TABLE_NAME)) {
-            return createFullStatisticsTable(context);
-        } else if (tableName.equals(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME)) {
-            return createHistogramStatisticsTable(context);
-        } else if (tableName.equals(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME)) {
-            return createExternalFullStatisticsTable(context);
-        } else {
-            throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
+            if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {
+                return createSampleStatisticsTable(context);
+            } else if (tableName.equals(StatsConstants.FULL_STATISTICS_TABLE_NAME)) {
+                return createFullStatisticsTable(context);
+            } else if (tableName.equals(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME)) {
+                return createHistogramStatisticsTable(context);
+            } else if (tableName.equals(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME)) {
+                return createExternalFullStatisticsTable(context);
+            } else {
+                throw new StarRocksPlannerException("Error table name " + tableName, ErrorType.INTERNAL_ERROR);
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -454,6 +454,7 @@ public class UtFrameUtils {
 
     public static Pair<String, ExecPlan> getPlanAndFragment(ConnectContext connectContext, String originStmt)
             throws Exception {
+        connectContext.setThreadLocalInfo();
         return buildPlan(connectContext, originStmt,
                 (context, statementBase, execPlan) -> new Pair<>(printPhysicalPlan(execPlan.getPhysicalPlan()),
                         execPlan));


### PR DESCRIPTION
Fixes #issue

Root cause: the `MetadataMgr::QueryMetadatas` does not get released after usage, except `StmtExecutor::execute`.

Fix the leak of `ConnectorMetadata`:
1. Close the `ConnectContext` after usage
2. Release the `MetadataMgr::QueryMetadatas` when closing the `ConnectContext`

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
