### PR TITLE
[BugFix] unify cast decimal to string between FE and BE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DecimalLiteral.java
@@ -378,7 +378,12 @@ public class DecimalLiteral extends LiteralExpr {
         // use BigDecimal.toPlainString() instead of BigDecimal.toString()
         // to avoid outputting scientific representation which cannot be
         // parsed in BE that uses regex to validation decimals in string format.
-        return value.toPlainString();
+        // Different print styles help us distinguish decimalV2 and decimalV3 in plan.
+        if (type.isDecimalV2()) {
+            return value.stripTrailingZeros().toPlainString();
+        } else {
+            return value.toPlainString();
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ConstantOperator.java
@@ -325,7 +325,8 @@ public final class ConstantOperator extends ScalarOperator implements Comparable
             BigDecimal decimal = BigDecimal.valueOf(val);
             return decimal.stripTrailingZeros().toPlainString();
         } else if (type.isDecimalV2()) {
-            return String.valueOf(value);
+            // remove trailing zero and use plain string, keep same with BE
+            return ((BigDecimal) value).stripTrailingZeros().toPlainString();
         } else if (type.isDecimalOfAnyVersion()) {
             // align zero, keep same with BE
             int scale = ((ScalarType) type).getScalarScale();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1587,4 +1587,11 @@ public class ExpressionTest extends PlanTestBase {
         String plan = getVerboseExplain(sql);
         assertContains(plan, "1.100000000");
     }
+
+    @Test
+    public void testDecimalV2Cast() throws Exception {
+        String sql = "select length(cast('12.13' as decimalV2(9,1)) * 200)";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "<slot 2> : length('2426')");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1595,6 +1595,10 @@ public class ExpressionTest extends PlanTestBase {
         assertContains(plan, "2 <-> length[('2471.34'); args: VARCHAR; result: INT;");
         sql = "select length(col) from (select cast('12.3567' as decimalV2(9,1)) * 200 as col) t";
         plan = getVerboseExplain(sql);
-        assertContains(plan, "3 <-> length[(cast(2471.34000 as VARCHAR)); args: VARCHAR; result: INT;");
+        assertContains(plan, "3 <-> length[(cast(2471.34 as VARCHAR)); args: VARCHAR; result: INT;");
+
+        sql = "select length(col) from (select cast('12.3567' as decimal(9,1)) * 200 as col) t";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "3 <-> length[(cast(2480.0 as VARCHAR)); args: VARCHAR; result: INT;");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1589,9 +1589,12 @@ public class ExpressionTest extends PlanTestBase {
     }
 
     @Test
-    public void testDecimalV2Cast() throws Exception {
-        String sql = "select length(cast('12.13' as decimalV2(9,1)) * 200)";
-        String plan = getFragmentPlan(sql);
-        assertContains(plan, "<slot 2> : length('2426')");
+    public void testDecimalV2Cast1() throws Exception {
+        String sql = "select length(cast('12.3567' as decimalV2(9,1)) * 200)";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "2 <-> length[('2471.34'); args: VARCHAR; result: INT;");
+        sql = "select length(col) from (select cast('12.3567' as decimalV2(9,1)) * 200 as col) t";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "3 <-> length[(cast(2471.34000 as VARCHAR)); args: VARCHAR; result: INT;");
     }
 }


### PR DESCRIPTION
Fixes #issue
BE ignores trailing zeros when cast decimalV2 to string, we need do same thing in FE.
![image](https://github.com/StarRocks/starrocks/assets/110370499/ceccc3f6-07eb-4baf-be19-8674edde71cb)
![image](https://github.com/StarRocks/starrocks/assets/110370499/a8f44a5b-6061-4113-92c4-5084127cced0)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
