### PR TITLE
[Enhancement] Enable declare nodiscard Status

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -23,8 +23,13 @@ class TStatus;
 
 template <typename T>
 class StatusOr;
+#ifdef STARROCKS_STATUS_NODISCARD
+#define STATUS_ATTRIBUTE [[nodiscard]]
+#else
+#define STATUS_ATTRIBUTE
+#endif
 
-class Status {
+class STATUS_ATTRIBUTE Status {
 public:
     Status() = default;
 


### PR DESCRIPTION
Add a new compile option STARROCKS_STATUS_NODISCARD. When enabled, Status will be declared as nodiscard.

#30285 attempted to find unhandled Status at runtime. It was later suggested Status could be declared nodiscard so missing checks are caught during compilation instead! I didn't know about this initially, adding it now.

To find missing Status checks at compile time:
 ```bash
 STARROCKS_CXX_COMMON_FLAGS='-DSTARROCKS_STATUS_NODISCARD -Wno-error=unused-result' ./build.sh --be
```


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
