### PR TITLE
[BugFix] copy partitionInfo to a new map 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
@@ -230,14 +230,4 @@ public class ExpressionRangePartitionInfoV2 extends RangePartitionInfo
     public void setSourcePartitionTypes(List<Type> sourcePartitionTypes) {
         this.sourcePartitionTypes = sourcePartitionTypes;
     }
-
-    @Override
-    protected Object clone() {
-        ExpressionRangePartitionInfoV2 v2 = (ExpressionRangePartitionInfoV2) super.clone();
-        v2.partitionExprs = Lists.newArrayList(this.partitionExprs);
-        v2.serializedPartitionExprs = Lists.newArrayList(this.serializedPartitionExprs);
-        v2.automaticPartition = this.automaticPartition;
-        v2.sourcePartitionTypes = Lists.newArrayList(sourcePartitionTypes);
-        return v2;
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -65,6 +65,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class RangePartitionInfo extends PartitionInfo {
     private static final Logger LOG = LogManager.getLogger(RangePartitionInfo.class);
@@ -563,8 +564,8 @@ public class RangePartitionInfo extends PartitionInfo {
     protected Object clone() {
         RangePartitionInfo info = (RangePartitionInfo) super.clone();
         info.partitionColumns = Lists.newArrayList(this.partitionColumns);
-        info.idToRange.putAll(this.idToRange);
-        info.idToTempRange.putAll(this.idToTempRange);
+        info.idToRange = new ConcurrentHashMap<>(this.idToRange);
+        info.idToTempRange = new ConcurrentHashMap<>(this.idToTempRange);
         info.isMultiColumnPartition = partitionColumns.size() > 1;
         return info;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/RangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/RangePartitionInfoTest.java
@@ -18,12 +18,14 @@
 package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.sql.ast.PartitionKeyDesc;
 import com.starrocks.sql.ast.PartitionKeyDesc.PartitionRangeType;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -341,6 +343,21 @@ public class RangePartitionInfoTest {
             singleRangePartitionDesc.analyze(columns, null);
             partitionInfo.handleNewSinglePartitionDesc(singleRangePartitionDesc, 20000L, false);
         }
+    }
+
+    @Test
+    public void testCopyPartitionInfo() throws Exception {
+        Column k1 = new Column("k1", new ScalarType(PrimitiveType.INT), true, null, "", "");
+        partitionColumns.add(k1);
+        RangePartitionInfo rangePartitionInfo = new RangePartitionInfo(partitionColumns);
+        PartitionKey partitionKey = PartitionKey.createInfinityPartitionKey(partitionColumns, true);
+        Range<PartitionKey> range = Range.atLeast(partitionKey);
+        rangePartitionInfo.addPartition(123L, false, range, null, (short) 1,
+                false, null);
+        RangePartitionInfo copyInfo = (RangePartitionInfo) rangePartitionInfo.clone();
+        rangePartitionInfo.dropPartition(123L);
+        Assert.assertTrue(copyInfo.getRange(123L) != null);
+        Assert.assertTrue(rangePartitionInfo.getRange(123L) == null);
     }
 
 }


### PR DESCRIPTION
Fixes #issue
When invoking the clone method,  it creates a new instance of the class of the current object and initializes all its fields with exactly the contents of the corresponding fields of this object. But we need put all the elements of the old map into a new map when shallow copy partitionInfo.
Remove some unnecessary process in EXPR_RANGE_V2 type.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
