### PR TITLE
[Refactor] put `hadoop.config.resources` fields as common attributes of CloudConfiguration

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/HdfsEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/HdfsEnvironment.java
@@ -18,6 +18,7 @@ import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import org.apache.hadoop.conf.Configuration;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class HdfsEnvironment {
@@ -29,7 +30,7 @@ public class HdfsEnvironment {
      */
     public HdfsEnvironment() {
         hdfsConfiguration = new Configuration();
-        cloudConfiguration = CloudConfigurationFactory.buildDefaultCloudConfiguration();
+        cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(new HashMap<>());
     }
 
     public HdfsEnvironment(Map<String, String> properties) {

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfiguration.java
@@ -65,7 +65,7 @@ public class CloudConfiguration {
     // So we need to generate an identifier for different CloudCredential, and used it as cache key.
     // getCredentialString() Method just like toString()
     public String getCredentialString() {
-        return String.format("CloudConfiguration(configResources=%s, runtimeJars=%s)",
+        return String.format("CloudConfiguration{configResources=%s, runtimeJars=%s}",
                 configResources == null ? "null" : configResources, runtimeJars == null ? "null" : runtimeJars);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfiguration.java
@@ -14,25 +14,72 @@
 
 package com.starrocks.credential;
 
+import com.google.common.base.Strings;
 import com.staros.proto.FileStoreInfo;
+import com.starrocks.StarRocksFE;
 import com.starrocks.thrift.TCloudConfiguration;
+import com.starrocks.thrift.TCloudType;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-public interface CloudConfiguration {
+import java.util.HashMap;
+import java.util.Map;
 
-    void toThrift(TCloudConfiguration tCloudConfiguration);
+import static com.starrocks.credential.CloudConfigurationConstants.HDFS_CONFIG_RESOURCES;
+import static com.starrocks.credential.CloudConfigurationConstants.HDFS_RUNTIME_JARS;
 
-    void applyToConfiguration(Configuration configuration);
+public class CloudConfiguration {
+    private static final Logger LOG = LogManager.getLogger(CloudConfiguration.class);
+
+    private String configResources;
+    private String runtimeJars;
+
+    public void toThrift(TCloudConfiguration tCloudConfiguration) {
+        tCloudConfiguration.cloud_type = TCloudType.DEFAULT;
+        Map<String, String> properties = new HashMap<>();
+        properties.put(HDFS_CONFIG_RESOURCES, configResources);
+        properties.put(HDFS_RUNTIME_JARS, runtimeJars);
+        tCloudConfiguration.setCloud_properties_v2(properties);
+    }
+
+    public static void addConfigResourcesToConfiguration(String configResources, Configuration conf) {
+        if (Strings.isNullOrEmpty(configResources)) {
+            return;
+        }
+        String[] parts = configResources.split(",");
+        for (String p : parts) {
+            Path path = new Path(StarRocksFE.STARROCKS_HOME_DIR + "/conf/", p);
+            LOG.debug(String.format("Add path '%s' to configuration", path.toString()));
+            conf.addResource(path);
+        }
+    }
+
+    public void applyToConfiguration(Configuration configuration) {
+        addConfigResourcesToConfiguration(configResources, configuration);
+    }
 
     // Hadoop FileSystem has a cache itself, it used request uri as a cache key by default,
     // so it cannot sense the CloudCredential changed.
     // So we need to generate an identifier for different CloudCredential, and used it as cache key.
     // getCredentialString() Method just like toString()
-    String getCredentialString();
+    public String getCredentialString() {
+        return String.format("CloudConfiguration(configResources=%s, runtimeJars=%s)",
+                configResources == null ? "null" : configResources, runtimeJars == null ? "null" : runtimeJars);
+    }
 
-    CloudType getCloudType();
+    public CloudType getCloudType() {
+        return CloudType.DEFAULT;
+    }
 
     // Convert to the protobuf used by staros.
-    FileStoreInfo toFileStoreInfo();
+    public FileStoreInfo toFileStoreInfo() {
+        return null;
+    }
 
+    public void loadCommonProperties(Map<String, String> properties) {
+        configResources = properties.getOrDefault(HDFS_CONFIG_RESOURCES, "");
+        runtimeJars = properties.getOrDefault(HDFS_RUNTIME_JARS, "");
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfiguration.java
@@ -63,8 +63,8 @@ public class CloudConfiguration {
     // Hadoop FileSystem has a cache itself, it used request uri as a cache key by default,
     // so it cannot sense the CloudCredential changed.
     // So we need to generate an identifier for different CloudCredential, and used it as cache key.
-    // getCredentialString() Method just like toString()
-    public String getCredentialString() {
+    // toConfString() Method just like toString()
+    public String toConfString() {
         return "CloudConfiguration{" + getCommonFieldsString() + "}";
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfiguration.java
@@ -65,8 +65,7 @@ public class CloudConfiguration {
     // So we need to generate an identifier for different CloudCredential, and used it as cache key.
     // getCredentialString() Method just like toString()
     public String getCredentialString() {
-        return String.format("CloudConfiguration{configResources=%s, runtimeJars=%s}",
-                configResources == null ? "null" : configResources, runtimeJars == null ? "null" : runtimeJars);
+        return "CloudConfiguration{" + getCommonFieldsString() + "}";
     }
 
     public CloudType getCloudType() {
@@ -78,8 +77,12 @@ public class CloudConfiguration {
         return null;
     }
 
-    public void loadCommonProperties(Map<String, String> properties) {
+    public void loadCommonFields(Map<String, String> properties) {
         configResources = properties.getOrDefault(HDFS_CONFIG_RESOURCES, "");
         runtimeJars = properties.getOrDefault(HDFS_RUNTIME_JARS, "");
+    }
+
+    public String getCommonFieldsString() {
+        return String.format("resources='%s', jars='%s'", configResources, runtimeJars);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
@@ -15,16 +15,12 @@
 package com.starrocks.credential;
 
 import com.google.common.collect.ImmutableList;
-import com.staros.proto.FileStoreInfo;
 import com.starrocks.credential.aliyun.AliyunCloudConfigurationProvider;
 import com.starrocks.credential.aws.AWSCloudConfigurationProvider;
 import com.starrocks.credential.aws.AWSCloudCredential;
 import com.starrocks.credential.azure.AzureCloudConfigurationProvider;
 import com.starrocks.credential.gcp.GCPCloudConfigurationProvoder;
 import com.starrocks.credential.hdfs.HDFSCloudConfigurationProvider;
-import com.starrocks.thrift.TCloudConfiguration;
-import com.starrocks.thrift.TCloudType;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.aws.AwsProperties;
 
@@ -38,23 +34,35 @@ public class CloudConfigurationFactory {
             new AzureCloudConfigurationProvider(),
             new GCPCloudConfigurationProvoder(),
             new AliyunCloudConfigurationProvider(),
-            new HDFSCloudConfigurationProvider());
+            new HDFSCloudConfigurationProvider(),
+            new CloudConfigurationProvider() {
+                @Override
+                public CloudConfiguration build(Map<String, String> properties) {
+                    return new CloudConfiguration();
+                }
+            });
 
     public static CloudConfiguration buildCloudConfigurationForStorage(Map<String, String> properties) {
         for (CloudConfigurationProvider factory : cloudConfigurationFactoryChain) {
             CloudConfiguration cloudConfiguration = factory.build(properties);
             if (cloudConfiguration != null) {
+                cloudConfiguration.loadCommonProperties(properties);
                 return cloudConfiguration;
             }
         }
-
-        return buildDefaultCloudConfiguration();
+        // Should never reach here.
+        return null;
     }
 
     public static AWSCloudCredential buildGlueCloudCredential(HiveConf hiveConf) {
-        AWSCloudConfigurationProvider awsCloudConfigurationProvider =
-                (AWSCloudConfigurationProvider) cloudConfigurationFactoryChain.get(0);
-        return awsCloudConfigurationProvider.buildGlueCloudCredential(hiveConf);
+        for (CloudConfigurationProvider factory : cloudConfigurationFactoryChain) {
+            if (factory instanceof AWSCloudConfigurationProvider) {
+                AWSCloudConfigurationProvider provider = ((AWSCloudConfigurationProvider) factory);
+                return provider.buildGlueCloudCredential(hiveConf);
+            }
+        }
+        // Should never reach here.
+        return null;
     }
 
     public static CloudConfiguration buildCloudConfigurationForTabular(Map<String, String> properties) {
@@ -70,37 +78,5 @@ public class CloudConfigurationFactory {
             copiedProperties.put(CloudConfigurationConstants.AWS_S3_REGION, region);
         }
         return buildCloudConfigurationForStorage(copiedProperties);
-    }
-
-    // If user didn't specific any credential, we create DefaultCloudConfiguration instead.
-    // It will use Hadoop default constructor instead, user can put core-site.xml into java CLASSPATH to control
-    // authentication manually
-    public static CloudConfiguration buildDefaultCloudConfiguration() {
-        return new CloudConfiguration() {
-            @Override
-            public void toThrift(TCloudConfiguration tCloudConfiguration) {
-                tCloudConfiguration.cloud_type = TCloudType.DEFAULT;
-            }
-
-            @Override
-            public void applyToConfiguration(Configuration configuration) {
-
-            }
-
-            @Override
-            public CloudType getCloudType() {
-                return CloudType.DEFAULT;
-            }
-
-            @Override
-            public FileStoreInfo toFileStoreInfo() {
-                return null;
-            }
-
-            @Override
-            public String getCredentialString() {
-                return "default";
-            }
-        };
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationFactory.java
@@ -46,7 +46,7 @@ public class CloudConfigurationFactory {
         for (CloudConfigurationProvider factory : cloudConfigurationFactoryChain) {
             CloudConfiguration cloudConfiguration = factory.build(properties);
             if (cloudConfiguration != null) {
-                cloudConfiguration.loadCommonProperties(properties);
+                cloudConfiguration.loadCommonFields(properties);
                 return cloudConfiguration;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudCredential.java
@@ -22,8 +22,8 @@ import java.util.Map;
 public interface CloudCredential {
 
     /**
-    * Set credentials into Hadoop configuration
-    */
+     * Set credentials into Hadoop configuration
+     */
     void applyToConfiguration(Configuration configuration);
 
     /**
@@ -39,7 +39,7 @@ public interface CloudCredential {
     void toThrift(Map<String, String> properties);
 
     // Generate unique credential string, used as cache key in FileSystem cache
-    String getCredentialString();
+    String toCredString();
 
     // Convert to the protobuf used by staros.
     FileStoreInfo toFileStoreInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudConfiguration.java
@@ -23,10 +23,9 @@ import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCloudType;
 import org.apache.hadoop.conf.Configuration;
 
-import java.util.HashMap;
 import java.util.Map;
 
-public class AliyunCloudConfiguration implements CloudConfiguration {
+public class AliyunCloudConfiguration extends CloudConfiguration {
 
     private final AliyunCloudCredential aliyunCloudCredential;
 
@@ -38,16 +37,16 @@ public class AliyunCloudConfiguration implements CloudConfiguration {
     // reuse aws client logic of BE
     @Override
     public void toThrift(TCloudConfiguration tCloudConfiguration) {
+        super.toThrift(tCloudConfiguration);
         tCloudConfiguration.setCloud_type(TCloudType.AWS);
-
-        Map<String, String> properties = new HashMap<>();
+        Map<String, String> properties = tCloudConfiguration.getCloud_properties_v2();
         properties.put(CloudConfigurationConstants.AWS_S3_ENABLE_SSL, String.valueOf(true));
         aliyunCloudCredential.toThrift(properties);
-        tCloudConfiguration.setCloud_properties_v2(properties);
     }
 
     @Override
     public void applyToConfiguration(Configuration configuration) {
+        super.applyToConfiguration(configuration);
         aliyunCloudCredential.applyToConfiguration(configuration);
     }
 
@@ -58,12 +57,11 @@ public class AliyunCloudConfiguration implements CloudConfiguration {
 
     @Override
     public FileStoreInfo toFileStoreInfo() {
-        // TODO: Support oss credential
         return aliyunCloudCredential.toFileStoreInfo();
     }
 
     @Override
     public String getCredentialString() {
-        return aliyunCloudCredential.getCredentialString();
+        return super.getCredentialString() + aliyunCloudCredential.getCredentialString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudConfiguration.java
@@ -61,8 +61,8 @@ public class AliyunCloudConfiguration extends CloudConfiguration {
     }
 
     @Override
-    public String getCredentialString() {
+    public String toConfString() {
         return String.format("AliyunCloudConfiguration{%s, cred=%s}", getCommonFieldsString(),
-                aliyunCloudCredential.getCredentialString());
+                aliyunCloudCredential.toCredString());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudConfiguration.java
@@ -62,6 +62,7 @@ public class AliyunCloudConfiguration extends CloudConfiguration {
 
     @Override
     public String getCredentialString() {
-        return super.getCredentialString() + aliyunCloudCredential.getCredentialString();
+        return String.format("AliyunCloudConfiguration{%s, cred=%s}", getCommonFieldsString(),
+                aliyunCloudCredential.getCredentialString());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudCredential.java
@@ -59,7 +59,7 @@ public class AliyunCloudCredential implements CloudCredential {
     }
 
     @Override
-    public String getCredentialString() {
+    public String toCredString() {
         return "AliyunCloudCredential{" +
                 "accessKey=" + accessKey +
                 ", secretKey='" + secretKey + '\'' +

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aliyun/AliyunCloudCredential.java
@@ -36,6 +36,7 @@ public class AliyunCloudCredential implements CloudCredential {
         this.secretKey = secretKey;
         this.endpoint = endpoint;
     }
+
     @Override
     public void applyToConfiguration(Configuration configuration) {
         configuration.set("fs.oss.impl", "com.aliyun.jindodata.oss.JindoOssFileSystem");
@@ -61,7 +62,7 @@ public class AliyunCloudCredential implements CloudCredential {
     @Override
     public String toCredString() {
         return "AliyunCloudCredential{" +
-                "accessKey=" + accessKey +
+                "accessKey='" + accessKey + '\'' +
                 ", secretKey='" + secretKey + '\'' +
                 ", endpoint='" + endpoint + '\'' +
                 '}';

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfiguration.java
@@ -103,11 +103,10 @@ public class AWSCloudConfiguration extends CloudConfiguration {
 
     @Override
     public String getCredentialString() {
-        String cred = "AWSCloudConfiguration{" +
-                "awsCloudCredential=" + awsCloudCredential.getCredentialString() +
+        return "AWSCloudConfiguration{" + getCommonFieldsString() +
+                ", cred=" + awsCloudCredential.getCredentialString() +
                 ", enablePathStyleAccess=" + enablePathStyleAccess +
                 ", enableSSL=" + enableSSL +
                 '}';
-        return super.getCredentialString() + cred;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfiguration.java
@@ -102,9 +102,9 @@ public class AWSCloudConfiguration extends CloudConfiguration {
     }
 
     @Override
-    public String getCredentialString() {
+    public String toConfString() {
         return "AWSCloudConfiguration{" + getCommonFieldsString() +
-                ", cred=" + awsCloudCredential.getCredentialString() +
+                ", cred=" + awsCloudCredential.toCredString() +
                 ", enablePathStyleAccess=" + enablePathStyleAccess +
                 ", enableSSL=" + enableSSL +
                 '}';

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfiguration.java
@@ -22,10 +22,9 @@ import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCloudType;
 import org.apache.hadoop.conf.Configuration;
 
-import java.util.HashMap;
 import java.util.Map;
 
-public class AWSCloudConfiguration implements CloudConfiguration {
+public class AWSCloudConfiguration extends CloudConfiguration {
 
     private final AWSCloudCredential awsCloudCredential;
 
@@ -59,6 +58,7 @@ public class AWSCloudConfiguration implements CloudConfiguration {
 
     @Override
     public void applyToConfiguration(Configuration configuration) {
+        super.applyToConfiguration(configuration);
         configuration.set("fs.s3.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
         configuration.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
         // Below storage using s3 compatible storage api
@@ -82,14 +82,13 @@ public class AWSCloudConfiguration implements CloudConfiguration {
 
     @Override
     public void toThrift(TCloudConfiguration tCloudConfiguration) {
+        super.toThrift(tCloudConfiguration);
         tCloudConfiguration.setCloud_type(TCloudType.AWS);
-
-        Map<String, String> properties = new HashMap<>();
+        Map<String, String> properties = tCloudConfiguration.getCloud_properties_v2();
         properties.put(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS,
                 String.valueOf(enablePathStyleAccess));
         properties.put(CloudConfigurationConstants.AWS_S3_ENABLE_SSL, String.valueOf(enableSSL));
         awsCloudCredential.toThrift(properties);
-        tCloudConfiguration.setCloud_properties_v2(properties);
     }
 
     @Override
@@ -104,10 +103,11 @@ public class AWSCloudConfiguration implements CloudConfiguration {
 
     @Override
     public String getCredentialString() {
-        return "AWSCloudConfiguration{" +
+        String cred = "AWSCloudConfiguration{" +
                 "awsCloudCredential=" + awsCloudCredential.getCredentialString() +
                 ", enablePathStyleAccess=" + enablePathStyleAccess +
                 ", enableSSL=" + enableSSL +
                 '}';
+        return super.getCredentialString() + cred;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudCredential.java
@@ -254,7 +254,7 @@ public class AWSCloudCredential implements CloudCredential {
     }
 
     @Override
-    public String getCredentialString() {
+    public String toCredString() {
         return "AWSCloudCredential{" +
                 "useAWSSDKDefaultBehavior=" + useAWSSDKDefaultBehavior +
                 ", useInstanceProfile=" + useInstanceProfile +

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfiguration.java
@@ -57,8 +57,8 @@ public class AzureCloudConfiguration extends CloudConfiguration {
     }
 
     @Override
-    public String getCredentialString() {
+    public String toConfString() {
         return String.format("AzureCloudConfiguration{%s, cred=%s}", getCommonFieldsString(),
-                azureStorageCloudCredential.getCredentialString());
+                azureStorageCloudCredential.toCredString());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfiguration.java
@@ -58,6 +58,7 @@ public class AzureCloudConfiguration extends CloudConfiguration {
 
     @Override
     public String getCredentialString() {
-        return super.getCredentialString() + azureStorageCloudCredential.getCredentialString();
+        return String.format("AzureCloudConfiguration{%s, cred=%s}", getCommonFieldsString(),
+                azureStorageCloudCredential.getCredentialString());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureCloudConfiguration.java
@@ -21,10 +21,9 @@ import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCloudType;
 import org.apache.hadoop.conf.Configuration;
 
-import java.util.HashMap;
 import java.util.Map;
 
-public class AzureCloudConfiguration implements CloudConfiguration {
+public class AzureCloudConfiguration extends CloudConfiguration {
 
     private final AzureStorageCloudCredential azureStorageCloudCredential;
 
@@ -34,14 +33,16 @@ public class AzureCloudConfiguration implements CloudConfiguration {
 
     @Override
     public void toThrift(TCloudConfiguration tCloudConfiguration) {
+        super.toThrift(tCloudConfiguration);
         tCloudConfiguration.setCloud_type(TCloudType.AZURE);
-        Map<String, String> properties = new HashMap<>();
+        Map<String, String> properties = tCloudConfiguration.getCloud_properties_v2();
         azureStorageCloudCredential.toThrift(properties);
         tCloudConfiguration.setCloud_properties_v2(properties);
     }
 
     @Override
     public void applyToConfiguration(Configuration configuration) {
+        super.applyToConfiguration(configuration);
         azureStorageCloudCredential.applyToConfiguration(configuration);
     }
 
@@ -57,6 +58,6 @@ public class AzureCloudConfiguration implements CloudConfiguration {
 
     @Override
     public String getCredentialString() {
-        return azureStorageCloudCredential.getCredentialString();
+        return super.getCredentialString() + azureStorageCloudCredential.getCredentialString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/azure/AzureStorageCloudCredential.java
@@ -105,7 +105,7 @@ class AzureBlobCloudCredential extends AzureStorageCloudCredential {
     }
 
     @Override
-    public String getCredentialString() {
+    public String toCredString() {
         return "AzureBlobCloudCredential{" +
                 "endpoint='" + endpoint + '\'' +
                 ", storageAccount='" + storageAccount + '\'' +
@@ -163,7 +163,7 @@ class AzureADLS1CloudCredential extends AzureStorageCloudCredential {
     }
 
     @Override
-    public String getCredentialString() {
+    public String toCredString() {
         return "AzureADLS1CloudCredential{" +
                 "useManagedServiceIdentity=" + useManagedServiceIdentity +
                 ", oauth2ClientId='" + oauth2ClientId + '\'' +
@@ -236,7 +236,7 @@ class AzureADLS2CloudCredential extends AzureStorageCloudCredential {
     }
 
     @Override
-    public String getCredentialString() {
+    public String toCredString() {
         return "AzureADLS2CloudCredential{" +
                 "oauth2ManagedIdentity=" + oauth2ManagedIdentity +
                 ", oauth2TenantId='" + oauth2TenantId + '\'' +

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfiguration.java
@@ -59,8 +59,8 @@ public class GCPCloudConfiguration extends CloudConfiguration {
     }
 
     @Override
-    public String getCredentialString() {
+    public String toConfString() {
         return String.format("GCPCloudConfiguration{%s, cred=%s}", getCommonFieldsString(),
-                gcpCloudCredential.getCredentialString());
+                gcpCloudCredential.toCredString());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfiguration.java
@@ -22,10 +22,9 @@ import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCloudType;
 import org.apache.hadoop.conf.Configuration;
 
-import java.util.HashMap;
 import java.util.Map;
 
-public class GCPCloudConfiguration implements CloudConfiguration {
+public class GCPCloudConfiguration extends CloudConfiguration {
 
     private final GCPCloudCredential gcpCloudCredential;
 
@@ -36,15 +35,16 @@ public class GCPCloudConfiguration implements CloudConfiguration {
 
     @Override
     public void toThrift(TCloudConfiguration tCloudConfiguration) {
+        super.toThrift(tCloudConfiguration);
         tCloudConfiguration.setCloud_type(TCloudType.AZURE);
-
-        Map<String, String> properties = new HashMap<>();
+        Map<String, String> properties = tCloudConfiguration.getCloud_properties_v2();
         gcpCloudCredential.toThrift(properties);
         tCloudConfiguration.setCloud_properties_v2(properties);
     }
 
     @Override
     public void applyToConfiguration(Configuration configuration) {
+        super.applyToConfiguration(configuration);
         gcpCloudCredential.applyToConfiguration(configuration);
     }
 
@@ -55,12 +55,11 @@ public class GCPCloudConfiguration implements CloudConfiguration {
 
     @Override
     public FileStoreInfo toFileStoreInfo() {
-        // TODO: Support gcp credential
         return gcpCloudCredential.toFileStoreInfo();
     }
 
     @Override
     public String getCredentialString() {
-        return gcpCloudCredential.getCredentialString();
+        return super.getCredentialString() + gcpCloudCredential.getCredentialString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfiguration.java
@@ -60,6 +60,7 @@ public class GCPCloudConfiguration extends CloudConfiguration {
 
     @Override
     public String getCredentialString() {
-        return super.getCredentialString() + gcpCloudCredential.getCredentialString();
+        return String.format("GCPCloudConfiguration{%s, cred=%s}", getCommonFieldsString(),
+                gcpCloudCredential.getCredentialString());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudCredential.java
@@ -87,7 +87,7 @@ public class GCPCloudCredential implements CloudCredential {
     }
 
     @Override
-    public String getCredentialString() {
+    public String toCredString() {
         return "GCPCloudCredential{" +
                 "useComputeEngineServiceAccount=" + useComputeEngineServiceAccount +
                 ", serviceAccountEmail='" + serviceAccountEmail + '\'' +

--- a/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudConfiguration.java
@@ -52,9 +52,9 @@ public class HDFSCloudConfiguration extends CloudConfiguration {
     }
 
     @Override
-    public String getCredentialString() {
+    public String toConfString() {
         return String.format("HDFSCloudConfiguration{%s, cred=%s}", getCommonFieldsString(),
-                hdfsCloudCredential.getCredentialString());
+                hdfsCloudCredential.toCredString());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudConfiguration.java
@@ -53,7 +53,8 @@ public class HDFSCloudConfiguration extends CloudConfiguration {
 
     @Override
     public String getCredentialString() {
-        return super.getCredentialString() + hdfsCloudCredential.getCredentialString();
+        return String.format("HDFSCloudConfiguration{%s, cred=%s}", getCommonFieldsString(),
+                hdfsCloudCredential.getCredentialString());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudConfiguration.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudConfiguration.java
@@ -15,84 +15,45 @@
 package com.starrocks.credential.hdfs;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.staros.proto.FileStoreInfo;
-import com.starrocks.StarRocksFE;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudType;
 import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCloudType;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.util.HashMap;
 import java.util.Map;
 
-import static com.starrocks.credential.CloudConfigurationConstants.HDFS_CONFIG_RESOURCES;
-import static com.starrocks.credential.CloudConfigurationConstants.HDFS_RUNTIME_JARS;
-
-public class HDFSCloudConfiguration implements CloudConfiguration {
-    private static final Logger LOG = LogManager.getLogger(HDFSCloudConfiguration.class);
+public class HDFSCloudConfiguration extends CloudConfiguration {
 
     private final HDFSCloudCredential hdfsCloudCredential;
-    private String configResources;
-    private String runtimeJars;
-
-    private static final String CONFIG_RESOURCES_SEPERATOR = ",";
 
     public HDFSCloudConfiguration(HDFSCloudCredential hdfsCloudCredential) {
         Preconditions.checkNotNull(hdfsCloudCredential);
         this.hdfsCloudCredential = hdfsCloudCredential;
     }
 
-    public void setConfigResources(String configResources) {
-        this.configResources = configResources;
-    }
-
-    public void setRuntimeJars(String runtimeJars) {
-        this.runtimeJars = runtimeJars;
-    }
-
     public HDFSCloudCredential getHdfsCloudCredential() {
         return hdfsCloudCredential;
     }
 
-    public void addConfigResourcesToConfiguration(String configResources, Configuration conf) {
-        if (Strings.isNullOrEmpty(configResources)) {
-            return;
-        }
-        String[] parts = configResources.split(CONFIG_RESOURCES_SEPERATOR);
-        for (String p : parts) {
-            Path path = new Path(StarRocksFE.STARROCKS_HOME_DIR + "/conf/", p);
-            LOG.debug(String.format("Add path '%s' to configuration", path.toString()));
-            conf.addResource(path);
-        }
-    }
-
     @Override
     public void toThrift(TCloudConfiguration tCloudConfiguration) {
+        super.toThrift(tCloudConfiguration);
         tCloudConfiguration.setCloud_type(TCloudType.HDFS);
-        Map<String, String> properties = new HashMap<>();
+        Map<String, String> properties = tCloudConfiguration.getCloud_properties_v2();
         hdfsCloudCredential.toThrift(properties);
-        properties.put(HDFS_CONFIG_RESOURCES, configResources);
-        properties.put(HDFS_RUNTIME_JARS, runtimeJars);
-        tCloudConfiguration.setCloud_properties_v2(properties);
     }
 
     @Override
     public void applyToConfiguration(Configuration configuration) {
+        super.applyToConfiguration(configuration);
         hdfsCloudCredential.applyToConfiguration(configuration);
-        addConfigResourcesToConfiguration(configResources, configuration);
     }
 
     @Override
     public String getCredentialString() {
-        return "HDFSCloudConfiguration{" +
-                "configResources=" + configResources +
-                ", runtimeJars=" + runtimeJars +
-                ", credential=" + hdfsCloudCredential.getCredentialString() + "}";
+        return super.getCredentialString() + hdfsCloudCredential.getCredentialString();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudConfigurationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudConfigurationProvider.java
@@ -15,7 +15,6 @@
 package com.starrocks.credential.hdfs;
 
 import autovalue.shaded.com.google.common.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationProvider;
 
@@ -25,14 +24,12 @@ import java.util.Map;
 import static com.starrocks.credential.CloudConfigurationConstants.HADOOP_KERBEROS_KEYTAB;
 import static com.starrocks.credential.CloudConfigurationConstants.HADOOP_KERBEROS_KEYTAB_CONTENT;
 import static com.starrocks.credential.CloudConfigurationConstants.HDFS_AUTHENTICATION;
-import static com.starrocks.credential.CloudConfigurationConstants.HDFS_CONFIG_RESOURCES;
 import static com.starrocks.credential.CloudConfigurationConstants.HDFS_KERBEROS_KEYTAB_CONTENT_DEPRECATED;
 import static com.starrocks.credential.CloudConfigurationConstants.HDFS_KERBEROS_KEYTAB_DEPRECATED;
 import static com.starrocks.credential.CloudConfigurationConstants.HDFS_KERBEROS_PRINCIPAL;
 import static com.starrocks.credential.CloudConfigurationConstants.HDFS_KERBEROS_PRINCIPAL_DEPRECATED;
 import static com.starrocks.credential.CloudConfigurationConstants.HDFS_PASSWORD;
 import static com.starrocks.credential.CloudConfigurationConstants.HDFS_PASSWORD_DEPRECATED;
-import static com.starrocks.credential.CloudConfigurationConstants.HDFS_RUNTIME_JARS;
 import static com.starrocks.credential.CloudConfigurationConstants.HDFS_USERNAME;
 import static com.starrocks.credential.CloudConfigurationConstants.HDFS_USERNAME_DEPRECATED;
 
@@ -72,18 +69,10 @@ public class HDFSCloudConfigurationProvider implements CloudConfigurationProvide
                 getOrDefault(properties, HADOOP_KERBEROS_KEYTAB_CONTENT, HDFS_KERBEROS_KEYTAB_CONTENT_DEPRECATED),
                 prop
         );
-        String configResources = getOrDefault(properties, HDFS_CONFIG_RESOURCES);
-        String runtimeJars = getOrDefault(prop, HDFS_RUNTIME_JARS);
-        boolean useHDFS = false;
-        if (!Strings.isNullOrEmpty(configResources) || !Strings.isNullOrEmpty(runtimeJars)) {
-            useHDFS = true;
-        }
-        if (!useHDFS && !hdfsCloudCredential.validate()) {
+        if (!hdfsCloudCredential.validate()) {
             return null;
         }
         HDFSCloudConfiguration conf = new HDFSCloudConfiguration(hdfsCloudCredential);
-        conf.setConfigResources(configResources);
-        conf.setRuntimeJars(runtimeJars);
         return conf;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudCredential.java
@@ -90,7 +90,7 @@ public class HDFSCloudCredential implements CloudCredential {
     @Override
     public String toCredString() {
         return "HDFSCloudCredential{" +
-                "authentication=" + authentication +
+                "authentication='" + authentication + '\'' +
                 ", username='" + userName + '\'' +
                 ", password='" + password + '\'' +
                 ", krbPrincipal='" + krbPrincipal + '\'' +

--- a/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/hdfs/HDFSCloudCredential.java
@@ -88,7 +88,7 @@ public class HDFSCloudCredential implements CloudCredential {
     }
 
     @Override
-    public String getCredentialString() {
+    public String toCredString() {
         return "HDFSCloudCredential{" +
                 "authentication=" + authentication +
                 ", username='" + userName + '\'' +

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -645,7 +645,7 @@ public class HdfsFsManager {
         WildcardURI pathUri = new WildcardURI(path);
 
         String host = pathUri.getUri().getScheme() + "://" + pathUri.getUri().getHost();
-        HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, cloudConfiguration.toString());
+        HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, cloudConfiguration.toConfString());
 
         cachedFileSystem.putIfAbsent(fileSystemIdentity, new HdfsFs(fileSystemIdentity));
         HdfsFs fileSystem = cachedFileSystem.get(fileSystemIdentity);

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -59,7 +59,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-
 class ConfigurationWrap extends Configuration {
     private static final Logger LOG = LogManager.getLogger(ConfigurationWrap.class);
 
@@ -646,7 +645,7 @@ public class HdfsFsManager {
         WildcardURI pathUri = new WildcardURI(path);
 
         String host = pathUri.getUri().getScheme() + "://" + pathUri.getUri().getHost();
-        HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, cloudConfiguration.getCredentialString());
+        HdfsFsIdentity fileSystemIdentity = new HdfsFsIdentity(host, cloudConfiguration.toString());
 
         cachedFileSystem.putIfAbsent(fileSystemIdentity, new HdfsFs(fileSystemIdentity));
         HdfsFs fileSystem = cachedFileSystem.get(fileSystemIdentity);
@@ -867,7 +866,7 @@ public class HdfsFsManager {
      * <p>
      * file system handle is cached, the identity is endpoint + bucket + accessKey_secretKey
      */
-    public HdfsFs getUniversalFileSystem(String path, Map<String, String> loadProperties, THdfsProperties tProperties) 
+    public HdfsFs getUniversalFileSystem(String path, Map<String, String> loadProperties, THdfsProperties tProperties)
             throws UserException {
 
         String disableCacheHDFS = loadProperties.getOrDefault(FS_HDFS_IMPL_DISABLE_CACHE, "true");
@@ -1098,7 +1097,7 @@ public class HdfsFsManager {
      * for tos
      */
     public HdfsFs getTOSFileSystem(String path, Map<String, String> loadProperties, THdfsProperties tProperties)
-        throws UserException {
+            throws UserException {
         CloudConfiguration cloudConfiguration =
                 CloudConfigurationFactory.buildCloudConfigurationForStorage(loadProperties);
         // If we don't set new authenticate parameters, we use original way (just for compatible)
@@ -1235,10 +1234,9 @@ public class HdfsFsManager {
             throw new UserException("file not found: " + path, e);
         } catch (IllegalArgumentException e) {
             LOG.error("The arguments of blob store(S3/Azure) may be wrong. You can check " +
-                      "the arguments like region, IAM, instance profile and so on.");
+                    "the arguments like region, IAM, instance profile and so on.");
             throw new UserException("The arguments of blob store(S3/Azure) may be wrong. " +
-                                    "You can check the arguments like region, IAM, " +
-                                    "instance profile and so on.", e);
+                    "You can check the arguments like region, IAM, instance profile and so on.", e);
         } catch (Exception e) {
             LOG.error("errors while get file status ", e);
             throw new UserException("listPath failed", e);
@@ -1265,13 +1263,11 @@ public class HdfsFsManager {
         boolean srcAuthorityNull = (srcPathUri.getAuthority() == null);
         boolean destAuthorityNull = (destPathUri.getAuthority() == null);
         if (srcAuthorityNull != destAuthorityNull) {
-            throw new UserException("Different authority info between srcPath: " + srcPath +
-                                    " and destPath: " + destPath);
+            throw new UserException("Different authority info between srcPath: " + srcPath + " and destPath: " + destPath);
         }
         if (!srcAuthorityNull && !destAuthorityNull &&
                 !srcPathUri.getAuthority().trim().equals(destPathUri.getAuthority().trim())) {
-            throw new UserException(
-                "only allow rename in same file system");
+            throw new UserException("only allow rename in same file system");
 
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AWSCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AWSCloudConfigurationTest.java
@@ -65,7 +65,7 @@ public class AWSCloudConfigurationTest {
         Assert.assertNotNull(awsCloudCredential);
         Assert.assertEquals("AWSCloudCredential{useAWSSDKDefaultBehavior=false, useInstanceProfile=false, " +
                 "accessKey='ak', secretKey='sk', sessionToken='', iamRoleArn='', externalId='', " +
-                "region='us-west-1', endpoint=''}", awsCloudCredential.getCredentialString());
+                "region='us-west-1', endpoint=''}", awsCloudCredential.toCredString());
 
         hiveConf = new HiveConf();
         awsCloudCredential = CloudConfigurationFactory.buildGlueCloudCredential(hiveConf);

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -33,10 +33,11 @@ public class CloudConfigurationFactoryTest {
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForTabular(map);
         Assert.assertNotNull(cloudConfiguration);
         Assert.assertEquals(CloudType.AWS, cloudConfiguration.getCloudType());
-        Assert.assertEquals("CloudConfiguration{configResources=, runtimeJars=}AWSCloudConfiguration{awsCloudCredential=AWSCloudCredential" +
-                "{useAWSSDKDefaultBehavior=false, useInstanceProfile=false, " +
-                "accessKey='ak', secretKey='sk', sessionToken='token', iamRoleArn='', " +
-                "externalId='', region='region', endpoint=''}, enablePathStyleAccess=false, " +
-                "enableSSL=true}", cloudConfiguration.getCredentialString());
+        Assert.assertEquals(
+                "CloudConfiguration{configResources=, runtimeJars=}AWSCloudConfiguration{awsCloudCredential=AWSCloudCredential" +
+                        "{useAWSSDKDefaultBehavior=false, useInstanceProfile=false, " +
+                        "accessKey='ak', secretKey='sk', sessionToken='token', iamRoleArn='', " +
+                        "externalId='', region='region', endpoint=''}, enablePathStyleAccess=false, " +
+                        "enableSSL=true}", cloudConfiguration.getCredentialString());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -14,6 +14,10 @@
 
 package com.starrocks.credential;
 
+import com.starrocks.credential.aws.AWSCloudCredential;
+import com.starrocks.thrift.TCloudConfiguration;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.aws.AwsProperties;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,10 +38,173 @@ public class CloudConfigurationFactoryTest {
         Assert.assertNotNull(cloudConfiguration);
         Assert.assertEquals(CloudType.AWS, cloudConfiguration.getCloudType());
         Assert.assertEquals(
-                "CloudConfiguration{configResources=, runtimeJars=}AWSCloudConfiguration{awsCloudCredential=AWSCloudCredential" +
-                        "{useAWSSDKDefaultBehavior=false, useInstanceProfile=false, " +
+                "AWSCloudConfiguration{resources='', jars='', cred=AWSCloudCredential{" +
+                        "useAWSSDKDefaultBehavior=false, useInstanceProfile=false, " +
                         "accessKey='ak', secretKey='sk', sessionToken='token', iamRoleArn='', " +
                         "externalId='', region='region', endpoint=''}, enablePathStyleAccess=false, " +
                         "enableSSL=true}", cloudConfiguration.getCredentialString());
+    }
+
+    @Test
+    public void testAWSCloudConfiguration() {
+        Map<String, String> map = new HashMap<String, String>() {
+            {
+                put(CloudConfigurationConstants.AWS_S3_ACCESS_KEY, "XX");
+                put(CloudConfigurationConstants.AWS_S3_SECRET_KEY, "YY");
+                put(CloudConfigurationConstants.AWS_S3_REGION, "ZZ");
+            }
+        };
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map);
+        Assert.assertEquals(cc.getCloudType(), CloudType.AWS);
+        TCloudConfiguration tc = new TCloudConfiguration();
+        cc.toThrift(tc);
+        Configuration conf = new Configuration();
+        cc.applyToConfiguration(conf);
+        cc.toFileStoreInfo();
+        System.out.println(cc.getCredentialString());
+    }
+
+    @Test
+    public void testAliyunCloudConfiguration() {
+        Map<String, String> map = new HashMap<String, String>() {
+            {
+                put(CloudConfigurationConstants.ALIYUN_OSS_ACCESS_KEY, "XX");
+                put(CloudConfigurationConstants.ALIYUN_OSS_SECRET_KEY, "YY");
+                put(CloudConfigurationConstants.ALIYUN_OSS_ENDPOINT, "ZZ");
+            }
+        };
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map);
+        Assert.assertEquals(cc.getCloudType(), CloudType.ALIYUN);
+        TCloudConfiguration tc = new TCloudConfiguration();
+        cc.toThrift(tc);
+        Configuration conf = new Configuration();
+        cc.applyToConfiguration(conf);
+        cc.toFileStoreInfo();
+        System.out.println(cc.getCredentialString());
+    }
+
+    @Test
+    public void testAzureBlobCloudConfiguration() {
+        Map<String, String> map = new HashMap<String, String>() {
+            {
+                put(CloudConfigurationConstants.AZURE_BLOB_SHARED_KEY, "XX");
+                put(CloudConfigurationConstants.AZURE_BLOB_CONTAINER, "XX");
+                put(CloudConfigurationConstants.AZURE_BLOB_SAS_TOKEN, "XX");
+                put(CloudConfigurationConstants.AZURE_BLOB_STORAGE_ACCOUNT, "XX");
+                put(CloudConfigurationConstants.AZURE_BLOB_ENDPOINT, "XX");
+            }
+        };
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map);
+        Assert.assertEquals(cc.getCloudType(), CloudType.AZURE);
+        TCloudConfiguration tc = new TCloudConfiguration();
+        cc.toThrift(tc);
+        Configuration conf = new Configuration();
+        cc.applyToConfiguration(conf);
+        cc.toFileStoreInfo();
+        System.out.println(cc.getCredentialString());
+    }
+
+    @Test
+    public void testAzurASLS1eCloudConfiguration() {
+        Map<String, String> map = new HashMap<String, String>() {
+            {
+                put(CloudConfigurationConstants.AZURE_ADLS1_OAUTH2_ENDPOINT, "XX");
+                put(CloudConfigurationConstants.AZURE_ADLS1_OAUTH2_CLIENT_ID, "XX");
+                put(CloudConfigurationConstants.AZURE_ADLS1_USE_MANAGED_SERVICE_IDENTITY, "XX");
+                put(CloudConfigurationConstants.AZURE_ADLS1_OAUTH2_CREDENTIAL, "XX");
+            }
+        };
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map);
+        Assert.assertEquals(cc.getCloudType(), CloudType.AZURE);
+        TCloudConfiguration tc = new TCloudConfiguration();
+        cc.toThrift(tc);
+        Configuration conf = new Configuration();
+        cc.applyToConfiguration(conf);
+        cc.toFileStoreInfo();
+        System.out.println(cc.getCredentialString());
+    }
+
+    @Test
+    public void testAzureADLS2CloudConfiguration() {
+        Map<String, String> map = new HashMap<String, String>() {
+            {
+                put(CloudConfigurationConstants.AZURE_ADLS2_SHARED_KEY, "XX");
+                put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ID, "XX");
+                put(CloudConfigurationConstants.AZURE_ADLS2_STORAGE_ACCOUNT, "XX");
+                put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_TENANT_ID, "XX");
+                put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_ENDPOINT, "XX");
+                put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_CLIENT_SECRET, "XX");
+                put(CloudConfigurationConstants.AZURE_ADLS2_OAUTH2_USE_MANAGED_IDENTITY, "XX");
+            }
+        };
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map);
+        Assert.assertEquals(cc.getCloudType(), CloudType.AZURE);
+        TCloudConfiguration tc = new TCloudConfiguration();
+        cc.toThrift(tc);
+        Configuration conf = new Configuration();
+        cc.applyToConfiguration(conf);
+        cc.toFileStoreInfo();
+        System.out.println(cc.getCredentialString());
+    }
+
+    @Test
+    public void testGCPCloudConfiguration() {
+        Map<String, String> map = new HashMap<String, String>() {
+            {
+                put(CloudConfigurationConstants.GCP_GCS_SERVICE_ACCOUNT_PRIVATE_KEY, "XX");
+                put(CloudConfigurationConstants.GCP_GCS_SERVICE_ACCOUNT_PRIVATE_KEY_ID, "XX");
+                put(CloudConfigurationConstants.GCP_GCS_SERVICE_ACCOUNT_EMAIL, "XX");
+                put(CloudConfigurationConstants.GCP_GCS_SERVICE_ACCOUNT_IMPERSONATION_SERVICE_ACCOUNT, "XX");
+                put(CloudConfigurationConstants.GCP_GCS_USE_COMPUTE_ENGINE_SERVICE_ACCOUNT, "XX");
+            }
+        };
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map);
+        Assert.assertEquals(cc.getCloudType(), CloudType.GCP);
+        TCloudConfiguration tc = new TCloudConfiguration();
+        cc.toThrift(tc);
+        Configuration conf = new Configuration();
+        cc.applyToConfiguration(conf);
+        cc.toFileStoreInfo();
+        System.out.println(cc.getCredentialString());
+    }
+
+    @Test
+    public void testHDFSCloudConfiguration() {
+        Map<String, String> map = new HashMap<String, String>() {
+            {
+                put(CloudConfigurationConstants.HDFS_AUTHENTICATION, "simple");
+                put(CloudConfigurationConstants.HDFS_USERNAME, "XX");
+                put(CloudConfigurationConstants.HDFS_PASSWORD, "XX");
+            }
+        };
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map);
+        Assert.assertEquals(cc.getCloudType(), CloudType.HDFS);
+        TCloudConfiguration tc = new TCloudConfiguration();
+        cc.toThrift(tc);
+        Configuration conf = new Configuration();
+        cc.applyToConfiguration(conf);
+        cc.toFileStoreInfo();
+        System.out.println(cc.getCredentialString());
+    }
+
+    @Test
+    public void testDefaultCloudConfiguration() {
+        Map<String, String> map = new HashMap<String, String>();
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(map);
+        Assert.assertEquals(cc.getCloudType(), CloudType.DEFAULT);
+        TCloudConfiguration tc = new TCloudConfiguration();
+        cc.toThrift(tc);
+        Configuration conf = new Configuration();
+        cc.applyToConfiguration(conf);
+        cc.toFileStoreInfo();
+        System.out.println(cc.getCredentialString());
+    }
+
+    @Test
+    public void testGlueCredential() {
+        HiveConf conf = new HiveConf();
+        conf.set(CloudConfigurationConstants.AWS_GLUE_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
+        AWSCloudCredential cred = CloudConfigurationFactory.buildGlueCloudCredential(conf);
+        System.out.println(cred.getCredentialString());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -58,10 +58,16 @@ public class CloudConfigurationFactoryTest {
         Assert.assertEquals(cc.getCloudType(), CloudType.AWS);
         TCloudConfiguration tc = new TCloudConfiguration();
         cc.toThrift(tc);
+        Assert.assertEquals(tc.getCloud_properties_v2().get(CloudConfigurationConstants.AWS_S3_ENABLE_SSL), "true");
+        Assert.assertEquals(tc.getCloud_properties_v2().get(CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS),
+                "false");
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.toConfString());
+        Assert.assertEquals(cc.toConfString(),
+                "AWSCloudConfiguration{resources='', jars='', cred=AWSCloudCredential{useAWSSDKDefaultBehavior=false, " +
+                        "useInstanceProfile=false, accessKey='XX', secretKey='YY', sessionToken='', iamRoleArn='', " +
+                        "externalId='', region='ZZ', endpoint=''}, enablePathStyleAccess=false, enableSSL=true}");
     }
 
     @Test
@@ -77,10 +83,13 @@ public class CloudConfigurationFactoryTest {
         Assert.assertEquals(cc.getCloudType(), CloudType.ALIYUN);
         TCloudConfiguration tc = new TCloudConfiguration();
         cc.toThrift(tc);
+        Assert.assertEquals(tc.getCloud_properties_v2().get(CloudConfigurationConstants.AWS_S3_ENABLE_SSL), "true");
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.toConfString());
+        Assert.assertEquals(cc.toConfString(),
+                "AliyunCloudConfiguration{resources='', jars='', cred=AliyunCloudCredential{accessKey='XX', secretKey='YY', " +
+                        "endpoint='ZZ'}}");
     }
 
     @Test
@@ -101,7 +110,9 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.toConfString());
+        Assert.assertEquals(cc.toConfString(),
+                "AzureCloudConfiguration{resources='', jars='', cred=AzureBlobCloudCredential{endpoint='XX', " +
+                        "storageAccount='XX', sharedKey='XX', container='XX', sasToken='XX'}}");
     }
 
     @Test
@@ -121,7 +132,9 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.toConfString());
+        Assert.assertEquals(cc.toConfString(),
+                "AzureCloudConfiguration{resources='', jars='', cred=AzureADLS1CloudCredential{useManagedServiceIdentity=false," +
+                        " oauth2ClientId='XX', oauth2Credential='XX', oauth2Endpoint='XX'}}");
     }
 
     @Test
@@ -144,7 +157,10 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.toConfString());
+        Assert.assertEquals(cc.toConfString(),
+                "AzureCloudConfiguration{resources='', jars='', cred=AzureADLS2CloudCredential{oauth2ManagedIdentity=false, " +
+                        "oauth2TenantId='XX', oauth2ClientId='XX', storageAccount='XX', sharedKey='XX', " +
+                        "oauth2ClientSecret='XX', oauth2ClientEndpoint='XX'}}");
     }
 
     @Test
@@ -165,7 +181,10 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.toConfString());
+        Assert.assertEquals(cc.toConfString(),
+                "GCPCloudConfiguration{resources='', jars='', cred=GCPCloudCredential{useComputeEngineServiceAccount=false, " +
+                        "serviceAccountEmail='XX', serviceAccountPrivateKeyId='XX', serviceAccountPrivateKey='XX', " +
+                        "impersonationServiceAccount='XX'}}");
     }
 
     @Test
@@ -184,7 +203,9 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.toConfString());
+        Assert.assertEquals(cc.toConfString(),
+                "HDFSCloudConfiguration{resources='', jars='', cred=HDFSCloudCredential{authentication='simple', username='XX'," +
+                        " password='XX', krbPrincipal='', krbKeyTabFile='', krbKeyTabData=''}}");
     }
 
     @Test
@@ -197,7 +218,7 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.toConfString());
+        Assert.assertEquals(cc.toConfString(), "CloudConfiguration{resources='', jars=''}");
     }
 
     @Test
@@ -205,6 +226,8 @@ public class CloudConfigurationFactoryTest {
         HiveConf conf = new HiveConf();
         conf.set(CloudConfigurationConstants.AWS_GLUE_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
         AWSCloudCredential cred = CloudConfigurationFactory.buildGlueCloudCredential(conf);
-        System.out.println(cred.toCredString());
+        Assert.assertEquals(cred.toCredString(),
+                "AWSCloudCredential{useAWSSDKDefaultBehavior=true, useInstanceProfile=false, accessKey='', secretKey='', " +
+                        "sessionToken='', iamRoleArn='', externalId='', region='', endpoint=''}");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -42,7 +42,7 @@ public class CloudConfigurationFactoryTest {
                         "useAWSSDKDefaultBehavior=false, useInstanceProfile=false, " +
                         "accessKey='ak', secretKey='sk', sessionToken='token', iamRoleArn='', " +
                         "externalId='', region='region', endpoint=''}, enablePathStyleAccess=false, " +
-                        "enableSSL=true}", cloudConfiguration.getCredentialString());
+                        "enableSSL=true}", cloudConfiguration.toConfString());
     }
 
     @Test
@@ -61,7 +61,7 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.getCredentialString());
+        System.out.println(cc.toConfString());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.getCredentialString());
+        System.out.println(cc.toConfString());
     }
 
     @Test
