### PR TITLE
[BugFix] fix lake primary table's local persistent index load (backport #30110)

### DIFF
--- a/be/src/storage/lake/lake_local_persistent_index.h
+++ b/be/src/storage/lake/lake_local_persistent_index.h
@@ -24,10 +24,14 @@
 namespace starrocks::lake {
 
 class MetaFileBuilder;
+class LakePrimaryIndex;
 
 class LakeLocalPersistentIndex : public PersistentIndex {
 public:
-    explicit LakeLocalPersistentIndex(std::string path) : PersistentIndex(path) { _path = path; }
+    explicit LakeLocalPersistentIndex(std::string path, LakePrimaryIndex* primary_index)
+            : PersistentIndex(path), _primary_index(primary_index) {
+        _path = path;
+    }
 
     ~LakeLocalPersistentIndex() override {}
 
@@ -36,6 +40,7 @@ public:
 
 private:
     std::string _path;
+    LakePrimaryIndex* _primary_index;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -80,7 +80,7 @@ Status LakePrimaryIndex::_do_lake_load(Tablet* tablet, const TabletMetadata& met
                     RETURN_IF_ERROR(
                             StorageEngine::instance()->get_persistent_index_store()->create_dir_if_path_not_exists(
                                     path));
-                    _persistent_index = std::make_unique<LakeLocalPersistentIndex>(path);
+                    _persistent_index = std::make_unique<LakeLocalPersistentIndex>(path, this);
                     return ((LakeLocalPersistentIndex*)_persistent_index.get())
                             ->load_from_lake_tablet(tablet, metadata, base_version, builder);
                 }

--- a/be/test/storage/lake/compaction_test_utils.h
+++ b/be/test/storage/lake/compaction_test_utils.h
@@ -23,12 +23,13 @@ namespace starrocks::lake {
 struct CompactionParam {
     CompactionAlgorithm algorithm = HORIZONTAL_COMPACTION;
     uint32_t vertical_compaction_max_columns_per_group = 5;
+    bool enable_persistent_index = false;
 };
 
 static std::string to_string_param_name(const testing::TestParamInfo<CompactionParam>& info) {
     std::stringstream ss;
     ss << CompactionUtils::compaction_algorithm_to_string(info.param.algorithm) << "_"
-       << info.param.vertical_compaction_max_columns_per_group;
+       << info.param.vertical_compaction_max_columns_per_group << "_" << info.param.enable_persistent_index;
     return ss.str();
 }
 

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -52,6 +52,7 @@ public:
         _tablet_metadata->set_version(1);
         _tablet_metadata->set_cumulative_point(0);
         _tablet_metadata->set_next_rowset_id(1);
+        _tablet_metadata->set_enable_persistent_index(GetParam().enable_persistent_index);
         //
         //  | column | type | KEY | NULL |
         //  +--------+------+-----+------+
@@ -620,8 +621,10 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyCompactionTest, LakePrimaryKeyCompactionTest,
-                         ::testing::Values(CompactionParam{HORIZONTAL_COMPACTION, 5},
-                                           CompactionParam{VERTICAL_COMPACTION, 1}),
+                         ::testing::Values(CompactionParam{HORIZONTAL_COMPACTION, 5, false},
+                                           CompactionParam{VERTICAL_COMPACTION, 1, false},
+                                           CompactionParam{HORIZONTAL_COMPACTION, 5, true},
+                                           CompactionParam{VERTICAL_COMPACTION, 1, true}),
                          to_string_param_name);
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -64,4 +64,8 @@ protected:
     std::unique_ptr<TabletManager> _tablet_mgr;
 };
 
+struct PrimaryKeyParam {
+    bool enable_persistent_index = false;
+};
+
 } // namespace starrocks::lake


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
