### PR TITLE
[Enhancement] turn the MetadataMgr into a cache from map

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2495,4 +2495,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static String access_control = "native";
+
+    @ConfField(mutable = true)
+    public static int catalog_metadata_cache_size = 500;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -71,7 +71,8 @@ import java.util.stream.Collectors;
 
 public class MetadataMgr {
     private static final Logger LOG = LogManager.getLogger(MetadataMgr.class);
-    private class QueryMetadatas {
+
+    public class QueryMetadatas {
         private final Map<String, ConnectorMetadata> metadatas = new HashMap<>();
 
         public QueryMetadatas() {}
@@ -102,9 +103,7 @@ public class MetadataMgr {
         QueryMetadatas meta = notification.getValue();
         if (meta != null) {
             meta.metadatas.values().forEach(ConnectorMetadata::clear);
-            if (notification.getCause() == RemovalCause.EXPLICIT) {
-                LOG.info("Succeed to deregister query level connector metadata on query id: {}", queryId);
-            } else {
+            if (notification.getCause() != RemovalCause.EXPLICIT) {
                 LOG.info("Evict cache due to {} and deregister query-level " +
                         "connector metadata on query id: {}", notification.getCause(), queryId);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -16,9 +16,12 @@
 package com.starrocks.server;
 
 import com.google.common.collect.Lists;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.utframe.StarRocksAssert;
@@ -35,8 +38,11 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.starrocks.connector.hive.HiveClassNames.MAPRED_PARQUET_INPUT_FORMAT_CLASS;
 
@@ -244,5 +250,27 @@ public class MetadataMgrTest {
         Assert.assertTrue(metadata.isPresent());
         metadata = metadataMgr.getOptionalMetadata("hive_catalog_not_exist");
         Assert.assertFalse(metadata.isPresent());
+    }
+
+    @Test
+    public void testRemoveCache() {
+        MetadataMgr mgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
+
+        Map<UUID, ConnectorMetadata> queryIdSet = new HashMap<>();
+        for (int i = 0; i < Config.catalog_metadata_cache_size; i++) {
+            UUID queryId = UUIDUtil.genUUID();
+            ConnectContext.get().setQueryId(queryId);
+            Optional<ConnectorMetadata> metadata = mgr.getOptionalMetadata("hive_catalog");
+            Assert.assertTrue(metadata.isPresent());
+            queryIdSet.put(queryId, metadata.get());
+        }
+
+        // cache evicted
+        UUID queryId = UUIDUtil.genUUID();
+        ConnectContext.get().setQueryId(queryId);
+        Optional<ConnectorMetadata> metadata = mgr.getOptionalMetadata("hive_catalog");
+        Assert.assertTrue(metadata.isPresent());
+        Assert.assertFalse(queryIdSet.containsValue(metadata.get()));
+        mgr.removeQueryMetadata();
     }
 }


### PR DESCRIPTION
Fixes #issue

Make the`MetadataMgr` as a cache, to avoid any kind of resource leak.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
