### PR TITLE
[BugFix] reset QueryState after modify session variable in MV

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -300,7 +300,7 @@ public class VariableMgr {
     }
 
     public static boolean containsVariable(String name) {
-        return CTX_BY_VAR_NAME.containsKey(name);
+        return CTX_BY_VAR_NAME.containsKey(name) || ALIASES.containsKey(name);
     }
 
     // Entry of handling SetVarStmt

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -26,7 +26,6 @@ import com.starrocks.load.loadv2.InsertLoadJob;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
-import com.starrocks.qe.VariableMgr;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.SystemVariable;
@@ -173,9 +172,6 @@ public class TaskRun implements Comparable<TaskRun> {
         runCtx.resetSessionVariable();
         if (properties != null) {
             for (String key : properties.keySet()) {
-                if (!VariableMgr.containsVariable(key)) {
-                    continue;
-                }
                 try {
                     runCtx.modifySystemVariable(new SystemVariable(key, new StringLiteral(properties.get(key))), true);
                 } catch (DdlException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -177,6 +177,8 @@ public class TaskRun implements Comparable<TaskRun> {
                 } catch (DdlException e) {
                     // not session variable
                     taskRunContextProperties.put(key, properties.get(key));
+                } finally {
+                    runCtx.getState().reset();
                 }
             }
         }


### PR DESCRIPTION
Fixes #issue

The QueryState will be affected after modify session variables even if it doesn't exist, which should be cleaned up.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
