### PR TITLE
[BugFix] Fix BE crash when enable filter_unused_columns and dictionary inconsistent

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -38,6 +38,7 @@
 #include "storage/column_predicate.h"
 #include "storage/column_predicate_rewriter.h"
 #include "storage/del_vector.h"
+#include "storage/delta_writer.h"
 #include "storage/lake/update_manager.h"
 #include "storage/olap_runtime_range_pruner.hpp"
 #include "storage/projection_iterator.h"
@@ -1143,7 +1144,17 @@ void SegmentIterator::_switch_context(ScanContext* to) {
                 _encoded_schema.append(field);
             }
         }
-        to->_final_chunk = ChunkHelper::new_chunk(this->_encoded_schema, _reserve_chunk_size);
+        Schema final_chunk_schema;
+        DCHECK_GE(_encoded_schema.num_fields(), output_schema().num_fields());
+        size_t output_schema_idx = 0;
+        for (size_t i = 0; i < _encoded_schema.num_fields(); ++i) {
+            if (_encoded_schema.field(i)->id() == output_schema().field(output_schema_idx)->id()) {
+                final_chunk_schema.append(_encoded_schema.field(i));
+                output_schema_idx++;
+            }
+        }
+
+        to->_final_chunk = ChunkHelper::new_chunk(final_chunk_schema, _reserve_chunk_size);
     } else {
         to->_final_chunk = ChunkHelper::new_chunk(this->output_schema(), _reserve_chunk_size);
     }
