### PR TITLE
[Enhancement] Support overflow mode for decimal type

### DIFF
--- a/be/src/exprs/arithmetic_operation.h
+++ b/be/src/exprs/arithmetic_operation.h
@@ -77,6 +77,43 @@ bool check_fpe_of_min_div_by_minus_one(LType lhs, RType rhs) {
     }
 }
 
+template <typename Op>
+std::string get_op_name() {
+    if constexpr (is_add_op<Op>) {
+        return "add";
+    } else if constexpr (is_sub_op<Op>) {
+        return "sub";
+    } else if constexpr (is_reverse_sub_op<Op>) {
+        return "reverse_sub";
+    } else if constexpr (is_reverse_mod_op<Op>) {
+        return "reverse_mod";
+    } else if constexpr (is_mul_op<Op>) {
+        return "mul";
+    } else if constexpr (is_div_op<Op>) {
+        return "div";
+    } else if constexpr (is_intdiv_op<Op>) {
+        return "intdiv";
+    } else if constexpr (is_mod_op<Op>) {
+        return "mod";
+    } else if constexpr (is_bitand_op<Op>) {
+        return "bitand";
+    } else if constexpr (is_bitor_op<Op>) {
+        return "bitor";
+    } else if constexpr (is_bitxor_op<Op>) {
+        return "bitxor";
+    } else if constexpr (is_bitnot_op<Op>) {
+        return "bitnot";
+    } else if constexpr (is_bit_shift_left_op<Op>) {
+        return "bit_shift_left";
+    } else if constexpr (is_bit_shift_right_op<Op>) {
+        return "bit_shift_right";
+    } else if constexpr (is_bit_shift_right_logical_op<Op>) {
+        return "bit_shift_right_logical";
+    } else {
+        return "unknown";
+    }
+}
+
 template <typename Op, LogicalType Type, typename = guard::Guard, typename = guard::Guard>
 struct ArithmeticBinaryOperator {
     template <typename LType, typename RType, typename ResultType>

--- a/be/src/exprs/decimal_binary_function.h
+++ b/be/src/exprs/decimal_binary_function.h
@@ -17,10 +17,11 @@
 #include "column/column_builder.h"
 #include "exprs/arithmetic_operation.h"
 #include "exprs/binary_function.h"
+#include "exprs/overflow.h"
 #include "types/logical_type.h"
 
 namespace starrocks {
-template <bool check_overflow, typename Op>
+template <OverflowMode overflow_mode, typename Op>
 struct DecimalBinaryFunction {
     // Adjust the scale of lhs operand, then evaluate binary operation, the rules about operand
     // scaling is defined in function: compute_result_type.  each operations are depicted as
@@ -57,10 +58,10 @@ struct DecimalBinaryFunction {
             lhs_datum = lhs_data[0];
             // adjust left operand
             if constexpr (adjust_left) {
-                overflow = DecimalV3Cast::scale_up<LhsCppType, LhsCppType, check_overflow>(lhs_datum, scale_factor,
-                                                                                           &lhs_datum);
+                overflow = DecimalV3Cast::scale_up<LhsCppType, LhsCppType, check_overflow<overflow_mode>>(
+                        lhs_datum, scale_factor, &lhs_datum);
                 // adjusting operand generates decimal overflow
-                if constexpr (check_overflow) {
+                if constexpr (check_overflow<overflow_mode>) {
                     if (overflow) {
                         return true;
                     }
@@ -74,24 +75,31 @@ struct DecimalBinaryFunction {
 
         for (auto i = 0; i < num_rows; ++i) {
             if constexpr (lhs_is_const && rhs_is_const) {
-                overflow = BinaryOperator::template apply<check_overflow, false, LhsCppType, RhsCppType, ResultCppType>(
-                        lhs_datum, rhs_datum, &result_data[i], scale_factor);
+                overflow = BinaryOperator::template apply<check_overflow<overflow_mode>, false, LhsCppType, RhsCppType,
+                                                          ResultCppType>(lhs_datum, rhs_datum, &result_data[i],
+                                                                         scale_factor);
             } else if constexpr (lhs_is_const) {
-                overflow = BinaryOperator::template apply<check_overflow, false, LhsCppType, RhsCppType, ResultCppType>(
-                        lhs_datum, rhs_data[i], &result_data[i], scale_factor);
+                overflow = BinaryOperator::template apply<check_overflow<overflow_mode>, false, LhsCppType, RhsCppType,
+                                                          ResultCppType>(lhs_datum, rhs_data[i], &result_data[i],
+                                                                         scale_factor);
             } else if constexpr (rhs_is_const) {
-                overflow = BinaryOperator::template apply<check_overflow, adjust_left, LhsCppType, RhsCppType,
-                                                          ResultCppType>(lhs_data[i], rhs_datum, &result_data[i],
-                                                                         scale_factor);
+                overflow = BinaryOperator::template apply<check_overflow<overflow_mode>, adjust_left, LhsCppType,
+                                                          RhsCppType, ResultCppType>(lhs_data[i], rhs_datum,
+                                                                                     &result_data[i], scale_factor);
             } else {
-                overflow = BinaryOperator::template apply<check_overflow, adjust_left, LhsCppType, RhsCppType,
-                                                          ResultCppType>(lhs_data[i], rhs_data[i], &result_data[i],
-                                                                         scale_factor);
+                overflow = BinaryOperator::template apply<check_overflow<overflow_mode>, adjust_left, LhsCppType,
+                                                          RhsCppType, ResultCppType>(lhs_data[i], rhs_data[i],
+                                                                                     &result_data[i], scale_factor);
             }
-            if constexpr (check_overflow) {
+            if constexpr (check_overflow<overflow_mode>) {
                 if (overflow) {
-                    *has_null = true;
-                    nulls[i] = DATUM_NULL;
+                    if constexpr (error_if_overflow<overflow_mode>) {
+                        throw std::overflow_error("Decimal overflow");
+                    } else {
+                        static_assert(null_if_overflow<overflow_mode>);
+                        *has_null = true;
+                        nulls[i] = DATUM_NULL;
+                    }
                 }
             }
         }
@@ -120,7 +128,7 @@ struct DecimalBinaryFunction {
         bool has_null = false;
         [[maybe_unused]] bool all_null = false;
 
-        if constexpr (check_overflow) {
+        if constexpr (check_overflow<overflow_mode>) {
             null_column = NullColumn::create();
             null_column->resize(num_rows);
             nulls = &null_column->get_data().front();
@@ -176,7 +184,7 @@ struct DecimalBinaryFunction {
                     num_rows, lhs_data, rhs_data, result_data, nulls, &has_null, adjust_scale);
         }
 
-        if constexpr (check_overflow) {
+        if constexpr (check_overflow<overflow_mode>) {
             if (all_null) {
                 // all the elements of the result are overflow, return const null column
                 return ColumnHelper::create_const_null_column(num_rows);
@@ -207,12 +215,12 @@ struct DecimalBinaryFunction {
     }
 };
 
-template <typename OP, bool check_overflow>
+template <typename OP, OverflowMode overflow_mode>
 class UnpackConstColumnDecimalBinaryFunction {
 public:
     template <LogicalType LType, LogicalType RType, LogicalType ResultType>
     static ColumnPtr evaluate(const ColumnPtr& v1, const ColumnPtr& v2) {
-        using Function = DecimalBinaryFunction<check_overflow, OP>;
+        using Function = DecimalBinaryFunction<overflow_mode, OP>;
         if (!v1->is_constant() && !v2->is_constant()) {
             return Function::template vector_vector<LType, RType, ResultType>(v1, v2);
         } else if (!v1->is_constant() && v2->is_constant()) {
@@ -229,13 +237,13 @@ public:
     }
 };
 
-template <typename OP, bool check_overflow = false>
+template <typename OP, OverflowMode overflow_mode = OverflowMode::IGNORE>
 using VectorizedStrictDecimalBinaryFunction =
-        UnionNullableColumnBinaryFunction<UnpackConstColumnDecimalBinaryFunction<OP, check_overflow>>;
+        UnionNullableColumnBinaryFunction<UnpackConstColumnDecimalBinaryFunction<OP, overflow_mode>>;
 
-template <LogicalType Type, typename OP, bool check_overflow = false>
+template <LogicalType Type, typename OP, OverflowMode overflow_mode = OverflowMode::IGNORE>
 using VectorizedUnstrictDecimalBinaryFunction =
         ProduceNullableColumnBinaryFunction<UnpackConstColumnBinaryFunction<ArithmeticRightZeroCheck<Type>>,
-                                            UnpackConstColumnDecimalBinaryFunction<OP, check_overflow>>;
+                                            UnpackConstColumnDecimalBinaryFunction<OP, overflow_mode>>;
 
 } //namespace starrocks

--- a/be/src/exprs/decimal_cast_expr.h
+++ b/be/src/exprs/decimal_cast_expr.h
@@ -72,7 +72,7 @@ struct DecimalDecimalCast {
                     if constexpr (check_overflow<overflow_mode>) {
                         if (overflow) {
                             if constexpr (error_if_overflow<overflow_mode>) {
-                                throw std::overflow_error("Decimal overflow");
+                                throw std::overflow_error("The type cast from decimal to decimal overflows");
                             } else {
                                 static_assert(null_if_overflow<overflow_mode>);
                                 has_null = true;
@@ -91,7 +91,7 @@ struct DecimalDecimalCast {
                 if constexpr (check_overflow<overflow_mode>) {
                     if (overflow) {
                         if constexpr (error_if_overflow<overflow_mode>) {
-                            throw std::overflow_error("Decimal overflow");
+                            throw std::overflow_error("The type cast from decimal to decimal overflows");
                         } else {
                             static_assert(null_if_overflow<overflow_mode>);
                             has_null = true;
@@ -109,7 +109,7 @@ struct DecimalDecimalCast {
                 if constexpr (check_overflow<overflow_mode>) {
                     if (overflow) {
                         if constexpr (error_if_overflow<overflow_mode>) {
-                            throw std::overflow_error("Decimal overflow");
+                            throw std::overflow_error("The type cast from decimal to decimal overflows");
                         } else {
                             static_assert(null_if_overflow<overflow_mode>);
                             has_null = true;
@@ -209,7 +209,7 @@ struct DecimalNonDecimalCast<overflow_mode, DecimalType, NonDecimalType, Decimal
             if constexpr (check_overflow<overflow_mode>) {
                 if (overflow) {
                     if constexpr (error_if_overflow<overflow_mode>) {
-                        throw std::overflow_error("Decimal overflow");
+                        throw std::overflow_error("The type cast from other types to decimal overflows");
                     } else {
                         static_assert(null_if_overflow<overflow_mode>);
                         has_null = true;
@@ -316,7 +316,7 @@ struct DecimalNonDecimalCast<overflow_mode, DecimalType, NonDecimalType, Decimal
             if (check_overflow<overflow_mode>) {
                 if (overflow) {
                     if constexpr (error_if_overflow<overflow_mode>) {
-                        throw std::overflow_error("Decimal overflow");
+                        throw std::overflow_error("The type cast from decimal to other types overflows");
                     } else {
                         static_assert(null_if_overflow<overflow_mode>);
                         nulls[i] = DATUM_NULL;
@@ -363,7 +363,7 @@ struct DecimalNonDecimalCast<overflow_mode, DecimalType, StringType, DecimalLTGu
             if constexpr (check_overflow<overflow_mode>) {
                 if (overflow) {
                     if constexpr (error_if_overflow<overflow_mode>) {
-                        throw std::overflow_error("Decimal overflow");
+                        throw std::overflow_error("The type cast from string to decimal overflows");
                     } else {
                         static_assert(null_if_overflow<overflow_mode>);
                         has_null = true;

--- a/be/src/exprs/decimal_cast_expr.h
+++ b/be/src/exprs/decimal_cast_expr.h
@@ -17,6 +17,7 @@
 #include <gutil/strings/fastmem.h>
 
 #include "column/column_builder.h"
+#include "exprs/overflow.h"
 #include "runtime/decimalv3.h"
 
 namespace starrocks {
@@ -25,7 +26,7 @@ UNION_VALUE_GUARD(LogicalType, FixedNonDecimalTypeGuard, lt_is_fixed_non_decimal
                   lt_is_integer_struct, lt_is_float_struct, lt_is_date_struct, lt_is_datetime_struct,
                   lt_is_decimalv2_struct, lt_is_time_struct)
 
-template <bool check_overflow, LogicalType Type, LogicalType ResultType>
+template <OverflowMode overflow_mode, LogicalType Type, LogicalType ResultType>
 struct DecimalDecimalCast {
     static inline ColumnPtr evaluate(const ColumnPtr& column, int to_precision, int to_scale) {
         using FromCppType = RunTimeCppType<Type>;
@@ -51,7 +52,7 @@ struct DecimalDecimalCast {
         auto has_null = false;
         auto result_data = &ColumnHelper::cast_to_raw<ResultType>(result)->get_data().front();
 
-        if constexpr (check_overflow) {
+        if constexpr (check_overflow<overflow_mode>) {
             null_column = NullColumn::create();
             null_column->resize(num_rows);
             nulls = &null_column->get_data().front();
@@ -60,17 +61,23 @@ struct DecimalDecimalCast {
         if (to_scale == from_scale) {
             if constexpr (sizeof(FromCppType) <= sizeof(ToCppType)) {
                 for (auto i = 0; i < num_rows; ++i) {
-                    (void)DecimalV3Cast::to_decimal_trivial<FromCppType, ToCppType, check_overflow>(data[i],
-                                                                                                    &result_data[i]);
+                    (void)DecimalV3Cast::to_decimal_trivial<FromCppType, ToCppType, check_overflow<overflow_mode>>(
+                            data[i], &result_data[i]);
                 }
             } else {
                 for (auto i = 0; i < num_rows; ++i) {
-                    auto overflow = DecimalV3Cast::to_decimal_trivial<FromCppType, ToCppType, check_overflow>(
-                            data[i], &result_data[i]);
-                    if constexpr (check_overflow) {
+                    auto overflow =
+                            DecimalV3Cast::to_decimal_trivial<FromCppType, ToCppType, check_overflow<overflow_mode>>(
+                                    data[i], &result_data[i]);
+                    if constexpr (check_overflow<overflow_mode>) {
                         if (overflow) {
-                            has_null = true;
-                            nulls[i] = DATUM_NULL;
+                            if constexpr (error_if_overflow<overflow_mode>) {
+                                throw std::overflow_error("Decimal overflow");
+                            } else {
+                                static_assert(null_if_overflow<overflow_mode>);
+                                has_null = true;
+                                nulls[i] = DATUM_NULL;
+                            }
                         }
                     }
                 }
@@ -78,29 +85,41 @@ struct DecimalDecimalCast {
         } else if (to_scale > from_scale) {
             const auto scale_factor = get_scale_factor<ToCppType>(to_scale - from_scale);
             for (auto i = 0; i < num_rows; ++i) {
-                auto overflow = DecimalV3Cast::to_decimal<FromCppType, ToCppType, ToCppType, true, check_overflow>(
-                        data[i], scale_factor, &result_data[i]);
-                if constexpr (check_overflow) {
+                auto overflow = DecimalV3Cast::to_decimal<FromCppType, ToCppType, ToCppType, true,
+                                                          check_overflow<overflow_mode>>(data[i], scale_factor,
+                                                                                         &result_data[i]);
+                if constexpr (check_overflow<overflow_mode>) {
                     if (overflow) {
-                        has_null = true;
-                        nulls[i] = DATUM_NULL;
+                        if constexpr (error_if_overflow<overflow_mode>) {
+                            throw std::overflow_error("Decimal overflow");
+                        } else {
+                            static_assert(null_if_overflow<overflow_mode>);
+                            has_null = true;
+                            nulls[i] = DATUM_NULL;
+                        }
                     }
                 }
             }
         } else {
             const auto scale_factor = get_scale_factor<FromCppType>(from_scale - to_scale);
             for (auto i = 0; i < num_rows; ++i) {
-                auto overflow = DecimalV3Cast::to_decimal<FromCppType, ToCppType, FromCppType, false, check_overflow>(
-                        data[i], scale_factor, &result_data[i]);
-                if constexpr (check_overflow) {
+                auto overflow = DecimalV3Cast::to_decimal<FromCppType, ToCppType, FromCppType, false,
+                                                          check_overflow<overflow_mode>>(data[i], scale_factor,
+                                                                                         &result_data[i]);
+                if constexpr (check_overflow<overflow_mode>) {
                     if (overflow) {
-                        has_null = true;
-                        nulls[i] = DATUM_NULL;
+                        if constexpr (error_if_overflow<overflow_mode>) {
+                            throw std::overflow_error("Decimal overflow");
+                        } else {
+                            static_assert(null_if_overflow<overflow_mode>);
+                            has_null = true;
+                            nulls[i] = DATUM_NULL;
+                        }
                     }
                 }
             }
         }
-        if constexpr (check_overflow) {
+        if constexpr (check_overflow<overflow_mode>) {
             ColumnBuilder<ResultType> builder(result, null_column, has_null);
             return builder.build(column->is_constant());
         } else {
@@ -108,12 +127,12 @@ struct DecimalDecimalCast {
         }
     }
 };
-template <bool check_overflow, LogicalType, LogicalType, typename = guard::Guard, typename = guard::Guard>
+template <OverflowMode overflow_mode, LogicalType, LogicalType, typename = guard::Guard, typename = guard::Guard>
 struct DecimalNonDecimalCast {};
 
 // cast: bool,integer,float,datetime,date, time <-> decimal
-template <bool check_overflow, LogicalType DecimalType, LogicalType NonDecimalType>
-struct DecimalNonDecimalCast<check_overflow, DecimalType, NonDecimalType, DecimalLTGuard<DecimalType>,
+template <OverflowMode overflow_mode, LogicalType DecimalType, LogicalType NonDecimalType>
+struct DecimalNonDecimalCast<overflow_mode, DecimalType, NonDecimalType, DecimalLTGuard<DecimalType>,
                              FixedNonDecimalTypeGuard<NonDecimalType>> {
     using DecimalCppType = RunTimeCppType<DecimalType>;
     using DecimalColumnType = RunTimeColumnType<DecimalType>;
@@ -128,7 +147,7 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, NonDecimalType, Decima
         NullColumnPtr null_column;
         NullColumn::ValueType* nulls = nullptr;
         bool has_null = false;
-        if constexpr (check_overflow) {
+        if constexpr (check_overflow<overflow_mode>) {
             null_column = NullColumn::create();
             null_column->resize(num_rows);
             nulls = &null_column->get_data().front();
@@ -140,11 +159,13 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, NonDecimalType, Decima
             bool overflow = false;
             if constexpr (lt_is_boolean<NonDecimalType>) {
                 using SignedBooleanType = std::make_signed_t<NonDecimalCppType>;
-                overflow = DecimalV3Cast::from_integer<SignedBooleanType, DecimalCppType, check_overflow>(
-                        (SignedBooleanType)(data[i]), scale_factor, &result_data[i]);
+                overflow =
+                        DecimalV3Cast::from_integer<SignedBooleanType, DecimalCppType, check_overflow<overflow_mode>>(
+                                (SignedBooleanType)(data[i]), scale_factor, &result_data[i]);
             } else if constexpr (lt_is_integer<NonDecimalType>) {
-                overflow = DecimalV3Cast::from_integer<NonDecimalCppType, DecimalCppType, check_overflow>(
-                        data[i], scale_factor, &result_data[i]);
+                overflow =
+                        DecimalV3Cast::from_integer<NonDecimalCppType, DecimalCppType, check_overflow<overflow_mode>>(
+                                data[i], scale_factor, &result_data[i]);
             } else if constexpr (lt_is_float<NonDecimalType>) {
                 overflow = DecimalV3Cast::from_float<NonDecimalCppType, DecimalCppType>(data[i], scale_factor,
                                                                                         &result_data[i]);
@@ -155,42 +176,49 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, NonDecimalType, Decima
             } else if constexpr (lt_is_date<NonDecimalType>) {
                 static_assert(std::is_same_v<NonDecimalCppType, DateValue>, "DateValue type is required");
                 int32_t datum = ((DateValue&)data[i]).to_date_literal();
-                overflow = DecimalV3Cast::from_integer<int32_t, DecimalCppType, check_overflow>(datum, scale_factor,
-                                                                                                &result_data[i]);
+                overflow = DecimalV3Cast::from_integer<int32_t, DecimalCppType, check_overflow<overflow_mode>>(
+                        datum, scale_factor, &result_data[i]);
             } else if constexpr (lt_is_datetime<NonDecimalType>) {
                 static_assert(std::is_same_v<NonDecimalCppType, TimestampValue>, "TimestampValue type is required");
                 auto datum = (int64_t)(((TimestampValue&)data[i]).to_timestamp_literal());
-                overflow = DecimalV3Cast::from_integer<int64_t, DecimalCppType, check_overflow>(datum, scale_factor,
-                                                                                                &result_data[i]);
+                overflow = DecimalV3Cast::from_integer<int64_t, DecimalCppType, check_overflow<overflow_mode>>(
+                        datum, scale_factor, &result_data[i]);
             } else if constexpr (lt_is_decimalv2<NonDecimalType>) {
                 static_assert(std::is_same_v<NonDecimalCppType, DecimalV2Value>, "TimestampValue type is required");
                 auto datum = (int128_t)(((DecimalV2Value&)data[i]).value());
                 if (scale == DecimalV2Value::SCALE) {
-                    overflow = DecimalV3Cast::to_decimal_trivial<int128_t, DecimalCppType, check_overflow>(
-                            datum, &result_data[i]);
+                    overflow =
+                            DecimalV3Cast::to_decimal_trivial<int128_t, DecimalCppType, check_overflow<overflow_mode>>(
+                                    datum, &result_data[i]);
                 } else if (scale < DecimalV2Value::SCALE) {
                     const auto scale_up_factor = get_scale_factor<int128_t>(DecimalV2Value::SCALE - scale);
-                    overflow = DecimalV3Cast::to_decimal<int128_t, DecimalCppType, int128_t, false, check_overflow>(
-                            datum, scale_up_factor, &result_data[i]);
+                    overflow = DecimalV3Cast::to_decimal<int128_t, DecimalCppType, int128_t, false,
+                                                         check_overflow<overflow_mode>>(datum, scale_up_factor,
+                                                                                        &result_data[i]);
                 } else {
                     const auto scale_down_factor = get_scale_factor<DecimalCppType>(scale - DecimalV2Value::SCALE);
-                    overflow =
-                            DecimalV3Cast::to_decimal<int128_t, DecimalCppType, DecimalCppType, true, check_overflow>(
-                                    datum, scale_down_factor, &result_data[i]);
+                    overflow = DecimalV3Cast::to_decimal<int128_t, DecimalCppType, DecimalCppType, true,
+                                                         check_overflow<overflow_mode>>(datum, scale_down_factor,
+                                                                                        &result_data[i]);
                 }
             } else {
                 static_assert(lt_is_fixed_non_decimal<NonDecimalType>,
                               "Only number type is a legal argument type to template parameter");
             }
 
-            if constexpr (check_overflow) {
+            if constexpr (check_overflow<overflow_mode>) {
                 if (overflow) {
-                    has_null = true;
-                    nulls[i] = DATUM_NULL;
+                    if constexpr (error_if_overflow<overflow_mode>) {
+                        throw std::overflow_error("Decimal overflow");
+                    } else {
+                        static_assert(null_if_overflow<overflow_mode>);
+                        has_null = true;
+                        nulls[i] = DATUM_NULL;
+                    }
                 }
             }
         }
-        if constexpr (check_overflow) {
+        if constexpr (check_overflow<overflow_mode>) {
             ColumnBuilder<DecimalType> builder(result, null_column, has_null);
             return builder.build(column->is_constant());
         } else {
@@ -210,7 +238,7 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, NonDecimalType, Decima
         NullColumnPtr null_column;
         NullColumn::ValueType* nulls = nullptr;
         bool has_null = false;
-        if constexpr (check_overflow) {
+        if constexpr (check_overflow<overflow_mode>) {
             null_column = NullColumn::create();
             null_column->resize(num_rows);
             nulls = &null_column->get_data().front();
@@ -223,7 +251,7 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, NonDecimalType, Decima
                 static constexpr auto zero = DecimalCppType(0);
                 result_data[i] = (data[i] != zero);
             } else if constexpr (lt_is_integer<NonDecimalType>) {
-                overflow = DecimalV3Cast::to_integer<DecimalCppType, NonDecimalCppType, check_overflow>(
+                overflow = DecimalV3Cast::to_integer<DecimalCppType, NonDecimalCppType, check_overflow<overflow_mode>>(
                         data[i], scale_factor, &result_data[i]);
             } else if constexpr (lt_is_float<NonDecimalType>) {
                 DecimalV3Cast::to_float<DecimalCppType, NonDecimalCppType>(data[i], scale_factor, &result_data[i]);
@@ -235,16 +263,16 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, NonDecimalType, Decima
                 uint64_t min = (datum / 100) % 100;
                 uint64_t sec = datum % 100;
                 result_data[i] = (hour * 60 + min) * 60 + sec;
-                if constexpr (check_overflow) {
+                if constexpr (check_overflow<overflow_mode>) {
                     overflow = overflow || (min > 59 || sec > 59);
                 }
             } else if constexpr (lt_is_date<NonDecimalType>) {
                 static_assert(std::is_same_v<NonDecimalCppType, DateValue>, "DateValue type is required");
                 int64_t datum;
-                overflow = DecimalV3Cast::to_integer<DecimalCppType, int64_t, check_overflow>(data[i], scale_factor,
-                                                                                              &datum);
+                overflow = DecimalV3Cast::to_integer<DecimalCppType, int64_t, check_overflow<overflow_mode>>(
+                        data[i], scale_factor, &datum);
                 auto& date_value = (DateValue&)result_data[i];
-                if constexpr (check_overflow) {
+                if constexpr (check_overflow<overflow_mode>) {
                     overflow = overflow || !date_value.from_date_literal_with_check(datum);
                 } else {
                     date_value.from_date_literal(datum);
@@ -252,10 +280,10 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, NonDecimalType, Decima
             } else if constexpr (lt_is_datetime<NonDecimalType>) {
                 static_assert(std::is_same_v<NonDecimalCppType, TimestampValue>, "TimestampValue is required");
                 int64_t datum;
-                overflow = DecimalV3Cast::to_integer<DecimalCppType, int64_t, check_overflow>(data[i], scale_factor,
-                                                                                              &datum);
+                overflow = DecimalV3Cast::to_integer<DecimalCppType, int64_t, check_overflow<overflow_mode>>(
+                        data[i], scale_factor, &datum);
                 auto& timestamp_value = (TimestampValue&)result_data[i];
-                if constexpr (check_overflow) {
+                if constexpr (check_overflow<overflow_mode>) {
                     overflow = overflow || !timestamp_value.from_timestamp_literal_with_check((uint64_t)datum);
                 } else {
                     timestamp_value.from_timestamp_literal((uint64_t)datum);
@@ -264,17 +292,19 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, NonDecimalType, Decima
                 static_assert(std::is_same_v<NonDecimalCppType, DecimalV2Value>, "TimestampValue type is required");
                 int128_t datum;
                 if (scale == DecimalV2Value::SCALE) {
-                    overflow = DecimalV3Cast::to_decimal_trivial<DecimalCppType, int128_t, check_overflow>(data[i],
-                                                                                                           &datum);
+                    overflow =
+                            DecimalV3Cast::to_decimal_trivial<DecimalCppType, int128_t, check_overflow<overflow_mode>>(
+                                    data[i], &datum);
                 } else if (scale < DecimalV2Value::SCALE) {
                     const auto scale_up_factor = get_scale_factor<int128_t>(DecimalV2Value::SCALE - scale);
-                    overflow = DecimalV3Cast::to_decimal<DecimalCppType, int128_t, int128_t, true, check_overflow>(
-                            data[i], scale_up_factor, &datum);
+                    overflow =
+                            DecimalV3Cast::to_decimal<DecimalCppType, int128_t, int128_t, true,
+                                                      check_overflow<overflow_mode>>(data[i], scale_up_factor, &datum);
                 } else {
                     const auto scale_down_factor = get_scale_factor<DecimalCppType>(scale - DecimalV2Value::SCALE);
-                    overflow =
-                            DecimalV3Cast::to_decimal<DecimalCppType, int128_t, DecimalCppType, false, check_overflow>(
-                                    data[i], scale_down_factor, &datum);
+                    overflow = DecimalV3Cast::to_decimal<DecimalCppType, int128_t, DecimalCppType, false,
+                                                         check_overflow<overflow_mode>>(data[i], scale_down_factor,
+                                                                                        &datum);
                 }
                 auto& decimalV2_value = (DecimalV2Value&)result_data[i];
                 decimalV2_value.set_value(datum);
@@ -283,14 +313,19 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, NonDecimalType, Decima
                               "Only number type is a legal argument type to template parameter");
             }
 
-            if (check_overflow) {
+            if (check_overflow<overflow_mode>) {
                 if (overflow) {
-                    nulls[i] = DATUM_NULL;
-                    has_null = true;
+                    if constexpr (error_if_overflow<overflow_mode>) {
+                        throw std::overflow_error("Decimal overflow");
+                    } else {
+                        static_assert(null_if_overflow<overflow_mode>);
+                        nulls[i] = DATUM_NULL;
+                        has_null = true;
+                    }
                 }
             }
         }
-        if constexpr (check_overflow) {
+        if constexpr (check_overflow<overflow_mode>) {
             ColumnBuilder<NonDecimalType> builder(result, null_column, has_null);
             return builder.build(false);
         } else {
@@ -300,8 +335,8 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, NonDecimalType, Decima
 };
 
 // cast: char/varchar <-> decimal
-template <bool check_overflow, LogicalType DecimalType, LogicalType StringType>
-struct DecimalNonDecimalCast<check_overflow, DecimalType, StringType, DecimalLTGuard<DecimalType>,
+template <OverflowMode overflow_mode, LogicalType DecimalType, LogicalType StringType>
+struct DecimalNonDecimalCast<overflow_mode, DecimalType, StringType, DecimalLTGuard<DecimalType>,
                              StringLTGuard<StringType>> {
     using DecimalCppType = RunTimeCppType<DecimalType>;
     using DecimalColumnType = RunTimeColumnType<DecimalType>;
@@ -315,7 +350,7 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, StringType, DecimalLTG
         NullColumnPtr null_column;
         NullColumn::ValueType* nulls = nullptr;
         auto has_null = false;
-        if constexpr (check_overflow) {
+        if constexpr (check_overflow<overflow_mode>) {
             null_column = NullColumn::create();
             null_column->resize(num_rows);
             nulls = &null_column->get_data().front();
@@ -325,14 +360,19 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, StringType, DecimalLTG
             auto slice = binary_data->get_slice(i);
             auto overflow = DecimalV3Cast::from_string<DecimalCppType>(
                     &result_data[i], decimal_precision_limit<DecimalCppType>, scale, slice.data, slice.size);
-            if constexpr (check_overflow) {
+            if constexpr (check_overflow<overflow_mode>) {
                 if (overflow) {
-                    has_null = true;
-                    nulls[i] = DATUM_NULL;
+                    if constexpr (error_if_overflow<overflow_mode>) {
+                        throw std::overflow_error("Decimal overflow");
+                    } else {
+                        static_assert(null_if_overflow<overflow_mode>);
+                        has_null = true;
+                        nulls[i] = DATUM_NULL;
+                    }
                 }
             }
         }
-        if constexpr (check_overflow) {
+        if constexpr (check_overflow<overflow_mode>) {
             ColumnBuilder<DecimalType> builder(result, null_column, has_null);
             return builder.build(column->is_constant());
         } else {
@@ -366,30 +406,30 @@ struct DecimalNonDecimalCast<check_overflow, DecimalType, StringType, DecimalLTG
     }
 };
 
-template <bool check_overflow>
+template <OverflowMode overflow_mode>
 struct DecimalToDecimal {
     template <LogicalType Type, LogicalType ResultType, typename... Args>
     static inline ColumnPtr evaluate(const ColumnPtr& column, Args&&... args) {
-        return DecimalDecimalCast<check_overflow, Type, ResultType>::evaluate(column, std::forward<Args>(args)...);
+        return DecimalDecimalCast<overflow_mode, Type, ResultType>::evaluate(column, std::forward<Args>(args)...);
     }
 };
 
 // cast: convert to decimal type from other types
-template <bool check_overflow>
+template <OverflowMode overflow_mode>
 struct DecimalFrom {
     template <LogicalType Type, LogicalType ResultType, typename... Args>
     static inline ColumnPtr evaluate(const ColumnPtr& column, Args&&... args) {
-        return DecimalNonDecimalCast<check_overflow, ResultType, Type>::decimal_from(column,
-                                                                                     std::forward<Args>(args)...);
+        return DecimalNonDecimalCast<overflow_mode, ResultType, Type>::decimal_from(column,
+                                                                                    std::forward<Args>(args)...);
     }
 };
 
 // cast: convert to other types from decimal type
-template <bool check_overflow>
+template <OverflowMode overflow_mode>
 struct DecimalTo {
     template <LogicalType Type, LogicalType ResultType>
     static inline ColumnPtr evaluate(const ColumnPtr& column) {
-        return DecimalNonDecimalCast<check_overflow, Type, ResultType>::decimal_to(column);
+        return DecimalNonDecimalCast<overflow_mode, Type, ResultType>::decimal_to(column);
     }
 };
 

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -186,4 +186,8 @@ StatusOr<ColumnPtr> ExprContext::evaluate(Expr* e, Chunk* chunk, uint8_t* filter
     }
 }
 
+bool ExprContext::error_if_overflow() const {
+    return _runtime_state != nullptr && _runtime_state->error_if_overflow();
+}
+
 } // namespace starrocks

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -115,6 +115,8 @@ public:
     StatusOr<ColumnPtr> evaluate(Chunk* chunk, uint8_t* filter = nullptr);
     StatusOr<ColumnPtr> evaluate(Expr* expr, Chunk* chunk, uint8_t* filter = nullptr);
 
+    bool error_if_overflow() const;
+
 private:
     friend class Expr;
     friend class OlapScanNode;

--- a/be/src/exprs/function_context.cpp
+++ b/be/src/exprs/function_context.cpp
@@ -156,6 +156,10 @@ const char* FunctionContext::error_msg() const {
     }
 }
 
+bool FunctionContext::error_if_overflow() const {
+    return _state != nullptr && _state->error_if_overflow();
+}
+
 void FunctionContext::set_function_state(FunctionStateScope scope, void* ptr) {
     switch (scope) {
     case THREAD_LOCAL:

--- a/be/src/exprs/function_context.h
+++ b/be/src/exprs/function_context.h
@@ -171,6 +171,8 @@ public:
     // min value is 4, default is 1024
     void set_group_concat_max_len(ssize_t len) { group_concat_max_len = len < 4 ? 4 : len; }
 
+    bool error_if_overflow() const;
+
 private:
     friend class ExprContext;
 

--- a/be/src/exprs/math_functions.h
+++ b/be/src/exprs/math_functions.h
@@ -373,8 +373,13 @@ public:
         } else if constexpr (lt_is_decimal<Type>) {
             // TODO(by satanson):
             //  FunctionContext carry decimal_overflow_check flag to control overflow checking.
-            using VectorizedDiv = VectorizedUnstrictDecimalBinaryFunction<Type, ModOp, false>;
-            return VectorizedDiv::template evaluate<Type>(l, r);
+            if (context != nullptr && context->error_if_overflow()) {
+                using VectorizedDiv = VectorizedUnstrictDecimalBinaryFunction<Type, ModOp, OverflowMode::REPORT_ERROR>;
+                return VectorizedDiv::template evaluate<Type>(l, r);
+            } else {
+                using VectorizedDiv = VectorizedUnstrictDecimalBinaryFunction<Type, ModOp, OverflowMode::OUTPUT_NULL>;
+                return VectorizedDiv::template evaluate<Type>(l, r);
+            }
         } else {
             return VectorizedUnstrictBinaryFunction<RValueCheckZeroImpl, modImpl>::evaluate<Type>(l, r);
         }

--- a/be/src/exprs/overflow.h
+++ b/be/src/exprs/overflow.h
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace starrocks {
+enum OverflowMode {
+    // We don't check overflow in this mode
+    IGNORE = 0,
+    // We will output NULL when overflow happens
+    OUTPUT_NULL = 1,
+    // We will report error when overflow happens
+    REPORT_ERROR = 2
+};
+
+template <OverflowMode mode>
+inline constexpr bool check_overflow = false;
+template <>
+inline constexpr bool check_overflow<OverflowMode::OUTPUT_NULL> = true;
+template <>
+inline constexpr bool check_overflow<OverflowMode::REPORT_ERROR> = true;
+
+template <OverflowMode mode>
+inline constexpr bool null_if_overflow = false;
+template <>
+inline constexpr bool null_if_overflow<OverflowMode::OUTPUT_NULL> = true;
+
+template <OverflowMode mode>
+inline constexpr bool error_if_overflow = false;
+template <>
+inline constexpr bool error_if_overflow<OverflowMode::REPORT_ERROR> = true;
+} // namespace starrocks

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -339,6 +339,10 @@ public:
 
     int32_t spill_encode_level() const { return _query_options.spill_encode_level; }
 
+    bool error_if_overflow() const {
+        return _query_options.__isset.overflow_mode && _query_options.overflow_mode == TOverflowMode::REPORT_ERROR;
+    }
+
     const std::vector<TTabletCommitInfo>& tablet_commit_infos() const { return _tablet_commit_infos; }
 
     std::vector<TTabletCommitInfo>& tablet_commit_infos() { return _tablet_commit_infos; }

--- a/be/test/exprs/decimal_binary_function_test.cpp
+++ b/be/test/exprs/decimal_binary_function_test.cpp
@@ -22,6 +22,7 @@
 #include <random>
 
 #include "exprs/decimal_cast_expr_test_helper.h"
+#include "exprs/overflow.h"
 
 namespace starrocks {
 
@@ -235,11 +236,11 @@ Columns prepare_const_const(const DecimalTestCase& test_case, int lhs_precision,
 
 using Func = std::function<ColumnPtr(ColumnPtr const&, ColumnPtr const&)>;
 
-template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, bool check_overflow,
+template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, OverflowMode overflow_mode,
           bool assert_overflow = false>
 void test_decimal_binary_functions(DecimalTestCaseArray const& test_cases, Columns columns, int result_precision,
                                    int result_scale, size_t off, [[maybe_unused]] const std::vector<bool>& overflows) {
-    using ColumnWiseOp = UnpackConstColumnDecimalBinaryFunction<Op, check_overflow>;
+    using ColumnWiseOp = UnpackConstColumnDecimalBinaryFunction<Op, overflow_mode>;
     using CppType = RunTimeCppType<ResultType>;
     using ColumnType = RunTimeColumnType<ResultType>;
     ASSERT_TRUE(columns.size() == 2);
@@ -251,7 +252,7 @@ void test_decimal_binary_functions(DecimalTestCaseArray const& test_cases, Colum
     if (result->is_constant()) {
         ASSERT_TRUE(test_cases.size() == 1);
         if (result->only_null()) {
-            ASSERT_TRUE(check_overflow);
+            ASSERT_TRUE(null_if_overflow<overflow_mode>);
         } else {
             auto* decimal_column = (ColumnType*)(ColumnHelper::get_data_column(result.get()));
             ASSERT_EQ(result_precision, decimal_column->precision());
@@ -276,7 +277,7 @@ void test_decimal_binary_functions(DecimalTestCaseArray const& test_cases, Colum
         return;
     }
 
-    if constexpr (!check_overflow) {
+    if constexpr (!check_overflow<overflow_mode>) {
         ASSERT_TRUE(!columns[0]->is_constant() || !columns[1]->is_constant());
     }
 
@@ -302,7 +303,7 @@ void test_decimal_binary_functions(DecimalTestCaseArray const& test_cases, Colum
         auto actual = DecimalV3Cast::to_string<CppType>(value, decimal_column->precision(), decimal_column->scale());
         //std::cout << "test#" << i << ": lhs=" << lhs_datum << ", rhs=" << rhs_datum << ", expect=" << expect
         //          << ", actual=" << actual << std::endl;
-        if constexpr (check_overflow) {
+        if constexpr (check_overflow<overflow_mode>) {
             if constexpr (assert_overflow) {
                 const auto& expect_overflow = overflows[i];
                 ASSERT_EQ(expect_overflow, result->is_null(row_idx));
@@ -322,7 +323,7 @@ void test_decimal_binary_functions(DecimalTestCaseArray const& test_cases, Colum
     }
 }
 
-template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, bool check_overflow,
+template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, OverflowMode overflow_mode,
           bool assert_overflow = false>
 void test_decimal_binary_functions_with_nullable_columns(DecimalTestCaseArray const& test_cases, Columns columns,
                                                          int result_precision, int result_scale, size_t off,
@@ -333,10 +334,10 @@ void test_decimal_binary_functions_with_nullable_columns(DecimalTestCaseArray co
     ASSERT_TRUE(columns.size() == 2);
     ColumnPtr result = nullptr;
     if constexpr (is_add_op<Op> || is_sub_op<Op> || is_mul_op<Op>) {
-        using ColumnWiseOp = VectorizedStrictDecimalBinaryFunction<Op, check_overflow>;
+        using ColumnWiseOp = VectorizedStrictDecimalBinaryFunction<Op, overflow_mode>;
         result = ColumnWiseOp::template evaluate<LhsType, RhsType, ResultType>(columns[0], columns[1]);
     } else {
-        using ColumnWiseOp = VectorizedUnstrictDecimalBinaryFunction<ResultType, Op, check_overflow>;
+        using ColumnWiseOp = VectorizedUnstrictDecimalBinaryFunction<ResultType, Op, overflow_mode>;
         result = ColumnWiseOp::template evaluate<LhsType, RhsType, ResultType>(columns[0], columns[1]);
     }
 
@@ -361,7 +362,7 @@ void test_decimal_binary_functions_with_nullable_columns(DecimalTestCaseArray co
 
         CppType& value = data[row_idx];
         auto actual = DecimalV3Cast::to_string<CppType>(value, decimal_column->precision(), decimal_column->scale());
-        if constexpr (check_overflow) {
+        if constexpr (check_overflow<overflow_mode>) {
             if constexpr (assert_overflow) {
                 const auto& expect_overflow = overflows[i];
                 ASSERT_EQ(expect_overflow, result->is_null(row_idx));
@@ -381,41 +382,41 @@ void test_decimal_binary_functions_with_nullable_columns(DecimalTestCaseArray co
     }
 }
 
-template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, bool check_overflow>
+template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, OverflowMode overflow_mode>
 void test_vector_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
                         int rhs_scale, int result_precision, int result_scale) {
     Columns columns = prepare_vector_vector<LhsType, RhsType>(test_cases, lhs_precision, lhs_scale, rhs_precision,
                                                               rhs_scale, 0, 0);
-    test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, check_overflow>(
+    test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, overflow_mode>(
             test_cases, columns, result_precision, result_scale, 0, std::vector<bool>());
 }
 
-template <LogicalType Type, typename Op, bool check_overflow>
+template <LogicalType Type, typename Op, OverflowMode overflow_mode>
 void test_vector_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
                         int rhs_scale, int result_precision, int result_scale) {
-    test_vector_vector<Type, Type, Type, Op, check_overflow>(test_cases, lhs_precision, lhs_scale, rhs_precision,
-                                                             rhs_scale, result_precision, result_scale);
+    test_vector_vector<Type, Type, Type, Op, overflow_mode>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                            rhs_scale, result_precision, result_scale);
 }
 
-template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, bool check_overflow>
+template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, OverflowMode overflow_mode>
 void test_vector_vector_assert_overflow(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                                         int rhs_precision, int rhs_scale, int result_precision, int result_scale,
                                         const std::vector<bool>& overflows) {
     Columns columns = prepare_vector_vector<LhsType, RhsType>(test_cases, lhs_precision, lhs_scale, rhs_precision,
                                                               rhs_scale, 0, 0);
-    test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, check_overflow, true>(
+    test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, overflow_mode, true>(
             test_cases, columns, result_precision, result_scale, 0, overflows);
 }
 
-template <LogicalType Type, typename Op, bool check_overflow>
+template <LogicalType Type, typename Op, OverflowMode overflow_mode>
 void test_vector_vector_assert_overflow(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                                         int rhs_precision, int rhs_scale, int result_precision, int result_scale,
                                         const std::vector<bool>& overflows) {
-    test_vector_vector_assert_overflow<Type, Type, Type, Op, check_overflow>(
+    test_vector_vector_assert_overflow<Type, Type, Type, Op, overflow_mode>(
             test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale, overflows);
 }
 
-template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, bool check_overflow>
+template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, OverflowMode overflow_mode>
 void test_const_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
                        int rhs_scale, int result_precision, int result_scale) {
     std::random_device rd;
@@ -426,20 +427,20 @@ void test_const_vector(DecimalTestCaseArray const& test_cases, int lhs_precision
     for (auto& tc : test_cases) {
         Columns columns = prepare_const_vector<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
                                                                  front_fill_size, rear_fill_size);
-        test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, check_overflow>(
+        test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, overflow_mode>(
                 DecimalTestCaseArray{tc}, columns, result_precision, result_scale, front_fill_size,
                 std::vector<bool>());
     }
 }
 
-template <LogicalType Type, typename Op, bool check_overflow>
+template <LogicalType Type, typename Op, OverflowMode overflow_mode>
 void test_const_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
                        int rhs_scale, int result_precision, int result_scale) {
-    test_const_vector<Type, Type, Type, Op, check_overflow>(test_cases, lhs_precision, lhs_scale, rhs_precision,
-                                                            rhs_scale, result_precision, result_scale);
+    test_const_vector<Type, Type, Type, Op, overflow_mode>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                           rhs_scale, result_precision, result_scale);
 }
 
-template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, bool check_overflow>
+template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, OverflowMode overflow_mode>
 void test_vector_const(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
                        int rhs_scale, int result_precision, int result_scale) {
     std::random_device rd;
@@ -450,37 +451,37 @@ void test_vector_const(DecimalTestCaseArray const& test_cases, int lhs_precision
     for (auto& tc : test_cases) {
         Columns columns = prepare_vector_const<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision, rhs_scale,
                                                                  front_fill_size, rear_fill_size);
-        test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, check_overflow>(
+        test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, overflow_mode>(
                 DecimalTestCaseArray{tc}, columns, result_precision, result_scale, front_fill_size,
                 std::vector<bool>());
     }
 }
 
-template <LogicalType Type, typename Op, bool check_overflow>
+template <LogicalType Type, typename Op, OverflowMode overflow_mode>
 void test_vector_const(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
                        int rhs_scale, int result_precision, int result_scale) {
-    return test_vector_const<Type, Type, Type, Op, check_overflow>(test_cases, lhs_precision, lhs_scale, rhs_precision,
-                                                                   rhs_scale, result_precision, result_scale);
+    return test_vector_const<Type, Type, Type, Op, overflow_mode>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                                  rhs_scale, result_precision, result_scale);
 }
 
-template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, bool check_overflow>
+template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, OverflowMode overflow_mode>
 void test_const_const(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
                       int rhs_scale, int result_precision, int result_scale) {
     for (auto& tc : test_cases) {
         Columns columns = prepare_const_const<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision, rhs_scale);
-        test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, check_overflow>(
+        test_decimal_binary_functions<LhsType, RhsType, ResultType, Op, overflow_mode>(
                 DecimalTestCaseArray{tc}, columns, result_precision, result_scale, 0, std::vector<bool>());
     }
 }
 
-template <LogicalType Type, typename Op, bool check_overflow>
+template <LogicalType Type, typename Op, OverflowMode overflow_mode>
 void test_const_const(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale, int rhs_precision,
                       int rhs_scale, int result_precision, int result_scale) {
-    test_const_const<Type, Type, Type, Op, check_overflow>(test_cases, lhs_precision, lhs_scale, rhs_precision,
-                                                           rhs_scale, result_precision, result_scale);
+    test_const_const<Type, Type, Type, Op, overflow_mode>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                          rhs_scale, result_precision, result_scale);
 }
 
-template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, bool check_overflow>
+template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, OverflowMode overflow_mode>
 void test_nullable_vector_const(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                                 int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
     std::random_device rd;
@@ -491,19 +492,19 @@ void test_nullable_vector_const(DecimalTestCaseArray const& test_cases, int lhs_
     for (auto& tc : test_cases) {
         Columns columns = prepare_nullable_vector_const<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision,
                                                                           rhs_scale, front_fill_size, rear_fill_size);
-        test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, check_overflow>(
+        test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, overflow_mode>(
                 DecimalTestCaseArray{tc}, columns, result_precision, result_scale, front_fill_size,
                 std::vector<bool>());
     }
 }
-template <LogicalType Type, typename Op, bool check_overflow>
+template <LogicalType Type, typename Op, OverflowMode overflow_mode>
 void test_nullable_vector_const(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                                 int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
-    test_nullable_vector_const<Type, Type, Type, Op, check_overflow>(
-            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+    test_nullable_vector_const<Type, Type, Type, Op, overflow_mode>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                                    rhs_scale, result_precision, result_scale);
 }
 
-template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, bool check_overflow>
+template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, OverflowMode overflow_mode>
 void test_const_nullable_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                                 int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
     std::random_device rd;
@@ -514,31 +515,55 @@ void test_const_nullable_vector(DecimalTestCaseArray const& test_cases, int lhs_
     for (auto& tc : test_cases) {
         Columns columns = prepare_const_nullable_vector<LhsType, RhsType>(tc, lhs_precision, lhs_scale, rhs_precision,
                                                                           rhs_scale, front_fill_size, rear_fill_size);
-        test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, check_overflow>(
+        test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, overflow_mode>(
                 DecimalTestCaseArray{tc}, columns, result_precision, result_scale, front_fill_size,
                 std::vector<bool>());
     }
 }
-template <LogicalType Type, typename Op, bool check_overflow>
+template <LogicalType Type, typename Op, OverflowMode overflow_mode>
 void test_const_nullable_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                                 int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
-    test_const_nullable_vector<Type, Type, Type, Op, check_overflow>(
-            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+    test_const_nullable_vector<Type, Type, Type, Op, overflow_mode>(test_cases, lhs_precision, lhs_scale, rhs_precision,
+                                                                    rhs_scale, result_precision, result_scale);
 }
 
-template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, bool check_overflow>
+template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op, OverflowMode overflow_mode>
 void test_nullable_vector_nullable_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                                           int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
     Columns columns = prepare_nullable_vector_nullable_vector<LhsType, RhsType>(test_cases, lhs_precision, lhs_scale,
                                                                                 rhs_precision, rhs_scale, 0, 0);
-    test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, check_overflow>(
+    test_decimal_binary_functions_with_nullable_columns<LhsType, RhsType, ResultType, Op, overflow_mode>(
             test_cases, columns, result_precision, result_scale, 0, std::vector<bool>());
 }
-template <LogicalType Type, typename Op, bool check_overflow>
+
+template <LogicalType Type, typename Op, OverflowMode overflow_mode>
 void test_nullable_vector_nullable_vector(DecimalTestCaseArray const& test_cases, int lhs_precision, int lhs_scale,
                                           int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
-    return test_nullable_vector_nullable_vector<Type, Type, Type, Op, check_overflow>(
+    return test_nullable_vector_nullable_vector<Type, Type, Type, Op, overflow_mode>(
             test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+}
+
+template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op>
+void test_overflow_report_error(const std::string& lv, const std::string& rv, int lhs_precision, int lhs_scale,
+                                int rhs_precision, int rhs_scale) {
+    using LhsCppType = RunTimeCppType<LhsType>;
+    using LhsColumnType = RunTimeColumnType<LhsType>;
+
+    using RhsCppType = RunTimeCppType<RhsType>;
+    using RhsColumnType = RunTimeColumnType<RhsType>;
+
+    auto lhs_column = LhsColumnType::create(lhs_precision, lhs_scale);
+    auto rhs_column = RhsColumnType::create(rhs_precision, rhs_scale);
+    lhs_column->resize(1);
+    rhs_column->resize(1);
+    auto lhs_data = &ColumnHelper::cast_to_raw<LhsType>(lhs_column)->get_data().front();
+    auto rhs_data = &ColumnHelper::cast_to_raw<RhsType>(rhs_column)->get_data().front();
+
+    DecimalV3Cast::from_string<LhsCppType>(&lhs_data[0], lhs_precision, lhs_scale, lv.c_str(), lv.size());
+    DecimalV3Cast::from_string<RhsCppType>(&rhs_data[0], rhs_precision, rhs_scale, rv.c_str(), rv.size());
+
+    using ColumnWiseOp = VectorizedStrictDecimalBinaryFunction<Op, OverflowMode::REPORT_ERROR>;
+    ColumnWiseOp::template evaluate<LhsType, RhsType, ResultType>(lhs_column, rhs_column);
 }
 
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p30s20_add_decimal128p38s28_eq_decimal128p38s28) {
@@ -620,17 +645,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p30s20_add_decimal128p38s28_eq_
              "436672123.5356179969190535681943088653"},
             {"4975741476.85157908539479032939", "7829802341.2748292194789550064799926301",
              "12805543818.1264083048737453358699926301"}};
-    test_vector_vector<TYPE_DECIMAL128, AddOp, true>(test_cases, 30, 20, 38, 28, 38, 28);
-    test_vector_vector<TYPE_DECIMAL128, AddOp, false>(test_cases, 30, 20, 38, 28, 38, 28);
-    test_vector_const<TYPE_DECIMAL128, AddOp, true>(test_cases, 30, 20, 38, 28, 38, 28);
-    test_vector_const<TYPE_DECIMAL128, AddOp, false>(test_cases, 30, 20, 38, 28, 38, 28);
-    test_const_vector<TYPE_DECIMAL128, AddOp, true>(test_cases, 30, 20, 38, 28, 38, 28);
-    test_const_vector<TYPE_DECIMAL128, AddOp, false>(test_cases, 30, 20, 38, 28, 38, 28);
-    test_const_const<TYPE_DECIMAL128, AddOp, true>(test_cases, 30, 20, 38, 28, 38, 28);
-    test_const_const<TYPE_DECIMAL128, AddOp, false>(test_cases, 30, 20, 38, 28, 38, 28);
-    test_const_nullable_vector<TYPE_DECIMAL128, AddOp, true>(test_cases, 30, 20, 38, 28, 38, 28);
-    test_nullable_vector_const<TYPE_DECIMAL128, AddOp, true>(test_cases, 30, 20, 38, 28, 38, 28);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, AddOp, true>(test_cases, 30, 20, 38, 28, 38, 28);
+    test_vector_vector<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 30, 20, 38, 28, 38, 28);
+    test_vector_vector<TYPE_DECIMAL128, AddOp, OverflowMode::IGNORE>(test_cases, 30, 20, 38, 28, 38, 28);
+    test_vector_const<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 30, 20, 38, 28, 38, 28);
+    test_vector_const<TYPE_DECIMAL128, AddOp, OverflowMode::IGNORE>(test_cases, 30, 20, 38, 28, 38, 28);
+    test_const_vector<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 30, 20, 38, 28, 38, 28);
+    test_const_vector<TYPE_DECIMAL128, AddOp, OverflowMode::IGNORE>(test_cases, 30, 20, 38, 28, 38, 28);
+    test_const_const<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 30, 20, 38, 28, 38, 28);
+    test_const_const<TYPE_DECIMAL128, AddOp, OverflowMode::IGNORE>(test_cases, 30, 20, 38, 28, 38, 28);
+    test_const_nullable_vector<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 30, 20, 38, 28, 38, 28);
+    test_nullable_vector_const<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 30, 20, 38, 28, 38, 28);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 30, 20, 38, 28,
+                                                                                            38, 28);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p6s2_add_decimal32p4s3_eq_decimal32p9s3) {
     DecimalTestCaseArray test_cases = {{"9999.99", "9.999", "10009.989"},
@@ -678,17 +704,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p6s2_add_decimal32p4s3_eq_decima
                                        {"3130.89", "6.757", "3137.647"},
                                        {"-6381.35", "-4.877", "-6386.227"},
                                        {"5306.82", "-3.635", "5303.185"}};
-    test_vector_vector<TYPE_DECIMAL32, AddOp, true>(test_cases, 6, 2, 4, 3, 9, 3);
-    test_vector_vector<TYPE_DECIMAL32, AddOp, false>(test_cases, 6, 2, 4, 3, 9, 3);
-    test_vector_const<TYPE_DECIMAL32, AddOp, true>(test_cases, 6, 2, 4, 3, 9, 3);
-    test_vector_const<TYPE_DECIMAL32, AddOp, false>(test_cases, 6, 2, 4, 3, 9, 3);
-    test_const_vector<TYPE_DECIMAL32, AddOp, true>(test_cases, 6, 2, 4, 3, 9, 3);
-    test_const_vector<TYPE_DECIMAL32, AddOp, false>(test_cases, 6, 2, 4, 3, 9, 3);
-    test_const_const<TYPE_DECIMAL32, AddOp, true>(test_cases, 6, 2, 4, 3, 9, 3);
-    test_const_const<TYPE_DECIMAL32, AddOp, false>(test_cases, 6, 2, 4, 3, 9, 3);
-    test_const_nullable_vector<TYPE_DECIMAL32, AddOp, true>(test_cases, 6, 2, 4, 3, 9, 3);
-    test_nullable_vector_const<TYPE_DECIMAL32, AddOp, true>(test_cases, 6, 2, 4, 3, 9, 3);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL32, AddOp, true>(test_cases, 6, 2, 4, 3, 9, 3);
+    test_vector_vector<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 6, 2, 4, 3, 9, 3);
+    test_vector_vector<TYPE_DECIMAL32, AddOp, OverflowMode::IGNORE>(test_cases, 6, 2, 4, 3, 9, 3);
+    test_vector_const<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 6, 2, 4, 3, 9, 3);
+    test_vector_const<TYPE_DECIMAL32, AddOp, OverflowMode::IGNORE>(test_cases, 6, 2, 4, 3, 9, 3);
+    test_const_vector<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 6, 2, 4, 3, 9, 3);
+    test_const_vector<TYPE_DECIMAL32, AddOp, OverflowMode::IGNORE>(test_cases, 6, 2, 4, 3, 9, 3);
+    test_const_const<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 6, 2, 4, 3, 9, 3);
+    test_const_const<TYPE_DECIMAL32, AddOp, OverflowMode::IGNORE>(test_cases, 6, 2, 4, 3, 9, 3);
+    test_const_nullable_vector<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 6, 2, 4, 3, 9, 3);
+    test_nullable_vector_const<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 6, 2, 4, 3, 9, 3);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 6, 2, 4, 3, 9,
+                                                                                           3);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p9s2_add_decimal64p18s9_eq_decimal64p18s9) {
     DecimalTestCaseArray test_cases = {{"9999999.99", "999999999.999999999", "1009999999.989999999"},
@@ -736,17 +763,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p9s2_add_decimal64p18s9_eq_decim
                                        {"-7395895.68", "-14389308.852363634", "-21785204.532363634"},
                                        {"-3100297.81", "933112676.101379889", "930012378.291379889"},
                                        {"-9657790.77", "-625096544.888136982", "-634754335.658136982"}};
-    test_vector_vector<TYPE_DECIMAL64, AddOp, true>(test_cases, 9, 2, 18, 9, 18, 9);
-    test_vector_vector<TYPE_DECIMAL64, AddOp, false>(test_cases, 9, 2, 18, 9, 18, 9);
-    test_vector_const<TYPE_DECIMAL64, AddOp, true>(test_cases, 9, 2, 18, 9, 18, 9);
-    test_vector_const<TYPE_DECIMAL64, AddOp, false>(test_cases, 9, 2, 18, 9, 18, 9);
-    test_const_vector<TYPE_DECIMAL64, AddOp, true>(test_cases, 9, 2, 18, 9, 18, 9);
-    test_const_vector<TYPE_DECIMAL64, AddOp, false>(test_cases, 9, 2, 18, 9, 18, 9);
-    test_const_const<TYPE_DECIMAL64, AddOp, true>(test_cases, 9, 2, 18, 9, 18, 9);
-    test_const_const<TYPE_DECIMAL64, AddOp, false>(test_cases, 9, 2, 18, 9, 18, 9);
-    test_const_nullable_vector<TYPE_DECIMAL64, AddOp, true>(test_cases, 9, 2, 18, 9, 18, 9);
-    test_nullable_vector_const<TYPE_DECIMAL64, AddOp, true>(test_cases, 9, 2, 18, 9, 18, 9);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL64, AddOp, true>(test_cases, 9, 2, 18, 9, 18, 9);
+    test_vector_vector<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 18, 9, 18, 9);
+    test_vector_vector<TYPE_DECIMAL64, AddOp, OverflowMode::IGNORE>(test_cases, 9, 2, 18, 9, 18, 9);
+    test_vector_const<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 18, 9, 18, 9);
+    test_vector_const<TYPE_DECIMAL64, AddOp, OverflowMode::IGNORE>(test_cases, 9, 2, 18, 9, 18, 9);
+    test_const_vector<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 18, 9, 18, 9);
+    test_const_vector<TYPE_DECIMAL64, AddOp, OverflowMode::IGNORE>(test_cases, 9, 2, 18, 9, 18, 9);
+    test_const_const<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 18, 9, 18, 9);
+    test_const_const<TYPE_DECIMAL64, AddOp, OverflowMode::IGNORE>(test_cases, 9, 2, 18, 9, 18, 9);
+    test_const_nullable_vector<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 18, 9, 18, 9);
+    test_nullable_vector_const<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 18, 9, 18, 9);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 18, 9, 18,
+                                                                                           9);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s29_add_decimal128p28s23_eq_decimal128p38s29) {
     DecimalTestCaseArray test_cases = {
@@ -826,17 +854,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s29_add_decimal128p28s23_eq_
              "346412976.64193176239014856229930720220"},
             {"814713310.91412625460492314804893469799", "14944.19745575522970573657688",
              "814728255.11158200983462888462581469799"}};
-    test_vector_vector<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 29, 28, 23, 38, 29);
-    test_vector_vector<TYPE_DECIMAL128, AddOp, false>(test_cases, 38, 29, 28, 23, 38, 29);
-    test_vector_const<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 29, 28, 23, 38, 29);
-    test_vector_const<TYPE_DECIMAL128, AddOp, false>(test_cases, 38, 29, 28, 23, 38, 29);
-    test_const_vector<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 29, 28, 23, 38, 29);
-    test_const_vector<TYPE_DECIMAL128, AddOp, false>(test_cases, 38, 29, 28, 23, 38, 29);
-    test_const_const<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 29, 28, 23, 38, 29);
-    test_const_const<TYPE_DECIMAL128, AddOp, false>(test_cases, 38, 29, 28, 23, 38, 29);
-    test_const_nullable_vector<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 29, 28, 23, 38, 29);
-    test_nullable_vector_const<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 29, 28, 23, 38, 29);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 29, 28, 23, 38, 29);
+    test_vector_vector<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 29, 28, 23, 38, 29);
+    test_vector_vector<TYPE_DECIMAL128, AddOp, OverflowMode::IGNORE>(test_cases, 38, 29, 28, 23, 38, 29);
+    test_vector_const<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 29, 28, 23, 38, 29);
+    test_vector_const<TYPE_DECIMAL128, AddOp, OverflowMode::IGNORE>(test_cases, 38, 29, 28, 23, 38, 29);
+    test_const_vector<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 29, 28, 23, 38, 29);
+    test_const_vector<TYPE_DECIMAL128, AddOp, OverflowMode::IGNORE>(test_cases, 38, 29, 28, 23, 38, 29);
+    test_const_const<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 29, 28, 23, 38, 29);
+    test_const_const<TYPE_DECIMAL128, AddOp, OverflowMode::IGNORE>(test_cases, 38, 29, 28, 23, 38, 29);
+    test_const_nullable_vector<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 29, 28, 23, 38, 29);
+    test_nullable_vector_const<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 29, 28, 23, 38, 29);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 29, 28, 23,
+                                                                                            38, 29);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p5s5_add_decimal32p6s2_eq_decimal32p9s5) {
     DecimalTestCaseArray test_cases = {{"0.99999", "9999.99", "10000.98999"},
@@ -884,17 +913,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p5s5_add_decimal32p6s2_eq_decima
                                        {"0.86931", "-2649.62", "-2648.75069"},
                                        {"0.46404", "-3843.14", "-3842.67596"},
                                        {"0.93959", "2124.67", "2125.60959"}};
-    test_vector_vector<TYPE_DECIMAL32, AddOp, true>(test_cases, 5, 5, 6, 2, 9, 5);
-    test_vector_vector<TYPE_DECIMAL32, AddOp, false>(test_cases, 5, 5, 6, 2, 9, 5);
-    test_vector_const<TYPE_DECIMAL32, AddOp, true>(test_cases, 5, 5, 6, 2, 9, 5);
-    test_vector_const<TYPE_DECIMAL32, AddOp, false>(test_cases, 5, 5, 6, 2, 9, 5);
-    test_const_vector<TYPE_DECIMAL32, AddOp, true>(test_cases, 5, 5, 6, 2, 9, 5);
-    test_const_vector<TYPE_DECIMAL32, AddOp, false>(test_cases, 5, 5, 6, 2, 9, 5);
-    test_const_const<TYPE_DECIMAL32, AddOp, true>(test_cases, 5, 5, 6, 2, 9, 5);
-    test_const_const<TYPE_DECIMAL32, AddOp, false>(test_cases, 5, 5, 6, 2, 9, 5);
-    test_const_nullable_vector<TYPE_DECIMAL32, AddOp, true>(test_cases, 5, 5, 6, 2, 9, 5);
-    test_nullable_vector_const<TYPE_DECIMAL32, AddOp, true>(test_cases, 5, 5, 6, 2, 9, 5);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL32, AddOp, true>(test_cases, 5, 5, 6, 2, 9, 5);
+    test_vector_vector<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 5, 6, 2, 9, 5);
+    test_vector_vector<TYPE_DECIMAL32, AddOp, OverflowMode::IGNORE>(test_cases, 5, 5, 6, 2, 9, 5);
+    test_vector_const<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 5, 6, 2, 9, 5);
+    test_vector_const<TYPE_DECIMAL32, AddOp, OverflowMode::IGNORE>(test_cases, 5, 5, 6, 2, 9, 5);
+    test_const_vector<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 5, 6, 2, 9, 5);
+    test_const_vector<TYPE_DECIMAL32, AddOp, OverflowMode::IGNORE>(test_cases, 5, 5, 6, 2, 9, 5);
+    test_const_const<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 5, 6, 2, 9, 5);
+    test_const_const<TYPE_DECIMAL32, AddOp, OverflowMode::IGNORE>(test_cases, 5, 5, 6, 2, 9, 5);
+    test_const_nullable_vector<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 5, 6, 2, 9, 5);
+    test_nullable_vector_const<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 5, 6, 2, 9, 5);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 5, 6, 2, 9,
+                                                                                           5);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p18s11_add_decimal64p12s5_eq_decimal64p18s11) {
     DecimalTestCaseArray test_cases = {{"9999999.99999999999", "9999999.99999", "19999999.99998999999"},
@@ -942,17 +972,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p18s11_add_decimal64p12s5_eq_dec
                                        {"310474.86147925182", "6780992.77370", "7091467.63517925182"},
                                        {"7066952.79949447594", "2017203.20571", "9084156.00520447594"},
                                        {"-6160737.94855374226", "-807330.86052", "-6968068.80907374226"}};
-    test_vector_vector<TYPE_DECIMAL64, AddOp, true>(test_cases, 18, 11, 12, 5, 18, 11);
-    test_vector_vector<TYPE_DECIMAL64, AddOp, false>(test_cases, 18, 11, 12, 5, 18, 11);
-    test_vector_const<TYPE_DECIMAL64, AddOp, true>(test_cases, 18, 11, 12, 5, 18, 11);
-    test_vector_const<TYPE_DECIMAL64, AddOp, false>(test_cases, 18, 11, 12, 5, 18, 11);
-    test_const_vector<TYPE_DECIMAL64, AddOp, true>(test_cases, 18, 11, 12, 5, 18, 11);
-    test_const_vector<TYPE_DECIMAL64, AddOp, false>(test_cases, 18, 11, 12, 5, 18, 11);
-    test_const_const<TYPE_DECIMAL64, AddOp, true>(test_cases, 18, 11, 12, 5, 18, 11);
-    test_const_const<TYPE_DECIMAL64, AddOp, false>(test_cases, 18, 11, 12, 5, 18, 11);
-    test_const_nullable_vector<TYPE_DECIMAL64, AddOp, true>(test_cases, 18, 11, 12, 5, 18, 11);
-    test_nullable_vector_const<TYPE_DECIMAL64, AddOp, true>(test_cases, 18, 11, 12, 5, 18, 11);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL64, AddOp, true>(test_cases, 18, 11, 12, 5, 18, 11);
+    test_vector_vector<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 11, 12, 5, 18, 11);
+    test_vector_vector<TYPE_DECIMAL64, AddOp, OverflowMode::IGNORE>(test_cases, 18, 11, 12, 5, 18, 11);
+    test_vector_const<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 11, 12, 5, 18, 11);
+    test_vector_const<TYPE_DECIMAL64, AddOp, OverflowMode::IGNORE>(test_cases, 18, 11, 12, 5, 18, 11);
+    test_const_vector<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 11, 12, 5, 18, 11);
+    test_const_vector<TYPE_DECIMAL64, AddOp, OverflowMode::IGNORE>(test_cases, 18, 11, 12, 5, 18, 11);
+    test_const_const<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 11, 12, 5, 18, 11);
+    test_const_const<TYPE_DECIMAL64, AddOp, OverflowMode::IGNORE>(test_cases, 18, 11, 12, 5, 18, 11);
+    test_const_nullable_vector<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 11, 12, 5, 18, 11);
+    test_nullable_vector_const<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 11, 12, 5, 18, 11);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 11, 12, 5,
+                                                                                           18, 11);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s38_add_decimal128p38s38_eq_decimal128p38s38) {
     DecimalTestCaseArray test_cases = {
@@ -1029,17 +1060,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s38_add_decimal128p38s38_eq_
              "-0.33748787165569134455062427983875276083"},
             {"-0.67467574067481850167560732049745640318", "-0.82039350481122346181845032396528195764",
              "-1.49506924548604196349405764446273836082"}};
-    test_vector_vector<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 38, 38, 38, 38, 38);
-    test_vector_vector<TYPE_DECIMAL128, AddOp, false>(test_cases, 38, 38, 38, 38, 38, 38);
-    test_vector_const<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 38, 38, 38, 38, 38);
-    test_vector_const<TYPE_DECIMAL128, AddOp, false>(test_cases, 38, 38, 38, 38, 38, 38);
-    test_const_vector<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 38, 38, 38, 38, 38);
-    test_const_vector<TYPE_DECIMAL128, AddOp, false>(test_cases, 38, 38, 38, 38, 38, 38);
-    test_const_const<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 38, 38, 38, 38, 38);
-    test_const_const<TYPE_DECIMAL128, AddOp, false>(test_cases, 38, 38, 38, 38, 38, 38);
-    test_const_nullable_vector<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 38, 38, 38, 38, 38);
-    test_nullable_vector_const<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 38, 38, 38, 38, 38);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, AddOp, true>(test_cases, 38, 38, 38, 38, 38, 38);
+    test_vector_vector<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 38, 38, 38, 38, 38);
+    test_vector_vector<TYPE_DECIMAL128, AddOp, OverflowMode::IGNORE>(test_cases, 38, 38, 38, 38, 38, 38);
+    test_vector_const<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 38, 38, 38, 38, 38);
+    test_vector_const<TYPE_DECIMAL128, AddOp, OverflowMode::IGNORE>(test_cases, 38, 38, 38, 38, 38, 38);
+    test_const_vector<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 38, 38, 38, 38, 38);
+    test_const_vector<TYPE_DECIMAL128, AddOp, OverflowMode::IGNORE>(test_cases, 38, 38, 38, 38, 38, 38);
+    test_const_const<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 38, 38, 38, 38, 38);
+    test_const_const<TYPE_DECIMAL128, AddOp, OverflowMode::IGNORE>(test_cases, 38, 38, 38, 38, 38, 38);
+    test_const_nullable_vector<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 38, 38, 38, 38, 38);
+    test_nullable_vector_const<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 38, 38, 38, 38, 38);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 38, 38, 38,
+                                                                                            38, 38);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p9s2_add_decimal32p9s2_eq_decimal32p9s2) {
     DecimalTestCaseArray test_cases = {{"9999999.99", "9999999.99", "19999999.98"},
@@ -1087,14 +1119,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p9s2_add_decimal32p9s2_eq_decima
                                        {"4367854.80", "2928178.33", "7296033.13"},
                                        {"4977479.77", "-7748164.05", "-2770684.28"},
                                        {"8140199.01", "6887181.94", "15027380.95"}};
-    test_vector_vector<TYPE_DECIMAL32, AddOp, true>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_vector_vector<TYPE_DECIMAL32, AddOp, false>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_vector_const<TYPE_DECIMAL32, AddOp, true>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_vector_const<TYPE_DECIMAL32, AddOp, false>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_const_vector<TYPE_DECIMAL32, AddOp, true>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_const_vector<TYPE_DECIMAL32, AddOp, false>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_const_const<TYPE_DECIMAL32, AddOp, true>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_const_const<TYPE_DECIMAL32, AddOp, false>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_vector_vector<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_vector_vector<TYPE_DECIMAL32, AddOp, OverflowMode::IGNORE>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_vector_const<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_vector_const<TYPE_DECIMAL32, AddOp, OverflowMode::IGNORE>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_const_vector<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_const_vector<TYPE_DECIMAL32, AddOp, OverflowMode::IGNORE>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_const_const<TYPE_DECIMAL32, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_const_const<TYPE_DECIMAL32, AddOp, OverflowMode::IGNORE>(test_cases, 9, 2, 9, 2, 9, 2);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p17s9_add_decimal64p17s9_eq_decimal64p18s9) {
     DecimalTestCaseArray test_cases = {{"99999999.999999999", "99999999.999999999", "199999999.999999998"},
@@ -1142,14 +1174,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p17s9_add_decimal64p17s9_eq_deci
                                        {"-62876211.621087932", "86876581.959110312", "24000370.338022380"},
                                        {"76564882.553342952", "-91266268.954760214", "-14701386.401417262"},
                                        {"-50140855.530337280", "-35274287.273107290", "-85415142.803444570"}};
-    test_vector_vector<TYPE_DECIMAL64, AddOp, true>(test_cases, 17, 9, 17, 9, 18, 9);
-    test_vector_vector<TYPE_DECIMAL64, AddOp, false>(test_cases, 17, 9, 17, 9, 18, 9);
-    test_vector_const<TYPE_DECIMAL64, AddOp, true>(test_cases, 17, 9, 17, 9, 18, 9);
-    test_vector_const<TYPE_DECIMAL64, AddOp, false>(test_cases, 17, 9, 17, 9, 18, 9);
-    test_const_vector<TYPE_DECIMAL64, AddOp, true>(test_cases, 17, 9, 17, 9, 18, 9);
-    test_const_vector<TYPE_DECIMAL64, AddOp, false>(test_cases, 17, 9, 17, 9, 18, 9);
-    test_const_const<TYPE_DECIMAL64, AddOp, true>(test_cases, 17, 9, 17, 9, 18, 9);
-    test_const_const<TYPE_DECIMAL64, AddOp, false>(test_cases, 17, 9, 17, 9, 18, 9);
+    test_vector_vector<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 17, 9, 17, 9, 18, 9);
+    test_vector_vector<TYPE_DECIMAL64, AddOp, OverflowMode::IGNORE>(test_cases, 17, 9, 17, 9, 18, 9);
+    test_vector_const<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 17, 9, 17, 9, 18, 9);
+    test_vector_const<TYPE_DECIMAL64, AddOp, OverflowMode::IGNORE>(test_cases, 17, 9, 17, 9, 18, 9);
+    test_const_vector<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 17, 9, 17, 9, 18, 9);
+    test_const_vector<TYPE_DECIMAL64, AddOp, OverflowMode::IGNORE>(test_cases, 17, 9, 17, 9, 18, 9);
+    test_const_const<TYPE_DECIMAL64, AddOp, OverflowMode::OUTPUT_NULL>(test_cases, 17, 9, 17, 9, 18, 9);
+    test_const_const<TYPE_DECIMAL64, AddOp, OverflowMode::IGNORE>(test_cases, 17, 9, 17, 9, 18, 9);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p15s11_div_decimal128p25s22_eq_decimal128p38s12) {
     DecimalTestCaseArray test_cases = {{"9999.99999999999", "999.9999999999999999999999", "10"},
@@ -1197,17 +1229,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p15s11_div_decimal128p25s22_eq_
                                        {"1352.82423985800", "-547.3441345315043848260712", "-2.471615487423"},
                                        {"729.55662250914", "380.6496092864635723207224", "1.916609408523"},
                                        {"-1585.50133094284", "347.3142457187999537378553", "-4.565033972797"}};
-    test_vector_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 15, 11, 25, 22, 38, 12);
-    test_vector_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 15, 11, 25, 22, 38, 12);
-    test_vector_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 15, 11, 25, 22, 38, 12);
-    test_vector_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 15, 11, 25, 22, 38, 12);
-    test_const_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 15, 11, 25, 22, 38, 12);
-    test_const_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 15, 11, 25, 22, 38, 12);
-    test_const_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 15, 11, 25, 22, 38, 12);
-    test_const_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 15, 11, 25, 22, 38, 12);
-    test_const_nullable_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 15, 11, 25, 22, 38, 12);
-    test_nullable_vector_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 15, 11, 25, 22, 38, 12);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 15, 11, 25, 22, 38, 12);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 15, 11, 25, 22, 38, 12);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 15, 11, 25, 22, 38, 12);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 15, 11, 25, 22, 38, 12);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 15, 11, 25, 22, 38, 12);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 15, 11, 25, 22, 38, 12);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 15, 11, 25, 22, 38, 12);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 15, 11, 25, 22, 38, 12);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 15, 11, 25, 22, 38, 12);
+    test_const_nullable_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 15, 11, 25, 22, 38, 12);
+    test_nullable_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 15, 11, 25, 22, 38, 12);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 15, 11, 25, 22,
+                                                                                            38, 12);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p7s2_div_decimal32p3s2_eq_decimal128p38s8) {
     DecimalTestCaseArray test_cases = {{"99999.99", "9.99", "10010.00900901"},
@@ -1255,17 +1288,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p7s2_div_decimal32p3s2_eq_decima
                                        {"-97770.51", "-5.82", "16799.05670103"},
                                        {"-27003.53", "4.11", "-6570.20194647"},
                                        {"-34864.13", "-2.06", "16924.33495146"}};
-    test_vector_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 7, 2, 3, 2, 38, 8);
-    test_vector_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 7, 2, 3, 2, 38, 8);
-    test_vector_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 7, 2, 3, 2, 38, 8);
-    test_vector_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 7, 2, 3, 2, 38, 8);
-    test_const_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 7, 2, 3, 2, 38, 8);
-    test_const_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 7, 2, 3, 2, 38, 8);
-    test_const_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 7, 2, 3, 2, 38, 8);
-    test_const_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 7, 2, 3, 2, 38, 8);
-    test_const_nullable_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 7, 2, 3, 2, 38, 8);
-    test_nullable_vector_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 7, 2, 3, 2, 38, 8);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 7, 2, 3, 2, 38, 8);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 2, 3, 2, 38, 8);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 7, 2, 3, 2, 38, 8);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 2, 3, 2, 38, 8);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 7, 2, 3, 2, 38, 8);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 2, 3, 2, 38, 8);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 7, 2, 3, 2, 38, 8);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 2, 3, 2, 38, 8);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 7, 2, 3, 2, 38, 8);
+    test_const_nullable_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 2, 3, 2, 38, 8);
+    test_nullable_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 2, 3, 2, 38, 8);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 2, 3, 2, 38,
+                                                                                            8);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p12s8_div_decimal64p9s6_eq_decimal128p38s12) {
     DecimalTestCaseArray test_cases = {{"9999.99999999", "999.999999", "10.000000009990"},
@@ -1313,14 +1347,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p12s8_div_decimal64p9s6_eq_decim
                                        {"6398.69670583", "565.243257", "11.320253053156"},
                                        {"-9450.30961930", "24.258915", "-389.560275853228"},
                                        {"1558.23869752", "-496.994912", "-3.135321227433"}};
-    test_vector_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 12, 8, 9, 6, 38, 12);
-    test_vector_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 12, 8, 9, 6, 38, 12);
-    test_vector_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 12, 8, 9, 6, 38, 12);
-    test_vector_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 12, 8, 9, 6, 38, 12);
-    test_const_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 12, 8, 9, 6, 38, 12);
-    test_const_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 12, 8, 9, 6, 38, 12);
-    test_const_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 12, 8, 9, 6, 38, 12);
-    test_const_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 12, 8, 9, 6, 38, 12);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 12, 8, 9, 6, 38, 12);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 12, 8, 9, 6, 38, 12);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 12, 8, 9, 6, 38, 12);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 12, 8, 9, 6, 38, 12);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 12, 8, 9, 6, 38, 12);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 12, 8, 9, 6, 38, 12);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 12, 8, 9, 6, 38, 12);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 12, 8, 9, 6, 38, 12);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p25s17_div_decimal128p9s0_eq_decimal128p38s17) {
     DecimalTestCaseArray test_cases = {{"99999999.99999999999999999", "999999999", "0.10000000010000000"},
@@ -1368,14 +1402,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p25s17_div_decimal128p9s0_eq_de
                                        {"68225778.23064308437573415", "-769973761", "-0.08860792625197404"},
                                        {"47367143.19011734346518047", "610301254", "0.07761272466616518"},
                                        {"85848629.92129111690055903", "364576713", "0.23547480368361080"}};
-    test_vector_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 25, 17, 9, 0, 38, 17);
-    test_vector_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 25, 17, 9, 0, 38, 17);
-    test_vector_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 25, 17, 9, 0, 38, 17);
-    test_vector_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 25, 17, 9, 0, 38, 17);
-    test_const_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 25, 17, 9, 0, 38, 17);
-    test_const_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 25, 17, 9, 0, 38, 17);
-    test_const_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 25, 17, 9, 0, 38, 17);
-    test_const_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 25, 17, 9, 0, 38, 17);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 25, 17, 9, 0, 38, 17);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 25, 17, 9, 0, 38, 17);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 25, 17, 9, 0, 38, 17);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 25, 17, 9, 0, 38, 17);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 25, 17, 9, 0, 38, 17);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 25, 17, 9, 0, 38, 17);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 25, 17, 9, 0, 38, 17);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 25, 17, 9, 0, 38, 17);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p9s3_div_decimal32p3s0_eq_decimal128p38s9) {
     DecimalTestCaseArray test_cases = {{"999999.999", "999", "1001.001000000"},
@@ -1423,14 +1457,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p9s3_div_decimal32p3s0_eq_decima
                                        {"242121.137", "973", "248.839811922"},
                                        {"-193814.768", "-446", "434.562260090"},
                                        {"-240048.747", "-929", "258.394776103"}};
-    test_vector_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 9, 3, 3, 0, 38, 9);
-    test_vector_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 9, 3, 3, 0, 38, 9);
-    test_vector_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 9, 3, 3, 0, 38, 9);
-    test_vector_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 9, 3, 3, 0, 38, 9);
-    test_const_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 9, 3, 3, 0, 38, 9);
-    test_const_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 9, 3, 3, 0, 38, 9);
-    test_const_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 9, 3, 3, 0, 38, 9);
-    test_const_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 9, 3, 3, 0, 38, 9);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 3, 3, 0, 38, 9);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 9, 3, 3, 0, 38, 9);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 3, 3, 0, 38, 9);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 9, 3, 3, 0, 38, 9);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 3, 3, 0, 38, 9);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 9, 3, 3, 0, 38, 9);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 3, 3, 0, 38, 9);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 9, 3, 3, 0, 38, 9);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p17s2_div_decimal64p15s0_eq_decimal128p38s8) {
     DecimalTestCaseArray test_cases = {{"999999999999999.99", "999999999999999", "1"},
@@ -1478,14 +1512,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p17s2_div_decimal64p15s0_eq_deci
                                        {"372085889948693.63", "936797518158384", "0.39718924"},
                                        {"904482717533081.91", "-425466412804779", "-2.12586162"},
                                        {"446252633031284.02", "-512319100731698", "-0.87104430"}};
-    test_vector_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 17, 2, 15, 0, 38, 8);
-    test_vector_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 17, 2, 15, 0, 38, 8);
-    test_vector_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 17, 2, 15, 0, 38, 8);
-    test_vector_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 17, 2, 15, 0, 38, 8);
-    test_const_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 17, 2, 15, 0, 38, 8);
-    test_const_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 17, 2, 15, 0, 38, 8);
-    test_const_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 17, 2, 15, 0, 38, 8);
-    test_const_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 17, 2, 15, 0, 38, 8);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 17, 2, 15, 0, 38, 8);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 17, 2, 15, 0, 38, 8);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 17, 2, 15, 0, 38, 8);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 17, 2, 15, 0, 38, 8);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 17, 2, 15, 0, 38, 8);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 17, 2, 15, 0, 38, 8);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 17, 2, 15, 0, 38, 8);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 17, 2, 15, 0, 38, 8);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p7s0_div_decimal32p3s1_eq_decimal128p38s6) {
     DecimalTestCaseArray test_cases = {{"9999999", "99.9", "100100.090090"},
@@ -1533,14 +1567,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p7s0_div_decimal32p3s1_eq_decima
                                        {"5811623", "-66.7", "-87130.779610"},
                                        {"2207779", "99.4", "22211.056338"},
                                        {"-542981", "87.4", "-6212.597254"}};
-    test_vector_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 7, 0, 3, 1, 38, 6);
-    test_vector_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 7, 0, 3, 1, 38, 6);
-    test_vector_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 7, 0, 3, 1, 38, 6);
-    test_vector_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 7, 0, 3, 1, 38, 6);
-    test_const_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 7, 0, 3, 1, 38, 6);
-    test_const_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 7, 0, 3, 1, 38, 6);
-    test_const_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 7, 0, 3, 1, 38, 6);
-    test_const_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 7, 0, 3, 1, 38, 6);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 0, 3, 1, 38, 6);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 7, 0, 3, 1, 38, 6);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 0, 3, 1, 38, 6);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 7, 0, 3, 1, 38, 6);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 0, 3, 1, 38, 6);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 7, 0, 3, 1, 38, 6);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 0, 3, 1, 38, 6);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 7, 0, 3, 1, 38, 6);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p19s0_mod_decimal128p25s10_eq_decimal128p38s10) {
     DecimalTestCaseArray test_cases = {
@@ -1589,17 +1623,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p19s0_mod_decimal128p25s10_eq_d
             {"-7341118520804255717", "626477587531744.1469953720", "-54150107277802.5082309040"},
             {"-1203448675473009682", "40966023177328.8636775864", "-30778615796982.6072219136"},
             {"-4287335955395136634", "354431798245120.1851337606", "-128923822162874.6220317824"}};
-    test_vector_vector<TYPE_DECIMAL128, ModOp, true>(test_cases, 19, 0, 25, 10, 38, 10);
-    test_vector_vector<TYPE_DECIMAL128, ModOp, false>(test_cases, 19, 0, 25, 10, 38, 10);
-    test_vector_const<TYPE_DECIMAL128, ModOp, true>(test_cases, 19, 0, 25, 10, 38, 10);
-    test_vector_const<TYPE_DECIMAL128, ModOp, false>(test_cases, 19, 0, 25, 10, 38, 10);
-    test_const_vector<TYPE_DECIMAL128, ModOp, true>(test_cases, 19, 0, 25, 10, 38, 10);
-    test_const_vector<TYPE_DECIMAL128, ModOp, false>(test_cases, 19, 0, 25, 10, 38, 10);
-    test_const_const<TYPE_DECIMAL128, ModOp, true>(test_cases, 19, 0, 25, 10, 38, 10);
-    test_const_const<TYPE_DECIMAL128, ModOp, false>(test_cases, 19, 0, 25, 10, 38, 10);
-    test_const_nullable_vector<TYPE_DECIMAL128, ModOp, true>(test_cases, 19, 0, 25, 10, 38, 10);
-    test_nullable_vector_const<TYPE_DECIMAL128, ModOp, true>(test_cases, 19, 0, 25, 10, 38, 10);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, ModOp, true>(test_cases, 19, 0, 25, 10, 38, 10);
+    test_vector_vector<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 19, 0, 25, 10, 38, 10);
+    test_vector_vector<TYPE_DECIMAL128, ModOp, OverflowMode::IGNORE>(test_cases, 19, 0, 25, 10, 38, 10);
+    test_vector_const<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 19, 0, 25, 10, 38, 10);
+    test_vector_const<TYPE_DECIMAL128, ModOp, OverflowMode::IGNORE>(test_cases, 19, 0, 25, 10, 38, 10);
+    test_const_vector<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 19, 0, 25, 10, 38, 10);
+    test_const_vector<TYPE_DECIMAL128, ModOp, OverflowMode::IGNORE>(test_cases, 19, 0, 25, 10, 38, 10);
+    test_const_const<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 19, 0, 25, 10, 38, 10);
+    test_const_const<TYPE_DECIMAL128, ModOp, OverflowMode::IGNORE>(test_cases, 19, 0, 25, 10, 38, 10);
+    test_const_nullable_vector<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 19, 0, 25, 10, 38, 10);
+    test_nullable_vector_const<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 19, 0, 25, 10, 38, 10);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 19, 0, 25, 10,
+                                                                                            38, 10);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p7s0_mod_decimal32p3s1_eq_decimal32p9s1) {
     DecimalTestCaseArray test_cases = {{"9999999", "99.9", "9"},
@@ -1647,17 +1682,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p7s0_mod_decimal32p3s1_eq_decima
                                        {"8204400", "-79.7", "2.3"},
                                        {"3174301", "93.5", "69.5"},
                                        {"-280267", "93.8", "-86.4"}};
-    test_vector_vector<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 0, 3, 1, 9, 1);
-    test_vector_vector<TYPE_DECIMAL32, ModOp, false>(test_cases, 7, 0, 3, 1, 9, 1);
-    test_vector_const<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 0, 3, 1, 9, 1);
-    test_vector_const<TYPE_DECIMAL32, ModOp, false>(test_cases, 7, 0, 3, 1, 9, 1);
-    test_const_vector<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 0, 3, 1, 9, 1);
-    test_const_vector<TYPE_DECIMAL32, ModOp, false>(test_cases, 7, 0, 3, 1, 9, 1);
-    test_const_const<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 0, 3, 1, 9, 1);
-    test_const_const<TYPE_DECIMAL32, ModOp, false>(test_cases, 7, 0, 3, 1, 9, 1);
-    test_const_nullable_vector<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 0, 3, 1, 9, 1);
-    test_nullable_vector_const<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 0, 3, 1, 9, 1);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 0, 3, 1, 9, 1);
+    test_vector_vector<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 0, 3, 1, 9, 1);
+    test_vector_vector<TYPE_DECIMAL32, ModOp, OverflowMode::IGNORE>(test_cases, 7, 0, 3, 1, 9, 1);
+    test_vector_const<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 0, 3, 1, 9, 1);
+    test_vector_const<TYPE_DECIMAL32, ModOp, OverflowMode::IGNORE>(test_cases, 7, 0, 3, 1, 9, 1);
+    test_const_vector<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 0, 3, 1, 9, 1);
+    test_const_vector<TYPE_DECIMAL32, ModOp, OverflowMode::IGNORE>(test_cases, 7, 0, 3, 1, 9, 1);
+    test_const_const<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 0, 3, 1, 9, 1);
+    test_const_const<TYPE_DECIMAL32, ModOp, OverflowMode::IGNORE>(test_cases, 7, 0, 3, 1, 9, 1);
+    test_const_nullable_vector<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 0, 3, 1, 9, 1);
+    test_nullable_vector_const<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 0, 3, 1, 9, 1);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 0, 3, 1, 9,
+                                                                                           1);
 }
 
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p10s0_mod_decimal64p9s5_eq_decimal64p18s5) {
@@ -1706,17 +1742,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p10s0_mod_decimal64p9s5_eq_decim
                                        {"6165666620", "3528.43279", "2008.79983"},
                                        {"-847919062", "-6873.70436", "-6386.96784"},
                                        {"3073937658", "-9682.00813", "6578.81443"}};
