### PR TITLE
[Feature] support for table-level primary index expire time

### DIFF
--- a/be/src/storage/base_tablet.h
+++ b/be/src/storage/base_tablet.h
@@ -82,6 +82,7 @@ public:
 
     // Property encapsulated in TabletMeta
     const TabletMetaSharedPtr tablet_meta();
+    const TabletMetaSharedPtr tablet_meta() const;
 
     void set_tablet_meta(const TabletMetaSharedPtr& tablet_meta) { _tablet_meta = tablet_meta; }
 
@@ -139,6 +140,10 @@ inline const std::string& BaseTablet::schema_hash_path() const {
 }
 
 inline const TabletMetaSharedPtr BaseTablet::tablet_meta() {
+    return _tablet_meta;
+}
+
+inline const TabletMetaSharedPtr BaseTablet::tablet_meta() const {
     return _tablet_meta;
 }
 

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1431,6 +1431,7 @@ void Tablet::build_tablet_report_info(TTabletInfo* tablet_info) {
     tablet_info->__set_storage_medium(_data_dir->storage_medium());
     tablet_info->__set_path_hash(_data_dir->path_hash());
     tablet_info->__set_enable_persistent_index(_tablet_meta->get_enable_persistent_index());
+    tablet_info->__set_primary_index_cache_expire_sec(_tablet_meta->get_primary_index_cache_expire_sec());
     if (_tablet_meta->get_binlog_config() != nullptr) {
         tablet_info->__set_binlog_config_version(_tablet_meta->get_binlog_config()->version);
     }

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -59,7 +59,8 @@ Status TabletMeta::create(const TCreateTabletReq& request, const TabletUid& tabl
             request.tablet_schema, next_unique_id,
             request.__isset.enable_persistent_index && request.enable_persistent_index, col_ordinal_to_unique_id,
             tablet_uid, request.__isset.tablet_type ? request.tablet_type : TTabletType::TABLET_TYPE_DISK,
-            request.__isset.compression_type ? request.compression_type : TCompressionType::LZ4_FRAME);
+            request.__isset.compression_type ? request.compression_type : TCompressionType::LZ4_FRAME,
+            request.__isset.primary_index_cache_expire_sec ? request.primary_index_cache_expire_sec : 0);
 
     if (request.__isset.binlog_config) {
         BinlogConfig binlog_config;
@@ -87,7 +88,7 @@ TabletMeta::TabletMeta(int64_t table_id, int64_t partition_id, int64_t tablet_id
                        bool enable_persistent_index,
                        const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id,
                        const TabletUid& tablet_uid, TTabletType::type tabletType,
-                       TCompressionType::type compression_type)
+                       TCompressionType::type compression_type, int32_t primary_index_cache_expire_sec)
         : _tablet_uid(0, 0) {
     TabletMetaPB tablet_meta_pb;
     tablet_meta_pb.set_table_id(table_id);
@@ -103,6 +104,7 @@ TabletMeta::TabletMeta(int64_t table_id, int64_t partition_id, int64_t tablet_id
     tablet_meta_pb.set_tablet_type(tabletType == TTabletType::TABLET_TYPE_MEMORY ? TabletTypePB::TABLET_TYPE_MEMORY
                                                                                  : TabletTypePB::TABLET_TYPE_DISK);
     tablet_meta_pb.set_in_restore_mode(false);
+    tablet_meta_pb.set_primary_index_cache_expire_sec(primary_index_cache_expire_sec);
 
     TabletSchemaPB* schema = tablet_meta_pb.mutable_schema();
     convert_t_schema_to_pb_schema(tablet_schema, next_unique_id, col_ordinal_to_unique_id, schema, compression_type);
@@ -291,6 +293,7 @@ void TabletMeta::init_from_pb(TabletMetaPB* ptablet_meta_pb) {
     }
 
     _enable_shortcut_compaction = tablet_meta_pb.enable_shortcut_compaction();
+    _primary_index_cache_expire_sec = tablet_meta_pb.primary_index_cache_expire_sec();
 }
 
 void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
@@ -349,6 +352,7 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
     }
 
     tablet_meta_pb->set_enable_shortcut_compaction(_enable_shortcut_compaction);
