### PR TITLE
[BugFix] refactor cloud native pk table publish & fix local persistent index usage

### DIFF
--- a/be/src/storage/lake/lake_local_persistent_index.cpp
+++ b/be/src/storage/lake/lake_local_persistent_index.cpp
@@ -29,6 +29,10 @@ Status LakeLocalPersistentIndex::load_from_lake_tablet(starrocks::lake::Tablet* 
         LOG(WARNING) << "tablet: " << tablet->id() << " is not primary key tablet";
         return Status::NotSupported("Only PrimaryKey table is supported to use persistent index");
     }
+    // persistent index' minor compaction is a new strategy to decrease the IO amplification.
+    // More detail: https://github.com/StarRocks/starrocks/issues/27581.
+    // disable minor_compaction in cloud native table for now, will enable it later
+    config::enable_pindex_minor_compaction = false;
 
     MonotonicStopWatch timer;
     timer.start();

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -69,7 +69,6 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std:
     for (const auto& del_file : op_write.dels()) {
         _trash_files->push_back(del_file);
     }
-    _has_update_index = true;
 }
 
 void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction) {
@@ -121,8 +120,6 @@ void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compact
         rowset->set_id(_tablet_meta->next_rowset_id());
         _tablet_meta->set_next_rowset_id(_tablet_meta->next_rowset_id() + rowset->segments_size());
     }
-
-    _has_update_index = true;
 
     VLOG(2) << fmt::format("MetaFileBuilder apply_opcompaction, id:{} input range:{} delvec del cnt:{} output:{}",
                            _tablet_meta->id(), del_range_ss.str(), delvec_erase_cnt,
@@ -198,6 +195,8 @@ Status MetaFileBuilder::finalize(int64_t txn_id) {
     RETURN_IF_ERROR(_tablet.put_metadata(_tablet_meta));
     _update_mgr->update_primary_index_data_version(_tablet, version);
     _fill_delvec_cache();
+    // Set _has_finalized at last, and if failure happens before this, we need to clear pk index
+    // and retry publish later.
     _has_finalized = true;
     return Status::OK();
 }

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -50,6 +50,7 @@ public:
     // when apply or finalize fail, need to clear primary index cache
     void handle_failure();
     bool has_update_index() const { return _has_update_index; }
+    void set_has_update_index() { _has_update_index = true; }
     // collect files that need to removed
     std::shared_ptr<std::vector<std::string>> trash_files() { return _trash_files; }
 

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -42,10 +42,10 @@ public:
     }
 
     ~PrimaryKeyTxnLogApplier() override {
+        // must release primary index before `handle_failure`, otherwise `handle_failure` will fail
+        _tablet.update_mgr()->release_primary_index(_index_entry);
         // handle failure first, then release lock
-        if (_check_meta_version_succ) {
-            _builder.handle_failure();
-        }
+        _builder.handle_failure();
         if (_inited) {
             _s_schema_change_set.erase(_tablet.id());
         }
@@ -64,7 +64,6 @@ public:
     Status check_meta_version() {
         // check tablet meta
         RETURN_IF_ERROR(_tablet.update_mgr()->check_meta_version(_tablet, _base_version));
-        _check_meta_version_succ = true;
         return Status::OK();
     }
 
@@ -82,7 +81,13 @@ public:
         return Status::OK();
     }
 
-    Status finish() override { return _builder.finalize(_max_txn_id); }
+    Status finish() override {
+        // Must call `commit_primary_index` before `finalize`,
+        // because if `commit_primary_index` or `finalize` fail, we can remove index in `handle_failure`.
+        // if `_index_entry` is null, do nothing.
+        RETURN_IF_ERROR(_tablet.update_mgr()->commit_primary_index(_index_entry, &_tablet));
+        return _builder.finalize(_max_txn_id);
+    }
 
     std::shared_ptr<std::vector<std::string>> trash_files() override { return _builder.trash_files(); }
 
@@ -92,8 +97,14 @@ private:
             !op_write.rowset().has_delete_predicate()) {
             return Status::OK();
         }
