### PR TITLE
[Enhancement] optimize mv plan cache by using lru cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -64,10 +64,8 @@ import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.common.RangePartitionDiff;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.common.UnsupportedException;
-import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.Utils;
-import com.starrocks.sql.optimizer.base.ColumnRefFactory;
-import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.statistic.StatsConstants;
@@ -109,6 +107,12 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     public enum RefreshMoment {
         IMMEDIATE,
         DEFERRED
+    }
+
+    public enum PlanMode {
+        VALID,
+        INVALID,
+        UNKNOWN
     }
 
     public static class BasePartitionInfo {
@@ -369,67 +373,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     @SerializedName(value = "maxMVRewriteStaleness")
     private int maxMVRewriteStaleness = 0;
 
-    // MVRewriteContextCache is a cache that stores metadata related to the materialized view rewrite context.
-    // This cache is used during the FE's lifecycle to improve the performance of materialized view
-    // rewriting operations.
-    // By caching the metadata related to the materialized view rewrite context,
-    // subsequent materialized view rewriting operations can avoid recomputing this metadata,
-    // which can save time and resources.
-    public static class MVRewriteContextCache {
-        // mv's logical plan
-        private final OptExpression logicalPlan;
-
-        // mv plan's output columns, used for mv rewrite
-        private final List<ColumnRefOperator> outputColumns;
-
-        // column ref factory used when compile mv plan
-        private final ColumnRefFactory refFactory;
-
-        // indidate whether this mv is a SPJG plan
-        // if not, we do not store other fields to save memory,
-        // because we will not use other fields
-        private boolean isValidMvPlan;
-
-        public MVRewriteContextCache() {
-            this.logicalPlan = null;
-            this.outputColumns = null;
-            this.refFactory = null;
-            this.isValidMvPlan = false;
-        }
-
-        public MVRewriteContextCache(
-                OptExpression logicalPlan,
-                List<ColumnRefOperator> outputColumns,
-                ColumnRefFactory refFactory) {
-            this.logicalPlan = logicalPlan;
-            this.outputColumns = outputColumns;
-            this.refFactory = refFactory;
-            this.isValidMvPlan = true;
-        }
-
-        public OptExpression getLogicalPlan() {
-            return logicalPlan;
-        }
-
-        public List<ColumnRefOperator> getOutputColumns() {
-            return outputColumns;
-        }
-
-        public ColumnRefFactory getRefFactory() {
-            return refFactory;
-        }
-
-        public boolean isValidMvPlan() {
-            return isValidMvPlan;
-        }
-    }
-
-    // Materialized view plan cache used for mv rewrite, it is kept in memory for now.
-    // NOTE: Invalidate this when the materialized view is activated again.
-    // TODO: Add more policies to valid/invalidate this:
-    //  - When session variables changed
-    //  - When executes multi times.
-    private MVRewriteContextCache mvRewriteContextCache;
+    // it is a property in momery, do not serialize it
+    private PlanMode planMode = PlanMode.UNKNOWN;
 
     public MaterializedView() {
         super(TableType.MATERIALIZED_VIEW);
@@ -501,14 +446,15 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * active the materialized again & reload the state.
      */
     public void setActive() {
-        // reset mv rewrite cache when it is active again
-        this.mvRewriteContextCache = null;
         this.active = true;
+        // reset mv rewrite cache when it is active again
+        CachingMvPlanContextBuilder.getInstance().invalidateFromCache(this);
     }
 
     public void setInactiveAndReason(String reason) {
         this.active = false;
         this.inactiveReason = reason;
+        CachingMvPlanContextBuilder.getInstance().invalidateFromCache(this);
     }
 
     public String getInactiveReason() {
@@ -553,6 +499,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     public void setRefreshScheme(MvRefreshScheme refreshScheme) {
         this.refreshScheme = refreshScheme;
+    }
+
+    public void setPlanMode(PlanMode planMode) {
+        this.planMode = planMode;
+    }
+
+    public boolean isValidPlan() {
+        return !planMode.equals(PlanMode.INVALID);
     }
 
     /**
@@ -1499,14 +1453,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     public void setMaintenancePlan(ExecPlan maintenancePlan) {
         this.maintenancePlan = maintenancePlan;
-    }
-
-    public MVRewriteContextCache getPlanContext() {
-        return mvRewriteContextCache;
-    }
-
-    public void setPlanContext(MVRewriteContextCache mvRewriteContextCache) {
-        this.mvRewriteContextCache = mvRewriteContextCache;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvPlanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvPlanContext.java
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+
+import java.util.List;
+
+// MvPlanContext is a item that stores metadata related to the materialized view rewrite context.
+// This cache is used during the FE's lifecycle to improve the performance of materialized view
+// rewriting operations.
+// By caching the metadata related to the materialized view rewrite context,
+// subsequent materialized view rewriting operations can avoid recomputing this metadata,
+// which can save time and resources.
+public class MvPlanContext {
+    // mv's logical plan
+    private final OptExpression logicalPlan;
+
+    // mv plan's output columns, used for mv rewrite
+    private final List<ColumnRefOperator> outputColumns;
+
+    // column ref factory used when compile mv plan
+    private final ColumnRefFactory refFactory;
+
+    // indicate whether this mv is a SPJG plan
+    // if not, we do not store other fields to save memory,
+    // because we will not use other fields
+    private boolean isValidMvPlan;
+
+    public MvPlanContext() {
+        this.logicalPlan = null;
+        this.outputColumns = null;
+        this.refFactory = null;
+        this.isValidMvPlan = false;
+    }
+
+    public MvPlanContext(
+            OptExpression logicalPlan,
+            List<ColumnRefOperator> outputColumns,
+            ColumnRefFactory refFactory) {
+        this.logicalPlan = logicalPlan;
+        this.outputColumns = outputColumns;
+        this.refFactory = refFactory;
+        this.isValidMvPlan = true;
+    }
+
+    public OptExpression getLogicalPlan() {
+        return logicalPlan;
+    }
+
+    public List<ColumnRefOperator> getOutputColumns() {
+        return outputColumns;
+    }
+
+    public ColumnRefFactory getRefFactory() {
+        return refFactory;
+    }
+
+    public boolean isValidMvPlan() {
+        return isValidMvPlan;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2499,4 +2499,10 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static int catalog_metadata_cache_size = 500;
+
+    /**
+     * mv plan cache expire interval in seconds
+     */
+    @ConfField(mutable = true)
+    public static long mv_plan_cache_expire_interval_sec = 24L * 60L * 60L;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2505,4 +2505,10 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static long mv_plan_cache_expire_interval_sec = 24L * 60L * 60L;
+
+    /**
+     * mv plan cache expire interval in seconds
+     */
+    @ConfField(mutable = true)
+    public static long mv_plan_cache_max_size = 1000;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -420,6 +420,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_MATERIALIZED_VIEW_REWRITE_GREEDY_MODE =
             "enable_materialized_view_rewrite_greedy_mode";
 
+    public static final String ENABLE_MATERIALIZED_VIEW_PLAN_CACHE = "enable_materialized_view_plan_cache";
+
     public static final String ENABLE_BIG_QUERY_LOG = "enable_big_query_log";
     public static final String BIG_QUERY_LOG_CPU_SECOND_THRESHOLD = "big_query_log_cpu_second_threshold";
     public static final String BIG_QUERY_LOG_SCAN_BYTES_THRESHOLD = "big_query_log_scan_bytes_threshold";
@@ -1197,6 +1199,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // - Use the max plan tree to rewrite in view-delta mode to avoid too many rewrites.
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_REWRITE_GREEDY_MODE)
     private boolean enableMaterializedViewRewriteGreedyMode = false;
+
+    // whether to use materialized view plan context cache to reduce mv rewrite time cost
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_PLAN_CACHE, flag = VariableMgr.INVISIBLE)
+    private boolean enableMaterializedViewPlanCache = true;
 
     @VarAttr(name = QUERY_EXCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
     private String queryExcludingMVNames = "";
@@ -2293,6 +2299,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableMaterializedViewRewriteGreedyMode() {
         return this.enableMaterializedViewRewriteGreedyMode;
+    }
+
+    public void setEnableMaterializedViewPlanCache(boolean enableMaterializedViewPlanCache) {
+        this.enableMaterializedViewPlanCache = enableMaterializedViewPlanCache;
+    }
+
+    public boolean isEnableMaterializedViewPlanCache() {
+        return this.enableMaterializedViewPlanCache;
     }
 
     public String getQueryExcludingMVNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -98,6 +98,7 @@ import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.ListPartitionDiff;
 import com.starrocks.sql.common.RangePartitionDiff;
 import com.starrocks.sql.common.SyncPartitionUtils;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
@@ -417,6 +418,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 throw new DmlException(
                         "update meta failed. materialized view:" + materializedView.getName() + " not exist");
             }
+            // invalid mv's plan cache because plan may change
+            CachingMvPlanContextBuilder.getInstance().invalidateFromCache(materializedView);
+
             // check
             if (mvRefreshedPartitions == null || refTableAndPartitionNames == null) {
                 return;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -98,7 +98,6 @@ import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.ListPartitionDiff;
 import com.starrocks.sql.common.RangePartitionDiff;
 import com.starrocks.sql.common.SyncPartitionUtils;
-import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
@@ -418,8 +417,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 throw new DmlException(
                         "update meta failed. materialized view:" + materializedView.getName() + " not exist");
             }
-            // invalid mv's plan cache because plan may change
-            CachingMvPlanContextBuilder.getInstance().invalidateFromCache(materializedView);
 
             // check
             if (mvRefreshedPartitions == null || refTableAndPartitionNames == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -220,6 +220,7 @@ import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.common.SyncPartitionUtils;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.system.Backend;
@@ -3296,11 +3297,12 @@ public class LocalMetastore implements ConnectorMetadata {
             Authorizer.checkMaterializedViewAction(ConnectContext.get().getCurrentUserIdentity(),
                     ConnectContext.get().getCurrentRoleIds(), stmt.getDbMvName(), PrivilegeType.DROP);
 
-            MaterializedView view = (MaterializedView) table;
-            MaterializedViewMgr.getInstance().stopMaintainMV(view);
+            MaterializedView mv = (MaterializedView) table;
+            MaterializedViewMgr.getInstance().stopMaintainMV(mv);
 
             MvId mvId = new MvId(db.getId(), table.getId());
             db.dropTable(table.getName(), stmt.isSetIfExists(), true);
+            CachingMvPlanContextBuilder.getInstance().invalidateFromCache(mv);
             List<BaseTableInfo> baseTableInfos = ((MaterializedView) table).getBaseTableInfos();
             if (baseTableInfos != null) {
                 for (BaseTableInfo baseTableInfo : baseTableInfos) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -17,26 +17,19 @@ package com.starrocks.sql.optimizer;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.common.Config;
 
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class CachingMvPlanContextBuilder {
     private static final CachingMvPlanContextBuilder INSTANCE = new CachingMvPlanContextBuilder();
 
-    private final Executor mvPlanCacheExecutor = Executors.newFixedThreadPool(10,
-            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("mv-plan-cache-refresher-%d").build());
-
     private Cache<MvId, MvPlanContext> mvPlanContextCache = Caffeine.newBuilder()
-            .expireAfterWrite(Config.mv_plan_cache_expire_interval_sec, TimeUnit.SECONDS)
-            .maximumSize(1000)
-            .executor(mvPlanCacheExecutor)
+            .expireAfterAccess(Config.mv_plan_cache_expire_interval_sec, TimeUnit.SECONDS)
+            .maximumSize(Config.mv_plan_cache_max_size)
             .build();
 
     private CachingMvPlanContextBuilder() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
+import com.starrocks.catalog.MvPlanContext;
+import com.starrocks.common.Config;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class CachingMvPlanContextBuilder {
+    private static final CachingMvPlanContextBuilder INSTANCE = new CachingMvPlanContextBuilder();
+
+    private final Executor mvPlanCacheExecutor = Executors.newFixedThreadPool(10,
+            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("mv-plan-cache-refresher-%d").build());
+
+    private Cache<MvId, MvPlanContext> mvPlanContextCache = Caffeine.newBuilder()
+            .expireAfterWrite(Config.mv_plan_cache_expire_interval_sec, TimeUnit.SECONDS)
+            .maximumSize(10000)
+            .executor(mvPlanCacheExecutor)
+            .build();
+
+    private CachingMvPlanContextBuilder() {
+
+    }
+
+    public static CachingMvPlanContextBuilder getInstance() {
+        return INSTANCE;
+    }
+
+    public MvPlanContext getPlanContext(MaterializedView mv, boolean useCache) {
+        MvId mvId = new MvId(mv.getDbId(), mv.getId());
+        MvPlanContext result = useCache ? mvPlanContextCache.getIfPresent(mvId) : null;
+        if (result == null) {
+            MvPlanContextBuilder builder = new MvPlanContextBuilder();
+            result = builder.getPlanContext(mv);
+            if (result.isValidMvPlan()) {
+                mvPlanContextCache.put(mvId, result);
+                mv.setPlanMode(MaterializedView.PlanMode.VALID);
+            }
+        }
+
+        return result;
+    }
+
+    public void invalidateFromCache(MaterializedView mv) {
+        mvPlanContextCache.invalidate(new MvId(mv.getDbId(), mv.getId()));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
@@ -34,7 +35,7 @@ public class CachingMvPlanContextBuilder {
 
     private Cache<MvId, MvPlanContext> mvPlanContextCache = Caffeine.newBuilder()
             .expireAfterWrite(Config.mv_plan_cache_expire_interval_sec, TimeUnit.SECONDS)
-            .maximumSize(10000)
+            .maximumSize(1000)
             .executor(mvPlanCacheExecutor)
             .build();
 
@@ -59,6 +60,11 @@ public class CachingMvPlanContextBuilder {
         }
 
         return result;
+    }
+
+    @VisibleForTesting
+    public boolean contains(MaterializedView mv) {
+        return mvPlanContextCache.asMap().containsKey(new MvId(mv.getDbId(), mv.getId()));
     }
 
     public void invalidateFromCache(MaterializedView mv) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
@@ -16,7 +16,7 @@
 package com.starrocks.sql.optimizer;
 
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.MaterializedView.MVRewriteContextCache;
+import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -24,9 +24,9 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 
 public class MaterializedViewOptimizer {
-    public MVRewriteContextCache optimize(MaterializedView mv,
-                                          ConnectContext connectContext,
-                                          OptimizerConfig optimizerConfig) {
+    public MvPlanContext optimize(MaterializedView mv,
+                                  ConnectContext connectContext,
+                                  OptimizerConfig optimizerConfig) {
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         String mvSql = mv.getViewDefineSql();
         Pair<OptExpression, LogicalPlan> plans =
@@ -36,10 +36,10 @@ public class MaterializedViewOptimizer {
         }
         OptExpression mvPlan = plans.first;
         if (!MvUtils.isValidMVPlan(mvPlan)) {
-            return new MVRewriteContextCache();
+            return new MvPlanContext();
         }
-        MVRewriteContextCache mvRewriteContext =
-                new MVRewriteContextCache(mvPlan, plans.second.getOutputColumn(), columnRefFactory);
+        MvPlanContext mvRewriteContext =
+                new MvPlanContext(mvPlan, plans.second.getOutputColumn(), columnRefFactory);
         return mvRewriteContext;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.rule.RuleSetType;
+import com.starrocks.sql.optimizer.rule.RuleType;
+
+public class MvPlanContextBuilder {
+    public MvPlanContext getPlanContext(MaterializedView mv) {
+        // build mv query logical plan
+        MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();
+        // optimize the sql by rule and disable rule based materialized view rewrite
+        OptimizerConfig optimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerAlgorithm.RULE_BASED);
+        optimizerConfig.disableRuleSet(RuleSetType.PARTITION_PRUNE);
+        optimizerConfig.disableRuleSet(RuleSetType.SINGLE_TABLE_MV_REWRITE);
+        optimizerConfig.disableRule(RuleType.TF_REWRITE_GROUP_BY_COUNT_DISTINCT);
+        // For sync mv, no rewrite query by original sync mv rule to avoid useless rewrite.
+        if (mv.getRefreshScheme().isSync()) {
+            optimizerConfig.disableRule(RuleType.TF_MATERIALIZED_VIEW);
+        }
+        optimizerConfig.setMVRewritePlan(true);
+        return mvOptimizer.optimize(mv, new ConnectContext(), optimizerConfig);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -31,6 +31,7 @@ import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
@@ -47,8 +48,6 @@ import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rule.RuleSetType;
-import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.logging.log4j.LogManager;
@@ -190,6 +189,10 @@ public class MvRewritePreprocessor {
 
         Set<ColumnRefOperator> originQueryColumns = Sets.newHashSet(queryColumnRefFactory.getColumnRefs());
         for (MaterializedView mv : relatedMvs) {
+            if (!mv.isValidPlan()) {
+                // skip to process unsupported plan tree
+                continue;
+            }
             try {
                 preprocessMv(mv, queryTables, originQueryColumns, isSyncMV);
             } catch (Exception e) {
@@ -218,34 +221,18 @@ public class MvRewritePreprocessor {
             return;
         }
 
-        MaterializedView.MVRewriteContextCache mvRewriteContextCache = mv.getPlanContext();
-        if (connectContext.getSessionVariable().isEnableMaterializedViewRewriteGreedyMode() ||
-                mvRewriteContextCache == null) {
-            // build mv query logical plan
-            MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();
-            // optimize the sql by rule and disable rule based materialized view rewrite
-            OptimizerConfig optimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerAlgorithm.RULE_BASED);
-            optimizerConfig.disableRuleSet(RuleSetType.PARTITION_PRUNE);
-            optimizerConfig.disableRuleSet(RuleSetType.SINGLE_TABLE_MV_REWRITE);
-            optimizerConfig.disableRule(RuleType.TF_REWRITE_GROUP_BY_COUNT_DISTINCT);
-            // For sync mv, no rewrite query by original sync mv rule to avoid useless rewrite.
-            if (mv.getRefreshScheme().isSync()) {
-                optimizerConfig.disableRule(RuleType.TF_MATERIALIZED_VIEW);
-            }
-            optimizerConfig.setMVRewritePlan(true);
-
-            mvRewriteContextCache = mvOptimizer.optimize(mv, connectContext, optimizerConfig);
-            mv.setPlanContext(mvRewriteContextCache);
-        }
-        if (mvRewriteContextCache == null) {
+        MvPlanContext mvPlanContext = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv,
+                connectContext.getSessionVariable().isEnableMaterializedViewPlanCache());
+        if (mvPlanContext == null) {
             logMVPrepare(connectContext, mv, "[SYNC={}] MV plan is not valid: {}, cannot generate plan for rewrite",
                         isSyncMV, mv.getName());
             return;
         }
-        if (!mvRewriteContextCache.isValidMvPlan()) {
-            if (mvRewriteContextCache.getLogicalPlan() != null) {
+        if (!mvPlanContext.isValidMvPlan()) {
+            mv.setPlanMode(MaterializedView.PlanMode.INVALID);
+            if (mvPlanContext.getLogicalPlan() != null) {
                 logMVPrepare(connectContext, mv, "[SYNC={}] MV plan is not valid: {}, plan:\n {}",
-                        isSyncMV, mv.getName(), mvRewriteContextCache.getLogicalPlan().debugString());
+                        isSyncMV, mv.getName(), mvPlanContext.getLogicalPlan().debugString());
             } else {
                 logMVPrepare(connectContext, mv, "[SYNC={}] MV plan is not valid: {}",
                         isSyncMV, mv.getName());
@@ -280,8 +267,8 @@ public class MvRewritePreprocessor {
             return;
         }
 
-        Preconditions.checkState(mvRewriteContextCache != null);
-        OptExpression mvPlan = mvRewriteContextCache.getLogicalPlan();
+        Preconditions.checkState(mvPlanContext != null);
+        OptExpression mvPlan = mvPlanContext.getLogicalPlan();
         Preconditions.checkState(mvPlan != null);
 
         ScalarOperator mvPartialPartitionPredicates = null;
@@ -306,9 +293,9 @@ public class MvRewritePreprocessor {
         List<Table> intersectingTables = baseTables.stream().filter(queryTables::contains).collect(Collectors.toList());
         MaterializationContext materializationContext =
                 new MaterializationContext(context, mv, mvPlan, queryColumnRefFactory,
-                        mv.getPlanContext().getRefFactory(), partitionNamesToRefresh,
+                        mvPlanContext.getRefFactory(), partitionNamesToRefresh,
                         baseTables, originQueryColumns, intersectingTables, mvPartialPartitionPredicates);
-        List<ColumnRefOperator> mvOutputColumns = mv.getPlanContext().getOutputColumns();
+        List<ColumnRefOperator> mvOutputColumns = mvPlanContext.getOutputColumns();
         // generate scan mv plan here to reuse it in rule applications
         LogicalOlapScanOperator scanMvOp = createScanMvOperator(materializationContext, partitionNamesToRefresh);
         materializationContext.setScanMvOperator(scanMvOp);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -636,6 +636,7 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 " on t0.v1 = test_all_type.t1d" +
                 " where t0.v1 < 100" +
                 " group by v1, test_all_type.t1d";
+        starRocksAssert.getCtx().getSessionVariable().setEnableMaterializedViewPlanCache(false);
         String plan2 = getFragmentPlan(query2);
         PlanTestBase.assertContains(plan2, "1:Project\n" +
                 "  |  <slot 1> : 16: v1\n" +
@@ -652,6 +653,7 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 " on t0.v1 = test_all_type.t1d" +
                 " where t0.v1 < 99" +
                 " group by v1, test_all_type.t1d";
+        starRocksAssert.getCtx().getSessionVariable().setEnableMaterializedViewPlanCache(true);
         String plan3 = getFragmentPlan(query3);
         PlanTestBase.assertContains(plan3, "1:Project\n" +
                 "  |  <slot 1> : 16: v1\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ForeignKeyConstraint;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.UniqueConstraint;
 import com.starrocks.common.FeConstants;
@@ -27,6 +28,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -1904,5 +1906,61 @@ public class MvRewriteTest extends MvRewriteTestBase {
         }
 
         starRocksAssert.dropMaterializedView("test_partition_tbl_mv3");
+    }
+
+    @Test
+    public void testPlanCache() throws Exception {
+        {
+            String mvSql = "create materialized view agg_join_mv_1" +
+                    " distributed by hash(v1) as SELECT t0.v1 as v1," +
+                    " test_all_type.t1d, sum(test_all_type.t1c) as total_sum, count(test_all_type.t1c) as total_num" +
+                    " from t0 join test_all_type on t0.v1 = test_all_type.t1d" +
+                    " where t0.v1 < 100" +
+                    " group by v1, test_all_type.t1d";
+            starRocksAssert.withMaterializedView(mvSql);
+
+            MaterializedView mv = getMv("test", "agg_join_mv_1");
+            MvPlanContext planContext = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, true);
+            Assert.assertNotNull(planContext);
+            Assert.assertTrue(CachingMvPlanContextBuilder.getInstance().contains(mv));
+            planContext = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, false);
+            Assert.assertNotNull(planContext);
+            starRocksAssert.dropMaterializedView("agg_join_mv_1");
+        }
+
+        {
+            String mvSql = "create materialized view mv_with_window" +
+                    " distributed by hash(t1d) as" +
+                    " SELECT test_all_type.t1d, row_number() over (partition by t1c)" +
+                    " from test_all_type";
+            starRocksAssert.withMaterializedView(mvSql);
+
+            MaterializedView mv = getMv("test", "mv_with_window");
+            MvPlanContext planContext = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, true);
+            Assert.assertNotNull(planContext);
+            Assert.assertFalse(CachingMvPlanContextBuilder.getInstance().contains(mv));
+            starRocksAssert.dropMaterializedView("mv_with_window");
+        }
+
+        {
+            for (int i = 0; i < 1010; i++) {
+                String mvName = "plan_cache_mv_" + i;
+                String mvSql = String.format("create materialized view %s" +
+                        " distributed by hash(v1) as SELECT t0.v1 as v1," +
+                        " test_all_type.t1d, sum(test_all_type.t1c) as total_sum, count(test_all_type.t1c) as total_num" +
+                        " from t0 join test_all_type on t0.v1 = test_all_type.t1d" +
+                        " where t0.v1 < 100" +
+                        " group by v1, test_all_type.t1d", mvName);
+                starRocksAssert.withMaterializedView(mvSql);
+
+                MaterializedView mv = getMv("test", mvName);
+                MvPlanContext planContext = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, true);
+                Assert.assertNotNull(planContext);
+            }
+            for (int i = 0; i < 1010; i++) {
+                String mvName = "plan_cache_mv_" + i;
+                starRocksAssert.dropMaterializedView(mvName);
+            }
+        }
     }
 }


### PR DESCRIPTION
optimize mv plan cache by using lru cache and clear cache item after mv become inactive/dropped.
Fixes #30361

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