+    tablet_meta_pb->set_primary_index_cache_expire_sec(_primary_index_cache_expire_sec);
 }
 
 void TabletMeta::to_json(string* json_string, json2pb::Pb2JsonOptions& options) {

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -105,7 +105,8 @@ public:
     TabletMeta(int64_t table_id, int64_t partition_id, int64_t tablet_id, int32_t schema_hash, uint64_t shard_id,
                const TTabletSchema& tablet_schema, uint32_t next_unique_id, bool enable_persistent_index,
                const std::unordered_map<uint32_t, uint32_t>& col_ordinal_to_unique_id, const TabletUid& tablet_uid,
-               TTabletType::type tabletType, TCompressionType::type compression_type);
+               TTabletType::type tabletType, TCompressionType::type compression_type,
+               int32_t primary_index_cache_expire_sec);
 
     virtual ~TabletMeta();
 
@@ -198,6 +199,11 @@ public:
         _enable_persistent_index = enable_persistent_index;
     }
 
+    int32_t get_primary_index_cache_expire_sec() const { return _primary_index_cache_expire_sec; }
+    void set_primary_index_cache_expire_sec(int32_t primary_index_cache_expire_sec) {
+        _primary_index_cache_expire_sec = primary_index_cache_expire_sec;
+    }
+
     std::shared_ptr<BinlogConfig> get_binlog_config() { return _binlog_config; }
 
     void set_binlog_config(const BinlogConfig& new_config) {
@@ -232,6 +238,7 @@ private:
     int64_t _creation_time = 0;
     int64_t _cumulative_layer_point = 0;
     bool _enable_persistent_index = false;
+    int32_t _primary_index_cache_expire_sec = 0;
     TabletUid _tablet_uid;
     TabletTypePB _tablet_type = TabletTypePB::TABLET_TYPE_DISK;
 

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -74,6 +74,8 @@ public:
 
     int64_t get_cache_expire_ms() const { return _cache_expire_ms; }
 
+    int64_t get_index_cache_expire_ms(const Tablet& tablet) const;
+
     Status get_del_vec_in_meta(KVStore* meta, const TabletSegmentId& tsid, int64_t version, DelVector* delvec,
                                int64_t* latest_version);
 

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -1354,7 +1354,7 @@ void build_persistent_index_from_tablet(size_t N) {
 
     auto manager = StorageEngine::instance()->update_manager();
     auto index_entry = manager->index_cache().get_or_create(tablet->tablet_id());
-    index_entry->update_expire_time(MonotonicMillis() + manager->get_cache_expire_ms());
+    index_entry->update_expire_time(MonotonicMillis() + manager->get_index_cache_expire_ms(*tablet));
     auto& primary_index = index_entry->value();
     st = primary_index.load(tablet.get());
     if (!st.ok()) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -582,7 +582,8 @@ public class AlterJobMgr {
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_TTL) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_SIZE) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT) ||
-                        properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT));
+                        properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT) ||
+                        properties.containsKey(PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC));
 
                 olapTable = (OlapTable) db.getTable(tableName);
                 if (olapTable.isCloudNativeTable()) {
@@ -604,6 +605,9 @@ public class AlterJobMgr {
                 } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_BUCKET_SIZE)) {
                     schemaChangeHandler.updateTableMeta(db, tableName, properties,
                             TTabletMetaType.BUCKET_SIZE);
+                } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC)) {
+                    schemaChangeHandler.updateTableMeta(db, tableName, properties,
+                            TTabletMetaType.PRIMARY_INDEX_CACHE_EXPIRE_SEC);
                 } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_ENABLE) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_TTL) ||
                         properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_SIZE)) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -343,8 +343,9 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                         CreateReplicaTask createReplicaTask = new CreateReplicaTask(backendId, dbId, tableId, partitionId,
                                 shadowIdxId, shadowTabletId, shadowShortKeyColumnCount, 0, Partition.PARTITION_INIT_VERSION,
                                 originKeysType, TStorageType.COLUMN, storageMedium, copiedShadowSchema, bfColumns, bfFpp,
-                                countDownLatch, indexes, table.isInMemory(), table.enablePersistentIndex(),
-                                TTabletType.TABLET_TYPE_LAKE, table.getCompressionType(), copiedSortKeyIdxes);
+                                countDownLatch, indexes, table.isInMemory(), table.enablePersistentIndex(), 
+                                table.primaryIndexCacheExpireSec(), TTabletType.TABLET_TYPE_LAKE, table.getCompressionType(), 
+                                copiedSortKeyIdxes);
 
                         Long baseTabletId = partitionIndexTabletMap.row(partitionId).get(shadowIdxId).get(shadowTabletId);
                         assert baseTabletId != null;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -265,6 +265,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                                 tbl.getCopiedIndexes(),
                                 tbl.isInMemory(),
                                 tbl.enablePersistentIndex(),