-    test_vector_vector<TYPE_DECIMAL64, ModOp, true>(test_cases, 10, 0, 9, 5, 18, 5);
-    test_vector_vector<TYPE_DECIMAL64, ModOp, false>(test_cases, 10, 0, 9, 5, 18, 5);
-    test_vector_const<TYPE_DECIMAL64, ModOp, true>(test_cases, 10, 0, 9, 5, 18, 5);
-    test_vector_const<TYPE_DECIMAL64, ModOp, false>(test_cases, 10, 0, 9, 5, 18, 5);
-    test_const_vector<TYPE_DECIMAL64, ModOp, true>(test_cases, 10, 0, 9, 5, 18, 5);
-    test_const_vector<TYPE_DECIMAL64, ModOp, false>(test_cases, 10, 0, 9, 5, 18, 5);
-    test_const_const<TYPE_DECIMAL64, ModOp, true>(test_cases, 10, 0, 9, 5, 18, 5);
-    test_const_const<TYPE_DECIMAL64, ModOp, false>(test_cases, 10, 0, 9, 5, 18, 5);
-    test_const_nullable_vector<TYPE_DECIMAL64, ModOp, true>(test_cases, 10, 0, 9, 5, 18, 5);
-    test_nullable_vector_const<TYPE_DECIMAL64, ModOp, true>(test_cases, 10, 0, 9, 5, 18, 5);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL64, ModOp, true>(test_cases, 10, 0, 9, 5, 18, 5);
+    test_vector_vector<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 10, 0, 9, 5, 18, 5);
+    test_vector_vector<TYPE_DECIMAL64, ModOp, OverflowMode::IGNORE>(test_cases, 10, 0, 9, 5, 18, 5);
+    test_vector_const<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 10, 0, 9, 5, 18, 5);
+    test_vector_const<TYPE_DECIMAL64, ModOp, OverflowMode::IGNORE>(test_cases, 10, 0, 9, 5, 18, 5);
+    test_const_vector<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 10, 0, 9, 5, 18, 5);
+    test_const_vector<TYPE_DECIMAL64, ModOp, OverflowMode::IGNORE>(test_cases, 10, 0, 9, 5, 18, 5);
+    test_const_const<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 10, 0, 9, 5, 18, 5);
+    test_const_const<TYPE_DECIMAL64, ModOp, OverflowMode::IGNORE>(test_cases, 10, 0, 9, 5, 18, 5);
+    test_const_nullable_vector<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 10, 0, 9, 5, 18, 5);
+    test_nullable_vector_const<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 10, 0, 9, 5, 18, 5);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 10, 0, 9, 5, 18,
+                                                                                           5);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p15s0_div_decimal128p25s17_eq_decimal128p38s6) {
     DecimalTestCaseArray test_cases = {{"999999999999999", "99999999.99999999999999999", "10000000"},
@@ -1764,14 +1801,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p15s0_div_decimal128p25s17_eq_d
                                        {"-192687054134394", "20305515.96744102909828465", "-9489394.627714"},
                                        {"-574633718564171", "26995620.02571797212079092", "-21286183.388888"},
                                        {"-562422579463537", "-40941330.91455957957681706", "13737281.297407"}};
-    test_vector_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 15, 0, 25, 17, 38, 6);
-    test_vector_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 15, 0, 25, 17, 38, 6);
-    test_vector_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 15, 0, 25, 17, 38, 6);
-    test_vector_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 15, 0, 25, 17, 38, 6);
-    test_const_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 15, 0, 25, 17, 38, 6);
-    test_const_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 15, 0, 25, 17, 38, 6);
-    test_const_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 15, 0, 25, 17, 38, 6);
-    test_const_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 15, 0, 25, 17, 38, 6);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 15, 0, 25, 17, 38, 6);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 15, 0, 25, 17, 38, 6);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 15, 0, 25, 17, 38, 6);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 15, 0, 25, 17, 38, 6);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 15, 0, 25, 17, 38, 6);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 15, 0, 25, 17, 38, 6);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 15, 0, 25, 17, 38, 6);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 15, 0, 25, 17, 38, 6);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p13s0_div_decimal64p9s3_eq_decimal128p38s6) {
     DecimalTestCaseArray test_cases = {{"9999999999999", "999999.999", "10000000.009999"},
@@ -1819,14 +1856,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p13s0_div_decimal64p9s3_eq_decim
                                        {"9732313140496", "-564089.673", "-17253131.206492"},
                                        {"-8313546164646", "-961638.869", "8645185.248482"},
                                        {"211575831776", "-156421.503", "-1352600.682887"}};
-    test_vector_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 13, 0, 9, 3, 38, 6);
-    test_vector_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 13, 0, 9, 3, 38, 6);
-    test_vector_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 13, 0, 9, 3, 38, 6);
-    test_vector_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 13, 0, 9, 3, 38, 6);
-    test_const_vector<TYPE_DECIMAL128, DivOp, true>(test_cases, 13, 0, 9, 3, 38, 6);
-    test_const_vector<TYPE_DECIMAL128, DivOp, false>(test_cases, 13, 0, 9, 3, 38, 6);
-    test_const_const<TYPE_DECIMAL128, DivOp, true>(test_cases, 13, 0, 9, 3, 38, 6);
-    test_const_const<TYPE_DECIMAL128, DivOp, false>(test_cases, 13, 0, 9, 3, 38, 6);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 13, 0, 9, 3, 38, 6);
+    test_vector_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 13, 0, 9, 3, 38, 6);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 13, 0, 9, 3, 38, 6);
+    test_vector_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 13, 0, 9, 3, 38, 6);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 13, 0, 9, 3, 38, 6);
+    test_const_vector<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 13, 0, 9, 3, 38, 6);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_cases, 13, 0, 9, 3, 38, 6);
+    test_const_const<TYPE_DECIMAL128, DivOp, OverflowMode::IGNORE>(test_cases, 13, 0, 9, 3, 38, 6);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p14s11_mod_decimal128p25s24_eq_decimal128p38s24) {
     DecimalTestCaseArray test_cases = {
@@ -1875,14 +1912,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p14s11_mod_decimal128p25s24_eq_
             {"-89.98857039894", "-5.219267312564343871218155", "-1.261026085346154189291365"},
             {"-417.25741255056", "-9.615706041593941633216225", "-3.782052762020509771702325"},
             {"-550.40864136515", "8.919012908470573845421394", "-6.348853948444995429294966"}};
-    test_vector_vector<TYPE_DECIMAL128, ModOp, true>(test_cases, 14, 11, 25, 24, 38, 24);
-    test_vector_vector<TYPE_DECIMAL128, ModOp, false>(test_cases, 14, 11, 25, 24, 38, 24);
-    test_vector_const<TYPE_DECIMAL128, ModOp, true>(test_cases, 14, 11, 25, 24, 38, 24);
-    test_vector_const<TYPE_DECIMAL128, ModOp, false>(test_cases, 14, 11, 25, 24, 38, 24);
-    test_const_vector<TYPE_DECIMAL128, ModOp, true>(test_cases, 14, 11, 25, 24, 38, 24);
-    test_const_vector<TYPE_DECIMAL128, ModOp, false>(test_cases, 14, 11, 25, 24, 38, 24);
-    test_const_const<TYPE_DECIMAL128, ModOp, true>(test_cases, 14, 11, 25, 24, 38, 24);
-    test_const_const<TYPE_DECIMAL128, ModOp, false>(test_cases, 14, 11, 25, 24, 38, 24);
+    test_vector_vector<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 14, 11, 25, 24, 38, 24);
+    test_vector_vector<TYPE_DECIMAL128, ModOp, OverflowMode::IGNORE>(test_cases, 14, 11, 25, 24, 38, 24);
+    test_vector_const<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 14, 11, 25, 24, 38, 24);
+    test_vector_const<TYPE_DECIMAL128, ModOp, OverflowMode::IGNORE>(test_cases, 14, 11, 25, 24, 38, 24);
+    test_const_vector<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 14, 11, 25, 24, 38, 24);
+    test_const_vector<TYPE_DECIMAL128, ModOp, OverflowMode::IGNORE>(test_cases, 14, 11, 25, 24, 38, 24);
+    test_const_const<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 14, 11, 25, 24, 38, 24);
+    test_const_const<TYPE_DECIMAL128, ModOp, OverflowMode::IGNORE>(test_cases, 14, 11, 25, 24, 38, 24);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p7s2_mod_decimal32p3s2_eq_decimal32p9s2) {
     DecimalTestCaseArray test_cases = {{"99999.99", "9.99", "0.09"},
@@ -1930,14 +1967,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p7s2_mod_decimal32p3s2_eq_decima
                                        {"-88487.59", "1.71", "-0.22"},
                                        {"-62357.07", "-4.26", "-3.45"},
                                        {"-34972.69", "-0.71", "-0.22"}};
-    test_vector_vector<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 2, 3, 2, 9, 2);
-    test_vector_vector<TYPE_DECIMAL32, ModOp, false>(test_cases, 7, 2, 3, 2, 9, 2);
-    test_vector_const<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 2, 3, 2, 9, 2);
-    test_vector_const<TYPE_DECIMAL32, ModOp, false>(test_cases, 7, 2, 3, 2, 9, 2);
-    test_const_vector<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 2, 3, 2, 9, 2);
-    test_const_vector<TYPE_DECIMAL32, ModOp, false>(test_cases, 7, 2, 3, 2, 9, 2);
-    test_const_const<TYPE_DECIMAL32, ModOp, true>(test_cases, 7, 2, 3, 2, 9, 2);
-    test_const_const<TYPE_DECIMAL32, ModOp, false>(test_cases, 7, 2, 3, 2, 9, 2);
+    test_vector_vector<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 2, 3, 2, 9, 2);
+    test_vector_vector<TYPE_DECIMAL32, ModOp, OverflowMode::IGNORE>(test_cases, 7, 2, 3, 2, 9, 2);
+    test_vector_const<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 2, 3, 2, 9, 2);
+    test_vector_const<TYPE_DECIMAL32, ModOp, OverflowMode::IGNORE>(test_cases, 7, 2, 3, 2, 9, 2);
+    test_const_vector<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 2, 3, 2, 9, 2);
+    test_const_vector<TYPE_DECIMAL32, ModOp, OverflowMode::IGNORE>(test_cases, 7, 2, 3, 2, 9, 2);
+    test_const_const<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 7, 2, 3, 2, 9, 2);
+    test_const_const<TYPE_DECIMAL32, ModOp, OverflowMode::IGNORE>(test_cases, 7, 2, 3, 2, 9, 2);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p11s8_mod_decimal64p9s7_eq_decimal64p18s8) {
     DecimalTestCaseArray test_cases = {{"999.99999999", "99.9999999", "0.00000099"},
@@ -1985,14 +2022,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p11s8_mod_decimal64p9s7_eq_decim
                                        {"519.39882254", "95.9184850", "39.80639754"},
                                        {"-144.80040473", "-70.5479193", "-3.70456613"},
                                        {"-621.54729545", "-76.2382137", "-11.64158585"}};
-    test_vector_vector<TYPE_DECIMAL64, ModOp, true>(test_cases, 11, 8, 9, 7, 18, 8);
-    test_vector_vector<TYPE_DECIMAL64, ModOp, false>(test_cases, 11, 8, 9, 7, 18, 8);
-    test_vector_const<TYPE_DECIMAL64, ModOp, true>(test_cases, 11, 8, 9, 7, 18, 8);
-    test_vector_const<TYPE_DECIMAL64, ModOp, false>(test_cases, 11, 8, 9, 7, 18, 8);
-    test_const_vector<TYPE_DECIMAL64, ModOp, true>(test_cases, 11, 8, 9, 7, 18, 8);
-    test_const_vector<TYPE_DECIMAL64, ModOp, false>(test_cases, 11, 8, 9, 7, 18, 8);
-    test_const_const<TYPE_DECIMAL64, ModOp, true>(test_cases, 11, 8, 9, 7, 18, 8);
-    test_const_const<TYPE_DECIMAL64, ModOp, false>(test_cases, 11, 8, 9, 7, 18, 8);
+    test_vector_vector<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 11, 8, 9, 7, 18, 8);
+    test_vector_vector<TYPE_DECIMAL64, ModOp, OverflowMode::IGNORE>(test_cases, 11, 8, 9, 7, 18, 8);
+    test_vector_const<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 11, 8, 9, 7, 18, 8);
+    test_vector_const<TYPE_DECIMAL64, ModOp, OverflowMode::IGNORE>(test_cases, 11, 8, 9, 7, 18, 8);
+    test_const_vector<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 11, 8, 9, 7, 18, 8);
+    test_const_vector<TYPE_DECIMAL64, ModOp, OverflowMode::IGNORE>(test_cases, 11, 8, 9, 7, 18, 8);
+    test_const_const<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 11, 8, 9, 7, 18, 8);
+    test_const_const<TYPE_DECIMAL64, ModOp, OverflowMode::IGNORE>(test_cases, 11, 8, 9, 7, 18, 8);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p37s10_mod_decimal128p19s0_eq_decimal128p38s10) {
     DecimalTestCaseArray test_cases = {
@@ -2041,14 +2078,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p37s10_mod_decimal128p19s0_eq_d
             {"703705951470571265241650745.6103595237", "-440292678426069664", "179896338935711609.6103595237"},
             {"-448396464273958359356356812.7270470068", "-1103614251073279439", "-433593374512676914.7270470068"},
             {"-516945573350517038940528510.3300588707", "703292555006229313", "-428755557624421724.3300588707"}};
-    test_vector_vector<TYPE_DECIMAL128, ModOp, true>(test_cases, 37, 10, 19, 0, 38, 10);
-    test_vector_vector<TYPE_DECIMAL128, ModOp, false>(test_cases, 37, 10, 19, 0, 38, 10);
-    test_vector_const<TYPE_DECIMAL128, ModOp, true>(test_cases, 37, 10, 19, 0, 38, 10);
-    test_vector_const<TYPE_DECIMAL128, ModOp, false>(test_cases, 37, 10, 19, 0, 38, 10);
-    test_const_vector<TYPE_DECIMAL128, ModOp, true>(test_cases, 37, 10, 19, 0, 38, 10);
-    test_const_vector<TYPE_DECIMAL128, ModOp, false>(test_cases, 37, 10, 19, 0, 38, 10);
-    test_const_const<TYPE_DECIMAL128, ModOp, true>(test_cases, 37, 10, 19, 0, 38, 10);
-    test_const_const<TYPE_DECIMAL128, ModOp, false>(test_cases, 37, 10, 19, 0, 38, 10);
+    test_vector_vector<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 37, 10, 19, 0, 38, 10);
+    test_vector_vector<TYPE_DECIMAL128, ModOp, OverflowMode::IGNORE>(test_cases, 37, 10, 19, 0, 38, 10);
+    test_vector_const<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 37, 10, 19, 0, 38, 10);
+    test_vector_const<TYPE_DECIMAL128, ModOp, OverflowMode::IGNORE>(test_cases, 37, 10, 19, 0, 38, 10);
+    test_const_vector<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 37, 10, 19, 0, 38, 10);
+    test_const_vector<TYPE_DECIMAL128, ModOp, OverflowMode::IGNORE>(test_cases, 37, 10, 19, 0, 38, 10);
+    test_const_const<TYPE_DECIMAL128, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 37, 10, 19, 0, 38, 10);
+    test_const_const<TYPE_DECIMAL128, ModOp, OverflowMode::IGNORE>(test_cases, 37, 10, 19, 0, 38, 10);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p9s3_mod_decimal32p3s0_eq_decimal32p9s3) {
     DecimalTestCaseArray test_cases = {{"999999.999", "999", "0.999"},
@@ -2096,14 +2133,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p9s3_mod_decimal32p3s0_eq_decima
                                        {"712934.753", "624", "326.753"},
                                        {"802450.008", "-288", "82.008"},
                                        {"-408672.100", "554", "-374.100"}};
-    test_vector_vector<TYPE_DECIMAL32, ModOp, true>(test_cases, 9, 3, 3, 0, 9, 3);
-    test_vector_vector<TYPE_DECIMAL32, ModOp, false>(test_cases, 9, 3, 3, 0, 9, 3);
-    test_vector_const<TYPE_DECIMAL32, ModOp, true>(test_cases, 9, 3, 3, 0, 9, 3);
-    test_vector_const<TYPE_DECIMAL32, ModOp, false>(test_cases, 9, 3, 3, 0, 9, 3);
-    test_const_vector<TYPE_DECIMAL32, ModOp, true>(test_cases, 9, 3, 3, 0, 9, 3);
-    test_const_vector<TYPE_DECIMAL32, ModOp, false>(test_cases, 9, 3, 3, 0, 9, 3);
-    test_const_const<TYPE_DECIMAL32, ModOp, true>(test_cases, 9, 3, 3, 0, 9, 3);
-    test_const_const<TYPE_DECIMAL32, ModOp, false>(test_cases, 9, 3, 3, 0, 9, 3);
+    test_vector_vector<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 3, 3, 0, 9, 3);
+    test_vector_vector<TYPE_DECIMAL32, ModOp, OverflowMode::IGNORE>(test_cases, 9, 3, 3, 0, 9, 3);
+    test_vector_const<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 3, 3, 0, 9, 3);
+    test_vector_const<TYPE_DECIMAL32, ModOp, OverflowMode::IGNORE>(test_cases, 9, 3, 3, 0, 9, 3);
+    test_const_vector<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 3, 3, 0, 9, 3);
+    test_const_vector<TYPE_DECIMAL32, ModOp, OverflowMode::IGNORE>(test_cases, 9, 3, 3, 0, 9, 3);
+    test_const_const<TYPE_DECIMAL32, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 3, 3, 0, 9, 3);
+    test_const_const<TYPE_DECIMAL32, ModOp, OverflowMode::IGNORE>(test_cases, 9, 3, 3, 0, 9, 3);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p17s5_mod_decimal64p11s0_eq_decimal64p18s5) {
     DecimalTestCaseArray test_cases = {{"999999999999.99999", "99999999999", "9.99999"},
@@ -2151,14 +2188,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p17s5_mod_decimal64p11s0_eq_deci
                                        {"901467078994.55401", "-38003812277", "27379396623.55401"},
                                        {"780876971551.84693", "-71583534641", "65041625141.84693"},
                                        {"966612870052.51187", "-5842683459", "2570099317.51187"}};
-    test_vector_vector<TYPE_DECIMAL64, ModOp, true>(test_cases, 17, 5, 11, 0, 18, 5);
-    test_vector_vector<TYPE_DECIMAL64, ModOp, false>(test_cases, 17, 5, 11, 0, 18, 5);
-    test_vector_const<TYPE_DECIMAL64, ModOp, true>(test_cases, 17, 5, 11, 0, 18, 5);
-    test_vector_const<TYPE_DECIMAL64, ModOp, false>(test_cases, 17, 5, 11, 0, 18, 5);
-    test_const_vector<TYPE_DECIMAL64, ModOp, true>(test_cases, 17, 5, 11, 0, 18, 5);
-    test_const_vector<TYPE_DECIMAL64, ModOp, false>(test_cases, 17, 5, 11, 0, 18, 5);
-    test_const_const<TYPE_DECIMAL64, ModOp, true>(test_cases, 17, 5, 11, 0, 18, 5);
-    test_const_const<TYPE_DECIMAL64, ModOp, false>(test_cases, 17, 5, 11, 0, 18, 5);
+    test_vector_vector<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 17, 5, 11, 0, 18, 5);
+    test_vector_vector<TYPE_DECIMAL64, ModOp, OverflowMode::IGNORE>(test_cases, 17, 5, 11, 0, 18, 5);
+    test_vector_const<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 17, 5, 11, 0, 18, 5);
+    test_vector_const<TYPE_DECIMAL64, ModOp, OverflowMode::IGNORE>(test_cases, 17, 5, 11, 0, 18, 5);
+    test_const_vector<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 17, 5, 11, 0, 18, 5);
+    test_const_vector<TYPE_DECIMAL64, ModOp, OverflowMode::IGNORE>(test_cases, 17, 5, 11, 0, 18, 5);
+    test_const_const<TYPE_DECIMAL64, ModOp, OverflowMode::OUTPUT_NULL>(test_cases, 17, 5, 11, 0, 18, 5);
+    test_const_const<TYPE_DECIMAL64, ModOp, OverflowMode::IGNORE>(test_cases, 17, 5, 11, 0, 18, 5);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p14s7_mul_decimal128p15s13_eq_decimal128p38s20) {
     DecimalTestCaseArray test_cases = {{"9999999.9999999", "99.9999999999999", "999999999.99998900000000000001"},
@@ -2206,17 +2243,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p14s7_mul_decimal128p15s13_eq_d
                                        {"2135270.8932478", "-59.4856253344513", "-127017924.34329778897388793214"},
                                        {"-5117146.3353753", "90.7328324270471", "-464293180.95228525464724927663"},
                                        {"-114625.2118252", "-64.7847660599647", "7425967.53266948134273457044"}};
-    test_vector_vector<TYPE_DECIMAL128, MulOp, true>(test_cases, 14, 7, 15, 13, 38, 20);
-    test_vector_vector<TYPE_DECIMAL128, MulOp, false>(test_cases, 14, 7, 15, 13, 38, 20);
-    test_vector_const<TYPE_DECIMAL128, MulOp, true>(test_cases, 14, 7, 15, 13, 38, 20);
-    test_vector_const<TYPE_DECIMAL128, MulOp, false>(test_cases, 14, 7, 15, 13, 38, 20);
-    test_const_vector<TYPE_DECIMAL128, MulOp, true>(test_cases, 14, 7, 15, 13, 38, 20);
-    test_const_vector<TYPE_DECIMAL128, MulOp, false>(test_cases, 14, 7, 15, 13, 38, 20);
-    test_const_const<TYPE_DECIMAL128, MulOp, true>(test_cases, 14, 7, 15, 13, 38, 20);
-    test_const_const<TYPE_DECIMAL128, MulOp, false>(test_cases, 14, 7, 15, 13, 38, 20);
-    test_const_nullable_vector<TYPE_DECIMAL128, MulOp, true>(test_cases, 14, 7, 15, 13, 38, 20);
-    test_nullable_vector_const<TYPE_DECIMAL128, MulOp, true>(test_cases, 14, 7, 15, 13, 38, 20);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, MulOp, true>(test_cases, 14, 7, 15, 13, 38, 20);
+    test_vector_vector<TYPE_DECIMAL128, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 14, 7, 15, 13, 38, 20);
+    test_vector_vector<TYPE_DECIMAL128, MulOp, OverflowMode::IGNORE>(test_cases, 14, 7, 15, 13, 38, 20);
+    test_vector_const<TYPE_DECIMAL128, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 14, 7, 15, 13, 38, 20);
+    test_vector_const<TYPE_DECIMAL128, MulOp, OverflowMode::IGNORE>(test_cases, 14, 7, 15, 13, 38, 20);
+    test_const_vector<TYPE_DECIMAL128, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 14, 7, 15, 13, 38, 20);
+    test_const_vector<TYPE_DECIMAL128, MulOp, OverflowMode::IGNORE>(test_cases, 14, 7, 15, 13, 38, 20);
+    test_const_const<TYPE_DECIMAL128, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 14, 7, 15, 13, 38, 20);
+    test_const_const<TYPE_DECIMAL128, MulOp, OverflowMode::IGNORE>(test_cases, 14, 7, 15, 13, 38, 20);
+    test_const_nullable_vector<TYPE_DECIMAL128, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 14, 7, 15, 13, 38, 20);
+    test_nullable_vector_const<TYPE_DECIMAL128, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 14, 7, 15, 13, 38, 20);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 14, 7, 15, 13,
+                                                                                            38, 20);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p5s2_mul_decimal32p5s1_eq_decimal32p9s3) {
     DecimalTestCaseArray test_cases = {{"999.99", "9999.9", "1409865.409"},
@@ -2264,17 +2302,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p5s2_mul_decimal32p5s1_eq_decima
                                        {"704.65", "-7497.9", "-988427.939"},
                                        {"662.39", "4582.8", "-1259366.404"},
                                        {"-546.47", "4504.4", "1833447.828"}};
-    test_vector_vector<TYPE_DECIMAL32, MulOp, true>(test_cases, 5, 2, 5, 1, 9, 3);
-    test_vector_vector<TYPE_DECIMAL32, MulOp, false>(test_cases, 5, 2, 5, 1, 9, 3);
-    test_vector_const<TYPE_DECIMAL32, MulOp, true>(test_cases, 5, 2, 5, 1, 9, 3);
-    test_vector_const<TYPE_DECIMAL32, MulOp, false>(test_cases, 5, 2, 5, 1, 9, 3);
-    test_const_vector<TYPE_DECIMAL32, MulOp, true>(test_cases, 5, 2, 5, 1, 9, 3);
-    test_const_vector<TYPE_DECIMAL32, MulOp, false>(test_cases, 5, 2, 5, 1, 9, 3);
-    test_const_const<TYPE_DECIMAL32, MulOp, true>(test_cases, 5, 2, 5, 1, 9, 3);
-    test_const_const<TYPE_DECIMAL32, MulOp, false>(test_cases, 5, 2, 5, 1, 9, 3);
-    test_const_nullable_vector<TYPE_DECIMAL32, MulOp, true>(test_cases, 5, 2, 5, 1, 9, 3);
-    test_nullable_vector_const<TYPE_DECIMAL32, MulOp, true>(test_cases, 5, 2, 5, 1, 9, 3);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL32, MulOp, true>(test_cases, 5, 2, 5, 1, 9, 3);
+    test_vector_vector<TYPE_DECIMAL32, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 2, 5, 1, 9, 3);
+    test_vector_vector<TYPE_DECIMAL32, MulOp, OverflowMode::IGNORE>(test_cases, 5, 2, 5, 1, 9, 3);
+    test_vector_const<TYPE_DECIMAL32, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 2, 5, 1, 9, 3);
+    test_vector_const<TYPE_DECIMAL32, MulOp, OverflowMode::IGNORE>(test_cases, 5, 2, 5, 1, 9, 3);
+    test_const_vector<TYPE_DECIMAL32, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 2, 5, 1, 9, 3);
+    test_const_vector<TYPE_DECIMAL32, MulOp, OverflowMode::IGNORE>(test_cases, 5, 2, 5, 1, 9, 3);
+    test_const_const<TYPE_DECIMAL32, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 2, 5, 1, 9, 3);
+    test_const_const<TYPE_DECIMAL32, MulOp, OverflowMode::IGNORE>(test_cases, 5, 2, 5, 1, 9, 3);
+    test_const_nullable_vector<TYPE_DECIMAL32, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 2, 5, 1, 9, 3);
+    test_nullable_vector_const<TYPE_DECIMAL32, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 2, 5, 1, 9, 3);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL32, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 5, 2, 5, 1, 9,
+                                                                                           3);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p16s4_mul_decimal64p4s3_eq_decimal64p18s7) {
     DecimalTestCaseArray test_cases = {{"999999999999.9999", "9.999", "775627963145.2231921"},
@@ -2322,17 +2361,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p16s4_mul_decimal64p4s3_eq_decim
                                        {"670097572887.8554", "3.989", "828344810878.7000290"},
                                        {"736082785867.9490", "6.370", "-845175876134.0303548"},
                                        {"-381480307337.5364", "7.793", "716472779660.4891580"}};
-    test_vector_vector<TYPE_DECIMAL64, MulOp, true>(test_cases, 16, 4, 4, 3, 18, 7);
-    test_vector_vector<TYPE_DECIMAL64, MulOp, false>(test_cases, 16, 4, 4, 3, 18, 7);
-    test_vector_const<TYPE_DECIMAL64, MulOp, true>(test_cases, 16, 4, 4, 3, 18, 7);
-    test_vector_const<TYPE_DECIMAL64, MulOp, false>(test_cases, 16, 4, 4, 3, 18, 7);
-    test_const_vector<TYPE_DECIMAL64, MulOp, true>(test_cases, 16, 4, 4, 3, 18, 7);
-    test_const_vector<TYPE_DECIMAL64, MulOp, false>(test_cases, 16, 4, 4, 3, 18, 7);
-    test_const_const<TYPE_DECIMAL64, MulOp, true>(test_cases, 16, 4, 4, 3, 18, 7);
-    test_const_const<TYPE_DECIMAL64, MulOp, false>(test_cases, 16, 4, 4, 3, 18, 7);
-    test_const_nullable_vector<TYPE_DECIMAL64, MulOp, true>(test_cases, 16, 4, 4, 3, 18, 7);
-    test_nullable_vector_const<TYPE_DECIMAL64, MulOp, true>(test_cases, 16, 4, 4, 3, 18, 7);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL64, MulOp, true>(test_cases, 16, 4, 4, 3, 18, 7);
+    test_vector_vector<TYPE_DECIMAL64, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 16, 4, 4, 3, 18, 7);
+    test_vector_vector<TYPE_DECIMAL64, MulOp, OverflowMode::IGNORE>(test_cases, 16, 4, 4, 3, 18, 7);
+    test_vector_const<TYPE_DECIMAL64, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 16, 4, 4, 3, 18, 7);
+    test_vector_const<TYPE_DECIMAL64, MulOp, OverflowMode::IGNORE>(test_cases, 16, 4, 4, 3, 18, 7);
+    test_const_vector<TYPE_DECIMAL64, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 16, 4, 4, 3, 18, 7);
+    test_const_vector<TYPE_DECIMAL64, MulOp, OverflowMode::IGNORE>(test_cases, 16, 4, 4, 3, 18, 7);
+    test_const_const<TYPE_DECIMAL64, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 16, 4, 4, 3, 18, 7);
+    test_const_const<TYPE_DECIMAL64, MulOp, OverflowMode::IGNORE>(test_cases, 16, 4, 4, 3, 18, 7);
+    test_const_nullable_vector<TYPE_DECIMAL64, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 16, 4, 4, 3, 18, 7);
+    test_nullable_vector_const<TYPE_DECIMAL64, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 16, 4, 4, 3, 18, 7);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL64, MulOp, OverflowMode::OUTPUT_NULL>(test_cases, 16, 4, 4, 3, 18,
+                                                                                           7);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p31s6_sub_decimal128p34s8_eq_decimal128p38s8) {
     DecimalTestCaseArray test_cases = {
@@ -2405,17 +2445,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p31s6_sub_decimal128p34s8_eq_de
              "56996805961234840915521075.00964909"},
             {"5808943082534482268879950.393443", "-38136483080721731398635132.11663572",
              "43945426163256213667515082.51007872"}};
