### PR TITLE
[Enhancement] Improve broker load error message

### DIFF
--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -26,17 +26,21 @@
 namespace starrocks {
 
 static std::string string_2_asc(const std::string& input) {
-    if (input.size() == 0) {
-        return "";
-    }
-    std::string output;
-    for (int i = 0; i < input.size(); i++) {
-        output += std::to_string(int(input[i]));
-        if (i != input.size() - 1) {
-            output += " ";
+    std::stringstream oss;
+    oss << "'";
+    for (char c : input) {
+        if (c == '\n') {
+            oss << "\\n";
+        } else if (c == '\t') {
+            oss << "\\t";
+        } else if (std::isprint(static_cast<unsigned char>(c))) {
+            oss << c;
+        } else {
+            oss << "0x" << std::hex << (static_cast<unsigned int>(c) & 0xFF);
         }
     }
-    return output;
+    oss << "'";
+    return oss.str();
 }
 
 static std::string make_column_count_not_matched_error_message(int expected_count, int actual_count,
@@ -44,7 +48,7 @@ static std::string make_column_count_not_matched_error_message(int expected_coun
     std::stringstream error_msg;
     error_msg << "Value count does not match column count: "
               << "expected = " << expected_count << ", actual = " << actual_count << ". "
-              << "Column delimiter: " << string_2_asc(parse_options.column_delimiter) << ", "
+              << "Column separator: " << string_2_asc(parse_options.column_delimiter) << ", "
               << "Row delimiter: " << string_2_asc(parse_options.row_delimiter);
     return error_msg.str();
 }

--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -25,7 +25,7 @@
 
 namespace starrocks {
 
-std::string string_2_asc(const std::string& input) {
+static std::string string_2_asc(const std::string& input) {
     if (input.size() == 0) {
         return "";
     }
@@ -38,6 +38,26 @@ std::string string_2_asc(const std::string& input) {
     }
     return output;
 }
+
+static std::string make_column_count_not_matched_error_message(int expected_count, int actual_count,
+                                                               CSVParseOptions& parse_options) {
+    std::stringstream error_msg;
+    error_msg << "Value count does not match column count: "
+              << "expected = " << expected_count << ", actual = " << actual_count << ". "
+              << "Column delimiter: " << string_2_asc(parse_options.column_delimiter) << ", "
+              << "Row delimiter: " << string_2_asc(parse_options.row_delimiter);
+    return error_msg.str();
+}
+
+static std::string make_value_type_not_matched_error_message(int field_pos, const Slice& field,
+                                                             const SlotDescriptor* slot) {
+    std::stringstream error_msg;
+    error_msg << "The field (name = " << slot->col_name() << ", pos = " << field_pos << ") is out of range. "
+              << "Type: " << slot->type().debug_string() << ", Value: " << field.to_string();
+    return error_msg.str();
+}
+
+static constexpr int REPORT_ERROR_MAX_NUMBER = 50;
 
 const std::string& CSVScanner::ScannerCSVReader::filename() {
     return _file->filename();
@@ -307,28 +327,21 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
             if (status.is_end_of_file()) {
                 break;
             }
-            if (_counter->num_rows_filtered++ < 50) {
-                std::stringstream error_msg;
-                error_msg << "Value count does not match column count. "
-                          << "Expect " << _num_fields_in_csv << ", but got " << row.columns.size() << "."
-                          << "Column delimiter: " << string_2_asc(_parse_options.column_delimiter) << ","
-                          << "Row delimiter: " << string_2_asc(_parse_options.row_delimiter) << ".";
-
-                _report_error(record.to_string(), error_msg.str());
+            if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
+                std::string error_msg = make_column_count_not_matched_error_message(_num_fields_in_csv,
+                                                                                    row.columns.size(), _parse_options);
+                _report_error(record, error_msg);
             }
             if (_state->enable_log_rejected_record()) {
-                std::stringstream error_msg;
-                error_msg << "Value count does not match column count. "
-                          << "Expect " << _num_fields_in_csv << ", but got " << row.columns.size() << "."
-                          << "Column delimiter: " << string_2_asc(_parse_options.column_delimiter) << ","
-                          << "Row delimiter: " << string_2_asc(_parse_options.row_delimiter) << ".";
-                _state->append_rejected_record_to_file(record.to_string(), error_msg.str(), _curr_reader->filename());
+                std::string error_msg = make_column_count_not_matched_error_message(_num_fields_in_csv,
+                                                                                    row.columns.size(), _parse_options);
+                _report_rejected_record(record, error_msg);
             }
             continue;
         }
         if (!validate_utf8(record.data, record.size)) {
-            if (_counter->num_rows_filtered++ < 50) {
-                _report_error(record.to_string(), "Invalid UTF-8 row");
+            if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
+                _report_error(record, "Invalid UTF-8 row");
             }
             if (_state->enable_log_rejected_record()) {
                 _state->append_rejected_record_to_file(record.to_string(), "Invalid UTF-8 row",
@@ -356,20 +369,13 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
             options.type_desc = &(slot->type());
             if (!_converters[k]->read_string_for_adaptive_null_column(_column_raw_ptrs[k], data, options)) {
                 chunk->set_num_rows(num_rows);
-                if (_counter->num_rows_filtered++ < 50) {
-                    std::stringstream error_msg;
-                    error_msg << "The field " << j << " is out of range. "
-                              << "Value is " << data.to_string() << "."
-                              << "The type of '" << slot->col_name() << "' is " << slot->type().debug_string();
-                    _report_error(record.to_string(), error_msg.str());
+                if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
+                    std::string error_msg = make_value_type_not_matched_error_message(j, data, slot);
+                    _report_error(record, error_msg);
                 }
                 if (_state->enable_log_rejected_record()) {
-                    std::stringstream error_msg;
-                    error_msg << "The field " << j << " is out of range. "
-                              << "Value is " << data.to_string() << "."
-                              << "The type of '" << slot->col_name() << "' is " << slot->type().debug_string();
-                    _state->append_rejected_record_to_file(record.to_string(), error_msg.str(),
-                                                           _curr_reader->filename());
+                    std::string error_msg = make_value_type_not_matched_error_message(j, data, slot);
+                    _report_rejected_record(record, error_msg);
                 }
                 has_error = true;
                 break;
@@ -414,31 +420,24 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
         _curr_reader->split_record(record, &fields);
 
         if (fields.size() != _num_fields_in_csv) {
-            if (_counter->num_rows_filtered++ < 50) {
-                std::stringstream error_msg;
-                error_msg << "Value count does not match column count. "
-                          << "Expect " << _num_fields_in_csv << ", but got " << row.columns.size() << "."
-                          << "Column delimiter: " << string_2_asc(_parse_options.column_delimiter) << ","
-                          << "Row delimiter: " << string_2_asc(_parse_options.row_delimiter) << ".";
-                _report_error(record.to_string(), error_msg.str());
+            if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
+                std::string error_msg = make_column_count_not_matched_error_message(_num_fields_in_csv,
+                                                                                    row.columns.size(), _parse_options);
+                _report_error(record, error_msg);
             }
             if (_state->enable_log_rejected_record()) {
-                std::stringstream error_msg;
-                error_msg << "Value count does not match column count. "
-                          << "Expect " << _num_fields_in_csv << ", but got " << row.columns.size() << "."
-                          << "Column delimiter: " << string_2_asc(_parse_options.column_delimiter) << ","
-                          << "Row delimiter: " << string_2_asc(_parse_options.row_delimiter) << ".";
-                _state->append_rejected_record_to_file(record.to_string(), error_msg.str(), _curr_reader->filename());
+                std::string error_msg = make_column_count_not_matched_error_message(_num_fields_in_csv,
+                                                                                    row.columns.size(), _parse_options);
+                _report_rejected_record(record, error_msg);
             }
             continue;
         }
         if (!validate_utf8(record.data, record.size)) {
-            if (_counter->num_rows_filtered++ < 50) {
-                _report_error(record.to_string(), "Invalid UTF-8 row");
+            if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
+                _report_error(record, "Invalid UTF-8 row");
             }
             if (_state->enable_log_rejected_record()) {
-                _state->append_rejected_record_to_file(record.to_string(), "Invalid UTF-8 row",
-                                                       _curr_reader->filename());
+                _report_rejected_record(record, "Invalid UTF-8 row");
             }
             continue;
         }
@@ -454,20 +453,13 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
             options.type_desc = &(slot->type());
             if (!_converters[k]->read_string_for_adaptive_null_column(_column_raw_ptrs[k], field, options)) {
                 chunk->set_num_rows(num_rows);
-                if (_counter->num_rows_filtered++ < 50) {
-                    std::stringstream error_msg;
-                    error_msg << "The field " << j << " is out of range. "
-                              << "Value is " << field.to_string() << "."
-                              << "The type of '" << slot->col_name() << "' is " << slot->type().debug_string();
-                    _report_error(record.to_string(), error_msg.str());
+                if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
+                    std::string error_msg = make_value_type_not_matched_error_message(j, field, slot);
+                    _report_error(record, error_msg);
                 }
                 if (_state->enable_log_rejected_record()) {
-                    std::stringstream error_msg;
-                    error_msg << "The field " << j << " is out of range. "
-                              << "Value is " << field.to_string() << "."
-                              << "The type of '" << slot->col_name() << "' is " << slot->type().debug_string();
-                    _state->append_rejected_record_to_file(record.to_string(), error_msg.str(),
-                                                           _curr_reader->filename());
+                    std::string error_msg = make_value_type_not_matched_error_message(j, field, slot);
+                    _report_rejected_record(record, error_msg);
                 }
                 has_error = true;
                 break;
@@ -498,8 +490,12 @@ ChunkPtr CSVScanner::_create_chunk(const std::vector<SlotDescriptor*>& slots) {
     return chunk;
 }
 
-void CSVScanner::_report_error(const std::string& line, const std::string& err_msg) {
-    _state->append_error_msg_to_file(line, err_msg);
+void CSVScanner::_report_error(const CSVReader::Record& record, const std::string& err_msg) {
+    _state->append_error_msg_to_file(record.to_string(), err_msg);
+}
+
+void CSVScanner::_report_rejected_record(const CSVReader::Record& record, const std::string& err_msg) {
+    _state->append_rejected_record_to_file(record.to_string(), err_msg, _curr_reader->filename());
 }
 
 } // namespace starrocks

--- a/be/src/exec/csv_scanner.h
+++ b/be/src/exec/csv_scanner.h
@@ -73,7 +73,8 @@ private:
 
     StatusOr<ChunkPtr> _materialize(ChunkPtr& src_chunk);
     void _materialize_src_chunk_adaptive_nullable_column(ChunkPtr& chunk);
-    void _report_error(const std::string& line, const std::string& err_msg);
+    void _report_error(const CSVReader::Record& record, const std::string& err_msg);
+    void _report_rejected_record(const CSVReader::Record& record, const std::string& err_msg);
 
     using ConverterPtr = std::unique_ptr<csv::Converter>;
     using CSVReaderPtr = std::unique_ptr<ScannerCSVReader>;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -365,7 +365,9 @@ public class BrokerLoadJob extends BulkLoadJob {
         // check data quality
         if (!checkDataQuality()) {
             cancelJobWithoutCheck(
-                    new FailMsg(FailMsg.CancelType.ETL_QUALITY_UNSATISFIED, DataQualityException.QUALITY_FAIL_MSG),
+                    new FailMsg(FailMsg.CancelType.ETL_QUALITY_UNSATISFIED,
+                            DataQualityException.QUALITY_FAIL_MSG +
+                                    ". You can find detailed error message from running `TrackingSQL`."),
                     true, true);
             return;
         }


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

This PR is to refactor broker load error message.

When broker load and error message type is `ETL_QUALITY_UNSATISFIED`, there is a extra field `TrackingSQL` to see the detailed error message, but many users don't know this. So I add a message "You can find detailed error message from running `TrackingSQL`" at the error message `ErrorMsg` field.

![image](https://github.com/StarRocks/starrocks/assets/1081215/67e81d71-0de0-4158-878f-81642f52d536)


And in detailed error message, I rephrase it a little bit.


![image](https://github.com/StarRocks/starrocks/assets/1081215/fa61de1f-4591-4a4e-b0d7-71ca7165d748)


```
// This one means it failes to fill a csv field.
Error: The field (name = pair, pos = 2) is out of range. Type: ARRAY<VARCHAR(65533)>, Value: [ "1", "2" ]. Row: 6817;a;"[ ""1"", ""2"" ]"

// This one means value count does not match column count.
Error: Value count does not match column count: expected = 3, actual = 5. Column delimiter: 59, Row delimiter: 10. Row: 6418;a\b;"[ ""a\\b"", ""c\""d"" ]"
6419;"c""d";
```


Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
