### PR TITLE
[BugFix] Fix 3-stage AGG got wrong result when enable dictionary optimize

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -727,6 +727,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                     new PhysicalHashAggregateOperator(aggOperator.getType(), newGroupBys, newPartitionsBy, newAggMap,
                             aggOperator.getSingleDistinctFunctionPos(), aggOperator.isSplit(), aggOperator.getLimit(),
                             aggOperator.getPredicate(), aggOperator.getProjection());
+            newHashAggregator.setUseStreamingPreAgg(aggOperator.isUseStreamingPreAgg());
             newHashAggregator.setUseSortAgg(aggOperator.isUseSortAgg());
             return newHashAggregator;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1087,6 +1087,8 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  <dict id 10> : <string id 7>"));
         Assert.assertTrue(plan.contains(":AGGREGATE (update serialize)\n" +
                 "  |  output: count(if(1: S_SUPPKEY IS NULL, NULL, 7))"));
+        assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+                "  |  group by: 1: S_SUPPKEY, 10: S_COMMENT");
 
         sql = "select count(distinct S_ADDRESS, S_COMMENT) from supplier";
         plan = getFragmentPlan(sql);
@@ -1095,6 +1097,7 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  <dict id 11> : <string id 7>"));
         Assert.assertTrue(plan.contains(" 5:AGGREGATE (update serialize)\n" +
                 "  |  output: count(if(3 IS NULL, NULL, 7))"));
+        System.out.println("plan = " + plan);
         FeConstants.runningUnitTest = false;
     }
 
@@ -1107,7 +1110,6 @@ public class LowCardinalityTest extends PlanTestBase {
         sql = "select max(S_NAME) as b from supplier group by S_ADDRESS order by b";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("group by: 10: S_ADDRESS"));
-
         sql = "select S_ADDRESS from supplier order by S_ADDRESS";
         plan = getVerboseExplain(sql);
         Assert.assertTrue(plan.contains("  1:SORT\n" +
@@ -1140,7 +1142,6 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  <dict id 12> : <string id 9>");
 
         // TODO add a case: Decode node before Sort Node
-
         connectContext.getSessionVariable().setNewPlanerAggStage(0);
     }
 


### PR DESCRIPTION
Fixes #30572

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
