### PR TITLE
[Enhancement] support to topn runtime filter with external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -842,7 +842,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
             for (TupleId tupleId : getTupleIds()) {
                 for (SlotDescriptor slot : descTbl.getTupleDesc(tupleId).getSlots()) {
                     // TopN Filter only works in no-nullable column
-                    if (slot.getId().equals(slotRef.getSlotId()) && !slotRef.isNullable()) {
+                    if (slot.getId().equals(slotRef.getSlotId()) && (!slotRef.isNullable() || rfDesc.isNullLast())) {
                         return true;
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RuntimeFilterDescription.java
@@ -17,6 +17,7 @@ package com.starrocks.planner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.SortInfo;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TRuntimeFilterBuildJoinMode;
@@ -73,6 +74,8 @@ public class RuntimeFilterDescription {
     // join's equal conjuncts size > 1.
     private final Map<Integer, List<Expr>> nodeIdToParitionByExprs = Maps.newHashMap();
 
+    private SortInfo sortInfo;
+
     public RuntimeFilterDescription(SessionVariable sv) {
         nodeIdToProbeExpr = new HashMap<>();
         mergeNodes = new ArrayList<>();
@@ -122,6 +125,14 @@ public class RuntimeFilterDescription {
         this.type = type;
     }
 
+    public SortInfo getSortInfo() {
+        return sortInfo;
+    }
+
+    public void setSortInfo(SortInfo sortInfo) {
+        this.sortInfo = sortInfo;
+    }
+
     public boolean canProbeUse(PlanNode node) {
         if (!canAcceptFilter(node)) {
             return false;
@@ -148,10 +159,24 @@ public class RuntimeFilterDescription {
 
     // return true if Node could accept the Filter
     public boolean canAcceptFilter(PlanNode node) {
-        if (RuntimeFilterType.TOPN_FILTER.equals(runtimeFilterType()) && !(node instanceof OlapScanNode)) {
+        if (RuntimeFilterType.TOPN_FILTER.equals(runtimeFilterType())) {
+            if (node instanceof ScanNode) {
+                ScanNode scanNode = (ScanNode) node;
+                return scanNode.isOlapScanNode() || scanNode.isExternalTableScanNodeWithFileSystem();
+            } else {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public boolean isNullLast() {
+        if (sortInfo != null) {
+            return !sortInfo.getNullsFirst().get(0);
+        } else {
             return false;
         }
-        return true;
     }
 
     public void enterExchangeNode() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -146,4 +146,13 @@ public abstract class ScanNode extends PlanNode {
 
         return columnAccessPaths.stream().map(ColumnAccessPath::toThrift).collect(Collectors.toList());
     }
+
+    public boolean isExternalTableScanNodeWithFileSystem() {
+        return this instanceof HdfsScanNode || this instanceof IcebergScanNode || this instanceof HudiScanNode ||
+                this instanceof PaimonScanNode || this instanceof DeltaLakeScanNode;
+    }
+
+    public boolean isOlapScanNode() {
+        return this instanceof OlapScanNode;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -158,6 +158,7 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
         rf.setExprOrder(0);
         rf.setJoinMode(JoinNode.DistributionMode.BROADCAST);
         rf.setOnlyLocal(true);
+        rf.setSortInfo(getSortInfo());
         rf.setBuildExpr(orderBy);
         rf.setRuntimeFilterType(RuntimeFilterDescription.RuntimeFilterType.TOPN_FILTER);
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -334,6 +334,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String RUNTIME_FILTER_ON_EXCHANGE_NODE = "runtime_filter_on_exchange_node";
     public static final String ENABLE_MULTI_COLUMNS_ON_GLOBAL_RUNTIME_FILTER =
             "enable_multicolumn_global_runtime_filter";
+
     public static final String ENABLE_OPTIMIZER_TRACE_LOG = "enable_optimizer_trace_log";
     public static final String ENABLE_MV_OPTIMIZER_TRACE_LOG = "enable_mv_optimizer_trace_log";
 


### PR DESCRIPTION
Fixes #issue
Because following two limitations when using topn rf.
1. Currently we don't support `or` predicate filtering.
2. External table column must be nullable.

So we can only build topn rf in case of null last on external table. Currently if the user can confirm that there is no null in sort column and want to use this optimization, they can
1. modify sql to "order by c1 NULLS LAST"
2. set sql_mode='SORT_NULLS_LAST';
3. set enable_external_table_topn_rf_with_null_first = true (Currently, it only supports order by column and cannot support order by expr, so this method is not supported now. )

Some test cases:
1 fe 3be 8c 16g tpch 1TB hive external table


case 1 :  `select l_partkey, l_orderkey from lineitem order by l_orderkey NULLS LAST  limit 10`
| file format | base | patched |
|--------|--------|--------|
| parquet   | 75s | 2s |
| orc   | 60s | 3s |

case 2: ` select l_partkey, l_orderkey from lineitem order by l_partkey NULLS LAST  limit 10;`

 file format | base | patched |
|--------|--------|--------|
| parquet   | 85s | 3s |
| orc   | 62s | 3.5s |

case 3 ` select l_orderkey,l_suppkey from lineitem order by l_suppkey  NULLS LAST limit 10;`

 file format | base | patched |
|--------|--------|--------|
| parquet   | 73s | 7s |
| orc   | 73s | 8.4s |

case 4 ` SELECT
    *
FROM
    (
        SELECT
            l.l_partkey, l.l_orderkey,
            p.p_name,
            p.p_brand
        FROM
            lineitem l
            LEFT JOIN part p ON l.l_partkey = p.p_partkey
    ) AS mocktable
ORDER BY
    mocktable.l_partkey NULLS LAST
LIMIT
    20;`

 file format | base | patched |
|--------|--------|--------|
| parquet   | 68s | 8s |
| orc   | 73s | 15s |

I think the effect will be better after parquet page index is supported.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