-    test_vector_vector<TYPE_DECIMAL128, SubOp, true>(test_cases, 31, 6, 34, 8, 38, 8);
-    test_vector_vector<TYPE_DECIMAL128, SubOp, false>(test_cases, 31, 6, 34, 8, 38, 8);
-    test_vector_const<TYPE_DECIMAL128, SubOp, true>(test_cases, 31, 6, 34, 8, 38, 8);
-    test_vector_const<TYPE_DECIMAL128, SubOp, false>(test_cases, 31, 6, 34, 8, 38, 8);
-    test_const_vector<TYPE_DECIMAL128, SubOp, true>(test_cases, 31, 6, 34, 8, 38, 8);
-    test_const_vector<TYPE_DECIMAL128, SubOp, false>(test_cases, 31, 6, 34, 8, 38, 8);
-    test_const_const<TYPE_DECIMAL128, SubOp, true>(test_cases, 31, 6, 34, 8, 38, 8);
-    test_const_const<TYPE_DECIMAL128, SubOp, false>(test_cases, 31, 6, 34, 8, 38, 8);
-    test_const_nullable_vector<TYPE_DECIMAL128, SubOp, true>(test_cases, 31, 6, 34, 8, 38, 8);
-    test_nullable_vector_const<TYPE_DECIMAL128, SubOp, true>(test_cases, 31, 6, 34, 8, 38, 8);
-    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, SubOp, true>(test_cases, 31, 6, 34, 8, 38, 8);
+    test_vector_vector<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 31, 6, 34, 8, 38, 8);
+    test_vector_vector<TYPE_DECIMAL128, SubOp, OverflowMode::IGNORE>(test_cases, 31, 6, 34, 8, 38, 8);
+    test_vector_const<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 31, 6, 34, 8, 38, 8);
+    test_vector_const<TYPE_DECIMAL128, SubOp, OverflowMode::IGNORE>(test_cases, 31, 6, 34, 8, 38, 8);
+    test_const_vector<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 31, 6, 34, 8, 38, 8);
+    test_const_vector<TYPE_DECIMAL128, SubOp, OverflowMode::IGNORE>(test_cases, 31, 6, 34, 8, 38, 8);
+    test_const_const<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 31, 6, 34, 8, 38, 8);
+    test_const_const<TYPE_DECIMAL128, SubOp, OverflowMode::IGNORE>(test_cases, 31, 6, 34, 8, 38, 8);
+    test_const_nullable_vector<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 31, 6, 34, 8, 38, 8);
+    test_nullable_vector_const<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 31, 6, 34, 8, 38, 8);
+    test_nullable_vector_nullable_vector<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 31, 6, 34, 8,
+                                                                                            38, 8);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p4s2_sub_decimal32p6s4_eq_decimal32p9s4) {
     DecimalTestCaseArray test_cases = {{"99.99", "99.9999", "-0.0099"},
@@ -2463,14 +2504,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p4s2_sub_decimal32p6s4_eq_decima
                                        {"-2.59", "-16.5820", "13.9920"},
                                        {"30.01", "-55.3397", "85.3497"},
                                        {"-34.59", "-74.7302", "40.1402"}};
-    test_vector_vector<TYPE_DECIMAL32, SubOp, true>(test_cases, 4, 2, 6, 4, 9, 4);
-    test_vector_vector<TYPE_DECIMAL32, SubOp, false>(test_cases, 4, 2, 6, 4, 9, 4);
-    test_vector_const<TYPE_DECIMAL32, SubOp, true>(test_cases, 4, 2, 6, 4, 9, 4);
-    test_vector_const<TYPE_DECIMAL32, SubOp, false>(test_cases, 4, 2, 6, 4, 9, 4);
-    test_const_vector<TYPE_DECIMAL32, SubOp, true>(test_cases, 4, 2, 6, 4, 9, 4);
-    test_const_vector<TYPE_DECIMAL32, SubOp, false>(test_cases, 4, 2, 6, 4, 9, 4);
-    test_const_const<TYPE_DECIMAL32, SubOp, true>(test_cases, 4, 2, 6, 4, 9, 4);
-    test_const_const<TYPE_DECIMAL32, SubOp, false>(test_cases, 4, 2, 6, 4, 9, 4);
+    test_vector_vector<TYPE_DECIMAL32, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 4, 2, 6, 4, 9, 4);
+    test_vector_vector<TYPE_DECIMAL32, SubOp, OverflowMode::IGNORE>(test_cases, 4, 2, 6, 4, 9, 4);
+    test_vector_const<TYPE_DECIMAL32, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 4, 2, 6, 4, 9, 4);
+    test_vector_const<TYPE_DECIMAL32, SubOp, OverflowMode::IGNORE>(test_cases, 4, 2, 6, 4, 9, 4);
+    test_const_vector<TYPE_DECIMAL32, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 4, 2, 6, 4, 9, 4);
+    test_const_vector<TYPE_DECIMAL32, SubOp, OverflowMode::IGNORE>(test_cases, 4, 2, 6, 4, 9, 4);
+    test_const_const<TYPE_DECIMAL32, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 4, 2, 6, 4, 9, 4);
+    test_const_const<TYPE_DECIMAL32, SubOp, OverflowMode::IGNORE>(test_cases, 4, 2, 6, 4, 9, 4);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p11s5_sub_decimal64p18s12_eq_decimal64p18s12) {
     DecimalTestCaseArray test_cases = {{"999999.99999", "999999.999999999999", "-0.000009999999"},
@@ -2518,14 +2559,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p11s5_sub_decimal64p18s12_eq_dec
                                        {"-179251.29605", "319444.891069099630", "-498696.187119099630"},
                                        {"113717.68336", "-377670.640222284138", "491388.323582284138"},
                                        {"468626.59505", "121406.960236864241", "347219.634813135759"}};
-    test_vector_vector<TYPE_DECIMAL64, SubOp, true>(test_cases, 11, 5, 18, 12, 18, 12);
-    test_vector_vector<TYPE_DECIMAL64, SubOp, false>(test_cases, 11, 5, 18, 12, 18, 12);
-    test_vector_const<TYPE_DECIMAL64, SubOp, true>(test_cases, 11, 5, 18, 12, 18, 12);
-    test_vector_const<TYPE_DECIMAL64, SubOp, false>(test_cases, 11, 5, 18, 12, 18, 12);
-    test_const_vector<TYPE_DECIMAL64, SubOp, true>(test_cases, 11, 5, 18, 12, 18, 12);
-    test_const_vector<TYPE_DECIMAL64, SubOp, false>(test_cases, 11, 5, 18, 12, 18, 12);
-    test_const_const<TYPE_DECIMAL64, SubOp, true>(test_cases, 11, 5, 18, 12, 18, 12);
-    test_const_const<TYPE_DECIMAL64, SubOp, false>(test_cases, 11, 5, 18, 12, 18, 12);
+    test_vector_vector<TYPE_DECIMAL64, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 11, 5, 18, 12, 18, 12);
+    test_vector_vector<TYPE_DECIMAL64, SubOp, OverflowMode::IGNORE>(test_cases, 11, 5, 18, 12, 18, 12);
+    test_vector_const<TYPE_DECIMAL64, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 11, 5, 18, 12, 18, 12);
+    test_vector_const<TYPE_DECIMAL64, SubOp, OverflowMode::IGNORE>(test_cases, 11, 5, 18, 12, 18, 12);
+    test_const_vector<TYPE_DECIMAL64, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 11, 5, 18, 12, 18, 12);
+    test_const_vector<TYPE_DECIMAL64, SubOp, OverflowMode::IGNORE>(test_cases, 11, 5, 18, 12, 18, 12);
+    test_const_const<TYPE_DECIMAL64, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 11, 5, 18, 12, 18, 12);
+    test_const_const<TYPE_DECIMAL64, SubOp, OverflowMode::IGNORE>(test_cases, 11, 5, 18, 12, 18, 12);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p34s7_sub_decimal128p29s5_eq_decimal128p38s7) {
     DecimalTestCaseArray test_cases = {
@@ -2598,14 +2639,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p34s7_sub_decimal128p29s5_eq_de
              "803877453756516477614629244.9383877"},
             {"733803306326475847099651045.2642731", "335471485030510034013807.16863",
              "733467834841445337065637238.0956431"}};