@@ -1386,6 +1397,8 @@ Status SegmentIterator::_build_context(ScanContext* ctx) {
 
     // build index map
     DCHECK_LE(output_schema().num_fields(), _schema.num_fields());
+    DCHECK(!(output_schema().num_fields() < _schema.num_fields()) || _opts.delete_predicates.empty())
+            << "delete condition couldn't work with filter_unused_columns";
 
     // skip dict_decode column in _read_schema would not be mapping
     std::unordered_map<ColumnId, size_t> read_indexes;   // fid -> read schema index
@@ -1607,7 +1620,7 @@ Status SegmentIterator::_encode_to_global_id(ScanContext* ctx) {
     auto final_chunk = ctx->_final_chunk;
 
     for (size_t i = 0; i < num_columns; i++) {
-        const FieldPtr& f = _schema.field(i);
+        const FieldPtr& f = output_schema().field(i);
         const ColumnId cid = f->id();
         ColumnPtr& col = ctx->_final_chunk->get_column_by_index(i);
         ColumnPtr& dst = ctx->_adapt_global_dict_chunk->get_column_by_index(i);

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -38,7 +38,6 @@
 #include "storage/column_predicate.h"
 #include "storage/column_predicate_rewriter.h"
 #include "storage/del_vector.h"
-#include "storage/delta_writer.h"
 #include "storage/lake/update_manager.h"
 #include "storage/olap_runtime_range_pruner.hpp"
 #include "storage/projection_iterator.h"

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -14,12 +14,16 @@
 
 #include "storage/rowset/segment_iterator.h"
 
+#include <fmt/core.h>
+
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <unordered_map>
 
 #include "common/object_pool.h"
 #include "fs/fs_memory.h"
+#include "gen_cpp/tablet_schema.pb.h"
 #include "gtest/gtest.h"
 #include "storage/chunk_helper.h"
 #include "storage/olap_common.h"
@@ -29,6 +33,7 @@
 #include "storage/rowset/segment_writer.h"
 #include "storage/tablet_schema_helper.h"
 #include "testutil/assert.h"
+#include "types/logical_type.h"
 
 namespace starrocks {
 
@@ -48,8 +53,318 @@ public:
     std::unique_ptr<MemTracker> _page_cache_mem_tracker = nullptr;
 };
 
+namespace test {
+struct TabletSchemaBuilder {
+private:
+    std::vector<ColumnPB> _column_pbs;
+    ColumnPB _create_pb(int32_t id, std::string name, bool nullable, LogicalType type, bool key) {
+        ColumnPB col;
+
+        col.set_unique_id(id);
+        col.set_name(name);
+        col.set_is_key(key);
+        col.set_is_nullable(nullable);
+
+        if (type == TYPE_INT) {
+            col.set_type("INT");
+            col.set_length(4);
+            col.set_index_length(4);
+        } else if (type == TYPE_VARCHAR) {
+            col.set_type("VARCHAR");
+            col.set_length(128);
+            col.set_index_length(16);
+        }
+
+        col.set_default_value("0");
+        col.set_aggregation("NONE");
+        col.set_is_bf_column(false);
+        col.set_has_bitmap_index(false);
+        return col;
+    }
+
+public:
+    TabletSchemaBuilder& create(int32_t id, bool nullable, LogicalType type, bool key = false) {
+        if (type == TYPE_INT) {
+            _column_pbs.emplace_back(_create_pb(id, std::to_string(id), nullable, type, key));
+        } else if (type == TYPE_VARCHAR) {
+            _column_pbs.emplace_back(_create_pb(id, std::to_string(id), nullable, type, key));
+        } else {
+            __builtin_unreachable();
+        }
+        return *this;
+    }
+    TabletSchemaBuilder& set_length(size_t length) {
+        _column_pbs.back().set_length(length);
+        return *this;
+    }
+
+    std::unique_ptr<TabletSchema> build() { return TabletSchemaHelper::create_tablet_schema(_column_pbs); }
+};
+
+struct TabletDataBuilder {
+    TabletDataBuilder(SegmentWriter& writer_, std::shared_ptr<TabletSchema> schema, size_t chunk_size_,
+                      size_t num_rows_)
+            : writer(writer_), _schema(schema), chunk_size(chunk_size_), num_rows(num_rows_) {}
+
+    template <class Provider>
+    Status append(int32_t idx, Provider&& provider) {
+        std::vector<uint32_t> column_indexes = {static_cast<unsigned int>(idx)};
+
+        RETURN_IF_ERROR(writer.init(column_indexes, true));
+
+        auto schema = ChunkHelper::convert_schema(_schema, column_indexes);
+        auto chunk = ChunkHelper::new_chunk(schema, chunk_size);
+        for (auto i = 0; i < num_rows % chunk_size; ++i) {
+            chunk->reset();
+            auto& cols = chunk->columns();
+            for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
+                cols[0]->append_datum(provider(static_cast<int32_t>(i * chunk_size + j)));
+            }
+            RETURN_IF_ERROR(writer.append_chunk(*chunk));
+        }
+
+        RETURN_IF_ERROR(writer.finalize_columns(&index_size));
+        return Status::OK();
+    }
+
+    Status finalize_footer() { return writer.finalize_footer(&file_size); }
+
+private:
+    SegmentWriter& writer;
+    std::shared_ptr<TabletSchema> _schema;
+    const size_t chunk_size;
+    const size_t num_rows;
+
+    uint64_t file_size = 0;
+    uint64_t index_size = 0;
+};
+
+struct VecSchemaBuilder {
+    VecSchemaBuilder& add(int32_t id, std::string name, LogicalType type, bool nullable = false) {
+        auto f = std::make_shared<Field>(id, name, type, -1, -1, nullable);
+        f->set_uid(id);
+        vec_schema.append(f);
+        return *this;
+    }
+    Schema build() { return std::move(vec_schema); }
+
+private:
+    Schema vec_schema;
+};
+
+} // namespace test
+
+// This case is only triggered by dictionary inconsistencies.
+// NOLINTNEXTLINE
+TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSetWithUnusedColumn) {
+    using namespace starrocks::test;
+
+    std::string file_name = kSegmentDir + "/low_card_cols_unused_column";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 10;
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema = builder.create(1, false, TYPE_INT, true)
+                                                          .create(2, false, TYPE_VARCHAR)
+                                                          .create(3, false, TYPE_INT)
+                                                          .create(4, false, TYPE_INT)
+                                                          .create(5, false, TYPE_VARCHAR)
+                                                          .build();
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = config::vector_chunk_size;
+    const size_t num_rows = 10000;
+
+    auto i32_provider = [](int32_t i) { return i; };
+    std::vector<std::string> values(64);
+    for (int i = 0; i < values.size(); ++i) {
+        values[i] = fmt::format("prefix-{}", i);
+    }
+    auto slice_provider = [&values](int32_t i) { return Slice(values[i % values.size()]); };
+
+    // tablet data builder
+    TabletDataBuilder segment_data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(segment_data_builder.append(0, i32_provider));
+    ASSERT_OK(segment_data_builder.append(1, slice_provider));
+    ASSERT_OK(segment_data_builder.append(2, i32_provider));
+    ASSERT_OK(segment_data_builder.append(3, i32_provider));
+    ASSERT_OK(segment_data_builder.append(4, slice_provider));
+    ASSERT_OK(segment_data_builder.finalize_footer());
+
+    //
+    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    SegmentReadOptions seg_options;
+    OlapReaderStatistics stats;
+    seg_options.fs = _fs;
+    seg_options.stats = &stats;
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_INT)
+            .add(1, "c1", TYPE_VARCHAR)
+            .add(2, "c2", TYPE_INT)
+            .add(3, "c3", TYPE_INT)
+            .add(4, "c4", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
+    ObjectPool pool;
+    SegmentReadOptions seg_opts;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+
+    //
+    ColumnIdToGlobalDictMap dict_map;
+    GlobalDictMap g_dict1;
+    GlobalDictMap g_dict2;
+    for (int i = 0; i < values.size() - 1; ++i) {
+        g_dict1[Slice(values[i])] = i;
+        g_dict2[Slice(values[i])] = i;
+    }
+    g_dict2[Slice(values[values.size() - 1])] = values.size() - 1;
+    dict_map[1] = &g_dict1;
+    dict_map[4] = &g_dict2;
+    seg_opts.global_dictmaps = &dict_map;
+    seg_opts.tablet_schema = tablet_schema;
+
+    std::unique_ptr<ColumnPredicate> predicate;
+    predicate.reset(new_column_ge_predicate(get_type_info(TYPE_VARCHAR), 1, "prefix"));
+    seg_opts.predicates[1].push_back(predicate.get());
+
+    auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_opts);
+    chunk_iter->init_encoded_schema(dict_map);
+    std::unordered_set<uint32_t> set;
+    set.insert(1);
+    chunk_iter->init_output_schema(set);
+
+    auto res_chunk = ChunkHelper::new_chunk(chunk_iter->output_schema(), chunk_size);
+
+    ASSERT_OK(chunk_iter->get_next(res_chunk.get()));
+    res_chunk->reset();
+    ASSERT_OK(chunk_iter->get_next(res_chunk.get()));
+    res_chunk->reset();
+    ASSERT_OK(chunk_iter->get_next(res_chunk.get()));
+    res_chunk->reset();
+}
+
+// NOLINTNEXTLINE
+TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDictWithUnusedColumn) {
+    // prepare dict data
+    const int slice_num = 2;
+    std::vector<std::string> values;
+    const int overflow_sz = 1024 * 1024 + 10; // 1M
+    for (int i = 0; i < slice_num; ++i) {
+        std::string bigstr;
+        bigstr.reserve(overflow_sz);
+        for (int j = 0; j < overflow_sz; ++j) {
+            bigstr.push_back(j);
+        }
+        bigstr.push_back(i);
+        values.emplace_back(std::move(bigstr));
+    }
+
+    std::sort(values.begin(), values.end());
+
+    std::vector<Slice> data_strs;
+    for (const auto& data : values) {
+        data_strs.emplace_back(data);
+    }
+
+    using namespace starrocks::test;
+
+    std::string file_name = kSegmentDir + "/no_dict_unused_column";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema = builder.create(1, false, TYPE_INT, true)
+                                                          .create(2, false, TYPE_VARCHAR)
+                                                          .set_length(overflow_sz + 10)
+                                                          .build();
+
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 1024;
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    int32_t chunk_size = config::vector_chunk_size;
+    size_t num_rows = slice_num;
+
+    auto i32_provider = [](int32_t i) { return i; };
+    auto slice_provider = [&data_strs](int32_t i) { return data_strs[i % data_strs.size()]; };
+
+    // tablet data builder
+    TabletDataBuilder segment_data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(segment_data_builder.append(0, i32_provider));
+    ASSERT_OK(segment_data_builder.append(1, slice_provider));
+    ASSERT_OK(segment_data_builder.finalize_footer());
+
+    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    ASSERT_EQ(segment->num_rows(), num_rows);
+
+    SegmentReadOptions seg_options;
+    OlapReaderStatistics stats;
+    seg_options.fs = _fs;
+    seg_options.stats = &stats;
+    seg_options.tablet_schema = tablet_schema;
+
+    ColumnIteratorOptions iter_opts;
+    ASSIGN_OR_ABORT(auto read_file, _fs->new_random_access_file(segment->file_name()));
+    iter_opts.stats = &stats;
+    iter_opts.use_page_cache = false;
+    iter_opts.read_file = read_file.get();
+    iter_opts.check_dict_encoding = true;
+    iter_opts.reader_type = READER_QUERY;
+
+    ASSIGN_OR_ABORT(auto scalar_iter, segment->new_column_iterator(1));
+    ASSERT_OK(scalar_iter->init(iter_opts));
+    ASSERT_FALSE(scalar_iter->all_page_dict_encoded());
+
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_INT).add(1, "c1", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
+
+    ObjectPool pool;
+    SegmentReadOptions seg_opts;
+    seg_opts.fs = _fs;
+    seg_opts.stats = &stats;
+    seg_opts.tablet_schema = tablet_schema;
+
+    ColumnIdToGlobalDictMap dict_map;
+    GlobalDictMap g_dict;
+    for (int i = 0; i < slice_num; ++i) {
+        g_dict[Slice(values[i])] = i;
+    }
+    dict_map[1] = &g_dict;
+
+    seg_opts.global_dictmaps = &dict_map;
+    std::unique_ptr<ColumnPredicate> predicate;
+    predicate.reset(new_column_ge_predicate(get_type_info(TYPE_VARCHAR), 1, values[0].c_str()));
+    seg_opts.predicates[1].push_back(predicate.get());
+
+    auto chunk_iter = new_segment_iterator(segment, vec_schema, seg_opts);
+    chunk_iter->init_encoded_schema(dict_map);
+    std::unordered_set<uint32_t> set;
+    set.insert(1);
+    chunk_iter->init_output_schema(set);
+
+    auto res_chunk = ChunkHelper::new_chunk(chunk_iter->output_schema(), chunk_size);
+
+    ASSERT_OK(chunk_iter->get_next(res_chunk.get()));
+    res_chunk->reset();
+}
+
 // NOLINTNEXTLINE
 TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
