### PR TITLE
[BugFix] Use default priority for publish version tasks to avoid starving abort tasks

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -192,7 +192,7 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
             g_publish_tablet_version_latency << (butil::gettimeofday_us() - run_ts);
         };
 
-        auto st = thread_pool->submit_func(task, ThreadPool::HIGH_PRIORITY);
+        auto st = thread_pool->submit_func(task);
         if (!st.ok()) {
             g_publish_version_failed_tasks << 1;
             LOG(WARNING) << "Fail to submit publish version task: " << st << ". tablet_id=" << tablet_id
@@ -254,7 +254,7 @@ void LakeServiceImpl::publish_log_version(::google::protobuf::RpcController* con
             }
         };
 
-        auto st = thread_pool->submit_func(task, ThreadPool::HIGH_PRIORITY);
+        auto st = thread_pool->submit_func(task);
         if (!st.ok()) {
             g_publish_version_failed_tasks << 1;
             LOG(WARNING) << "Fail to submit publish log version task: " << st;


### PR DESCRIPTION
Previously, publish version tasks had higher priority than abort tasks and shared the same thread pool. When many publish version requests came in, it could starve the abort tasks from executing.

This led to the abort task queue becoming full and unable to accept new abort requests. Transactions would get stuck unable to be aborted.

This commit lowers the publish version tasks to use the default pool priority instead of high priority. This prevents publish version from always getting precedence and starving abort tasks.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
