### PR TITLE
[BugFix] fix persistent index delete flag lost when flush l0 (backport #29997)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -949,7 +949,7 @@ CONF_mInt64(l0_snapshot_size, "16777216"); // 16MB
 CONF_mInt64(max_tmp_l1_num, "10");
 CONF_mBool(enable_parallel_get_and_bf, "true");
 // Control if using the minor compaction strategy
-CONF_mBool(enable_pindex_minor_compaction, "false");
+CONF_Bool(enable_pindex_minor_compaction, "false");
 // if l2 num is larger than this, stop doing async compaction,
 // add this config to prevent l2 grow too large.
 CONF_mInt64(max_allow_pindex_l2_num, "5");

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -791,7 +791,7 @@ public:
     bool dump(phmap::BinaryOutputArchive& ar) override { return _map.dump(ar); }
 
     std::vector<std::vector<KVRef>> get_kv_refs_by_shard(size_t nshard, size_t num_entry,
-                                                         bool without_null) const override {
+                                                         bool with_null) const override {
         std::vector<std::vector<KVRef>> ret(nshard);
         uint32_t shard_bits = log2(nshard);
         for (auto i = 0; i < nshard; ++i) {
@@ -799,7 +799,7 @@ public:
         }
         auto hasher = FixedKeyHash<KeySize>();
         for (const auto& [key, value] : _map) {
-            if (without_null && value.get_value() == NullIndexValue) {
+            if (!with_null && value.get_value() == NullIndexValue) {
                 continue;
             }
             IndexHash h(hasher(key));
@@ -809,9 +809,9 @@ public:
     }
 
     Status flush_to_immutable_index(std::unique_ptr<ImmutableIndexWriter>& writer, size_t nshard, size_t npage_hint,
-                                    size_t nbucket, bool without_null, BloomFilter* bf) const override {
+                                    size_t nbucket, bool with_null, BloomFilter* bf) const override {
         if (nshard > 0) {
-            const auto& kv_ref_by_shard = get_kv_refs_by_shard(nshard, size(), without_null);
+            const auto& kv_ref_by_shard = get_kv_refs_by_shard(nshard, size(), with_null);
             if (bf != nullptr) {
                 for (const auto& kvs : kv_ref_by_shard) {
                     for (const auto& kv : kvs) {
@@ -1195,7 +1195,7 @@ public:
     }
 
     std::vector<std::vector<KVRef>> get_kv_refs_by_shard(size_t nshard, size_t num_entry,
-                                                         bool without_null) const override {
+                                                         bool with_null) const override {
         std::vector<std::vector<KVRef>> ret(nshard);
         uint32_t shard_bits = log2(nshard);
         for (auto i = 0; i < nshard; ++i) {
@@ -1204,7 +1204,7 @@ public:
         for (const auto& composite_key : _set) {
             const auto value = UNALIGNED_LOAD64(composite_key.data() + composite_key.size() - kIndexValueSize);
             IndexHash h(StringHasher2()(composite_key));
-            if (without_null && value == NullIndexValue) {
+            if (!with_null && value == NullIndexValue) {
                 continue;
             }
             ret[h.shard(shard_bits)].emplace_back((uint8_t*)(composite_key.data()), h.hash, composite_key.size());
@@ -1213,9 +1213,9 @@ public:
     }
 
     Status flush_to_immutable_index(std::unique_ptr<ImmutableIndexWriter>& writer, size_t nshard, size_t npage_hint,
-                                    size_t nbucket, bool without_null, BloomFilter* bf) const override {
+                                    size_t nbucket, bool with_null, BloomFilter* bf) const override {
         if (nshard > 0) {
-            const auto& kv_ref_by_shard = get_kv_refs_by_shard(nshard, size(), without_null);
+            const auto& kv_ref_by_shard = get_kv_refs_by_shard(nshard, size(), with_null);
             if (bf != nullptr) {
                 for (const auto& kvs : kv_ref_by_shard) {
                     for (const auto& kv : kvs) {
@@ -1876,7 +1876,7 @@ Status ShardByLengthMutableIndex::load(const MutableIndexMetaPB& meta) {
 }
 
 Status ShardByLengthMutableIndex::flush_to_immutable_index(const std::string& path, const EditVersion& version,
-                                                           bool write_tmp_l1,
+                                                           bool write_tmp_l1, bool keep_delete,
                                                            std::map<size_t, std::unique_ptr<BloomFilter>>* bf_map) {
     auto writer = std::make_unique<ImmutableIndexWriter>();
     std::string idx_file_path;
@@ -1912,11 +1912,11 @@ Status ShardByLengthMutableIndex::flush_to_immutable_index(const std::string& pa
                     }
                     bf->init(size, 0.05, HASH_MURMUR3_X64_64);
                     RETURN_IF_ERROR(_shards[shard_offset + i]->flush_to_immutable_index(
-                            writer, expand_exponent, npage_hint, nbucket, !write_tmp_l1, bf.get()));
+                            writer, expand_exponent, npage_hint, nbucket, keep_delete, bf.get()));
                     (*bf_map)[key_size] = std::move(bf);
                 } else {
                     RETURN_IF_ERROR(_shards[shard_offset + i]->flush_to_immutable_index(
-                            writer, expand_exponent, npage_hint, nbucket, !write_tmp_l1, nullptr));
+                            writer, expand_exponent, npage_hint, nbucket, keep_delete, nullptr));
                 }
             }
         }
@@ -2630,6 +2630,20 @@ Status PersistentIndex::_insert_rowsets(Tablet* tablet, std::vector<RowsetShared
     return Status::OK();
 }
 
+bool PersistentIndex::_need_rebuild_index(const PersistentIndexMetaPB& index_meta) {
+    if (index_meta.format_version() != PERSISTENT_INDEX_VERSION_2 &&
+        index_meta.format_version() != PERSISTENT_INDEX_VERSION_3) {
+        // If format version is not equal to PERSISTENT_INDEX_VERSION_3, this maybe upgrade from
+        // PERSISTENT_INDEX_VERSION_2.
+        // We need to rebuild persistent index because the meta structure is changed
+        return true;
+    } else if (index_meta.l2_versions_size() > 0 && !config::enable_pindex_minor_compaction) {
+        // When l2 exist, and we choose to disable minor compaction, then we need to rebuild index.
+        return true;
+    }
+    return false;
+}
+
 Status PersistentIndex::load_from_tablet(Tablet* tablet) {
     MonotonicStopWatch timer;
     timer.start();
@@ -2662,11 +2676,7 @@ Status PersistentIndex::load_from_tablet(Tablet* tablet) {
         // so we can load persistent index according to PersistentIndexMetaPB
         EditVersion version = index_meta.version();
         if (version == lastest_applied_version) {
-            // If format version is not equal to PERSISTENT_INDEX_VERSION_3, this maybe upgrade from
-            // PERSISTENT_INDEX_VERSION_2.
-            // We need to rebuild persistent index because the meta structure is changed
-            if (index_meta.format_version() != PERSISTENT_INDEX_VERSION_2 &&
-                index_meta.format_version() != PERSISTENT_INDEX_VERSION_3) {
+            if (_need_rebuild_index(index_meta)) {
                 LOG(WARNING) << "different format version, we need to rebuild persistent index";
                 status = Status::InternalError("different format version");
             } else {
@@ -3353,9 +3363,9 @@ Status PersistentIndex::flush_advance() {
             strings::Substitute("$0/index.l1.$1.$2.$3.tmp", _path, _version.major(), _version.minor(), idx);
     std::map<size_t, std::unique_ptr<BloomFilter>> bf_map;
     if (_need_bloom_filter) {
-        RETURN_IF_ERROR(_l0->flush_to_immutable_index(l1_tmp_file, _version, true, &bf_map));
+        RETURN_IF_ERROR(_l0->flush_to_immutable_index(l1_tmp_file, _version, true, true, &bf_map));
     } else {
-        RETURN_IF_ERROR(_l0->flush_to_immutable_index(l1_tmp_file, _version, true, nullptr));
+        RETURN_IF_ERROR(_l0->flush_to_immutable_index(l1_tmp_file, _version, true, true, nullptr));
     }
 
     LOG(INFO) << "flush tmp l1, idx: " << idx << ", file_path: " << l1_tmp_file << " success";
@@ -3380,7 +3390,8 @@ Status PersistentIndex::flush_advance() {
 }
 
 Status PersistentIndex::_flush_l0() {
-    return _l0->flush_to_immutable_index(_path, _version, false, nullptr);
+    // when l2 exist, must flush l0 with Delete Flag
+    return _l0->flush_to_immutable_index(_path, _version, false, !_l2_vec.empty(), nullptr);
 }
 
 Status PersistentIndex::_reload(const PersistentIndexMetaPB& index_meta) {
@@ -3805,7 +3816,7 @@ Status PersistentIndex::_merge_compaction_internal(ImmutableIndexWriter* writer,
         const auto l0_kv_pairs_size = std::accumulate(std::next(_l0->_shards.begin(), l0_shard_offset),
                                                       std::next(_l0->_shards.begin(), l0_shard_offset + l0_shard_size),
                                                       0UL, [](size_t s, const auto& e) { return s + e->size(); });
-        auto l0_kvs_by_shard = _l0->_shards[l0_shard_offset]->get_kv_refs_by_shard(nshard, l0_kv_pairs_size, false);
+        auto l0_kvs_by_shard = _l0->_shards[l0_shard_offset]->get_kv_refs_by_shard(nshard, l0_kv_pairs_size, true);
 
         int merge_l1_num = l1_end_idx - l1_start_idx;
         std::vector<std::vector<std::vector<KVRef>>> l1_kvs_by_shard;
@@ -3941,8 +3952,7 @@ Status PersistentIndex::_minor_compaction(PersistentIndexMetaPB* index_meta) {
         // 1, remove delete key when l2 not exist
         // 2. skip merge l1, only merge tmp-l1 and l0
         RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), _has_l1 ? 1 : 0, _l1_vec.size(),
-                                                   _usage_and_size_by_key_length, _l2_vec.empty() ? false : true,
-                                                   nullptr));
+                                                   _usage_and_size_by_key_length, !_l2_vec.empty(), nullptr));
         RETURN_IF_ERROR(writer->finish());
         LOG(INFO) << "PersistentIndex minor compaction, merge tmp l1, merge cnt: " << _l1_vec.size()
                   << ", output: " << new_l1_filename;
@@ -3999,8 +4009,8 @@ Status PersistentIndex::_merge_compaction() {
     const std::string idx_file_path =
             strings::Substitute("$0/index.l1.$1.$2", _path, _version.major(), _version.minor());
     RETURN_IF_ERROR(writer->init(idx_file_path, _version, true));
-    RETURN_IF_ERROR(
-            _merge_compaction_internal(writer.get(), 0, _l1_vec.size(), _usage_and_size_by_key_length, false, nullptr));
+    RETURN_IF_ERROR(_merge_compaction_internal(writer.get(), 0, _l1_vec.size(), _usage_and_size_by_key_length,
+                                               !_l2_vec.empty(), nullptr));
     // _usage should be equal to total_kv_size. But they may be differen because of compatibility problem when we upgrade
     // from old version and _usage maybe not accurate.
     // so we use total_kv_size to correct the _usage.
@@ -4019,7 +4029,8 @@ Status PersistentIndex::_merge_compaction_advance() {
     int merge_l1_start_idx = _l1_vec.size() - config::max_tmp_l1_num;
     int merge_l1_end_idx = _l1_vec.size();
     LOG(INFO) << "merge compaction advance, start_idx: " << merge_l1_start_idx << " end_idx: " << merge_l1_end_idx;
-    bool keep_delete = (merge_l1_start_idx != 0);
+    // keep delete flag when older l1 or l2 exist
+    bool keep_delete = (merge_l1_start_idx != 0) || !_l2_vec.empty();
 
     std::map<uint32_t, std::pair<int64_t, int64_t>> usage_and_size_stat;
     for (const auto& [key_size, shard_info] : _l0->_shard_info_by_key_size) {

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -169,15 +169,15 @@ public:
     // get all key-values pair references by shard, the result will remain valid until next modification
     // |nshard|: number of shard
     // |num_entry|: number of entries expected, it should be:
-    //                 the num of KV entries if without_null == false
-    //                 the num of KV entries excluding nulls if without_null == true
-    // |without_null|: whether to include null entries
+    //                 the num of KV entries if with_null == true
+    //                 the num of KV entries excluding nulls if with_null == false
+    // |with_null|: whether to include null entries
     // [not thread-safe]
     virtual std::vector<std::vector<KVRef>> get_kv_refs_by_shard(size_t nshard, size_t num_entry,
-                                                                 bool without_null) const = 0;
+                                                                 bool with_null) const = 0;
 
     virtual Status flush_to_immutable_index(std::unique_ptr<ImmutableIndexWriter>& writer, size_t nshard,
-                                            size_t npage_hint, size_t nbucket, bool without_null,
+                                            size_t npage_hint, size_t nbucket, bool with_null,
                                             BloomFilter* bf = nullptr) const = 0;
 
     // get the number of entries in the index (including NullIndexValue)
@@ -290,19 +290,19 @@ public:
 
     // get all key-values pair references by shard, the result will remain valid until next modification
     // |num_entry|: number of entries expected, it should be:
-    //                 the num of KV entries if without_null == false
-    //                 the num of KV entries excluding nulls if without_null == true
-    // |without_null|: whether to include null entries
+    //                 the num of KV entries if with_null == true
+    //                 the num of KV entries excluding nulls if with_null == false
+    // |with_null|: whether to include null entries
     std::vector<std::pair<uint32_t, std::vector<std::vector<KVRef>>>> get_kv_refs_by_shard(size_t num_entry,
-                                                                                           bool without_null);
+                                                                                           bool with_null);
 
     std::vector<std::vector<size_t>> split_keys_by_shard(size_t nshard, const Slice* keys, size_t idx_begin,
                                                          size_t idx_end);
     std::vector<std::vector<size_t>> split_keys_by_shard(size_t nshard, const Slice* keys,
                                                          const std::vector<size_t>& idxes);
 
-    Status flush_to_immutable_index(const std::string& dir, const EditVersion& version, bool write_tmp_l1 = false,
-                                    std::map<size_t, std::unique_ptr<BloomFilter>>* bf_map = nullptr);
+    Status flush_to_immutable_index(const std::string& dir, const EditVersion& version, bool write_tmp_l1,
+                                    bool keep_delete, std::map<size_t, std::unique_ptr<BloomFilter>>* bf_map = nullptr);
 
     // get the number of entries in the index (including NullIndexValue)
     size_t size();
@@ -700,6 +700,8 @@ private:
     size_t _get_tmp_l1_count();
 
     bool _l0_is_full();
+
+    bool _need_rebuild_index(const PersistentIndexMetaPB& index_meta);
 
 protected:
     // prevent concurrent operations

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -2071,4 +2071,108 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1_fixlen) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
+PARALLEL_TEST(PersistentIndexTest, test_multi_l2_delete) {
+    config::l0_max_mem_usage = 1024;
+    config::max_tmp_l1_num = 10;
+    FileSystem* fs = FileSystem::Default();
+    const std::string kPersistentIndexDir = "./PersistentIndexTest_test_multi_l2_delete";
+    const std::string kIndexFile = "./PersistentIndexTest_test_multi_l2_delete/index.l0.0.0";
+    bool created;
+    ASSERT_OK(fs->create_dir_if_missing(kPersistentIndexDir, &created));
+
+    using Key = std::string;
+    PersistentIndexMetaPB index_meta;
+    const int N = 1000000;
+    const int DEL_N = 900000;
+    int64_t cur_version = 0;
+    // insert
+    vector<Key> keys(N);
+    vector<Slice> key_slices;
+    vector<IndexValue> values;
+    key_slices.reserve(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = "test_varlen_" + std::to_string(i);
+        values.emplace_back(i);
+        key_slices.emplace_back(keys[i]);
+    }
+    // erase
+    vector<Key> erase_keys(DEL_N);
+    vector<Slice> erase_key_slices;
+    erase_key_slices.reserve(DEL_N);
+    for (int i = 0; i < DEL_N; i++) {
+        erase_keys[i] = "test_varlen_" + std::to_string(i);
+        erase_key_slices.emplace_back(erase_keys[i]);
+    }
+
+    {
+        ASSIGN_OR_ABORT(auto wfile, FileSystem::Default()->new_writable_file(kIndexFile));
+        ASSERT_OK(wfile->close());
+    }
+
+    {
+        EditVersion version(cur_version++, 0);
+        index_meta.set_key_size(0);
+        index_meta.set_size(0);
+        version.to_pb(index_meta.mutable_version());
+        MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
+        IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
+        version.to_pb(snapshot_meta->mutable_version());
+
+        PersistentIndex index(kPersistentIndexDir);
+
+        ASSERT_OK(index.load(index_meta));
+        ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), N));
+        ASSERT_OK(index.insert(N, key_slices.data(), values.data(), false));
+        ASSERT_OK(index.commit(&index_meta));
+        ASSERT_OK(index.on_commited());
+
+        // generate 3 versions
+        for (int i = 0; i < 3; i++) {
+            std::vector<IndexValue> old_values(keys.size());
+            ASSERT_TRUE(index.prepare(EditVersion(cur_version++, 0), keys.size()).ok());
+            ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
+            ASSERT_TRUE(index.commit(&index_meta).ok());
+            ASSERT_TRUE(index.on_commited().ok());
+        }
+
+        vector<IndexValue> erase_old_values(erase_keys.size());
+        ASSERT_TRUE(index.prepare(EditVersion(cur_version++, 0), erase_keys.size()).ok());
+        // not trigger l0 advance flush
+        config::l0_max_mem_usage = 100 * 1024 * 1024; // 100MB
+        ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
+        // update PersistentMetaPB in memory
+        // trigger l0 flush
+        config::l0_max_mem_usage = 1024;
+        ASSERT_TRUE(index.commit(&index_meta).ok());
+        ASSERT_TRUE(index.on_commited().ok());
+
+        std::vector<IndexValue> get_values(keys.size());
+        ASSERT_TRUE(index.get(keys.size(), key_slices.data(), get_values.data()).ok());
+        ASSERT_EQ(keys.size(), get_values.size());
+        for (int i = 0; i < DEL_N; i++) {
+            ASSERT_EQ(NullIndexValue, get_values[i].get_value());
+        }
+        for (int i = DEL_N; i < values.size(); i++) {
+            ASSERT_EQ(values[i], get_values[i]);
+        }
+    }
+
+    {
+        // rebuild mutableindex according PersistentIndexMetaPB
+        PersistentIndex new_index(kPersistentIndexDir);
+        ASSERT_TRUE(new_index.load(index_meta).ok());
+
+        std::vector<IndexValue> get_values(keys.size());
+        ASSERT_TRUE(new_index.get(keys.size(), key_slices.data(), get_values.data()).ok());
+        ASSERT_EQ(keys.size(), get_values.size());
+        for (int i = 0; i < DEL_N; i++) {
+            ASSERT_EQ(NullIndexValue, get_values[i].get_value());
+        }
+        for (int i = DEL_N; i < values.size(); i++) {
+            ASSERT_EQ(values[i], get_values[i]);
+        }
+    }
+    ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
