### PR TITLE
[Feature] support any/all_match() for arrays (backport #24692) 

### DIFF
--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -1511,6 +1511,14 @@ StatusOr<ColumnPtr> ArrayFunctions::array_max_varchar([[maybe_unused]] FunctionC
     return ArrayFunctions::template array_max<TYPE_VARCHAR>(columns);
 }
 
+StatusOr<ColumnPtr> ArrayFunctions::all_match(FunctionContext* context, const Columns& columns) {
+    return ArrayMatch<false>::process(context, columns);
+}
+
+StatusOr<ColumnPtr> ArrayFunctions::any_match(FunctionContext* context, const Columns& columns) {
+    return ArrayMatch<true>::process(context, columns);
+}
+
 StatusOr<ColumnPtr> ArrayFunctions::concat(FunctionContext* ctx, const Columns& columns) {
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
 

--- a/be/src/exprs/array_functions.h
+++ b/be/src/exprs/array_functions.h
@@ -174,6 +174,8 @@ public:
     DEFINE_VECTORIZED_FN(array_contains_all);
     DEFINE_VECTORIZED_FN(array_map);
     DEFINE_VECTORIZED_FN(array_filter);
+    DEFINE_VECTORIZED_FN(all_match);
+    DEFINE_VECTORIZED_FN(any_match);
 
     enum ArithmeticType { SUM, AVG, MIN, MAX };
 

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -837,6 +837,68 @@ private:
     }
 };
 
+// all/any_match(lambda_func, array1, array2...)-> all/any_match(array_map(lambda_func, array1, array2...))
+// -> all/any_match(bool_array), result is bool type.
+// any_match: if there are true  matched, return true,  else if there are null, return null, otherwise, return false;
+// all_match: if there are false matched, return false, else if there are null, return null, otherwise, return true;
+template <bool isAny>
+class ArrayMatch {
+public:
+    static ColumnPtr process([[maybe_unused]] FunctionContext* ctx, const Columns& columns) {
+        return _array_match(columns);
+    }
+
+private:
+    static ColumnPtr _array_match(const Columns& columns) {
+        DCHECK(columns.size() == 1);
+        RETURN_IF_COLUMNS_ONLY_NULL(columns);
+        size_t chunk_size = columns[0]->size();
+        ColumnPtr bool_column = ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[0]);
+
+        auto dest_null_column = NullColumn::create(chunk_size, 0);
+        auto dest_data_column = BooleanColumn::create(chunk_size);
+        dest_null_column->get_data().resize(chunk_size, 0);
+
+        ArrayColumn* bool_array;
+        NullColumn* array_null_map = nullptr;
+
+        if (bool_column->is_nullable()) {
+            auto nullable_column = down_cast<NullableColumn*>(bool_column.get());
+            bool_array = down_cast<ArrayColumn*>(nullable_column->data_column().get());
+            array_null_map = nullable_column->null_column().get();
+        } else {
+            bool_array = down_cast<ArrayColumn*>(bool_column.get());
+        }
+        auto offsets = bool_array->offsets().get_data();
+
+        ColumnViewer<TYPE_BOOLEAN> bool_elements(bool_array->elements_column());
+
+        for (size_t i = 0; i < chunk_size; ++i) {
+            if (array_null_map == nullptr || !array_null_map->get_data()[i]) { // array_null_map[i] is not null
+                bool has_null = false;
+                bool res = !isAny;
+                for (auto id = offsets[i]; id < offsets[i + 1]; ++id) {
+                    if (bool_elements.is_null(id)) {
+                        has_null = true;
+                    } else {
+                        if (bool_elements.value(id) == isAny) {
+                            res = isAny;
+                            break;
+                        }
+                    }
+                }
+                dest_null_column->get_data()[i] = res != isAny && has_null;
+                dest_data_column->get_data()[i] = res;
+            } else { // array_null_map[i] is null, result is null
+                dest_null_column->get_data()[i] = 1;
+                dest_data_column->get_data()[i] = 0;
+            }
+        }
+
+        return NullableColumn::create(dest_data_column, dest_null_column);
+    }
+};
+
 // by design array_filter(array, bool_array), if bool_array is null, return an empty array. We do not return null, as
 // it will change the null property of return results which keeps the same with the first argument array.
 class ArrayFilter {

--- a/be/test/exprs/array_functions_test.cpp
+++ b/be/test/exprs/array_functions_test.cpp
@@ -4964,4 +4964,113 @@ TEST_F(ArrayFunctionsTest, array_sortby_with_only_null) {
     }
 }
 