+                                tbl.primaryIndexCacheExpireSec(),
                                 tabletType, tbl.getCompressionType(), index.getSortKeyIdxes());
                         createReplicaTask.setBaseTablet(tabletIdMap.get(rollupTabletId), baseSchemaHash);
                         batchTask.addTask(createReplicaTask);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1591,6 +1591,12 @@ public class SchemaChangeHandler extends AlterHandler {
             if (bucketSize == olapTable.getAutomaticBucketSize()) {
                 return;
             }
+        } else if (metaType == TTabletMetaType.PRIMARY_INDEX_CACHE_EXPIRE_SEC) {
+            int primaryIndexCacheExpireSec = Integer.parseInt(properties.get(
+                    PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC));
+            if (primaryIndexCacheExpireSec == olapTable.primaryIndexCacheExpireSec()) {
+                return;
+            }
         } else {
             LOG.warn("meta type: {} does not support", metaType);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -363,6 +363,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                     copiedShadowSchema, bfColumns, bfFpp, countDownLatch, indexes,
                                     tbl.isInMemory(),
                                     tbl.enablePersistentIndex(),
+                                    tbl.primaryIndexCacheExpireSec(),
                                     tbl.getPartitionInfo().getTabletType(partitionId),
                                     tbl.getCompressionType(), copiedSortKeyIdxes);
                             createReplicaTask.setBaseTablet(

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -867,6 +867,7 @@ public class RestoreJob extends AbstractJob {
                             localTbl.getCopiedIndexes(),
                             localTbl.isInMemory(),
                             localTbl.enablePersistentIndex(),
+                            localTbl.primaryIndexCacheExpireSec(),
                             localTbl.getPartitionInfo().getTabletType(restorePart.getId()),
                             localTbl.getCompressionType(), indexMeta.getSortKeyIdxes());
                     task.setInRestoreMode(true);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2128,6 +2128,13 @@ public class OlapTable extends Table {
         return false;
     }
 
+    public int primaryIndexCacheExpireSec() {
+        if (tableProperty != null) {
+            return tableProperty.primaryIndexCacheExpireSec();
+        }
+        return 0;
+    }
+
     public String getPersistentIndexTypeString() {
         if (tableProperty != null) {
             return tableProperty.getPersistentIndexTypeString();
@@ -2170,6 +2177,16 @@ public class OlapTable extends Table {
                 .modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,
                         Boolean.valueOf(enablePersistentIndex).toString());
         tableProperty.buildEnablePersistentIndex();
+    }
+
+    public void setPrimaryIndexCacheExpireSec(int primaryIndexCacheExpireSec) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty
+                .modifyTableProperties(PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC,
+                        Integer.valueOf(primaryIndexCacheExpireSec).toString());
+        tableProperty.buildPrimaryIndexCacheExpireSec();
     }
 
     public void setPersistentIndexType(TPersistentIndexType persistentIndexType) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -151,6 +151,8 @@ public class TableProperty implements Writable, GsonPostProcessable {
     // and it's null in SHARED NOTHGING
     TPersistentIndexType persistendIndexType;
 
+    private int primaryIndexCacheExpireSec = 0;
+
     /*
      * the default storage volume of this table.
      * DEFAULT: depends on FE's config 'run_mode'
@@ -244,6 +246,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 break;
             case OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX:
                 buildEnablePersistentIndex();
+                break;
+            case OperationType.OP_MODIFY_PRIMARY_INDEX_CACHE_EXPIRE_SEC:
+                buildPrimaryIndexCacheExpireSec();
                 break;
             case OperationType.OP_MODIFY_WRITE_QUORUM:
                 buildWriteQuorum();
@@ -479,6 +484,12 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildPrimaryIndexCacheExpireSec() {
+        primaryIndexCacheExpireSec = Integer.parseInt(properties.getOrDefault(
+                PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC, "0"));
+        return this;
+    }
+
     public TableProperty buildPersistentIndexType() {
         String type = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, "LOCAL");
         if (type.equals("LOCAL")) {
@@ -617,6 +628,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return enablePersistentIndex;
     }
 
+    public int primaryIndexCacheExpireSec() {
+        return primaryIndexCacheExpireSec;
+    }
+
     public String getPersistentIndexTypeString() {
         return persistentIndexTypeToString(persistendIndexType);
     }
@@ -739,6 +754,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildStorageCoolDownTTL();
         buildEnablePersistentIndex();
         buildPersistentIndexType();
+        buildPrimaryIndexCacheExpireSec();
         buildCompressionType();
         buildWriteQuorum();
         buildPartitionTTL();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -903,6 +903,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     olapTable.getCopiedIndexes(),
                     olapTable.isInMemory(),
                     olapTable.enablePersistentIndex(),
+                    olapTable.primaryIndexCacheExpireSec(),
                     olapTable.getPartitionInfo().getTabletType(partitionId),
                     olapTable.getCompressionType(), indexMeta.getSortKeyIdxes());
             createReplicaTask.setIsRecoverTask(true);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -140,6 +140,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_BUCKET_SIZE = "bucket_size";
 
+    public static final String PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC = "primary_index_cache_expire_sec";
+
     public static final String PROPERTIES_TABLET_TYPE = "tablet_type";
 
     public static final String PROPERTIES_STRICT_RANGE = "strict_range";
@@ -769,6 +771,26 @@ public class PropertyAnalyzer {
                 throw new AnalysisException("Invalid " + propKey + " format: " + valStr);
             }
             properties.remove(propKey);
+        }
+        return val;
+    }
+
+    public static int analyzePrimaryIndexCacheExpireSecProp(Map<String, String> properties, String propKey, int defaultVal)
+            throws AnalysisException {
+        int val = 0;
+        if (properties != null && properties.containsKey(PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC)) {
+            String valStr = properties.get(PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC);
+            try {
+                val = Integer.parseInt(valStr);
+                if (val < 0) {
+                    throw new AnalysisException("Property " + PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC 
+                            + " must not be less than 0");
+                }
+            } catch (NumberFormatException e) {
+                throw new AnalysisException("Property " + PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC 
+                        + " must be integer: " + valStr);
+            }
+            properties.remove(PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC);
         }
         return val;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -833,6 +833,7 @@ public class JournalEntity implements Writable {
             case OperationType.OP_MODIFY_BINLOG_CONFIG:
             case OperationType.OP_MODIFY_BINLOG_AVAILABLE_VERSION:
             case OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX:
+            case OperationType.OP_MODIFY_PRIMARY_INDEX_CACHE_EXPIRE_SEC:
             case OperationType.OP_ALTER_TABLE_PROPERTIES:
             case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY: {
                 data = ModifyTablePropertyOperationLog.read(in);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -841,6 +841,7 @@ public class EditLog {
                 case OperationType.OP_MODIFY_BINLOG_AVAILABLE_VERSION:
                 case OperationType.OP_MODIFY_BINLOG_CONFIG:
                 case OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX:
+                case OperationType.OP_MODIFY_PRIMARY_INDEX_CACHE_EXPIRE_SEC:
                 case OperationType.OP_ALTER_TABLE_PROPERTIES:
                 case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY: {
                     ModifyTablePropertyOperationLog modifyTablePropertyOperationLog =
@@ -1844,6 +1845,10 @@ public class EditLog {
 
     public void logModifyEnablePersistentIndex(ModifyTablePropertyOperationLog info) {
         logEdit(OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX, info);
+    }
+
+    public void logModifyPrimaryIndexCacheExpireSec(ModifyTablePropertyOperationLog info) {
+        logEdit(OperationType.OP_MODIFY_PRIMARY_INDEX_CACHE_EXPIRE_SEC, info);
     }
 
     public void logModifyWriteQuorum(ModifyTablePropertyOperationLog info) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -496,6 +496,9 @@ public class OperationType {
     // Pipe operations log
     public static final short OP_PIPE = 12200;
 
+    // Primary key
+    public static final short OP_MODIFY_PRIMARY_INDEX_CACHE_EXPIRE_SEC = 13200;
+
     /**
      * NOTICE: OperationType cannot use a value exceeding 20000, and an error will be reported if it exceeds
      */

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2793,6 +2793,13 @@ public class GlobalStateMgr {
                 }
             }
 
+            if (olapTable.primaryIndexCacheExpireSec() > 0) {
+                sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR)
+                        .append(PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC)
+                        .append("\" = \"");
+                sb.append(olapTable.primaryIndexCacheExpireSec()).append("\"");
+            }
+
             // compression type
             sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_COMPRESSION)
                     .append("\" = \"");

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -318,6 +318,13 @@ public class OlapTableFactory implements AbstractTableFactory {
             }
             table.setEnablePersistentIndex(enablePersistentIndex);
 
