### PR TITLE
[Feature] Support plan_cpu_cost_range and plan_mem_cost_range in resource group classifier

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -38,6 +38,8 @@ public class ResourceGroup implements Writable {
     public static final String QUERY_TYPE = "query_type";
     public static final String SOURCE_IP = "source_ip";
     public static final String DATABASES = "db";
+    public static final String PLAN_CPU_COST_RANGE = "plan_cpu_cost_range";
+    public static final String PLAN_MEM_COST_RANGE = "plan_mem_cost_range";
     public static final String CPU_CORE_LIMIT = "cpu_core_limit";
     public static final String MAX_CPU_CORES = "max_cpu_cores";
     public static final String MEM_LIMIT = "mem_limit";

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
@@ -266,7 +266,7 @@ public class ResourceGroupClassifier implements Writable {
      * than max.
      */
     public static class CostRange {
-        private static final String STR_RANGE_REGEX = "\\s*\\[\\s*(.+?)\\s*,\\s*(.+?)\\s*\\)\\s*";
+        private static final String STR_RANGE_REGEX = "^\\s*\\[\\s*(.+?)\\s*,\\s*(.+?)\\s*\\)\\s*$";
         private static final Pattern STR_RANGE_PATTERN = Pattern.compile(STR_RANGE_REGEX, Pattern.CASE_INSENSITIVE);
 
         public static final String FORMAT_STR_RANGE_MESSAGE = "the format must be '[min, max)' " +

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -54,6 +55,12 @@ public class ResourceGroupClassifier implements Writable {
     private long resourceGroupId;
     @SerializedName(value = "databaseIds")
     private Set<Long> databaseIds;
+
+    @SerializedName(value = "planCpuCostRange")
+    private CostRange planCpuCostRange;
+
+    @SerializedName(value = "planMemCostRange")
+    private CostRange planMemCostRange;
 
     public static ResourceGroupClassifier read(DataInput in) throws IOException {
         String json = Text.readString(in);
@@ -116,6 +123,14 @@ public class ResourceGroupClassifier implements Writable {
         return this.databaseIds;
     }
 
+    public void setPlanCpuCostRange(CostRange planCpuCostRange) {
+        this.planCpuCostRange = planCpuCostRange;
+    }
+
+    public void setPlanMemCostRange(CostRange planMemCostRange) {
+        this.planMemCostRange = planMemCostRange;
+    }
+
     @Override
     public void write(DataOutput out) throws IOException {
         String json = GsonUtils.GSON.toJson(this);
@@ -123,15 +138,21 @@ public class ResourceGroupClassifier implements Writable {
     }
 
     public boolean isSatisfied(String user, List<String> activeRoles, QueryType queryType, String sourceIp,
-                               Set<Long> dbIds) {
+                               Set<Long> dbIds, double planCpuCost, double planMemCost) {
         if (!isVisible(user, activeRoles, sourceIp)) {
             return false;
         }
         if (CollectionUtils.isNotEmpty(queryTypes) && !this.queryTypes.contains(queryType)) {
             return false;
         }
-        if (CollectionUtils.isNotEmpty(databaseIds)) {
-            return CollectionUtils.isNotEmpty(dbIds) && databaseIds.containsAll(dbIds);
+        if (CollectionUtils.isNotEmpty(databaseIds) && !(CollectionUtils.isNotEmpty(dbIds) && databaseIds.containsAll(dbIds))) {
+            return false;
+        }
+        if (planCpuCostRange != null && !planCpuCostRange.contains(planCpuCost)) {
+            return false;
+        }
+        if (planMemCostRange != null && !planMemCostRange.contains(planMemCost)) {
+            return false;
         }
 
         return true;
@@ -156,6 +177,12 @@ public class ResourceGroupClassifier implements Writable {
             w += 1;
         }
         if (role != null) {
+            w += 1;
+        }
+        if (planCpuCostRange != null) {
+            w += 1;
+        }
+        if (planMemCostRange != null) {
             w += 1;
         }
         if (queryTypes != null && !queryTypes.isEmpty()) {
@@ -201,6 +228,12 @@ public class ResourceGroupClassifier implements Writable {
         if (sourceIp != null) {
             classifiersStr.append(", source_ip=" + sourceIp);
         }
+        if (planCpuCostRange != null) {
+            classifiersStr.append(", ").append(ResourceGroup.PLAN_CPU_COST_RANGE).append("=").append(planCpuCostRange);
+        }
+        if (planMemCostRange != null) {
+            classifiersStr.append(", ").append(ResourceGroup.PLAN_MEM_COST_RANGE).append("=").append(planMemCostRange);
+        }
         classifiersStr.append(")");
         return classifiersStr.toString();
     }
@@ -223,6 +256,68 @@ public class ResourceGroupClassifier implements Writable {
             return type == TQueryType.LOAD
                     ? ResourceGroupClassifier.QueryType.INSERT
                     : ResourceGroupClassifier.QueryType.SELECT;
+        }
+    }
+
+    /**
+     * The cost range.
+     * <p> Fow now it always includes the left endpoint {@link #min} and excludes the right endpoint {@link #max}.
+     * The pattern is {@code [min, max)}, where min and max are double (including infinity and -infinity) and min must be less
+     * than max.
+     */
+    public static class CostRange {
+        private static final String STR_RANGE_REGEX = "\\s*\\[\\s*(.+?)\\s*,\\s*(.+?)\\s*\\)\\s*";
+        private static final Pattern STR_RANGE_PATTERN = Pattern.compile(STR_RANGE_REGEX, Pattern.CASE_INSENSITIVE);
+
+        public static final String FORMAT_STR_RANGE_MESSAGE = "the format must be '[min, max)' " +
+                "where min and max are double (including infinity and -infinity) " +
+                "and min must be less than max";
+
+        private final double min;
+        private final double max;
+
+        public CostRange(double min, double max) {
+            this.min = min;
+            this.max = max;
+        }
+
+        public static CostRange fromString(String rangeStr) {
+            Matcher matcher = STR_RANGE_PATTERN.matcher(rangeStr);
+            if (!matcher.find()) {
+                return null;
+            }
+
+            try {
+                double min = parseDoubleWithInfinity(matcher.group(1));
+                double max = parseDoubleWithInfinity(matcher.group(2));
+
+                if (min >= max) {
+                    return null;
+                }
+
+                return new CostRange(min, max);
+            } catch (Exception e) {
+                return null;
+            }
+        }
+
+        public boolean contains(double value) {
+            return min <= value && value < max;
+        }
+
+        @Override
+        public String toString() {
+            return "[" + min + ", " + max + ")";
+        }
+
+        private static double parseDoubleWithInfinity(String input) {
+            if ("infinity".equalsIgnoreCase(input)) {
+                return Double.POSITIVE_INFINITY;
+            } else if ("-infinity".equalsIgnoreCase(input)) {
+                return Double.NEGATIVE_INFINITY;
+            } else {
+                return Double.parseDouble(input);
+            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -560,21 +560,24 @@ public class ResourceGroupMgr implements Writable {
         try {
             String user = getUnqualifiedUser(ctx);
             String remoteIp = ctx.getRemoteIP();
+            final double planCpuCost = ctx.getAuditEventBuilder().build().planCpuCosts;
+            final double planMemCost = ctx.getAuditEventBuilder().build().planMemCosts;
 
             // check short query first
             if (shortQueryResourceGroup != null) {
-                List<ResourceGroupClassifier> shortQueryClassifierList =
-                        shortQueryResourceGroup.classifiers.stream().filter(
-                                        f -> f.isSatisfied(user, activeRoles, queryType, remoteIp, databases))
-                                .sorted(Comparator.comparingDouble(ResourceGroupClassifier::weight))
-                                .collect(Collectors.toList());
+                List<ResourceGroupClassifier> shortQueryClassifierList = shortQueryResourceGroup.classifiers.stream()
+                        .filter(f -> f.isSatisfied(user, activeRoles, queryType, remoteIp, databases, planCpuCost, planMemCost))
+                        .sorted(Comparator.comparingDouble(ResourceGroupClassifier::weight))
+                        .collect(Collectors.toList());
                 if (!shortQueryClassifierList.isEmpty()) {
                     return shortQueryResourceGroup.toThrift();
                 }
             }
 
             List<ResourceGroupClassifier> classifierList =
-                    classifierMap.values().stream().filter(f -> f.isSatisfied(user, activeRoles, queryType, remoteIp, databases))
+                    classifierMap.values().stream()
+                            .filter(f -> f.isSatisfied(user, activeRoles, queryType, remoteIp, databases, planCpuCost,
+                                    planMemCost))
                             .sorted(Comparator.comparingDouble(ResourceGroupClassifier::weight))
                             .collect(Collectors.toList());
             if (classifierList.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
@@ -91,6 +91,22 @@ public class ResourceGroupAnalyzer {
                         databaseIds.add(db.getId());
                     }
                     classifier.setDatabases(databaseIds);
+                } else if (key.equalsIgnoreCase(ResourceGroup.PLAN_CPU_COST_RANGE)) {
+                    ResourceGroupClassifier.CostRange planCpuCostRange = ResourceGroupClassifier.CostRange.fromString(value);
+                    if (planCpuCostRange == null) {
+                        throw new SemanticException(String.format("Illegal classifier specifier '%s': '%s', and "
+                                        + ResourceGroupClassifier.CostRange.FORMAT_STR_RANGE_MESSAGE,
+                                ResourceGroup.PLAN_CPU_COST_RANGE, eqPred.toSql()));
+                    }
+                    classifier.setPlanCpuCostRange(planCpuCostRange);
+                } else if (key.equalsIgnoreCase(ResourceGroup.PLAN_MEM_COST_RANGE)) {
+                    ResourceGroupClassifier.CostRange planMemCostRange = ResourceGroupClassifier.CostRange.fromString(value);
+                    if (planMemCostRange == null) {
+                        throw new SemanticException(String.format("Illegal classifier specifier '%s': '%s', and "
+                                        + ResourceGroupClassifier.CostRange.FORMAT_STR_RANGE_MESSAGE,
+                                ResourceGroup.PLAN_MEM_COST_RANGE, eqPred.toSql()));
+                    }
+                    classifier.setPlanMemCostRange(planMemCostRange);
                 } else {
                     throw new SemanticException(String.format("Unsupported classifier specifier: '%s'", key));
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -1,5 +1,6 @@
 package com.starrocks.analysis;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.ResourceGroupClassifier;
 import com.starrocks.common.AnalysisException;
@@ -899,5 +900,325 @@ public class ResourceGroupStmtTest {
         }
 
         starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg_valid_max_cpu_cores");
+    }
+
+    @Test
+    public void testChooseResourceGroupWithPlanCost() throws Exception {
+        String createRg1SQL = "create resource group rg1_plan_cost\n" +
+                "to (\n" +
+                "   user='rg1_user1'," +
+                "   plan_cpu_cost_range='[0, 1000)'," +
+                "   plan_mem_cost_range='[100, 200)'" +
+                ")\n" +
+                "   with (" +
+                "   'mem_limit' = '20%'," +
+                "   'cpu_core_limit' = '17'," +
+                "   'concurrency_limit' = '11'," +
+                "   'type' = 'normal'" +
+                "   );";
+        String createRg2SQL = "create resource group rg2_plan_cost\n" +
+                "to (\n" +
+                "   user='rg1_user1'," +
+                "   plan_cpu_cost_range='[0, 1000)'," +
+                "   plan_mem_cost_range='[151, 200)'" +
+                ")\n" +
+                "   with (" +
+                "   'mem_limit' = '20%'," +
+                "   'cpu_core_limit' = '17'," +
+                "   'concurrency_limit' = '11'," +
+                "   'type' = 'normal'" +
+                "   );";
+        String createRg3SQL = "create resource group rg3_plan_cost\n" +
+                "to (\n" +
+                "   user='rg1_user1'" +
+                ")\n" +
+                "   with (" +
+                "   'mem_limit' = '20%'," +
+                "   'cpu_core_limit' = '17'," +
+                "   'concurrency_limit' = '11'," +
+                "   'type' = 'normal'" +
+                "   );";
+        starRocksAssert.executeResourceGroupDdlSql(createRg1SQL);
+        starRocksAssert.executeResourceGroupDdlSql(createRg2SQL);
+        starRocksAssert.executeResourceGroupDdlSql(createRg3SQL);
+
+        final String qualifiedUser = "rg1_user1";
+        final String remoteIp = "192.168.2.4";
+
+        starRocksAssert.getCtx().setQualifiedUser(qualifiedUser);
+        starRocksAssert.getCtx().setCurrentUserIdentity(new UserIdentity(qualifiedUser, "%"));
+        starRocksAssert.getCtx().setCurrentRoleIds(
+                starRocksAssert.getCtx().getGlobalStateMgr().getAuthorizationMgr().getRoleIdsByUser(
+                        new UserIdentity(qualifiedUser, "%")
+                )
+        );
+        starRocksAssert.getCtx().setRemoteIP(remoteIp);
+
+        {
+            starRocksAssert.getCtx().getAuditEventBuilder().setPlanCpuCosts(100);
+            starRocksAssert.getCtx().getAuditEventBuilder().setPlanMemCosts(150);
+
+            TWorkGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
+                    starRocksAssert.getCtx(),
+                    ResourceGroupClassifier.QueryType.SELECT,
+                    null);
+            Assert.assertEquals("rg1_plan_cost", wg.getName());
+        }
+
+        {
+            starRocksAssert.getCtx().getAuditEventBuilder().setPlanCpuCosts(10000);
+            starRocksAssert.getCtx().getAuditEventBuilder().setPlanMemCosts(150);
+
+            TWorkGroup wg = GlobalStateMgr.getCurrentState().getResourceGroupMgr().chooseResourceGroup(
+                    starRocksAssert.getCtx(),
+                    ResourceGroupClassifier.QueryType.SELECT,
+                    null);
+            Assert.assertEquals("rg3_plan_cost", wg.getName());
+        }
+
+        starRocksAssert.executeResourceGroupDdlSql("drop resource group rg1_plan_cost");
+        starRocksAssert.executeResourceGroupDdlSql("drop resource group rg2_plan_cost");
+        starRocksAssert.executeResourceGroupDdlSql("drop resource group rg3_plan_cost");
+    }
+
+    @Test
+    public void testCreateWithLegalPlanCostRange() throws Exception {
+        String createSQLTemplate = "create resource group rg_valid_plan_cost_range\n" +
+                "to (\n" +
+                "   user='rg1_if_not_exists'," +
+                "   plan_cpu_cost_range='%s'," +
+                "   plan_mem_cost_range='%s'" +
+                ")\n" +
+                "   with (" +
+                "   'mem_limit' = '20%%'," +
+                "   'cpu_core_limit' = '17'," +
+                "   'concurrency_limit' = '11'," +
+                "   'type' = 'normal'" +
+                "   );";
+
+        class TestCase {
+            final String planCpuCostRange;
+            final String PlanMemCostRange;
+            final String expectedOutput;
+
+            public TestCase(String planCpuCostRange, String planMemCostRange, String expectedOutput) {
+                this.planCpuCostRange = planCpuCostRange;
+                PlanMemCostRange = planMemCostRange;
+                this.expectedOutput = expectedOutput;
+            }
+        }
+
+        List<TestCase> testCases = ImmutableList.of(
+                new TestCase("[1.12345678901234567,10.2)", "[2, 100.2)",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[1.1234567890123457, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
+                new TestCase("[1.1,10.2)", "[2, 100.2)",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[1.1, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
+
+                new TestCase("[-1,10)", "[2, 100)",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[-1.0, 10.0), plan_mem_cost_range=[2.0, 100.0))"),
+                new TestCase("[0, 10)", "[0, 100)",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))"),
+                new TestCase(" [ 0,  10) ", "  [ 0,  100  )  ",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))"),
+
+                new TestCase(" [ -infinity,  infinity) ", "  [ 0,  infinity  )  ",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[-Infinity, Infinity), plan_mem_cost_range=[0.0, Infinity))"),
+                new TestCase(" [ -Infinity,  INFINITY) ", "  [ 0,  INFINITY  )  ",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[-Infinity, Infinity), plan_mem_cost_range=[0.0, Infinity))"),
+                new TestCase(" [ -INFINITY,  infinity) ", "  [ 0,  infinity  )  ",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_if_not_exists, plan_cpu_cost_range=[-Infinity, Infinity), plan_mem_cost_range=[0.0, Infinity))")
+        );
+        for (TestCase c : testCases) {
+            String createSQL = String.format(createSQLTemplate, c.planCpuCostRange, c.PlanMemCostRange);
+            starRocksAssert.executeResourceGroupDdlSql(createSQL);
+
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg_valid_plan_cost_range");
+            String actual = rowsToString(rows);
+            Assert.assertEquals(c.expectedOutput, actual);
+
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg_valid_plan_cost_range");
+        }
+    }
+
+    @Test
+    public void testAlterWithLegalPlanCostRange() throws Exception {
+        String createSQL = "create resource group rg_valid_plan_cost_range\n" +
+                "to (\n" +
+                "   user='rg1_user'," +
+                "   plan_cpu_cost_range='[100, 1000)'," +
+                "   plan_mem_cost_range='[0, 100)'" +
+                ")\n" +
+                "   with (" +
+                "   'mem_limit' = '20%'," +
+                "   'cpu_core_limit' = '17'," +
+                "   'concurrency_limit' = '11'," +
+                "   'type' = 'normal'" +
+                "   );";
+
+        String alterTemplate = "ALTER RESOURCE GROUP rg_valid_plan_cost_range \n" +
+                "ADD \n" +
+                "   (user='rg1_user', plan_cpu_cost_range='%s', plan_mem_cost_range='%s')";
+
+        class TestCase {
+            final String planCpuCostRange;
+            final String PlanMemCostRange;
+            final String expectedOutput;
+
+            public TestCase(String planCpuCostRange, String planMemCostRange, String expectedOutput) {
+                this.planCpuCostRange = planCpuCostRange;
+                PlanMemCostRange = planMemCostRange;
+                this.expectedOutput = expectedOutput;
+            }
+        }
+
+        List<TestCase> testCases = ImmutableList.of(
+                new TestCase("[1.12345678901234567,10.2)", "[2, 100.2)",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.1234567890123457, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
+                new TestCase("[1.1,10.2)", "[2, 100.2)",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.1, 10.2), plan_mem_cost_range=[2.0, 100.2))"),
+
+                new TestCase("[-1,10)", "[2, 100)",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[-1.0, 10.0), plan_mem_cost_range=[2.0, 100.0))"),
+                new TestCase("[0, 10)", "[0, 100)",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))"),
+                new TestCase(" [ 0,  10) ", "  [ 0,  100  )  ",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[0.0, 10.0), plan_mem_cost_range=[0.0, 100.0))"),
+
+                new TestCase(" [ -infinity,  infinity) ", "  [ 0,  infinity  )  ",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[-Infinity, Infinity), plan_mem_cost_range=[0.0, Infinity))"),
+                new TestCase(" [ -Infinity,  INFINITY) ", "  [ 0,  INFINITY  )  ",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[-Infinity, Infinity), plan_mem_cost_range=[0.0, Infinity))"),
+                new TestCase(" [ -INFINITY,  infinity) ", "  [ 0,  infinity  )  ",
+                        "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[100.0, 1000.0), plan_mem_cost_range=[0.0, 100.0))\n" +
+                                "rg_valid_plan_cost_range|17|20.0%|null|0|0|0|11|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[-Infinity, Infinity), plan_mem_cost_range=[0.0, Infinity))")
+        );
+        for (TestCase c : testCases) {
+            starRocksAssert.executeResourceGroupDdlSql(createSQL);
+
+            String alterSQL = String.format(alterTemplate, c.planCpuCostRange, c.PlanMemCostRange);
+            starRocksAssert.executeResourceGroupDdlSql(alterSQL);
+
+            List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource group rg_valid_plan_cost_range");
+            String actual = rowsToString(rows);
+            Assert.assertEquals(c.expectedOutput, actual);
+
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg_valid_plan_cost_range");
+        }
+
+    }
+
+    @Test
+    public void testCreateWithIllegalPlanCostRange() {
+        String createSQLTemplate = "create resource group rg_valid_plan_cost_range\n" +
+                "to (\n" +
+                "   user='rg1_if_not_exists'," +
+                "   plan_cpu_cost_range='%s'," +
+                "   plan_mem_cost_range='%s'" +
+                ")\n" +
+                "   with (" +
+                "   'mem_limit' = '20%%'," +
+                "   'cpu_core_limit' = '17'," +
+                "   'concurrency_limit' = '11'," +
+                "   'type' = 'normal'" +
+                "   );";
+
+        class TestCase {
+            final String planCpuCostRange;
+            final String PlanMemCostRange;
+            final String expectedErrMsg;
+
+            public TestCase(String planCpuCostRange, String planMemCostRange) {
+                this.planCpuCostRange = planCpuCostRange;
+                PlanMemCostRange = planMemCostRange;
+                this.expectedErrMsg = ResourceGroupClassifier.CostRange.FORMAT_STR_RANGE_MESSAGE;
+            }
+        }
+
+        List<TestCase> testCases = ImmutableList.of(
+                new TestCase("[1, 10]", "[2, 100)"),
+
+                new TestCase("[1,1 0)", "[2, 100)"),
+                new TestCase("[1,1.1.0)", "[2, 100)"),
+                new TestCase("[2, 100)", "[-1-2, 1.0)"),
+                new TestCase("[- 1, 1.0)", "[2, 100)"),
+                new TestCase("[I nfinity, 10)", "[2, 100)"),
+
+                new TestCase("[1000,10)", "[2, 100)"),
+                new TestCase("[1000,-1)", "[2, 100)"),
+                new TestCase("[1000,-infinity)", "[2, 100)"),
+                new TestCase("[infinity,1000)", "[2, 100)"),
+
+                new TestCase("[abc, 1000)", "[2, 100)")
+        );
+        for (TestCase c : testCases) {
+            String sql = String.format(createSQLTemplate, c.planCpuCostRange, c.PlanMemCostRange);
+            Assert.assertThrows(c.expectedErrMsg, SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(sql));
+        }
+    }
+
+    @Test
+    public void testAlterWithIllegalPlanCostRange() throws Exception {
+        String createSQL = "create resource group rg_valid_plan_cost_range\n" +
+                "to (\n" +
+                "   user='rg1_user'," +
+                "   plan_cpu_cost_range='[100, 1000)'," +
+                "   plan_mem_cost_range='[0, 100)'" +
+                ")\n" +
+                "   with (" +
+                "   'mem_limit' = '20%'," +
+                "   'cpu_core_limit' = '17'," +
+                "   'concurrency_limit' = '11'," +
+                "   'type' = 'normal'" +
+                "   );";
+
+        String alterTemplate = "ALTER RESOURCE GROUP rg_valid_plan_cost_range \n" +
+                "ADD \n" +
+                "   (user='rg1_user', plan_cpu_cost_range='%s', plan_mem_cost_range='%s')";
+
+        class TestCase {
+            final String planCpuCostRange;
+            final String PlanMemCostRange;
+            final String expectedErrMsg;
+
+            public TestCase(String planCpuCostRange, String planMemCostRange) {
+                this.planCpuCostRange = planCpuCostRange;
+                PlanMemCostRange = planMemCostRange;
+                this.expectedErrMsg = ResourceGroupClassifier.CostRange.FORMAT_STR_RANGE_MESSAGE;
+            }
+        }
+
+        List<TestCase> testCases = ImmutableList.of(
+                new TestCase("[1, 10]", "[2, 100)"),
+
+                new TestCase("[1,1 0)", "[2, 100)"),
+                new TestCase("[1,1.1.0)", "[2, 100)"),
+                new TestCase("[-1-2, 1.0)", "[2, 100)"),
+                new TestCase("[- 1, 1.0)", "[2, 100)"),
+                new TestCase("[I nfinity, 10)", "[2, 100)"),
+
+                new TestCase("[1000,10)", "[2, 100)"),
+                new TestCase("[1000,-1)", "[2, 100)"),
+                new TestCase("[1000,-infinity)", "[2, 100)"),
+                new TestCase("[infinity,1000)", "[2, 100)"),
+
+                new TestCase("[abc, 1000)", "[2, 100)")
+        );
+        for (TestCase c : testCases) {
+            starRocksAssert.executeResourceGroupDdlSql(createSQL);
+
+            String alterSQL = String.format(alterTemplate, c.planCpuCostRange, c.PlanMemCostRange);
+            Assert.assertThrows(c.expectedErrMsg, SemanticException.class,
+                    () -> starRocksAssert.executeResourceGroupDdlSql(alterSQL));
+
+            starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP rg_valid_plan_cost_range");
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -1142,6 +1142,9 @@ public class ResourceGroupStmtTest {
         }
 
         List<TestCase> testCases = ImmutableList.of(
+                new TestCase("a [1, 10)", "[2, 100)"),
+                new TestCase("[1, 10)", "[2, 100) b"),
+
                 new TestCase("[1, 10]", "[2, 100)"),
 
                 new TestCase("[1,1 0)", "[2, 100)"),


### PR DESCRIPTION
```SQL
> create resource group rg1 to (  
    query_type in ('select'), 
    plan_cpu_cost_range='[1, 10)', 
    plan_mem_cost_range='[1,1e200)'  
) with (
    'cpu_core_limit' = '2', 
    'mem_limit' = '80%', 
    'concurrency_limit'='3',
    'max_cpu_cores'='2');

> SHOW RESOURCE GROUPs  ALL
-------------------------------------------------+
| name | id    | cpu_core_limit | mem_limit | max_cpu_cores | big_query_cpu_second_limit | big_query_scan_rows_limit | big_query_mem_limit | concurrency_limit | type   | classifiers                                                                                                          |
+------+-------+----------------+-----------+---------------+----------------------------+---------------------------+---------------------+-------------------+--------+----------------------------------------------------------------------------------------------------------------------+
| rg1  | 14003 | 2              | 80.0%     | 2             | 0                          | 0                         | 0                   | 3                 | NORMAL | (id=14004, weight=3.1, query_type in (SELECT), plan_cpu_cost_range=[1.0, 10.0), plan_mem_cost_range=[1.0, 1e200)) |
+------+-------+----------------+-----------+---------------+----------------------------+---------------------------+---------------------+-------------------+--------+----------------------------------------------------------------------------------------------------------------------+
```

I would update the document in the next PR.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