+TEST_F(ArrayFunctionsTest, array_match_nullable) {
+    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
+    src_column->append_datum(DatumArray{(int8_t)1, (int8_t)1, (int8_t)0});
+    src_column->append_datum(DatumArray{(int8_t)0});
+    src_column->append_datum(DatumArray{(int8_t)1});
+    src_column->append_datum(Datum());
+    src_column->append_datum(DatumArray{(int8_t)1, Datum()});
+    src_column->append_datum(DatumArray{(int8_t)0, Datum()});
+    src_column->append_datum(DatumArray{});
+
+
+    auto dest_column = ArrayMatch<true>::process(nullptr, {src_column});
+    ASSERT_TRUE(dest_column->is_nullable());
+    ASSERT_EQ(dest_column->size(), 7);
+    ASSERT_TRUE(dest_column->get(0).get_int8());
+    ASSERT_FALSE(dest_column->get(1).get_int8());
+    ASSERT_TRUE(dest_column->get(2).get_int8());
+    ASSERT_TRUE(dest_column->get(3).is_null());
+    ASSERT_TRUE(dest_column->get(4).get_int8());
+    ASSERT_TRUE(dest_column->get(5).is_null());
+    ASSERT_FALSE(dest_column->get(6).get_int8());
+
+
+    dest_column = ArrayMatch<false>::process(nullptr, {src_column});
+    ASSERT_TRUE(dest_column->is_nullable());
+    ASSERT_EQ(dest_column->size(), 7);
+    ASSERT_FALSE(dest_column->get(0).get_int8());
+    ASSERT_FALSE(dest_column->get(1).get_int8());
+    ASSERT_TRUE(dest_column->get(2).get_int8());
+    ASSERT_TRUE(dest_column->get(3).is_null());
+    ASSERT_TRUE(dest_column->get(4).is_null());
+    ASSERT_FALSE(dest_column->get(5).get_int8());
+    ASSERT_TRUE(dest_column->get(6).get_int8());
+}
+
+TEST_F(ArrayFunctionsTest, array_match_not_null) {
+    auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, false);
+    src_column->append_datum(DatumArray{(int8_t)1, (int8_t)1, (int8_t)0});
+    src_column->append_datum(DatumArray{(int8_t)0});
+    src_column->append_datum(DatumArray{(int8_t)1});
+    src_column->append_datum(DatumArray{Datum()});
+    src_column->append_datum(DatumArray{(int8_t)1, Datum()});
+    src_column->append_datum(DatumArray{(int8_t)0, Datum()});
+    src_column->append_datum(DatumArray{});
+
+    auto dest_column = ArrayMatch<true>::process(nullptr, {src_column});
+    ASSERT_TRUE(dest_column->is_nullable());
+    ASSERT_EQ(dest_column->size(), 7);
+    ASSERT_TRUE(dest_column->get(0).get_int8());
+    ASSERT_FALSE(dest_column->get(1).get_int8());
+    ASSERT_TRUE(dest_column->get(2).get_int8());
+    ASSERT_TRUE(dest_column->get(3).is_null());
+    ASSERT_TRUE(dest_column->get(4).get_int8());
+    ASSERT_TRUE(dest_column->get(5).is_null());
+    ASSERT_FALSE(dest_column->get(6).get_int8());
+
+
+    dest_column = ArrayMatch<false>::process(nullptr, {src_column});
+    ASSERT_TRUE(dest_column->is_nullable());
+    ASSERT_EQ(dest_column->size(), 7);
+    ASSERT_FALSE(dest_column->get(0).get_int8());
+    ASSERT_FALSE(dest_column->get(1).get_int8());
+    ASSERT_TRUE(dest_column->get(2).get_int8());
+    ASSERT_TRUE(dest_column->get(3).is_null());
+    ASSERT_TRUE(dest_column->get(4).is_null());
+    ASSERT_FALSE(dest_column->get(5).get_int8());
+    ASSERT_TRUE(dest_column->get(6).get_int8());
+}
+
+TEST_F(ArrayFunctionsTest, array_match_only_null) {
+    // test only null
+    {
+        auto src_column = ColumnHelper::create_const_null_column(3);
+        auto dest_column = ArrayMatch<false>::process(nullptr, {src_column});
+        ASSERT_EQ(dest_column->size(), 3);
+        ASSERT_TRUE(dest_column->only_null());
+
+        dest_column = ArrayMatch<true>::process(nullptr, {src_column});
+        ASSERT_EQ(dest_column->size(), 3);
+        ASSERT_TRUE(dest_column->only_null());
+    }
+    // test const
+    {
+        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
+        src_column->append_datum(DatumArray{(uint8) false, (uint8) true});
+        src_column = std::make_shared<ConstColumn>(src_column, 3);
+        auto dest_column = ArrayMatch<false>::process(nullptr, {src_column});
+        ASSERT_EQ(dest_column->size(), 3);
+        ASSERT_FALSE(dest_column->get(0).get_int8());
+
+        dest_column = ArrayMatch<true>::process(nullptr, {src_column});
+        ASSERT_EQ(dest_column->size(), 3);
+        ASSERT_TRUE(dest_column->get(0).get_int8());
+    }
+    // test const
+    {
+        auto src_column = ColumnHelper::create_column(TYPE_ARRAY_BOOLEAN, true);
+        src_column->append_datum(DatumArray{});
+        src_column = std::make_shared<ConstColumn>(src_column, 3);
+        auto dest_column = ArrayMatch<true>::process(nullptr, {src_column});
+        ASSERT_EQ(dest_column->size(), 3);
+        ASSERT_FALSE(dest_column->get(0).get_int8());
+
+        dest_column = ArrayMatch<false>::process(nullptr, {src_column});
+        ASSERT_EQ(dest_column->size(), 3);
+        ASSERT_TRUE(dest_column->get(0).get_int8());
+    }
+}
+
 } // namespace starrocks

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -359,6 +359,8 @@
       + [var_samp](./sql-reference/sql-functions/aggregate-functions/var_samp.md)
       + [window_funnel](./sql-reference/sql-functions/aggregate-functions/window_funnel.md)
     + Array Functions