+            try {
+                table.setPrimaryIndexCacheExpireSec(PropertyAnalyzer.analyzePrimaryIndexCacheExpireSecProp(properties, 
+                        PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC, 0));
+            } catch (AnalysisException e) {
+                throw new DdlException(e.getMessage());
+            }
+
             if (properties != null && (properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_ENABLE) ||
                     properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_SIZE) ||
                     properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_TTL))) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -220,6 +220,12 @@ public class InformationSchemaDataSource {
         propsMap.put(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,
                 String.valueOf(olapTable.enablePersistentIndex()));
 
+        // primary index cache expire sec
+        if (olapTable.primaryIndexCacheExpireSec() > 0) {
+            propsMap.put(PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC,
+                    String.valueOf(olapTable.primaryIndexCacheExpireSec()));
+        }
+
         // compression type
         if (olapTable.getCompressionType() == TCompressionType.LZ4_FRAME ||
                 olapTable.getCompressionType() == TCompressionType.LZ4) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
@@ -187,7 +187,21 @@ public class AlterTableClauseVisitor extends AstVisitor<Void, ConnectContext> {
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_INMEMORY)) {
             clause.setNeedTableStable(false);
             clause.setOpType(AlterOpType.MODIFY_TABLE_PROPERTY_SYNC);
-        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC)) {
+            String valStr = properties.get(PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC);
+            try {
+                int val = Integer.parseInt(valStr);
+                if (val < 0) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Property " 
+                            + PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC + " must not be less than 0");
+                }
+            } catch (NumberFormatException e) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Property " 
+                        + PropertyAnalyzer.PROPERTIES_PRIMARY_INDEX_CACHE_EXPIRE_SEC + " must be integer: " + valStr);
+            }
+            clause.setNeedTableStable(false);
+            clause.setOpType(AlterOpType.MODIFY_TABLE_PROPERTY_SYNC);
+        }  else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
             if (!properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX).equalsIgnoreCase("true") &&
                     !properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX).equalsIgnoreCase("false")) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateReplicaTask.java