+    using namespace starrocks::test;
+
+    std::string file_name = kSegmentDir + "/low_card_cols";
+    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 10;
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema =
+            builder.create(1, false, TYPE_INT, true).create(2, false, TYPE_VARCHAR).build();
+    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
+
+    const int32_t chunk_size = config::vector_chunk_size;
+    const size_t num_rows = 10000;
+
     const int slice_num = 64;
     std::string prefix = "lowcard-";
     std::vector<std::string> values;
@@ -64,58 +379,14 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
         data_strs.emplace_back(data);
     }
 
-    ColumnPB c1 = create_int_key_pb(1);
-    ColumnPB c2 = create_with_default_value_pb("VARCHAR", "");
-    c2.set_length(128);
+    auto i32_provider = [](int32_t i) { return i; };
+    auto slice_provider = [&data_strs](int32_t i) { return data_strs[i % data_strs.size()]; };
 
-    std::shared_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema({c1, c2});
-
-    SegmentWriterOptions opts;
-    opts.num_rows_per_block = 10;
-
-    std::string file_name = kSegmentDir + "/low_card_cols";
-    ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
-
-    SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
-
-    int32_t chunk_size = config::vector_chunk_size;
-    size_t num_rows = 10000;
-    uint64_t file_size = 0;
-    uint64_t index_size = 0;
-
-    {
-        // col0
-        std::vector<uint32_t> column_indexes = {0};
-        ASSERT_OK(writer.init(column_indexes, true));
-        auto schema = ChunkHelper::convert_schema(tablet_schema, column_indexes);
-        auto chunk = ChunkHelper::new_chunk(schema, chunk_size);
-        for (auto i = 0; i < num_rows % chunk_size; ++i) {
-            chunk->reset();
-            auto& cols = chunk->columns();
-            for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
-            }
-            ASSERT_OK(writer.append_chunk(*chunk));
-        }
-        ASSERT_OK(writer.finalize_columns(&index_size));
-    }
-    {
-        // col1
-        std::vector<uint32_t> column_indexes{1};
-        ASSERT_OK(writer.init(column_indexes, false));
-        auto schema = ChunkHelper::convert_schema(tablet_schema, column_indexes);
-        auto chunk = ChunkHelper::new_chunk(schema, chunk_size);
-        for (auto i = 0; i < num_rows % chunk_size; ++i) {
-            chunk->reset();
-            auto& cols = chunk->columns();
-            for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(data_strs[j % slice_num]));
-            }
-            ASSERT_OK(writer.append_chunk(*chunk));
-        }
-        ASSERT_OK(writer.finalize_columns(&index_size));
-    }
-    ASSERT_OK(writer.finalize_footer(&file_size));
+    // tablet data builder
+    TabletDataBuilder segment_data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(segment_data_builder.append(0, i32_provider));
+    ASSERT_OK(segment_data_builder.append(1, slice_provider));
+    ASSERT_OK(segment_data_builder.finalize_footer());
 
     auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
     ASSERT_EQ(segment->num_rows(), num_rows);
