### PR TITLE
[BugFix] Fix grascale upgrade between main and lower version

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -838,8 +838,8 @@ public class OlapScanNode extends ScanNode {
         } else { // If you find yourself changing this code block, see also the above code block
             msg.node_type = TPlanNodeType.OLAP_SCAN_NODE;
             msg.olap_scan_node =
-                    new TOlapScanNode(desc.getId().asInt(), keyColumnNames,
-                        keyColumnTypes, isPreAggregation, columnsDesc);
+                    new TOlapScanNode(desc.getId().asInt(), keyColumnNames, keyColumnTypes, isPreAggregation);
+            msg.olap_scan_node.setColumns_desc(columnsDesc);
             msg.olap_scan_node.setSort_key_column_names(keyColumnNames);
             msg.olap_scan_node.setRollup_name(olapTable.getIndexNameById(selectedIndexId));
             if (!conjuncts.isEmpty()) {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -495,7 +495,7 @@ struct TOlapScanNode {
   29: optional list<TColumnAccessPath> column_access_paths
 
   30: optional bool use_pk_index
-  31: required list<Descriptors.TColumn> columns_desc
+  31: optional list<Descriptors.TColumn> columns_desc
   32: optional bool output_chunk_by_bucket
 }
 


### PR DESCRIPTION
Introduced by #26246.

`TOlapScanNode.columns_desc` should be `optional` instead of `required`.

BTW, some codes in BE use `thrift_olap_scan_node.columns_desc` directly. This is safe, because the default value of `thrift_olap_scan_node.columns_desc` is an empty `std::vector<>`.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
