### PR TITLE
[BugFix] Fix primary key alter sort key bug

### DIFF
--- a/test/sql/test_ddl/R/alter_table
+++ b/test/sql/test_ddl/R/alter_table
@@ -27,3 +27,59 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 -- !result
+CREATE TABLE `test_pk_tbl1` (
+`k1` DATE,
+`k2` DATETIME,
+`k3` VARCHAR(20),
+`k4` VARCHAR(20),
+`k5` BOOLEAN,
+`v1` TINYINT NULL,
+`v2` SMALLINT NULL,
+`v3` INT NULL,
+`v4` BIGINT NOT NULL,
+INDEX init_bitmap_index (k2) USING BITMAP
+) ENGINE=OLAP
+PRIMARY KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
+COMMENT "OLAP"
+PARTITION BY RANGE (k1) (
+    START ("1970-01-01") END ("2030-01-01") EVERY (INTERVAL 30 YEAR)
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 50
+ORDER BY(`k2`, `v4`)
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_format" = "v2",
+    "enable_persistent_index" = "true",
+    "bloom_filter_columns" = "k1,k2"
+);
+-- result:
+-- !result
+insert into test_pk_tbl1 values ('2023-09-07', '2023-09-07 13:35:00', 'a', 'a', true, 1, 1, 1, 10),  ('2023-09-06', '2023-09-07 13:35:00', 'a', 'a', true, 1, 1, 1, 10);
+-- result:
+-- !result
+select count(1) from test_pk_tbl1;
+-- result:
+2
+-- !result
+ALTER TABLE test_pk_tbl1 ORDER BY (k3);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select count(1) from test_pk_tbl1;
+-- result:
+2
+-- !result
+ALTER TABLE test_pk_tbl1 ORDER BY (k3,v1,v3,k2);
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select count(1) from test_pk_tbl1;
+-- result:
+2
+-- !result

--- a/test/sql/test_ddl/T/alter_table
+++ b/test/sql/test_ddl/T/alter_table
@@ -4,3 +4,38 @@ use db_${uuid0};
 CREATE TABLE t1 (id1 int) DUPLICATE KEY(id1) COMMENT "c1" DISTRIBUTED BY HASH(id1) BUCKETS 1 properties('replication_num' = '1');
 ALTER TABLE t1 COMMENT="c2";
 SHOW CREATE TABLE t1;
+
+CREATE TABLE `test_pk_tbl1` (
+`k1` DATE,
+`k2` DATETIME,
+`k3` VARCHAR(20),
+`k4` VARCHAR(20),
+`k5` BOOLEAN,
+`v1` TINYINT NULL,
+`v2` SMALLINT NULL,
+`v3` INT NULL,
+`v4` BIGINT NOT NULL,
+INDEX init_bitmap_index (k2) USING BITMAP
+) ENGINE=OLAP
+PRIMARY KEY(`k1`, `k2`, `k3`, `k4`, `k5`)
+COMMENT "OLAP"
+PARTITION BY RANGE (k1) (
+    START ("1970-01-01") END ("2030-01-01") EVERY (INTERVAL 30 YEAR)
+)
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 50
+ORDER BY(`k2`, `v4`)
+PROPERTIES (
+    "replication_num" = "1",
+    "storage_format" = "v2",
+    "enable_persistent_index" = "true",
+    "bloom_filter_columns" = "k1,k2"
+);
+insert into test_pk_tbl1 values ('2023-09-07', '2023-09-07 13:35:00', 'a', 'a', true, 1, 1, 1, 10),  ('2023-09-06', '2023-09-07 13:35:00', 'a', 'a', true, 1, 1, 1, 10);
+select count(1) from test_pk_tbl1;
+ALTER TABLE test_pk_tbl1 ORDER BY (k3);
+function: wait_alter_table_finish()
+select count(1) from test_pk_tbl1;
+
+ALTER TABLE test_pk_tbl1 ORDER BY (k3,v1,v3,k2);
+function: wait_alter_table_finish()
+select count(1) from test_pk_tbl1;


### PR DESCRIPTION
Fixes #30534


`std::mismatch` is not safe in the old cpp version.

`std::mismatch` :
```
1737   template<typename _InputIterator1, typename _InputIterator2,
1738            typename _BinaryPredicate>
1739     _GLIBCXX20_CONSTEXPR
1740     pair<_InputIterator1, _InputIterator2>
1741     __mismatch(_InputIterator1 __first1, _InputIterator1 __last1,
1742                _InputIterator2 __first2, _BinaryPredicate __binary_pred)
1743     {
1744       while (__first1 != __last1 && __binary_pred(__first1, __first2))
1745         {
1746           ++__first1;
1747           ++__first2;
1748         }
1749       return pair<_InputIterator1, _InputIterator2>(__first1, __first2);
1750     }
1751
```

new version: `std::mismatch`

```
1815 #if __cplusplus > 201103L
1816
1817   template<typename _InputIterator1, typename _InputIterator2,
1818            typename _BinaryPredicate>
1819     _GLIBCXX20_CONSTEXPR
1820     pair<_InputIterator1, _InputIterator2>
1821     __mismatch(_InputIterator1 __first1, _InputIterator1 __last1,
1822                _InputIterator2 __first2, _InputIterator2 __last2,
1823                _BinaryPredicate __binary_pred)
1824     {
1825       while (__first1 != __last1 && __first2 != __last2
1826              && __binary_pred(__first1, __first2))
1827         {
1828           ++__first1;
1829           ++__first2;
1830         }
1831       return pair<_InputIterator1, _InputIterator2>(__first1, __first2);
1832     }
```
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
