### PR TITLE
[BugFix] close StreamMgr after FragmantMgr::close

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -503,10 +503,6 @@ void ExecEnv::add_rf_event(const RfTracePoint& pt) {
 }
 
 void ExecEnv::stop() {
-    if (_stream_mgr != nullptr) {
-        _stream_mgr->close();
-    }
-
     if (_load_channel_mgr) {
         // Clear load channel should be executed before stopping the storage engine,
         // otherwise some writing tasks will still be in the MemTableFlushThreadPool of the storage engine,
@@ -520,6 +516,10 @@ void ExecEnv::stop() {
 
     if (_fragment_mgr) {
         _fragment_mgr->close();
+    }
+
+    if (_stream_mgr != nullptr) {
+        _stream_mgr->close();
     }
 
     if (_pipeline_sink_io_pool) {


### PR DESCRIPTION
Fixes #issue

FragmentMgr depends on StreamMgr, so we need to close FragmentMgr first, otherwise there will be Crash.

```
void DataStreamMgr::close() {
    for (size_t i = 0; i < _receiver_map->size(); i++) {
        std::lock_guard<Mutex> l(_lock[i]);
        for (auto& iter : _receiver_map[i]) {
            for (auto& sub_iter : *iter.second) {
                sub_iter.second->cancel_stream();
            }
        }
    }
    _pass_through_chunk_buffer_manager.close();
}
```

```
PassThroughChunkBuffer::~PassThroughChunkBuffer() {
    DCHECK(_ref_count == 0); // crash here
    for (auto& it : _key_to_channel) {
        delete it.second;
    }
    _key_to_channel.clear();
}
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
