### PR TITLE
[WIP][BugFix] The max readable version of tablet during schema change should be set as max version

### DIFF
--- a/be/src/storage/publish_version_manager.cpp
+++ b/be/src/storage/publish_version_manager.cpp
@@ -134,7 +134,11 @@ void PublishVersionManager::update_tablet_version(TFinishTaskRequest& finish_tas
         int64_t tablet_id = tablet_versions[i].tablet_id;
         TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
         if (tablet != nullptr) {
-            tablet_versions[i].__set_version(tablet->max_readable_version());
+            if (tablet->tablet_state() == TabletState::TABLET_RUNNING) {
+                tablet_versions[i].__set_version(tablet->max_readable_version());
+            } else {
+                tablet_versions[i].__set_version(tablet->max_continuous_version());
+            }
         }
     }
 }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2710,7 +2710,7 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
             auto& last = _edit_version_infos.back();
             version = last->version.major_number();
             // tablet maybe doing schema change, set max readable version as max version
-            if (_tablet->state() != TABLET_RUNNING) {
+            if (_tablet.tablet_state() != TABLET_RUNNING) {
                 max_readable_version = version;
             }
             rowsets = last->rowsets;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2709,6 +2709,10 @@ void TabletUpdates::get_tablet_info_extra(TTabletInfo* info) {
             max_readable_version = _edit_version_infos[_apply_version_idx]->version.major_number();
             auto& last = _edit_version_infos.back();
             version = last->version.major_number();
+            // tablet maybe doing schema change, set max readable version as max version
+            if (_tablet->state() != TABLET_RUNNING) {
+                max_readable_version = version;
+            }
             rowsets = last->rowsets;
             has_pending = _pending_commits.size() > 0;
             // version count in primary key table contains two parts:


### PR DESCRIPTION
If enable sync publish, we will use the max readable version as the tablet version when report the replica version to FE. But if the tablet is doing schema change, the max readable version may never grow before the alter job is finished because these tablets do not have the version before the schema change job and this may cause the alter job to hang. We should skip the version check for these tablets and report the max version as the max readable version.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
