### PR TITLE
[BugFix] Fix metatool total kv and bytes not match item sum

### DIFF
--- a/be/src/storage/rowset/rowset_meta_manager.cpp
+++ b/be/src/storage/rowset/rowset_meta_manager.cpp
@@ -91,6 +91,10 @@ Status RowsetMetaManager::traverse_rowset_metas(
         RowsetId rowset_id;
         rowset_id.init(std::string_view(parts[2].data(), parts[2].size()));
         std::vector<StringPiece> uid_parts = strings::Split(parts[1], "-");
+        if (uid_parts.size() != 2) {
+            LOG(WARNING) << "invalid rowset key:" << key << ", uid splitted size:" << uid_parts.size();
+            return true;
+        }
         std::string_view p1(uid_parts[0].data(), uid_parts[0].size());
         std::string_view p2(uid_parts[1].data(), uid_parts[1].size());
         TabletUid tablet_uid(p1, p2);

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -56,6 +56,7 @@
 #include "storage/kv_store.h"
 #include "storage/olap_define.h"
 #include "storage/rocksdb_status_adapter.h"
+#include "storage/rowset/rowset_meta_manager.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_updates.h"
 #include "util/coding.h"
@@ -1458,15 +1459,42 @@ Status TabletMetaManager::get_stats(DataDir* store, MetaStoreStats* stats, bool 
     };
     RETURN_IF_ERROR(meta->iterate(META_COLUMN_FAMILY_INDEX, HEADER_PREFIX, traverse_tabletmeta_func));
     stats->total_count += stats->tablet_count;
-    stats->total_count += stats->update_tablet_count;
     stats->total_meta_bytes += stats->tablet_meta_bytes;
+    stats->total_count += stats->update_tablet_count;
+    stats->total_meta_bytes += stats->update_tablet_meta_bytes;
 
-    auto traverse_rst_func = [&](std::string_view key, std::string_view value) -> bool {
-        stats->rowset_count++;
-        stats->rowset_meta_bytes += value.size();
-        return true;
-    };
-    RETURN_IF_ERROR(meta->iterate(META_COLUMN_FAMILY_INDEX, "rst_", traverse_rst_func));
+    RowsetMetaManager::traverse_rowset_metas(
+            meta, [&](const TabletUid& tablet_uid, const RowsetId& rowset_id, std::string_view value) -> bool {
+                stats->rowset_count++;
+                stats->rowset_meta_bytes += value.size();
+                if (detail) {
+                    bool parsed = false;
+                    auto rowset_meta = std::make_shared<RowsetMeta>(value, &parsed);
+                    if (!parsed) {
+                        LOG(WARNING) << "parse rowset meta string failed for rowset_id:" << rowset_id;
+                        return true;
+                    }
+                    if (rowset_meta->tablet_uid() != tablet_uid) {
+                        LOG(WARNING) << "tablet uid is not equal, skip the rowset"
+                                     << ", rowset_id=" << rowset_meta->rowset_id()
+                                     << ", in_put_tablet_uid=" << tablet_uid
+                                     << ", tablet_uid in rowset meta=" << rowset_meta->tablet_uid();
+                        return true;
+                    }
+                    auto itr = stats->tablets.find(rowset_meta->tablet_id());
+                    if (itr == stats->tablets.end()) {
+                        // reduce print warning log here, cause there may be many orphan rowsets
+                        stats->error_count++;
+                        LOG_EVERY_SECOND(WARNING)
+                                << "rst_ rowset without tablet tablet_id:" << rowset_meta->tablet_id()
+                                << " rowset_id:" << rowset_meta->rowset_id() << " version:" << rowset_meta->version();
+                    } else {
+                        itr->second.rowset_count++;
+                        itr->second.rowset_meta_bytes += value.size();
+                    }
+                }
+                return true;
+            });
     stats->total_count += stats->rowset_count;
     stats->total_meta_bytes += stats->rowset_meta_bytes;
 
@@ -1484,6 +1512,7 @@ Status TabletMetaManager::get_stats(DataDir* store, MetaStoreStats* stats, bool 
             auto itr = stats->tablets.find(tid);
             if (itr == stats->tablets.end()) {
                 LOG(WARNING) << "tablet_meta_log without tablet tablet_id:" << tid << " logid:" << logid;
+                stats->error_count++;
             } else {
                 itr->second.log_count++;
                 itr->second.log_meta_bytes += value.size();
@@ -1505,7 +1534,8 @@ Status TabletMetaManager::get_stats(DataDir* store, MetaStoreStats* stats, bool 
         if (detail) {
             auto itr = stats->tablets.find(tid);
             if (itr == stats->tablets.end()) {
-                LOG(WARNING) << "tablet_delvec without tablet tablet_id:" << tid;
+                LOG(WARNING) << "tablet_delvec without tablet tablet_id:" << tid << " rssid:" << rssid
+                             << " version:" << version;
                 stats->error_count++;
             } else {
                 itr->second.delvec_count++;
@@ -1556,7 +1586,7 @@ Status TabletMetaManager::get_stats(DataDir* store, MetaStoreStats* stats, bool 
         if (detail) {
             auto itr = stats->tablets.find(tid);
             if (itr == stats->tablets.end()) {
-                LOG(WARNING) << "tablet_rowset without tablet tablet_id:" << tid;
+                LOG(WARNING) << "pending_rowset without tablet tablet_id:" << tid << " version:" << version;
                 stats->error_count++;
             } else {
                 itr->second.pending_rowset_count++;

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -304,8 +304,9 @@ void list_meta(DataDir* data_dir) {
                st.tablet_meta_bytes, st.log_count, st.log_meta_bytes, st.delvec_count, st.delvec_meta_bytes,
                st.rowset_count, st.rowset_meta_bytes, st.pending_rowset_count, st.pending_rowset_meta_bytes);
     }
-    printf("  Total KV: %zu Bytes: %zu Tablets: %zu Error: %zu\n", stats.total_count, stats.total_meta_bytes,
-           stats.tablets.size(), stats.error_count);
+    printf("  Total KV: %zu Bytes: %zu Tablets: %zu (PK: %zu Other: %zu) Error: %zu\n", stats.total_count,
+           stats.total_meta_bytes, stats.tablets.size(), stats.update_tablet_count, stats.tablet_count,
+           stats.error_count);
 }
 
 Status init_data_dir(const std::string& dir, std::unique_ptr<DataDir>* ret, bool read_only = false) {


### PR DESCRIPTION
Fixes #30501

This PR fixes some output inconsistencies of metatool stats.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
