### PR TITLE
[Feature] Add base64_to_hll function

### DIFF
--- a/be/src/exprs/hyperloglog_functions.h
+++ b/be/src/exprs/hyperloglog_functions.h
@@ -51,6 +51,13 @@ public:
     DEFINE_VECTORIZED_FN(hll_serialize);
 
     DEFINE_VECTORIZED_FN(hll_deserialize);
+
+    /**
+     * @param:
+     * @paramType columns: [TYPE_VARCHAR]
+     * @return TYPE_OBJECT
+     */
+    DEFINE_VECTORIZED_FN(base64_to_hll);
 };
 
 } // namespace starrocks

--- a/be/src/types/hll.h
+++ b/be/src/types/hll.h
@@ -144,6 +144,8 @@ public:
     // common interface
     void clear();
 
+    HllDataType get_type() { return _type; }
+
 private:
     using ElementSet = phmap::flat_hash_set<uint64_t>;
 

--- a/be/test/exprs/hyperloglog_functions_test.cpp
+++ b/be/test/exprs/hyperloglog_functions_test.cpp
@@ -258,8 +258,8 @@ TEST_F(HyperLogLogFunctionsTest, base64ToEmptyHllTest) {
         Columns columns;
         columns.push_back(col);
 
-        auto resultCol = HyperloglogFunction::base64_to_hll(ctx, columns);
-        ColumnViewer<TYPE_HLL> viewer(resultCol);
+        auto resultCol = HyperloglogFunctions::base64_to_hll(ctx, columns);
+        ColumnViewer<TYPE_HLL> viewer(resultCol.value());
         ASSERT_EQ(0, viewer.value(0)->estimate_cardinality());
     }
 }
@@ -269,7 +269,6 @@ TEST_F(HyperLogLogFunctionsTest, base64ToHllTest) {
 
     { // explicit hll
         HyperLogLog hll;
-        int HLL_EXPLICLIT_INT64_NUM = 160;
         for (int i = 0; i < HLL_EXPLICLIT_INT64_NUM; i++) {
             hll.update(hash(i));
         }
@@ -297,9 +296,9 @@ TEST_F(HyperLogLogFunctionsTest, base64ToHllTest) {
         columns.push_back(col);
 
         // base64 string to hll
-        auto resultCol = HyperloglogFunction::base64_to_hll(ctx, columns);
+        auto resultCol = HyperloglogFunctions::base64_to_hll(ctx, columns);
 
-        ColumnViewer<TYPE_HLL> viewer(resultCol);
+        ColumnViewer<TYPE_HLL> viewer(resultCol.value());
         ASSERT_EQ(HLL_EXPLICLIT_INT64_NUM, viewer.value(0)->estimate_cardinality());
     }
 }
@@ -331,9 +330,9 @@ TEST_F(HyperLogLogFunctionsTest, base64ToExplicitHllTest) {
         columns.push_back(col);
 
         // base64 string to hll
-        auto resultCol = HyperloglogFunction::base64_to_hll(ctx, columns);
+        auto resultCol = HyperloglogFunctions::base64_to_hll(ctx, columns);
 
-        ColumnViewer<TYPE_HLL> viewer(resultCol);
+        ColumnViewer<TYPE_HLL> viewer(resultCol.value());
         for (int i = 0; i < HLL_EXPLICLIT_INT64_NUM; i++) {
             ASSERT_EQ(i + 1, viewer.value(i)->estimate_cardinality());
         }
@@ -368,9 +367,9 @@ TEST_F(HyperLogLogFunctionsTest, base64ToSparseHllTest) {
         columns.push_back(col);
 
         // base64 string to hll
-        auto resultCol = HyperloglogFunction::base64_to_hll(ctx, columns);
+        auto resultCol = HyperloglogFunctions::base64_to_hll(ctx, columns);
 
-        ColumnViewer<TYPE_HLL> viewer(resultCol);
+        ColumnViewer<TYPE_HLL> viewer(resultCol.value());
         for (int i = 0; i < HLL_SPARSE_THRESHOLD; i++) {
             auto cardinality = viewer.value(i)->estimate_cardinality();
             if (i < HLL_EXPLICLIT_INT64_NUM) {
@@ -408,9 +407,9 @@ TEST_F(HyperLogLogFunctionsTest, base64ToFullHllTest) {
         columns.push_back(col);
 
         // base64 string to hll
-        auto resultCol = HyperloglogFunction::base64_to_hll(ctx, columns);
+        auto resultCol = HyperloglogFunctions::base64_to_hll(ctx, columns);
 
-        ColumnViewer<TYPE_HLL> viewer(resultCol);
+        ColumnViewer<TYPE_HLL> viewer(resultCol.value());
         for (int i = 0; i < HLL_SPARSE_THRESHOLD + 100; i++) {
             auto cardinality = viewer.value(i)->estimate_cardinality();
             if (i < HLL_EXPLICLIT_INT64_NUM) {

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -588,6 +588,7 @@ vectorized_functions = [
 
     [80040, 'hll_serialize', 'VARCHAR', ['HLL'], 'HyperloglogFunctions::hll_serialize'],
     [80041, 'hll_deserialize', 'HLL', ['VARCHAR'], 'HyperloglogFunctions::hll_deserialize'],
+    [80050, 'base64_to_hll', 'HLL', ['VARCHAR'], 'HyperloglogFunction::base64_to_hll'],
 
     # bitmap function
     [90010, 'to_bitmap', 'BITMAP', ['VARCHAR'], 'BitmapFunctions::to_bitmap<TYPE_VARCHAR>', False],

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -588,7 +588,7 @@ vectorized_functions = [
 
     [80040, 'hll_serialize', 'VARCHAR', ['HLL'], 'HyperloglogFunctions::hll_serialize'],
     [80041, 'hll_deserialize', 'HLL', ['VARCHAR'], 'HyperloglogFunctions::hll_deserialize'],
-    [80050, 'base64_to_hll', 'HLL', ['VARCHAR'], 'HyperloglogFunction::base64_to_hll'],
+    [80050, 'base64_to_hll', 'HLL', ['VARCHAR'], 'HyperloglogFunctions::base64_to_hll'],
 
     # bitmap function
     [90010, 'to_bitmap', 'BITMAP', ['VARCHAR'], 'BitmapFunctions::to_bitmap<TYPE_VARCHAR>', False],


### PR DESCRIPTION
Add base64_to_hll function, which is used to transfer base64 encoded string to hyperloglog.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