@@ -106,6 +106,8 @@ public class CreateReplicaTask extends AgentTask {
     // true if this task is created by recover request(See comment of Config.recover_with_empty_tablet)
     private boolean isRecoverTask = false;
 
+    private int primaryIndexCacheExpireSec = 0;
+
     public CreateReplicaTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
                              short shortKeyColumnCount, int schemaHash, long version,
                              KeysType keysType, TStorageType storageType,
@@ -114,10 +116,12 @@ public class CreateReplicaTask extends AgentTask {
                              List<Index> indexes,
                              boolean isInMemory,
                              boolean enablePersistentIndex,
+                             int primaryIndexCacheExpireSec,
                              TTabletType tabletType, TCompressionType compressionType) {
         this(backendId, dbId, tableId, partitionId, indexId, tabletId, shortKeyColumnCount,
                 schemaHash, version, keysType, storageType, storageMedium, columns, bfColumns,
-                bfFpp, latch, indexes, isInMemory, enablePersistentIndex, tabletType, compressionType, null);
+                bfFpp, latch, indexes, isInMemory, enablePersistentIndex, primaryIndexCacheExpireSec, 
+                tabletType, compressionType, null);
     }
 
     public CreateReplicaTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
@@ -128,12 +132,13 @@ public class CreateReplicaTask extends AgentTask {
                              List<Index> indexes,
                              boolean isInMemory,
                              boolean enablePersistentIndex,
+                             int primaryIndexCacheExpireSec,
                              BinlogConfig binlogConfig,
                              TTabletType tabletType, TCompressionType compressionType, List<Integer> sortKeyIdxes) {
 
         this(backendId, dbId, tableId, partitionId, indexId, tabletId, shortKeyColumnCount, schemaHash, version,
                 keysType, storageType, storageMedium, columns, bfColumns, bfFpp, latch, indexes, isInMemory,
-                enablePersistentIndex, tabletType, compressionType, sortKeyIdxes);
+                enablePersistentIndex, primaryIndexCacheExpireSec, tabletType, compressionType, sortKeyIdxes);
         this.binlogConfig = binlogConfig;
     }
 