-    test_vector_vector<TYPE_DECIMAL128, SubOp, true>(test_cases, 34, 7, 29, 5, 38, 7);
-    test_vector_vector<TYPE_DECIMAL128, SubOp, false>(test_cases, 34, 7, 29, 5, 38, 7);
-    test_vector_const<TYPE_DECIMAL128, SubOp, true>(test_cases, 34, 7, 29, 5, 38, 7);
-    test_vector_const<TYPE_DECIMAL128, SubOp, false>(test_cases, 34, 7, 29, 5, 38, 7);
-    test_const_vector<TYPE_DECIMAL128, SubOp, true>(test_cases, 34, 7, 29, 5, 38, 7);
-    test_const_vector<TYPE_DECIMAL128, SubOp, false>(test_cases, 34, 7, 29, 5, 38, 7);
-    test_const_const<TYPE_DECIMAL128, SubOp, true>(test_cases, 34, 7, 29, 5, 38, 7);
-    test_const_const<TYPE_DECIMAL128, SubOp, false>(test_cases, 34, 7, 29, 5, 38, 7);
+    test_vector_vector<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 34, 7, 29, 5, 38, 7);
+    test_vector_vector<TYPE_DECIMAL128, SubOp, OverflowMode::IGNORE>(test_cases, 34, 7, 29, 5, 38, 7);
+    test_vector_const<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 34, 7, 29, 5, 38, 7);
+    test_vector_const<TYPE_DECIMAL128, SubOp, OverflowMode::IGNORE>(test_cases, 34, 7, 29, 5, 38, 7);
+    test_const_vector<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 34, 7, 29, 5, 38, 7);
+    test_const_vector<TYPE_DECIMAL128, SubOp, OverflowMode::IGNORE>(test_cases, 34, 7, 29, 5, 38, 7);
+    test_const_const<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 34, 7, 29, 5, 38, 7);
+    test_const_const<TYPE_DECIMAL128, SubOp, OverflowMode::IGNORE>(test_cases, 34, 7, 29, 5, 38, 7);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p6s5_sub_decimal32p4s2_eq_decimal32p9s5) {
     DecimalTestCaseArray test_cases = {{"9.99999", "99.99", "-89.99001"},
@@ -2653,14 +2694,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p6s5_sub_decimal32p4s2_eq_decima
                                        {"6.20602", "-92.21", "98.41602"},
                                        {"1.32342", "84.60", "-83.27658"},
                                        {"-8.14264", "-76.72", "68.57736"}};
-    test_vector_vector<TYPE_DECIMAL32, SubOp, true>(test_cases, 6, 5, 4, 2, 9, 5);
-    test_vector_vector<TYPE_DECIMAL32, SubOp, false>(test_cases, 6, 5, 4, 2, 9, 5);
-    test_vector_const<TYPE_DECIMAL32, SubOp, true>(test_cases, 6, 5, 4, 2, 9, 5);
-    test_vector_const<TYPE_DECIMAL32, SubOp, false>(test_cases, 6, 5, 4, 2, 9, 5);
-    test_const_vector<TYPE_DECIMAL32, SubOp, true>(test_cases, 6, 5, 4, 2, 9, 5);
-    test_const_vector<TYPE_DECIMAL32, SubOp, false>(test_cases, 6, 5, 4, 2, 9, 5);
-    test_const_const<TYPE_DECIMAL32, SubOp, true>(test_cases, 6, 5, 4, 2, 9, 5);
-    test_const_const<TYPE_DECIMAL32, SubOp, false>(test_cases, 6, 5, 4, 2, 9, 5);
+    test_vector_vector<TYPE_DECIMAL32, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 6, 5, 4, 2, 9, 5);
+    test_vector_vector<TYPE_DECIMAL32, SubOp, OverflowMode::IGNORE>(test_cases, 6, 5, 4, 2, 9, 5);
+    test_vector_const<TYPE_DECIMAL32, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 6, 5, 4, 2, 9, 5);
+    test_vector_const<TYPE_DECIMAL32, SubOp, OverflowMode::IGNORE>(test_cases, 6, 5, 4, 2, 9, 5);
+    test_const_vector<TYPE_DECIMAL32, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 6, 5, 4, 2, 9, 5);
+    test_const_vector<TYPE_DECIMAL32, SubOp, OverflowMode::IGNORE>(test_cases, 6, 5, 4, 2, 9, 5);
+    test_const_const<TYPE_DECIMAL32, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 6, 5, 4, 2, 9, 5);
+    test_const_const<TYPE_DECIMAL32, SubOp, OverflowMode::IGNORE>(test_cases, 6, 5, 4, 2, 9, 5);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p18s13_sub_decimal64p11s6_eq_decimal64p18s13) {
     DecimalTestCaseArray test_cases = {{"99999.9999999999999", "99999.999999", "0.0000009999999"},
@@ -2708,14 +2749,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p18s13_sub_decimal64p11s6_eq_dec
                                        {"74719.8269072728377", "75169.943624", "-450.1167167271623"},
                                        {"-15781.6385731459534", "-12923.439599", "-2858.1989741459534"},
                                        {"-91298.4606984177119", "14193.444740", "-105491.9054384177119"}};
-    test_vector_vector<TYPE_DECIMAL64, SubOp, true>(test_cases, 18, 13, 11, 6, 18, 13);
-    test_vector_vector<TYPE_DECIMAL64, SubOp, false>(test_cases, 18, 13, 11, 6, 18, 13);
-    test_vector_const<TYPE_DECIMAL64, SubOp, true>(test_cases, 18, 13, 11, 6, 18, 13);
-    test_vector_const<TYPE_DECIMAL64, SubOp, false>(test_cases, 18, 13, 11, 6, 18, 13);
-    test_const_vector<TYPE_DECIMAL64, SubOp, true>(test_cases, 18, 13, 11, 6, 18, 13);
-    test_const_vector<TYPE_DECIMAL64, SubOp, false>(test_cases, 18, 13, 11, 6, 18, 13);
-    test_const_const<TYPE_DECIMAL64, SubOp, true>(test_cases, 18, 13, 11, 6, 18, 13);
-    test_const_const<TYPE_DECIMAL64, SubOp, false>(test_cases, 18, 13, 11, 6, 18, 13);
+    test_vector_vector<TYPE_DECIMAL64, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 13, 11, 6, 18, 13);
+    test_vector_vector<TYPE_DECIMAL64, SubOp, OverflowMode::IGNORE>(test_cases, 18, 13, 11, 6, 18, 13);
+    test_vector_const<TYPE_DECIMAL64, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 13, 11, 6, 18, 13);
+    test_vector_const<TYPE_DECIMAL64, SubOp, OverflowMode::IGNORE>(test_cases, 18, 13, 11, 6, 18, 13);
+    test_const_vector<TYPE_DECIMAL64, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 13, 11, 6, 18, 13);
+    test_const_vector<TYPE_DECIMAL64, SubOp, OverflowMode::IGNORE>(test_cases, 18, 13, 11, 6, 18, 13);
+    test_const_const<TYPE_DECIMAL64, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 13, 11, 6, 18, 13);
+    test_const_const<TYPE_DECIMAL64, SubOp, OverflowMode::IGNORE>(test_cases, 18, 13, 11, 6, 18, 13);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s37_sub_decimal128p38s37_eq_decimal128p38s37) {
     DecimalTestCaseArray test_cases = {
@@ -2792,14 +2833,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s37_sub_decimal128p38s37_eq_
              "2.7628504469790028870787606558795472037"},
             {"-8.7242732380520100061423696468014466798", "-4.7009748792012557916712889114003709319",
              "-4.0232983588507542144710807354010757479"}};
