### PR TITLE
[Enhancement][BugFix] fix the problem that the spill dir cannot be deleted when the query exits abnormally

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -238,6 +238,7 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(RuntimeState* state, const 
                                                        _parent->_is_pipeline_level_shuffle ? driver_sequence : -1));
             _current_request_bytes += chunk_size;
             COUNTER_UPDATE(_parent->_bytes_pass_through_counter, chunk_size);
+            COUNTER_SET(_parent->_pass_through_buffer_peak_mem_usage, _pass_through_context.total_bytes());
         } else {
             if (_parent->_is_pipeline_level_shuffle) {
                 _chunk_request->add_driver_sequences(driver_sequence);
@@ -441,6 +442,9 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
     _serialize_chunk_timer = ADD_TIMER(_unique_metrics, "SerializeChunkTime");
     _shuffle_hash_timer = ADD_TIMER(_unique_metrics, "ShuffleHashTime");
     _compress_timer = ADD_TIMER(_unique_metrics, "CompressTime");
+    _pass_through_buffer_peak_mem_usage = _unique_metrics->AddHighWaterMarkCounter(
+            "PassThroughBufferPeakMemoryUsage", TUnit::BYTES,
+            RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_FIRST_MERGE));
 
     for (auto& [_, channel] : _instance_id2channel) {
         RETURN_IF_ERROR(channel->init(state));

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -177,6 +177,7 @@ private:
     RuntimeProfile::Counter* _compress_timer = nullptr;
     RuntimeProfile::Counter* _bytes_pass_through_counter = nullptr;
     RuntimeProfile::Counter* _uncompressed_bytes_counter = nullptr;
+    RuntimeProfile::HighWaterMarkCounter* _pass_through_buffer_peak_mem_usage = nullptr;
 
     std::atomic<bool> _is_finished = false;
     std::atomic<bool> _is_cancelled = false;

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
@@ -68,6 +68,7 @@ bool BalancedChunkBuffer::try_get(int buffer_index, ChunkPtr* output_chunk) {
     bool ok = _get_sub_buffer(buffer_index)->try_get(&chunk_with_token);
     if (ok) {
         *output_chunk = std::move(chunk_with_token.first);
+        _memory_usage -= (*output_chunk)->memory_usage();
     }
     return ok;
 }
@@ -77,18 +78,24 @@ bool BalancedChunkBuffer::put(int buffer_index, ChunkPtr chunk, ChunkBufferToken
     // EOS chunks may be empty and must be delivered in order to notify CacheOperator that all chunks of the tablet
     // has been processed.
     if (!chunk || (!chunk->owner_info().is_last_chunk() && chunk->num_rows() == 0)) return true;
+    bool ret;
+    size_t memory_usage = chunk->memory_usage();
     if (_strategy == BalanceStrategy::kDirect) {
-        return _get_sub_buffer(buffer_index)->put(std::make_pair(std::move(chunk), std::move(chunk_token)));
+        ret = _get_sub_buffer(buffer_index)->put(std::make_pair(std::move(chunk), std::move(chunk_token)));
     } else if (_strategy == BalanceStrategy::kRoundRobin) {
         // TODO: try to balance data according to number of rows
         // But the hard part is, that may needs to maintain a min-heap to account the rows of each
         // output operator, which would introduce some extra overhead
         int target_index = _output_index.fetch_add(1);
         target_index %= _output_operators;
-        return _get_sub_buffer(target_index)->put(std::make_pair(std::move(chunk), std::move(chunk_token)));
+        ret = _get_sub_buffer(target_index)->put(std::make_pair(std::move(chunk), std::move(chunk_token)));
     } else {
         CHECK(false) << "unreachable";
     }
+    if (ret) {
+        _memory_usage += memory_usage;
+    }
+    return ret;
 }
 
 void BalancedChunkBuffer::set_finished(int buffer_index) {

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
@@ -46,6 +46,8 @@ public:
     ChunkBufferLimiter* limiter() { return _limiter.get(); }
     void update_limiter(Chunk* chunk);
 
+    int64_t memory_usage() const { return _memory_usage; }
+
 private:
     struct LimiterContext {
         // ========================
@@ -67,6 +69,7 @@ private:
     const BalanceStrategy _strategy;
     std::vector<SubBuffer> _sub_buffers;
     std::atomic_int64_t _output_index = 0;
+    std::atomic_int64_t _memory_usage = 0;
 
     ChunkBufferLimiterPtr _limiter;
     LimiterContext _limiter_context;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -225,6 +225,12 @@ size_t ConnectorScanOperator::buffer_capacity() const {
     return buffer.limiter()->capacity();
 }
 
+size_t ConnectorScanOperator::buffer_memory_usage() const {
+    auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
+    auto& buffer = factory->get_chunk_buffer();
+    return buffer.memory_usage();
+}
+
 size_t ConnectorScanOperator::default_buffer_capacity() const {
     auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
     auto& buffer = factory->get_chunk_buffer();

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -82,6 +82,7 @@ public:
     size_t num_buffered_chunks() const override;
     size_t buffer_size() const override;
     size_t buffer_capacity() const override;
+    size_t buffer_memory_usage() const override;
     size_t default_buffer_capacity() const override;
     ChunkBufferTokenPtr pin_chunk(int num_chunks) override;
     bool is_buffer_full() const override;

--- a/be/src/exec/pipeline/scan/meta_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/meta_scan_operator.cpp
@@ -82,6 +82,10 @@ size_t MetaScanOperator::buffer_capacity() const {
     return _ctx->get_chunk_buffer().limiter()->capacity();
 }
 
+size_t MetaScanOperator::buffer_memory_usage() const {
+    return _ctx->get_chunk_buffer().memory_usage();
+}
+
 size_t MetaScanOperator::default_buffer_capacity() const {
     return _ctx->get_chunk_buffer().limiter()->default_capacity();
 }

--- a/be/src/exec/pipeline/scan/meta_scan_operator.h
+++ b/be/src/exec/pipeline/scan/meta_scan_operator.h
@@ -62,6 +62,7 @@ private:
     size_t num_buffered_chunks() const override;
     size_t buffer_size() const override;
     size_t buffer_capacity() const override;
+    size_t buffer_memory_usage() const override;
     size_t default_buffer_capacity() const override;
     ChunkBufferTokenPtr pin_chunk(int num_chunks) override;
     bool is_buffer_full() const override;

--- a/be/src/exec/pipeline/scan/olap_meta_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_meta_scan_operator.cpp
@@ -87,6 +87,10 @@ size_t OlapMetaScanOperator::buffer_capacity() const {
     return _ctx->get_chunk_buffer().limiter()->capacity();
 }
 
+size_t OlapMetaScanOperator::buffer_memory_usage() const {
+    return _ctx->get_chunk_buffer().memory_usage();
+}
+
 size_t OlapMetaScanOperator::default_buffer_capacity() const {
     return _ctx->get_chunk_buffer().limiter()->default_capacity();
 }

--- a/be/src/exec/pipeline/scan/olap_meta_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_meta_scan_operator.h
@@ -62,6 +62,7 @@ private:
     size_t num_buffered_chunks() const override;
     size_t buffer_size() const override;
     size_t buffer_capacity() const override;
+    size_t buffer_memory_usage() const override;
     size_t default_buffer_capacity() const override;
     ChunkBufferTokenPtr pin_chunk(int num_chunks) override;
     bool is_buffer_full() const override;

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -142,6 +142,10 @@ size_t OlapScanOperator::buffer_capacity() const {
     return _ctx->get_chunk_buffer().limiter()->capacity();
 }
 
+size_t OlapScanOperator::buffer_memory_usage() const {
+    return _ctx->get_chunk_buffer().memory_usage();
+}
+
 size_t OlapScanOperator::default_buffer_capacity() const {
     return _ctx->get_chunk_buffer().limiter()->default_capacity();
 }

--- a/be/src/exec/pipeline/scan/olap_scan_operator.h
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.h
@@ -71,6 +71,7 @@ protected:
     size_t num_buffered_chunks() const override;
     size_t buffer_size() const override;
     size_t buffer_capacity() const override;
+    size_t buffer_memory_usage() const override;
     size_t default_buffer_capacity() const override;
     ChunkBufferTokenPtr pin_chunk(int num_chunks) override;
     bool is_buffer_full() const override;

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -72,6 +72,11 @@ Status ScanOperator::prepare(RuntimeState* state) {
             RuntimeProfile::Counter::create_strategy(TUnit::UNIT, TCounterMergeType::SKIP_ALL),
             RuntimeProfile::ROOT_COUNTER);
 
+    _peak_buffer_memory_usage = _unique_metrics->AddHighWaterMarkCounter(
+            "PeakChunkBufferMemoryUsage", TUnit::BYTES,
+            RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_ALL),
+            RuntimeProfile::ROOT_COUNTER);
+
     _morsels_counter = ADD_COUNTER(_unique_metrics, "MorselsCount", TUnit::UNIT);
     _submit_task_counter = ADD_COUNTER(_unique_metrics, "SubmitTaskCount", TUnit::UNIT);
     _peak_scan_task_queue_size_counter = _unique_metrics->AddHighWaterMarkCounter(
@@ -227,6 +232,7 @@ StatusOr<ChunkPtr> ScanOperator::pull_chunk(RuntimeState* state) {
     RETURN_IF_ERROR(_get_scan_status());
 
     _peak_buffer_size_counter->set(buffer_size());
+    _peak_buffer_memory_usage->set(buffer_memory_usage());
 
     RETURN_IF_ERROR(_try_to_trigger_next_scan(state));
     ChunkPtr res = get_chunk_from_buffer();

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -103,6 +103,7 @@ protected:
     virtual size_t num_buffered_chunks() const = 0;
     virtual size_t buffer_size() const = 0;
     virtual size_t buffer_capacity() const = 0;
+    virtual size_t buffer_memory_usage() const = 0;
     virtual size_t default_buffer_capacity() const = 0;
     virtual ChunkBufferTokenPtr pin_chunk(int num_chunks) = 0;
     virtual bool is_buffer_full() const = 0;
@@ -190,6 +191,7 @@ private:
     RuntimeProfile::Counter* _buffer_capacity_counter = nullptr;
     RuntimeProfile::HighWaterMarkCounter* _peak_buffer_size_counter = nullptr;
     RuntimeProfile::HighWaterMarkCounter* _peak_scan_task_queue_size_counter = nullptr;
+    RuntimeProfile::HighWaterMarkCounter* _peak_buffer_memory_usage = nullptr;
     // The total number of the original tablets in this fragment instance.
     RuntimeProfile::Counter* _tablets_counter = nullptr;
     RuntimeProfile::HighWaterMarkCounter* _peak_io_tasks_counter = nullptr;

--- a/be/src/exec/pipeline/scan/schema_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/schema_scan_operator.cpp
@@ -78,6 +78,10 @@ size_t SchemaScanOperator::buffer_capacity() const {
     return _ctx->get_chunk_buffer().limiter()->capacity();
 }
 
+size_t SchemaScanOperator::buffer_memory_usage() const {
+    return _ctx->get_chunk_buffer().memory_usage();
+}
+
 size_t SchemaScanOperator::default_buffer_capacity() const {
     return _ctx->get_chunk_buffer().limiter()->default_capacity();
 }

--- a/be/src/exec/pipeline/scan/schema_scan_operator.h
+++ b/be/src/exec/pipeline/scan/schema_scan_operator.h
@@ -63,6 +63,7 @@ private:
     size_t num_buffered_chunks() const override;
     size_t buffer_size() const override;
     size_t buffer_capacity() const override;
+    size_t buffer_memory_usage() const override;
     size_t default_buffer_capacity() const override;
     ChunkBufferTokenPtr pin_chunk(int num_chunks) override;
     bool is_buffer_full() const override;

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -45,6 +45,8 @@ public:
     ~LogBlockContainer() {
         TRACE_SPILL_LOG << "delete spill container file: " << path();
         WARN_IF_ERROR(_dir->fs()->delete_file(path()), fmt::format("cannot delete spill container file: {}", path()));
+        // try to delete related dir, only the last one can success, we ignore the error
+        (void)(_dir->fs()->delete_dir(parent_path()));
     }
 
     Status open();
@@ -60,12 +62,9 @@ public:
         return _writable_file->size();
     }
     std::string path() const {
-        // std::ostringstream oss;
-        // oss << _dir->dir() << "/" << print_id(_query_id) << "/" << _plan_node_name << "-" << _plan_node_id << "-"
-        //     << _id;
         return fmt::format("{}/{}/{}-{}-{}", _dir->dir(), print_id(_query_id), _plan_node_name, _plan_node_id, _id);
-        // return oss.str();
     }
+    std::string parent_path() const { return fmt::format("{}/{}", _dir->dir(), print_id(_query_id)); }
     uint64_t id() const { return _id; }
 
     Status ensure_preallocate(size_t length);
@@ -230,11 +229,6 @@ LogBlockManager::~LogBlockManager() {
         for (auto& [_, containers] : *container_map) {
             containers.reset();
         }
-        // @TODO context dependency?
-        // @TODO make lifecycle is correct
-        std::string container_dir = dir->dir() + "/" + print_id(_query_id);
-        WARN_IF_ERROR(dir->fs()->delete_dir(container_dir),
-                      fmt::format("cannot delete spill container dir: {}", container_dir));
     }
 }
 

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -60,10 +60,11 @@ public:
         return _writable_file->size();
     }
     std::string path() const {
-        std::ostringstream oss;
-        oss << _dir->dir() << "/" << print_id(_query_id) << "/" << _plan_node_name << "-" << _plan_node_id << "-"
-            << _id;
-        return oss.str();
+        // std::ostringstream oss;
+        // oss << _dir->dir() << "/" << print_id(_query_id) << "/" << _plan_node_name << "-" << _plan_node_id << "-"
+        //     << _id;
+        return fmt::format("{}/{}/{}-{}-{}", _dir->dir(), print_id(_query_id), _plan_node_name, _plan_node_id, _id);
+        // return oss.str();
     }
     uint64_t id() const { return _id; }
 
@@ -229,6 +230,8 @@ LogBlockManager::~LogBlockManager() {
         for (auto& [_, containers] : *container_map) {
             containers.reset();
         }
+        // @TODO context dependency?
+        // @TODO make lifecycle is correct
         std::string container_dir = dir->dir() + "/" + print_id(_query_id);
         WARN_IF_ERROR(dir->fs()->delete_dir(container_dir),
                       fmt::format("cannot delete spill container dir: {}", container_dir));

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -70,6 +70,14 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile, std::atomic_in
     partition_writer_peak_memory_usage =
             profile->AddHighWaterMarkCounter("PartitionWriterPeakMemoryBytes", TUnit::BYTES,
                                              RuntimeProfile::Counter::create_strategy(TUnit::BYTES), parent);
+
+    block_count = ADD_CHILD_COUNTER(profile, "BlockCount", TUnit::UNIT, parent);
+    flush_io_task_count = ADD_CHILD_COUNTER(profile, "FlushIOTaskCount", TUnit::UNIT, parent);
+    peak_flush_io_task_count = profile->AddHighWaterMarkCounter(
+            "PeakFlushIOTaskCount", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT), parent);
+    restore_io_task_count = ADD_CHILD_COUNTER(profile, "RestoreIOTaskCount", TUnit::UNIT, parent);
+    peak_restore_io_task_count = profile->AddHighWaterMarkCounter(
+            "PeakRestoreIOTaskCount", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT), parent);
 }
 
 Status Spiller::prepare(RuntimeState* state) {

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -76,6 +76,10 @@ public:
     RuntimeProfile::HighWaterMarkCounter* mem_table_peak_memory_usage = nullptr;
     // peak memory usage of input stream
     RuntimeProfile::HighWaterMarkCounter* input_stream_peak_memory_usage = nullptr;
+    // time spent to sort chunk before flush
+    RuntimeProfile::Counter* sort_chunk_timer = nullptr;
+    // time spent to materialize chunk by permutation
+    RuntimeProfile::Counter* materialize_chunk_timer = nullptr;
 
     // time spent to shuffle data to the corresponding partition, only used in join operator
     RuntimeProfile::Counter* shuffle_timer = nullptr;
@@ -87,6 +91,14 @@ public:
     RuntimeProfile::Counter* restore_from_mem_table_rows = nullptr;
     // peak memory usage of partition writer, only used in join operator
     RuntimeProfile::HighWaterMarkCounter* partition_writer_peak_memory_usage = nullptr;
+
+    // the number of blocks created
+    RuntimeProfile::Counter* block_count = nullptr;
+    // spill task/ restore task
+    RuntimeProfile::Counter* flush_io_task_count = nullptr;
+    RuntimeProfile::HighWaterMarkCounter* peak_flush_io_task_count = nullptr;
+    RuntimeProfile::Counter* restore_io_task_count = nullptr;
+    RuntimeProfile::HighWaterMarkCounter* peak_restore_io_task_count = nullptr;
 };
 
 // major spill interfaces

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -170,6 +170,8 @@ Status RawSpillerWriter::flush(RuntimeState* state, TaskExecutor&& executor, Mem
     };
     // submit io task
     RETURN_IF_ERROR(executor.submit(std::move(task)));
+    COUNTER_UPDATE(_spiller->metrics().flush_io_task_count, 1);
+    COUNTER_SET(_spiller->metrics().peak_flush_io_task_count, _running_flush_tasks);
     return Status::OK();
 }
 
