### PR TITLE
[Enhancement] Remove DCHECK in es_predicate.cpp to avoid BE crashed in ASAN mode

### DIFF
--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -424,7 +424,7 @@ Status EsPredicate::_build_in_predicate(const Expr* conjunct, bool* handled) {
             BUILD_INPRED_VALUES(TYPE_CHAR)
             BUILD_INPRED_VALUES(TYPE_VARCHAR)
         default:
-            DCHECK(false) << "unsupported type:" << expr->type().type;
+            // We don't support pushdown json type's in_predicates to ES now.
             return Status::InternalError("unsupported type to push down to ES");
         }
 

--- a/be/src/exec/es/es_predicate.cpp
+++ b/be/src/exec/es/es_predicate.cpp
@@ -425,6 +425,7 @@ Status EsPredicate::_build_in_predicate(const Expr* conjunct, bool* handled) {
             BUILD_INPRED_VALUES(TYPE_VARCHAR)
         default:
             // We don't support pushdown json type's in_predicates to ES now.
+            // If failed here, we will fallback in_predicates executed on the BE side.
             return Status::InternalError("unsupported type to push down to ES");
         }
 


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/30391

We don't support pushdown JSON's in_predicate into es now.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
