### PR TITLE
[Refactor] Move `getCloudConfiguration` to `ConnectorMetadata` from `Connector`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnector.java
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector;
 
 import com.starrocks.connector.informationschema.InformationSchemaConnector;
-import com.starrocks.credential.CloudConfiguration;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -42,9 +40,5 @@ public class CatalogConnector implements Connector {
 
     public void shutdown() {
         normalConnector.shutdown();
-    }
-
-    public CloudConfiguration getCloudConfiguration() {
-        return normalConnector.getCloudConfiguration();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -27,6 +27,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.connector.informationschema.InformationSchemaMetadata;
+import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterTableCommentClause;
@@ -265,5 +266,10 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     @Override
     public void alterView(AlterViewStmt stmt) throws DdlException, UserException {
         normal.alterView(stmt);
+    }
+
+    @Override
+    public CloudConfiguration getCloudConfiguration() {
+        return normal.getCloudConfiguration();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/Connector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/Connector.java
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector;
 
 import com.starrocks.connector.config.ConnectorConfig;
-import com.starrocks.credential.CloudConfiguration;
 
 public interface Connector {
     /**
@@ -33,19 +31,12 @@ public interface Connector {
      * no methods will be called on the connector or any objects that
      * have been returned from the connector.
      */
-    default void shutdown() {}
+    default void shutdown() {
+    }
 
     /**
      * check connector config
      */
-    default void bindConfig(ConnectorConfig config) {}
-
-    /**
-     * TODO: This is a temporary interface used to get cloud configurantion.
-     * After the refactoring of cloud configuration is complete,
-     * it should be placed elsewhere like connector metadata.
-     */
-    default CloudConfiguration getCloudConfiguration() {
-        return null;
+    default void bindConfig(ConnectorConfig config) {
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector;
 
 import com.google.common.collect.Lists;
@@ -80,6 +79,7 @@ public interface ConnectorMetadata {
 
     /**
      * Return all partition names of the table.
+     *
      * @param databaseName the name of the database
      * @param tableName the name of the table
      * @return a list of partition names
@@ -90,6 +90,7 @@ public interface ConnectorMetadata {
 
     /**
      * Return partial partition names of the table using partitionValues to filter.
+     *
      * @param databaseName the name of the database
      * @param tableName the name of the table
      * @param partitionValues the partition value to filter
@@ -103,7 +104,7 @@ public interface ConnectorMetadata {
     /**
      * Get Table descriptor for the table specific by `dbName`.`tblName`
      *
-     * @param dbName  - the string represents the database name
+     * @param dbName - the string represents the database name
      * @param tblName - the string represents the table name
      * @return a Table instance
      */
@@ -114,7 +115,7 @@ public interface ConnectorMetadata {
     /**
      * Get Table descriptor and materialized index for the materialized view index specific by `dbName`.`tblName`
      *
-     * @param dbName  - the string represents the database name
+     * @param dbName - the string represents the database name
      * @param tblName - the string represents the table name
      * @return a Table instance
      */
@@ -127,12 +128,12 @@ public interface ConnectorMetadata {
      * There are two ways of current connector table.
      * 1. Get the remote files information from hdfs or s3 according to table or partition.
      * 2. Get file scan tasks for iceberg metadata by query predicate.
+     *
      * @param table
      * @param partitionKeys selected partition columns
      * @param snapshotId selected snapshot id
      * @param predicate used to filter metadata for iceberg, etc
      * @param fieldNames all selected columns (including partition columns)
-     *
      * @return the remote file information of the query to scan.
      */
     default List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
@@ -146,12 +147,12 @@ public interface ConnectorMetadata {
 
     /**
      * Get statistics for the table.
+     *
      * @param session optimizer context
      * @param table
      * @param columns selected columns
      * @param partitionKeys selected partition keys
      * @param predicate used to filter metadata for iceberg, etc
-     *
      * @return the table statistics for the table.
      */
     default Statistics getTableStatistics(OptimizerContext session,
@@ -266,7 +267,7 @@ public interface ConnectorMetadata {
     }
 
     default CloudConfiguration getCloudConfiguration() {
-        return null;
+        throw new StarRocksConnectorException("This connector doesn't support getting cloud configuration");
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -28,6 +28,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
 import com.starrocks.sql.ast.AlterTableCommentClause;
@@ -264,5 +265,8 @@ public interface ConnectorMetadata {
     default void alterView(AlterViewStmt stmt) throws DdlException, UserException {
     }
 
+    default CloudConfiguration getCloudConfiguration() {
+        return null;
+    }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/HdfsEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/HdfsEnvironment.java
@@ -29,6 +29,7 @@ public class HdfsEnvironment {
      */
     public HdfsEnvironment() {
         hdfsConfiguration = new Configuration();
+        cloudConfiguration = CloudConfigurationFactory.buildDefaultCloudConfiguration();
     }
 
     public HdfsEnvironment(Map<String, String> properties) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/HdfsEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/HdfsEnvironment.java
@@ -21,48 +21,39 @@ import org.apache.hadoop.conf.Configuration;
 import java.util.Map;
 
 public class HdfsEnvironment {
-    private final HdfsConfiguration hdfsConfiguration;
+    private final Configuration hdfsConfiguration;
+    private CloudConfiguration cloudConfiguration;
 
     /**
      * Create default Hdfs environment
      */
     public HdfsEnvironment() {
-        this.hdfsConfiguration = new HdfsConfiguration();
+        hdfsConfiguration = new Configuration();
     }
 
     public HdfsEnvironment(Map<String, String> properties) {
         this();
         if (properties != null) {
-            this.hdfsConfiguration.applyToCloudConfiguration(
-                    CloudConfigurationFactory.buildCloudConfigurationForStorage(properties));
+            CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+            this.cloudConfiguration = cc;
+            cc.applyToConfiguration(hdfsConfiguration);
         }
     }
 
-    public HdfsEnvironment(CloudConfiguration cloudConfiguration) {
+    public HdfsEnvironment(CloudConfiguration cc) {
         this();
         if (cloudConfiguration != null) {
-            this.hdfsConfiguration.applyToCloudConfiguration(cloudConfiguration);
+            this.cloudConfiguration = cc;
+            cc.applyToConfiguration(hdfsConfiguration);
         }
     }
 
     public Configuration getConfiguration() {
-        return hdfsConfiguration.getConfiguration();
+        return hdfsConfiguration;
     }
 
-    private static class HdfsConfiguration {
-        private final Configuration configuration;
-
-        public HdfsConfiguration() {
-            this.configuration = new Configuration();
-        }
-
-        public void applyToCloudConfiguration(CloudConfiguration cloudConfiguration) {
-            cloudConfiguration.applyToConfiguration(configuration);
-        }
-
-        public Configuration getConfiguration() {
-            return configuration;
-        }
+    public CloudConfiguration getCloudConfiguration() {
+        return cloudConfiguration;
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.delta;
 
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.hive.HiveMetastoreOperations;
-import org.apache.hadoop.conf.Configuration;
+import com.starrocks.credential.CloudConfiguration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -28,12 +28,12 @@ import java.util.List;
 
 public class DeltaLakeMetadata implements ConnectorMetadata {
     private static final Logger LOG = LogManager.getLogger(DeltaLakeMetadata.class);
-    private final Configuration configuration;
     private final String catalogName;
     private final HiveMetastoreOperations hmsOps;
+    private final HdfsEnvironment hdfsEnvironment;
 
-    public DeltaLakeMetadata(Configuration configuration, String catalogName, HiveMetastoreOperations hmsOps) {
-        this.configuration = configuration;
+    public DeltaLakeMetadata(HdfsEnvironment hdfsEnvironment, String catalogName, HiveMetastoreOperations hmsOps) {
+        this.hdfsEnvironment = hdfsEnvironment;
         this.catalogName = catalogName;
         this.hmsOps = hmsOps;
     }
@@ -68,10 +68,16 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
             HiveTable hiveTable = (HiveTable) table;
             String path = hiveTable.getTableLocation();
             long createTime = table.getCreateTime();
-            return DeltaUtils.convertDeltaToSRTable(catalogName, dbName, tblName, path, configuration, createTime);
+            return DeltaUtils.convertDeltaToSRTable(catalogName, dbName, tblName, path, hdfsEnvironment.getConfiguration(),
+                    createTime);
         } catch (Exception e) {
             LOG.warn(e.getMessage());
             return null;
         }
+    }
+
+    @Override
+    public CloudConfiguration getCloudConfiguration() {
+        return hdfsEnvironment.getCloudConfiguration();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadataFactory.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.delta;
 
 import com.starrocks.connector.HdfsEnvironment;
@@ -48,6 +47,6 @@ public class DeltaLakeMetadataFactory {
                 metastore instanceof CachingHiveMetastore,
                 hdfsEnvironment.getConfiguration(), metastoreType, catalogName);
 
-        return new DeltaLakeMetadata(hdfsEnvironment.getConfiguration(), catalogName, hiveMetastoreOperations);
+        return new DeltaLakeMetadata(hdfsEnvironment, catalogName, hiveMetastoreOperations);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveConnector.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hive;
 
 import com.starrocks.connector.Connector;
@@ -32,7 +31,6 @@ public class HiveConnector implements Connector {
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
     public static final String HIVE_METASTORE_TYPE = "hive.metastore.type";
     private final Map<String, String> properties;
-    private final CloudConfiguration cloudConfiguration;
     private final String catalogName;
     private final HiveConnectorInternalMgr internalMgr;
     private final HiveMetadataFactory metadataFactory;
@@ -40,7 +38,7 @@ public class HiveConnector implements Connector {
     public HiveConnector(ConnectorContext context) {
         this.properties = context.getProperties();
         this.catalogName = context.getCatalogName();
-        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
         this.internalMgr = new HiveConnectorInternalMgr(catalogName, properties, hdfsEnvironment);
         this.metadataFactory = createMetadataFactory(hdfsEnvironment);
@@ -66,7 +64,7 @@ public class HiveConnector implements Connector {
                 internalMgr.getUpdateStatisticsExecutor(),
                 internalMgr.isSearchRecursive(),
                 internalMgr.enableHmsEventsIncrementalSync(),
-                hdfsEnvironment.getConfiguration(),
+                hdfsEnvironment,
                 internalMgr.getMetastoreType()
         );
     }
@@ -92,9 +90,5 @@ public class HiveConnector implements Connector {
         metadataFactory.getCacheUpdateProcessor().ifPresent(CacheUpdateProcessor::invalidateAll);
         GlobalStateMgr.getCurrentState().getMetastoreEventsProcessor().unRegisterCacheUpdateProcessor(catalogName);
         GlobalStateMgr.getCurrentState().getConnectorTableMetadataProcessor().unRegisterCacheUpdateProcessor(catalogName);
-    }
-
-    public CloudConfiguration getCloudConfiguration() {
-        return cloudConfiguration;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -27,11 +27,13 @@ import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileOperations;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.PartitionUpdate.UpdateMode;
+import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateTableStmt;
@@ -60,6 +62,7 @@ public class HiveMetadata implements ConnectorMetadata {
     private static final Logger LOG = LogManager.getLogger(HiveMetadata.class);
     public static final String STARROCKS_QUERY_ID = "starrocks_query_id";
     private final String catalogName;
+    private final HdfsEnvironment hdfsEnvironment;
     private final HiveMetastoreOperations hmsOps;
     private final RemoteFileOperations fileOps;
     private final HiveStatisticsProvider statisticsProvider;
@@ -67,12 +70,14 @@ public class HiveMetadata implements ConnectorMetadata {
     private Executor updateExecutor;
 
     public HiveMetadata(String catalogName,
+                        HdfsEnvironment hdfsEnvironment,
                         HiveMetastoreOperations hmsOps,
                         RemoteFileOperations fileOperations,
                         HiveStatisticsProvider statisticsProvider,
                         Optional<CacheUpdateProcessor> cacheUpdateProcessor,
                         Executor updateExecutor) {
         this.catalogName = catalogName;
+        this.hdfsEnvironment = hdfsEnvironment;
         this.hmsOps = hmsOps;
         this.fileOps = fileOperations;
         this.statisticsProvider = statisticsProvider;
@@ -301,5 +306,10 @@ public class HiveMetadata implements ConnectorMetadata {
     public void clear() {
         hmsOps.invalidateAll();
         fileOps.invalidateAll();
+    }
+
+    @Override
+    public CloudConfiguration getCloudConfiguration() {
+        return hdfsEnvironment.getCloudConfiguration();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadataFactory.java
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hive;
 
 import com.starrocks.connector.CachingRemoteFileConf;
 import com.starrocks.connector.CachingRemoteFileIO;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.RemoteFileIO;
 import com.starrocks.connector.RemoteFileOperations;
-import org.apache.hadoop.conf.Configuration;
 
 import java.util.Optional;
 import java.util.concurrent.Executor;
@@ -39,7 +38,7 @@ public class HiveMetadataFactory {
     private final Executor updateStatisticsExecutor;
     private final boolean isRecursive;
     private final boolean enableHmsEventsIncrementalSync;
-    private final Configuration configuration;
+    private final HdfsEnvironment hdfsEnvironment;
     private final MetastoreType metastoreType;
 
     public HiveMetadataFactory(String catalogName,
@@ -52,7 +51,7 @@ public class HiveMetadataFactory {
                                Executor updateStatisticsExecutor,
                                boolean isRecursive,
                                boolean enableHmsEventsIncrementalSync,
-                               Configuration configuration,
+                               HdfsEnvironment hdfsEnvironment,
                                MetastoreType metastoreType) {
         this.catalogName = catalogName;
         this.metastore = metastore;
@@ -64,7 +63,7 @@ public class HiveMetadataFactory {
         this.updateStatisticsExecutor = updateStatisticsExecutor;
         this.isRecursive = isRecursive;
         this.enableHmsEventsIncrementalSync = enableHmsEventsIncrementalSync;
-        this.configuration = configuration;
+        this.hdfsEnvironment = hdfsEnvironment;
         this.metastoreType = metastoreType;
     }
 
@@ -72,18 +71,18 @@ public class HiveMetadataFactory {
         HiveMetastoreOperations hiveMetastoreOperations = new HiveMetastoreOperations(
                 createQueryLevelInstance(metastore, perQueryMetastoreMaxNum),
                 metastore instanceof CachingHiveMetastore,
-                configuration, metastoreType, catalogName);
+                hdfsEnvironment.getConfiguration(), metastoreType, catalogName);
         RemoteFileOperations remoteFileOperations = new RemoteFileOperations(
                 CachingRemoteFileIO.createQueryLevelInstance(remoteFileIO, perQueryCacheRemotePathMaxNum),
                 pullRemoteFileExecutor,
                 updateRemoteFilesExecutor,
                 isRecursive,
                 remoteFileIO instanceof CachingRemoteFileIO,
-                configuration);
+                hdfsEnvironment.getConfiguration());
         HiveStatisticsProvider statisticsProvider = new HiveStatisticsProvider(hiveMetastoreOperations, remoteFileOperations);
 
         Optional<CacheUpdateProcessor> cacheUpdateProcessor = getCacheUpdateProcessor();
-        return new HiveMetadata(catalogName, hiveMetastoreOperations, remoteFileOperations,
+        return new HiveMetadata(catalogName, hdfsEnvironment, hiveMetastoreOperations, remoteFileOperations,
                 statisticsProvider, cacheUpdateProcessor, updateStatisticsExecutor);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -248,7 +248,7 @@ public class HiveMetastoreApiConverter {
         Configuration configuration = new Configuration();
         if (catalogName != null) {
             CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);
-            CloudConfiguration cloudConfiguration = connector.getCloudConfiguration();
+            CloudConfiguration cloudConfiguration = connector.getMetadata().getCloudConfiguration();
             HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
             configuration = hdfsEnvironment.getConfiguration();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiConnector.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hudi;
 
 import com.google.common.collect.Lists;
@@ -31,17 +30,14 @@ import java.util.Map;
 
 public class HudiConnector implements Connector {
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
-    public static final String HIVE_METASTORE_TYPE = "hive.metastore.type";
     public static final List<String> SUPPORTED_METASTORE_TYPE = Lists.newArrayList("hive", "glue", "dlf");
-    private final Map<String, String> properties;
-    private final CloudConfiguration cloudConfiguration;
     private final String catalogName;
     private final HudiConnectorInternalMgr internalMgr;
     private final HudiMetadataFactory metadataFactory;
 
     public HudiConnector(ConnectorContext context) {
-        this.properties = context.getProperties();
-        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        Map<String, String> properties = context.getProperties();
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
         this.catalogName = context.getCatalogName();
         this.internalMgr = new HudiConnectorInternalMgr(catalogName, properties, hdfsEnvironment);
@@ -65,16 +61,12 @@ public class HudiConnector implements Connector {
                 internalMgr.getRemoteFileConf(),
                 internalMgr.getPullRemoteFileExecutor(),
                 internalMgr.isSearchRecursive(),
-                hdfsEnvironment.getConfiguration(),
+                hdfsEnvironment,
                 internalMgr.getMetastoreType()
         );
     }
 
     public void onCreate() {
-    }
-
-    public CloudConfiguration getCloudConfiguration() {
-        return cloudConfiguration;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hudi;
 
 import com.google.common.base.Preconditions;
@@ -25,6 +24,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileOperations;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -32,6 +32,7 @@ import com.starrocks.connector.hive.CacheUpdateProcessor;
 import com.starrocks.connector.hive.HiveMetastoreOperations;
 import com.starrocks.connector.hive.HiveStatisticsProvider;
 import com.starrocks.connector.hive.Partition;
+import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.DropTableStmt;
@@ -53,17 +54,21 @@ import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceM
 public class HudiMetadata implements ConnectorMetadata {
     private static final Logger LOG = LogManager.getLogger(HudiMetadata.class);
     private final String catalogName;
+    private final HdfsEnvironment hdfsEnvironment;
+
     private final HiveMetastoreOperations hmsOps;
     private final RemoteFileOperations fileOps;
     private final HiveStatisticsProvider statisticsProvider;
     private final Optional<CacheUpdateProcessor> cacheUpdateProcessor;
 
     public HudiMetadata(String catalogName,
+                        HdfsEnvironment hdfsEnvironment,
                         HiveMetastoreOperations hmsOps,
                         RemoteFileOperations fileOperations,
                         HiveStatisticsProvider statisticsProvider,
                         Optional<CacheUpdateProcessor> cacheUpdateProcessor) {
         this.catalogName = catalogName;
+        this.hdfsEnvironment = hdfsEnvironment;
         this.hmsOps = hmsOps;
         this.fileOps = fileOperations;
         this.statisticsProvider = statisticsProvider;
@@ -204,5 +209,10 @@ public class HudiMetadata implements ConnectorMetadata {
     public void clear() {
         hmsOps.invalidateAll();
         fileOps.invalidateAll();
+    }
+
+    @Override
+    public CloudConfiguration getCloudConfiguration() {
+        return hdfsEnvironment.getCloudConfiguration();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.iceberg;
 
 import com.google.common.base.Strings;
@@ -45,7 +44,6 @@ public class IcebergConnector implements Connector {
     public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
     public static final String ICEBERG_CUSTOM_PROPERTIES_PREFIX = "iceberg.catalog.";
     private final Map<String, String> properties;
-    private final CloudConfiguration cloudConfiguration;
     private final HdfsEnvironment hdfsEnvironment;
     private final String catalogName;
     private IcebergCatalog icebergNativeCatalog;
@@ -53,7 +51,7 @@ public class IcebergConnector implements Connector {
     public IcebergConnector(ConnectorContext context) {
         this.catalogName = context.getCatalogName();
         this.properties = context.getProperties();
-        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
         this.hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
     }
 
@@ -93,7 +91,7 @@ public class IcebergConnector implements Connector {
 
     @Override
     public ConnectorMetadata getMetadata() {
-        return new IcebergMetadata(catalogName, getNativeCatalog());
+        return new IcebergMetadata(catalogName, hdfsEnvironment, getNativeCatalog());
     }
 
     // In order to be compatible with the catalog created with the wrong configuration,
@@ -103,9 +101,5 @@ public class IcebergConnector implements Connector {
             this.icebergNativeCatalog = buildIcebergNativeCatalog();
         }
         return icebergNativeCatalog;
-    }
-
-    public CloudConfiguration getCloudConfiguration() {
-        return cloudConfiguration;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.iceberg;
 
 import com.google.common.base.Preconditions;
@@ -28,12 +27,14 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
 import com.starrocks.connector.iceberg.cost.IcebergStatisticProvider;
+import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.ListPartitionDesc;
@@ -90,6 +91,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     private static final Logger LOG = LogManager.getLogger(IcebergMetadata.class);
     private final String catalogName;
+    private final HdfsEnvironment hdfsEnvironment;
     private final IcebergCatalog icebergCatalog;
     private final IcebergStatisticProvider statisticProvider = new IcebergStatisticProvider();
 
@@ -97,8 +99,9 @@ public class IcebergMetadata implements ConnectorMetadata {
     private final Map<String, Database> databases = new ConcurrentHashMap<>();
     private final Map<IcebergFilter, List<FileScanTask>> tasks = new ConcurrentHashMap<>();
 
-    public IcebergMetadata(String catalogName, IcebergCatalog icebergCatalog) {
+    public IcebergMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, IcebergCatalog icebergCatalog) {
         this.catalogName = catalogName;
+        this.hdfsEnvironment = hdfsEnvironment;
         this.icebergCatalog = icebergCatalog;
         new IcebergMetricsReporter().setThreadLocalReporter();
     }
@@ -409,6 +412,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     interface BatchWrite {
         void addFile(DataFile file);
+
         void commit();
     }
 
@@ -494,5 +498,10 @@ public class IcebergMetadata implements ConnectorMetadata {
         public int hashCode() {
             return Arrays.hashCode(values);
         }
+    }
+
+    @Override
+    public CloudConfiguration getCloudConfiguration() {
+        return hdfsEnvironment.getCloudConfiguration();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
@@ -18,14 +18,13 @@ import com.google.common.base.Strings;
 import com.starrocks.connector.Connector;
 import com.starrocks.connector.ConnectorContext;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import com.starrocks.credential.CloudType;
 import com.starrocks.credential.aws.AWSCloudConfiguration;
 import com.starrocks.credential.aws.AWSCloudCredential;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
@@ -38,11 +37,10 @@ import static org.apache.paimon.options.CatalogOptions.URI;
 import static org.apache.paimon.options.CatalogOptions.WAREHOUSE;
 
 public class PaimonConnector implements Connector {
-    private static final Logger LOG = LogManager.getLogger(PaimonConnector.class);
     private static final String PAIMON_CATALOG_TYPE = "paimon.catalog.type";
     private static final String PAIMON_CATALOG_WAREHOUSE = "paimon.catalog.warehouse";
     private static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
-    private final CloudConfiguration cloudConfiguration;
+    private final HdfsEnvironment hdfsEnvironment;
     private Catalog paimonNativeCatalog;
     private final String catalogType;
     private final String metastoreUris;
@@ -53,7 +51,8 @@ public class PaimonConnector implements Connector {
     public PaimonConnector(ConnectorContext context) {
         Map<String, String> properties = context.getProperties();
         this.catalogName = context.getCatalogName();
-        this.cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        this.hdfsEnvironment = new HdfsEnvironment(cloudConfiguration);
         this.catalogType = properties.get(PAIMON_CATALOG_TYPE);
         this.metastoreUris = properties.get(HIVE_METASTORE_URIS);
         this.warehousePath = properties.get(PAIMON_CATALOG_WAREHOUSE);
@@ -76,8 +75,8 @@ public class PaimonConnector implements Connector {
         }
         paimonOptions.setString(WAREHOUSE.key(), warehousePath);
 
-        if (this.cloudConfiguration.getCloudType() == CloudType.AWS && this.cloudConfiguration instanceof AWSCloudConfiguration) {
-            AWSCloudConfiguration awsCloudConfiguration = (AWSCloudConfiguration) this.cloudConfiguration;
+        if (cloudConfiguration.getCloudType() == CloudType.AWS && cloudConfiguration instanceof AWSCloudConfiguration) {
+            AWSCloudConfiguration awsCloudConfiguration = (AWSCloudConfiguration) cloudConfiguration;
             paimonOptions.set("s3.connection.ssl.enabled", String.valueOf(awsCloudConfiguration.getEnableSSL()));
             paimonOptions.set("s3.path.style.access", String.valueOf(awsCloudConfiguration.getEnablePathStyleAccess()));
             AWSCloudCredential awsCloudCredential = awsCloudConfiguration.getAWSCloudCredential();
@@ -106,11 +105,7 @@ public class PaimonConnector implements Connector {
 
     @Override
     public ConnectorMetadata getMetadata() {
-        return new PaimonMetadata(catalogName, getPaimonNativeCatalog(), catalogType, metastoreUris, warehousePath);
-    }
-
-    @Override
-    public CloudConfiguration getCloudConfiguration() {
-        return cloudConfiguration;
+        return new PaimonMetadata(catalogName, hdfsEnvironment, getPaimonNativeCatalog(), catalogType, metastoreUris,
+                warehousePath);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
@@ -75,7 +75,7 @@ public class PaimonConnector implements Connector {
         }
         paimonOptions.setString(WAREHOUSE.key(), warehousePath);
 
-        if (cloudConfiguration.getCloudType() == CloudType.AWS && cloudConfiguration instanceof AWSCloudConfiguration) {
+        if (cloudConfiguration.getCloudType() == CloudType.AWS) {
             AWSCloudConfiguration awsCloudConfiguration = (AWSCloudConfiguration) cloudConfiguration;
             paimonOptions.set("s3.connection.ssl.enabled", String.valueOf(awsCloudConfiguration.getEnableSSL()));
             paimonOptions.set("s3.path.style.access", String.valueOf(awsCloudConfiguration.getEnablePathStyleAccess()));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -24,9 +24,11 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.connector.ColumnTypeConverter;
 import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -58,6 +60,7 @@ import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
 public class PaimonMetadata implements ConnectorMetadata {
     private static final Logger LOG = LogManager.getLogger(PaimonMetadata.class);
     private final Catalog paimonNativeCatalog;
+    private final HdfsEnvironment hdfsEnvironment;
     private final String catalogType;
     private final String metastoreUris;
     private final String warehousePath;
@@ -65,9 +68,11 @@ public class PaimonMetadata implements ConnectorMetadata {
     private final Map<Identifier, Table> tables = new ConcurrentHashMap<>();
     private final Map<String, Database> databases = new ConcurrentHashMap<>();
     private final Map<PaimonFilter, PaimonSplitsInfo> paimonSplits = new ConcurrentHashMap<>();
-    public PaimonMetadata(String catalogName, Catalog paimonNativeCatalog,
+
+    public PaimonMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, Catalog paimonNativeCatalog,
                           String catalogType, String metastoreUris, String warehousePath) {
         this.paimonNativeCatalog = paimonNativeCatalog;
+        this.hdfsEnvironment = hdfsEnvironment;
         this.catalogType = catalogType;
         this.metastoreUris = metastoreUris;
         this.warehousePath = warehousePath;
@@ -230,5 +235,10 @@ public class PaimonMetadata implements ConnectorMetadata {
             }
         }
         return predicates;
+    }
+
+    @Override
+    public CloudConfiguration getCloudConfiguration() {
+        return hdfsEnvironment.getCloudConfiguration();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -94,7 +94,7 @@ public class DeltaLakeScanNode extends ScanNode {
         }
         CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
         if (connector != null) {
-            cloudConfiguration = connector.getCloudConfiguration();
+            cloudConfiguration = connector.getMetadata().getCloudConfiguration();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.planner;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
@@ -93,9 +93,11 @@ public class DeltaLakeScanNode extends ScanNode {
             return;
         }
         CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
-        if (connector != null) {
-            cloudConfiguration = connector.getMetadata().getCloudConfiguration();
-        }
+        Preconditions.checkState(connector != null,
+                String.format("connector of catalog %s should not be null", catalog));
+        cloudConfiguration = connector.getMetadata().getCloudConfiguration();
+        Preconditions.checkState(cloudConfiguration != null,
+                String.format("cloudConfiguration of catalog %s should not be null", catalog));
     }
 
     @Override
@@ -252,7 +254,8 @@ public class DeltaLakeScanNode extends ScanNode {
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();
                 if (type.isComplexType()) {
-                    output.append(prefix).append(String.format("Pruned type: %d <-> [%s]\n", slotDescriptor.getId().asInt(), type));
+                    output.append(prefix)
+                            .append(String.format("Pruned type: %d <-> [%s]\n", slotDescriptor.getId().asInt(), type));
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.planner;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotDescriptor;
@@ -93,9 +93,11 @@ public class HdfsScanNode extends ScanNode {
             return;
         }
         CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
-        if (connector != null) {
-            cloudConfiguration = connector.getMetadata().getCloudConfiguration();
-        }
+        Preconditions.checkState(connector != null,
+                String.format("connector of catalog %s should not be null", catalog));
+        cloudConfiguration = connector.getMetadata().getCloudConfiguration();
+        Preconditions.checkState(cloudConfiguration != null,
+                String.format("cloudConfiguration of catalog %s should not be null", catalog));
     }
 
     @Override
@@ -147,7 +149,8 @@ public class HdfsScanNode extends ScanNode {
             for (SlotDescriptor slotDescriptor : desc.getSlots()) {
                 Type type = slotDescriptor.getOriginType();
                 if (type.isComplexType()) {
-                    output.append(prefix).append(String.format("Pruned type: %d <-> [%s]\n", slotDescriptor.getId().asInt(), type));
+                    output.append(prefix)
+                            .append(String.format("Pruned type: %d <-> [%s]\n", slotDescriptor.getId().asInt(), type));
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HdfsScanNode.java
@@ -94,7 +94,7 @@ public class HdfsScanNode extends ScanNode {
         }
         CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
         if (connector != null) {
-            cloudConfiguration = connector.getCloudConfiguration();
+            cloudConfiguration = connector.getMetadata().getCloudConfiguration();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HiveTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HiveTableSink.java
@@ -60,7 +60,7 @@ public class HiveTableSink extends DataSink {
         Preconditions.checkState(connector != null,
                 String.format("connector of catalog %s should not be null", catalogName));
 
-        this.cloudConfiguration = connector.getCloudConfiguration();
+        this.cloudConfiguration = connector.getMetadata().getCloudConfiguration();
 
         Preconditions.checkState(cloudConfiguration != null,
                 String.format("cloudConfiguration of catalog %s should not be null", catalogName));

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
@@ -78,7 +78,7 @@ public class HudiScanNode extends ScanNode {
         }
         CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
         if (connector != null) {
-            cloudConfiguration = connector.getCloudConfiguration();
+            cloudConfiguration = connector.getMetadata().getCloudConfiguration();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HudiScanNode.java
@@ -15,6 +15,7 @@
 package com.starrocks.planner;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotDescriptor;
@@ -77,9 +78,11 @@ public class HudiScanNode extends ScanNode {
             return;
         }
         CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
-        if (connector != null) {
-            cloudConfiguration = connector.getMetadata().getCloudConfiguration();
-        }
+        Preconditions.checkState(connector != null,
+                String.format("connector of catalog %s should not be null", catalog));
+        cloudConfiguration = connector.getMetadata().getCloudConfiguration();
+        Preconditions.checkState(cloudConfiguration != null,
+                String.format("cloudConfiguration of catalog %s should not be null", catalog));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -15,6 +15,7 @@
 package com.starrocks.planner;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.Expr;
@@ -118,9 +119,11 @@ public class IcebergScanNode extends ScanNode {
             cloudConfiguration = tabularTempCloudConfiguration;
         } else {
             CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);
-            if (connector != null) {
-                cloudConfiguration = connector.getMetadata().getCloudConfiguration();
-            }
+            Preconditions.checkState(connector != null,
+                    String.format("connector of catalog %s should not be null", catalogName));
+            cloudConfiguration = connector.getMetadata().getCloudConfiguration();
+            Preconditions.checkState(cloudConfiguration != null,
+                    String.format("cloudConfiguration of catalog %s should not be null", catalogName));
         }
     }
 
@@ -378,7 +381,7 @@ public class IcebergScanNode extends ScanNode {
 
         msg.hdfs_scan_node.setTable_name(srIcebergTable.getRemoteTableName());
 
-       if (cloudConfiguration != null) {
+        if (cloudConfiguration != null) {
             TCloudConfiguration tCloudConfiguration = new TCloudConfiguration();
             cloudConfiguration.toThrift(tCloudConfiguration);
             msg.hdfs_scan_node.setCloud_configuration(tCloudConfiguration);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -119,7 +119,7 @@ public class IcebergScanNode extends ScanNode {
         } else {
             CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);
             if (connector != null) {
-                cloudConfiguration = connector.getCloudConfiguration();
+                cloudConfiguration = connector.getMetadata().getCloudConfiguration();
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
@@ -86,7 +86,7 @@ public class IcebergTableSink extends DataSink {
         if (tabularTempCloudConfiguration.getCloudType() != CloudType.DEFAULT) {
             this.cloudConfiguration = tabularTempCloudConfiguration;
         } else {
-            this.cloudConfiguration = connector.getCloudConfiguration();
+            this.cloudConfiguration = connector.getMetadata().getCloudConfiguration();
         }
 
         Preconditions.checkState(cloudConfiguration != null,

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -15,6 +15,7 @@
 package com.starrocks.planner;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotDescriptor;
@@ -85,9 +86,11 @@ public class PaimonScanNode extends ScanNode {
             return;
         }
         CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
-        if (connector != null) {
-            cloudConfiguration = connector.getMetadata().getCloudConfiguration();
-        }
+        Preconditions.checkState(connector != null,
+                String.format("connector of catalog %s should not be null", catalog));
+        cloudConfiguration = connector.getMetadata().getCloudConfiguration();
+        Preconditions.checkState(cloudConfiguration != null,
+                String.format("cloudConfiguration of catalog %s should not be null", catalog));
     }
 
     @Override
@@ -104,7 +107,8 @@ public class PaimonScanNode extends ScanNode {
     }
 
     public void setupScanRangeLocations(TupleDescriptor tupleDescriptor, ScalarOperator predicate) {
-        List<String> fieldNames = tupleDescriptor.getSlots().stream().map(s -> s.getColumn().getName()).collect(Collectors.toList());
+        List<String> fieldNames =
+                tupleDescriptor.getSlots().stream().map(s -> s.getColumn().getName()).collect(Collectors.toList());
         List<RemoteFileInfo> fileInfos = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
                 paimonTable.getCatalogName(), paimonTable, null, -1, predicate, fieldNames);
         RemoteFileDesc remoteFileDesc = fileInfos.get(0).getFiles().get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -86,7 +86,7 @@ public class PaimonScanNode extends ScanNode {
         }
         CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
         if (connector != null) {
-            cloudConfiguration = connector.getCloudConfiguration();
+            cloudConfiguration = connector.getMetadata().getCloudConfiguration();
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -29,6 +29,7 @@ import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.CachingRemoteFileIO;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.RemoteFileBlockDesc;
@@ -120,7 +121,7 @@ public class HiveMetadataTest {
         connectContext = UtFrameUtils.createDefaultCtx();
         columnRefFactory = new ColumnRefFactory();
         optimizerContext = new OptimizerContext(new Memo(), columnRefFactory, connectContext);
-        hiveMetadata = new HiveMetadata("hive_catalog", hmsOps, fileOps, statisticsProvider,
+        hiveMetadata = new HiveMetadata("hive_catalog", new HdfsEnvironment(), hmsOps, fileOps, statisticsProvider,
                 Optional.empty(), executorForHmsRefresh);
     }
 
@@ -259,7 +260,7 @@ public class HiveMetadataTest {
 
         Statistics statistics = hiveMetadata.getTableStatistics(optimizerContext, hiveTable, columns,
                 Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), null);
-        Assert.assertEquals(1,  statistics.getOutputRowCount(), 0.001);
+        Assert.assertEquals(1, statistics.getOutputRowCount(), 0.001);
         Assert.assertEquals(2, statistics.getColumnStatistics().size());
 
         cachingHiveMetastore.getPartitionStatistics(hiveTable, Lists.newArrayList("col1=1", "col1=2"));
@@ -347,7 +348,6 @@ public class HiveMetadataTest {
         tSinkCommitInfo.setHive_file_info(fileInfo);
         hiveMetadata.finishSink("hive_db", "hive_table", Lists.newArrayList(tSinkCommitInfo));
     }
-
 
     @Test(expected = StarRocksConnectorException.class)
     public void testAddPartition() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -27,6 +27,8 @@ import com.starrocks.connector.hive.HiveMetastore;
 import com.starrocks.connector.hive.HiveMetastoreOperations;
 import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.connector.hive.HiveStatisticsProvider;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.utframe.UtFrameUtils;
@@ -117,5 +119,11 @@ public class HudiMetadataTest {
         Database database = hudiMetadata.getDb("db1");
         Assert.assertEquals("db1", database.getFullName());
 
+    }
+
+    @Test
+    public void testGetCloudConfiguration() {
+        CloudConfiguration cc = hudiMetadata.getCloudConfiguration();
+        Assert.assertEquals(cc.getCloudType(), CloudType.DEFAULT);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.hudi;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.FeConstants;
 import com.starrocks.connector.CachingRemoteFileIO;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.MetastoreType;
 import com.starrocks.connector.RemoteFileOperations;
 import com.starrocks.connector.hive.CachingHiveMetastore;
@@ -82,7 +82,8 @@ public class HudiMetadataTest {
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         columnRefFactory = new ColumnRefFactory();
-        hudiMetadata = new HudiMetadata("hive_catalog", hmsOps, fileOps, statisticsProvider, Optional.empty());
+        hudiMetadata =
+                new HudiMetadata("hive_catalog", new HdfsEnvironment(), hmsOps, fileOps, statisticsProvider, Optional.empty());
     }
 
     @After

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -25,6 +25,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
 import com.starrocks.thrift.TIcebergColumnStats;
@@ -62,6 +63,7 @@ import static com.starrocks.connector.iceberg.IcebergConnector.ICEBERG_CATALOG_T
 
 public class IcebergMetadataTest extends TableTestBase {
     private static final String CATALOG_NAME = "IcebergCatalog";
+    private static final HdfsEnvironment HDFS_ENVIRONMENT = new HdfsEnvironment();
 
     @Test
     public void testListDatabaseNames(@Mocked IcebergCatalog icebergCatalog) {
@@ -73,7 +75,7 @@ public class IcebergMetadataTest extends TableTestBase {
             }
         };
 
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergCatalog);
         List<String> expectResult = Lists.newArrayList("db1", "db2");
         Assert.assertEquals(expectResult, metadata.listDbNames());
     }
@@ -90,7 +92,7 @@ public class IcebergMetadataTest extends TableTestBase {
             }
         };
 
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
         Database expectResult = new Database(0, db);
         Assert.assertEquals(expectResult, metadata.getDb(db));
     }
@@ -107,7 +109,7 @@ public class IcebergMetadataTest extends TableTestBase {
             }
         };
 
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
         Assert.assertNull(metadata.getDb(db));
     }
 
@@ -125,7 +127,7 @@ public class IcebergMetadataTest extends TableTestBase {
             }
         };
 
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
         List<String> expectResult = Lists.newArrayList("tbl1", "tbl2");
         Assert.assertEquals(expectResult, metadata.listTableNames(db1));
     }
@@ -142,7 +144,7 @@ public class IcebergMetadataTest extends TableTestBase {
             }
         };
 
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
         Table actual = metadata.getTable("db", "tbl");
         Assert.assertEquals("tbl", actual.getName());
         Assert.assertEquals(ICEBERG, actual.getType());
@@ -162,13 +164,13 @@ public class IcebergMetadataTest extends TableTestBase {
             }
         };
 
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
         Assert.assertNull(metadata.getTable("db", "tbl2"));
     }
 
     @Test(expected = AlreadyExistsException.class)
     public void testCreateDuplicatedDb(@Mocked IcebergHiveCatalog icebergHiveCatalog) throws AlreadyExistsException {
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
         new Expectations() {
             {
                 icebergHiveCatalog.listAllDatabases();
@@ -183,7 +185,7 @@ public class IcebergMetadataTest extends TableTestBase {
     @Test(expected = IllegalArgumentException.class)
     public void testCreateDbWithErrorConfig() throws AlreadyExistsException {
         IcebergHiveCatalog hiveCatalog = new IcebergHiveCatalog("iceberg_catalog", new Configuration(), new HashMap<>());
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, hiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, hiveCatalog);
 
         new Expectations(hiveCatalog) {
             {
@@ -202,7 +204,7 @@ public class IcebergMetadataTest extends TableTestBase {
         config.put(HIVE_METASTORE_URIS, "thrift://188.122.12.1:8732");
         config.put(ICEBERG_CATALOG_TYPE, "hive");
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog("iceberg_catalog", new Configuration(), config);
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
 
         new Expectations(icebergHiveCatalog) {
             {
@@ -227,7 +229,7 @@ public class IcebergMetadataTest extends TableTestBase {
         config.put(HIVE_METASTORE_URIS, "thrift://188.122.12.1:8732");
         config.put(ICEBERG_CATALOG_TYPE, "hive");
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog("iceberg_catalog", new Configuration(), config);
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
 
         new Expectations(icebergHiveCatalog) {
             {
@@ -253,7 +255,7 @@ public class IcebergMetadataTest extends TableTestBase {
         config.put(HIVE_METASTORE_URIS, "thrift://188.122.12.1:8732");
         config.put(ICEBERG_CATALOG_TYPE, "hive");
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog("iceberg_catalog", new Configuration(), config);
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
         List<TableIdentifier> mockTables = new ArrayList<>();
         mockTables.add(TableIdentifier.of("table1"));
         mockTables.add(TableIdentifier.of("table2"));
@@ -282,7 +284,7 @@ public class IcebergMetadataTest extends TableTestBase {
         config.put(ICEBERG_CATALOG_TYPE, "hive");
         Config.hive_meta_store_timeout_s = 1;
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog("iceberg_catalog", new Configuration(), config);
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
 
         new Expectations(icebergHiveCatalog) {
             {
@@ -339,7 +341,7 @@ public class IcebergMetadataTest extends TableTestBase {
         config.put(HIVE_METASTORE_URIS, "thrift://188.122.12.1:8732");
         config.put(ICEBERG_CATALOG_TYPE, "hive");
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog("iceberg_catalog", new Configuration(), config);
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
 
         new Expectations(icebergHiveCatalog) {
             {
@@ -370,7 +372,7 @@ public class IcebergMetadataTest extends TableTestBase {
         config.put(ICEBERG_CATALOG_TYPE, "hive");
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog("iceberg_catalog", new Configuration(), config);
 
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
         IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog", "resource_name", "iceberg_db",
                 "iceberg_table", Lists.newArrayList(), table, Maps.newHashMap());
 
@@ -456,7 +458,7 @@ public class IcebergMetadataTest extends TableTestBase {
         config.put(ICEBERG_CATALOG_TYPE, "hive");
         IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog("iceberg_catalog", new Configuration(), config);
 
-        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, icebergHiveCatalog);
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog);
         IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog", "resource_name", "iceberg_db",
                 "iceberg_table", Lists.newArrayList(), table, Maps.newHashMap());
 
@@ -483,7 +485,6 @@ public class IcebergMetadataTest extends TableTestBase {
                 minTimes = 0;
             }
         };
-
 
         File fakeFile = temp.newFile();
         fakeFile.createNewFile();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -19,6 +19,8 @@ import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudType;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.paimon.catalog.Catalog;
@@ -172,5 +174,11 @@ public class PaimonMetadataTest {
                          @Mocked ReadBuilder readBuilder) {
         PaimonTable paimonTable = (PaimonTable) metadata.getTable("db1", "tbl1");
         Assert.assertTrue(paimonTable.getUUID().startsWith("paimon_catalog.db1.tbl1"));
+    }
+
+    @Test
+    public void testGetCloudConfiguration() {
+        CloudConfiguration cc = metadata.getCloudConfiguration();
+        Assert.assertEquals(cc.getCloudType(), CloudType.DEFAULT);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.paimon;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.ScalarType;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileInfo;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -55,7 +56,8 @@ public class PaimonMetadataTest {
 
     @Before
     public void setUp() {
-        this.metadata = new PaimonMetadata("paimon_catalog", paimonNativeCatalog,
+
+        this.metadata = new PaimonMetadata("paimon_catalog", new HdfsEnvironment(), paimonNativeCatalog,
                 "filesystem", null, "hdfs://127.0.0.1:9999/warehouse");
 
         BinaryRow row1 = new BinaryRow(2);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/DeltaLakeScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/DeltaLakeScanNodeTest.java
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.DeltaLakeTable;
+import com.starrocks.connector.CatalogConnector;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.server.GlobalStateMgr;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class DeltaLakeScanNodeTest {
+    @Test
+    public void testInit(@Mocked GlobalStateMgr globalStateMgr,
+                         @Mocked CatalogConnector connector,
+                         @Mocked DeltaLakeTable table) {
+        String catalog = "XXX";
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(new HashMap<>());
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
+                result = connector;
+                connector.getMetadata().getCloudConfiguration();
+                result = cc;
+                table.getCatalogName();
+                result = catalog;
+            }
+        };
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+        DeltaLakeScanNode scanNode = new DeltaLakeScanNode(new PlanNodeId(0), desc, "XXX");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HdfsScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HdfsScanNodeTest.java
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.connector.CatalogConnector;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.server.GlobalStateMgr;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class HdfsScanNodeTest {
+    @Test
+    public void testInit(@Mocked GlobalStateMgr globalStateMgr,
+                         @Mocked CatalogConnector connector,
+                         @Mocked HiveTable table) {
+        String catalog = "XXX";
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(new HashMap<>());
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
+                result = connector;
+                connector.getMetadata().getCloudConfiguration();
+                result = cc;
+                table.getCatalogName();
+                result = catalog;
+            }
+        };
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+        HdfsScanNode scanNode = new HdfsScanNode(new PlanNodeId(0), desc, "XXX");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HiveTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HiveTableSinkTest.java
@@ -76,7 +76,7 @@ public class HiveTableSinkTest {
 
         new Expectations() {
             {
-                hiveConnector.getCloudConfiguration();
+                hiveConnector.getMetadata().getCloudConfiguration();
                 result = CloudConfigurationFactory.buildDefaultCloudConfiguration();
                 minTimes = 1;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HudiScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HudiScanNodeTest.java
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.HudiTable;
+import com.starrocks.catalog.PaimonTable;
+import com.starrocks.connector.CatalogConnector;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.server.GlobalStateMgr;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class HudiScanNodeTest {
+    @Test
+    public void testInit(@Mocked GlobalStateMgr globalStateMgr,
+                         @Mocked CatalogConnector connector,
+                         @Mocked HudiTable table) {
+        String catalog = "XXX";
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(new HashMap<>());
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
+                result = connector;
+                connector.getMetadata().getCloudConfiguration();
+                result = cc;
+                table.getCatalogName();
+                result = catalog;
+            }
+        };
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+        HudiScanNode scanNode = new HudiScanNode(new PlanNodeId(0), desc, "XXX");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.PaimonTable;
+import com.starrocks.connector.CatalogConnector;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.server.GlobalStateMgr;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class PaimonScanNodeTest {
+    @Test
+    public void testInit(@Mocked GlobalStateMgr globalStateMgr,
+                         @Mocked CatalogConnector connector,
+                         @Mocked PaimonTable table) {
+        String catalog = "XXX";
+        CloudConfiguration cc = CloudConfigurationFactory.buildCloudConfigurationForStorage(new HashMap<>());
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
+                result = connector;
+                connector.getMetadata().getCloudConfiguration();
+                result = cc;
+                table.getCatalogName();
+                result = catalog;
+            }
+        };
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(table);
+        PaimonScanNode scanNode = new PaimonScanNode(new PlanNodeId(0), desc, "XXX");
+    }
+}


### PR DESCRIPTION
Fixes #issue

This PR move `getCloudConfiguration` to `ConnectorMetadata` from `Connector`

And to do this:
1. let `HdfsEnvrionment` to hold `CloudConfiguration`
2. and pass `HdfsEnvironment` down to `ConnectorMetadata`
3. in future, I think we can move `properties` to `hdfsEvnrionment`, which will make arch easier to reason about.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
