### PR TITLE
[BugFix] Lost replica by mistake on BE if tablet meta checkpoint and restore executed concurrently (#30588)

### DIFF
--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -727,8 +727,11 @@ Status SnapshotLoader::move(const std::string& snapshot_path, const TabletShared
     // snapshot loader not need to change tablet uid
     // fixme: there is no header now and can not call load_one_tablet here
     // reload header
-    status = StorageEngine::instance()->tablet_manager()->load_tablet_from_dir(store, tablet_id, schema_hash,
-                                                                               tablet_path, true);
+    {
+        std::unique_lock l(tablet->get_meta_store_lock());
+        status = StorageEngine::instance()->tablet_manager()->load_tablet_from_dir(store, tablet_id, schema_hash,
+                                                                                   tablet_path, true);
+    }
     if (!status.ok()) {
         LOG(WARNING) << "Fail to reload header of tablet. tablet_id=" << tablet_id << " err=" << status.to_string();
         return status;

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -187,6 +187,8 @@ public:
     // should use with migration lock.
     void set_is_migrating(bool is_migrating) { _is_migrating = is_migrating; }
 
+    std::shared_mutex& get_meta_store_lock() { return _meta_store_lock; }
+
     // check tablet is migrating or has been migrated.
     // if tablet is migrating or has been migrated, return true.
     // should use with migration lock.
@@ -359,6 +361,8 @@ private:
     OnceFlag _init_once;
     // meta store lock is used for prevent 2 threads do checkpoint concurrently
     // it will be used in econ-mode in the future
+    // This lock will be also used for prevent SnapshotLoader::move and checkpoint
+    // concurrently for restoring the tablet.
     std::shared_mutex _meta_store_lock;
     std::mutex _ingest_lock;
     std::mutex _base_lock;


### PR DESCRIPTION
Problem:
This problem caused by concurrency between tablet meta checkpoint and restore. For restore of non-primary key table, StarRocks will create a new tablet to replace the old tablet which create in the beginning of restore. If the tablet meta checkpoint get the old tablet before the replacement and finish the checkpoint after replacement, the new tablet meta will be overwrite by the wrong metadata. If BE restart, it will get the wrong tablet meta.

The following is the thread execution flow that triggers the bug:

Thread tablet_meta_checkpoint: get the old tablet
Thread restore: create a new tablet, reset backup rowsetid and replace the old tablet, save the
                new tablet meta in rocksdb
Thread tablet_meta_checkpoint: save the old tablet meta which overwrite the new tablet meta cause the problem.

This problem will only affect non-primary key table

Solution:
use the _meta_store_lock to prevent SnapshotLoader::move and checkpoint

Fixes #30588

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