@@ -125,13 +396,9 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
     seg_options.fs = _fs;
     seg_options.stats = &stats;
 
-    Schema vec_schema;
-    auto f0 = std::make_shared<Field>(0, "c1", TYPE_INT, -1, -1, false);
-    f0->set_uid(0);
-    auto f1 = std::make_shared<Field>(1, "c2", TYPE_VARCHAR, -1, -1, false);
-    f1->set_uid(1);
-    vec_schema.append(f0);
-    vec_schema.append(f1);
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_INT).add(1, "c1", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
 
     ObjectPool pool;
     SegmentReadOptions seg_opts;
@@ -168,6 +435,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
 
 // NOLINTNEXTLINE
 TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
+    // prepare dict data
     const int slice_num = 2;
     std::vector<std::string> values;
     const int overflow_sz = 1024 * 1024 + 10; // 1M
@@ -188,58 +456,31 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
         data_strs.emplace_back(data);
     }
 
-    ColumnPB c1 = create_int_key_pb(1);
-    ColumnPB c2 = create_with_default_value_pb("VARCHAR", "");
-    c2.set_length(overflow_sz + 10);
-
-    std::shared_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema({c1, c2});
-
-    SegmentWriterOptions opts;
-    opts.num_rows_per_block = 1024;
+    using namespace starrocks::test;
 
     std::string file_name = kSegmentDir + "/no_dict";
     ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+    TabletSchemaBuilder builder;
