### PR TITLE
[BugFix] remove orphan rowset meta during BE restart and trash sweep

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1026,7 +1026,7 @@ CONF_mInt64(file_write_history_size, "10000");
 CONF_mInt32(update_cache_evict_internal_sec, "11");
 CONF_mBool(enable_auto_evict_update_cache, "true");
 
-CONF_mInt64(load_tablet_timeout_seconds, "30");
+CONF_mInt64(load_tablet_timeout_seconds, "60");
 
 CONF_mBool(enable_pk_value_column_zonemap, "true");
 

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -261,36 +261,10 @@ std::string DataDir::get_root_path_from_schema_hash_path_in_trash(const std::str
 
 // TODO(ygl): deal with rowsets and tablets when load failed
 Status DataDir::load() {
-    LOG(INFO) << "start to load tablets from " << _path;
-    // load rowset meta from meta env and create rowset
-    // COMMITTED: add to txn manager
-    // VISIBLE: add to tablet
-    // if one rowset load failed, then the total data dir will not be loaded
-    std::vector<RowsetMetaSharedPtr> dir_rowset_metas;
-    LOG(INFO) << "begin loading rowset from meta";
-    auto load_rowset_func = [&dir_rowset_metas](const TabletUid& tablet_uid, RowsetId rowset_id,
-                                                std::string_view meta_str) -> bool {
-        bool parsed = false;
-        auto rowset_meta = std::make_shared<RowsetMeta>(meta_str, &parsed);
-        if (!parsed) {
-            LOG(WARNING) << "parse rowset meta string failed for rowset_id:" << rowset_id;
-            // return false will break meta iterator, return true to skip this error
-            return true;
-        }
-        dir_rowset_metas.push_back(rowset_meta);
-        return true;
-    };
-    Status load_rowset_status = RowsetMetaManager::traverse_rowset_metas(_kv_store, load_rowset_func);
-
-    if (!load_rowset_status.ok()) {
-        LOG(WARNING) << "errors when load rowset meta from meta env, skip this data dir:" << _path;
-    } else {
-        LOG(INFO) << "load rowset from meta finished, data dir: " << _path;
-    }
-
     // load tablet
     // create tablet from tablet meta and add it to tablet mgr
-    LOG(INFO) << "begin loading tablet from meta";
+    int64_t load_tablet_start = MonotonicMillis();
+    LOG(INFO) << "begin loading tablet from meta " << _path;
     std::set<int64_t> tablet_ids;
     std::set<int64_t> failed_tablet_ids;
     auto load_tablet_func = [this, &tablet_ids, &failed_tablet_ids](int64_t tablet_id, int32_t schema_hash,
@@ -315,14 +289,16 @@ Status DataDir::load() {
     Status load_tablet_status =
             TabletMetaManager::walk_until_timeout(_kv_store, load_tablet_func, config::load_tablet_timeout_seconds);
     if (load_tablet_status.is_time_out()) {
+        LOG(WARNING) << "load tablets from rocksdb timeout, try to compact meta and retry. path: " << _path;
         Status s = _kv_store->compact();
         if (!s.ok()) {
-            LOG(ERROR) << "data dir " << _path << " compact meta befor load failed";
+            LOG(ERROR) << "data dir " << _path << " compact meta before load failed";
             return s;
         }
         for (auto tablet_id : tablet_ids) {
             _tablet_manager->drop_tablet(tablet_id, kKeepMetaAndFiles);
         }
+        LOG(WARNING) << "compact meta finished, retry load tablets from rocksdb. path: " << _path;
         tablet_ids.clear();
         failed_tablet_ids.clear();
         load_tablet_status = TabletMetaManager::walk(_kv_store, load_tablet_func);
@@ -337,13 +313,14 @@ Status DataDir::load() {
         }
     }
     if (!load_tablet_status.ok()) {
-        LOG(FATAL) << "there is failure when loading tablet headers, quit process"
+        LOG(FATAL) << "there is failure when scan rockdb tablet metas, quit process"
                    << ". loaded tablet: " << tablet_ids.size() << " error tablet: " << failed_tablet_ids.size()
-                   << ", path: " << _path;
+                   << ", path: " << _path << " error: " << load_tablet_status.get_error_msg()
+                   << " duration: " << (MonotonicMillis() - load_tablet_start) << "ms";
     } else {
         LOG(INFO) << "load tablet from meta finished"
                   << ", loaded tablet: " << tablet_ids.size() << ", error tablet: " << failed_tablet_ids.size()
-                  << ", path: " << _path;
+                  << ", path: " << _path << " duration: " << (MonotonicMillis() - load_tablet_start) << "ms";
     }
 
     for (int64_t tablet_id : tablet_ids) {
@@ -355,18 +332,32 @@ Status DataDir::load() {
         }
     }
 
-    // traverse rowset
-    // 1. add committed rowset to txn map
-    // 2. add visible rowset to tablet
-    // ignore any errors when load tablet or rowset, because fe will repair them after report
-    for (const auto& rowset_meta : dir_rowset_metas) {
+    // load rowset meta from meta env and create rowset
+    // COMMITTED: add to txn manager
+    // VISIBLE: add to tablet
+    // if one rowset load failed, then the total data dir will not be loaded
+    int64_t load_rowset_start = MonotonicMillis();
+    size_t error_rowset_count = 0;
+    size_t total_rowset_count = 0;
+    LOG(INFO) << "begin loading rowset from meta " << _path;
+    auto load_rowset_func = [&](const TabletUid& tablet_uid, RowsetId rowset_id, std::string_view meta_str) -> bool {
+        total_rowset_count++;
+        bool parsed = false;
+        auto rowset_meta = std::make_shared<RowsetMeta>(meta_str, &parsed);
+        if (!parsed) {
+            LOG(WARNING) << "parse rowset meta string failed for rowset_id:" << rowset_id;
+            // return false will break meta iterator, return true to skip this error
+            error_rowset_count++;
+            return true;
+        }
         TabletSharedPtr tablet = _tablet_manager->get_tablet(rowset_meta->tablet_id(), false);
         // tablet maybe dropped, but not drop related rowset meta
         if (tablet == nullptr) {
-            // LOG(WARNING) << "could not find tablet id: " << rowset_meta->tablet_id()
-            //              << ", schema hash: " << rowset_meta->tablet_schema_hash()
-            //              << ", for rowset: " << rowset_meta->rowset_id() << ", skip this rowset";
-            continue;
+            // maybe too many due to historical bug, limit logging
+            LOG_EVERY_SECOND(WARNING) << "could not find tablet id: " << rowset_meta->tablet_id()
+                                      << " for rowset: " << rowset_meta->rowset_id() << ", skip loading this rowset";
+            error_rowset_count++;
+            return true;
         }
         RowsetSharedPtr rowset;
         Status create_status =
@@ -374,7 +365,8 @@ Status DataDir::load() {
         if (!create_status.ok()) {
             LOG(WARNING) << "Fail to create rowset from rowsetmeta,"
                          << " rowset=" << rowset_meta->rowset_id() << " state=" << rowset_meta->rowset_state();
-            continue;
+            error_rowset_count++;
+            return true;
         }
         if (rowset_meta->rowset_state() == RowsetStatePB::COMMITTED &&
             rowset_meta->tablet_uid() == tablet->tablet_uid()) {
@@ -389,11 +381,10 @@ Status DataDir::load() {
             if (!commit_txn_status.ok() && !commit_txn_status.is_already_exist()) {
                 LOG(WARNING) << "Fail to add committed rowset=" << rowset_meta->rowset_id()
                              << " tablet=" << rowset_meta->tablet_id() << " txn_id: " << rowset_meta->txn_id();
+                error_rowset_count++;
             } else {
                 LOG(INFO) << "Added committed rowset=" << rowset_meta->rowset_id()
-                          << " tablet=" << rowset_meta->tablet_id()
-                          << " schema hash=" << rowset_meta->tablet_schema_hash()
-                          << " txn_id: " << rowset_meta->txn_id();
+                          << " tablet=" << rowset_meta->tablet_id() << " txn_id: " << rowset_meta->txn_id();
             }
 
         } else if (rowset_meta->rowset_state() == RowsetStatePB::VISIBLE &&
@@ -408,13 +399,26 @@ Status DataDir::load() {
                              << " to tablet=" << rowset_meta->tablet_id() << " txn id=" << rowset_meta->txn_id()
                              << " start version=" << rowset_meta->version().first
                              << " end version=" << rowset_meta->version().second;
+                error_rowset_count++;
             }
         } else {
             LOG(WARNING) << "Found invalid rowset=" << rowset_meta->rowset_id()
                          << " tablet id=" << rowset_meta->tablet_id() << " tablet uid=" << rowset_meta->tablet_uid()
-                         << " schema hash=" << rowset_meta->tablet_schema_hash() << " txn_id: " << rowset_meta->txn_id()
+                         << " txn_id: " << rowset_meta->txn_id()
                          << " current valid tablet uid=" << tablet->tablet_uid();
+            error_rowset_count++;
         }
+        return true;
+    };
+    Status load_rowset_status = RowsetMetaManager::traverse_rowset_metas(_kv_store, load_rowset_func);
+
+    if (!load_rowset_status.ok()) {
+        LOG(WARNING) << "load rowset from meta finished, data dir: " << _path << " error/total: " << error_rowset_count
+                     << "/" << total_rowset_count << " error: " << load_rowset_status.get_error_msg()
+                     << " duration: " << (MonotonicMillis() - load_rowset_start) << "ms";
+    } else {
+        LOG(INFO) << "load rowset from meta finished, data dir: " << _path << " error/total: " << error_rowset_count
+                  << "/" << total_rowset_count << " duration: " << (MonotonicMillis() - load_rowset_start) << "ms";
     }
 
     for (int64_t tablet_id : tablet_ids) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1063,40 +1063,54 @@ void StorageEngine::do_manual_compact(bool force_compact) {
 }
 
 void StorageEngine::_clean_unused_rowset_metas() {
-    std::vector<RowsetMetaSharedPtr> invalid_rowset_metas;
-    auto clean_rowset_func = [this, &invalid_rowset_metas](const TabletUid& tablet_uid, RowsetId rowset_id,
-                                                           std::string_view meta_str) -> bool {
+    size_t total_rowset_meta_count = 0;
+    std::vector<std::pair<TabletUid, RowsetId>> invalid_rowsets;
+    auto clean_rowset_func = [&](const TabletUid& tablet_uid, RowsetId rowset_id, std::string_view meta_str) -> bool {
+        total_rowset_meta_count++;
         bool parsed = false;
         auto rowset_meta = std::make_shared<RowsetMeta>(meta_str, &parsed);
         if (!parsed) {
-            LOG(WARNING) << "parse rowset meta string failed for rowset_id:" << rowset_id;
-            // return false will break meta iterator, return true to skip this error
+            LOG(WARNING) << "parse rowset meta string failed, remove rowset meta, rowset_id:" << rowset_id
+                         << " tablet_uid: " << tablet_uid;
+            invalid_rowsets.emplace_back(rowset_meta->tablet_uid(), rowset_meta->rowset_id());
             return true;
         }
         if (rowset_meta->tablet_uid() != tablet_uid) {
-            LOG(WARNING) << "tablet uid is not equal, skip the rowset"
-                         << ", rowset_id=" << rowset_meta->rowset_id() << ", in_put_tablet_uid=" << tablet_uid
+            LOG(WARNING) << "tablet uid is not match, remove rowset meta, rowset_id=" << rowset_meta->rowset_id()
+                         << " tablet: " << rowset_meta->tablet_id() << ", tablet_uid_in_key=" << tablet_uid
                          << ", tablet_uid in rowset meta=" << rowset_meta->tablet_uid();
+            invalid_rowsets.emplace_back(rowset_meta->tablet_uid(), rowset_meta->rowset_id());
             return true;
         }
 
         TabletSharedPtr tablet = _tablet_manager->get_tablet(rowset_meta->tablet_id(), tablet_uid);
         if (tablet == nullptr) {
+            // maybe too many due to historical bug, limit logging
+            LOG_EVERY_SECOND(WARNING) << "tablet not found, remove rowset meta, rowset_id=" << rowset_meta->rowset_id()
+                                      << " tablet: " << rowset_meta->tablet_id();
+            invalid_rowsets.emplace_back(rowset_meta->tablet_uid(), rowset_meta->rowset_id());
             return true;
         }
         if (rowset_meta->rowset_state() == RowsetStatePB::VISIBLE && (!tablet->rowset_meta_is_useful(rowset_meta))) {
-            LOG(INFO) << "rowset meta is useless any more, remote it. rowset_id=" << rowset_meta->rowset_id();
-            invalid_rowset_metas.push_back(rowset_meta);
+            LOG(INFO) << "rowset meta is useless, remove rowset meta, rowset_id=" << rowset_meta->rowset_id()
+                      << " tablet:" << tablet->tablet_id();
+            invalid_rowsets.emplace_back(rowset_meta->tablet_uid(), rowset_meta->rowset_id());
         }
         return true;
     };
     auto data_dirs = get_stores();
     for (auto data_dir : data_dirs) {
+        int64_t start_ts = MonotonicMillis();
         (void)RowsetMetaManager::traverse_rowset_metas(data_dir->get_meta(), clean_rowset_func);
-        for (auto& rowset_meta : invalid_rowset_metas) {
-            (void)RowsetMetaManager::remove(data_dir->get_meta(), rowset_meta->tablet_uid(), rowset_meta->rowset_id());
+        if (!invalid_rowsets.empty()) {
+            for (auto& rowset : invalid_rowsets) {
+                (void)RowsetMetaManager::remove(data_dir->get_meta(), rowset.first, rowset.second);
+            }
+            LOG(WARNING) << "traverse_rowset_meta and remove " << invalid_rowsets.size() << "/"
+                         << total_rowset_meta_count << " invalid rowset metas, path:" << data_dir->path()
+                         << " duration:" << (MonotonicMillis() - start_ts) << "ms";
+            invalid_rowsets.clear();
         }
-        invalid_rowset_metas.clear();
     }
 }
 


### PR DESCRIPTION
Fixes #30624

Historical bug may leads to lots of rowset metas left in rocksdb, causing high memory usage during BE start. This PR optimizes tablet&rowset loading process to reduce memory usage, it also tries to delete those rowsets during trash sweep.
Ideally, those metas could also be removed when tablet is dropped, this PR doesn't do this, in consideration of prudent.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