+      + [all_match](./sql-reference/sql-functions/array-functions/all_match.md)
+      + [any_match](./sql-reference/sql-functions/array-functions/any_match.md)
       + [array_agg](./sql-reference/sql-functions/array-functions/array_agg.md)
       + [array_append](./sql-reference/sql-functions/array-functions/array_append.md)
       + [array_avg](./sql-reference/sql-functions/array-functions/array_avg.md)

--- a/docs/sql-reference/sql-functions/array-functions/all_match.md
+++ b/docs/sql-reference/sql-functions/array-functions/all_match.md
@@ -1,0 +1,73 @@
+# all_match
+
+## Description
+
+Returns whether all elements of an array match the given predicate. 
+Returns true if all the elements match the predicate (a special case is when the array is empty); false if one or more elements don’t match; NULL if the predicate function returns NULL for one or more elements and true for all other elements.
+
+
+## Syntax
+
+```Haskell
+all_match(lambda_function, arr1, arr2...)
+```
+
+Returns whether all elements of `arr1` match the given predicate in the lambda function.
+
+## Parameters
+
+`arr1`: the array to match.
+
+`arrN`: optional arrays used in the lambda function.
+
+`lambda_function`: the lambda function used to match values.
+
+## Usage notes
+
+- The lambda function follows the usage notes in [array_map()](array_map.md), it returns array<bool>.
+- If the input array is null or the lambda function results null, null is returned.
+- if `arr1` is empty, return true.
+- Map types can use it by rewriting `any/all_match((k,v)->k>v,map)` to `any/all_match(map_values(transform_values((k,v)->k>v, map)))`.
+
+
+## Examples
+
+```Plain
+-- check whether all elements in x that are less than the elements in y.
+
+select all_match((x,y) -> x < y, [1,2,-8], [4,5,6]);
++---------------------------------------------------+
+| all_match((x, y) -> x < y, [1, 2, -8], [4, 5, 6]) |
++---------------------------------------------------+
+|                                                 1 |
++---------------------------------------------------+
+
+select all_match((x,y) -> x < y, [1,2,null], [4,5,6]);
++-----------------------------------------------------+
+| all_match((x, y) -> x < y, [1, 2, NULL], [4, 5, 6]) |
++-----------------------------------------------------+
+|                                                NULL |
++-----------------------------------------------------+
+
+select all_match((x,y) -> x < y, [1,2,8], [4,5,6]);
++--------------------------------------------------+
+| all_match((x, y) -> x < y, [1, 2, 8], [4, 5, 6]) |
++--------------------------------------------------+
+|                                                0 |
++--------------------------------------------------+
+
+select all_match((x,y) -> x < y, [], []);
++------------------------------------+
+| all_match((x, y) -> x < y, [], []) |
++------------------------------------+
+|                                  1 |
++------------------------------------+
+
+mysql> select all_match((x,y) -> x < y, null, [4,5,6]);
++---------------------------------------------+
+| all_match((x, y) -> x < y, NULL, [4, 5, 6]) |
++---------------------------------------------+
+|                                        NULL |
++---------------------------------------------+
+
+```

