### PR TITLE
[Enhancement] Support ignoring invalid directories when listing hive directory recursively.

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/connector/CachingRemoteFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CachingRemoteFileIOTest.java
@@ -29,14 +29,14 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 
 public class CachingRemoteFileIOTest {
 
     @Test
     public void testGetHiveRemoteFiles() {
         HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
         ExecutorService executor = Executors.newFixedThreadPool(5);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -44,14 +44,14 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 
 public class RemoteFileOperationsTest {
     @Test
     public void testGetHiveRemoteFiles() {
         HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
         ExecutorService executorToRefresh = Executors.newFixedThreadPool(5);
@@ -110,7 +110,7 @@ public class RemoteFileOperationsTest {
     @Test
     public void asyncRenameFilesTest() {
         HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
         ExecutorService executorToRefresh = Executors.newFixedThreadPool(5);
@@ -134,7 +134,7 @@ public class RemoteFileOperationsTest {
         RemoteFileOperations ops1 = new RemoteFileOperations(cachingFileIO, executorToLoad, Executors.newSingleThreadExecutor(),
                 false, true, new Configuration());
 
-        FileSystem mockedFs = new MockedRemoteFileSystem(TEST_FILES) {
+        FileSystem mockedFs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE) {
             @Override
             public boolean exists(Path path) {
                 return true;
@@ -180,7 +180,7 @@ public class RemoteFileOperationsTest {
     @Test
     public void testRenameDir() {
         HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
         ExecutorService executorToRefresh = Executors.newSingleThreadExecutor();
@@ -208,7 +208,7 @@ public class RemoteFileOperationsTest {
     @Test
     public void testRenameDirFailed() {
         HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
         ExecutorService executorToRefresh = Executors.newSingleThreadExecutor();
@@ -220,7 +220,7 @@ public class RemoteFileOperationsTest {
 
         Path writePath = new Path("hdfs://hadoop01:9000/tmp/starrocks/queryid");
         Path targetPath = new Path("hdfs://hadoop01:9000/user/hive/warehouse/test.db/t1");
-        FileSystem mockedFs = new MockedRemoteFileSystem(TEST_FILES) {
+        FileSystem mockedFs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE) {
             @Override
             public boolean exists(Path path) {
                 if (path.equals(targetPath.getParent())) {
@@ -247,7 +247,7 @@ public class RemoteFileOperationsTest {
     @Test
     public void testRemoveNotCurrentQueryFiles() {
         HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
         ExecutorService executorToRefresh = Executors.newSingleThreadExecutor();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 
 public class HiveConnectorTest {
     private HiveMetaClient client;
@@ -60,7 +60,7 @@ public class HiveConnectorTest {
         cachingHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
                 metastore, executorForHmsRefresh, 100, 10, 1000, false);
         hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         cachingRemoteFileIO = CachingRemoteFileIO.createCatalogLevelInstance(
                 hiveRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 10);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -73,7 +73,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 import static com.starrocks.connector.hive.HiveMetadata.STARROCKS_QUERY_ID;
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 
 public class HiveMetadataTest {
     private HiveMetaClient client;
@@ -107,7 +107,7 @@ public class HiveMetadataTest {
         hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true, new Configuration(), MetastoreType.HMS, "hive_catalog");
 
         hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         cachingRemoteFileIO = CachingRemoteFileIO.createCatalogLevelInstance(
                 hiveRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 10);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveRemoteFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveRemoteFileIOTest.java
@@ -27,12 +27,13 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Map;
 
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_RECURSIVE_TABLE;
 
 public class HiveRemoteFileIOTest {
     @Test
     public void testGetRemoteFiles() {
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         HiveRemoteFileIO fileIO = new HiveRemoteFileIO(new Configuration());
         fileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
@@ -60,8 +61,39 @@ public class HiveRemoteFileIOTest {
     }
 
     @Test
+    public void testGetRemoteRecursiveFiles() {
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_RECURSIVE_TABLE);
+        HiveRemoteFileIO fileIO = new HiveRemoteFileIO(new Configuration());
+        fileIO.setFileSystem(fs);
+        FeConstants.runningUnitTest = true;
+        String tableLocation = "hdfs://127.0.0.1:10000/hive.db/recursive_tbl";
+        RemotePathKey pathKey = RemotePathKey.of(tableLocation, true);
+        Map<RemotePathKey, List<RemoteFileDesc>> remoteFileInfos = fileIO.getRemoteFiles(pathKey);
+        List<RemoteFileDesc> fileDescs = remoteFileInfos.get(pathKey);
+        Assert.assertNotNull(fileDescs);
+        Assert.assertEquals(2, fileDescs.size());
+        RemoteFileDesc fileDesc = fileDescs.get(0);
+        Assert.assertNotNull(fileDesc);
+        Assert.assertEquals("subdir1/000000_0", fileDesc.getFileName());
+        Assert.assertEquals("", fileDesc.getCompression());
+        Assert.assertEquals(20, fileDesc.getLength());
+        Assert.assertEquals(1234567890, fileDesc.getModificationTime());
+        Assert.assertFalse(fileDesc.isSplittable());
+        Assert.assertNull(fileDesc.getTextFileFormatDesc());
+
+        fileDesc = fileDescs.get(1);
+        Assert.assertNotNull(fileDesc);
+        Assert.assertEquals("subdir1/000000_1", fileDesc.getFileName());
+        Assert.assertEquals("", fileDesc.getCompression());
+        Assert.assertEquals(20, fileDesc.getLength());
+        Assert.assertEquals(1234567890, fileDesc.getModificationTime());
+        Assert.assertFalse(fileDesc.isSplittable());
+        Assert.assertNull(fileDesc.getTextFileFormatDesc());
+    }
+
+    @Test
     public void testPathContainsEmptySpace() {
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         HiveRemoteFileIO fileIO = new HiveRemoteFileIO(new Configuration());
         fileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
@@ -52,7 +52,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 
 public class HiveStatisticsProviderTest {
     private HiveMetaClient client;
@@ -84,7 +84,7 @@ public class HiveStatisticsProviderTest {
         hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true, new Configuration(), MetastoreType.HMS, "hive_catalog");
 
         hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         cachingRemoteFileIO = CachingRemoteFileIO.createCatalogLevelInstance(
                 hiveRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 10);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveWriteUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveWriteUtilsTest.java
@@ -29,7 +29,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 
 public class HiveWriteUtilsTest {
     @Test
@@ -57,7 +57,7 @@ public class HiveWriteUtilsTest {
         new MockUp<FileSystem>() {
             @Mock
             public FileSystem get(URI uri, Configuration conf) {
-                return new MockedRemoteFileSystem(TEST_FILES);
+                return new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
             }
         };
         Assert.assertFalse(HiveWriteUtils.pathExists(path, new Configuration()));
@@ -73,7 +73,7 @@ public class HiveWriteUtilsTest {
         new MockUp<FileSystem>() {
             @Mock
             public FileSystem get(URI uri, Configuration conf) {
-                return new MockedRemoteFileSystem(TEST_FILES);
+                return new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
             }
         };
         Assert.assertFalse(HiveWriteUtils.isDirectory(path, new Configuration()));
@@ -89,7 +89,7 @@ public class HiveWriteUtilsTest {
         new MockUp<FileSystem>() {
             @Mock
             public FileSystem get(URI uri, Configuration conf) {
-                return new MockedRemoteFileSystem(TEST_FILES);
+                return new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
             }
         };
         ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,


### PR DESCRIPTION
For the following reasons, we manually implement the `listFilesRecursive` method to replace the hadoop filesystem `listFiles` api when list hdfs path recursively.
* The hadoop filesystem doesn't provide an api with a filter parameter to ignore invalid directories when listing path recursively. Sometimes many residual or temporary files exist in table subdirectories, which make it too slow when listing remote files. So, we need to skip these invalid directories and only scan the data directories.
* For some data sources, like COS metadata acceleration buckets, `recursive` parameter in hadoop filesystem has no effect on them and we need to use their own libraries to achieve it. So, we can manually implement the list method to achieve the same purpose.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