-        return _tablet.update_mgr()->publish_primary_key_tablet(op_write, txn_id, *_metadata, &_tablet, &_builder,
-                                                                _base_version);
+        // We call `prepare_primary_index` only when first time we apply `write_log` or `compaction_log`, instead of
+        // in `TxnLogApplier.init`, because we have to build primary index after apply `schema_change_log` finish.
+        if (_index_entry == nullptr) {
+            ASSIGN_OR_RETURN(_index_entry, _tablet.update_mgr()->prepare_primary_index(*_metadata, &_tablet, &_builder,
+                                                                                       _base_version, _new_version));
+        }
+        return _tablet.update_mgr()->publish_primary_key_tablet(op_write, txn_id, *_metadata, &_tablet, _index_entry,
+                                                                &_builder, _base_version);
     }
 
     Status apply_compaction_log(const TxnLogPB_OpCompaction& op_compaction) {
@@ -101,8 +112,14 @@ private:
             DCHECK(!op_compaction.has_output_rowset() || op_compaction.output_rowset().num_rows() == 0);
             return Status::OK();
         }
-        return _tablet.update_mgr()->publish_primary_compaction(op_compaction, *_metadata, &_tablet, &_builder,
-                                                                _base_version);
+        // We call `prepare_primary_index` only when first time we apply `write_log` or `compaction_log`, instead of
+        // in `TxnLogApplier.init`, because we have to build primary index after apply `schema_change_log` finish.
+        if (_index_entry == nullptr) {
+            ASSIGN_OR_RETURN(_index_entry, _tablet.update_mgr()->prepare_primary_index(*_metadata, &_tablet, &_builder,
+                                                                                       _base_version, _new_version));
+        }
+        return _tablet.update_mgr()->publish_primary_compaction(op_compaction, *_metadata, &_tablet, _index_entry,
+                                                                &_builder, _base_version);
     }
 
     Status apply_schema_change_log(const TxnLogPB_OpSchemaChange& op_schema_change) {
@@ -139,8 +156,8 @@ private:
     int64_t _new_version{0};
     int64_t _max_txn_id{0}; // Used as the file name prefix of the delvec file
     MetaFileBuilder _builder;
+    DynamicCache<uint64_t, LakePrimaryIndex>::Entry* _index_entry{nullptr};
     bool _inited{false};
-    bool _check_meta_version_succ{false};
 };
 
 class NonPrimaryKeyTxnLogApplier : public TxnLogApplier {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -25,6 +25,7 @@
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/default_value_column_iterator.h"
 #include "storage/tablet_manager.h"
+#include "storage/tablet_meta_manager.h"
 #include "util/pretty_printer.h"
 #include "util/trace.h"
 
@@ -51,11 +52,9 @@ Status LakeDelvecLoader::load(const TabletSegmentId& tsid, int64_t version, DelV
     return _update_mgr->get_del_vec(tsid, version, _pk_builder, pdelvec);
 }
 
-// |metadata| contain last tablet meta info with new version
-Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_write, int64_t txn_id,
-                                                 const TabletMetadata& metadata, Tablet* tablet,
-                                                 MetaFileBuilder* builder, int64_t base_version) {
-    // 1. update primary index
+StatusOr<IndexEntry*> UpdateManager::prepare_primary_index(const TabletMetadata& metadata, Tablet* tablet,
+                                                           MetaFileBuilder* builder, int64_t base_version,
+                                                           int64_t new_version) {
     auto index_entry = _index_cache.get_or_create(tablet->id());
     index_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
     auto& index = index_entry->value();
@@ -63,14 +62,57 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     _index_cache.update_object_size(index_entry, index.memory_usage());
     if (!st.ok()) {
         _index_cache.remove(index_entry);
-        std::string msg =
-                strings::Substitute("publish_primary_key_tablet: load primary index failed: $0", st.to_string());
+        std::string msg = strings::Substitute("prepare_primary_index: load primary index failed: $0", st.to_string());
         LOG(ERROR) << msg;
-        return st;
+        return Status::InternalError(msg);
     }
-    // release index entry but keep it in cache
-    DeferOp release_index_entry([&] { _index_cache.release(index_entry); });
-    // 2. load rowset update data to cache, get upsert and delete list
+    st = index.prepare(EditVersion(new_version, 0), 0);
+    if (!st.ok()) {
+        _index_cache.remove(index_entry);
+        std::string msg =
+                strings::Substitute("prepare_primary_index: prepare primary index failed: $0", st.to_string());
+        LOG(ERROR) << msg;
+        return Status::InternalError(msg);
+    }
+    builder->set_has_update_index();
+    return index_entry;
+}
+
+Status UpdateManager::commit_primary_index(IndexEntry* index_entry, Tablet* tablet) {
+    if (index_entry != nullptr) {
+        auto& index = index_entry->value();
+        if (index.enable_persistent_index()) {
+            // only take affect in local persistent index
+            PersistentIndexMetaPB index_meta;
+            PersistentIndexMetaLockGuard index_meta_lock_guard;
+            DataDir* data_dir = StorageEngine::instance()->get_persistent_index_store();
+            index.get_persistent_index_meta_lock_guard(&index_meta_lock_guard);
+            RETURN_IF_ERROR(TabletMetaManager::get_persistent_index_meta(data_dir, tablet->id(), &index_meta));
+            RETURN_IF_ERROR(index.commit(&index_meta));
+            RETURN_IF_ERROR(TabletMetaManager::write_persistent_index_meta(data_dir, tablet->id(), index_meta));
+            // Call `on_commited` here, which will remove old files is safe.
+            // Because if publish version fail after `on_commited`, index will be rebuild.
+            RETURN_IF_ERROR(index.on_commited());
+            TRACE("commit primary index");
+        }
+    }
+
+    return Status::OK();
+}
+
+void UpdateManager::release_primary_index(IndexEntry* index_entry) {
+    if (index_entry != nullptr) {
+        _index_cache.release(index_entry);
+    }
+}
+
+// |metadata| contain last tablet meta info with new version
+Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_write, int64_t txn_id,
+                                                 const TabletMetadata& metadata, Tablet* tablet,
+                                                 IndexEntry* index_entry, MetaFileBuilder* builder,
+                                                 int64_t base_version) {
+    auto& index = index_entry->value();
+    // 1. load rowset update data to cache, get upsert and delete list
     const uint32_t rowset_id = metadata.next_rowset_id();
     auto tablet_schema = std::make_shared<TabletSchema>(metadata.schema());
     auto state_entry = _update_state_cache.get_or_create(strings::Substitute("$0_$1", tablet->id(), txn_id));
@@ -80,7 +122,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     auto& state = state_entry->value();
     RETURN_IF_ERROR(state.load(op_write, metadata, base_version, tablet, builder, true));
     _update_state_cache.update_object_size(state_entry, state.memory_usage());
-    // 3. rewrite segment file if it is partial update
+    // 2. rewrite segment file if it is partial update
     std::vector<std::string> orphan_files;
     RETURN_IF_ERROR(state.rewrite_segment(op_write, metadata, tablet, &orphan_files));
     PrimaryIndex::DeletesMap new_deletes;
@@ -90,6 +132,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     auto& upserts = state.upserts();
     // handle merge condition, skip update row which's merge condition column value is smaller than current row
     int32_t condition_column = _get_condition_column(op_write, *tablet_schema);
+    // 3. update primary index, and generate delete info.
     for (uint32_t i = 0; i < upserts.size(); i++) {
         if (upserts[i] != nullptr) {
             if (condition_column < 0) {
@@ -449,26 +492,13 @@ size_t UpdateManager::get_rowset_num_deletes(int64_t tablet_id, int64_t version,
 
 Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op_compaction,
                                                  const TabletMetadata& metadata, Tablet* tablet,
-                                                 MetaFileBuilder* builder, int64_t base_version) {
+                                                 IndexEntry* index_entry, MetaFileBuilder* builder,
+                                                 int64_t base_version) {
     std::stringstream cost_str;
     MonotonicStopWatch watch;
     watch.start();
-    // 1. load primary index
-    auto index_entry = _index_cache.get_or_create(tablet->id());
-    index_entry->update_expire_time(MonotonicMillis() + get_cache_expire_ms());
     auto& index = index_entry->value();
-    Status st = index.lake_load(tablet, metadata, base_version, builder);
-    _index_cache.update_object_size(index_entry, index.memory_usage());
-    if (!st.ok()) {
-        _index_cache.remove(index_entry);
-        LOG(ERROR) << strings::Substitute("publish_primary_key_tablet: load primary index failed: $0", st.to_string());
-        return st;
-    }
-    cost_str << " [primary index load] " << watch.elapsed_time();
-    watch.reset();
-    // release index entry but keep it in cache
-    DeferOp release_index_entry([&] { _index_cache.release(index_entry); });
-    // 2. iterate output rowset, update primary index and generate delvec
+    // 1. iterate output rowset, update primary index and generate delvec
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(metadata.schema());
     RowsetPtr output_rowset =
             std::make_shared<Rowset>(tablet, std::make_shared<RowsetMetadata>(op_compaction.output_rowset()));
@@ -486,6 +516,7 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
                                      [&](const RowsetMetadata& r) { return r.id() == max_rowset_id; });
     uint32_t max_src_rssid = max_rowset_id + input_rowset->segments_size() - 1;
 
+    // 2. update primary index, and generate delete info.
     for (size_t i = 0; i < compaction_state->pk_cols.size(); i++) {
         RETURN_IF_ERROR(compaction_state->load_segments(output_rowset.get(), tablet_schema, i));
         auto& pk_col = compaction_state->pk_cols[i];

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -37,6 +37,7 @@ class Tablet;
 class MetaFileBuilder;
 class UpdateManager;
 struct AutoIncrementPartialUpdateState;
+using IndexEntry = DynamicCache<uint64_t, LakePrimaryIndex>::Entry;
 
 class LakeDelvecLoader : public DelvecLoader {
 public:
@@ -60,7 +61,8 @@ public:
 
     // publish primary key tablet, update primary index and delvec, then update meta file
     Status publish_primary_key_tablet(const TxnLogPB_OpWrite& op_write, int64_t txn_id, const TabletMetadata& metadata,
-                                      Tablet* tablet, MetaFileBuilder* builder, int64_t base_version);
+                                      Tablet* tablet, IndexEntry* index_entry, MetaFileBuilder* builder,
+                                      int64_t base_version);
 
     // get rowids from primary index by each upserts
     Status get_rowids_from_pkindex(Tablet* tablet, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
@@ -88,7 +90,8 @@ public:
     size_t get_rowset_num_deletes(int64_t tablet_id, int64_t version, const RowsetMetadataPB& rowset_meta);
 
     Status publish_primary_compaction(const TxnLogPB_OpCompaction& op_compaction, const TabletMetadata& metadata,
-                                      Tablet* tablet, MetaFileBuilder* builder, int64_t base_version);
+                                      Tablet* tablet, IndexEntry* index_entry, MetaFileBuilder* builder,
+                                      int64_t base_version);
 
     // remove primary index entry from cache, called when publish version error happens.
     // Because update primary index isn't idempotent, so if primary index update success, but
@@ -119,6 +122,16 @@ public:
     }
 
     MemTracker* compaction_state_mem_tracker() const { return _compaction_state_mem_tracker.get(); }
+
+    // get or create primary index, and prepare primary index state
+    StatusOr<IndexEntry*> prepare_primary_index(const TabletMetadata& metadata, Tablet* tablet,
+                                                MetaFileBuilder* builder, int64_t base_version, int64_t new_version);
+
+    // commit primary index, only take affect when it is local persistent index
+    Status commit_primary_index(IndexEntry* index_entry, Tablet* tablet);
+
+    // release index entry if it isn't nullptr
+    void release_primary_index(IndexEntry* index_entry);
 
 private:
     // print memory tracker state

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -626,6 +626,8 @@ public:
     Status load_from_tablet(Tablet* tablet);
 
     // start modification with intended version
+    // | version |: intended commit version
+    // | n |: deprecated
     Status prepare(const EditVersion& version, size_t n);
 
     // abort modification

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -221,6 +221,9 @@ TEST_P(ConditionUpdateTest, test_condition_update) {
         ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
         EXPECT_EQ(new_tablet_metadata->rowsets_size(), 4 + i);
     }
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 TEST_P(ConditionUpdateTest, test_condition_update_multi_segment) {
@@ -270,6 +273,9 @@ TEST_P(ConditionUpdateTest, test_condition_update_multi_segment) {
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 4 == c1) && (c0 * 5 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 5);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 TEST_P(ConditionUpdateTest, test_condition_update_in_memtable) {
@@ -302,6 +308,9 @@ TEST_P(ConditionUpdateTest, test_condition_update_in_memtable) {
               }));
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(ConditionUpdateTest, ConditionUpdateTest,

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -233,6 +233,9 @@ TEST_P(PartialUpdateTest, test_write) {
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 TEST_P(PartialUpdateTest, test_write_multi_segment) {
@@ -286,6 +289,9 @@ TEST_P(PartialUpdateTest, test_write_multi_segment) {
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
     // check segment size in last metadata
     EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 TEST_P(PartialUpdateTest, test_write_multi_segment_by_diff_val) {
@@ -340,6 +346,9 @@ TEST_P(PartialUpdateTest, test_write_multi_segment_by_diff_val) {
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
     // check segment size in last metadata
     EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 TEST_P(PartialUpdateTest, test_resolve_conflict) {
@@ -392,6 +401,9 @@ TEST_P(PartialUpdateTest, test_resolve_conflict) {
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 TEST_P(PartialUpdateTest, test_resolve_conflict_multi_segment) {
@@ -451,6 +463,9 @@ TEST_P(PartialUpdateTest, test_resolve_conflict_multi_segment) {
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
     // check segment size in last metadata
     EXPECT_EQ(new_tablet_metadata->rowsets(5).segments_size(), 2);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(PartialUpdateTest, PartialUpdateTest,

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -245,6 +245,9 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
     ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
     version++;
     ASSERT_EQ(kChunkSize, read(version));
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 
     ASSIGN_OR_ABORT(auto new_tablet_metadata2, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata2->rowsets_size(), 1);
@@ -291,6 +294,9 @@ TEST_P(LakePrimaryKeyCompactionTest, test2) {
     ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
@@ -345,6 +351,9 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
     EXPECT_EQ(100, progress.value());
     ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
     version++;
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
     ASSERT_EQ(kChunkSize * 2, read(version));
 
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -240,6 +240,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_multitime_check_result) {
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
@@ -286,9 +289,12 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
         new_metadata->set_version(version + 1);
         std::unique_ptr<MetaFileBuilder> builder = std::make_unique<MetaFileBuilder>(tablet, new_metadata);
         // update primary table state, such as primary index
+        ASSIGN_OR_ABORT(auto index_entry, tablet.update_mgr()->prepare_primary_index(
+                                                  *new_metadata, &tablet, builder.get(), version, version + 1));
         ASSERT_OK(tablet.update_mgr()->publish_primary_key_tablet(txn_log->op_write(), txn_log->txn_id(), *new_metadata,
-                                                                  &tablet, builder.get(), version));
+                                                                  &tablet, index_entry, builder.get(), version));
         // if builder.finalize fail, remove primary index cache and retry
+        tablet.update_mgr()->release_primary_index(index_entry);
         builder->handle_failure();
     }
     // write success
@@ -308,6 +314,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
     ASSERT_EQ(kChunkSize * 5, read_rows(tablet_id, version));
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 5);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_times) {
@@ -339,6 +348,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_times) {
     // advince publish should fail, because version + 1 don't exist
     ASSERT_ERROR(_tablet_mgr->publish_version(tablet_id, version + 1, version + 2, &txns.back(), 1).status());
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_publish_concurrent) {
@@ -367,6 +379,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_concurrent) {
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_resolve_conflict) {
@@ -412,6 +427,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_resolve_conflict) {
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_write_read_success_multiple_tablet) {
@@ -448,6 +466,39 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_read_success_multiple_tablet) {
     auto chunk3 = read(tablet_id_2, version);
     assert_chunk_equals(*chunk0, *chunk2);
     assert_chunk_equals(*chunk1, *chunk3);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id_1, version);
+        check_local_persistent_index_meta(tablet_id_2, version);
+    }
+}
+
+TEST_P(LakePrimaryKeyPublishTest, test_write_largedata) {
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    const int N = 1000;
+    int64_t old_config = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 1024;
+    for (int i = 0; i < N; i++) {
+        auto [chunk0, indexes] = gen_data_and_index(kChunkSize, i, true);
+        int64_t txn_id = next_id();
+        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
+                                                _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_noexist(tablet_id, txn_id));
+        version++;
+    }
+    ASSERT_EQ(kChunkSize * N, read_rows(tablet_id, version));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), N);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
+    config::l0_max_mem_usage = old_config;
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyPublishTest, LakePrimaryKeyPublishTest,

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -23,6 +23,7 @@
 #include "storage/lake/join_path.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/update_manager.h"
+#include "storage/tablet_meta_manager.h"
 #include "testutil/assert.h"
 
 namespace starrocks::lake {
@@ -54,6 +55,13 @@ protected:
         CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kSegmentDirectoryName)));
         CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kMetadataDirectoryName)));
         CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kTxnLogDirectoryName)));
+    }
+
+    void check_local_persistent_index_meta(int64_t tablet_id, int64_t expected_version) {
+        PersistentIndexMetaPB index_meta;
+        DataDir* data_dir = StorageEngine::instance()->get_persistent_index_store();
+        CHECK_OK(TabletMetaManager::get_persistent_index_meta(data_dir, tablet_id, &index_meta));
+        ASSERT_TRUE(index_meta.version().major_number() == expected_version);
     }
 
     std::string _test_dir;


### PR DESCRIPTION
This PR contains two parts:
1. Fix local persistent index in cloud native pk table, because it was missing the call to `prepare & commit`.
2. Get or create primary index when first time apply `write_log` or `compaction_log`, and release it when `TxnLogApply` end.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