@@ -214,6 +216,8 @@ Status SpillerReader::trigger_restore(RuntimeState* state, TaskExecutor&& execut
             return Status::OK();
         };
         RETURN_IF_ERROR(executor.submit(std::move(restore_task)));
+        COUNTER_UPDATE(_spiller->metrics().restore_io_task_count, 1);
+        COUNTER_SET(_spiller->metrics().peak_flush_io_task_count, _running_restore_tasks);
     }
     return Status::OK();
 }
@@ -293,6 +297,8 @@ Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush,
     };
 
     RETURN_IF_ERROR(executor.submit(std::move(task)));
+    COUNTER_UPDATE(_spiller->metrics().flush_io_task_count, 1);
+    COUNTER_SET(_spiller->metrics().peak_flush_io_task_count, _running_flush_tasks);
 
     return Status::OK();
 }

--- a/be/src/runtime/local_pass_through_buffer.h
+++ b/be/src/runtime/local_pass_through_buffer.h
@@ -62,6 +62,7 @@ public:
     void init();
     void append_chunk(int sender_id, const Chunk* chunk, size_t chunk_size, int32_t driver_sequence);
     void pull_chunks(int sender_id, ChunkUniquePtrVector* chunks, std::vector<size_t>* bytes);
+    int64_t total_bytes() const;
 
 private:
     // hold this chunk buffer to avoid early deallocation.


### PR DESCRIPTION
1. fix the problem that the spill directory cannot be deleted when the query exits abnormally
2. add more metrics to observe the memory occupied by buffers in each operator, such as the chunk buffer of scan operator, the passthrough buffer of exchange operator, etc.
3. add more metrics to observe the number of spill io tasks
4. add more metrics to observe the time spent in spill mem table sort

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