@@ -145,6 +150,7 @@ public class CreateReplicaTask extends AgentTask {
                              List<Index> indexes,
                              boolean isInMemory,
                              boolean enablePersistentIndex,
+                             int primaryIndexCacheExpireSec,
                              TTabletType tabletType, TCompressionType compressionType, List<Integer> sortKeyIdxes) {
         super(null, backendId, TTaskType.CREATE, dbId, tableId, partitionId, indexId, tabletId);
 
@@ -168,6 +174,7 @@ public class CreateReplicaTask extends AgentTask {
 
         this.isInMemory = isInMemory;
         this.enablePersistentIndex = enablePersistentIndex;
+        this.primaryIndexCacheExpireSec = primaryIndexCacheExpireSec;
         this.tabletType = tabletType;
 
         this.compressionType = compressionType;
@@ -181,11 +188,12 @@ public class CreateReplicaTask extends AgentTask {
                              List<Index> indexes,
                              boolean isInMemory,
                              boolean enablePersistentIndex,
+                             int primaryIndexCacheExpireSec,
                              TPersistentIndexType persistentIndexType,
                              TTabletType tabletType, TCompressionType compressionType, List<Integer> sortKeyIdxes) {
         this(backendId, dbId, tableId, partitionId, indexId, tabletId, shortKeyColumnCount, schemaHash, version,
                 keysType, storageType, storageMedium, columns, bfColumns, bfFpp, latch, indexes, isInMemory,
-                enablePersistentIndex, tabletType, compressionType, sortKeyIdxes);
+                enablePersistentIndex, primaryIndexCacheExpireSec, tabletType, compressionType, sortKeyIdxes);
         this.persistentIndexType = persistentIndexType;
     }
 
@@ -280,6 +288,8 @@ public class CreateReplicaTask extends AgentTask {
         if (persistentIndexType != null) {
             createTabletReq.setPersistent_index_type(persistentIndexType);
         }
+
+        createTabletReq.setPrimary_index_cache_expire_sec(primaryIndexCacheExpireSec);
 
         if (binlogConfig != null) {
             TBinlogConfig tBinlogConfig = binlogConfig.toTBinlogConfig();

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -102,6 +102,8 @@ public class AgentTaskTest {
     private AgentTask modifyEnablePersistentIndexTask1;
     private AgentTask modifyEnablePersistentIndexTask2;
     private AgentTask modifyInMemoryTask;
+    private AgentTask modifyPrimaryIndexCacheExpireSecTask1;
+    private AgentTask modifyPrimaryIndexCacheExpireSecTask2;
 
     @Before
     public void setUp() throws AnalysisException {
@@ -125,7 +127,7 @@ public class AgentTaskTest {
                 version, KeysType.AGG_KEYS,
                 storageType, TStorageMedium.SSD,
                 columns, null, 0, latch, null,
-                false, false, TTabletType.TABLET_TYPE_DISK, TCompressionType.LZ4_FRAME);
+                false, false, 0, TTabletType.TABLET_TYPE_DISK, TCompressionType.LZ4_FRAME);
 
         // drop
         dropTask = new DropReplicaTask(backendId1, tabletId1, schemaHash1, false);
@@ -154,6 +156,15 @@ public class AgentTaskTest {
                         countDownLatch, TTabletMetaType.ENABLE_PERSISTENT_INDEX);
         modifyInMemoryTask =
                 new UpdateTabletMetaInfoTask(backendId1, tabletToMeta, TTabletMetaType.INMEMORY);
+
+        List<Triple<Long, Integer, Integer>> tabletToMeta2 = Lists.newArrayList();
+        tabletToMeta2.add(new ImmutableTriple<>(tabletId1, schemaHash1, 7200));
+        modifyPrimaryIndexCacheExpireSecTask1 =
+                new UpdateTabletMetaInfoTask(backendId1, tabletToMeta2, TTabletMetaType.PRIMARY_INDEX_CACHE_EXPIRE_SEC);
+        MarkedCountDownLatch<Long, Set<Pair<Long, Integer>>> countDownLatch2 = new MarkedCountDownLatch<>(1);
+        modifyPrimaryIndexCacheExpireSecTask2 =
+                new UpdateTabletMetaInfoTask(backendId1, tabletIdWithSchemaHash, true,
+                        countDownLatch2, TTabletMetaType.PRIMARY_INDEX_CACHE_EXPIRE_SEC);
     }
 
     @Test
@@ -221,6 +232,19 @@ public class AgentTaskTest {
         Assert.assertEquals(TTaskType.UPDATE_TABLET_META_INFO, request9.getTask_type());
         Assert.assertEquals(modifyInMemoryTask.getSignature(), request9.getSignature());
         Assert.assertNotNull(request9.getUpdate_tablet_meta_info_req());
+
+        // modify primary index cache
+        TAgentTaskRequest request10 = (TAgentTaskRequest) toAgentTaskRequest.invoke(agentBatchTask, 
+                modifyPrimaryIndexCacheExpireSecTask1);
+        Assert.assertEquals(TTaskType.UPDATE_TABLET_META_INFO, request10.getTask_type());
+        Assert.assertEquals(modifyPrimaryIndexCacheExpireSecTask1.getSignature(), request10.getSignature());
+        Assert.assertNotNull(request10.getUpdate_tablet_meta_info_req());
+
+        TAgentTaskRequest request11 = (TAgentTaskRequest) toAgentTaskRequest.invoke(agentBatchTask, 
+                modifyPrimaryIndexCacheExpireSecTask2);
+        Assert.assertEquals(TTaskType.UPDATE_TABLET_META_INFO, request11.getTask_type());
+        Assert.assertEquals(modifyPrimaryIndexCacheExpireSecTask2.getSignature(), request11.getSignature());
+        Assert.assertNotNull(request11.getUpdate_tablet_meta_info_req());
     }
 
     @Test

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -238,8 +238,8 @@ message TabletMetaOpPB {
     optional EditVersionPB apply = 3;
 }
 
-message TabletMetaLogPB {
-    repeated TabletMetaOpPB ops = 1;
+message TabletMetaLogPB { 
+    repeated TabletMetaOpPB ops = 1; 
 }
 
 message TabletUpdatesPB {
@@ -286,6 +286,7 @@ message TabletMetaPB {
     optional BinlogConfigPB binlog_config = 52;
     optional BinlogLsnPB binlog_min_lsn = 53;
     optional bool enable_shortcut_compaction = 60 [default = true];
+    optional int32 primary_index_cache_expire_sec = 61 [default = 0];
 }
 
 message OLAPIndexHeaderMessage {
@@ -303,6 +304,6 @@ message OLAPDataHeaderMessage {
     required uint32 segment = 2;
 }
 
-message OLAPRawDeltaHeaderMessage {
+message OLAPRawDeltaHeaderMessage { 
     required int32 schema_hash = 2;
 }

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -109,6 +109,7 @@ struct TCreateTabletReq {
     16: optional Types.TCompressionType compression_type = Types.TCompressionType.LZ4_FRAME
     17: optional TBinlogConfig binlog_config;
     18: optional TPersistentIndexType persistent_index_type;
+    19: optional i32 primary_index_cache_expire_sec;
 }
 
 struct TDropTabletReq {
@@ -343,7 +344,8 @@ enum TTabletMetaType {
     REPLICATED_STORAGE,
     DISABLE_BINLOG,
     BINLOG_CONFIG,
-    BUCKET_SIZE
+    BUCKET_SIZE,
+    PRIMARY_INDEX_CACHE_EXPIRE_SEC
 }
 
 struct TTabletMetaInfo {
@@ -354,6 +356,7 @@ struct TTabletMetaInfo {
     5: optional bool is_in_memory // Deprecated
     6: optional bool enable_persistent_index
     7: optional TBinlogConfig binlog_config
+    8: optional i32 primary_index_cache_expire_sec
 }
 
 struct TUpdateTabletMetaInfoReq {

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -63,6 +63,7 @@ struct TTabletInfo {
     18: optional bool is_error_state
     19: optional Types.TVersion max_readable_version
     20: optional i64 max_rowset_creation_time
+    21: optional i32 primary_index_cache_expire_sec
 }
 
 struct TTabletVersionPair {

--- a/test/sql/test_primary_index_cache_expire/R/test_primary_index_cache_expire
+++ b/test/sql/test_primary_index_cache_expire/R/test_primary_index_cache_expire
@@ -1,0 +1,140 @@
+-- name: test_primary_index_cache_expire
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1",
+    "primary_index_cache_expire_sec" = "3600"
+);
+-- result:
+-- !result
+show create table tab1;
+-- result:
+tab1	CREATE TABLE `tab1` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k2` varchar(50) NOT NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"primary_index_cache_expire_sec" = "3600",
+"compression" = "LZ4"
+);
+-- !result
+insert into tab1 values(100, "100", 100, 100, 100), (200, "200", 200, 200, 200), (300, "300", 300, 300, 300);
+-- result:
+-- !result
+select * from tab1 where v2 = 200;
+-- result:
+200	200	200	200	200
+-- !result
+alter table tab1 set ("primary_index_cache_expire_sec" = "0");
+-- result:
+-- !result
+show create table tab1;
+-- result:
+tab1	CREATE TABLE `tab1` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k2` varchar(50) NOT NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- !result
+alter table tab1 set ("primary_index_cache_expire_sec" = "7200");
+-- result:
+-- !result
+show create table tab1;
+-- result:
+tab1	CREATE TABLE `tab1` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `k2` varchar(50) NOT NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "true",
+"replicated_storage" = "true",
+"primary_index_cache_expire_sec" = "7200",
+"compression" = "LZ4"
+);
+-- !result
+select * from tab1 where v2 = 200;
+-- result:
+200	200	200	200	200
+-- !result
+alter table tab1 set ("primary_index_cache_expire_sec" = "add");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Property primary_index_cache_expire_sec must be integer: add.')
+-- !result
+alter table tab1 set ("primary_index_cache_expire_sec" = "-1");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Property primary_index_cache_expire_sec must not be less than 0.')
+-- !result
+alter table tab1 set ("primary_index_cache_expire_sec" = "-3600");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Property primary_index_cache_expire_sec must not be less than 0.')
+-- !result
+CREATE table tab2 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1",
+    "primary_index_cache_expire_sec" = "-100"
+);
+-- result:
+E: (1064, 'Unexpected exception: Property primary_index_cache_expire_sec must not be less than 0')
+-- !result
+CREATE table tab3 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1",
+    "primary_index_cache_expire_sec" = "asd"
+);
+-- result:
+E: (1064, 'Unexpected exception: Property primary_index_cache_expire_sec must be integer: asd')
+-- !result

--- a/test/sql/test_primary_index_cache_expire/T/test_primary_index_cache_expire
+++ b/test/sql/test_primary_index_cache_expire/T/test_primary_index_cache_expire
@@ -1,0 +1,60 @@
+-- name: test_primary_index_cache_expire
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1",
+    "primary_index_cache_expire_sec" = "3600"
+);
+
+show create table tab1;
+insert into tab1 values(100, "100", 100, 100, 100), (200, "200", 200, 200, 200), (300, "300", 300, 300, 300);
+select * from tab1 where v2 = 200;
+
+alter table tab1 set ("primary_index_cache_expire_sec" = "0");
+show create table tab1;
+alter table tab1 set ("primary_index_cache_expire_sec" = "7200");
+show create table tab1;
+
+select * from tab1 where v2 = 200;
+
+alter table tab1 set ("primary_index_cache_expire_sec" = "add");
+alter table tab1 set ("primary_index_cache_expire_sec" = "-1");
+alter table tab1 set ("primary_index_cache_expire_sec" = "-3600");
+CREATE table tab2 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1",
+    "primary_index_cache_expire_sec" = "-100"
+);
+
+CREATE table tab3 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+    "replication_num" = "1",
+    "primary_index_cache_expire_sec" = "asd"
+);


### PR DESCRIPTION
Currently, we use config `update_cache_expire_sec` to control the expire time of primary index. This config is cluster-level. 
Now we add property `primary_index_cache_expire_sec` to table, it can control the expire time of primary index in table-level.

E.g. we can create table with property `primary_index_cache_expire_sec`
```
CREATE TABLE `demo` (
  `id` bigint(20) NOT NULL COMMENT "",
  `pass` int NOT NULL,
  `info` int NOT NULL
) ENGINE=OLAP
PRIMARY KEY(`id`)
DISTRIBUTED BY HASH(`id`) BUCKETS 1
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"primary_index_cache_expire_sec" = "3600",
"compression" = "LZ4"
);
```

Or, we can use alter table to change this property:
```
alter table demo set ("primary_index_cache_expire_sec" = "3600");
```

Use show create table, we can make sure it work:
```
mysql> show create table demo;
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                                                                                                                                                                                                                                                                       |
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| demo  | CREATE TABLE `demo` (
  `id` bigint(20) NOT NULL COMMENT "",
  `pass` int(11) NOT NULL COMMENT "",
  `info` int(11) NOT NULL COMMENT ""
) ENGINE=OLAP
PRIMARY KEY(`id`)
DISTRIBUTED BY HASH(`id`) BUCKETS 1
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"primary_index_cache_expire_sec" = "3600",
"compression" = "LZ4"
); |
+-------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```
Property `primary_index_cache_expire_sec` must not less than 0, and `primary_index_cache_expire_sec == 0` means use config `update_cache_expire_sec` by default.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
