### PR TITLE
[BugFix] Remove isAssignedStrLenInColDefinition parameter in ScalarType

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/CastExpr.java
@@ -36,7 +36,6 @@ package com.starrocks.analysis;
 
 import com.google.common.base.Preconditions;
 import com.starrocks.catalog.Function;
-import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.server.GlobalStateMgr;
@@ -185,17 +184,7 @@ public class CastExpr extends Expr {
     @Override
     public void analyzeImpl(Analyzer analyzer) throws AnalysisException {
         Preconditions.checkState(!isImplicit);
-        // When cast target type is string and it's length is default -1, the result length
-        // of cast is decided by child.
-        if (targetTypeDef.getType().isScalarType()) {
-            final ScalarType targetType = (ScalarType) targetTypeDef.getType();
-            if (!(targetType.getPrimitiveType().isStringType()
-                    && !targetType.isAssignedStrLenInColDefinition())) {
-                targetTypeDef.analyze(analyzer);
-            }
-        } else {
-            targetTypeDef.analyze(analyzer);
-        }
+        targetTypeDef.analyze(analyzer);
         type = targetTypeDef.getType();
         analyze();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -77,7 +77,7 @@ public class ScalarType extends Type implements Cloneable {
     // Only used for type CHAR.
     @SerializedName(value = "len")
     private int len = -1;
-    private boolean isAssignedStrLenInColDefinition = false;
+    private boolean isAssignedStrLenInColDefinition = true;
 
     // Only used if type is DECIMAL. -1 (for both) is used to represent a
     // decimal with any precision and scale.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -77,7 +77,6 @@ public class ScalarType extends Type implements Cloneable {
     // Only used for type CHAR.
     @SerializedName(value = "len")
     private int len = -1;
-    private boolean isAssignedStrLenInColDefinition = true;
 
     // Only used if type is DECIMAL. -1 (for both) is used to represent a
     // decimal with any precision and scale.
@@ -286,20 +285,17 @@ public class ScalarType extends Type implements Cloneable {
 
     public static ScalarType createDefaultString() {
         ScalarType stringType = ScalarType.createVarcharType(ScalarType.DEFAULT_STRING_LENGTH);
-        stringType.setAssignedStrLenInColDefinition();
         return stringType;
     }
 
     // Use for Hive string now.
     public static ScalarType createDefaultExternalTableString() {
         ScalarType stringType = ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
-        stringType.setAssignedStrLenInColDefinition();
         return stringType;
     }
 
     public static ScalarType createMaxVarcharType() {
         ScalarType stringType = ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
-        stringType.setAssignedStrLenInColDefinition();
         return stringType;
     }
 
@@ -705,14 +701,6 @@ public class ScalarType extends Type implements Cloneable {
 
     public void setLength(int len) {
         this.len = len;
-    }
-
-    public boolean isAssignedStrLenInColDefinition() {
-        return isAssignedStrLenInColDefinition;
-    }
-
-    public void setAssignedStrLenInColDefinition() {
-        this.isAssignedStrLenInColDefinition = true;
     }
 
     // add scalar infix to override with getPrecision

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -1188,15 +1188,9 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         }
         if (typeName.equals("varchar")) {
             ScalarType type = ScalarType.createVarcharType(length);
-            if (length != -1) {
-                type.setAssignedStrLenInColDefinition();
-            }
             return type;
         } else if (typeName.equals("char")) {
             ScalarType type = ScalarType.createCharType(length);
-            if (length != -1) {
-                type.setAssignedStrLenInColDefinition();
-            }
             return type;
         } else if (typeName.equals("decimal")) {
             if (precision != -1) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -757,12 +757,11 @@ public class AnalyzerUtils {
                 int len = ScalarType.MAX_VARCHAR_LENGTH;
                 if (srcType instanceof ScalarType) {
                     ScalarType scalarType = (ScalarType) srcType;
-                    if (scalarType.getLength() > 0 && scalarType.isAssignedStrLenInColDefinition()) {
+                    if (scalarType.getLength() > 0) {
                         len = scalarType.getLength();
                     }
                 }
                 ScalarType stringType = ScalarType.createVarcharType(len);
-                stringType.setAssignedStrLenInColDefinition();
                 newType = stringType;
             } else if (PrimitiveType.FLOAT == srcType.getPrimitiveType() ||
                     PrimitiveType.DOUBLE == srcType.getPrimitiveType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ColumnDef.java
@@ -289,7 +289,7 @@ public class ColumnDef implements ParseNode {
         if (typeDef.getType().isScalarType()) {
             final ScalarType targetType = (ScalarType) typeDef.getType();
             if (targetType.getPrimitiveType().isStringType()) {
-                if (!targetType.isAssignedStrLenInColDefinition()) {
+                if (targetType.getLength() <= 0) {
                     targetType.setLength(1);
                 }
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -6609,31 +6609,20 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         }
         if (context.STRING() != null || context.TEXT() != null) {
             ScalarType type = ScalarType.createVarcharType(ScalarType.DEFAULT_STRING_LENGTH);
-            type.setAssignedStrLenInColDefinition();
             return type;
         } else if (context.VARCHAR() != null) {
             ScalarType type = ScalarType.createVarcharType(length);
-            if (length != -1) {
-                type.setAssignedStrLenInColDefinition();
-            }
             return type;
         } else if (context.CHAR() != null) {
             ScalarType type = ScalarType.createCharType(length);
-            if (length != -1) {
-                type.setAssignedStrLenInColDefinition();
-            }
             return type;
         } else if (context.SIGNED() != null) {
             return Type.INT;
         } else if (context.HLL() != null) {
             ScalarType type = ScalarType.createHllType();
-            type.setAssignedStrLenInColDefinition();
             return type;
         } else if (context.BINARY() != null || context.VARBINARY() != null) {
             ScalarType type = ScalarType.createVarbinary(length);
-            if (length != -1) {
-                type.setAssignedStrLenInColDefinition();
-            }
             return type;
         } else {
             return ScalarType.createType(context.getChild(0).getText());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -271,19 +271,6 @@ public class StatisticUtils {
         ScalarType mostCommonValueType = ScalarType.createMaxVarcharType();
         ScalarType catalogNameType = ScalarType.createVarcharType(65530);
 
-        // varchar type column need call setAssignedStrLenInColDefinition here,
-        // otherwise it will be set length to 1 at analyze
-        columnNameType.setAssignedStrLenInColDefinition();
-        tableNameType.setAssignedStrLenInColDefinition();
-        tableUUIDType.setAssignedStrLenInColDefinition();
-        partitionNameType.setAssignedStrLenInColDefinition();
-        dbNameType.setAssignedStrLenInColDefinition();
-        maxType.setAssignedStrLenInColDefinition();
-        minType.setAssignedStrLenInColDefinition();
-        bucketsType.setAssignedStrLenInColDefinition();
-        mostCommonValueType.setAssignedStrLenInColDefinition();
-        catalogNameType.setAssignedStrLenInColDefinition();
-
         if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {
             return ImmutableList.of(
                     new ColumnDef("table_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),


### PR DESCRIPTION
### Cause
- `isAssignedStrLenInColDefinition` in ScalarType.java is not persisted, so it will be always false after fe restart.

```
    // Only used for type CHAR.
    @SerializedName(value = "len")
    private int len = -1;
    private boolean isAssignedStrLenInColDefinition = false;
```
- `transformTableColumnType` will generate type with the `MAX_VARCHAR_LENGTH` length rather than the user defined len.
```
    public static Type transformTableColumnType(Type srcType, boolean convertDouble) {
 ...
                int len = ScalarType.MAX_VARCHAR_LENGTH;
                if (srcType instanceof ScalarType) {
                    ScalarType scalarType = (ScalarType) srcType;
                    if (scalarType.getLength() > 0 && scalarType.isAssignedStrLenInColDefinition()) {
                        len = scalarType.getLength();
                    }
                }
```

## Fix
`isAssignedStrLenInColDefinition`  will set be true for table's full schema in fe restart.

## TODO
- Remove `isAssignedStrLenInColDefinition` later because we only need to know which column is coming from the table scan ?

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
