### PR TITLE
[BugFix] close before destruct DataStreamRecvr

### DIFF
--- a/be/src/runtime/data_stream_recvr.cpp
+++ b/be/src/runtime/data_stream_recvr.cpp
@@ -274,9 +274,13 @@ void DataStreamRecvr::close() {
     _cascade_merger.reset();
 
     _closure_block_timer->update(_closure_block_timer->value() / std::max(1, _degree_of_parallelism));
+    _close = true;
 }
 
 DataStreamRecvr::~DataStreamRecvr() {
+    if (!_close) {
+        close();
+    }
     DCHECK(_mgr == nullptr) << "Must call close()";
 }
 

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -239,6 +239,7 @@ private:
     PassThroughContext _pass_through_context;
 
     int _encode_level;
+    bool _close = false;
 };
 
 } // end namespace starrocks


### PR DESCRIPTION
Fixes #issue

```
DataStreamRecvr::~DataStreamRecvr() {
    DCHECK(_mgr == nullptr) << "Must call close()"; //crash here
}
```


```
*** Aborted at 1692268563 (unix time) try "date -d @1692268563" if you are using GNU date ***
PC: @     0x7ff7ac950387 __GI_raise
*** SIGABRT (@0x3e80000099a) received by PID 2458 (TID 0x7ff7ae8d1700) from PID 2458; stack trace: ***
    @         0x14766bb2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7ff7ad405630 (unknown)
    @     0x7ff7ac950387 __GI_raise
    @     0x7ff7ac951a78 __GI_abort
    @          0x9c49fbb starrocks::failure_function()
    @         0x1475a58d google::LogMessage::Fail()
    @         0x1475c9ff google::LogMessage::SendToLog()
    @         0x1475a0de google::LogMessage::Flush()
    @         0x1475d009 google::LogMessageFatal::~LogMessageFatal()
    @          0xa2682e9 starrocks::DataStreamRecvr::~DataStreamRecvr()
    @          0xa1ca443 std::_Sp_counted_ptr<>::_M_dispose()
    @          0x9b3b769 std::_Sp_counted_base<>::_M_release()
    @          0x9b3549c std::__shared_count<>::~__shared_count()
    @          0xa1b70a6 std::__shared_ptr<>::~__shared_ptr()
    @          0xa1b70c2 std::shared_ptr<>::~shared_ptr()
    @          0xa1b710e std::pair<>::~pair()
    @          0xa1c2db5 std::destroy_at<>()
    @          0xa1c07dc std::allocator_traits<>::destroy<>()
    @          0xa1bf8a5 _ZN5phmap16allocator_traitsISaISt4pairIKiSt10shared_ptrIN9starrocks15DataStreamRecvrEEEEE12destroy_implIS8_S1_IiS6_EEEDTclsrSt16allocator_traitsIT_E7destroyfp0_fp1_EEiRSD_PT0_
    @          0xa1bee19 phmap::allocator_traits<>::destroy<>()
    @          0xa1be2e7 phmap::priv::map_slot_policy<>::destroy<>()
    @          0xa1bd53b phmap::priv::FlatHashMapPolicy<>::destroy<>()
    @          0xa1bbdad phmap::priv::hash_policy_traits<>::destroy<>()
    @          0xa1c0e65 phmap::priv::raw_hash_set<>::destroy_slots()
    @          0xa1bfd8a phmap::priv::raw_hash_set<>::~raw_hash_set()
    @          0xa1bf164 phmap::priv::raw_hash_map<>::~raw_hash_map()
    @          0xa1ca4e8 phmap::flat_hash_map<>::~flat_hash_map()
    @          0xa1ca503 std::destroy_at<>()
    @          0xa1ca4be std::allocator_traits<>::destroy<>()
    @          0xa1ca257 std::_Sp_counted_ptr_inplace<>::_M_dispose()
    @          0x9b3b769 std::_Sp_counted_base<>::_M_release()
    @          0x9b3549c std::__shared_count<>::~__shared_count()
```

If prepare failed, the close() for DataStreamRecvr will not execute, so close() before destruct DataStreamRecvr

```
void ExchangeParallelMergeSourceOperatorFactory::close_stream_recvr() {
    if (--_stream_recvr_cnt == 0) {
        _stream_recvr->close();
    }
}
```

```
OperatorPtr ExchangeParallelMergeSourceOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
    ++_stream_recvr_cnt;
    return std::make_shared<ExchangeParallelMergeSourceOperator>(this, _id, _plan_node_id, driver_sequence);
}
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
