### PR TITLE
[BugFix] remove varchar length check for jdbc scanner

### DIFF
--- a/be/src/exec/jdbc_scanner.cpp
+++ b/be/src/exec/jdbc_scanner.cpp
@@ -396,24 +396,6 @@ Status JDBCScanner::_fill_chunk(jobject jchunk, size_t num_rows, ChunkPtr* chunk
             auto st =
                     helper.get_result_from_boxed_array(_result_column_types[i], result_column.get(), jcolumn, num_rows);
             RETURN_IF_ERROR(st);
-            // check data's length for string type
-            auto origin_type = _slot_descs[i]->type().type;
-            if (origin_type == TYPE_VARCHAR || origin_type == TYPE_CHAR) {
-                DCHECK_EQ(_result_column_types[i], TYPE_VARCHAR);
-                int max_len = _slot_descs[i]->type().len;
-                ColumnViewer<TYPE_VARCHAR> viewer(result_column);
-                for (int row = 0; row < viewer.size(); row++) {
-                    if (viewer.is_null(row)) {
-                        continue;
-                    }
-                    auto value = viewer.value(row);
-                    if ((int)value.size > max_len) {
-                        return Status::DataQualityError(fmt::format(
-                                "Value length exceeds limit on column[{}], max length is [{}], value is [{}]",
-                                _slot_descs[i]->col_name(), max_len, value));
-                    }
-                }
-            }
             down_cast<NullableColumn*>(result_column.get())->update_has_null();
         }
     }


### PR DESCRIPTION
Fixes #issue
remove varchar length check for jdbc scanner
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