-    test_vector_vector<TYPE_DECIMAL128, SubOp, true>(test_cases, 38, 37, 38, 37, 38, 37);
-    test_vector_vector<TYPE_DECIMAL128, SubOp, false>(test_cases, 38, 37, 38, 37, 38, 37);
-    test_vector_const<TYPE_DECIMAL128, SubOp, true>(test_cases, 38, 37, 38, 37, 38, 37);
-    test_vector_const<TYPE_DECIMAL128, SubOp, false>(test_cases, 38, 37, 38, 37, 38, 37);
-    test_const_vector<TYPE_DECIMAL128, SubOp, true>(test_cases, 38, 37, 38, 37, 38, 37);
-    test_const_vector<TYPE_DECIMAL128, SubOp, false>(test_cases, 38, 37, 38, 37, 38, 37);
-    test_const_const<TYPE_DECIMAL128, SubOp, true>(test_cases, 38, 37, 38, 37, 38, 37);
-    test_const_const<TYPE_DECIMAL128, SubOp, false>(test_cases, 38, 37, 38, 37, 38, 37);
+    test_vector_vector<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 37, 38, 37, 38, 37);
+    test_vector_vector<TYPE_DECIMAL128, SubOp, OverflowMode::IGNORE>(test_cases, 38, 37, 38, 37, 38, 37);
+    test_vector_const<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 37, 38, 37, 38, 37);
+    test_vector_const<TYPE_DECIMAL128, SubOp, OverflowMode::IGNORE>(test_cases, 38, 37, 38, 37, 38, 37);
+    test_const_vector<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 37, 38, 37, 38, 37);
+    test_const_vector<TYPE_DECIMAL128, SubOp, OverflowMode::IGNORE>(test_cases, 38, 37, 38, 37, 38, 37);
+    test_const_const<TYPE_DECIMAL128, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 38, 37, 38, 37, 38, 37);
+    test_const_const<TYPE_DECIMAL128, SubOp, OverflowMode::IGNORE>(test_cases, 38, 37, 38, 37, 38, 37);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal32p9s2_sub_decimal32p9s2_eq_decimal32p9s2) {
     DecimalTestCaseArray test_cases = {{"9999999.99", "9999999.99", "0"},
@@ -2847,14 +2888,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal32p9s2_sub_decimal32p9s2_eq_decima
                                        {"206849.83", "-9297503.07", "9504352.90"},
                                        {"8765765.42", "-6104097.70", "14869863.12"},
                                        {"2314600.13", "-6732808.59", "9047408.72"}};
-    test_vector_vector<TYPE_DECIMAL32, SubOp, true>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_vector_vector<TYPE_DECIMAL32, SubOp, false>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_vector_const<TYPE_DECIMAL32, SubOp, true>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_vector_const<TYPE_DECIMAL32, SubOp, false>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_const_vector<TYPE_DECIMAL32, SubOp, true>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_const_vector<TYPE_DECIMAL32, SubOp, false>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_const_const<TYPE_DECIMAL32, SubOp, true>(test_cases, 9, 2, 9, 2, 9, 2);
-    test_const_const<TYPE_DECIMAL32, SubOp, false>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_vector_vector<TYPE_DECIMAL32, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_vector_vector<TYPE_DECIMAL32, SubOp, OverflowMode::IGNORE>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_vector_const<TYPE_DECIMAL32, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_vector_const<TYPE_DECIMAL32, SubOp, OverflowMode::IGNORE>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_const_vector<TYPE_DECIMAL32, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_const_vector<TYPE_DECIMAL32, SubOp, OverflowMode::IGNORE>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_const_const<TYPE_DECIMAL32, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 9, 2, 9, 2, 9, 2);
+    test_const_const<TYPE_DECIMAL32, SubOp, OverflowMode::IGNORE>(test_cases, 9, 2, 9, 2, 9, 2);
 }
 TEST_F(DecimalBinaryFunctionTest, test_decimal64p18s15_sub_decimal64p18s15_eq_decimal64p18s15) {
     DecimalTestCaseArray test_cases = {{"999.999999999999999", "999.999999999999999", "0"},
@@ -2902,14 +2943,14 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal64p18s15_sub_decimal64p18s15_eq_de
                                        {"87.222692156793347", "209.659799435793034", "-122.437107278999687"},
                                        {"259.513532937364050", "-571.904356334394336", "831.417889271758386"},
                                        {"-57.241918690550156", "-668.401908164319819", "611.159989473769663"}};
-    test_vector_vector<TYPE_DECIMAL64, SubOp, true>(test_cases, 18, 15, 18, 15, 18, 15);
-    test_vector_vector<TYPE_DECIMAL64, SubOp, false>(test_cases, 18, 15, 18, 15, 18, 15);
-    test_vector_const<TYPE_DECIMAL64, SubOp, true>(test_cases, 18, 15, 18, 15, 18, 15);
-    test_vector_const<TYPE_DECIMAL64, SubOp, false>(test_cases, 18, 15, 18, 15, 18, 15);
-    test_const_vector<TYPE_DECIMAL64, SubOp, true>(test_cases, 18, 15, 18, 15, 18, 15);
-    test_const_vector<TYPE_DECIMAL64, SubOp, false>(test_cases, 18, 15, 18, 15, 18, 15);
-    test_const_const<TYPE_DECIMAL64, SubOp, true>(test_cases, 18, 15, 18, 15, 18, 15);
-    test_const_const<TYPE_DECIMAL64, SubOp, false>(test_cases, 18, 15, 18, 15, 18, 15);
+    test_vector_vector<TYPE_DECIMAL64, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 15, 18, 15, 18, 15);
+    test_vector_vector<TYPE_DECIMAL64, SubOp, OverflowMode::IGNORE>(test_cases, 18, 15, 18, 15, 18, 15);
+    test_vector_const<TYPE_DECIMAL64, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 15, 18, 15, 18, 15);
+    test_vector_const<TYPE_DECIMAL64, SubOp, OverflowMode::IGNORE>(test_cases, 18, 15, 18, 15, 18, 15);
+    test_const_vector<TYPE_DECIMAL64, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 15, 18, 15, 18, 15);
+    test_const_vector<TYPE_DECIMAL64, SubOp, OverflowMode::IGNORE>(test_cases, 18, 15, 18, 15, 18, 15);
+    test_const_const<TYPE_DECIMAL64, SubOp, OverflowMode::OUTPUT_NULL>(test_cases, 18, 15, 18, 15, 18, 15);
+    test_const_const<TYPE_DECIMAL64, SubOp, OverflowMode::IGNORE>(test_cases, 18, 15, 18, 15, 18, 15);
 }
 
 using DecimalOverflowTestCase = std::tuple<std::string, std::string, std::string, bool>;
