### PR TITLE
[BugFix] Fix limit offset bugs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithLimitRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithLimitRule.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -78,10 +77,6 @@ public class MergeLimitWithLimitRule extends TransformationRule {
 
         Operator result;
         if (l1.hasOffset() || l2.hasOffset()) {
-            if (l1.hasOffset()) {
-                Preconditions.checkState(!l1.isLocal());
-            }
-
             // l2 range
             long l2Min = l2.hasOffset() ? l2.getOffset() : Operator.DEFAULT_OFFSET;
             long l2Max = l2Min + l2.getLimit();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/OptExpressionValidator.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -76,6 +77,11 @@ public class OptExpressionValidator extends OptExpressionVisitor<OptExpression, 
 
     @Override
     public OptExpression visitLogicalLimit(OptExpression optExpression, Void context) {
+        LogicalLimitOperator limit = optExpression.getOp().cast();
+        if (limit.hasOffset() && limit.isLocal()) {
+            ErrorReport.reportValidateException(ErrorCode.ERR_PLAN_VALIDATE_ERROR,
+                    ErrorType.INTERNAL_ERROR, optExpression, "offset limit transfer error, must be gather operator");
+        }
         return commonValidate(optExpression);
     }
 

--- a/test/sql/test_limit/R/test_limit
+++ b/test/sql/test_limit/R/test_limit
@@ -67,7 +67,7 @@ select count(*) from (select * from t0 limit 50, 20) xx;
 -- !result
 select COUNT(*) from (select * from (select * from t0 limit 10) x limit 10, 20) xx;
 -- result:
-10
+0
 -- !result
 select COUNT(*) from (select * from (select * from t0 limit 10, 10) x limit 1, 2) xx;
 -- result:
@@ -101,13 +101,13 @@ select COUNT(*) from (select * from (select * from t0 limit 30, 2) x limit 5) xx
 -- result:
 2
 -- !result
-select COUNT(*) from (select * from (select * from t0 limit 30) x limit 10, 40) xx;
--- result:
-23
--- !result
-select COUNT(*) from (select * from (select * from t0 limit 30) x limit 10, 10) xx;
+select COUNT(*) from (select * from (select * from t0 limit 20) x limit 10, 40) xx;
 -- result:
 10
+-- !result
+select COUNT(*) from (select * from (select * from t0 limit 10) x limit 10, 10) xx;
+-- result:
+0
 -- !result
 select COUNT(*) from (select * from (select * from t0 limit 30) x limit 50, 10) xx;
 -- result:

--- a/test/sql/test_limit/T/test_limit
+++ b/test/sql/test_limit/T/test_limit
@@ -64,8 +64,8 @@ select COUNT(*) from (select * from (select * from t0 limit 40, 2) x limit 1) xx
 select COUNT(*) from (select * from (select * from t0 limit 30, 10) x limit 2) xx;
 select COUNT(*) from (select * from (select * from t0 limit 30, 2) x limit 1) xx;
 select COUNT(*) from (select * from (select * from t0 limit 30, 2) x limit 5) xx;
-select COUNT(*) from (select * from (select * from t0 limit 30) x limit 10, 40) xx;
-select COUNT(*) from (select * from (select * from t0 limit 30) x limit 10, 10) xx;
+select COUNT(*) from (select * from (select * from t0 limit 20) x limit 10, 40) xx;
+select COUNT(*) from (select * from (select * from t0 limit 10) x limit 10, 10) xx;
 select COUNT(*) from (select * from (select * from t0 limit 30) x limit 50, 10) xx;
 
 select count(*) from (select * from TABLE(generate_series(1, 100000)) limit 50000, 10) x;


### PR DESCRIPTION
Fixes #issue

* compute offset error, the result should be 0 rows, but 10 rows now
```
MySQL td> explain select count(*) from (select * from (select * from t0 limit 10) x limit 10, 10) xx;
+---------------------------------+
| Explain String                  |
+---------------------------------+
| PLAN FRAGMENT 0                 |
|  OUTPUT EXPRS:4: count          |
|   PARTITION: UNPARTITIONED      |
|                                 |
|   RESULT SINK                   |
|                                 |
|   3:AGGREGATE (update finalize) |
|   |  output: count(*)           |
|   |  group by:                  |
|   |                             |
|   2:MERGING-EXCHANGE            |
|      offset: 10                 |
|      limit: 10                  |
|                                 |
| PLAN FRAGMENT 1                 |
|  OUTPUT EXPRS:                  |
|   PARTITION: RANDOM             |
|                                 |
|   STREAM DATA SINK              |
|     EXCHANGE ID: 02             |
|     UNPARTITIONED               |
|                                 |
|   1:Project                     |
|   |  <slot 9> : 1               |
|   |  limit: 20                  |
|   |                             |
|   0:OlapScanNode                |
|      TABLE: t0                  |
|      PREAGGREGATION: ON         |
|      partitions=0/1             |
|      rollup: t0                 |
|      tabletRatio=0/0            |
|      tabletList=                |
|      cardinality=1              |
|      avgRowSize=2.0             |
|      limit: 20                  |
+---------------------------------+
36 rows in set
Time: 1.384s
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
