### PR TITLE
[BugFix] Fix lost resource group in audit log for insert

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupClassifier.java
@@ -20,6 +20,10 @@ import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.DmlStmt;
+import com.starrocks.sql.ast.LoadStmt;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.thrift.TQueryType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.net.util.SubnetUtils;
@@ -220,9 +224,21 @@ public class ResourceGroupClassifier implements Writable {
         SYSTEM_OTHER;
 
         public static QueryType fromTQueryType(TQueryType type) {
-            return type == TQueryType.LOAD
-                    ? ResourceGroupClassifier.QueryType.INSERT
-                    : ResourceGroupClassifier.QueryType.SELECT;
+            return type == TQueryType.LOAD ? INSERT : SELECT;
+        }
+
+        public static QueryType fromStatement(StatementBase stmt) {
+            if (stmt instanceof QueryStatement) {
+                return SELECT;
+            }
+            if (stmt instanceof DmlStmt) {
+                return INSERT;
+            }
+            if (stmt instanceof LoadStmt) {
+                return INSERT;
+            }
+
+            return SELECT;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -200,6 +200,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
+import static com.starrocks.qe.CoordinatorPreprocessor.prepareResourceGroup;
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 
 // Do one COM_QUERY process.
@@ -476,6 +477,9 @@ public class StmtExecutor {
                 return;
             }
             if (isForwardToLeader()) {
+                // Write the resource group information to audit log.
+                prepareResourceGroup(context, ResourceGroupClassifier.QueryType.fromStatement(parsedStmt));
+
                 forwardToLeader();
                 return;
             } else {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupMgrTest.java
@@ -47,5 +47,11 @@ public class ResourceGroupMgrTest {
             ResourceGroupClassifier.QueryType queryType = ResourceGroupClassifier.QueryType.fromStatement(stmt);
             Assert.assertEquals(ResourceGroupClassifier.QueryType.SELECT, queryType);
         }
+        {
+            String sql = "show running queries";
+            StatementBase stmt = SqlParser.parse(sql, ctx.getSessionVariable().getSqlMode()).get(0);
+            ResourceGroupClassifier.QueryType queryType = ResourceGroupClassifier.QueryType.fromStatement(stmt);
+            Assert.assertEquals(ResourceGroupClassifier.QueryType.SELECT, queryType);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupMgrTest.java
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.catalog.ResourceGroupClassifier;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ResourceGroupMgrTest {
+
+    @Test
+    public void testResourceGroupTypeFromStatement() {
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+
+        {
+            String sql = "LOAD LABEL label0 (DATA INFILE('path/k2=1/file1') INTO TABLE t2 FORMAT AS 'orc' (k1,k33,v) " +
+                    "COLUMNS FROM PATH AS (k2) set (k3 = substr(k33,1,5))) WITH BROKER 'broker0'";
+            StatementBase stmt = SqlParser.parse(sql, ctx.getSessionVariable().getSqlMode()).get(0);
+            ResourceGroupClassifier.QueryType queryType = ResourceGroupClassifier.QueryType.fromStatement(stmt);
+            Assert.assertEquals(ResourceGroupClassifier.QueryType.INSERT, queryType);
+        }
+        {
+            String sql = "insert into t1 select * from t1";
+            StatementBase stmt = SqlParser.parse(sql, ctx.getSessionVariable().getSqlMode()).get(0);
+            ResourceGroupClassifier.QueryType queryType = ResourceGroupClassifier.QueryType.fromStatement(stmt);
+            Assert.assertEquals(ResourceGroupClassifier.QueryType.INSERT, queryType);
+        }
+        {
+            String sql = "select * from t1";
+            StatementBase stmt = SqlParser.parse(sql, ctx.getSessionVariable().getSqlMode()).get(0);
+            ResourceGroupClassifier.QueryType queryType = ResourceGroupClassifier.QueryType.fromStatement(stmt);
+            Assert.assertEquals(ResourceGroupClassifier.QueryType.SELECT, queryType);
+        }
+    }
+}


### PR DESCRIPTION
The `INSERT INTO` and `LOAD` SQLs are forwarded to the leader FE.
The field `ResourceGroup` in the audit log are written after creating `Coordinator`, which only happens in the leader FE.

Therefore, the `INSERT INTO` and `LOAD` SQLs requested from follower FEs will not write `ResourceGroup` to the audit log.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