@@ -101,7 +101,7 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.getCredentialString());
+        System.out.println(cc.toConfString());
     }
 
     @Test
@@ -121,7 +121,7 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.getCredentialString());
+        System.out.println(cc.toConfString());
     }
 
     @Test
@@ -144,7 +144,7 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.getCredentialString());
+        System.out.println(cc.toConfString());
     }
 
     @Test
@@ -165,7 +165,7 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.getCredentialString());
+        System.out.println(cc.toConfString());
     }
 
     @Test
@@ -184,7 +184,7 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.getCredentialString());
+        System.out.println(cc.toConfString());
     }
 
     @Test
@@ -197,7 +197,7 @@ public class CloudConfigurationFactoryTest {
         Configuration conf = new Configuration();
         cc.applyToConfiguration(conf);
         cc.toFileStoreInfo();
-        System.out.println(cc.getCredentialString());
+        System.out.println(cc.toConfString());
     }
 
     @Test
@@ -205,6 +205,6 @@ public class CloudConfigurationFactoryTest {
         HiveConf conf = new HiveConf();
         conf.set(CloudConfigurationConstants.AWS_GLUE_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
         AWSCloudCredential cred = CloudConfigurationFactory.buildGlueCloudCredential(conf);
-        System.out.println(cred.getCredentialString());
+        System.out.println(cred.toCredString());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -33,7 +33,7 @@ public class CloudConfigurationFactoryTest {
         CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForTabular(map);
         Assert.assertNotNull(cloudConfiguration);
         Assert.assertEquals(CloudType.AWS, cloudConfiguration.getCloudType());
-        Assert.assertEquals("AWSCloudConfiguration{awsCloudCredential=AWSCloudCredential" +
+        Assert.assertEquals("CloudConfiguration{configResources=, runtimeJars=}AWSCloudConfiguration{awsCloudCredential=AWSCloudCredential" +
                 "{useAWSSDKDefaultBehavior=false, useInstanceProfile=false, " +
                 "accessKey='ak', secretKey='sk', sessionToken='token', iamRoleArn='', " +
                 "externalId='', region='region', endpoint=''}, enablePathStyleAccess=false, " +

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HiveTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HiveTableSinkTest.java
@@ -77,7 +77,7 @@ public class HiveTableSinkTest {
         new Expectations() {
             {
                 hiveConnector.getMetadata().getCloudConfiguration();
-                result = CloudConfigurationFactory.buildDefaultCloudConfiguration();
+                result = CloudConfigurationFactory.buildCloudConfigurationForStorage(new HashMap<>());
                 minTimes = 1;
             }
         };


### PR DESCRIPTION
Fixes #issue

Some attributes of CloudConfiguration are common:
- put `CloudConfiguration` to class instead of interface
- there are some common fields/methods in `CloudConfiguration`
- when build thrift/configuration/credential, we should add those fields.

After refactor, the CloudConfiguration string representation looks like

```
AzureCloudConfiguration{resources='', jars='', cred=AzureADLS1CloudCredential{useManagedServiceIdentity=false, oauth2ClientId='XX', oauth2Credential='XX', oauth2Endpoint='XX'}}

AzureCloudConfiguration{resources='', jars='', cred=AzureBlobCloudCredential{endpoint='XX', storageAccount='XX', sharedKey='XX', container='XX', sasToken='XX'}}

GCPCloudConfiguration{resources='', jars='', cred=GCPCloudCredential{useComputeEngineServiceAccount=false, serviceAccountEmail='XX', serviceAccountPrivateKeyId='XX', serviceAccountPrivateKey='XX', impersonationServiceAccount='XX'}}

HDFSCloudConfiguration{resources='', jars='', cred=HDFSCloudCredential{authentication=simple, username='XX', password='XX', krbPrincipal='', krbKeyTabFile='', krbKeyTabData=''}}

CloudConfiguration{resources='', jars=''}

AliyunCloudConfiguration{resources='', jars='', cred=AliyunCloudCredential{accessKey=XX, secretKey='YY', endpoint='ZZ'}}

AzureCloudConfiguration{resources='', jars='', cred=AzureADLS2CloudCredential{oauth2ManagedIdentity=false, oauth2TenantId='XX', oauth2ClientId='XX', storageAccount='XX', sharedKey='XX', oauth2ClientSecret='XX', oauth2ClientEndpoint='XX'}}

AWSCloudConfiguration{resources='', jars='', cred=AWSCloudCredential{useAWSSDKDefaultBehavior=false, useInstanceProfile=false, accessKey='XX', secretKey='YY', sessionToken='', iamRoleArn='', externalId='', region='ZZ', endpoint=''}, enablePathStyleAccess=false, enableSSL=true}
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [X] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
