### PR TITLE
[BugFix] Fix crash in batch delete caused by empty paths

### DIFF
--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -505,6 +505,10 @@ public:
     }
 
     Status delete_files(const std::vector<std::string>& paths) override {
+        if (paths.empty()) {
+            return Status::OK();
+        }
+
         std::vector<std::string> parsed_paths;
         parsed_paths.reserve(paths.size());
         std::shared_ptr<staros::starlet::fslib::FileSystem> fs = nullptr;

--- a/be/test/fs/fs_starlet_test.cpp
+++ b/be/test/fs/fs_starlet_test.cpp
@@ -361,8 +361,12 @@ TEST_P(StarletFileSystemTest, test_delete_files) {
 
     EXPECT_OK(fs->path_exists(uri1));
     EXPECT_OK(fs->path_exists(uri2));
-    std::vector<std::string> paths{uri1, uri2};
 
+    std::vector<std::string> paths;
+    EXPECT_OK(fs->delete_files(paths));
+
+    paths.emplace_back(uri1);
+    paths.emplace_back(uri2);
     EXPECT_OK(fs->delete_files(paths));
     EXPECT_TRUE(fs->path_exists(uri1).is_not_found());
     EXPECT_TRUE(fs->path_exists(uri2).is_not_found());


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
