### PR TITLE
[Refactor] deprecate enable_pipeline_load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2026,6 +2026,7 @@ public class Config extends ConfigBase {
     /**
      * Enable pipeline engine load
      */
+    @Deprecated
     @ConfField(mutable = true)
     public static boolean enable_pipeline_load = true;
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
@@ -246,7 +246,7 @@ public class LoadingTaskPlanner {
             enableAutomaticPartition = table.supportedAutomaticPartition();
         }
         Preconditions.checkState(!CollectionUtils.isEmpty(partitionIds));
-        OlapTableSink olapTableSink = new OlapTableSink(table, tupleDesc, partitionIds, true,
+        OlapTableSink olapTableSink = new OlapTableSink(table, tupleDesc, partitionIds,
                 table.writeQuorum(), forceReplicatedStorage ? true : table.enableReplicatedStorage(),
                 checkNullExprInAutoIncrement(), enableAutomaticPartition);
         if (table.getAutomaticBucketSize() > 0) {
@@ -262,15 +262,10 @@ public class LoadingTaskPlanner {
         sinkFragment.setSink(olapTableSink);
 
         if (this.context != null) {
-            if (this.context.getSessionVariable().isEnablePipelineEngine() && Config.enable_pipeline_load) {
-                sinkFragment.setPipelineDop(parallelInstanceNum);
-                sinkFragment.setParallelExecNum(1);
-                sinkFragment.setHasOlapTableSink();
-                sinkFragment.setForceAssignScanRangesPerDriverSeq();
-            } else {
-                sinkFragment.setPipelineDop(1);
-                sinkFragment.setParallelExecNum(parallelInstanceNum);
-            }
+            sinkFragment.setPipelineDop(parallelInstanceNum);
+            sinkFragment.setParallelExecNum(1);
+            sinkFragment.setHasOlapTableSink();
+            sinkFragment.setForceAssignScanRangesPerDriverSeq();
         } else {
             sinkFragment.setPipelineDop(1);
             sinkFragment.setParallelExecNum(parallelInstanceNum);
@@ -331,7 +326,7 @@ public class LoadingTaskPlanner {
         } else {
             enableAutomaticPartition = table.supportedAutomaticPartition();
         }
-        OlapTableSink olapTableSink = new OlapTableSink(table, tupleDesc, partitionIds, true,
+        OlapTableSink olapTableSink = new OlapTableSink(table, tupleDesc, partitionIds,
                 table.writeQuorum(), table.enableReplicatedStorage(),
                 checkNullExprInAutoIncrement(), enableAutomaticPartition);
         if (table.getAutomaticBucketSize() > 0) {
@@ -349,11 +344,9 @@ public class LoadingTaskPlanner {
         // which may lead to inconsistent replica for primary key.
         // If you want to set tablet sink dop > 1, please enable single tablet loading and disable shuffle service
         if (this.context != null) {
-            if (this.context.getSessionVariable().isEnablePipelineEngine() && Config.enable_pipeline_load) {
-                sinkFragment.setHasOlapTableSink();
-                sinkFragment.setForceSetTableSinkDop();
-                sinkFragment.setForceAssignScanRangesPerDriverSeq();
-            }
+            sinkFragment.setHasOlapTableSink();
+            sinkFragment.setForceSetTableSinkDop();
+            sinkFragment.setForceAssignScanRangesPerDriverSeq();
             sinkFragment.setPipelineDop(1);
             sinkFragment.setParallelExecNum(parallelInstanceNum);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataSink.java
@@ -91,7 +91,7 @@ public abstract class DataSink {
 
     public static boolean canTableSinkUsePipeline(Table table) {
         if (table instanceof OlapTable) {
-            return Config.enable_pipeline_load;
+            return true;
         } else if (table instanceof MysqlTable) {
             return true;
         } else if (table instanceof IcebergTable) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -690,7 +690,7 @@ public class FileScanNode extends LoadScanNode {
     protected void toThrift(TPlanNode msg) {
         msg.node_type = TPlanNodeType.FILE_SCAN_NODE;
         TFileScanNode fileScanNode = new TFileScanNode(desc.getId().asInt());
-        fileScanNode.setEnable_pipeline_load(Config.enable_pipeline_load);
+        fileScanNode.setEnable_pipeline_load(true);
         msg.setFile_scan_node(fileScanNode);
     }
 
@@ -767,8 +767,7 @@ public class FileScanNode extends LoadScanNode {
 
     @Override
     public boolean canUsePipeLine() {
-        // @TODO(silverbullet233): remove this config and always return true
-        return Config.enable_pipeline_load;
+        return true;
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -119,7 +119,6 @@ public class OlapTableSink extends DataSink {
     // set after init called
     private TDataSink tDataSink;
 
-    private final boolean enablePipelineLoad;
     private final TWriteQuorumType writeQuorum;
     private final boolean enableReplicatedStorage;
 
@@ -133,18 +132,10 @@ public class OlapTableSink extends DataSink {
     public OlapTableSink(OlapTable dstTable, TupleDescriptor tupleDescriptor, List<Long> partitionIds,
                          TWriteQuorumType writeQuorum, boolean enableReplicatedStorage,
                          boolean nullExprInAutoIncrement, boolean enableAutomaticPartition) {
-        this(dstTable, tupleDescriptor, partitionIds, true, writeQuorum, enableReplicatedStorage,
-                nullExprInAutoIncrement, enableAutomaticPartition);
-    }
-
-    public OlapTableSink(OlapTable dstTable, TupleDescriptor tupleDescriptor, List<Long> partitionIds,
-                         boolean enablePipelineLoad, TWriteQuorumType writeQuorum, boolean enableReplicatedStorage,
-                         boolean nullExprInAutoIncrement, boolean enableAutomaticPartition) {
         this.dstTable = dstTable;
         this.tupleDescriptor = tupleDescriptor;
         this.partitionIds = partitionIds;
         this.clusterId = dstTable.getClusterId();
-        this.enablePipelineLoad = enablePipelineLoad;
         this.writeQuorum = writeQuorum;
         this.enableReplicatedStorage = enableReplicatedStorage;
         this.nullExprInAutoIncrement = nullExprInAutoIncrement;
@@ -616,8 +607,7 @@ public class OlapTableSink extends DataSink {
     }
 
     public boolean canUsePipeLine() {
-        // @TODO(silverbullet233): remove this config and always return true
-        return Config.enable_pipeline_load && enablePipelineLoad;
+        return true;
     }
 
     public int getClusterId() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadScanNode.java
@@ -413,7 +413,7 @@ public class StreamLoadScanNode extends LoadScanNode {
     protected void toThrift(TPlanNode planNode) {
         planNode.setNode_type(TPlanNodeType.FILE_SCAN_NODE);
         TFileScanNode fileScanNode = new TFileScanNode(desc.getId().asInt());
-        fileScanNode.setEnable_pipeline_load(Config.enable_pipeline_load);
+        fileScanNode.setEnable_pipeline_load(true);
         planNode.setFile_scan_node(fileScanNode);
     }
 
@@ -434,7 +434,6 @@ public class StreamLoadScanNode extends LoadScanNode {
 
     @Override
     public boolean canUsePipeLine() {
-        // @TODO(silverbullet233): remove this config and always return true
-        return Config.enable_pipeline_load;
+        return true;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -250,7 +250,7 @@ public class InsertPlanner {
 
                 }
                 dataSink = new OlapTableSink(olapTable, tupleDesc, targetPartitionIds,
-                        canUsePipeline, olapTable.writeQuorum(),
+                        olapTable.writeQuorum(),
                         forceReplicatedStorage ? true : olapTable.enableReplicatedStorage(),
                         nullExprInAutoIncrement, enableAutomaticPartition);
                 if (olapTable.getAutomaticBucketSize() > 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -256,7 +256,7 @@ public class PlanFragmentBuilder {
         view.setMaintenancePlan(execPlan);
         List<Long> fakePartitionIds = Arrays.asList(1L, 2L, 3L);
 
-        DataSink tableSink = new OlapTableSink(view, tupleDesc, fakePartitionIds, true,
+        DataSink tableSink = new OlapTableSink(view, tupleDesc, fakePartitionIds,
                 view.writeQuorum(), view.enableReplicatedStorage(), false, false);
         execPlan.getTopFragment().setSink(tableSink);
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
@@ -203,20 +203,6 @@ public class LoadPlannerTest {
         locationsList = scanNode.getScanRangeLocations(0);
         Assert.assertEquals(4, locationsList.size());
 
-        // load_parallel_instance_num: 2, non pipeline
-        Config.enable_pipeline_load = false;
-        ctx.getSessionVariable().setEnablePipelineEngine(false);
-        Config.load_parallel_instance_num = 2;
-        planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
-                timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
-                brokerDesc, fileGroups, fileStatusesList, 2);
-        planner.plan();
-        scanNode = (FileScanNode) planner.getScanNodes().get(0);
-        locationsList = scanNode.getScanRangeLocations(0);
-        Assert.assertEquals(4, locationsList.size());
-        Assert.assertEquals(1, planner.getFragments().get(0).getPipelineDop());
-        Assert.assertEquals(2, planner.getFragments().get(0).getParallelExecNum());
-
         // load_parallel_instance_num: 2, pipeline
         ctx.getSessionVariable().setEnablePipelineEngine(true);
         Config.enable_pipeline_load = true;

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -42,7 +42,6 @@ import com.starrocks.analysis.LabelName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
-import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.LoadException;
 import com.starrocks.common.MetaNotFoundException;
@@ -54,15 +53,12 @@ import com.starrocks.load.EtlJobType;
 import com.starrocks.load.EtlStatus;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.EditLog;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterLoadStmt;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.task.LeaderTask;
 import com.starrocks.task.LeaderTaskExecutor;
-import com.starrocks.task.PriorityLeaderTask;
-import com.starrocks.task.PriorityLeaderTaskExecutor;
 import com.starrocks.transaction.TransactionState;
 import mockit.Expectations;
 import mockit.Injectable;
@@ -360,78 +356,6 @@ public class BrokerLoadJobTest {
         brokerLoadJob.onTaskFinished(attachment);
         Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
         Assert.assertEquals(0, idToTasks.size());
-    }
-
-    @Test
-    public void testPendingTaskOnFinished(@Injectable BrokerPendingTaskAttachment attachment,
-                                          @Mocked GlobalStateMgr globalStateMgr,
-                                          @Injectable Database database,
-                                          @Injectable BrokerFileGroupAggInfo fileGroupAggInfo,
-                                          @Injectable BrokerFileGroup brokerFileGroup1,
-                                          @Injectable BrokerFileGroup brokerFileGroup2,
-                                          @Injectable BrokerFileGroup brokerFileGroup3,
-                                          @Mocked LeaderTaskExecutor leaderTaskExecutor,
-                                          @Mocked PriorityLeaderTaskExecutor priorityLeaderTaskExecutor,
-                                          @Injectable OlapTable olapTable,
-                                          @Mocked LoadingTaskPlanner loadingTaskPlanner) {
-        Config.enable_pipeline_load = false;
-        BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
-        brokerLoadJob.setConnectContext(new ConnectContext());
-        Deencapsulation.setField(brokerLoadJob, "state", JobState.LOADING);
-        long taskId = 1L;
-        long tableId1 = 1L;
-        long tableId2 = 2L;
-        long partitionId1 = 3L;
-        long partitionId2 = 4;
-
-        Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToFileGroups = Maps.newHashMap();
-        List<BrokerFileGroup> fileGroups1 = Lists.newArrayList();
-        fileGroups1.add(brokerFileGroup1);
-        aggKeyToFileGroups.put(new FileGroupAggKey(tableId1, null), fileGroups1);
-
-        List<BrokerFileGroup> fileGroups2 = Lists.newArrayList();
-        fileGroups2.add(brokerFileGroup2);
-        fileGroups2.add(brokerFileGroup3);
-        aggKeyToFileGroups.put(new FileGroupAggKey(tableId2, Lists.newArrayList(partitionId1)), fileGroups2);
-        // add another file groups with different partition id
-        aggKeyToFileGroups.put(new FileGroupAggKey(tableId2, Lists.newArrayList(partitionId2)), fileGroups2);
-
-        Deencapsulation.setField(brokerLoadJob, "fileGroupAggInfo", fileGroupAggInfo);
-        new Expectations() {
-            {
-                attachment.getTaskId();
-                minTimes = 0;
-                result = taskId;
-                globalStateMgr.getDb(anyLong);
-                minTimes = 0;
-                result = database;
-                fileGroupAggInfo.getAggKeyToFileGroups();
-                minTimes = 0;
-                result = aggKeyToFileGroups;
-                database.getTable(anyLong);
-                minTimes = 0;
-                result = olapTable;
-                globalStateMgr.getNextId();
-                minTimes = 0;
-                result = 1L;
-                result = 2L;
-                result = 3L;
-                leaderTaskExecutor.submit((LeaderTask) any);
-                minTimes = 0;
-                result = true;
-                priorityLeaderTaskExecutor.submit((PriorityLeaderTask) any);
-                minTimes = 0;
-                result = true;
-            }
-        };
-
-        brokerLoadJob.onTaskFinished(attachment);
-        Set<Long> finishedTaskIds = Deencapsulation.getField(brokerLoadJob, "finishedTaskIds");
-        Assert.assertEquals(1, finishedTaskIds.size());
-        Assert.assertEquals(true, finishedTaskIds.contains(taskId));
-        Map<Long, LoadTask> idToTasks = Deencapsulation.getField(brokerLoadJob, "idToTasks");
-        Assert.assertEquals(3, idToTasks.size());
-        Config.enable_pipeline_load = true;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
@@ -100,20 +100,10 @@ public class PipelineParallelismTest extends PlanTestBase {
     public void testInsert() throws Exception {
         boolean prevEnablePipelineLoad = Config.enable_pipeline_load;
         try {
-            Config.enable_pipeline_load = false;
-            ExecPlan plan = getExecPlan("insert into t0 select * from t0");
-            PlanFragment fragment0 = plan.getFragments().get(0);
-            assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
-            // Disable pipeline_load by Config, so ParallelExecNum of fragment is 
-            // equal to the corresponding session variables.
-            Assert.assertEquals(parallelExecInstanceNum, fragment0.getParallelExecNum());
-            Assert.assertEquals(1, fragment0.getPipelineDop());
-
             connectContext.getSessionVariable().setEnableAdaptiveSinkDop(false);
 
-            Config.enable_pipeline_load = true;
-            plan = getExecPlan("insert into t0 select * from t0");
-            fragment0 = plan.getFragments().get(0);
+            ExecPlan plan = getExecPlan("insert into t0 select * from t0");
+            PlanFragment fragment0 = plan.getFragments().get(0);
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
             // ParallelExecNum of fragment not 1. still can not use pipeline
             Assert.assertEquals(1, fragment0.getParallelExecNum());
@@ -121,7 +111,6 @@ public class PipelineParallelismTest extends PlanTestBase {
 
             connectContext.getSessionVariable().setEnableAdaptiveSinkDop(true);
 
-            Config.enable_pipeline_load = true;
             plan = getExecPlan("insert into t0 select * from t0");
             fragment0 = plan.getFragments().get(0);
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
@@ -137,21 +126,10 @@ public class PipelineParallelismTest extends PlanTestBase {
     public void testDelete() throws Exception {
         boolean prevEnablePipelineLoad = Config.enable_pipeline_load;
         try {
-            Config.enable_pipeline_load = false;
-            ExecPlan plan = getExecPlan("delete from tprimary where pk = 1");
-            System.out.println(plan.getExplainString(TExplainLevel.NORMAL));
-            PlanFragment fragment0 = plan.getFragments().get(0);
-            assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
-            // Disable pipeline_load by Config, so ParallelExecNum of fragment is 
-            // equal to the corresponding session variables.
-            Assert.assertEquals(parallelExecInstanceNum, fragment0.getParallelExecNum());
-            Assert.assertEquals(1, fragment0.getPipelineDop());
-
             connectContext.getSessionVariable().setEnableAdaptiveSinkDop(false);
 
-            Config.enable_pipeline_load = true;
-            plan = getExecPlan("delete from tprimary where pk = 1");
-            fragment0 = plan.getFragments().get(0);
+            ExecPlan plan = getExecPlan("delete from tprimary where pk = 1");
+            PlanFragment fragment0 = plan.getFragments().get(0);
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
             // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
             Assert.assertEquals(1, fragment0.getParallelExecNum());
@@ -159,7 +137,6 @@ public class PipelineParallelismTest extends PlanTestBase {
 
             connectContext.getSessionVariable().setEnableAdaptiveSinkDop(true);
 
-            Config.enable_pipeline_load = true;
             plan = getExecPlan("delete from tprimary where pk = 1");
             fragment0 = plan.getFragments().get(0);
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
@@ -175,21 +152,10 @@ public class PipelineParallelismTest extends PlanTestBase {
     public void tesUpdate() throws Exception {
         boolean prevEnablePipelineLoad = Config.enable_pipeline_load;
         try {
-            Config.enable_pipeline_load = false;
-            ExecPlan plan = getExecPlan("update tprimary set v1 = 'aaa' where pk = 1");
-            System.out.println(plan.getExplainString(TExplainLevel.NORMAL));
-            PlanFragment fragment0 = plan.getFragments().get(0);
-            assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
-            // Disable pipeline_load by Config, so ParallelExecNum of fragment is 
-            // equal to the corresponding session variables.
-            Assert.assertEquals(parallelExecInstanceNum, fragment0.getParallelExecNum());
-            Assert.assertEquals(1, fragment0.getPipelineDop());
-
             connectContext.getSessionVariable().setEnableAdaptiveSinkDop(false);
 
-            Config.enable_pipeline_load = true;
-            plan = getExecPlan("update tprimary set v1 = 'aaa' where pk = 1");
-            fragment0 = plan.getFragments().get(0);
+            ExecPlan plan = getExecPlan("update tprimary set v1 = 'aaa' where pk = 1");
+            PlanFragment fragment0 = plan.getFragments().get(0);
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");
             // enable pipeline_load by Config, so ParallelExecNum of fragment is set to 1.
             Assert.assertEquals(1, fragment0.getParallelExecNum());
@@ -197,7 +163,6 @@ public class PipelineParallelismTest extends PlanTestBase {
 
             connectContext.getSessionVariable().setEnableAdaptiveSinkDop(true);
 
-            Config.enable_pipeline_load = true;
             plan = getExecPlan("update tprimary set v1 = 'aaa' where pk = 1");
             fragment0 = plan.getFragments().get(0);
             assertContains(fragment0.getExplainString(TExplainLevel.NORMAL), "OLAP TABLE SINK");


### PR DESCRIPTION
a continuous work after #30106

in this PR, I deprecate `enable_pipeline_load` configuration in FE and make all load use pipeline engine by default.


NOTE: **after this change, enable_pipeline_load will no longer take effect.**

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [x] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
