### PR TITLE
[Enhancement] Support ignoring invalid directories when list hive directory recursively. (#30363)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveRemoteFileIO.java
@@ -24,10 +24,12 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class HiveRemoteFileIO implements RemoteFileIO {
@@ -66,7 +68,7 @@ public class HiveRemoteFileIO implements RemoteFileIO {
             if (!pathKey.isRecursive()) {
                 blockIterator = fileSystem.listLocatedStatus(new Path(uri.getPath()));
             } else {
-                blockIterator = fileSystem.listFiles(new Path(uri.getPath()), true);
+                blockIterator = listFilesRecursive(fileSystem, new Path(uri.getPath()));
             }
             while (blockIterator.hasNext()) {
                 LocatedFileStatus locatedFileStatus = blockIterator.next();
@@ -91,14 +93,70 @@ public class HiveRemoteFileIO implements RemoteFileIO {
         return resultPartitions.put(pathKey, fileDescs).build();
     }
 
+    private RemoteIterator<LocatedFileStatus> listFilesRecursive(FileSystem fileSystem, Path f)
+        throws FileNotFoundException, IOException {
+        return new RemoteIterator<LocatedFileStatus>() {
+            private Stack<RemoteIterator<LocatedFileStatus>> itors = new Stack<>();
+            private RemoteIterator<LocatedFileStatus> curItor = fileSystem.listLocatedStatus(f);
+            private LocatedFileStatus curFile;
+
+            @Override
+            public boolean hasNext() throws IOException {
+                while (curFile == null) {
+                    if (curItor.hasNext()) {
+                        handleFileStat(curItor.next());
+                    } else if (!itors.empty()) {
+                        curItor = itors.pop();
+                    } else {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            // Process the input stat.
+            // If it is a file, return the file stat.
+            // If it is a valid directory, traverse it.
+            private void handleFileStat(LocatedFileStatus stat) throws IOException {
+                if (stat.isFile()) {
+                    curFile = stat;
+                } else if (isValidDirectory(stat)) {
+                    try {
+                        RemoteIterator<LocatedFileStatus> newDirItor = fileSystem.listLocatedStatus(stat.getPath());
+                        itors.push(curItor);
+                        curItor = newDirItor;
+                    } catch (FileNotFoundException ignored) {
+                        LOG.debug("Directory {} deleted while attempting for recursive listing", stat.getPath());
+                    }
+                }
+            }
+
+            @Override
+            public LocatedFileStatus next() throws IOException {
+                if (hasNext()) {
+                    LocatedFileStatus result = curFile;
+                    curFile = null;
+                    return result;
+                }
+                throw new java.util.NoSuchElementException("No more entry in " + f);
+            }
+        };
+    }
     private boolean isValidDataFile(FileStatus fileStatus) {
-        if (fileStatus.isDirectory()) {
+        if (!fileStatus.isFile()) {
             return false;
         }
-
         String lcFileName = fileStatus.getPath().getName().toLowerCase();
         return !(lcFileName.startsWith(".") || lcFileName.startsWith("_") ||
                 lcFileName.endsWith(".copying") || lcFileName.endsWith(".tmp"));
+    }
+
+    private boolean isValidDirectory(FileStatus fileStatus) {
+        if (!fileStatus.isDirectory()) {
+            return false;
+        }
+        String dirName = fileStatus.getPath().getName();
+        return !(dirName.startsWith("."));
     }
 
     protected List<RemoteFileBlockDesc> getRemoteFileBlockDesc(BlockLocation[] blockLocations) throws IOException {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CachingRemoteFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CachingRemoteFileIOTest.java
@@ -20,14 +20,14 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 
 public class CachingRemoteFileIOTest {
 
     @Test
     public void testGetHiveRemoteFiles() {
         HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
         ExecutorService executor = Executors.newFixedThreadPool(5);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -27,13 +27,13 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 
 public class RemoteFileOperationsTest {
     @Test
     public void testGetHiveRemoteFiles() {
         HiveRemoteFileIO hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
         ExecutorService executorToRefresh = Executors.newFixedThreadPool(5);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveConnectorTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 
 public class HiveConnectorTest {
     private HiveMetaClient client;
@@ -47,7 +47,7 @@ public class HiveConnectorTest {
         cachingHiveMetastore = CachingHiveMetastore.createCatalogLevelInstance(
                 metastore, executorForHmsRefresh, 100, 10, 1000, false);
         hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         cachingRemoteFileIO = CachingRemoteFileIO.createCatalogLevelInstance(
                 hiveRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 10);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -39,7 +39,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 
 public class HiveMetadataTest {
     private HiveMetaClient client;
@@ -73,7 +73,7 @@ public class HiveMetadataTest {
         hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true);
 
         hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         cachingRemoteFileIO = CachingRemoteFileIO.createCatalogLevelInstance(
                 hiveRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 10);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveRemoteFileIOTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveRemoteFileIOTest.java
@@ -14,12 +14,13 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Map;
 
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_RECURSIVE_TABLE;
 
 public class HiveRemoteFileIOTest {
     @Test
     public void testGetRemoteFiles() {
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         HiveRemoteFileIO fileIO = new HiveRemoteFileIO(new Configuration());
         fileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;
@@ -47,8 +48,39 @@ public class HiveRemoteFileIOTest {
     }
 
     @Test
+    public void testGetRemoteRecursiveFiles() {
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_RECURSIVE_TABLE);
+        HiveRemoteFileIO fileIO = new HiveRemoteFileIO(new Configuration());
+        fileIO.setFileSystem(fs);
+        FeConstants.runningUnitTest = true;
+        String tableLocation = "hdfs://127.0.0.1:10000/hive.db/recursive_tbl";
+        RemotePathKey pathKey = RemotePathKey.of(tableLocation, true);
+        Map<RemotePathKey, List<RemoteFileDesc>> remoteFileInfos = fileIO.getRemoteFiles(pathKey);
+        List<RemoteFileDesc> fileDescs = remoteFileInfos.get(pathKey);
+        Assert.assertNotNull(fileDescs);
+        Assert.assertEquals(2, fileDescs.size());
+        RemoteFileDesc fileDesc = fileDescs.get(0);
+        Assert.assertNotNull(fileDesc);
+        Assert.assertEquals("subdir1/000000_0", fileDesc.getFileName());
+        Assert.assertEquals("", fileDesc.getCompression());
+        Assert.assertEquals(20, fileDesc.getLength());
+        Assert.assertEquals(1234567890, fileDesc.getModificationTime());
+        Assert.assertFalse(fileDesc.isSplittable());
+        Assert.assertNull(fileDesc.getTextFileFormatDesc());
+
+        fileDesc = fileDescs.get(1);
+        Assert.assertNotNull(fileDesc);
+        Assert.assertEquals("subdir1/000000_1", fileDesc.getFileName());
+        Assert.assertEquals("", fileDesc.getCompression());
+        Assert.assertEquals(20, fileDesc.getLength());
+        Assert.assertEquals(1234567890, fileDesc.getModificationTime());
+        Assert.assertFalse(fileDesc.isSplittable());
+        Assert.assertNull(fileDesc.getTextFileFormatDesc());
+    }
+
+    @Test
     public void testPathContainsEmptySpace() {
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         HiveRemoteFileIO fileIO = new HiveRemoteFileIO(new Configuration());
         fileIO.setFileSystem(fs);
         FeConstants.runningUnitTest = true;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveStatisticsProviderTest.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static com.starrocks.connector.hive.MockedRemoteFileSystem.TEST_FILES;
+import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 
 public class HiveStatisticsProviderTest {
     private HiveMetaClient client;
@@ -70,7 +70,7 @@ public class HiveStatisticsProviderTest {
         hmsOps = new HiveMetastoreOperations(cachingHiveMetastore, true);
 
         hiveRemoteFileIO = new HiveRemoteFileIO(new Configuration());
-        FileSystem fs = new MockedRemoteFileSystem(TEST_FILES);
+        FileSystem fs = new MockedRemoteFileSystem(HDFS_HIVE_TABLE);
         hiveRemoteFileIO.setFileSystem(fs);
         cachingRemoteFileIO = CachingRemoteFileIO.createCatalogLevelInstance(
                 hiveRemoteFileIO, executorForRemoteFileRefresh, 100, 10, 10);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedRemoteFileSystem.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedRemoteFileSystem.java
@@ -16,28 +16,79 @@ import org.apache.hadoop.util.Progressable;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 public class MockedRemoteFileSystem extends FileSystem {
-    private final List<LocatedFileStatus> files;
+    public static final String HDFS_HOST = "hdfs://127.0.0.1:10000";
+    public static final String HDFS_HIVE_TABLE = HDFS_HOST + "/hive.db/hive_tbl";
+    public static final String HDFS_RECURSIVE_TABLE = HDFS_HOST + "/hive.db/recursive_tbl";
 
-    public static final String TEST_PATH_1_STR = "hdfs://127.0.0.1:10000/hive.db/hive_tbl/000000_0";
-    public static final Path TEST_PATH_1 = new Path(TEST_PATH_1_STR);
-    public static final List<LocatedFileStatus> TEST_FILES = ImmutableList.of(locatedFileStatus(TEST_PATH_1));
+    private Map<String, List<LocatedFileStatus>> fileEntries;
+    private String hdfsTable;
 
-    public MockedRemoteFileSystem(List<LocatedFileStatus> files) {
-        this.files = files;
+    public MockedRemoteFileSystem(String tbl) {
+        if (tbl == HDFS_HIVE_TABLE) {
+            this.fileEntries = createHiveEntries();
+        } else if (tbl == HDFS_RECURSIVE_TABLE) {
+            this.fileEntries = createRecursiveEntries();
+        }
+        this.hdfsTable = tbl;
     }
 
-    public static LocatedFileStatus locatedFileStatus(Path path) {
-        return locatedFileStatus(path, 20, 1234567890);
+    private Map<String, List<LocatedFileStatus>> createHiveEntries() {
+        Map<String, List<LocatedFileStatus>> hiveEntries = new HashMap<String, List<LocatedFileStatus>>();
+        List<LocatedFileStatus> tblDirs = ImmutableList.of(
+                locatedFileStatus(new Path(HDFS_HIVE_TABLE + "/000000_0"), false)
+                );
+        hiveEntries.put(HDFS_HIVE_TABLE, tblDirs);
+
+        return hiveEntries;
     }
 
-    public static LocatedFileStatus locatedFileStatus(Path path, long fileLength, long modificationTime) {
+    private Map<String, List<LocatedFileStatus>> createRecursiveEntries() {
+        Map<String, List<LocatedFileStatus>> recEntries = new HashMap<String, List<LocatedFileStatus>>();
+        List<LocatedFileStatus> tblDirs = ImmutableList.of(
+                locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/subdir1"), true),
+                locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/subdir2"), true),
+                locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/.subdir3"), true)
+                );
+        recEntries.put(HDFS_RECURSIVE_TABLE, tblDirs);
+
+        List<LocatedFileStatus> subDir1 = ImmutableList.of(
+                locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/subdir1/000000_0"), false),
+                locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/subdir1/000000_1"), false)
+                );
+        recEntries.put(HDFS_RECURSIVE_TABLE + "/subdir1", subDir1);
+
+        List<LocatedFileStatus> subDir2 = ImmutableList.of(
+                locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/subdir2/.000000_2"), false)
+                );
+        recEntries.put(HDFS_RECURSIVE_TABLE + "/subdir2", subDir2);
+
+        List<LocatedFileStatus> subDir3 = ImmutableList.of(
+                locatedFileStatus(new Path(HDFS_RECURSIVE_TABLE + "/.subdir3/000000_3"), false)
+                );
+        recEntries.put(HDFS_RECURSIVE_TABLE + "/.subdir3", subDir3);
+
+        return recEntries;
+    }
+
+    @Override
+    public boolean exists(Path f) throws IOException {
+        return false;
+    }
+
+    public static LocatedFileStatus locatedFileStatus(Path path, boolean isDir) {
+        return locatedFileStatus(path, isDir, 20, 1234567890);
+    }
+
+    public static LocatedFileStatus locatedFileStatus(Path path, boolean isDir, long fileLength, long modificationTime) {
         return new LocatedFileStatus(
                 fileLength,
-                false,
+                isDir,
                 0,
                 0L,
                 modificationTime,
@@ -51,10 +102,18 @@ public class MockedRemoteFileSystem extends FileSystem {
                         new String[] {"localhost"}, 0, fileLength)});
     }
 
+    public static String formatFilePath(String filepath) {
+        if (filepath.startsWith("/")) {
+            filepath = HDFS_HOST + filepath;
+        }
+        filepath = filepath.replaceAll(" ", "");
+        return filepath;
+    }
+
     @Override
     public RemoteIterator<LocatedFileStatus> listLocatedStatus(Path f) {
         return new RemoteIterator<LocatedFileStatus>() {
-            private final Iterator<LocatedFileStatus> iterator = files.iterator();
+            private final Iterator<LocatedFileStatus> iterator = locatedFileList(f).iterator();
 
             @Override
             public boolean hasNext() {
@@ -64,6 +123,11 @@ public class MockedRemoteFileSystem extends FileSystem {
             @Override
             public LocatedFileStatus next() {
                 return iterator.next();
+            }
+
+            public List<LocatedFileStatus> locatedFileList(Path f) {
+                String key = hdfsTable == HDFS_HIVE_TABLE ? HDFS_HIVE_TABLE : formatFilePath(f.toString());
+                return fileEntries.get(key);
             }
         };
     }
@@ -126,6 +190,17 @@ public class MockedRemoteFileSystem extends FileSystem {
 
     @Override
     public FileStatus getFileStatus(Path path) {
-        throw new UnsupportedOperationException();
+        if (hdfsTable == HDFS_HIVE_TABLE) {
+            return fileEntries.get(HDFS_HIVE_TABLE).get(0);
+        }
+
+        Path parent = path.getParent();
+        List<LocatedFileStatus> entries = fileEntries.get(formatFilePath(parent.toString()));
+        for (int i = 0; i < entries.size(); ++i) {
+            if (entries.get(i).getPath() == path) {
+                return entries.get(i);
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
For the following reasons, we manually implement the listFilesRecursive method to replace the hadoop filesystem listFiles api when list hdfs path recursively.

* The hadoop filesystem doesn't provide an api with a filter parameter to ignore invalid directories when listing path recursively. Sometimes many residual or temporary files exist in table subdirectories, which make it too slow when listing remote files. So, we need to skip these invalid directories and only scan the data directories.
* For some data sources, like COS metadata acceleration buckets, recursive parameter in hadoop filesystem has no effect on them and we need to use their own libraries to achieve it. So, we can manually implement the list method to achieve the same purpose.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