@@ -2929,8 +2970,8 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s16_div_decimal128p38s16_eq_
         test_case_array.emplace_back(std::get<0>(tc), std::get<1>(tc), std::get<2>(tc));
         overflows.emplace_back(std::get<3>(tc));
     }
-    test_vector_vector_assert_overflow<TYPE_DECIMAL128, DivOp, true>(test_case_array, 38, 16, 38, 16, 38, 16,
-                                                                     overflows);
+    test_vector_vector_assert_overflow<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_case_array, 38, 16, 38,
+                                                                                          16, 38, 16, overflows);
 }
 
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s15_div_decimal128p38s15_eq_decimal128p38s15) {
@@ -2948,8 +2989,8 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s15_div_decimal128p38s15_eq_
         test_case_array.emplace_back(std::get<0>(tc), std::get<1>(tc), std::get<2>(tc));
         overflows.emplace_back(std::get<3>(tc));
     }
-    test_vector_vector_assert_overflow<TYPE_DECIMAL128, DivOp, true>(test_case_array, 38, 15, 38, 15, 38, 15,
-                                                                     overflows);
+    test_vector_vector_assert_overflow<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_case_array, 38, 15, 38,
+                                                                                          15, 38, 15, overflows);
 }
 
 TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s14_div_decimal128p38s14_eq_decimal128p38s14) {
@@ -2967,29 +3008,29 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal128p38s14_div_decimal128p38s14_eq_
         test_case_array.emplace_back(std::get<0>(tc), std::get<1>(tc), std::get<2>(tc));
         overflows.emplace_back(std::get<3>(tc));
     }
