### PR TITLE
[Enhancement] turn the MetadataMgr into a cache from map

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2097,4 +2097,7 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static int external_table_commit_timeout_ms = 10000; // 10s
+
+    @ConfField(mutable = true)
+    public static int catalog_metadata_cache_size = 500;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -3,12 +3,18 @@
 package com.starrocks.server;
 
 import com.google.common.base.Preconditions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalCause;
+import com.google.common.cache.RemovalListener;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorMetadata;
@@ -24,12 +30,13 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 public class MetadataMgr {
     private static final Logger LOG = LogManager.getLogger(MetadataMgr.class);
@@ -37,7 +44,33 @@ public class MetadataMgr {
     private final LocalMetastore localMetastore;
     private final ConnectorMgr connectorMgr;
     private final ConnectorTblMetaInfoMgr connectorTblMetaInfoMgr;
-    private final Map<String, QueryMetadatas> metadataByQueryId = new ConcurrentHashMap<>();
+
+    private static final RemovalListener<String, QueryMetadatas> CACHE_REMOVAL_LISTENER = (notification) -> {
+        String queryId = notification.getKey();
+        QueryMetadatas meta = notification.getValue();
+        if (meta != null) {
+            meta.metadatas.values().forEach(ConnectorMetadata::clear);
+            if (notification.getCause() == RemovalCause.EXPLICIT) {
+                LOG.info("Succeed to deregister query level connector metadata on query id: {}", queryId);
+            } else {
+                LOG.info("Evict cache due to {} and deregister query-level " +
+                        "connector metadata on query id: {}", notification.getCause(), queryId);
+            }
+        }
+    };
+
+    private final LoadingCache<String, QueryMetadatas> metadataCacheByQueryId =
+            CacheBuilder.newBuilder()
+                    .maximumSize(Config.catalog_metadata_cache_size)
+                    .expireAfterAccess(300, TimeUnit.SECONDS)
+                    .removalListener(CACHE_REMOVAL_LISTENER)
+                    .build(new CacheLoader<String, QueryMetadatas>() {
+                        @NotNull
+                        @Override
+                        public QueryMetadatas load(String key) throws Exception {
+                            return new QueryMetadatas();
+                        }
+                    });
 
     public MetadataMgr(LocalMetastore localMetastore, ConnectorMgr connectorMgr,
                        ConnectorTblMetaInfoMgr connectorTblMetaInfoMgr) {
@@ -54,7 +87,7 @@ public class MetadataMgr {
             String queryId = ConnectContext.get() != null && ConnectContext.get().getQueryId() != null ?
                     ConnectContext.get().getQueryId().toString() : null;
             if (queryId != null) {
-                QueryMetadatas queryMetadatas = metadataByQueryId.computeIfAbsent(queryId, ignored -> new QueryMetadatas());
+                QueryMetadatas queryMetadatas = metadataCacheByQueryId.getUnchecked(queryId);
                 return Optional.ofNullable(queryMetadatas.getConnectorMetadata(catalogName, queryId));
             } else {
                 Connector connector = connectorMgr.getConnector(catalogName);
@@ -72,12 +105,7 @@ public class MetadataMgr {
         String queryId = ConnectContext.get() != null && ConnectContext.get().getQueryId() != null ?
                 ConnectContext.get().getQueryId().toString() : null;
         if (queryId != null) {
-            QueryMetadatas queryMetadatas = metadataByQueryId.get(queryId);
-            if (queryMetadatas != null) {
-                queryMetadatas.metadatas.values().forEach(ConnectorMetadata::clear);
-                metadataByQueryId.remove(queryId);
-                LOG.info("Succeed to deregister query level connector metadata on query id: {}", queryId);
-            }
+            metadataCacheByQueryId.invalidate(queryId);
         }
     }
 


### PR DESCRIPTION
Fixes #issue

Make theMetadataMgr as a cache, to avoid any kind of resource leak.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
