### PR TITLE
[BugFix] Fix PerBucketCompute crash in local-shuffle AGG

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -81,9 +81,11 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
     const auto use_cache = _fragment_ctx->enable_cache();
 
     // attach ticket_checker to both ScanOperator and SplitMorselQueue
-    auto should_attach_ticket_checker = (dynamic_cast<ScanOperator*>(source_op) != nullptr) &&
-                                        _morsel_queue != nullptr && _morsel_queue->could_attch_ticket_checker() &&
-                                        (use_cache || down_cast<ScanOperator*>(source_op)->output_chunk_by_bucket());
+    auto should_attach_ticket_checker =
+            (dynamic_cast<ScanOperator*>(source_op) != nullptr) && _morsel_queue != nullptr &&
+            _morsel_queue->could_attch_ticket_checker() &&
+            (use_cache || dynamic_cast<BucketSequenceMorselQueue*>(_morsel_queue) != nullptr);
+
     if (should_attach_ticket_checker) {
         auto* scan_op = dynamic_cast<ScanOperator*>(source_op);
         auto ticket_checker = std::make_shared<query_cache::TicketChecker>();

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -196,9 +196,10 @@ StatusOr<int64_t> BucketSequenceMorselQueue::_peek_sequence_id() const {
     int64_t next_owner_id = -1;
     if (!_morsel_queue->empty()) {
         ASSIGN_OR_RETURN(auto next_morsel, _morsel_queue->try_get());
-        auto* next_scan_morsel = down_cast<ScanMorsel*>(next_morsel.get());
-        next_owner_id = next_scan_morsel->owner_id();
-        _morsel_queue->unget(std::move(next_morsel));
+        if (auto* next_scan_morsel = down_cast<ScanMorsel*>(next_morsel.get())) {
+            next_owner_id = next_scan_morsel->owner_id();
+            _morsel_queue->unget(std::move(next_morsel));
+        }
     }
     return next_owner_id;
 }

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -299,6 +299,12 @@ public:
     BucketSequenceMorselQueue(MorselQueuePtr&& morsel_queue);
     std::vector<TInternalScanRange*> olap_scan_ranges() const override;
 
+    void set_key_ranges(const std::vector<std::unique_ptr<OlapScanRange>>& key_ranges) override {
+        _morsel_queue->set_key_ranges(key_ranges);
+    }
+
+    void set_tablets(const std::vector<TabletSharedPtr>& tablets) override { _morsel_queue->set_tablets(tablets); }
+
     void set_tablet_rowsets(const std::vector<std::vector<RowsetSharedPtr>>& tablet_rowsets) override {
         _morsel_queue->set_tablet_rowsets(tablet_rowsets);
     }

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -109,6 +109,7 @@ StatusOr<pipeline::MorselQueueFactoryPtr> ScanNode::convert_scan_range_to_morsel
         const std::map<int32_t, std::vector<TScanRangeParams>>& scan_ranges_per_driver_seq, int node_id,
         int pipeline_dop, bool enable_tablet_internal_parallel,
         TTabletInternalParallelMode::type tablet_internal_parallel_mode) {
+    DCHECK(!output_chunk_by_bucket() || !scan_ranges_per_driver_seq.empty());
     if (scan_ranges_per_driver_seq.empty()) {
         ASSIGN_OR_RETURN(auto morsel_queue,
                          convert_scan_range_to_morsel_queue(global_scan_ranges, node_id, pipeline_dop,

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -723,7 +723,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         // Do nothing.
     }
 
-    public void disablePhysicalDistributionOptimize() {
+    public void disablePhysicalPropertyOptimize() {
         forEachNode(planRoot, PlanNode::disablePhysicalPropertyOptimize);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/LocalFragmentAssignmentStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/LocalFragmentAssignmentStrategy.java
@@ -161,7 +161,7 @@ public class LocalFragmentAssignmentStrategy implements FragmentAssignmentStrate
 
         if (!assignPerDriverSeq) {
             // these optimize depend on assignPerDriverSeq.
-            fragment.disablePhysicalDistributionOptimize();
+            fragment.disablePhysicalPropertyOptimize();
         }
 
         workerIdToBucketSeqs.forEach((workerId, bucketSeqsOfWorker) -> {
@@ -233,6 +233,7 @@ public class LocalFragmentAssignmentStrategy implements FragmentAssignmentStrate
 
                     if (!enableAssignScanRangesPerDriverSeq(fragment, scanRanges)) {
                         instance.addScanRanges(scanId, scanRanges);
+                        fragment.disablePhysicalPropertyOptimize();
                     } else {
                         int expectedDop = Math.max(1, Math.min(pipelineDop, scanRanges.size()));
                         List<List<TScanRangeParams>> scanRangesPerDriverSeq;

--- a/test/sql/test_agg/R/test_bucket_agg
+++ b/test/sql/test_agg/R/test_bucket_agg
@@ -1,0 +1,138 @@
+-- name: test_bucket_agg
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 2
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+insert into t0 select * from t0;
+-- result:
+-- !result
+set tablet_internal_parallel_mode="force_split";
+-- result:
+-- !result
+select distinct c0 from t0 order by 1 limit 5;
+-- result:
+1
+2
+3
+4
+5
+-- !result
+select distinct c0, c1 from t0 order by 1, 2 limit 5;
+-- result:
+1	4095
+2	4094
+3	4093
+4	4092
+5	4091
+-- !result
+select distinct c0, c1, c2 from t0 order by 1, 2, 3 limit 5;
+-- result:
+1	4095	1
+2	4094	2
+3	4093	3
+4	4092	4
+5	4091	5
+-- !result
+select sum(c1) from t0 group by c0, c2 order by 1 limit 5;
+-- result:
+0
+2
+4
+6
+8
+-- !result
+select sum(c2) from t0 group by c0, c1 order by 1 limit 5;
+-- result:
+2
+4
+6
+8
+10
+-- !result
+select sum(c1), max(c2) from t0 group by c0 order by 1, 2 limit 5;
+-- result:
+0	4096
+2	4095
+4	4094
+6	4093
+8	4092
+-- !result
+select count(*) from (select distinct c0 from t0) tb;
+-- result:
+4096
+-- !result
+select count(*) from (select c0, c1, sum(c2) from t0 group by c0, c1) tb;
+-- result:
+4096
+-- !result
+set tablet_internal_parallel_mode="auto";
+-- result:
+-- !result
+select distinct c0 from t0 order by 1 limit 5;
+-- result:
+1
+2
+3
+4
+5
+-- !result
+select distinct c0, c1 from t0 order by 1, 2 limit 5;
+-- result:
+1	4095
+2	4094
+3	4093
+4	4092
+5	4091
+-- !result
+select distinct c0, c1, c2 from t0 order by 1, 2, 3 limit 5;
+-- result:
+1	4095	1
+2	4094	2
+3	4093	3
+4	4092	4
+5	4091	5
+-- !result
+select sum(c1) from t0 group by c0, c2 order by 1 limit 5;
+-- result:
+0
+2
+4
+6
+8
+-- !result
+select sum(c2) from t0 group by c0, c1 order by 1 limit 5;
+-- result:
+2
+4
+6
+8
+10
+-- !result
+select sum(c1), max(c2) from t0 group by c0 order by 1, 2 limit 5;
+-- result:
+0	4096
+2	4095
+4	4094
+6	4093
+8	4092
+-- !result
+select count(*) from (select distinct c0 from t0) tb;
+-- result:
+4096
+-- !result
+select count(*) from (select c0, c1, sum(c2) from t0 group by c0, c1) tb;
+-- result:
+4096
+-- !result

--- a/test/sql/test_agg/T/test_bucket_agg
+++ b/test/sql/test_agg/T/test_bucket_agg
@@ -1,0 +1,41 @@
+-- name: test_bucket_agg
+
+CREATE TABLE `t0` (
+  `c0` bigint DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 2
+PROPERTIES (
+"replication_num" = "1"
+);
+
+
+insert into t0 SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1,  4096));
+insert into t0 select * from t0;
+
+set tablet_internal_parallel_mode="force_split";
+
+select distinct c0 from t0 order by 1 limit 5;
+select distinct c0, c1 from t0 order by 1, 2 limit 5;
+select distinct c0, c1, c2 from t0 order by 1, 2, 3 limit 5;
+select sum(c1) from t0 group by c0, c2 order by 1 limit 5;
+select sum(c2) from t0 group by c0, c1 order by 1 limit 5;
+select sum(c1), max(c2) from t0 group by c0 order by 1, 2 limit 5;
+
+select count(*) from (select distinct c0 from t0) tb;
+select count(*) from (select c0, c1, sum(c2) from t0 group by c0, c1) tb;
+
+set tablet_internal_parallel_mode="auto";
+
+select distinct c0 from t0 order by 1 limit 5;
+select distinct c0, c1 from t0 order by 1, 2 limit 5;
+select distinct c0, c1, c2 from t0 order by 1, 2, 3 limit 5;
+select sum(c1) from t0 group by c0, c2 order by 1 limit 5;
+select sum(c2) from t0 group by c0, c1 order by 1 limit 5;
+select sum(c1), max(c2) from t0 group by c0 order by 1, 2 limit 5;
+
+select count(*) from (select distinct c0 from t0) tb;
+select count(*) from (select c0, c1, sum(c2) from t0 group by c0, c1) tb;


### PR DESCRIPTION
problem 1:
if a table is not a partition table and bucket number x 4 < dop. we will generate a local shuffle AGG. BE ticket checker may cause crash

problem 2:
we need overwrite set_key_ranges set_tablets for BucketSequenceMorselQueue.

```
#0  starrocks::query_cache::TicketChecker::leave (this=<optimized out>, id=id@entry=0)
    at /root/starrocks/be/src/exec/query_cache/ticket_checker.cpp:33
#1  0x000000000333ef35 in starrocks::pipeline::ScanOperator::_should_emit_eos (
    chunk=std::shared_ptr<starrocks::Chunk> (use count 1, weak count 0) = {...}, this=0x7efcb1b14010)
    at /root/starrocks/be/src/exec/pipeline/scan/scan_operator.cpp:248
#2  starrocks::pipeline::ScanOperator::pull_chunk (this=0x7efcb1b14010, state=<optimized out>)
    at /root/starrocks/be/src/exec/pipeline/scan/scan_operator.cpp:236
#3  0x00000000033c676e in starrocks::pipeline::PipelineDriver::process (this=0x7efc935f7710, runtime_state=0x7efdb68aca00, 
    worker_id=<optimized out>) at /root/starrocks/be/src/exec/pipeline/pipeline_driver.cpp:292
#4  0x00000000033b88b7 in starrocks::pipeline::GlobalDriverExecutor::_worker_thread (this=0x7efdb7ba8f80)
    at /root/starrocks/be/src/exec/pipeline/pipeline_driver_executor.cpp:151
#5  0x0000000002ac16ea in std::function<void ()>::operator()() const (this=0x7efd9f600a18)
    at /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/std_function.h:622
#6  starrocks::FunctionRunnable::run (this=0x7efd9f600a10) at /root/starrocks/be/src/util/threadpool.cpp:58
#7  starrocks::ThreadPool::dispatch_thread (this=0x7efd9f637540) at /root/starrocks/be/src/util/threadpool.cpp:553
#8  0x0000000002abc1ba in std::function<void ()>::operator()() const (this=0x7efda461a418)
    at /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/std_function.h:622
#9  starrocks::Thread::supervise_thread (arg=0x7efda461a400) at /root/starrocks/be/src/util/thread.cpp:364
#10 0x00007efdbfb3bea5 in start_thread () from /lib64/libpthread.so.0
#11 0x00007efdbf156b0d in clone () from /lib64/libc.so.6
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