-    test_vector_vector_assert_overflow<TYPE_DECIMAL128, DivOp, true>(test_case_array, 38, 14, 38, 14, 38, 14,
-                                                                     overflows);
+    test_vector_vector_assert_overflow<TYPE_DECIMAL128, DivOp, OverflowMode::OUTPUT_NULL>(test_case_array, 38, 14, 38,
+                                                                                          14, 38, 14, overflows);
 }
 
 template <LogicalType LhsType, LogicalType RhsType, LogicalType ResultType, typename Op>
 void test_decimal_fast_mul_help(const DecimalTestCaseArray& test_cases, int lhs_precision, int lhs_scale,
                                 int rhs_precision, int rhs_scale, int result_precision, int result_scale) {
 #if defined(__x86_64__) && defined(__GNUC__)
-    test_vector_vector<LhsType, RhsType, ResultType, Op, false>(test_cases, lhs_precision, lhs_scale, rhs_precision,
-                                                                rhs_scale, result_precision, result_scale);
-    test_vector_const<LhsType, RhsType, ResultType, Op, false>(test_cases, lhs_precision, lhs_scale, rhs_precision,
-                                                               rhs_scale, result_precision, result_scale);
-    test_const_vector<LhsType, RhsType, ResultType, Op, false>(test_cases, lhs_precision, lhs_scale, rhs_precision,
-                                                               rhs_scale, result_precision, result_scale);
-    test_const_const<LhsType, RhsType, ResultType, Op, false>(test_cases, lhs_precision, lhs_scale, rhs_precision,
-                                                              rhs_scale, result_precision, result_scale);
-    test_nullable_vector_const<LhsType, RhsType, ResultType, Op, false>(
+    test_vector_vector<LhsType, RhsType, ResultType, Op, OverflowMode::IGNORE>(
             test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
-    test_const_nullable_vector<LhsType, RhsType, ResultType, Op, false>(
+    test_vector_const<LhsType, RhsType, ResultType, Op, OverflowMode::IGNORE>(
             test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
-    test_nullable_vector_nullable_vector<LhsType, RhsType, ResultType, Op, false>(
+    test_const_vector<LhsType, RhsType, ResultType, Op, OverflowMode::IGNORE>(
             test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
-    test_vector_vector<ResultType, ResultType, ResultType, MulOp, false>(
+    test_const_const<LhsType, RhsType, ResultType, Op, OverflowMode::IGNORE>(
+            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+    test_nullable_vector_const<LhsType, RhsType, ResultType, Op, OverflowMode::IGNORE>(
+            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+    test_const_nullable_vector<LhsType, RhsType, ResultType, Op, OverflowMode::IGNORE>(
+            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+    test_nullable_vector_nullable_vector<LhsType, RhsType, ResultType, Op, OverflowMode::IGNORE>(
+            test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
+    test_vector_vector<ResultType, ResultType, ResultType, MulOp, OverflowMode::IGNORE>(
             test_cases, lhs_precision, lhs_scale, rhs_precision, rhs_scale, result_precision, result_scale);
 #endif
 }
@@ -3087,6 +3128,18 @@ TEST_F(DecimalBinaryFunctionTest, test_decimal_fast_mul_64x64) {
             {"60915079068521.5269", "-99999121308263.0016", "-6091454381275516575941632856.40914304"}};
     test_decimal_fast_mul_help<TYPE_DECIMAL64, TYPE_DECIMAL64, TYPE_DECIMAL128, MulOp64x64_128>(test_cases, 18, 4, 18,
                                                                                                 4, 38, 8);
+}
+
+TEST_F(DecimalBinaryFunctionTest, test_overflow_report_error) {
+    ASSERT_THROW((test_overflow_report_error<TYPE_DECIMAL32, TYPE_DECIMAL32, TYPE_DECIMAL32, MulOp>(
+                         "274.97790", "1.0000", 9, 5, 9, 4)),
+                 std::overflow_error);
+    ASSERT_THROW((test_overflow_report_error<TYPE_DECIMAL64, TYPE_DECIMAL64, TYPE_DECIMAL64, MulOp>(
+                         "274.97790000000", "1.000000", 18, 11, 18, 6)),
+                 std::overflow_error);
+    ASSERT_THROW((test_overflow_report_error<TYPE_DECIMAL128, TYPE_DECIMAL128, TYPE_DECIMAL128, MulOp>(
+                         "274.97790000000000000000", "1.0000000000000000", 38, 20, 38, 16)),
+                 std::overflow_error);
 }
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -157,7 +157,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM = "parallel_fragment_exec_instance_num";
     public static final String MAX_PARALLEL_SCAN_INSTANCE_NUM = "max_parallel_scan_instance_num";
     public static final String ENABLE_INSERT_STRICT = "enable_insert_strict";
-    public static final String ENABLE_ERROR_IF_OVERFLOW = "enable_error_if_overflow";
     public static final String ENABLE_SPILL = "enable_spill";
     public static final String SPILLABLE_OPERATOR_MASK = "spillable_operator_mask";
     // spill mode: auto, force
@@ -799,9 +798,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_INSERT_STRICT)
     private boolean enableInsertStrict = true;
-
-    @VariableMgr.VarAttr(name = ENABLE_ERROR_IF_OVERFLOW)
-    private boolean enableErrorIfOverflow = false;
 
     @VariableMgr.VarAttr(name = ENABLE_SPILL)
     private boolean enableSpill = false;
@@ -2537,7 +2533,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             tResult.setMax_pushdown_conditions_per_column(maxPushdownConditionsPerColumn);
         }
 
-        if (enableErrorIfOverflow) {
+        if (SqlModeHelper.check(sqlMode, SqlModeHelper.MODE_ERROR_IF_OVERFLOW)) {
             tResult.setOverflow_mode(TOverflowMode.REPORT_ERROR);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -47,6 +47,7 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.VariableMgr.VarAttr;
 import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TCompressionType;
+import com.starrocks.thrift.TOverflowMode;
 import com.starrocks.thrift.TPipelineProfileLevel;
 import com.starrocks.thrift.TQueryOptions;
 import com.starrocks.thrift.TSpillMode;
@@ -156,6 +157,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM = "parallel_fragment_exec_instance_num";
     public static final String MAX_PARALLEL_SCAN_INSTANCE_NUM = "max_parallel_scan_instance_num";
     public static final String ENABLE_INSERT_STRICT = "enable_insert_strict";
+    public static final String ENABLE_ERROR_IF_OVERFLOW = "enable_error_if_overflow";
     public static final String ENABLE_SPILL = "enable_spill";
     public static final String SPILLABLE_OPERATOR_MASK = "spillable_operator_mask";
     // spill mode: auto, force
@@ -797,6 +799,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_INSERT_STRICT)
     private boolean enableInsertStrict = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_ERROR_IF_OVERFLOW)
+    private boolean enableErrorIfOverflow = false;
 
     @VariableMgr.VarAttr(name = ENABLE_SPILL)
     private boolean enableSpill = false;
@@ -2530,6 +2535,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         }
         if (maxPushdownConditionsPerColumn > -1) {
             tResult.setMax_pushdown_conditions_per_column(maxPushdownConditionsPerColumn);
+        }
+
+        if (enableErrorIfOverflow) {
+            tResult.setOverflow_mode(TOverflowMode.REPORT_ERROR);
         }
 
         tResult.setEnable_spill(enableSpill);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SqlModeHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SqlModeHelper.java
@@ -91,6 +91,7 @@ public class SqlModeHelper {
     public static final long MODE_TIME_TRUNCATE_FRACTIONAL = 1L << 32;
     public static final long MODE_SORT_NULLS_LAST = 1L << 33;
     public static final long MODE_LAST = 1L << 34;
+    public static final long MODE_ERROR_IF_OVERFLOW = 1L << 35;
 
     public static final long MODE_ALLOWED_MASK =
             (MODE_REAL_AS_FLOAT | MODE_PIPES_AS_CONCAT | MODE_ANSI_QUOTES |
@@ -102,7 +103,7 @@ public class SqlModeHelper {
                     MODE_NO_ZERO_DATE | MODE_INVALID_DATES | MODE_ERROR_FOR_DIVISION_BY_ZERO |
                     MODE_HIGH_NOT_PRECEDENCE | MODE_NO_ENGINE_SUBSTITUTION |
                     MODE_PAD_CHAR_TO_FULL_LENGTH | MODE_TRADITIONAL | MODE_ANSI |
-                    MODE_TIME_TRUNCATE_FRACTIONAL | MODE_SORT_NULLS_LAST);
+                    MODE_TIME_TRUNCATE_FRACTIONAL | MODE_SORT_NULLS_LAST) | MODE_ERROR_IF_OVERFLOW;
 
     private static final Map<String, Long> SQL_MODE_SET = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
 
@@ -135,6 +136,7 @@ public class SqlModeHelper {
         SQL_MODE_SET.put("PAD_CHAR_TO_FULL_LENGTH", MODE_PAD_CHAR_TO_FULL_LENGTH);
         SQL_MODE_SET.put("TIME_TRUNCATE_FRACTIONAL", MODE_TIME_TRUNCATE_FRACTIONAL);
         SQL_MODE_SET.put("SORT_NULLS_LAST", MODE_SORT_NULLS_LAST);
+        SQL_MODE_SET.put("ERROR_IF_OVERFLOW", MODE_ERROR_IF_OVERFLOW);
 
         COMBINE_MODE_SET.put("ANSI", (MODE_REAL_AS_FLOAT | MODE_PIPES_AS_CONCAT |
                 MODE_ANSI_QUOTES | MODE_IGNORE_SPACE | MODE_ONLY_FULL_GROUP_BY));

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -119,6 +119,11 @@ enum TTabletInternalParallelMode {
   FORCE_SPLIT
 }
 
+enum TOverflowMode {
+  OUTPUT_NULL = 0;
+  REPORT_ERROR = 1;
+}
+
 // Query options with their respective defaults
 struct TQueryOptions {
   2: optional i32 max_errors = 0
@@ -221,6 +226,8 @@ struct TQueryOptions {
   102: optional bool enable_collect_table_level_scan_stats;
 
   103: optional i32 interleaving_group_size;
+
+  104: optional TOverflowMode overflow_mode = TOverflowMode.OUTPUT_NULL;
 }
 
 

--- a/test/sql/test_decimal/R/test_decimal_overflow
+++ b/test/sql/test_decimal/R/test_decimal_overflow
@@ -21,7 +21,7 @@ select 274.97790000000000000000 * (round(1103.00000000000000000000 * 1.0000,16) 
 -- result:
 None
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ 274.97790000000000000000 * (round(1103.00000000000000000000 * 1.0000,16) /round(1103.00000000000000000000,16));
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ 274.97790000000000000000 * (round(1103.00000000000000000000 * 1.0000,16) /round(1103.00000000000000000000,16));
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result
@@ -73,51 +73,51 @@ select cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_
 -- result:
 None
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 2;
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 1;
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 2;
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 1;
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 2;
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 1;
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 2;
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 1;
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 2;
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 1;
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 2;
 -- result:
 E: (1064, 'Expr evaluate meet error: Decimal overflow')
 -- !result

--- a/test/sql/test_decimal/R/test_decimal_overflow
+++ b/test/sql/test_decimal/R/test_decimal_overflow
@@ -23,7 +23,7 @@ None
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ 274.97790000000000000000 * (round(1103.00000000000000000000 * 1.0000,16) /round(1103.00000000000000000000,16));
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, "Expr evaluate meet error: The 'mul' operation involving decimal values overflows")
 -- !result
 select cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
 -- result:
@@ -75,49 +75,49 @@ None
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 2;
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 1;
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 2;
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 1;
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, "Expr evaluate meet error: The 'mul' operation involving decimal values overflows")
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 2;
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, "Expr evaluate meet error: The 'mul' operation involving decimal values overflows")
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 1;
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 2;
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 1;
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 2;
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, 'Expr evaluate meet error: The type cast from decimal to decimal overflows')
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 1;
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, "Expr evaluate meet error: The 'mul' operation involving decimal values overflows")
 -- !result
 select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 2;
 -- result:
-E: (1064, 'Expr evaluate meet error: Decimal overflow')
+E: (1064, "Expr evaluate meet error: The 'mul' operation involving decimal values overflows")
 -- !result

--- a/test/sql/test_decimal/R/test_decimal_overflow
+++ b/test/sql/test_decimal/R/test_decimal_overflow
@@ -1,0 +1,123 @@
+-- name: test_decimal_overflow
+CREATE TABLE `t_decimal_overflow` (
+  `c_id` int(11) NOT NULL,
+  `c_d32` decimal32(9,3) NOT NULL,
+  `c_d64` decimal64(18,5) NOT NULL,
+  `c_d128` decimal128(38,7) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c_id`)
+DISTRIBUTED BY HASH(`c_id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `t_decimal_overflow` (c_id, c_d32, c_d64, c_d128) values
+   (1, 999999.99, 9999999999999.99999, 9999999999999999999999999999999.9999999),
+   (2, -999999.99, -9999999999999.99999, -9999999999999999999999999999999.9999999);
+-- result:
+-- !result
+select 274.97790000000000000000 * (round(1103.00000000000000000000 * 1.0000,16) /round(1103.00000000000000000000,16));
+-- result:
+None
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ 274.97790000000000000000 * (round(1103.00000000000000000000 * 1.0000,16) /round(1103.00000000000000000000,16));
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result
+select cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
+-- result:
+None
+-- !result
+select cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 2;
+-- result:
+None
+-- !result
+select cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 1;
+-- result:
+None
+-- !result
+select cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 2;
+-- result:
+None
+-- !result
+select cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 1;
+-- result:
+None
+-- !result
+select cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 2;
+-- result:
+None
+-- !result
+select cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 1;
+-- result:
+None
+-- !result
+select cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 2;
+-- result:
+None
+-- !result
+select cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 1;
+-- result:
+None
+-- !result
+select cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 2;
+-- result:
+None
+-- !result
+select cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 1;
+-- result:
+None
+-- !result
+select cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 2;
+-- result:
+None
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 2;
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 1;
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 2;
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 1;
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 2;
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 1;
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 2;
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 1;
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 2;
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 1;
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 2;
+-- result:
+E: (1064, 'Expr evaluate meet error: Decimal overflow')
+-- !result

--- a/test/sql/test_decimal/T/test_decimal_overflow
+++ b/test/sql/test_decimal/T/test_decimal_overflow
@@ -16,7 +16,7 @@ INSERT INTO `t_decimal_overflow` (c_id, c_d32, c_d64, c_d128) values
    (2, -999999.99, -9999999999999.99999, -9999999999999999999999999999999.9999999);
 
 select 274.97790000000000000000 * (round(1103.00000000000000000000 * 1.0000,16) /round(1103.00000000000000000000,16));
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ 274.97790000000000000000 * (round(1103.00000000000000000000 * 1.0000,16) /round(1103.00000000000000000000,16));
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ 274.97790000000000000000 * (round(1103.00000000000000000000 * 1.0000,16) /round(1103.00000000000000000000,16));
 
 select cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
 select cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 2;
@@ -31,15 +31,15 @@ select cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 
 select cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 1;
 select cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 2;
 
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 2;
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 1;
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 2;
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 1;
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 2;
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 1;
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 2;
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 1;
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 2;
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 1;
-select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(sql_mode='ERROR_IF_OVERFLOW')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 2;

--- a/test/sql/test_decimal/T/test_decimal_overflow
+++ b/test/sql/test_decimal/T/test_decimal_overflow
@@ -1,0 +1,45 @@
+-- name: test_decimal_overflow
+CREATE TABLE `t_decimal_overflow` (
+  `c_id` int(11) NOT NULL,
+  `c_d32` decimal32(9,3) NOT NULL,
+  `c_d64` decimal64(18,5) NOT NULL,
+  `c_d128` decimal128(38,7) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c_id`)
+DISTRIBUTED BY HASH(`c_id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+INSERT INTO `t_decimal_overflow` (c_id, c_d32, c_d64, c_d128) values
+   (1, 999999.99, 9999999999999.99999, 9999999999999999999999999999999.9999999),
+   (2, -999999.99, -9999999999999.99999, -9999999999999999999999999999999.9999999);
+
+select 274.97790000000000000000 * (round(1103.00000000000000000000 * 1.0000,16) /round(1103.00000000000000000000,16));
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ 274.97790000000000000000 * (round(1103.00000000000000000000 * 1.0000,16) /round(1103.00000000000000000000,16));
+
+select cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
+select cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 2;
+select cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 1;
+select cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 2;
+select cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 1;
+select cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 2;
+select cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 1;
+select cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 2;
+select cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 1;
+select cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 2;
+select cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 1;
+select cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 2;
+
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * c_d32 as decimal32) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * c_d64 as decimal64) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * c_d128 as decimal128) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d32 * 1.000 as decimal32) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d64 * 1.000000 as decimal64) from t_decimal_overflow where c_id = 2;
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 1;
+select /*+ SET_VAR(enable_error_if_overflow='true')*/ cast(c_d128 * 1.000000000 as decimal128) from t_decimal_overflow where c_id = 2;


### PR DESCRIPTION
## Main work

Support error reporting when decimal overflow by introducing a OverflowMode, which has three different modes:
* IGNORE
* OUTPUT_NULL
* REPORT_ERROR

This behavior can be enabled by setting session varaible `set sql_mode='ERROR_IF_OVERFLOW'`

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
