### PR TITLE
[Feature] support using expr predicate to prune partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
@@ -83,7 +83,7 @@ public class DateLiteral extends LiteralExpr {
         super();
     }
 
-    public DateLiteral(Type type, boolean isMax) throws AnalysisException {
+    public DateLiteral(Type type, boolean isMax) {
         super();
         this.type = type;
         if (type.isDate()) {
@@ -157,7 +157,7 @@ public class DateLiteral extends LiteralExpr {
         type = other.type;
     }
 
-    public static DateLiteral createMinValue(Type type) throws AnalysisException {
+    public static DateLiteral createMinValue(Type type) {
         return new DateLiteral(type, false);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
@@ -45,6 +45,7 @@ import static java.util.stream.Collectors.toList;
  * ExpressionRangePartitionInfo replace columns with expressions
  * Some Descriptions:
  * 1. no overwrite old serialized method: read、write and readFields, because we use gson now
+ * 2. As of 2023-09, it's still used to describe auto range using expr like PARTITION BY date_trunc('day', col).
  */
 @Deprecated
 public class ExpressionRangePartitionInfo extends RangePartitionInfo implements GsonPreProcessable, GsonPostProcessable {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
@@ -49,6 +49,7 @@ import static java.util.stream.Collectors.toList;
  * because ExpressionRangePartitionInfo is not easily scalable
  * and get more extensions by extracting objects
  * in the future this will replace all expr range partition info
+ * As of 2023-09, it's used to describe range using expr like partition by range cast((substring(col, 3)) as int)
  */
 public class ExpressionRangePartitionInfoV2 extends RangePartitionInfo
         implements GsonPreProcessable, GsonPostProcessable {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PartitionColumnFilter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PartitionColumnFilter.java
@@ -165,5 +165,4 @@ public class PartitionColumnFilter {
         }
         return str;
     }
-};
-/* vim: set ts=4 sw=4 sts=4 tw=100 noet: */
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -496,6 +496,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String CBO_PUSHDOWN_TOPN_LIMIT = "cbo_push_down_topn_limit";
 
+    public static final String ENABLE_EXPR_PRUNE_PARTITION = "enable_expr_prune_partition";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1275,6 +1277,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = HIVE_TEMP_STAGING_DIR)
     private String hiveTempStagingDir = "/tmp/starrocks";
+
+    @VarAttr(name = ENABLE_EXPR_PRUNE_PARTITION, flag = VariableMgr.INVISIBLE)
+    private boolean enableExprPrunePartition = true;
 
     private int exprChildrenLimit = -1;
 
@@ -2461,6 +2466,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableCountStarOptimization(boolean v) {
         enableCountStarOptimization = v;
+    }
+
+    public boolean isEnableExprPrunePartition() {
+        return enableExprPrunePartition;
+    }
+
+    public void setEnableExprPrunePartition(boolean enableExprPrunePartition) {
+        this.enableExprPrunePartition = enableExprPrunePartition;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -156,7 +156,7 @@ public class ColumnFilterConverter {
 
     public static void convertColumnFilter(ScalarOperator predicate, Map<String, PartitionColumnFilter> result,
                                            Table table) {
-        if (predicate.getChildren().size() <= 0) {
+        if (predicate.getChildren().size() == 0) {
             return;
         }
 
@@ -188,7 +188,9 @@ public class ColumnFilterConverter {
         Expr predicateExpr = firstPartitionExpr.clone();
 
         // only support binary predicate
-        if (predicate instanceof BinaryPredicateOperator && predicate.getChildren().size() == 2) {
+        if (predicate instanceof BinaryPredicateOperator
+                && predicate.getChild(0) instanceof ColumnRefOperator
+                && predicate.getChild(1) instanceof ConstantOperator) {
             List<ScalarOperator> argument = predicate.getChildren();
             ColumnRefOperator columnRef = (ColumnRefOperator) argument.get(0);
             ConstantOperator constant = (ConstantOperator) argument.get(1);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -156,7 +156,7 @@ public class ColumnFilterConverter {
 
     public static void convertColumnFilter(ScalarOperator predicate, Map<String, PartitionColumnFilter> result,
                                            Table table) {
-        if (predicate.getChildren().size() == 0) {
+        if (CollectionUtils.isEmpty(predicate.getChildren())) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -186,6 +186,26 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
         return new ConstantOperator(value, binaryType);
     }
 
+    public static ConstantOperator createExampleValueByType(Type type) {
+        if (type.isTinyint()) {
+            return createTinyInt((byte) 1);
+        } else if (type.isSmallint()) {
+            return createSmallInt((short) 1);
+        } else if (type.isInt()) {
+            return createInt(1);
+        } else if (type.isBigint()) {
+            return createBigint(1L);
+        } else if (type.isLargeint()) {
+            return createLargeInt(new BigInteger("1"));
+        } else if (type.isDate()) {
+            return createDate(LocalDateTime.of(2000, 1, 1, 00, 00, 00));
+        } else if (type.isDatetime()) {
+            return createDatetime(LocalDateTime.of(2000, 1, 1, 00, 00, 00));
+        } else {
+            throw new IllegalArgumentException("unsupported type: " + type);
+        }
+    }
+
     public boolean isNull() {
         return isNull;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ConstantFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ConstantFunction.java
@@ -36,6 +36,8 @@ public @interface ConstantFunction {
      */
     boolean isMetaFunction() default false;
 
+    boolean isMonotonic() default false;
+
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     @interface List {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ConstantFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ConstantFunction.java
@@ -36,6 +36,13 @@ public @interface ConstantFunction {
      */
     boolean isMetaFunction() default false;
 
+    /**
+     * When a function is a monotonic function, which means for any value within a range,
+     * the first and last endpoints yield the new extreme points after the function mapping.
+     * This helps us to determine the result range according the only first and last endpoints
+     * of the input of a function.
+     * For example, date_trunc() is a monotonic function while abs() is not.
+     */
     boolean isMonotonic() default false;
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -18,8 +18,12 @@ package com.starrocks.sql.optimizer.rewrite;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -333,7 +337,7 @@ public class OptOlapPartitionPruner {
                 partitionInfo.getPartitionColumns(), operator.getColumnFilters());
         try {
             return partitionPruner.prune();
-        } catch (AnalysisException e) {
+        } catch (Exception e) {
             LOG.warn("PartitionPrune Failed. ", e);
         }
         return null;
@@ -341,22 +345,29 @@ public class OptOlapPartitionPruner {
 
     private static boolean isNeedFurtherPrune(List<Long> candidatePartitions, LogicalOlapScanOperator olapScanOperator,
                                               PartitionInfo partitionInfo) {
-        boolean probeResult = true;
-        if (candidatePartitions.isEmpty()) {
-            probeResult = false;
-        } else if (!partitionInfo.isRangePartition()) {
-            probeResult = false;
-        } else if (((RangePartitionInfo) partitionInfo).getPartitionColumns().size() > 1) {
-            probeResult = false;
-        } else if (((RangePartitionInfo) partitionInfo).getIdToRange(true)
-                .containsKey(candidatePartitions.get(0))) {
-            // it's a temp partition list, no need to do the further prune
-            probeResult = false;
-        } else if (olapScanOperator.getPredicate() == null) {
-            probeResult = false;
+        if (candidatePartitions.isEmpty()
+                || olapScanOperator.getPredicate() == null) {
+            return false;
         }
 
-        return probeResult;
+        // only support RANGE and EXPR_RANGE
+        // EXPR_RANGE_V2 type like partition by RANGE(cast(substring(col, 3)) as int)) is unsupported
+        if (partitionInfo.getType() == PartitionType.RANGE) {
+            RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) partitionInfo;
+            return rangePartitionInfo.getPartitionColumns().size() == 1
+                    && !rangePartitionInfo.getIdToRange(true).containsKey(candidatePartitions.get(0));
+        } else if (partitionInfo.getType() == PartitionType.EXPR_RANGE) {
+            ExpressionRangePartitionInfo exprPartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
+            List<Expr> partitionExpr = exprPartitionInfo.getPartitionExprs();
+            if (partitionExpr.size() == 1 && partitionExpr.get(0) instanceof FunctionCallExpr) {
+                FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr.get(0);
+                String functionName = functionCallExpr.getFnName().getFunction();
+                return (FunctionSet.DATE_TRUNC.equalsIgnoreCase(functionName)
+                        || FunctionSet.TIME_SLICE.equalsIgnoreCase(functionName))
+                        && !exprPartitionInfo.getIdToRange(true).containsKey(candidatePartitions.get(0));
+            }
+        }
+        return false;
     }
 
     private static boolean containsNullValue(Column column, PartitionKey minRange) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
@@ -294,7 +294,7 @@ public class PartitionColPredicateEvaluator {
             for (int i = 0; i < candidateNum; i++) {
                 Range<PartitionKey> range = ranges.get(i);
                 if (range.isConnected(predicateRange) && !range.intersection(predicateRange).isEmpty()) {
-                    if (isCanonicalType(partitionColumn.getType())) {
+                    if (isCanonicalType(scalarOperator.getType())) {
                         // try to canonical predicate
                         Range intersectedRange = range.intersection(predicateRange);
                         Range canonicalRange = intersectedRange.canonical(new PartitionKeyDiscreteDomain());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
@@ -148,8 +148,16 @@ public class PartitionColPredicateEvaluator {
                         Optional<LiteralExpr> mappingLowerBound = mapRangeBoundValue(call, lowerBound);
                         Optional<LiteralExpr> mappingUpperBound = mapRangeBoundValue(call, upperBound);
                         if (mappingLowerBound.isPresent() && mappingUpperBound.isPresent()) {
-                            lowerKey.pushColumn(mappingLowerBound.get(), returnType);
-                            upperKey.pushColumn(mappingUpperBound.get(), returnType);
+                            LiteralExpr newLowerBound = mappingLowerBound.get();
+                            LiteralExpr newUpperBound = mappingUpperBound.get();
+                            // switch bound value
+                            if (newLowerBound.compareTo(newUpperBound) > 0) {
+                                LiteralExpr tmp = newLowerBound;
+                                newLowerBound = newUpperBound;
+                                newUpperBound = tmp;
+                            }
+                            lowerKey.pushColumn(newLowerBound, returnType);
+                            upperKey.pushColumn(newUpperBound, returnType);
                             newRange = Range.range(lowerKey, BoundType.CLOSED, upperKey, BoundType.OPEN);
                         } else {
                             newRange = createFullScopeRange(call.getType().getPrimitiveType());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
@@ -15,31 +15,43 @@
 
 package com.starrocks.sql.optimizer.rewrite;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.starrocks.analysis.BinaryType;
+import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.LargeIntLiteral;
 import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.MaxLiteral;
+import com.starrocks.analysis.NullLiteral;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PartitionKeyDiscreteDomain;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.optimizer.operator.ColumnFilterConverter;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class PartitionColPredicateEvaluator {
@@ -48,13 +60,15 @@ public class PartitionColPredicateEvaluator {
 
     private static final int IN_OPERANDS_LIMIT = 50;
 
-    private List<Long> candidatePartitions;
+    private final List<Long> candidatePartitions;
 
-    private List<Range<PartitionKey>> candidateRanges;
+    private final List<Range<PartitionKey>> candidateRanges;
 
-    private int candidateNum = 0;
+    private final Map<ScalarOperator, List<Range<PartitionKey>>> exprToCandidateRanges;
 
-    private Column partitionColumn;
+    private final int candidateNum;
+
+    private final Column partitionColumn;
 
     public PartitionColPredicateEvaluator(RangePartitionInfo rangePartitionInfo, List<Long> candidatePartitions) {
         this.candidatePartitions = candidatePartitions;
@@ -64,6 +78,7 @@ public class PartitionColPredicateEvaluator {
         for (long id : candidatePartitions) {
             candidateRanges.add(rangePartitionInfo.getIdToRange(false).get(id));
         }
+        exprToCandidateRanges = Maps.newHashMap();
     }
 
     public List<Long> prunePartitions(PartitionColPredicateExtractor extractor, ScalarOperator predicates) {
@@ -96,13 +111,68 @@ public class PartitionColPredicateEvaluator {
 
         @Override
         public BitSet visitConstant(ConstantOperator literal, Void context) {
-            Preconditions.checkState(Type.BOOLEAN == literal.getType());
             return literal.getBoolean() ? createAllTrueBitSet() : new BitSet(candidateNum);
+        }
+
+        @Override
+        public BitSet visitCall(CallOperator call, Void context) {
+            if (!exprToCandidateRanges.containsKey(call)) {
+                List<Range<PartitionKey>> mappingRanges = Lists.newArrayList();
+                PrimitiveType returnType = call.getType().getPrimitiveType();
+                for (Range<PartitionKey> range : candidateRanges) {
+                    Range<PartitionKey> newRange;
+                    if (!range.hasUpperBound() || range.upperEndpoint().getKeys().get(0) instanceof MaxLiteral) {
+                        newRange = createFullScopeRange(returnType);
+                    } else if (!range.hasLowerBound()) {
+                        PartitionKey lowerKey = new PartitionKey();
+                        PartitionKey upperKey = new PartitionKey();
+
+                        LiteralExpr lowerBound = createInfinity(partitionColumn.getType(), false);
+
+                        Optional<LiteralExpr> mappingLowerBound = mapRangeBoundValue(call, lowerBound);
+                        Optional<LiteralExpr> mappingUpperBound = mapRangeBoundValue(call,
+                                range.upperEndpoint().getKeys().get(0));
+                        if (mappingLowerBound.isPresent() && mappingUpperBound.isPresent()) {
+                            lowerKey.pushColumn(mappingLowerBound.get(), returnType);
+                            upperKey.pushColumn(mappingUpperBound.get(), returnType);
+                            newRange = Range.range(lowerKey, BoundType.CLOSED, upperKey, BoundType.OPEN);
+                        } else {
+                            newRange = createFullScopeRange(call.getType().getPrimitiveType());
+                        }
+                    } else {
+                        PartitionKey lowerKey = new PartitionKey();
+                        PartitionKey upperKey = new PartitionKey();
+
+                        LiteralExpr lowerBound = range.lowerEndpoint().getKeys().get(0);
+                        LiteralExpr upperBound = range.upperEndpoint().getKeys().get(0);
+                        Optional<LiteralExpr> mappingLowerBound = mapRangeBoundValue(call, lowerBound);
+                        Optional<LiteralExpr> mappingUpperBound = mapRangeBoundValue(call, upperBound);
+                        if (mappingLowerBound.isPresent() && mappingUpperBound.isPresent()) {
+                            lowerKey.pushColumn(mappingLowerBound.get(), returnType);
+                            upperKey.pushColumn(mappingUpperBound.get(), returnType);
+                            newRange = Range.range(lowerKey, BoundType.CLOSED, upperKey, BoundType.OPEN);
+                        } else {
+                            newRange = createFullScopeRange(call.getType().getPrimitiveType());
+                        }
+                    }
+                    mappingRanges.add(newRange);
+                }
+
+                exprToCandidateRanges.put(call, mappingRanges);
+            }
+            return null;
+        }
+
+        @Override
+        public BitSet visitVariableReference(ColumnRefOperator variable, Void context) {
+            exprToCandidateRanges.put(variable, candidateRanges);
+            return null;
         }
 
         @Override
         public BitSet visitBinaryPredicate(BinaryPredicateOperator predicate, Void context) {
             BinaryType type = predicate.getBinaryType();
+            predicate.getChild(0).accept(this, null);
             ConstantOperator constantOperator = (ConstantOperator) predicate.getChild(1);
             LiteralExpr literalExpr;
             try {
@@ -111,7 +181,6 @@ public class PartitionColPredicateEvaluator {
                     literalExpr = LiteralExpr.createInfinity(columnType, false);
                 } else {
                     literalExpr = ColumnFilterConverter.convertLiteral(constantOperator);
-
                 }
             } catch (AnalysisException e) {
                 return createAllTrueBitSet();
@@ -140,7 +209,7 @@ public class PartitionColPredicateEvaluator {
                 default:
                     predicateRange = Range.all();
             }
-            return evaluateRangeHitSet(predicateRange);
+            return evaluateRangeHitSet(predicate.getChild(0), predicateRange);
         }
 
         @Override
@@ -162,6 +231,7 @@ public class PartitionColPredicateEvaluator {
         // only process in scene
         @Override
         public BitSet visitInPredicate(InPredicateOperator predicate, Void context) {
+            predicate.getChild(0).accept(this, null);
             List<ConstantOperator> constList = predicate.getChildren().stream()
                     .skip(1).map(ConstantOperator.class::cast)
                     .filter(e -> !e.isNull()).sorted().collect(Collectors.toList());
@@ -174,7 +244,7 @@ public class PartitionColPredicateEvaluator {
                         PartitionKey conditionKey = new PartitionKey();
                         conditionKey.pushColumn(literalExpr, partitionColumn.getPrimitiveType());
                         Range<PartitionKey> predicateRange = Range.closed(conditionKey, conditionKey);
-                        res.or(evaluateRangeHitSet(predicateRange));
+                        res.or(evaluateRangeHitSet(predicate.getChild(0), predicateRange));
                     } catch (AnalysisException e) {
                         encounterEx = true;
                         break;
@@ -189,7 +259,7 @@ public class PartitionColPredicateEvaluator {
                     PartitionKey maxKey = new PartitionKey();
                     maxKey.pushColumn(max, partitionColumn.getPrimitiveType());
                     Range<PartitionKey> coarseRange = Range.range(minKey, BoundType.CLOSED, maxKey, BoundType.CLOSED);
-                    res.or(evaluateRangeHitSet(coarseRange));
+                    res.or(evaluateRangeHitSet(predicate.getChild(0), coarseRange));
                 } catch (AnalysisException e) {
                     encounterEx = true;
                 }
@@ -203,6 +273,7 @@ public class PartitionColPredicateEvaluator {
 
         @Override
         public BitSet visitIsNullPredicate(IsNullPredicateOperator predicate, Void context) {
+            predicate.getChild(0).accept(this, null);
             PartitionKey conditionKey = new PartitionKey();
             Type columnType = Type.fromPrimitiveType(partitionColumn.getPrimitiveType());
             try {
@@ -211,13 +282,17 @@ public class PartitionColPredicateEvaluator {
                 return createAllTrueBitSet();
             }
             Range<PartitionKey> predicateRange = Range.closed(conditionKey, conditionKey);
-            return evaluateRangeHitSet(predicateRange);
+            return evaluateRangeHitSet(predicate.getChild(0), predicateRange);
         }
 
-        private BitSet evaluateRangeHitSet(Range<PartitionKey> predicateRange) {
+        private BitSet evaluateRangeHitSet(ScalarOperator scalarOperator, Range<PartitionKey> predicateRange) {
             BitSet bitSet = new BitSet(candidateNum);
+            if (!exprToCandidateRanges.containsKey(scalarOperator)) {
+                return createAllTrueBitSet();
+            }
+            List<Range<PartitionKey>> ranges = exprToCandidateRanges.get(scalarOperator);
             for (int i = 0; i < candidateNum; i++) {
-                Range<PartitionKey> range = candidateRanges.get(i);
+                Range<PartitionKey> range = ranges.get(i);
                 if (range.isConnected(predicateRange) && !range.intersection(predicateRange).isEmpty()) {
                     if (isCanonicalType(partitionColumn.getType())) {
                         // try to canonical predicate
@@ -243,5 +318,73 @@ public class PartitionColPredicateEvaluator {
             res.flip(0, candidateNum);
             return res;
         }
+
+        private LiteralExpr createInfinity(Type type, boolean isMax) {
+            if (isMax) {
+                return MaxLiteral.MAX_VALUE;
+            }
+
+            switch (type.getPrimitiveType()) {
+                case TINYINT:
+                case SMALLINT:
+                case INT:
+                case BIGINT:
+                    return IntLiteral.createMinValue(type);
+                case LARGEINT:
+                    return LargeIntLiteral.createMinValue();
+                case DATE:
+                case DATETIME:
+                    return DateLiteral.createMinValue(type);
+                default:
+                    throw new IllegalArgumentException("Invalid data type for creating infinity: " + type);
+            }
+        }
+
+        private Optional<LiteralExpr> mapRangeBoundValue(CallOperator callOperator, LiteralExpr literalExpr) {
+            ColumnRefReplacer refReplacer = new ColumnRefReplacer(literalExpr);
+            CallOperator newCall = (CallOperator) callOperator.accept(refReplacer, null);
+
+            ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();
+            ScalarOperator result = rewriter.rewrite(newCall,
+                    Collections.singletonList(new FoldConstantsRule(true)));
+            if (result.isConstantRef()) {
+                LiteralExpr newLiteralExpr;
+                try {
+                    newLiteralExpr = ColumnFilterConverter.convertLiteral((ConstantOperator) result);
+                } catch (Exception e) {
+                    return Optional.empty();
+                }
+                return Optional.of(newLiteralExpr);
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        private Range<PartitionKey> createFullScopeRange(PrimitiveType type) {
+            PartitionKey upperKey = new PartitionKey();
+            upperKey.pushColumn(MaxLiteral.MAX_VALUE, type);
+            return Range.lessThan(upperKey);
+        }
+    }
+
+    private class ColumnRefReplacer extends BaseScalarOperatorShuttle {
+
+        private final LiteralExpr literalExpr;
+
+        public ColumnRefReplacer(LiteralExpr literalExpr) {
+            this.literalExpr = literalExpr;
+        }
+
+        @Override
+        public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void context) {
+            if (literalExpr instanceof NullLiteral) {
+                return ConstantOperator.createNull(literalExpr.getType());
+            } else if (literalExpr instanceof MaxLiteral) {
+                return variable;
+            } else {
+                return ConstantOperator.createObject(literalExpr.getRealObjectValue(), literalExpr.getType());
+            }
+        }
+
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateExtractor.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rewrite;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
@@ -93,7 +94,8 @@ public class PartitionColPredicateExtractor extends ScalarOperatorVisitor<Scalar
 
     @Override
     public ScalarOperator visitCall(CallOperator call, Void context) {
-        if (call.getColumnRefs().size() == 1 && partitionColumnSet.containsAll(call.getUsedColumns())) {
+        if (ConnectContext.get().getSessionVariable().isEnableExprPrunePartition()
+                && call.getColumnRefs().size() == 1 && partitionColumnSet.containsAll(call.getUsedColumns())) {
             BaseScalarOperatorShuttle replaceShuttle = new BaseScalarOperatorShuttle() {
                 @Override
                 public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateExtractor.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rewrite;
 
 import com.google.common.collect.Lists;
@@ -30,7 +29,9 @@ import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -48,7 +49,7 @@ import static com.starrocks.analysis.BinaryType.EQ_FOR_NULL;
  */
 public class PartitionColPredicateExtractor extends ScalarOperatorVisitor<ScalarOperator, Void> {
 
-    private ColumnRefSet partitionColumnSet;
+    private final ColumnRefSet partitionColumnSet;
 
     public PartitionColPredicateExtractor(RangePartitionInfo rangePartitionInfo,
                                           Map<Column, ColumnRefOperator> columnMetaToColRefMap) {
@@ -92,6 +93,29 @@ public class PartitionColPredicateExtractor extends ScalarOperatorVisitor<Scalar
 
     @Override
     public ScalarOperator visitCall(CallOperator call, Void context) {
+        if (call.getColumnRefs().size() == 1 && partitionColumnSet.containsAll(call.getUsedColumns())) {
+            BaseScalarOperatorShuttle replaceShuttle = new BaseScalarOperatorShuttle() {
+                @Override
+                public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void context) {
+                    return ConstantOperator.createExampleValueByType(variable.getType());
+                }
+            };
+
+            ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();
+            try {
+                ScalarOperator replaced = call.accept(replaceShuttle, null);
+                ScalarOperator result = rewriter.rewrite(replaced,
+                        Collections.singletonList(new FoldConstantsRule(true)));
+
+                if (result instanceof ConstantOperator) {
+                    return call;
+                } else {
+                    return null;
+                }
+            } catch (Exception e) {
+                return null;
+            }
+        }
         return null;
     }
 
@@ -99,11 +123,11 @@ public class PartitionColPredicateExtractor extends ScalarOperatorVisitor<Scalar
     public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator predicate, Void context) {
         if (partitionColumnSet.containsAll(predicate.getUsedColumns())) {
             ScalarOperator left = predicate.getChild(0).accept(this, null);
-            if (isColumnOrPrune(left)) {
+            if (!isPartitionColExpr(left)) {
                 return ConstantOperator.createBoolean(true);
             }
             ScalarOperator right = predicate.getChild(1).accept(this, null);
-            if (isValueOrPrune(right)) {
+            if (!isConstantValue(right)) {
                 return ConstantOperator.createBoolean(true);
             }
 
@@ -174,7 +198,7 @@ public class PartitionColPredicateExtractor extends ScalarOperatorVisitor<Scalar
     @Override
     public ScalarOperator visitInPredicate(InPredicateOperator predicate, Void context) {
         ScalarOperator first = predicate.getChild(0).accept(this, null);
-        if (isColumnOrPrune(first)) {
+        if (!isPartitionColExpr(first)) {
             return ConstantOperator.createBoolean(true);
         } else {
             if (predicate.allValuesMatch(ScalarOperator::isConstantRef)) {
@@ -192,7 +216,7 @@ public class PartitionColPredicateExtractor extends ScalarOperatorVisitor<Scalar
     @Override
     public ScalarOperator visitIsNullPredicate(IsNullPredicateOperator predicate, Void context) {
         ScalarOperator first = predicate.getChild(0).accept(this, null);
-        if (isColumnOrPrune(first) || predicate.isNotNull()) {
+        if (predicate.isNotNull() || !isPartitionColExpr(first)) {
             return ConstantOperator.createBoolean(true);
         } else {
             return predicate;
@@ -206,21 +230,22 @@ public class PartitionColPredicateExtractor extends ScalarOperatorVisitor<Scalar
         return ConstantOperator.createBoolean(true);
     }
 
-    // For the operator in inExpr(first child), binaryExpr(first child), we need it's a columnRef.
+    // For the operator in inExpr(first child), binaryExpr(first child), we need it's a partition col or
+    // a callExpr just contains partition col and support constant fold.
     // For compoundExpr, its children may a bool type column or other expr.
-    // when it == null or it's not a columnRef,
+    // when it == null or it's not a satisfied expr,
     // it means this predicate node cannot been used for further evaluator
-    // we return a true flag to prune this predicate.
-    private boolean isColumnOrPrune(ScalarOperator operator) {
-        return operator == null || !operator.isColumnRef();
+    // we return a false flag to prune this predicate.
+    private boolean isPartitionColExpr(ScalarOperator operator) {
+        return operator != null && (operator instanceof ColumnRefOperator || operator instanceof CallOperator);
     }
 
     // For the second operator in binaryPredicateExpr, we need it's a constant value
-    // when it == null or it's not a constant,
+    // when it == null, or it's not a constant,
     // it means this predicate node cannot been used for further evaluator
-    // we return a true flag to prune this predicate.
-    private boolean isValueOrPrune(ScalarOperator operator) {
-        return operator == null || !operator.isConstant();
+    // we return a false flag to prune this predicate.
+    private boolean isConstantValue(ScalarOperator operator) {
+        return operator != null && operator.isConstant();
     }
 
     private boolean isConstantNull(ScalarOperator operator) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -147,89 +147,119 @@ public class ScalarOperatorFunctions {
     /**
      * date and time function
      */
-    @ConstantFunction(name = "timediff", argTypes = {DATETIME, DATETIME}, returnType = TIME)
+    @ConstantFunction(name = "timediff", argTypes = {DATETIME, DATETIME}, returnType = TIME, isMonotonic = true)
     public static ConstantOperator timeDiff(ConstantOperator first, ConstantOperator second) {
         return ConstantOperator.createTime(Duration.between(second.getDatetime(), first.getDatetime()).getSeconds());
     }
 
-    @ConstantFunction(name = "datediff", argTypes = {DATETIME, DATETIME}, returnType = INT)
+    @ConstantFunction(name = "datediff", argTypes = {DATETIME, DATETIME}, returnType = INT, isMonotonic = true)
     public static ConstantOperator dateDiff(ConstantOperator first, ConstantOperator second) {
         return ConstantOperator.createInt((int) Duration.between(
                 second.getDatetime().truncatedTo(ChronoUnit.DAYS),
                 first.getDatetime().truncatedTo(ChronoUnit.DAYS)).toDays());
     }
 
-    @ConstantFunction(name = "years_add", argTypes = {DATETIME, INT}, returnType = DATETIME)
+    @ConstantFunction(name = "years_add", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator yearsAdd(ConstantOperator date, ConstantOperator year) {
         return ConstantOperator.createDatetime(date.getDatetime().plusYears(year.getInt()));
     }
 
     @ConstantFunction.List(list = {
-            @ConstantFunction(name = "months_add", argTypes = {DATETIME, INT}, returnType = DATETIME),
-            @ConstantFunction(name = "add_months", argTypes = {DATETIME, INT}, returnType = DATETIME)
+            @ConstantFunction(name = "months_add", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true),
+            @ConstantFunction(name = "add_months", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     })
     public static ConstantOperator monthsAdd(ConstantOperator date, ConstantOperator month) {
         return ConstantOperator.createDatetime(date.getDatetime().plusMonths(month.getInt()));
     }
 
     @ConstantFunction.List(list = {
-            @ConstantFunction(name = "adddate", argTypes = {DATETIME, INT}, returnType = DATETIME),
-            @ConstantFunction(name = "date_add", argTypes = {DATETIME, INT}, returnType = DATETIME),
-            @ConstantFunction(name = "days_add", argTypes = {DATETIME, INT}, returnType = DATETIME)
+            @ConstantFunction(name = "adddate", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true),
+            @ConstantFunction(name = "date_add", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true),
+            @ConstantFunction(name = "days_add", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     })
     public static ConstantOperator daysAdd(ConstantOperator date, ConstantOperator day) {
         return ConstantOperator.createDatetime(date.getDatetime().plusDays(day.getInt()));
     }
 
-    @ConstantFunction(name = "hours_add", argTypes = {DATETIME, INT}, returnType = DATETIME)
+    @ConstantFunction(name = "hours_add", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator hoursAdd(ConstantOperator date, ConstantOperator hour) {
         return ConstantOperator.createDatetime(date.getDatetime().plusHours(hour.getInt()));
     }
 
-    @ConstantFunction(name = "minutes_add", argTypes = {DATETIME, INT}, returnType = DATETIME)
+    @ConstantFunction(name = "minutes_add", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator minutesAdd(ConstantOperator date, ConstantOperator minute) {
         return ConstantOperator.createDatetime(date.getDatetime().plusMinutes(minute.getInt()));
     }
 
-    @ConstantFunction(name = "seconds_add", argTypes = {DATETIME, INT}, returnType = DATETIME)
+    @ConstantFunction(name = "seconds_add", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator secondsAdd(ConstantOperator date, ConstantOperator second) {
         return ConstantOperator.createDatetime(date.getDatetime().plusSeconds(second.getInt()));
     }
 
-    @ConstantFunction(name = "date_trunc", argTypes = {VARCHAR, DATETIME}, returnType = DATETIME)
+
+    @ConstantFunction.List(list = {
+            @ConstantFunction(name = "date_trunc", argTypes = {VARCHAR, DATETIME}, returnType = DATETIME, isMonotonic = true),
+            @ConstantFunction(name = "date_trunc", argTypes = {VARCHAR, DATE}, returnType = DATE, isMonotonic = true)
+    })
     public static ConstantOperator dateTrunc(ConstantOperator fmt, ConstantOperator date) {
-        switch (fmt.getVarchar()) {
-            case "second":
-                return ConstantOperator.createDatetime(date.getDatetime().truncatedTo(ChronoUnit.SECONDS));
-            case "minute":
-                return ConstantOperator.createDatetime(date.getDatetime().truncatedTo(ChronoUnit.MINUTES));
-            case "hour":
-                return ConstantOperator.createDatetime(date.getDatetime().truncatedTo(ChronoUnit.HOURS));
-            case "day":
-                return ConstantOperator.createDatetime(date.getDatetime().truncatedTo(ChronoUnit.DAYS));
-            case "month":
-                return ConstantOperator.createDatetime(
-                        date.getDatetime().with(TemporalAdjusters.firstDayOfMonth()).truncatedTo(ChronoUnit.DAYS));
-            case "year":
-                return ConstantOperator.createDatetime(
-                        date.getDatetime().with(TemporalAdjusters.firstDayOfYear()).truncatedTo(ChronoUnit.DAYS));
-            case "week":
-                return ConstantOperator.createDatetime(
-                        date.getDatetime().with(DayOfWeek.MONDAY).truncatedTo(ChronoUnit.DAYS));
-            case "quarter":
-                int year = date.getDatetime().getYear();
-                int month = date.getDatetime().getMonthValue();
-                int quarterMonth = (month - 1) / 3 * 3 + 1;
-                LocalDateTime quarterDate = LocalDateTime.of(year, quarterMonth, 1, 0, 0);
-                return ConstantOperator.createDatetime(quarterDate);
-            default:
-                throw new IllegalArgumentException(fmt + " not supported in date_trunc format string");
+        if (date.getType().isDate()) {
+            switch (fmt.getVarchar()) {
+                case "day":
+                    return ConstantOperator.createDate(date.getDate().truncatedTo(ChronoUnit.DAYS));
+                case "month":
+                    return ConstantOperator.createDate(
+                            date.getDate().with(TemporalAdjusters.firstDayOfMonth()).truncatedTo(ChronoUnit.DAYS));
+                case "year":
+                    return ConstantOperator.createDate(
+                            date.getDate().with(TemporalAdjusters.firstDayOfYear()).truncatedTo(ChronoUnit.DAYS));
+                case "week":
+                    return ConstantOperator.createDate(
+                            date.getDate().with(DayOfWeek.MONDAY).truncatedTo(ChronoUnit.DAYS));
+                case "quarter":
+                    int year = date.getDate().getYear();
+                    int month = date.getDate().getMonthValue();
+                    int quarterMonth = (month - 1) / 3 * 3 + 1;
+                    LocalDateTime quarterDate = LocalDateTime.of(year, quarterMonth, 1, 0, 0);
+                    return ConstantOperator.createDate(quarterDate);
+                default:
+                    throw new IllegalArgumentException(fmt + " not supported in date_trunc format string");
+            }
+
+        } else {
+            switch (fmt.getVarchar()) {
+                case "second":
+                    return ConstantOperator.createDatetime(date.getDatetime().truncatedTo(ChronoUnit.SECONDS));
+                case "minute":
+                    return ConstantOperator.createDatetime(date.getDatetime().truncatedTo(ChronoUnit.MINUTES));
+                case "hour":
+                    return ConstantOperator.createDatetime(date.getDatetime().truncatedTo(ChronoUnit.HOURS));
+                case "day":
+                    return ConstantOperator.createDatetime(date.getDatetime().truncatedTo(ChronoUnit.DAYS));
+                case "month":
+                    return ConstantOperator.createDatetime(
+                            date.getDatetime().with(TemporalAdjusters.firstDayOfMonth()).truncatedTo(ChronoUnit.DAYS));
+                case "year":
+                    return ConstantOperator.createDatetime(
+                            date.getDatetime().with(TemporalAdjusters.firstDayOfYear()).truncatedTo(ChronoUnit.DAYS));
+                case "week":
+                    return ConstantOperator.createDatetime(
+                            date.getDatetime().with(DayOfWeek.MONDAY).truncatedTo(ChronoUnit.DAYS));
+                case "quarter":
+                    int year = date.getDatetime().getYear();
+                    int month = date.getDatetime().getMonthValue();
+                    int quarterMonth = (month - 1) / 3 * 3 + 1;
+                    LocalDateTime quarterDate = LocalDateTime.of(year, quarterMonth, 1, 0, 0);
+                    return ConstantOperator.createDatetime(quarterDate);
+                default:
+                    throw new IllegalArgumentException(fmt + " not supported in date_trunc format string");
+            }
         }
+
     }
 
     @ConstantFunction.List(list = {
-            @ConstantFunction(name = "date_format", argTypes = {DATETIME, VARCHAR}, returnType = VARCHAR),
-            @ConstantFunction(name = "date_format", argTypes = {DATE, VARCHAR}, returnType = VARCHAR)
+            @ConstantFunction(name = "date_format", argTypes = {DATETIME, VARCHAR}, returnType = VARCHAR, isMonotonic = true),
+            @ConstantFunction(name = "date_format", argTypes = {DATE, VARCHAR}, returnType = VARCHAR, isMonotonic = true)
     })
     public static ConstantOperator dateFormat(ConstantOperator date, ConstantOperator fmtLiteral) {
         String format = fmtLiteral.getVarchar();
@@ -247,8 +277,8 @@ public class ScalarOperatorFunctions {
     }
 
     @ConstantFunction.List(list = {
-            @ConstantFunction(name = "to_iso8601", argTypes = {DATETIME}, returnType = VARCHAR),
-            @ConstantFunction(name = "to_iso8601", argTypes = {DATE}, returnType = VARCHAR)
+            @ConstantFunction(name = "to_iso8601", argTypes = {DATETIME}, returnType = VARCHAR, isMonotonic = true),
+            @ConstantFunction(name = "to_iso8601", argTypes = {DATE}, returnType = VARCHAR, isMonotonic = true)
     })
     public static ConstantOperator toISO8601(ConstantOperator date) {
         if (date.getType().isDatetime()) {
@@ -290,36 +320,36 @@ public class ScalarOperatorFunctions {
         return ConstantOperator.createDatetime(ld.atTime(0, 0, 0), Type.DATE);
     }
 
-    @ConstantFunction(name = "years_sub", argTypes = {DATETIME, INT}, returnType = DATETIME)
+    @ConstantFunction(name = "years_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator yearsSub(ConstantOperator date, ConstantOperator year) {
         return ConstantOperator.createDatetime(date.getDatetime().minusYears(year.getInt()));
     }
 
-    @ConstantFunction(name = "months_sub", argTypes = {DATETIME, INT}, returnType = DATETIME)
+    @ConstantFunction(name = "months_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator monthsSub(ConstantOperator date, ConstantOperator month) {
         return ConstantOperator.createDatetime(date.getDatetime().minusMonths(month.getInt()));
     }
 
     @ConstantFunction.List(list = {
-            @ConstantFunction(name = "subdate", argTypes = {DATETIME, INT}, returnType = DATETIME),
-            @ConstantFunction(name = "date_sub", argTypes = {DATETIME, INT}, returnType = DATETIME),
-            @ConstantFunction(name = "days_sub", argTypes = {DATETIME, INT}, returnType = DATETIME)
+            @ConstantFunction(name = "subdate", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true),
+            @ConstantFunction(name = "date_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true),
+            @ConstantFunction(name = "days_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     })
     public static ConstantOperator daysSub(ConstantOperator date, ConstantOperator day) {
         return ConstantOperator.createDatetime(date.getDatetime().minusDays(day.getInt()));
     }
 
-    @ConstantFunction(name = "hours_sub", argTypes = {DATETIME, INT}, returnType = DATETIME)
+    @ConstantFunction(name = "hours_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator hoursSub(ConstantOperator date, ConstantOperator hour) {
         return ConstantOperator.createDatetime(date.getDatetime().minusHours(hour.getInt()));
     }
 
-    @ConstantFunction(name = "minutes_sub", argTypes = {DATETIME, INT}, returnType = DATETIME)
+    @ConstantFunction(name = "minutes_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator minutesSub(ConstantOperator date, ConstantOperator minute) {
         return ConstantOperator.createDatetime(date.getDatetime().minusMinutes(minute.getInt()));
     }
 
-    @ConstantFunction(name = "seconds_sub", argTypes = {DATETIME, INT}, returnType = DATETIME)
+    @ConstantFunction(name = "seconds_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator secondsSub(ConstantOperator date, ConstantOperator second) {
         return ConstantOperator.createDatetime(date.getDatetime().minusSeconds(second.getInt()));
     }
@@ -473,7 +503,7 @@ public class ScalarOperatorFunctions {
         return ConstantOperator.createDatetime(utcStartTime);
     }
 
-    @ConstantFunction(name = "next_day", argTypes = {DATETIME, VARCHAR}, returnType = DATE)
+    @ConstantFunction(name = "next_day", argTypes = {DATETIME, VARCHAR}, returnType = DATE, isMonotonic = true)
     public static ConstantOperator nextDay(ConstantOperator date, ConstantOperator dow) {
         int dateDowValue = date.getDate().getDayOfWeek().getValue();
         switch (dow.getVarchar()) {
@@ -510,7 +540,7 @@ public class ScalarOperatorFunctions {
         }
     }
 
-    @ConstantFunction(name = "previous_day", argTypes = {DATETIME, VARCHAR}, returnType = DATE)
+    @ConstantFunction(name = "previous_day", argTypes = {DATETIME, VARCHAR}, returnType = DATE, isMonotonic = true)
     public static ConstantOperator previousDay(ConstantOperator date, ConstantOperator dow) {
         int dateDowValue = date.getDate().getDayOfWeek().getValue();
         switch (dow.getVarchar()) {
@@ -573,13 +603,14 @@ public class ScalarOperatorFunctions {
         return ConstantOperator.createDate(ld.atTime(0, 0, 0));
     }
 
-    @ConstantFunction(name = "time_slice", argTypes = {DATETIME, INT, VARCHAR}, returnType = DATETIME)
+    @ConstantFunction(name = "time_slice", argTypes = {DATETIME, INT, VARCHAR}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator timeSlice(ConstantOperator datetime, ConstantOperator interval,
                                              ConstantOperator unit) throws AnalysisException {
         return timeSlice(datetime, interval, unit, ConstantOperator.createVarchar("floor"));
     }
 
-    @ConstantFunction(name = "time_slice", argTypes = {DATETIME, INT, VARCHAR, VARCHAR}, returnType = DATETIME)
+    @ConstantFunction(name = "time_slice", argTypes = {DATETIME, INT, VARCHAR, VARCHAR}, returnType = DATETIME,
+            isMonotonic = true)
     public static ConstantOperator timeSlice(ConstantOperator datetime, ConstantOperator interval,
                                              ConstantOperator unit, ConstantOperator boundary)
             throws AnalysisException {
@@ -621,17 +652,17 @@ public class ScalarOperatorFunctions {
     /**
      * Arithmetic function
      */
-    @ConstantFunction(name = "add", argTypes = {SMALLINT, SMALLINT}, returnType = SMALLINT)
+    @ConstantFunction(name = "add", argTypes = {SMALLINT, SMALLINT}, returnType = SMALLINT, isMonotonic = true)
     public static ConstantOperator addSmallInt(ConstantOperator first, ConstantOperator second) {
         return ConstantOperator.createSmallInt((short) Math.addExact(first.getSmallint(), second.getSmallint()));
     }
 
-    @ConstantFunction(name = "add", argTypes = {INT, INT}, returnType = INT)
+    @ConstantFunction(name = "add", argTypes = {INT, INT}, returnType = INT, isMonotonic = true)
     public static ConstantOperator addInt(ConstantOperator first, ConstantOperator second) {
         return ConstantOperator.createInt(Math.addExact(first.getInt(), second.getInt()));
     }
 
-    @ConstantFunction(name = "add", argTypes = {BIGINT, BIGINT}, returnType = BIGINT)
+    @ConstantFunction(name = "add", argTypes = {BIGINT, BIGINT}, returnType = BIGINT, isMonotonic = true)
     public static ConstantOperator addBigInt(ConstantOperator first, ConstantOperator second) {
         return ConstantOperator.createBigint(Math.addExact(first.getBigint(), second.getBigint()));
     }
@@ -651,22 +682,22 @@ public class ScalarOperatorFunctions {
         return createDecimalConstant(first.getDecimal().add(second.getDecimal()));
     }
 
-    @ConstantFunction(name = "add", argTypes = {LARGEINT, LARGEINT}, returnType = LARGEINT)
+    @ConstantFunction(name = "add", argTypes = {LARGEINT, LARGEINT}, returnType = LARGEINT, isMonotonic = true)
     public static ConstantOperator addLargeInt(ConstantOperator first, ConstantOperator second) {
         return ConstantOperator.createLargeInt(first.getLargeInt().add(second.getLargeInt()));
     }
 
-    @ConstantFunction(name = "subtract", argTypes = {SMALLINT, SMALLINT}, returnType = SMALLINT)
+    @ConstantFunction(name = "subtract", argTypes = {SMALLINT, SMALLINT}, returnType = SMALLINT, isMonotonic = true)
     public static ConstantOperator subtractSmallInt(ConstantOperator first, ConstantOperator second) {
         return ConstantOperator.createSmallInt((short) Math.subtractExact(first.getSmallint(), second.getSmallint()));
     }
 
-    @ConstantFunction(name = "subtract", argTypes = {INT, INT}, returnType = INT)
+    @ConstantFunction(name = "subtract", argTypes = {INT, INT}, returnType = INT, isMonotonic = true)
     public static ConstantOperator subtractInt(ConstantOperator first, ConstantOperator second) {
         return ConstantOperator.createInt(Math.subtractExact(first.getInt(), second.getInt()));
     }
 
-    @ConstantFunction(name = "subtract", argTypes = {BIGINT, BIGINT}, returnType = BIGINT)
+    @ConstantFunction(name = "subtract", argTypes = {BIGINT, BIGINT}, returnType = BIGINT, isMonotonic = true)
     public static ConstantOperator subtractBigInt(ConstantOperator first, ConstantOperator second) {
         return ConstantOperator.createBigint(Math.subtractExact(first.getBigint(), second.getBigint()));
     }
@@ -686,7 +717,7 @@ public class ScalarOperatorFunctions {
         return createDecimalConstant(first.getDecimal().subtract(second.getDecimal()));
     }
 
-    @ConstantFunction(name = "subtract", argTypes = {LARGEINT, LARGEINT}, returnType = LARGEINT)
+    @ConstantFunction(name = "subtract", argTypes = {LARGEINT, LARGEINT}, returnType = LARGEINT, isMonotonic = true)
     public static ConstantOperator subtractLargeInt(ConstantOperator first, ConstantOperator second) {
         return ConstantOperator.createLargeInt(first.getLargeInt().subtract(second.getLargeInt()));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
@@ -35,12 +35,22 @@ import java.util.List;
 public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
     private static final Logger LOG = LogManager.getLogger(FoldConstantsRule.class);
 
+    private final boolean needMonotonicFunc;
+
+    public FoldConstantsRule() {
+        this(false);
+    }
+
+    public FoldConstantsRule(boolean needMonotonicFunc) {
+        this.needMonotonicFunc = needMonotonicFunc;
+    }
+
     @Override
     public ScalarOperator visitCall(CallOperator call, ScalarOperatorRewriteContext context) {
         if (call.isAggregate() || notAllConstant(call.getChildren())) {
             return call;
         }
-        return ScalarOperatorEvaluator.INSTANCE.evaluation(call);
+        return ScalarOperatorEvaluator.INSTANCE.evaluation(call, needMonotonicFunc);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -548,13 +548,8 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                 if (minLiteral instanceof DateLiteral) {
                     DateLiteral minDateLiteral = (DateLiteral) minLiteral;
                     DateLiteral maxDateLiteral;
-                    try {
-                        maxDateLiteral = maxLiteral instanceof MaxLiteral ? new DateLiteral(Type.DATE, true) :
-                                (DateLiteral) maxLiteral;
-                    } catch (AnalysisException e) {
-                        LOG.warn("get max date literal failed, msg : " + e.getMessage());
-                        return null;
-                    }
+                    maxDateLiteral = maxLiteral instanceof MaxLiteral ? new DateLiteral(Type.DATE, true) :
+                            (DateLiteral) maxLiteral;
                     min = Utils.getLongFromDateTime(minDateLiteral.toLocalDateTime());
                     max = Utils.getLongFromDateTime(maxDateLiteral.toLocalDateTime());
                 } else {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluatorTest.java
@@ -25,8 +25,10 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import mockit.Expectations;
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.math.BigInteger;
 import java.time.LocalDateTime;
 
 import static org.junit.Assert.assertEquals;
@@ -125,6 +127,20 @@ public class ScalarOperatorEvaluatorTest {
         ScalarOperator result = ScalarOperatorEvaluator.INSTANCE.evaluation(operator);
 
         assertEquals(result, operator);
+    }
+
+    @Test
+    public void testCreateConstantValue() {
+        ConstantOperator tinyInt = ConstantOperator.createExampleValueByType(Type.TINYINT);
+        Assert.assertTrue(tinyInt.getTinyInt() == 1);
+        ConstantOperator smallInt = ConstantOperator.createExampleValueByType(Type.SMALLINT);
+        Assert.assertTrue(smallInt.getSmallint() == 1);
+        ConstantOperator intValue = ConstantOperator.createExampleValueByType(Type.INT);
+        Assert.assertTrue(intValue.getInt() == 1);
+        ConstantOperator bigInt = ConstantOperator.createExampleValueByType(Type.BIGINT);
+        Assert.assertTrue(bigInt.getBigint() == 1L);
+        ConstantOperator largeInt = ConstantOperator.createExampleValueByType(Type.LARGEINT);
+        Assert.assertTrue(largeInt.getLargeInt().equals(new BigInteger("1")));
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
@@ -222,10 +222,9 @@ class FurtherPartitionPruneTest extends PlanTestBase {
             String matchedLine = matcher.group();
             System.out.println(matchedLine);
             String[] values = matchedLine.split("=")[1].split("/");
-            Assert.assertTrue(matchedLine,Integer.valueOf(values[0]) == Integer.valueOf(values[1]));
+            Assert.assertTrue(matchedLine, Integer.valueOf(values[0]) == Integer.valueOf(values[1]));
         }
     }
-
 
     private static Stream<Arguments> emptyPartitionSqlList() {
         List<String> sqlList = Lists.newArrayList();
@@ -437,7 +436,6 @@ class FurtherPartitionPruneTest extends PlanTestBase {
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 
-
     private static Stream<Arguments> cannotPrunePredicateSqls() {
         List<String> sqlList = Lists.newArrayList();
         sqlList.add("select * from tbl_int where (k1 >= 0 and k1 < 200) or s1 = 'a'");
@@ -471,18 +469,19 @@ class FurtherPartitionPruneTest extends PlanTestBase {
         List<String> sqlList = Lists.newArrayList();
         sqlList.add("select * from less_than_tbl where date_trunc('year', k1) < '2020-08-01'");
         sqlList.add("select * from less_than_tbl where date_trunc('year', k1) is null");
-        sqlList.add("select * from less_than_tbl where date_trunc('year', k1) is null or k1 in ('2020-09-01', '2020-09-02', '2020-09-03')");
+        sqlList.add(
+                "select * from less_than_tbl where date_trunc('year', k1) is null or k1 in ('2020-09-01', '2020-09-02', '2020-09-03')");
         sqlList.add("select * from less_than_tbl where date_trunc('year', k1) > '2050-08-01'");
 
         sqlList.add("select * from less_than_tbl where date_trunc('month', date_trunc('day', k1)) < '2020-08-01'");
         sqlList.add("select * from less_than_tbl where date_trunc('month', date_trunc('day', k1)) < '2020-08-01' " +
                 "or date_trunc('month', date_trunc('day', k1)) > '2020-09-01'");
 
-        sqlList.add("select * from less_than_tbl where date_trunc('month', date_trunc('day', k1)) < '2020-08-01 10:00:00'");
+        sqlList.add(
+                "select * from less_than_tbl where date_trunc('month', date_trunc('day', k1)) < '2020-08-01 10:00:00'");
         sqlList.add("select * from maxvalue_range where days_add('2020-01-01' ,v1) > '2050-01-01'");
         sqlList.add("select * from maxvalue_range where hours_add(days_add('2020-01-01' ,v1), 100) > '2050-01-01'");
         sqlList.add("select * from maxvalue_range where hours_add(days_add('2020-01-01' ,v1), 100) > '2050-01-01'");
-
 
         sqlList.add("select * from less_than_tbl where k1 != '2020-09-01' and " +
                 "(date_trunc('year', k1) > '2030-01-01' or (k1 > '2020-09-01' and k1 <= '2020-10-01'))");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
@@ -17,17 +17,24 @@ package com.starrocks.sql.optimizer.rule.transformation;
 import com.google.common.collect.Lists;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class FurtherPartitionPruneTest extends PlanTestBase {
 
     @BeforeAll
@@ -98,10 +105,40 @@ class FurtherPartitionPruneTest extends PlanTestBase {
                 "PARTITION `p202009` VALUES LESS THAN (\"2020-10-01\") ) " +
                 "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3 " +
                 "PROPERTIES ( \"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE `expr_range` " +
+                "( `k1` date, `k2` datetime, `k3` char(20), `k4` varchar(20), `k5` boolean) " +
+                "ENGINE=OLAP DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) " +
+                "PARTITION BY date_trunc('month', k1) " +
+                "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3 " +
+                "PROPERTIES ( \"replication_num\" = \"1\");");
+        starRocksAssert.withTable("CREATE TABLE `maxvalue_range` (\n" +
+                "  `v1` bigint(20) NULL COMMENT \"\",\n" +
+                "  `v2` bigint(20) NULL COMMENT \"\",\n" +
+                "  `v3` bigint(20) NULL COMMENT \"\",\n" +
+                "  `v4` varchar(20) NULL COMMENT \"\",\n" +
+                "  `pay_dt` date NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`, `v2`, `v3`)\n" +
+                "PARTITION BY RANGE (v1)\n" +
+                "(\n" +
+                "    PARTITION p202101 VALUES [('1'), ('100')),\n" +
+                "    PARTITION p202102 VALUES [('500'), ('800')),\n" +
+                "    PARTITION p202103 VALUES [('1000'), (MAXVALUE))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"enable_persistent_index\" = \"false\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"compression\" = \"LZ4\"\n" +
+                ");");
     }
 
     @ParameterizedTest(name = "sql_{index}: {0}.")
     @MethodSource("emptyPartitionSqlList")
+    @Order(1)
     void testEmptyPartitionSql(String sql) throws Exception {
         String plan = getFragmentPlan(sql);
         assertTrue(plan, plan.contains("partitions=0/4"));
@@ -109,6 +146,7 @@ class FurtherPartitionPruneTest extends PlanTestBase {
 
     @ParameterizedTest(name = "sql_{index}: {0}.")
     @MethodSource("onePartitionSqlList")
+    @Order(2)
     void testOnePartitionSql(String sql) throws Exception {
         String plan = getFragmentPlan(sql);
         assertTrue(plan, plan.contains("partitions=1/4"));
@@ -116,6 +154,7 @@ class FurtherPartitionPruneTest extends PlanTestBase {
 
     @ParameterizedTest(name = "sql_{index}: {0}.")
     @MethodSource("twoPartitionsSqlList")
+    @Order(3)
     void testTwoPartitionsSql(String sql) throws Exception {
         String plan = getFragmentPlan(sql);
         assertTrue(plan, plan.contains("partitions=2/4"));
@@ -123,6 +162,7 @@ class FurtherPartitionPruneTest extends PlanTestBase {
 
     @ParameterizedTest(name = "sql_{index}: {0}.")
     @MethodSource("threePartitionsSqlList")
+    @Order(3)
     void testThreePartitionsSql(String sql) throws Exception {
         String plan = getFragmentPlan(sql);
         assertTrue(plan, plan.contains("partitions=3/4"));
@@ -130,6 +170,7 @@ class FurtherPartitionPruneTest extends PlanTestBase {
 
     @ParameterizedTest(name = "sql_{index}: {0}.")
     @MethodSource("fourPartitionsSqlList")
+    @Order(4)
     void testFourPartitionsSql(String sql) throws Exception {
         String plan = getFragmentPlan(sql);
         assertTrue(plan, plan.contains("partitions=4/4"));
@@ -137,6 +178,7 @@ class FurtherPartitionPruneTest extends PlanTestBase {
 
     @ParameterizedTest(name = "sql_{index}: {0}.")
     @MethodSource("cannotPrunePredicateSqls")
+    @Order(5)
     void testCannotPrunePredicateSqls(String sql) throws Exception {
         String plan = getFragmentPlan(sql);
         assertTrue(plan, plan.contains("PREDICATES: "));
@@ -144,9 +186,44 @@ class FurtherPartitionPruneTest extends PlanTestBase {
 
     @ParameterizedTest(name = "sql_{index}: {0}.")
     @MethodSource("canPrunePredicateSqls")
+    @Order(6)
     void testCanPrunePredicateSqls(String sql) throws Exception {
         String plan = getFragmentPlan(sql);
         assertFalse(plan, plan.contains("PREDICATES: "));
+    }
+
+    @ParameterizedTest(name = "sql_{index}: {0}.")
+    @MethodSource("exprPrunePartitionSqls")
+    @Order(7)
+    void testExprPrunePartition(String sql) throws Exception {
+        String plan = getFragmentPlan(sql);
+
+        Pattern pattern = Pattern.compile("partitions=.*");
+        Matcher matcher = pattern.matcher(plan);
+
+        while (matcher.find()) {
+            String matchedLine = matcher.group();
+            System.out.println(matchedLine);
+            String[] values = matchedLine.split("=")[1].split("/");
+            Assert.assertTrue(matchedLine, Integer.valueOf(values[0]) < Integer.valueOf(values[1]));
+        }
+    }
+
+    @ParameterizedTest(name = "sql_{index}: {0}.")
+    @MethodSource("exprPrunePartitionSqls")
+    @Order(8)
+    void testDisableExprPrunePartition(String sql) throws Exception {
+        connectContext.getSessionVariable().setEnableExprPrunePartition(false);
+        String plan = getFragmentPlan(sql);
+        Pattern pattern = Pattern.compile("partitions=.*");
+        Matcher matcher = pattern.matcher(plan);
+
+        while (matcher.find()) {
+            String matchedLine = matcher.group();
+            System.out.println(matchedLine);
+            String[] values = matchedLine.split("=")[1].split("/");
+            Assert.assertTrue(matchedLine,Integer.valueOf(values[0]) == Integer.valueOf(values[1]));
+        }
     }
 
 
@@ -387,6 +464,31 @@ class FurtherPartitionPruneTest extends PlanTestBase {
                 "and cast(d2 as date) < '2020-04-01'");
         sqlList.add("select * from ptest where d2 < cast('20200101' as date)");
         sqlList.add("select * from ptest where d2 < str_to_date('20200401', '%Y%m%d')");
+        return sqlList.stream().map(e -> Arguments.of(e));
+    }
+
+    private static Stream<Arguments> exprPrunePartitionSqls() {
+        List<String> sqlList = Lists.newArrayList();
+        sqlList.add("select * from less_than_tbl where date_trunc('year', k1) < '2020-08-01'");
+        sqlList.add("select * from less_than_tbl where date_trunc('year', k1) is null");
+        sqlList.add("select * from less_than_tbl where date_trunc('year', k1) is null or k1 in ('2020-09-01', '2020-09-02', '2020-09-03')");
+        sqlList.add("select * from less_than_tbl where date_trunc('year', k1) > '2050-08-01'");
+
+        sqlList.add("select * from less_than_tbl where date_trunc('month', date_trunc('day', k1)) < '2020-08-01'");
+        sqlList.add("select * from less_than_tbl where date_trunc('month', date_trunc('day', k1)) < '2020-08-01' " +
+                "or date_trunc('month', date_trunc('day', k1)) > '2020-09-01'");
+
+        sqlList.add("select * from less_than_tbl where date_trunc('month', date_trunc('day', k1)) < '2020-08-01 10:00:00'");
+        sqlList.add("select * from maxvalue_range where days_add('2020-01-01' ,v1) > '2050-01-01'");
+        sqlList.add("select * from maxvalue_range where hours_add(days_add('2020-01-01' ,v1), 100) > '2050-01-01'");
+        sqlList.add("select * from maxvalue_range where hours_add(days_add('2020-01-01' ,v1), 100) > '2050-01-01'");
+
+
+        sqlList.add("select * from less_than_tbl where k1 != '2020-09-01' and " +
+                "(date_trunc('year', k1) > '2030-01-01' or (k1 > '2020-09-01' and k1 <= '2020-10-01'))");
+
+        sqlList.add("select * from less_than_tbl where previous_day(k1, 'Monday') in ('2020-07-01', '2020-08-01', " +
+                "'2020-08-06') and k3 = 'a'");
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
@@ -489,6 +489,7 @@ class FurtherPartitionPruneTest extends PlanTestBase {
 
         sqlList.add("select * from less_than_tbl where previous_day(k1, 'Monday') in ('2020-07-01', '2020-08-01', " +
                 "'2020-08-06') and k3 = 'a'");
+        sqlList.add("select * from less_than_tbl where datediff('2020-08-01', k1) < 0");
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
@@ -470,7 +470,8 @@ class FurtherPartitionPruneTest extends PlanTestBase {
         sqlList.add("select * from less_than_tbl where date_trunc('year', k1) < '2020-08-01'");
         sqlList.add("select * from less_than_tbl where date_trunc('year', k1) is null");
         sqlList.add(
-                "select * from less_than_tbl where date_trunc('year', k1) is null or k1 in ('2020-09-01', '2020-09-02', '2020-09-03')");
+                "select * from less_than_tbl where date_trunc('year', k1) is null or k1 in " +
+                        "('2020-09-01', '2020-09-02', '2020-09-03')");
         sqlList.add("select * from less_than_tbl where date_trunc('year', k1) > '2050-08-01'");
 
         sqlList.add("select * from less_than_tbl where date_trunc('month', date_trunc('day', k1)) < '2020-08-01'");

--- a/test/sql/test_partition_by_expr/R/test_expr_prune_partition
+++ b/test/sql/test_partition_by_expr/R/test_expr_prune_partition
@@ -49,7 +49,6 @@ insert into ptest_expr (k1, d2) values (1, '1000-01-01'), (2, '1000-01-02'), (3,
 (12, '2020-04-26'), (13, '2020-06-30'), (14, '2020-07-01'), (14, '2050-01-05'), (15, null), (16, null);
 -- result:
 -- !result
-
 select k1, d2 from ptest where date_trunc('day', d2) is null order by k1;
 -- result:
 -- !result
@@ -106,6 +105,9 @@ select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by 
 14	2020-07-01
 14	2050-01-05
 -- !result
+select * from ptest where datediff('2020-08-01', k1) < 0 order by k1;
+-- result:
+-- !result
 select k1, d2 from ptest_expr where date_trunc('day', d2) is null order by k1;
 -- result:
 15	None
@@ -132,7 +134,7 @@ select k1, d2 from ptest_expr where date_trunc('day', d2) not in ('2020-01-01', 
 14	2050-01-05
 14	2020-07-01
 -- !result
-select k1, d2 from ptest where date_trunc('day', d2) >='2030-01-01' and date_trunc('month', d2) >='2030-01-01' order by k1;
+select k1, d2 from ptest_expr where date_trunc('day', d2) >='2030-01-01' and date_trunc('month', d2) >='2030-01-01' order by k1;
 -- result:
 14	2050-01-05
 -- !result
@@ -146,7 +148,7 @@ select k1, d2 from ptest_expr where (days_add(d2, 1) in ('1000-01-02', '1999-03-
 1	1000-01-01
 14	2050-01-05
 -- !result
-select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
+select k1, d2 from ptest_expr where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
 -- result:
 1	1000-01-01
 2	1000-01-02
@@ -161,6 +163,9 @@ select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by 
 11	2020-04-01
 12	2020-04-26
 13	2020-06-30
-14	2020-07-01
 14	2050-01-05
+14	2020-07-01
+-- !result
+select * from ptest_expr where datediff('2020-08-01', k1) < 0 order by k1;
+-- result:
 -- !result

--- a/test/sql/test_partition_by_expr/R/test_expr_prune_partition
+++ b/test/sql/test_partition_by_expr/R/test_expr_prune_partition
@@ -1,0 +1,166 @@
+-- name: test_expr_prune_partition
+CREATE TABLE `ptest` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `d2` date NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT "",
+  `s1` varchar(255) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`, `d2`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`d2`)
+(PARTITION p202001 VALUES [('1000-01-01'), ('2020-01-01')),
+PARTITION p202004 VALUES [('2020-01-01'), ('2020-04-01')),
+PARTITION p202007 VALUES [('2020-04-01'), ('2020-07-01')),
+PARTITION p202012 VALUES [('2020-07-01'), (MAXVALUE)))
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false"
+);
+-- result:
+-- !result
+CREATE TABLE `ptest_expr` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `d2` date NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT "",
+  `s1` varchar(255) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`, `d2`)
+COMMENT "OLAP"
+PARTITION BY date_trunc('month', d2)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false"
+);
+-- result:
+-- !result
+insert into ptest (k1, d2) values (1, '1000-01-01'), (2, '1000-01-02'), (3, '1100-05-06'), (4, '1500-06-06'), (5, '1999-07-08'),
+(6, '2020-01-01'), (7, '2020-01-04'), (8, '2020-02-06'), (9, '2020-03-21'), (10, '2020-03-31'), (11, '2020-04-01'),
+(12, '2020-04-26'), (13, '2020-06-30'), (14, '2020-07-01'), (14, '2050-01-05');
+-- result:
+-- !result
+insert into ptest_expr (k1, d2) values (1, '1000-01-01'), (2, '1000-01-02'), (3, '1100-05-06'), (4, '1500-06-06'), (5, '1999-07-08'),
+(6, '2020-01-01'), (7, '2020-01-04'), (8, '2020-02-06'), (9, '2020-03-21'), (10, '2020-03-31'), (11, '2020-04-01'),
+(12, '2020-04-26'), (13, '2020-06-30'), (14, '2020-07-01'), (14, '2050-01-05'), (15, null), (16, null);
+-- result:
+-- !result
+
+select k1, d2 from ptest where date_trunc('day', d2) is null order by k1;
+-- result:
+-- !result
+select k1, d2 from ptest where date_trunc('day', d2) in ('2020-01-01', '2020-06-30') order by k1;
+-- result:
+6	2020-01-01
+13	2020-06-30
+-- !result
+select k1, d2 from ptest where date_trunc('day', d2) not in ('2020-01-01', '2020-06-30') order by k1;
+-- result:
+1	1000-01-01
+2	1000-01-02
+3	1100-05-06
+4	1500-06-06
+5	1999-07-08
+7	2020-01-04
+8	2020-02-06
+9	2020-03-21
+10	2020-03-31
+11	2020-04-01
+12	2020-04-26
+14	2020-07-01
+14	2050-01-05
+-- !result
+select k1, d2 from ptest where date_trunc('day', d2) >='2030-01-01' and date_trunc('month', d2) >='2030-01-01' order by k1;
+-- result:
+14	2050-01-05
+-- !result
+select k1, d2 from ptest where date_trunc('day', date_trunc('day', d2)) in ('2020-01-01', '2020-06-30') order by k1;
+-- result:
+6	2020-01-01
+13	2020-06-30
+-- !result
+select k1, d2 from ptest where (days_add(d2, 1) in ('1000-01-02', '1999-03-22') or d2 > '2020-07-01') and v2 is null and v3 is null order by k1;
+-- result:
+1	1000-01-01
+14	2050-01-05
+-- !result
+select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
+-- result:
+1	1000-01-01
+2	1000-01-02
+3	1100-05-06
+4	1500-06-06
+5	1999-07-08
+6	2020-01-01
+7	2020-01-04
+8	2020-02-06
+9	2020-03-21
+10	2020-03-31
+11	2020-04-01
+12	2020-04-26
+13	2020-06-30
+14	2020-07-01
+14	2050-01-05
+-- !result
+select k1, d2 from ptest_expr where date_trunc('day', d2) is null order by k1;
+-- result:
+15	None
+16	None
+-- !result
+select k1, d2 from ptest_expr where date_trunc('day', d2) in ('2020-01-01', '2020-06-30') order by k1;
+-- result:
+6	2020-01-01
+13	2020-06-30
+-- !result
+select k1, d2 from ptest_expr where date_trunc('day', d2) not in ('2020-01-01', '2020-06-30') order by k1;
+-- result:
+1	1000-01-01
+2	1000-01-02
+3	1100-05-06
+4	1500-06-06
+5	1999-07-08
+7	2020-01-04
+8	2020-02-06
+9	2020-03-21
+10	2020-03-31
+11	2020-04-01
+12	2020-04-26
+14	2050-01-05
+14	2020-07-01
+-- !result
+select k1, d2 from ptest where date_trunc('day', d2) >='2030-01-01' and date_trunc('month', d2) >='2030-01-01' order by k1;
+-- result:
+14	2050-01-05
+-- !result
+select k1, d2 from ptest_expr where date_trunc('day', date_trunc('day', d2)) in ('2020-01-01', '2020-06-30') order by k1;
+-- result:
+6	2020-01-01
+13	2020-06-30
+-- !result
+select k1, d2 from ptest_expr where (days_add(d2, 1) in ('1000-01-02', '1999-03-22') or d2 > '2020-07-01') and v2 is null and v3 is null order by k1;
+-- result:
+1	1000-01-01
+14	2050-01-05
+-- !result
+select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
+-- result:
+1	1000-01-01
+2	1000-01-02
+3	1100-05-06
+4	1500-06-06
+5	1999-07-08
+6	2020-01-01
+7	2020-01-04
+8	2020-02-06
+9	2020-03-21
+10	2020-03-31
+11	2020-04-01
+12	2020-04-26
+13	2020-06-30
+14	2020-07-01
+14	2050-01-05
+-- !result

--- a/test/sql/test_partition_by_expr/R/test_expr_prune_partition
+++ b/test/sql/test_partition_by_expr/R/test_expr_prune_partition
@@ -105,8 +105,9 @@ select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by 
 14	2020-07-01
 14	2050-01-05
 -- !result
-select * from ptest where datediff('2020-08-01', k1) < 0 order by k1;
+select k1, d2 from ptest where datediff('2020-08-01', d2) < 0 order by k1;
 -- result:
+14	2050-01-05
 -- !result
 select k1, d2 from ptest_expr where date_trunc('day', d2) is null order by k1;
 -- result:
@@ -166,6 +167,7 @@ select k1, d2 from ptest_expr where date_trunc('day', d2) > days_sub(d2, 4) orde
 14	2050-01-05
 14	2020-07-01
 -- !result
-select * from ptest_expr where datediff('2020-08-01', k1) < 0 order by k1;
+select k1, d2 from ptest_expr where datediff('2020-08-01', d2) < 0 order by k1;
 -- result:
+14	2050-01-05
 -- !result

--- a/test/sql/test_partition_by_expr/T/test_expr_prune_partition
+++ b/test/sql/test_partition_by_expr/T/test_expr_prune_partition
@@ -1,0 +1,63 @@
+-- name: test_expr_prune_partition
+CREATE TABLE `ptest` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `d2` date NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT "",
+  `s1` varchar(255) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`, `d2`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`d2`)
+(PARTITION p202001 VALUES [('1000-01-01'), ('2020-01-01')),
+PARTITION p202004 VALUES [('2020-01-01'), ('2020-04-01')),
+PARTITION p202007 VALUES [('2020-04-01'), ('2020-07-01')),
+PARTITION p202012 VALUES [('2020-07-01'), (MAXVALUE)))
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false"
+);
+
+CREATE TABLE `ptest_expr` (
+  `k1` int(11) NOT NULL COMMENT "",
+  `d2` date NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT "",
+  `s1` varchar(255) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`, `d2`)
+COMMENT "OLAP"
+PARTITION BY date_trunc('month', d2)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false"
+);
+
+insert into ptest (k1, d2) values (1, '1000-01-01'), (2, '1000-01-02'), (3, '1100-05-06'), (4, '1500-06-06'), (5, '1999-07-08'),
+(6, '2020-01-01'), (7, '2020-01-04'), (8, '2020-02-06'), (9, '2020-03-21'), (10, '2020-03-31'), (11, '2020-04-01'),
+(12, '2020-04-26'), (13, '2020-06-30'), (14, '2020-07-01'), (14, '2050-01-05');
+
+insert into ptest_expr (k1, d2) values (1, '1000-01-01'), (2, '1000-01-02'), (3, '1100-05-06'), (4, '1500-06-06'), (5, '1999-07-08'),
+(6, '2020-01-01'), (7, '2020-01-04'), (8, '2020-02-06'), (9, '2020-03-21'), (10, '2020-03-31'), (11, '2020-04-01'),
+(12, '2020-04-26'), (13, '2020-06-30'), (14, '2020-07-01'), (14, '2050-01-05'), (15, null), (16, null);
+
+select k1, d2 from ptest where date_trunc('day', d2) is null order by k1;
+select k1, d2 from ptest where date_trunc('day', d2) in ('2020-01-01', '2020-06-30') order by k1;
+select k1, d2 from ptest where date_trunc('day', d2) not in ('2020-01-01', '2020-06-30') order by k1;
+select k1, d2 from ptest where date_trunc('day', d2) >='2030-01-01' and date_trunc('month', d2) >='2030-01-01' order by k1;
+select k1, d2 from ptest where date_trunc('day', date_trunc('day', d2)) in ('2020-01-01', '2020-06-30') order by k1;
+select k1, d2 from ptest where (days_add(d2, 1) in ('1000-01-02', '1999-03-22') or d2 > '2020-07-01') and v2 is null and v3 is null order by k1;
+select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
+
+select k1, d2 from ptest_expr where date_trunc('day', d2) is null order by k1;
+select k1, d2 from ptest_expr where date_trunc('day', d2) in ('2020-01-01', '2020-06-30') order by k1;
+select k1, d2 from ptest_expr where date_trunc('day', d2) not in ('2020-01-01', '2020-06-30') order by k1;
+select k1, d2 from ptest where date_trunc('day', d2) >='2030-01-01' and date_trunc('month', d2) >='2030-01-01' order by k1;
+select k1, d2 from ptest_expr where date_trunc('day', date_trunc('day', d2)) in ('2020-01-01', '2020-06-30') order by k1;
+select k1, d2 from ptest_expr where (days_add(d2, 1) in ('1000-01-02', '1999-03-22') or d2 > '2020-07-01') and v2 is null and v3 is null order by k1;
+select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
+

--- a/test/sql/test_partition_by_expr/T/test_expr_prune_partition
+++ b/test/sql/test_partition_by_expr/T/test_expr_prune_partition
@@ -52,12 +52,15 @@ select k1, d2 from ptest where date_trunc('day', d2) >='2030-01-01' and date_tru
 select k1, d2 from ptest where date_trunc('day', date_trunc('day', d2)) in ('2020-01-01', '2020-06-30') order by k1;
 select k1, d2 from ptest where (days_add(d2, 1) in ('1000-01-02', '1999-03-22') or d2 > '2020-07-01') and v2 is null and v3 is null order by k1;
 select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
+select * from ptest where datediff('2020-08-01', d2) < 0 order by k1;
 
 select k1, d2 from ptest_expr where date_trunc('day', d2) is null order by k1;
 select k1, d2 from ptest_expr where date_trunc('day', d2) in ('2020-01-01', '2020-06-30') order by k1;
 select k1, d2 from ptest_expr where date_trunc('day', d2) not in ('2020-01-01', '2020-06-30') order by k1;
-select k1, d2 from ptest where date_trunc('day', d2) >='2030-01-01' and date_trunc('month', d2) >='2030-01-01' order by k1;
+select k1, d2 from ptest_expr where date_trunc('day', d2) >='2030-01-01' and date_trunc('month', d2) >='2030-01-01' order by k1;
 select k1, d2 from ptest_expr where date_trunc('day', date_trunc('day', d2)) in ('2020-01-01', '2020-06-30') order by k1;
 select k1, d2 from ptest_expr where (days_add(d2, 1) in ('1000-01-02', '1999-03-22') or d2 > '2020-07-01') and v2 is null and v3 is null order by k1;
-select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
+select k1, d2 from ptest_expr where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
+select * from ptest_expr where datediff('2020-08-01', d2) < 0 order by k1;
+
 

--- a/test/sql/test_partition_by_expr/T/test_expr_prune_partition
+++ b/test/sql/test_partition_by_expr/T/test_expr_prune_partition
@@ -52,7 +52,7 @@ select k1, d2 from ptest where date_trunc('day', d2) >='2030-01-01' and date_tru
 select k1, d2 from ptest where date_trunc('day', date_trunc('day', d2)) in ('2020-01-01', '2020-06-30') order by k1;
 select k1, d2 from ptest where (days_add(d2, 1) in ('1000-01-02', '1999-03-22') or d2 > '2020-07-01') and v2 is null and v3 is null order by k1;
 select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
-select * from ptest where datediff('2020-08-01', d2) < 0 order by k1;
+select k1, d2 from ptest where datediff('2020-08-01', d2) < 0 order by k1;
 
 select k1, d2 from ptest_expr where date_trunc('day', d2) is null order by k1;
 select k1, d2 from ptest_expr where date_trunc('day', d2) in ('2020-01-01', '2020-06-30') order by k1;
@@ -61,6 +61,6 @@ select k1, d2 from ptest_expr where date_trunc('day', d2) >='2030-01-01' and dat
 select k1, d2 from ptest_expr where date_trunc('day', date_trunc('day', d2)) in ('2020-01-01', '2020-06-30') order by k1;
 select k1, d2 from ptest_expr where (days_add(d2, 1) in ('1000-01-02', '1999-03-22') or d2 > '2020-07-01') and v2 is null and v3 is null order by k1;
 select k1, d2 from ptest_expr where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
-select * from ptest_expr where datediff('2020-08-01', d2) < 0 order by k1;
+select k1, d2 from ptest_expr where datediff('2020-08-01', d2) < 0 order by k1;
 
 


### PR DESCRIPTION
### Main work
When a function is a monotonic fucntion, which means for any value within a range, the first and last endpoints are the new extreme points after the function mapping. Then we can remapping the partition ranges using constant folding rule to obatin a new range to helps us prune paritions.

### supported scence
RANGE partition with only one column, like `partition by range (col)` or `partition by expr(col)` except `paitition by range (expx(col))`

### Performance problem
For a table with 15000 partitions, if the there is a complex predicate like `date_trunc('day', col) in (values) or date_trunc('month', col) in (values)`, we have remapping the partition ranges using the date_trunc function and evaluate each value in the in list whether it is in the new remapping ranges. This work is a bit of time consuming. 
The test result shows **10w** calculations  date_trunc('day', col) cost almost 100 ms. The further work will optimize this.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
