### PR TITLE
[Feature] support run export in sync mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -179,6 +179,23 @@ public class ExportMgr {
         return result;
     }
 
+    public ExportJob getExportByQueryId(UUID queryId) {
+        if (queryId == null) {
+            return null;
+        }
+        readLock();
+        try {
+            for (ExportJob job : idToJob.values()) {
+                if (queryId.equals(job.getQueryId())) {
+                    return job;
+                }
+            }
+        } finally {
+            readUnlock();
+        }
+        return null;
+    }
+
     // NOTE: jobid and states may both specified, or only one of them, or neither
     public List<List<String>> getExportJobInfosByIdOrState(
             long dbId, long jobId, Set<ExportJob.JobState> states, UUID queryId,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -82,6 +82,7 @@ import com.starrocks.connector.exception.RemoteFileNotFoundException;
 import com.starrocks.http.HttpConnectContext;
 import com.starrocks.http.HttpResultSender;
 import com.starrocks.load.EtlJobType;
+import com.starrocks.load.ExportJob;
 import com.starrocks.load.InsertOverwriteJob;
 import com.starrocks.load.InsertOverwriteJobMgr;
 import com.starrocks.load.loadv2.LoadJob;
@@ -139,6 +140,7 @@ import com.starrocks.sql.ast.SetCatalogStmt;
 import com.starrocks.sql.ast.SetDefaultRoleStmt;
 import com.starrocks.sql.ast.SetRoleStmt;
 import com.starrocks.sql.ast.SetStmt;
+import com.starrocks.sql.ast.ShowExportStmt;
 import com.starrocks.sql.ast.ShowStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SystemVariable;
@@ -1450,6 +1452,50 @@ public class StmtExecutor {
         ExportStmt exportStmt = (ExportStmt) parsedStmt;
         exportStmt.setExportStartTime(context.getStartTime());
         context.getGlobalStateMgr().getExportMgr().addExportJob(queryId, exportStmt);
+
+        if (!exportStmt.getSync()) {
+            return;
+        }
+        // poll and check export job state
+        int timeoutSeconds = Config.export_task_default_timeout_second + Config.export_checker_interval_second;
+        long start = System.currentTimeMillis();
+        while (System.currentTimeMillis() < (start + timeoutSeconds * 1000L)) {
+            ExportJob exportJob = context.getGlobalStateMgr().getExportMgr().getExportByQueryId(queryId);
+            if (exportJob != null) {
+                timeoutSeconds = exportJob.getTimeoutSecond() + Config.export_checker_interval_second;
+            }
+            if (exportJob == null ||
+                    (exportJob.getState() != ExportJob.JobState.FINISHED
+                            && exportJob.getState() != ExportJob.JobState.CANCELLED)) {
+                try {
+                    Thread.sleep(Config.export_checker_interval_second * 1000L);
+                } catch (InterruptedException interruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                continue;
+            }
+            break;
+        }
+
+        // proxy send show export result
+        String db = exportStmt.getTblName().getDb();
+        String showStmt = String.format("SHOW EXPORT FROM %s WHERE QueryId = \"%s\";", db, queryId);
+        StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse(showStmt, context.getSessionVariable()).get(0);
+        ShowExportStmt showExportStmt = (ShowExportStmt) statementBase;
+        showExportStmt.setQueryId(queryId);
+        ShowExecutor executor = new ShowExecutor(context, showExportStmt);
+        ShowResultSet resultSet = executor.execute();
+        if (resultSet == null) {
+            // state changed in execute
+            return;
+        }
+        if (isProxy) {
+            proxyResultSet = resultSet;
+            context.getState().setEof();
+            return;
+        }
+
+        sendShowResult(resultSet);
     }
 
     private void handleUpdateFailPointStatusStmt() throws Exception {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExportStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExportStmt.java
@@ -77,6 +77,7 @@ public class ExportStmt extends StatementBase {
     // may catalog.db.table
     private TableRef tableRef;
     private long exportStartTime;
+    private boolean sync;
 
     public ExportStmt(TableRef tableRef, List<String> columnNames, String path,
                       Map<String, String> properties, BrokerDesc brokerDesc) {
@@ -85,6 +86,11 @@ public class ExportStmt extends StatementBase {
 
     public ExportStmt(TableRef tableRef, List<String> columnNames, String path,
                       Map<String, String> properties, BrokerDesc brokerDesc, NodePosition pos) {
+        this(tableRef, columnNames, path, properties, brokerDesc, pos, false);
+    }
+
+    public ExportStmt(TableRef tableRef, List<String> columnNames, String path,
+                      Map<String, String> properties, BrokerDesc brokerDesc, NodePosition pos, boolean sync) {
         super(pos);
         this.tableRef = tableRef;
         this.columnNames = columnNames;
@@ -96,6 +102,15 @@ public class ExportStmt extends StatementBase {
         this.columnSeparator = DEFAULT_COLUMN_SEPARATOR;
         this.rowDelimiter = DEFAULT_LINE_DELIMITER;
         this.includeQueryId = true;
+        this.sync = sync;
+    }
+
+    public boolean getSync() {
+        return sync;
+    }
+
+    public void setSync(boolean sync) {
+        this.sync = sync;
     }
 
     public long getExportStartTime() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2955,8 +2955,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         }
         // brokers
         BrokerDesc brokerDesc = getBrokerDesc(context.brokerDesc());
+        boolean sync = context.SYNC() != null;
         return new ExportStmt(tableRef, getColumnNames(context.columnAliases()),
-                stringLiteral.getValue(), properties, brokerDesc, createPos(context));
+                stringLiteral.getValue(), properties, brokerDesc, createPos(context), sync);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1724,7 +1724,7 @@ showWhiteListStatement
 // ------------------------------------------- Export Statement --------------------------------------------------------
 
 exportStatement
-    : EXPORT TABLE tableDesc columnAliases? TO string properties? brokerDesc?
+    : EXPORT TABLE tableDesc columnAliases? TO string (WITH (SYNC | ASYNC) MODE)? properties? brokerDesc?
     ;
 
 cancelExportStatement

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ExportRelativeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ExportRelativeStmtTest.java
@@ -51,6 +51,13 @@ public class ExportRelativeStmtTest {
                 " WITH BROKER 'broker' (\"password\" = \"***\", \"username\" = \"test\")", stmt.toString());
         Assert.assertEquals(stmt.getPath(), "hdfs://hdfs_host:port/a/b/c/");
 
+        // run with sync mode
+        originStmt = "EXPORT TABLE tall TO \"hdfs://hdfs_host:port/a/b/c/\" " +
+                "WITH SYNC MODE " +
+                "WITH BROKER \"broker\" (\"username\"=\"test\", \"password\"=\"test\");";
+        stmt = (ExportStmt) analyzeSuccess(originStmt);
+        Assert.assertTrue(stmt.getSync());
+
         // partition data
         originStmt = "EXPORT TABLE tp PARTITION (p1,p2) TO \"hdfs://hdfs_host:port/a/b/c/test_data_\" PROPERTIES " +
                 "(\"column_separator\"=\",\") WITH BROKER \"broker\" (\"username\"=\"test\", \"password\"=\"test\");";

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
@@ -75,6 +75,15 @@ public class ExportMgrTest {
         mgr.replayUpdateJobState(job3.getId(), ExportJob.JobState.FINISHED);
         Assert.assertEquals(2, mgr.getIdToJob().size());
 
+        // 6. get job by queryId
+        ExportJob jobResult = mgr.getExportByQueryId(job3.getQueryId());
+        Assert.assertNotNull(jobResult);
+        Assert.assertEquals(3, jobResult.getId());
+        ExportJob jobResultNull = mgr.getExportByQueryId(null);
+        Assert.assertNull(jobResultNull);
+        ExportJob jobResultNotExist = mgr.getExportByQueryId(new UUID(4, 4));
+        Assert.assertNull(jobResultNotExist);
+
         // 5. save image
         File tempFile = File.createTempFile("GlobalTransactionMgrTest", ".image");
         System.err.println("write image " + tempFile.getAbsolutePath());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ExportHandleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ExportHandleTest.java
@@ -1,0 +1,112 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.analysis.BrokerDesc;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.LoadException;
+import com.starrocks.common.UserException;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.fs.HdfsUtil;
+import com.starrocks.load.ExportJob;
+import com.starrocks.load.ExportMgr;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AuthorizerStmtVisitor;
+import com.starrocks.sql.ast.ExportStmt;
+import com.starrocks.thrift.THdfsProperties;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExportHandleTest {
+    private static ConnectContext connectContext;
+
+    private static StarRocksAssert starRocksAssert;
+    private ShowResultSet exportResultSet;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        Config.export_checker_interval_second = 1;
+        Config.export_task_default_timeout_second = 2;
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        UtFrameUtils.setUpForPersistTest();
+
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE test.export_tbl(k1 int, k2 int, k3 int) " +
+                        "distributed by hash(k1) buckets 3 properties('replication_num' = '1');");
+    }
+
+    @Test
+    public void testExportHandler() throws Exception {
+        String exportStmtStr = "EXPORT TABLE export_tbl TO \"hdfs://hdfs_host:port/a/b/c/\" " +
+                "WITH SYNC MODE " +
+                "WITH BROKER (\"username\"=\"test\", \"password\"=\"test\");";
+        ExportStmt exportStmt = (ExportStmt) UtFrameUtils.parseStmtWithNewParser(exportStmtStr, connectContext);
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, exportStmt);
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public boolean isLeader() {
+                return true;
+            }
+        };
+        new MockUp<AuthorizerStmtVisitor>() {
+            @Mock
+            public Void visitExportStatement(ExportStmt statement, ConnectContext context) {
+                return null;
+            }
+        };
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void sendShowResult(ShowResultSet resultSet) {
+                exportResultSet = resultSet;
+            }
+        };
+        new MockUp<HdfsUtil>() {
+            @Mock
+            public void getTProperties(String path, BrokerDesc brokerDesc, THdfsProperties tProperties) throws UserException {
+            }
+        };
+        // let ExportChecker never run this job
+        new MockUp<ExportMgr>() {
+            @Mock
+            public List<ExportJob> getExportJobs(ExportJob.JobState state) {
+                return new ArrayList<>();
+            }
+        };
+        try {
+            stmtExecutor.execute();
+        } catch (LoadException e) {
+            Assert.fail(e.getMessage());
+        }
+        Assert.assertNotNull(exportResultSet);
+        Assert.assertEquals(1, exportResultSet.getResultRows().size());
+        List<String> row = exportResultSet.getResultRows().get(0);
+        Assert.assertEquals("PENDING", row.get(2));
+    }
+}


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information

Currenttly run export command always in async mode, user should `select last_query_id()` and then check execute result by `show export where queryid='{queryId}'`, this pr add `sync` after origin command make it run in sync mode and result in final execute result when export finished or cancelled. return user with final show export result.

```sql
/* difference: add sync at end of export comand */
mysql> EXPORT TABLE olap_tbl_02 PARTITION (p20220418) TO "s3a://hoffer/tmp/" properties (     
  "load_mem_limit"="21474836480",     
  "bytes_per_file" = "123731968" 
) WITH BROKER (     
  "fs.s3a.access.key" = "xxxxx",     
  "fs.s3a.secret.key" = "yyyyy",      
  "fs.s3a.connection.ssl.enabled" = "false",     
   "fs.s3a.signing-algorithm" = "S3SignerType",      
   "fs.s3a.etag.checksum" = "false",      
   "fs.s3a.endpoint" = "cos.ap-guangzhou.tencentcos.cn" 
 ) sync \G
*************************** 1. row ***************************
     JobId: 561118
   QueryId: af7cbd51-4636-11ee-b324-02422fe84e07
     State: FINISHED
  Progress: 100%
  TaskInfo: {"partitions":["p20220418"],"column separator":"\t","columns":["*"],"broker":"","row delimiter":"\n","mem limit":21474836480,"tablet num":1,"where":"","coord num":2,"db":"hoffertest","tbl":"olap_tbl_02"}
      Path: s3a://hoffer/temp/
CreateTime: 2023-08-29 14:38:38
 StartTime: 2023-08-29 14:38:39
FinishTime: 2023-08-29 14:38:48
   Timeout: 86400
  ErrorMsg: NULL
1 row in set (15.01 sec)
```

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
