### PR TITLE
[Enhancement] Add back pressure to LakeTabletChannel when too many memtable need flush

### DIFF
--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -53,6 +53,8 @@ public:
 
     void close();
 
+    [[nodiscard]] int64_t queueing_memtable_num() const { return _writer->queueing_memtable_num(); }
+
     [[nodiscard]] int64_t tablet_id() const { return _writer->tablet_id(); }
 
     [[nodiscard]] int64_t partition_id() const { return _writer->partition_id(); }
@@ -236,6 +238,10 @@ void AsyncDeltaWriter::finish(Callback cb) {
 
 void AsyncDeltaWriter::close() {
     _impl->close();
+}
+
+int64_t AsyncDeltaWriter::queueing_memtable_num() const {
+    return _impl->queueing_memtable_num();
 }
 
 int64_t AsyncDeltaWriter::tablet_id() const {

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -86,6 +86,8 @@ public:
     // [thread-safe]
     void close();
 
+    [[nodiscard]] int64_t queueing_memtable_num() const;
+
     [[nodiscard]] int64_t tablet_id() const;
 
     [[nodiscard]] int64_t partition_id() const;

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -114,6 +114,8 @@ public:
 
     [[nodiscard]] Status flush_async();
 
+    int64_t queueing_memtable_num() const;
+
     std::vector<std::string> files() const;
 
     int64_t data_size() const;
@@ -576,6 +578,14 @@ int64_t DeltaWriterImpl::num_rows() const {
     return (_tablet_writer != nullptr) ? _tablet_writer->num_rows() : 0;
 }
 
+int64_t DeltaWriterImpl::queueing_memtable_num() const {
+    if (_flush_token != nullptr) {
+        return _flush_token->get_stats().queueing_memtable_num;
+    } else {
+        return 0;
+    }
+}
+
 //// DeltaWriter
 
 DeltaWriter::~DeltaWriter() {
@@ -629,6 +639,10 @@ Status DeltaWriter::flush_async() {
 
 std::vector<std::string> DeltaWriter::files() const {
     return _impl->files();
+}
+
+const int64_t DeltaWriter::queueing_memtable_num() const {
+    return _impl->queueing_memtable_num();
 }
 
 int64_t DeltaWriter::data_size() const {

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -80,6 +80,8 @@ public:
 
     [[nodiscard]] MemTracker* mem_tracker();
 
+    const int64_t queueing_memtable_num() const;
+
     // Return the list of files created by this DeltaWriter.
     // NOTE: Do NOT invoke this function after `close()`, otherwise may get unexpected result.
     std::vector<std::string> files() const;


### PR DESCRIPTION
backport https://github.com/StarRocks/starrocks/pull/22669 to LakeTabletChannel

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
