### PR TITLE
[Enhancement] Surface missing Status checks

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -662,6 +662,12 @@ if (ENABLE_FAULT_INJECTION)
     message(STATUS "enable fault injection")
 endif()
 
+option(ASSERT_STATUS_CHECKED "build with assert status checked" OFF)
+if (ASSERT_STATUS_CHECKED)
+    message(STATUS "Build with assert status checked")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DSTARROCKS_ASSERT_STATUS_CHECKED")
+endif()
+
 # For CMAKE_BUILD_TYPE=Debug
 #   -ggdb: Enable gdb debugging
 # Debug information is stored as dwarf2 to be as compatible as possible

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -62,6 +62,7 @@ const char* Status::copy_state_with_extra_ctx(const char* state, Slice ctx) {
 }
 
 Status::Status(const TStatus& s) {
+    must_check();
     if (s.status_code != TStatusCode::OK) {
         if (s.error_msgs.empty()) {
             _state = assemble_state(s.status_code, Slice(), Slice());
@@ -72,6 +73,7 @@ Status::Status(const TStatus& s) {
 }
 
 Status::Status(const StatusPB& s) {
+    must_check();
     auto code = (TStatusCode::type)s.status_code();
     if (code != TStatusCode::OK) {
         if (s.error_msgs_size() == 0) {
@@ -128,6 +130,7 @@ bool Status::in_directory_of_inject(const std::string& direct_name) {
 #endif
 
 void Status::to_thrift(TStatus* s) const {
+    mark_checked();
     s->error_msgs.clear();
     if (_state == nullptr) {
         s->status_code = TStatusCode::OK;
@@ -140,6 +143,7 @@ void Status::to_thrift(TStatus* s) const {
 }
 
 void Status::to_protobuf(StatusPB* s) const {
+    mark_checked();
     s->clear_error_msgs();
     if (_state == nullptr) {
         s->set_status_code((int)TStatusCode::OK);
@@ -151,6 +155,7 @@ void Status::to_protobuf(StatusPB* s) const {
 }
 
 std::string Status::code_as_string() const {
+    mark_checked();
     if (_state == nullptr) {
         return "OK";
     }
@@ -227,6 +232,7 @@ std::string Status::code_as_string() const {
 }
 
 std::string Status::to_string() const {
+    mark_checked();
     std::string result(code_as_string());
     if (_state == nullptr) {
         return result;
@@ -239,6 +245,7 @@ std::string Status::to_string() const {
 }
 
 Slice Status::message() const {
+    mark_checked();
     if (_state == nullptr) {
         return {};
     }
@@ -249,6 +256,7 @@ Slice Status::message() const {
 }
 
 Slice Status::detailed_message() const {
+    mark_checked();
     if (_state == nullptr) {
         return {};
     }
@@ -261,6 +269,7 @@ Slice Status::detailed_message() const {
     return {_state + 5, length};
 }
 Status Status::clone_and_prepend(const Slice& msg) const {
+    mark_checked();
     if (ok()) {
         return *this;
     }
@@ -271,6 +280,7 @@ Status Status::clone_and_prepend(const Slice& msg) const {
 }
 
 Status Status::clone_and_append(const Slice& msg) const {
+    mark_checked();
     if (ok()) {
         return *this;
     }
@@ -281,6 +291,7 @@ Status Status::clone_and_append(const Slice& msg) const {
 }
 
 Status Status::clone_and_append_context(const char* filename, int line, const char* expr) const {
+    mark_checked();
     if (UNLIKELY(ok())) {
         return *this;
     }

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -396,8 +396,10 @@ private:
 };
 
 inline void Status::update(const Status& new_status) {
+    new_status.mark_checked();
     if (ok()) {
         *this = new_status;
+        must_check();
     }
 }
 

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -12,6 +12,10 @@
 #include "gen_cpp/StatusCode_types.h" // for TStatus
 #include "util/slice.h"               // for Slice
 #include "util/time.h"
+#ifdef STARROCKS_ASSERT_STATUS_CHECKED
+#include "util/stack_util.h"
+#endif
+
 namespace starrocks {
 
 class StatusPB;
@@ -22,8 +26,20 @@ class StatusOr;
 
 class Status {
 public:
-    Status() {}
+    Status() = default;
+
     ~Status() noexcept {
+#ifdef STARROCKS_ASSERT_STATUS_CHECKED
+        if (!_checked) {
+            auto stack = get_stack_trace();
+            fprintf(stderr, "Failed to check status %p:\n%s\n", this, stack.c_str());
+            // TODO: abort on unhandled statuses
+            // For now, log and continue on unhandled status due to widespread issues
+            // To be fixed in refactoring to handle statuses correctly everywhere
+            // In the future, should abort on unhandled statuses
+            // std::abort();
+        }
+#endif
         if (!is_moved_from(_state)) {
             delete[] _state;
         }
@@ -37,16 +53,25 @@ public:
 #endif
 
     // Copy c'tor makes copy of error detail so Status can be returned by value
-    Status(const Status& s) : _state(s._state == nullptr ? nullptr : copy_state(s._state)) {}
+    Status(const Status& s) : _state(s._state == nullptr ? nullptr : copy_state(s._state)) {
+        s.mark_checked();
+        must_check();
+    }
 
     // Move c'tor
-    Status(Status&& s) noexcept : _state(s._state) { s._state = moved_from_state(); }
+    Status(Status&& s) noexcept : _state(s._state) {
+        s._state = moved_from_state();
+        s.mark_checked();
+        must_check();
+    }
 
     // Same as copy c'tor
     Status& operator=(const Status& s) {
         if (this != &s) {
             Status tmp(s);
             std::swap(this->_state, tmp._state);
+            tmp.mark_checked();
+            must_check();
         }
         return *this;
     }
@@ -56,6 +81,8 @@ public:
         if (this != &s) {
             Status tmp(std::move(s));
             std::swap(this->_state, tmp._state);
+            tmp.mark_checked();
+            must_check();
         }
         return *this;
     }
@@ -83,6 +110,20 @@ public:
     //
     void update(const Status& new_status);
     void update(Status&& new_status);
+
+    // In case of intentionally swallowing an error, user must explicitly call
+    // this function. That way we are easily able to search the code to find where
+    // error swallowing occurs.
+    //
+    // Inspired by Status in RocksDB:
+    // https://github.com/facebook/rocksdb/blob/05daa123323b1471bde4723dc441763d687fd825/include/rocksdb/status.h#L67
+    void permit_unchecked_error() const { mark_checked(); }
+
+    inline void must_check() const {
+#ifdef STARROCKS_ASSERT_STATUS_CHECKED
+        _checked = false;
+#endif // STARROCKS_ASSERT_STATUS_CHECKED
+    }
 
     static Status OK() { return Status(); }
 
@@ -151,40 +192,109 @@ public:
 
     static Status RemoteFileNotFound(const Slice& msg) { return Status(TStatusCode::REMOTE_FILE_NOT_FOUND, msg); }
 
-    bool ok() const { return _state == nullptr; }
+    bool ok() const {
+        mark_checked();
+        return _state == nullptr;
+    }
 
-    bool is_cancelled() const { return code() == TStatusCode::CANCELLED; }
-    bool is_mem_limit_exceeded() const { return code() == TStatusCode::MEM_LIMIT_EXCEEDED; }
-    bool is_thrift_rpc_error() const { return code() == TStatusCode::THRIFT_RPC_ERROR; }
-    bool is_end_of_file() const { return code() == TStatusCode::END_OF_FILE; }
-    bool is_ok_or_eof() const { return ok() || is_end_of_file(); }
-    bool is_not_found() const { return code() == TStatusCode::NOT_FOUND; }
-    bool is_already_exist() const { return code() == TStatusCode::ALREADY_EXIST; }
-    bool is_io_error() const { return code() == TStatusCode::IO_ERROR; }
-    bool is_not_supported() const { return code() == TStatusCode::NOT_IMPLEMENTED_ERROR; }
-    bool is_corruption() const { return code() == TStatusCode::CORRUPTION; }
+    bool is_cancelled() const {
+        mark_checked();
+        return code() == TStatusCode::CANCELLED;
+    }
+
+    bool is_mem_limit_exceeded() const {
+        mark_checked();
+        return code() == TStatusCode::MEM_LIMIT_EXCEEDED;
+    }
+
+    bool is_thrift_rpc_error() const {
+        mark_checked();
+        return code() == TStatusCode::THRIFT_RPC_ERROR;
+    }
+
+    bool is_end_of_file() const {
+        mark_checked();
+        return code() == TStatusCode::END_OF_FILE;
+    }
+
+    bool is_ok_or_eof() const {
+        mark_checked();
+        return ok() || is_end_of_file();
+    }
+
+    bool is_not_found() const {
+        mark_checked();
+        return code() == TStatusCode::NOT_FOUND;
+    }
+
+    bool is_already_exist() const {
+        mark_checked();
+        return code() == TStatusCode::ALREADY_EXIST;
+    }
+
+    bool is_io_error() const {
+        mark_checked();
+        return code() == TStatusCode::IO_ERROR;
+    }
+
+    bool is_not_supported() const {
+        mark_checked();
+        return code() == TStatusCode::NOT_IMPLEMENTED_ERROR;
+    }
+
+    bool is_corruption() const {
+        mark_checked();
+        return code() == TStatusCode::CORRUPTION;
+    }
 
     /// @return @c true if the status indicates Uninitialized.
-    bool is_uninitialized() const { return code() == TStatusCode::UNINITIALIZED; }
+    bool is_uninitialized() const {
+        mark_checked();
+        return code() == TStatusCode::UNINITIALIZED;
+    }
 
     // @return @c true if the status indicates an Aborted error.
-    bool is_aborted() const { return code() == TStatusCode::ABORTED; }
+    bool is_aborted() const {
+        mark_checked();
+        return code() == TStatusCode::ABORTED;
+    }
 
     /// @return @c true if the status indicates an InvalidArgument error.
-    bool is_invalid_argument() const { return code() == TStatusCode::INVALID_ARGUMENT; }
+    bool is_invalid_argument() const {
+        mark_checked();
+        return code() == TStatusCode::INVALID_ARGUMENT;
+    }
 
     // @return @c true if the status indicates ServiceUnavailable.
-    bool is_service_unavailable() const { return code() == TStatusCode::SERVICE_UNAVAILABLE; }
+    bool is_service_unavailable() const {
+        mark_checked();
+        return code() == TStatusCode::SERVICE_UNAVAILABLE;
+    }
 
-    bool is_data_quality_error() const { return code() == TStatusCode::DATA_QUALITY_ERROR; }
+    bool is_data_quality_error() const {
+        mark_checked();
+        return code() == TStatusCode::DATA_QUALITY_ERROR;
+    }
 
-    bool is_version_already_merged() const { return code() == TStatusCode::OLAP_ERR_VERSION_ALREADY_MERGED; }
+    bool is_version_already_merged() const {
+        mark_checked();
+        return code() == TStatusCode::OLAP_ERR_VERSION_ALREADY_MERGED;
+    }
 
-    bool is_duplicate_rpc_invocation() const { return code() == TStatusCode::DUPLICATE_RPC_INVOCATION; }
+    bool is_duplicate_rpc_invocation() const {
+        mark_checked();
+        return code() == TStatusCode::DUPLICATE_RPC_INVOCATION;
+    }
 
-    bool is_time_out() const { return code() == TStatusCode::TIMEOUT; }
+    bool is_time_out() const {
+        mark_checked();
+        return code() == TStatusCode::TIMEOUT;
+    }
 
-    bool is_eagain() const { return code() == TStatusCode::SR_EAGAIN; }
+    bool is_eagain() const {
+        mark_checked();
+        return code() == TStatusCode::SR_EAGAIN;
+    }
 
     // Convert into TStatus. Call this if 'status_container' contains an optional
     // TStatus field named 'status'. This also sets __isset.status.
@@ -199,6 +309,7 @@ public:
     void to_protobuf(StatusPB* status) const;
 
     std::string get_error_msg() const {
+        mark_checked();
         auto msg = message();
         return std::string(msg.data, msg.size);
     }
@@ -225,6 +336,7 @@ public:
     Slice detailed_message() const;
 
     TStatusCode::type code() const {
+        mark_checked();
         return _state == nullptr ? TStatusCode::OK : static_cast<TStatusCode::type>(_state[4]);
     }
 
@@ -261,6 +373,12 @@ private:
     Status(TStatusCode::type code, Slice msg) : Status(code, msg, {}) {}
     Status(TStatusCode::type code, Slice msg, Slice ctx);
 
+    void mark_checked() const {
+#ifdef STARROCKS_ASSERT_STATUS_CHECKED
+        _checked = true;
+#endif
+    }
+
 private:
     // OK status has a nullptr _state.  Otherwise, _state is a new[] array
     // of the following form:
@@ -270,6 +388,11 @@ private:
     //    _state[5.. 5 + len1]                == message
     //    _state[5 + len1 .. 5 + len1 + len2] == context
     const char* _state = nullptr;
+#ifdef STARROCKS_ASSERT_STATUS_CHECKED
+    // This field design follows Status in RocksDB
+    // https://github.com/facebook/rocksdb/blob/05daa123323b1471bde4723dc441763d687fd825/include/rocksdb/status.h#L467
+    mutable bool _checked = false;
+#endif
 };
 
 inline void Status::update(const Status& new_status) {
@@ -279,8 +402,10 @@ inline void Status::update(const Status& new_status) {
 }
 
 inline void Status::update(Status&& new_status) {
+    new_status.mark_checked();
     if (ok()) {
         *this = std::move(new_status);
+        must_check();
     }
 }
 


### PR DESCRIPTION
This commit adds the option ASSERT_STATUS_CHECKED when compiling the BE. When enabled, any unhandled Status will print the call stack to stderr to surface missing status checks.

This behavior is inspired by the Status in RocksDB.

The goal is to incrementally add proper status checking everywhere over time. The assertions will help uncover these gaps early during testing and debugging.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