--- a/docs/sql-reference/sql-functions/array-functions/any_match.md
+++ b/docs/sql-reference/sql-functions/array-functions/any_match.md
@@ -1,0 +1,70 @@
+# any_match
+
+## Description
+
+Returns whether any elements of an array match the given predicate.
+Returns true if one or more elements match the predicate; false if none of the elements matches (a special case is when the array is empty); NULL if the predicate function returns NULL for one or more elements and false for all other elements.
+
+## Syntax
+
+```Haskell
+any_match(lambda_function, arr1, arr2...)
+```
+Returns whether any elements of `arr1` match the given predicate in the lambda function.
+
+
+## Parameters
+
+`arr1`: the array to match.
+
+`arrN`: optional arrays used in the lambda function.
+
+`lambda_function`: the lambda function used to match values.
+
+## Usage notes
+
+- The lambda function follows the usage notes in [array_map()](array_map.md), it returns array<bool>.
+- If the input array is null or the lambda function results null, null is returned.
+- if `arr1` is empty, return false.
+- Map types can use it by rewriting `any/all_match((k,v)->k>v,map)` to `any/all_match(map_values(transform_values((k,v)->k>v, map)))`.
+
+## Examples
+
+```Plain
+-- check whether any element in x that is less than the elements in y.
+
+select any_match((x,y) -> x < y, [1,2,8], [4,5,6]);
++--------------------------------------------------+
+| any_match((x, y) -> x < y, [1, 2, 8], [4, 5, 6]) |
++--------------------------------------------------+
+|                                                1 |
++--------------------------------------------------+
+
+select any_match((x,y) -> x < y, [11,12,8], [4,5,6]);
++----------------------------------------------------+
+| any_match((x, y) -> x < y, [11, 12, 8], [4, 5, 6]) |
++----------------------------------------------------+
+|                                                  0 |
++----------------------------------------------------+
+
+select any_match((x,y) -> x < y, [11,12,null], [4,5,6]);
++-------------------------------------------------------+
+| any_match((x, y) -> x < y, [11, 12, NULL], [4, 5, 6]) |
++-------------------------------------------------------+
+|                                                  NULL |
++-------------------------------------------------------+
+
+select any_match((x,y) -> x < y, [], []);
++------------------------------------+
+| any_match((x, y) -> x < y, [], []) |
++------------------------------------+
+|                                  0 |
++------------------------------------+
+
+mysql> select any_match((x,y) -> x < y, null, [4,5,6]);
++---------------------------------------------+
+| any_match((x, y) -> x < y, NULL, [4, 5, 6]) |
++---------------------------------------------+
+|                                        NULL |
++---------------------------------------------+
+```

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -305,6 +305,8 @@ public class FunctionSet {
     public static final String ARRAY_REMOVE = "array_remove";
     public static final String ARRAY_FILTER = "array_filter";
     public static final String ARRAY_SORTBY = "array_sortby";
+    public static final String ANY_MATCH = "any_match";
+    public static final String ALL_MATCH = "all_match";
 
     public static final String ELEMENT_AT = "element_at";
     public static final String CARDINALITY = "cardinality";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1056,6 +1056,19 @@ public class ExpressionAnalyzer {
                             " should be an array or a lambda function.");
                 }
                 fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            } else if (fnName.equals(FunctionSet.ALL_MATCH) || fnName.equals(FunctionSet.ANY_MATCH)) {
+                if (node.getChildren().size() != 1) {
+                    throw new SemanticException(fnName + " should have a input array");
+                }
+                if (!node.getChild(0).getType().isArrayType() && !node.getChild(0).getType().isNull()) {
+                    throw new SemanticException("The first input of " + fnName + " should be an array");
+                }
+                // force the second array be of Type.ARRAY_BOOLEAN
+                if (!Type.canCastTo(node.getChild(0).getType(), Type.ARRAY_BOOLEAN)) {
+                    throw new SemanticException("The second input of " + fnName +
+                            node.getChild(0).getType().toString() + "  can't cast to ARRAY<BOOL>");
+                }
+                fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             } else if (fnName.equals(FunctionSet.ARRAY_SLICE)) {
                 // Default type is TINYINT, it would match to a wrong function
                 for (int i = 1; i < argumentTypes.length; i++) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -142,6 +142,8 @@ public class ExpressionAnalyzer {
         if (expr instanceof FunctionCallExpr) {
             if (((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.ARRAY_MAP) ||
                     ((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.ARRAY_FILTER) ||
+                    ((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.ANY_MATCH) ||
+                    ((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.ALL_MATCH) ||
                     ((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.ARRAY_SORTBY)) {
                 return true;
             } else if (((FunctionCallExpr) expr).getFnName().getFunction().equals(FunctionSet.TRANSFORM)) {
@@ -166,33 +168,49 @@ public class ExpressionAnalyzer {
         return isArrayHighOrderFunction(expr) || isMapHighOrderFunction(expr);
     }
 
-    private Expr rewriteHighOrderFunction(Expr expr) {
+    private void rewriteHighOrderFunction(Expr expr, Visitor visitor, Scope scope) {
         Preconditions.checkState(expr instanceof FunctionCallExpr);
         FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
-        if (functionCallExpr.getFnName().getFunction().equals(FunctionSet.ARRAY_FILTER)
-                && functionCallExpr.getChild(0) instanceof LambdaFunctionExpr) {
-            // array_filter(lambda_func_expr, arr1...) -> array_filter(arr1, array_map(lambda_func_expr, arr1...))
-            FunctionCallExpr arrayMap = new FunctionCallExpr(FunctionSet.ARRAY_MAP,
-                    Lists.newArrayList(functionCallExpr.getChildren()));
-            arrayMap.setType(Type.BOOLEAN);
-            Expr arr1 = functionCallExpr.getChild(1);
-            functionCallExpr.clearChildren();
-            functionCallExpr.addChild(arr1);
-            functionCallExpr.addChild(arrayMap);
-            return arrayMap;
-        } else if (functionCallExpr.getFnName().getFunction().equals(FunctionSet.ARRAY_SORTBY)
-                && functionCallExpr.getChild(0) instanceof LambdaFunctionExpr) {
-            // array_sortby(lambda_func_expr, arr1...) -> array_sortby(arr1, array_map(lambda_func_expr, arr1...))
-            FunctionCallExpr arrayMap = new FunctionCallExpr(FunctionSet.ARRAY_MAP,
-                    Lists.newArrayList(functionCallExpr.getChildren()));
-            Expr arr1 = functionCallExpr.getChild(1);
-            functionCallExpr.clearChildren();
-            functionCallExpr.addChild(arr1);
-            functionCallExpr.addChild(arrayMap);
-            functionCallExpr.setType(arr1.getType());
-            return arrayMap;
+        if (!(functionCallExpr.getChild(0) instanceof LambdaFunctionExpr)) {
+            return;
         }
-        return null;
+        switch (functionCallExpr.getFnName().getFunction()) {
+            case FunctionSet.ARRAY_FILTER: {
+                // array_filter(lambda_func_expr, arr1...) -> array_filter(arr1, array_map(lambda_func_expr, arr1...))
+                FunctionCallExpr arrayMap = new FunctionCallExpr(FunctionSet.ARRAY_MAP,
+                        Lists.newArrayList(functionCallExpr.getChildren()));
+                arrayMap.setType(Type.ARRAY_BOOLEAN);
+                Expr arr1 = functionCallExpr.getChild(1);
+                functionCallExpr.clearChildren();
+                functionCallExpr.addChild(arr1);
+                functionCallExpr.addChild(arrayMap);
+                visitor.visit(arrayMap, scope);
+                break;
+            }
+            case FunctionSet.ALL_MATCH:
+            case FunctionSet.ANY_MATCH: {
+                // func(lambda_func_expr, arr1...) -> func(array_map(lambda_func_expr, arr1...))
+                FunctionCallExpr arrayMap = new FunctionCallExpr(FunctionSet.ARRAY_MAP,
+                        Lists.newArrayList(functionCallExpr.getChildren()));
+                arrayMap.setType(Type.ARRAY_BOOLEAN);
+                functionCallExpr.clearChildren();
+                functionCallExpr.addChild(arrayMap);
+                visitor.visit(arrayMap, scope);
+                break;
+            }
+            case FunctionSet.ARRAY_SORTBY: {
+                // array_sortby(lambda_func_expr, arr1...) -> array_sortby(arr1, array_map(lambda_func_expr, arr1...))
+                FunctionCallExpr arrayMap = new FunctionCallExpr(FunctionSet.ARRAY_MAP,
+                        Lists.newArrayList(functionCallExpr.getChildren()));
+                Expr arr1 = functionCallExpr.getChild(1);
+                functionCallExpr.clearChildren();
+                functionCallExpr.addChild(arr1);
+                functionCallExpr.addChild(arrayMap);
+                functionCallExpr.setType(arr1.getType());
+                visitor.visit(arrayMap, scope);
+                break;
+            }
+        }
     }
 
     // only high-order functions can use lambda functions.
@@ -260,10 +278,7 @@ public class ExpressionAnalyzer {
         }
         // visit LambdaFunction
         visitor.visit(expression.getChild(0), scope);
-        Expr res = rewriteHighOrderFunction(expression);
-        if (res != null) {
-            visitor.visit(res, scope);
-        }
+        rewriteHighOrderFunction(expression, visitor, scope);
         scope.clearLambdaInputs();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -167,24 +167,6 @@ public class FunctionAnalyzer {
             }
         }
 
-        if (fnName.getFunction().equals(FunctionSet.ARRAYS_OVERLAP)) {
-            if (functionCallExpr.getChildren().size() != 2) {
-                throw new SemanticException("arrays_overlap only support 2 parameters");
-            }
-        }
-
-        if (fnName.getFunction().equals(FunctionSet.ARRAY_FILTER)) {
-            if (functionCallExpr.getChildren().size() != 2) {
-                throw new SemanticException("array_filter only support 2 parameters");
-            }
-        }
-
-        if (fnName.getFunction().equals(FunctionSet.ARRAY_SORTBY)) {
-            if (functionCallExpr.getChildren().size() != 2) {
-                throw new SemanticException("array_sortby only support 2 parameters");
-            }
-        }
-
         if (fnName.getFunction().equals(FunctionSet.RETENTION)) {
             if (!arg.getType().isArrayType()) {
                 throw new SemanticException("retention only support Array<BOOLEAN>");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeExprTest.java
@@ -180,6 +180,39 @@ public class AnalyzeExprTest {
         analyzeFail("select array_filter([2],1)");
     }
     @Test
+    public void testLambdaFunctionArrayMatch() {
+        analyzeSuccess("select all_match((x,y) -> x < y, null, [4,5,6])");
+        analyzeSuccess("select all_match((x,y) -> x < y, [], [])");
+        analyzeSuccess("select all_match((x,y) -> x < y, null, [])");
+        analyzeSuccess("select all_match((x,y) -> x < y, null, null)");
+        analyzeSuccess("select any_match((x,y) -> x < y, null, [4,5,6])");
+        analyzeSuccess("select any_match((x,y) -> x < y, [], [])");
+        analyzeSuccess("select any_match((x,y) -> x < y, null, [])");
+        analyzeSuccess("select any_match((x,y) -> x < y, null, null)");
+        analyzeSuccess("select all_match([0],x->1)");
+        analyzeSuccess("select any_match([0],x->1)");
+        analyzeSuccess("select any_match([],x->1)");
+        analyzeSuccess("select any_match(null)");
+        analyzeSuccess("select any_match([])");
+        analyzeSuccess("select all_match([])");
+
+        analyzeFail("select all_match((x,y) -> x < y, []);");
+        analyzeFail("select all_match((x,y) -> x < y, [],{});");
+        analyzeFail("select all_match([],null)");
+        analyzeFail("select all_match({})");
+        analyzeFail("select all_match()");
+        analyzeFail("select all_match(null,[])");
+        analyzeFail("select all_match(null,null)");
+        analyzeFail("select any_match((x,y) -> x < y, []);");
+        analyzeFail("select any_match((x,y) -> x < y, [],{});");
+        analyzeFail("select any_match([],null)");
+        analyzeFail("select any_match({})");
+        analyzeFail("select any_match()");
+        analyzeFail("select any_match(null,[])");
+        analyzeFail("select any_match(null,null)");
+        analyzeFail("select all_match([[]])");
+    }
+    @Test
     public void testLambdaFunctionMapApply() {
         analyzeSuccess("select map_apply((k,v)->(k+1,length(v)), col_map) from " +
                 "(select map_from_arrays([1,3,null,2,null],['ab','cdd',null,null,'']) as col_map " +

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -888,6 +888,9 @@ vectorized_functions = [
     [150282, 'array_contains_all', 'BOOLEAN', ['ANY_ARRAY', 'ANY_ARRAY'], 'ArrayFunctions::array_contains_all'],
 
     [150300, 'array_filter', 'ANY_ARRAY',   ['ANY_ARRAY', 'ARRAY_BOOLEAN'],   'ArrayFunctions::array_filter'],
+    [150301, 'all_match', 'BOOLEAN',   ['ARRAY_BOOLEAN'],   'ArrayFunctions::all_match'],
+    [150302, 'any_match', 'BOOLEAN',   ['ARRAY_BOOLEAN'],   'ArrayFunctions::any_match'],
+
 
     [150311, 'array_sortby', 'ANY_ARRAY',  ['ANY_ARRAY', 'ARRAY_BOOLEAN'],   'ArrayFunctions::array_sortby_boolean'],
     [150312, 'array_sortby', 'ANY_ARRAY',  ['ANY_ARRAY', 'ARRAY_TINYINT'],   'ArrayFunctions::array_sortby_tinyint'],

--- a/test/sql/test_array_fn/R/test_array_fn
+++ b/test/sql/test_array_fn/R/test_array_fn
@@ -1,10 +1,11 @@
+-- name: testArrayFunc
 select array_contains( cast ('[40360,40361]' as array<int>), 40360);
 -- result:
 1
 -- !result
 select array_contains_all( cast ('[40360,40361]' as array<int>), 40360);
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 7 to line 1, column 70. Detail message: No matching function with signature: array_contains_all(array<int(11)>, int(11)).')
+E: (1064, 'No matching function with signature: array_contains_all(ARRAY<int(11)>, int(11)).')
 -- !result
 select array_append( cast ('[40360,40361]' as array<int>), 40360);
 -- result:
@@ -12,7 +13,7 @@ select array_append( cast ('[40360,40361]' as array<int>), 40360);
 -- !result
 select array_avg( cast ('[40360,40361]' as array<int>), 40360);
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 7 to line 1, column 61. Detail message: No matching function with signature: array_avg(array<int(11)>, int(11)).')
+E: (1064, 'No matching function with signature: array_avg(ARRAY<int(11)>, int(11)).')
 -- !result
 select array_concat( cast ('[40360,40361]' as array<int>), [40360]);
 -- result:
@@ -108,7 +109,7 @@ None
 -- !result
 select array_contains_all( cast ('null' as array<int>), 40360);
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 7 to line 1, column 61. Detail message: No matching function with signature: array_contains_all(array<int(11)>, int(11)).')
+E: (1064, 'No matching function with signature: array_contains_all(ARRAY<int(11)>, int(11)).')
 -- !result
 select array_append( cast ('null' as array<int>), 40360);
 -- result:
@@ -116,7 +117,7 @@ None
 -- !result
 select array_avg( cast ('null' as array<int>), 40360);
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 7 to line 1, column 52. Detail message: No matching function with signature: array_avg(array<int(11)>, int(11)).')
+E: (1064, 'No matching function with signature: array_avg(ARRAY<int(11)>, int(11)).')
 -- !result
 select array_concat( cast ('null' as array<int>), [40360]);
 -- result:
@@ -205,4 +206,140 @@ None
 select REVERSE( cast ('null' as array<int>));
 -- result:
 None
+-- !result
+select all_match((x,y) -> x < y, null, [4,5,6]);
+-- result:
+None
+-- !result
+select all_match((x,y) -> x < y, [], []);
+-- result:
+1
+-- !result
+select all_match((x,y) -> x < y, null, []);
+-- result:
+None
+-- !result
+select all_match((x,y) -> x < y, null, null);
+-- result:
+None
+-- !result
+select any_match((x,y) -> x < y, null, [4,5,6]);
+-- result:
+None
+-- !result
+select any_match((x,y) -> x < y, [], []);
+-- result:
+0
+-- !result
+select any_match((x,y) -> x < y, null, []);
+-- result:
+None
+-- !result
+select any_match((x,y) -> x < y, null, null);
+-- result:
+None
+-- !result
+select all_match([0],x->1);
+-- result:
+1
+-- !result
+select any_match([0],x->1);
+-- result:
+1
+-- !result
+select any_match([],x->1);
+-- result:
+0
+-- !result
+select any_match(null);
+-- result:
+None
+-- !result
+select any_match([]);
+-- result:
+0
+-- !result
+select all_match([]);
+-- result:
+1
+-- !result
+select any_match((x,y) -> x < y, [1,2,8], [4,5,6]);
+-- result:
+1
+-- !result
+select any_match((x,y) -> x < y, [11,12,8], [4,5,6]);
+-- result:
+0
+-- !result
+select any_match((x,y) -> x < y, [11,12,null], [4,5,6]);
+-- result:
+None
+-- !result
+select all_match((x,y) -> x < y, [1,2,null], [4,5,6]);
+-- result:
+None
+-- !result
+select all_match((x,y) -> x < y, [1,2,null], [4,5,6]), any_match((x,y) -> x < y, [11,12,8], [4,5,6]);
+-- result:
+None	0
+-- !result
+select all_match((x,y) -> x < y, []);
+-- result:
+E: (1064, 'Lambda arguments should equal to lambda input arrays.')
+-- !result
+select all_match((x,y) -> x < y, [],{});
+-- result:
+E: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '}' at line 1")
+-- !result
+select all_match([],null);
+-- result:
+E: (1064, 'all_match should have a input array')
+-- !result
+select all_match({});
+-- result:
+E: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '}' at line 1")
+-- !result
+select all_match();
+-- result:
+E: (1064, 'all_match should have a input array')
+-- !result
+select all_match(null,[]);
+-- result:
+E: (1064, 'all_match should have a input array')
+-- !result
+select all_match(null,null);
+-- result:
+E: (1064, 'all_match should have a input array')
+-- !result
+select any_match((x,y) -> x < y, []);
+-- result:
+E: (1064, 'Lambda arguments should equal to lambda input arrays.')
+-- !result
+select any_match((x,y) -> x < y, [],{});
+-- result:
+E: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '}' at line 1")
+-- !result
+select any_match([],null);
+-- result:
+E: (1064, 'any_match should have a input array')
+-- !result
+select any_match({});
+-- result:
+E: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '}' at line 1")
+-- !result
+select any_match();
+-- result:
+E: (1064, 'any_match should have a input array')
+-- !result
+select any_match(null,[]);
+-- result:
+E: (1064, 'any_match should have a input array')
+-- !result
+select any_match(null,null);
+-- result:
+E: (1064, 'any_match should have a input array')
+-- !result
+select all_match([[]]);
+-- result:
+E: (1064, "The second input of all_matchARRAY<ARRAY<NULL_TYPE>>  can't cast to ARRAY<BOOL>")
 -- !result

--- a/test/sql/test_array_fn/T/test_array_fn
+++ b/test/sql/test_array_fn/T/test_array_fn
@@ -1,3 +1,4 @@
+-- name: testArrayFunc
 select array_contains( cast ('[40360,40361]' as array<int>), 40360);
 select array_contains_all( cast ('[40360,40361]' as array<int>), 40360);
 select array_append( cast ('[40360,40361]' as array<int>), 40360);
@@ -25,7 +26,6 @@ select array_to_bitmap( cast ('[40360,40361]' as array<int>));
 select bitmap_to_array(array_to_bitmap(cast ('[40360,40361]' as array<int>)));
 select REVERSE( cast ('[40360,40361]' as array<int>));
 
-
 select array_contains( cast ('null' as array<int>), 40360);
 select array_contains_all( cast ('null' as array<int>), 40360);
 select array_append( cast ('null' as array<int>), 40360);
@@ -52,3 +52,39 @@ select array_sum( cast ('null' as array<int>));
 select array_to_bitmap( cast ('null' as array<int>));
 select bitmap_to_array(array_to_bitmap(cast ('null' as array<int>)));
 select REVERSE( cast ('null' as array<int>));
+
+select all_match((x,y) -> x < y, null, [4,5,6]);
+select all_match((x,y) -> x < y, [], []);
+select all_match((x,y) -> x < y, null, []);
+select all_match((x,y) -> x < y, null, null);
+select any_match((x,y) -> x < y, null, [4,5,6]);
+select any_match((x,y) -> x < y, [], []);
+select any_match((x,y) -> x < y, null, []);
+select any_match((x,y) -> x < y, null, null);
+select all_match([0],x->1);
+select any_match([0],x->1);
+select any_match([],x->1);
+select any_match(null);
+select any_match([]);
+select all_match([]);
+select any_match((x,y) -> x < y, [1,2,8], [4,5,6]);
+select any_match((x,y) -> x < y, [11,12,8], [4,5,6]);
+select any_match((x,y) -> x < y, [11,12,null], [4,5,6]);
+select all_match((x,y) -> x < y, [1,2,null], [4,5,6]);
+select all_match((x,y) -> x < y, [1,2,null], [4,5,6]), any_match((x,y) -> x < y, [11,12,8], [4,5,6]);
+
+select all_match((x,y) -> x < y, []);
+select all_match((x,y) -> x < y, [],{});
+select all_match([],null);
+select all_match({});
+select all_match();
+select all_match(null,[]);
+select all_match(null,null);
+select any_match((x,y) -> x < y, []);
+select any_match((x,y) -> x < y, [],{});
+select any_match([],null);
+select any_match({});
+select any_match();
+select any_match(null,[]);
+select any_match(null,null);
+select all_match([[]]);


### PR DESCRIPTION
Fixes #issue
support any/all_match() for arrays.
maps can use it by rewriting `any/all_match((k,v)->k>v,map)` to `any/all_match(map_values(transform_values((k,v)->k>v, map)))`.

---------

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
