### PR TITLE
[Enhancement] improve cloud native pk table memory use and tracker

### DIFF
--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -208,8 +208,6 @@ Status RowsetUpdateState::_do_load_upserts_deletes(const TxnLogPB_OpWrite& op_wr
         auto col = pk_column->clone();
         auto itr = itrs[i].get();
         if (itr != nullptr) {
-            auto num_rows = rowset_ptr->num_rows();
-            col->reserve(num_rows);
             while (true) {
                 chunk->reset();
                 auto st = itr->get_next(chunk);

--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -18,18 +18,22 @@
 #include "storage/chunk_helper.h"
 #include "storage/chunk_iterator.h"
 #include "storage/lake/rowset.h"
+#include "storage/lake/update_manager.h"
 #include "storage/primary_key_encoder.h"
 #include "storage/tablet_manager.h"
 
 namespace starrocks::lake {
 
-CompactionState::CompactionState(Rowset* rowset) {
+CompactionState::CompactionState(Rowset* rowset, UpdateManager* update_manager) {
     if (rowset->num_segments() > 0) {
         pk_cols.resize(rowset->num_segments());
     }
+    _update_manager = update_manager;
 }
 
-CompactionState::~CompactionState() = default;
+CompactionState::~CompactionState() {
+    _update_manager->compaction_state_mem_tracker()->release(_memory_usage);
+}
 
 Status CompactionState::load_segments(Rowset* rowset, const TabletSchemaCSPtr& tablet_schema, uint32_t segment_id) {
     if (segment_id >= pk_cols.size() && pk_cols.size() != 0) {
@@ -74,8 +78,6 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
     auto& dest = pk_cols[segment_id];
     auto col = pk_column->clone();
     if (itr != nullptr) {
-        const auto num_rows = rowset->num_rows();
-        col->reserve(num_rows);
         while (true) {
             chunk->reset();
             auto st = itr->get_next(chunk);
@@ -91,6 +93,8 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
     }
     dest = std::move(col);
     dest->raw_data();
+    _memory_usage += dest->memory_usage();
+    _update_manager->compaction_state_mem_tracker()->consume(dest->memory_usage());
 
     return Status::OK();
 }
@@ -99,6 +103,8 @@ void CompactionState::release_segments(uint32_t segment_id) {
     if (segment_id >= pk_cols.size() || pk_cols[segment_id] == nullptr) {
         return;
     }
+    _memory_usage -= pk_cols[segment_id]->memory_usage();
+    _update_manager->compaction_state_mem_tracker()->release(pk_cols[segment_id]->memory_usage());
     pk_cols[segment_id]->reset_column();
 }
 

--- a/be/src/storage/lake/update_compaction_state.h
+++ b/be/src/storage/lake/update_compaction_state.h
@@ -26,10 +26,11 @@ namespace starrocks {
 
 namespace lake {
 class Rowset;
+class UpdateManager;
 
 class CompactionState {
 public:
-    CompactionState(Rowset* rowset);
+    CompactionState(Rowset* rowset, UpdateManager* update_manager);
     ~CompactionState();
 
     CompactionState(const CompactionState&) = delete;
@@ -42,6 +43,9 @@ public:
 
 private:
     Status _load_segments(Rowset* rowset, const TabletSchemaCSPtr& tablet_schema, uint32_t segment_id);
+
+    UpdateManager* _update_manager;
+    size_t _memory_usage = 0;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -37,6 +37,7 @@ UpdateManager::UpdateManager(LocationProvider* location_provider, MemTracker* me
     _update_mem_tracker = mem_tracker;
     _update_state_mem_tracker = std::make_unique<MemTracker>(-1, "lake_rowset_update_state", mem_tracker);
     _index_cache_mem_tracker = std::make_unique<MemTracker>(-1, "lake_index_cache", mem_tracker);
+    _compaction_state_mem_tracker = std::make_unique<MemTracker>(-1, "compaction_state_cache", mem_tracker);
 
     _index_cache.set_mem_tracker(_index_cache_mem_tracker.get());
     _update_state_cache.set_mem_tracker(_update_state_mem_tracker.get());
@@ -59,6 +60,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     index_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
     auto& index = index_entry->value();
     Status st = index.lake_load(tablet, metadata, base_version, builder);
+    _index_cache.update_object_size(index_entry, index.memory_usage());
     if (!st.ok()) {
         _index_cache.remove(index_entry);
         std::string msg =
@@ -456,6 +458,7 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
     index_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
     auto& index = index_entry->value();
     Status st = index.lake_load(tablet, metadata, base_version, builder);
+    _index_cache.update_object_size(index_entry, index.memory_usage());
     if (!st.ok()) {
         _index_cache.remove(index_entry);
         LOG(ERROR) << strings::Substitute("publish_primary_key_tablet: load primary index failed: $0", st.to_string());
@@ -469,7 +472,7 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(metadata.schema());
     RowsetPtr output_rowset =
             std::make_shared<Rowset>(tablet, std::make_shared<RowsetMetadata>(op_compaction.output_rowset()));
-    auto compaction_state = std::make_unique<CompactionState>(output_rowset.get());
+    auto compaction_state = std::make_unique<CompactionState>(output_rowset.get(), this);
     size_t total_deletes = 0;
     size_t total_rows = 0;
     vector<std::pair<uint32_t, DelVectorPtr>> delvecs;
@@ -571,11 +574,13 @@ void UpdateManager::update_primary_index_data_version(const Tablet& tablet, int6
 void UpdateManager::_print_memory_stats() {
     static std::atomic<int64_t> last_print_ts;
     if (time(nullptr) > last_print_ts.load() + kPrintMemoryStatsInterval && _update_mem_tracker != nullptr) {
-        LOG(INFO) << strings::Substitute("[lake update manager memory]index:$0 update_state:$1 total:$2/$3",
-                                         PrettyPrinter::print_bytes(_index_cache_mem_tracker->consumption()),
-                                         PrettyPrinter::print_bytes(_update_state_mem_tracker->consumption()),
-                                         PrettyPrinter::print_bytes(_update_mem_tracker->consumption()),
-                                         PrettyPrinter::print_bytes(_update_mem_tracker->limit()));
+        LOG(INFO) << strings::Substitute(
+                "[lake update manager memory]index:$0 update_state:$1 compact_state:$2 total:$3/$4",
+                PrettyPrinter::print_bytes(_index_cache_mem_tracker->consumption()),
+                PrettyPrinter::print_bytes(_update_state_mem_tracker->consumption()),
+                PrettyPrinter::print_bytes(_compaction_state_mem_tracker->consumption()),
+                PrettyPrinter::print_bytes(_update_mem_tracker->consumption()),
+                PrettyPrinter::print_bytes(_update_mem_tracker->limit()));
         last_print_ts.store(time(nullptr));
     }
 }

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -118,6 +118,8 @@ public:
         return Status::OK();
     }
 
+    MemTracker* compaction_state_mem_tracker() const { return _compaction_state_mem_tracker.get(); }
+
 private:
     // print memory tracker state
     void _print_memory_stats();
@@ -150,6 +152,7 @@ private:
     MemTracker* _update_mem_tracker = nullptr;
     std::unique_ptr<MemTracker> _index_cache_mem_tracker;
     std::unique_ptr<MemTracker> _update_state_mem_tracker;
+    std::unique_ptr<MemTracker> _compaction_state_mem_tracker;
 };
 
 } // namespace lake

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -37,6 +37,7 @@
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reader.h"
 #include "storage/lake/test_util.h"
+#include "storage/lake/update_compaction_state.h"
 #include "storage/lake/vertical_compaction_task.h"
 #include "storage/tablet_schema.h"
 #include "testutil/assert.h"
@@ -101,6 +102,7 @@ protected:
     void TearDown() override {
         // check primary index cache's ref
         EXPECT_TRUE(_update_mgr->TEST_check_primary_index_cache_ref(_tablet_metadata->id(), 1));
+        EXPECT_EQ(_update_mgr->compaction_state_mem_tracker()->consumption(), 0);
         (void)fs::remove_all(kTestDirectory);
     }
 
@@ -603,6 +605,19 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
+    // check compaction state
+    ASSIGN_OR_ABORT(auto txn_log, tablet.get_txn_log(txn_id));
+    RowsetPtr output_rowset = std::make_shared<Rowset>(
+            &tablet, std::make_shared<RowsetMetadata>(txn_log->op_compaction().output_rowset()));
+    auto compaction_state = std::make_unique<CompactionState>(output_rowset.get(), _update_mgr.get());
+    for (size_t i = 0; i < compaction_state->pk_cols.size(); i++) {
+        ASSERT_OK(compaction_state->load_segments(output_rowset.get(), _tablet_schema, i));
+        auto& pk_col = compaction_state->pk_cols[i];
+        EXPECT_EQ(_update_mgr->compaction_state_mem_tracker()->consumption(), pk_col->memory_usage());
+        compaction_state->release_segments(i);
+        EXPECT_EQ(_update_mgr->compaction_state_mem_tracker()->consumption(), 0);
+    }
+    // publish version
     ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));


### PR DESCRIPTION
This pr contains two parts:
1. Add cloud native primary key table's compaction state tracker
2. Improve memory alloc when do loading upsert/delete keys.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
