### PR TITLE
[BugFix] Fix negative audit values

### DIFF
--- a/be/src/runtime/query_statistics.cpp
+++ b/be/src/runtime/query_statistics.cpp
@@ -148,11 +148,21 @@ void QueryStatistics::merge(int sender_id, QueryStatistics& other) {
 }
 
 void QueryStatistics::merge_pb(const PQueryStatistics& statistics) {
-    scan_rows += statistics.scan_rows();
-    scan_bytes += statistics.scan_bytes();
-    cpu_ns += statistics.cpu_cost_ns();
-    spill_bytes += statistics.spill_bytes();
-    mem_cost_bytes = std::max<int64_t>(mem_cost_bytes, statistics.mem_cost_bytes());
+    if (statistics.has_scan_rows()) {
+        scan_rows += statistics.scan_rows();
+    }
+    if (statistics.has_scan_bytes()) {
+        scan_bytes += statistics.scan_bytes();
+    }
+    if (statistics.has_cpu_cost_ns()) {
+        cpu_ns += statistics.cpu_cost_ns();
+    }
+    if (statistics.has_spill_bytes()) {
+        spill_bytes += statistics.spill_bytes();
+    }
+    if (statistics.has_mem_cost_bytes()) {
+        mem_cost_bytes = std::max<int64_t>(mem_cost_bytes, statistics.mem_cost_bytes());
+    }
     {
         std::lock_guard l(_lock);
         for (int i = 0; i < statistics.stats_items_size(); ++i) {


### PR DESCRIPTION
## Root cause

In some scenarios, exchange won't attach intermediate statistics to the receiver, which resulting in the uninitialized `PQueryStatistics`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
