### PR TITLE
[Enhancement] provide a way to skip building java extensions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -347,14 +347,18 @@ if [ ${BUILD_BE} -eq 1 ] ; then
 
     ${BUILD_SYSTEM} install
 
-    # Build JDBC Bridge
-    echo "Build Java Extensions"
-    cd ${STARROCKS_HOME}/java-extensions
-    if [ ${CLEAN} -eq 1 ]; then
-        ${MVN_CMD} clean
+    # Build Java Extensions
+    if [ ${BUILD_JAVA_EXT}"X" = "OFFX" ]; then
+        echo "Skip Building Java Extensions"
+    else
+        echo "Build Java Extensions"
+        cd ${STARROCKS_HOME}/java-extensions
+        if [ ${CLEAN} -eq 1 ]; then
+            ${MVN_CMD} clean
+        fi
+        ${MVN_CMD} package -DskipTests
+        cd ${STARROCKS_HOME}
     fi
-    ${MVN_CMD} package -DskipTests
-    cd ${STARROCKS_HOME}
 fi
 
 cd ${STARROCKS_HOME}

--- a/build.sh
+++ b/build.sh
@@ -87,6 +87,7 @@ Usage: $0 <options>
      --without-gcov     build Backend without gcov(default)
      --with-bench       build Backend with bench(default without bench)
      --with-clang-tidy  build Backend with clang-tidy(default without clang-tidy)
+     --without-java-ext build Backend without java-extensions(default with java-extensions)
      -j                 build Backend parallel
 
   Eg.
@@ -112,6 +113,7 @@ OPTS=$(getopt \
   -l 'with-bench' \
   -l 'with-clang-tidy' \
   -l 'without-gcov' \
+  -l 'without-java-ext' \
   -l 'use-staros' \
   -o 'j:' \
   -l 'help' \
@@ -132,6 +134,7 @@ WITH_GCOV=OFF
 WITH_BENCH=OFF
 WITH_CLANG_TIDY=OFF
 USE_STAROS=OFF
+BUILD_JAVA_EXT=ON
 MSG=""
 MSG_FE="Frontend"
 MSG_DPP="Spark Dpp application"
@@ -216,6 +219,7 @@ else
             --use-staros) USE_STAROS=ON; shift ;;
             --with-bench) WITH_BENCH=ON; shift ;;
             --with-clang-tidy) WITH_CLANG_TIDY=ON; shift ;;
+            --without-java-ext) BUILD_JAVA_EXT=OFF; shift ;;
             -h) HELP=1; shift ;;
             --help) HELP=1; shift ;;
             -j) PARALLEL=$2; shift 2 ;;
@@ -252,6 +256,7 @@ echo "Get params:
     ENABLE_QUERY_DEBUG_TRACE -- $ENABLE_QUERY_DEBUG_TRACE
     WITH_CACHELIB       -- $WITH_CACHELIB
     ENABLE_FAULT_INJECTION -- $ENABLE_FAULT_INJECTION
+    BUILD_JAVA_EXT      -- $BUILD_JAVA_EXT
 "
 
 check_tool()
@@ -348,9 +353,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
     ${BUILD_SYSTEM} install
 
     # Build Java Extensions
-    if [ ${BUILD_JAVA_EXT}"X" = "OFFX" ]; then
-        echo "Skip Building Java Extensions"
-    else
+    if [ ${BUILD_JAVA_EXT} = "ON" ]; then
         echo "Build Java Extensions"
         cd ${STARROCKS_HOME}/java-extensions
         if [ ${CLEAN} -eq 1 ]; then
@@ -358,6 +361,8 @@ if [ ${BUILD_BE} -eq 1 ] ; then
         fi
         ${MVN_CMD} package -DskipTests
         cd ${STARROCKS_HOME}
+    else
+        echo "Skip Building Java Extensions"
     fi
 fi
 


### PR DESCRIPTION
Fixes #issue

Reason why to skip building java extensions is, some modules take a very long time to build, but we rarely need to use them in development stage.

Like paimon-reader module, it takes a very long time to package all jars into a uber jar.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
