### PR TITLE
[BugFix][CherryPick] fix insert overwrite bug with duplicate target partitions for 3.0 (#27545)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -98,7 +98,14 @@ public class InsertAnalyzer {
                     throw new SemanticException("No partition specified in partition lists");
                 }
 
-                for (String partitionName : targetPartitionNames.getPartitionNames()) {
+                List<String> deduplicatePartitionNames =
+                        targetPartitionNames.getPartitionNames().stream().distinct().collect(Collectors.toList());
+                if (deduplicatePartitionNames.size() != targetPartitionNames.getPartitionNames().size()) {
+                    insertStmt.setTargetPartitionNames(new PartitionNames(targetPartitionNames.isTemp(),
+                            deduplicatePartitionNames, targetPartitionNames.getPartitionColNames(),
+                            targetPartitionNames.getPartitionColValues()));
+                }
+                for (String partitionName : deduplicatePartitionNames) {
                     if (Strings.isNullOrEmpty(partitionName)) {
                         throw new SemanticException("there are empty partition name");
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/InsertOverwriteJobRunnerTest.java
@@ -33,6 +33,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.sql.SQLException;
+
 public class InsertOverwriteJobRunnerTest {
 
     private static ConnectContext connectContext;
@@ -128,5 +130,12 @@ public class InsertOverwriteJobRunnerTest {
         InsertOverwriteJob insertOverwriteJob = new InsertOverwriteJob(100L, insertStmt, database.getId(), olapTable.getId());
         InsertOverwriteJobRunner runner = new InsertOverwriteJobRunner(insertOverwriteJob, connectContext, executor);
         Assert.assertFalse(runner.isFinished());
+    }
+
+    @Test
+    public void testInsertOverwriteWithDuplicatePartitions() throws SQLException {
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000000);
+        String sql = "insert overwrite t3 partitions(p1, p1) select * from t4";
+        cluster.runSql("insert_overwrite_test", sql);
     }
 }


### PR DESCRIPTION
Fixes #27521

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