+    std::shared_ptr<TabletSchema> tablet_schema = builder.create(1, false, TYPE_INT, true)
+                                                          .create(2, false, TYPE_VARCHAR)
+                                                          .set_length(overflow_sz + 10)
+                                                          .build();
 
+    SegmentWriterOptions opts;
+    opts.num_rows_per_block = 1024;
     SegmentWriter writer(std::move(wfile), 0, tablet_schema, opts);
 
     int32_t chunk_size = config::vector_chunk_size;
     size_t num_rows = slice_num;
-    uint64_t file_size = 0;
-    uint64_t index_size = 0;
 
-    {
-        // col0
-        std::vector<uint32_t> column_indexes = {0};
-        ASSERT_OK(writer.init(column_indexes, true));
-        auto schema = ChunkHelper::convert_schema(tablet_schema, column_indexes);
-        auto chunk = ChunkHelper::new_chunk(schema, chunk_size);
-        for (auto i = 0; i < num_rows % chunk_size; ++i) {
-            chunk->reset();
-            auto& cols = chunk->columns();
-            for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(static_cast<int32_t>(i * chunk_size + j)));
-            }
-            ASSERT_OK(writer.append_chunk(*chunk));
-        }
-        ASSERT_OK(writer.finalize_columns(&index_size));
-    }
-    {
-        // col1
-        std::vector<uint32_t> column_indexes{1};
-        ASSERT_OK(writer.init(column_indexes, false));
-        auto schema = ChunkHelper::convert_schema(tablet_schema, column_indexes);
-        auto chunk = ChunkHelper::new_chunk(schema, chunk_size);
-        for (auto i = 0; i < num_rows % chunk_size; ++i) {
-            chunk->reset();
-            auto& cols = chunk->columns();
-            for (auto j = 0; j < chunk_size && i * chunk_size + j < num_rows; ++j) {
-                cols[0]->append_datum(Datum(data_strs[j % slice_num]));
-            }
-            ASSERT_OK(writer.append_chunk(*chunk));
-        }
-        ASSERT_OK(writer.finalize_columns(&index_size));
-    }
-    ASSERT_OK(writer.finalize_footer(&file_size));
+    auto i32_provider = [](int32_t i) { return i; };
+    auto slice_provider = [&data_strs](int32_t i) { return data_strs[i % data_strs.size()]; };
+
+    // tablet data builder
+    TabletDataBuilder segment_data_builder(writer, tablet_schema, chunk_size, num_rows);
+    ASSERT_OK(segment_data_builder.append(0, i32_provider));
+    ASSERT_OK(segment_data_builder.append(1, slice_provider));
+    ASSERT_OK(segment_data_builder.finalize_footer());
 
     auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
     ASSERT_EQ(segment->num_rows(), num_rows);
@@ -260,13 +501,9 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
     ASSERT_OK(scalar_iter->init(iter_opts));
     ASSERT_FALSE(scalar_iter->all_page_dict_encoded());
 
-    Schema vec_schema;
-    auto f0 = std::make_shared<Field>(0, "c1", TYPE_INT, -1, -1, false);
-    f0->set_uid(0);
-    auto f1 = std::make_shared<Field>(1, "c2", TYPE_VARCHAR, -1, -1, false);
-    f1->set_uid(1);
-    vec_schema.append(f0);
-    vec_schema.append(f1);
+    VecSchemaBuilder schema_builder;
+    schema_builder.add(0, "c0", TYPE_INT).add(1, "c1", TYPE_VARCHAR);
+    auto vec_schema = schema_builder.build();
 
     ObjectPool pool;
     SegmentReadOptions seg_opts;


### PR DESCRIPTION
Usually this doesn't happen. This is because the only known inconsistency that occurs is triggering DELETE. This PR is only programmed as a defense.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
