### PR TITLE
[BugFix] fix show create materialized errors

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1066,109 +1066,18 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
         // properties
         sb.append("\nPROPERTIES (\n");
-
-        // replicationNum
-        sb.append("\"").append(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM).append("\" = \"");
-        sb.append(getDefaultReplicationNum()).append("\"");
-
         Map<String, String> properties = this.getTableProperty().getProperties();
-        // replicated storage
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)) {
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)
-                    .append("\" = \"");
-            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE)).append("\"");
-        }
-
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_BUCKET_SIZE)) {
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_BUCKET_SIZE)
-                    .append("\" = \"");
-            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_BUCKET_SIZE)).append("\"");
-        }
-
-        // partition TTL
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER)) {
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER)
-                    .append("\" = \"");
-            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER)).append("\"");
-        }
-
-        // auto refresh partitions limit
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT)) {
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR)
-                    .append(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT)
-                    .append("\" = \"");
-            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT)).append("\"");
-        }
-
-        // partition refresh number
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)) {
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR)
-                    .append(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)
-                    .append("\" = \"");
-            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)).append("\"");
-        }
-
-        // excluded trigger tables
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES)) {
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR)
-                    .append(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES)
-                    .append("\" = \"");
-            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES)).append("\"");
-        }
-
-        // force_external_table_query_rewrite
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)) {
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(
-                    PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE).append("\" = \"");
-            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_FORCE_EXTERNAL_TABLE_QUERY_REWRITE)).append("\"");
-        }
-
-        // mv_rewrite_staleness
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_MV_REWRITE_STALENESS_SECOND)) {
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(
-                    PropertyAnalyzer.PROPERTIES_MV_REWRITE_STALENESS_SECOND).append("\" = \"");
-            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_MV_REWRITE_STALENESS_SECOND)).append("\"");
-        }
-
-        // unique constraints
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)) {
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)
-                    .append("\" = \"");
-            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_UNIQUE_CONSTRAINT)).append("\"");
-        }
-
-        // foreign keys constraints
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT)) {
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR)
-                    .append(PropertyAnalyzer.PROPERTIES_FOREIGN_KEY_CONSTRAINT)
-                    .append("\" = \"");
-            sb.append(ForeignKeyConstraint.getShowCreateTableConstraintDesc(getForeignKeyConstraints()))
-                    .append("\"");
-        }
-
-        // colocateTable
-        if (colocateGroup != null) {
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(PropertyAnalyzer.PROPERTIES_COLOCATE_WITH)
-                    .append("\" = \"");
-            sb.append(colocateGroup).append("\"");
-        }
-
-        // resource group
-        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP)) {
-            sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(
-                    PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP).append("\" = \"");
-            sb.append(properties.get(PropertyAnalyzer.PROPERTIES_RESOURCE_GROUP)).append("\"");
-        }
-
-        // storage medium
-        appendUniqueProperties(sb);
-
-        // session properties
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            if (entry.getKey().startsWith(PropertyAnalyzer.PROPERTIES_MATERIALIZED_VIEW_SESSION_PREFIX)) {
-                sb.append(StatsConstants.TABLE_PROPERTY_SEPARATOR).append(entry.getKey())
-                        .append("\" = \"").append(entry.getValue()).append("\"");
+        boolean first = true;
+        for (Map.Entry<String, String> entry : this.getTableProperty().getProperties().entrySet()) {
+            if (!first) {
+                sb.append(",\n");
             }
+            first = false;
+            String name = entry.getKey();
+            String value = entry.getValue();
+            sb.append("\"").append(name.toUpperCase()).append("\"");
+            sb.append(" = ");
+            sb.append("\"").append(value.toUpperCase()).append("\"");
         }
 
         sb.append("\n)");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1040,6 +1040,12 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         DistributionInfo distributionInfo = this.getDefaultDistributionInfo();
         sb.append("\n").append(distributionInfo.toSql());
 
+        // order by
+        if (CollectionUtils.isNotEmpty(getTableProperty().getMvSortKeys())) {
+            String str = Joiner.on(",").join(getTableProperty().getMvSortKeys());
+            sb.append("\nORDER BY (").append(str).append(")");
+        }
+
         // refresh scheme
         MvRefreshScheme refreshScheme = this.getRefreshScheme();
         if (refreshScheme == null) {
@@ -1066,19 +1072,20 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
         // properties
         sb.append("\nPROPERTIES (\n");
-        Map<String, String> properties = this.getTableProperty().getProperties();
         boolean first = true;
-        for (Map.Entry<String, String> entry : this.getTableProperty().getProperties().entrySet()) {
+        Map<String, String> properties = this.getTableProperty().getProperties();
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            String name = entry.getKey();
+            String value = entry.getValue();
             if (!first) {
                 sb.append(",\n");
             }
             first = false;
-            String name = entry.getKey();
-            String value = entry.getValue();
-            sb.append("\"").append(name.toUpperCase()).append("\"");
+            sb.append("\"").append(name).append("\"");
             sb.append(" = ");
-            sb.append("\"").append(value.toUpperCase()).append("\"");
+            sb.append("\"").append(value).append("\"");
         }
+        appendUniqueProperties(sb);
 
         sb.append("\n)");
         String define = this.getSimpleDefineSql();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -59,6 +59,7 @@ import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TPersistentIndexType;
 import com.starrocks.thrift.TWriteQuorumType;
 import org.apache.commons.lang3.EnumUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.parquet.Strings;
@@ -69,6 +70,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -132,6 +134,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
     // This property only applies to materialized views,
     // Indicates which tables do not listen to auto refresh events when load
     private List<TableName> excludedTriggerTables;
+
+    // This property only applies to materialized views
+    private List<String> mvSortKeys;
 
     // This property only applies to materialized views,
     // Specify the query rewrite behaviour for external table
@@ -207,6 +212,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
     private Boolean useSchemaLightChange;
 
     private PeriodDuration dataCachePartitionDuration;
+
+    public TableProperty() {
+        this.properties = new LinkedHashMap<>();
+    }
 
     public TableProperty(Map<String, String> properties) {
         this.properties = properties;
@@ -287,6 +296,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildExcludedTriggerTables();
         buildResourceGroup();
         buildConstraint();
+        buildMvSortKeys();
         return this;
     }
 
@@ -386,6 +396,20 @@ public class TableProperty implements Writable, GsonPostProcessable {
             excludedTriggerTables = tables;
         }
         return this;
+    }
+
+    public TableProperty buildMvSortKeys() {
+        String sortKeys = properties.get(PropertyAnalyzer.PROPERTY_MV_SORT_KEYS);
+        this.mvSortKeys = analyzeMvSortKeys(sortKeys);
+        return this;
+    }
+
+    public static List<String> analyzeMvSortKeys(String value) {
+        if (StringUtils.isEmpty(value)) {
+            return Lists.newArrayList();
+        } else {
+            return Splitter.on(",").omitEmptyStrings().trimResults().splitToList(value);
+        }
     }
 
     public static QueryRewriteConsistencyMode analyzeQueryRewriteMode(String value) {
@@ -611,6 +635,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public void setExcludedTriggerTables(List<TableName> excludedTriggerTables) {
         this.excludedTriggerTables = excludedTriggerTables;
+    }
+
+    public List<String> getMvSortKeys() {
+        return mvSortKeys;
+    }
+
+    public void setMvSortKeys(List<String> sortKeys) {
+        this.mvSortKeys = sortKeys;
     }
 
     public QueryRewriteConsistencyMode getForceExternalTableQueryRewrite() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -185,6 +185,11 @@ public class PropertyAnalyzer {
     // positive value: use [0, mv_randomize_start) as random interval
     public static final String PROPERTY_MV_RANDOMIZE_START = "mv_randomize_start";
 
+    /**
+     * Materialized View sort keys
+     */
+    public static final String PROPERTY_MV_SORT_KEYS = "mv_sort_keys";
+
     // light schema change
     public static final String PROPERTIES_USE_LIGHT_SCHEMA_CHANGE = "light_schema_change";
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2973,6 +2973,11 @@ public class LocalMetastore implements ConnectorMetadata {
                             baseDistribution, mvRefreshScheme);
         }
 
+        // sort keys
+        if (CollectionUtils.isNotEmpty(stmt.getSortKeys())) {
+            materializedView.setTableProperty(new TableProperty());
+            materializedView.getTableProperty().setMvSortKeys(stmt.getSortKeys());
+        }
         // set comment
         materializedView.setComment(stmt.getComment());
         // set baseTableIds
@@ -3201,6 +3206,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 String storageVolumeId = svm.getStorageVolumeIdOfTable(materializedView.getId());
                 setLakeStorageInfo(materializedView, storageVolumeId, properties);
             }
+
             // session properties
             if (!properties.isEmpty()) {
                 // analyze properties
@@ -3275,8 +3281,8 @@ public class LocalMetastore implements ConnectorMetadata {
             TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
             taskManager.createTask(task, false);
             // for event triggered type, run task
-            if (task.getType() == Constants.TaskType.EVENT_TRIGGERED ||
-                    refreshMoment.equals(MaterializedView.RefreshMoment.IMMEDIATE)) {
+            if (task.getType() == Constants.TaskType.EVENT_TRIGGERED &&
+                    !refreshMoment.equals(MaterializedView.RefreshMoment.DEFERRED)) {
                 taskManager.executeTask(task.getName());
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -2763,16 +2763,6 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testCreateImmediateDeferred() throws Exception {
-        UtFrameUtils.parseStmtWithNewParser(
-                "create materialized view immediate_mv refresh deferred async distributed by hash(c_1_9) as" +
-                        " select c_1_9, c_1_4 from t1", connectContext);
-        UtFrameUtils.parseStmtWithNewParser(
-                "create materialized view immediate_mv refresh immediate async distributed by hash(c_1_9) as" +
-                        " select c_1_9, c_1_4 from t1", connectContext);
-    }
-
-    @Test
     public void testCreateImmediateDeferred(@Mocked TaskManager taskManager) throws Exception {
         new Expectations() {
             {
@@ -2781,12 +2771,12 @@ public class CreateMaterializedViewTest {
             }
         };
         String createImmediate =
-                "create materialized view immediate_mv refresh deferred manual distributed by hash(c_1_9) as" +
+                "create materialized view immediate_mv refresh deferred async distributed by hash(c_1_9) as" +
                         " select c_1_9, c_1_4 from t1";
         starRocksAssert.withMaterializedView(createImmediate);
 
         String createDeferred =
-                "create materialized view deferred_mv refresh immediate manual distributed by hash(c_1_9) as" +
+                "create materialized view deferred_mv refresh immediate async distributed by hash(c_1_9) as" +
                         " select c_1_9, c_1_4 from t1";
         starRocksAssert.withMaterializedView(createDeferred);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
@@ -98,9 +98,9 @@ public class ShowCreateMaterializedViewStmtTest {
                 "DISTRIBUTED BY HASH(`k1`) BUCKETS 10 \n" +
                 "REFRESH MANUAL\n" +
                 "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
                 "\"replicated_storage\" = \"true\",\n" +
                 "\"unique_constraints\" = \"default_catalog.test.tbl2.k1\",\n" +
+                "\"replication_num\" = \"1\",\n" +
                 "\"foreign_key_constraints\" = \"default_catalog.test.tbl1(k1) REFERENCES default_catalog.test.tbl2(k1)\",\n" +
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
@@ -126,9 +126,9 @@ public class ShowCreateMaterializedViewStmtTest {
                         "DISTRIBUTED BY HASH(`c1`) BUCKETS 10 \n" +
                         "REFRESH MANUAL\n" +
                         "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
                         "\"replicated_storage\" = \"true\",\n" +
                         "\"unique_constraints\" = \"hive0.partitioned_db2.t2.c2\",\n" +
+                        "\"replication_num\" = \"1\",\n" +
                         "\"foreign_key_constraints\" = \"hive0.partitioned_db.t1(c2) REFERENCES hive0.partitioned_db2.t2(c2)\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
@@ -168,8 +168,8 @@ public class ShowCreateMaterializedViewStmtTest {
                 "DISTRIBUTED BY HASH(`k1`) BUCKETS 10 \n" +
                 "REFRESH MANUAL\n" +
                 "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
                 "\"replicated_storage\" = \"true\",\n" +
+                "\"replication_num\" = \"1\",\n" +
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
                 "AS SELECT `tbl1`.`k1`, `tbl1`.`k2`\nFROM `test`.`tbl1`;");
@@ -196,8 +196,8 @@ public class ShowCreateMaterializedViewStmtTest {
                 "DISTRIBUTED BY HASH(`k3`) BUCKETS 10 \n" +
                 "REFRESH MANUAL\n" +
                 "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
                 "\"replicated_storage\" = \"true\",\n" +
+                "\"replication_num\" = \"1\",\n" +
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
                 "AS SELECT `tbl1`.`k1` AS `k3`, `tbl1`.`k2`\nFROM `test`.`tbl1`;");
@@ -224,8 +224,8 @@ public class ShowCreateMaterializedViewStmtTest {
                 "DISTRIBUTED BY HASH(`k3`) BUCKETS 10 \n" +
                 "REFRESH MANUAL\n" +
                 "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
                 "\"replicated_storage\" = \"true\",\n" +
+                "\"replication_num\" = \"1\",\n" +
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
                 "AS SELECT `tbl1`.`k1`, `tbl1`.`k2` + `tbl1`.`v1` AS `k3`\n" +
@@ -253,8 +253,8 @@ public class ShowCreateMaterializedViewStmtTest {
                 "DISTRIBUTED BY HASH(`k3`) BUCKETS 10 \n" +
                 "REFRESH MANUAL\n" +
                 "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
                 "\"replicated_storage\" = \"true\",\n" +
+                "\"replication_num\" = \"1\",\n" +
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
                 "AS SELECT `tbl1`.`k1` AS `k3`, `tbl1`.`k2`\nFROM `test`.`tbl1`;");
@@ -287,10 +287,10 @@ public class ShowCreateMaterializedViewStmtTest {
                 "DISTRIBUTED BY HASH(`k3`) BUCKETS 10 \n" +
                 "REFRESH ASYNC START(\"2122-12-31 00:00:00\") EVERY(INTERVAL 1 HOUR)\n" +
                 "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
                 "\"replicated_storage\" = \"true\",\n" +
+                "\"storage_cooldown_time\" = \"2122-12-31 23:59:59\",\n" +
                 "\"storage_medium\" = \"SSD\",\n" +
-                "\"storage_cooldown_time\" = \"2122-12-31 23:59:59\"\n" +
+                "\"replication_num\" = \"1\"\n" +
                 ")\n" +
                 "AS SELECT `tbl1`.`k1` AS `k3`, `tbl1`.`k2`\nFROM `test`.`tbl1`;");
         String copySql = createTableStmt.get(0).replaceAll("mv5", "mv5_copy");
@@ -322,10 +322,10 @@ public class ShowCreateMaterializedViewStmtTest {
                 "DISTRIBUTED BY HASH(`k3`) BUCKETS 10 \n" +
                 "REFRESH ASYNC\n" +
                 "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
                 "\"replicated_storage\" = \"true\",\n" +
+                "\"storage_cooldown_time\" = \"2122-12-31 23:59:59\",\n" +
                 "\"storage_medium\" = \"SSD\",\n" +
-                "\"storage_cooldown_time\" = \"2122-12-31 23:59:59\"\n" +
+                "\"replication_num\" = \"1\"\n" +
                 ")\n" +
                 "AS SELECT `tbl1`.`k1` AS `k3`, `tbl1`.`k2`\nFROM `test`.`tbl1`;");
         String copySql = createTableStmt.get(0).replaceAll("mv6", "mv6_copy");
@@ -352,17 +352,17 @@ public class ShowCreateMaterializedViewStmtTest {
         Table table = currentState.getDb("test").getTable("mv7");
         List<String> createTableStmt = Lists.newArrayList();
         GlobalStateMgr.getDdlStmt(table, createTableStmt, null, null, false, true);
-        Assert.assertEquals(createTableStmt.get(0), "CREATE MATERIALIZED VIEW `mv7` (`k3`, `k2`)\n" +
+        Assert.assertEquals("CREATE MATERIALIZED VIEW `mv7` (`k3`, `k2`)\n" +
                 "PARTITION BY (date_trunc('month', `k3`))\n" +
                 "DISTRIBUTED BY HASH(`k3`) BUCKETS 10 \n" +
                 "REFRESH ASYNC EVERY(INTERVAL 1 HOUR)\n" +
                 "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
                 "\"replicated_storage\" = \"true\",\n" +
+                "\"storage_cooldown_time\" = \"2122-12-31 23:59:59\",\n" +
                 "\"storage_medium\" = \"SSD\",\n" +
-                "\"storage_cooldown_time\" = \"2122-12-31 23:59:59\"\n" +
+                "\"replication_num\" = \"1\"\n" +
                 ")\n" +
-                "AS SELECT `tbl1`.`k1` AS `k3`, `tbl1`.`k2`\nFROM `test`.`tbl1`;");
+                "AS SELECT `tbl1`.`k1` AS `k3`, `tbl1`.`k2`\nFROM `test`.`tbl1`;", createTableStmt.get(0));
         String copySql = createTableStmt.get(0).replaceAll("mv7", "mv7_copy");
         currentState.createMaterializedView(
                 (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(copySql, ctx));
@@ -386,8 +386,8 @@ public class ShowCreateMaterializedViewStmtTest {
                 "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10 \n" +
                 "REFRESH MANUAL\n" +
                 "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
                 "\"replicated_storage\" = \"true\",\n" +
+                "\"replication_num\" = \"1\",\n" +
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
                 "AS SELECT `lineitem`.`l_orderkey`, `lineitem`.`l_partkey`, `lineitem`.`l_shipdate`\n" +
@@ -421,6 +421,8 @@ public class ShowCreateMaterializedViewStmtTest {
         String copySql = createTableStmt.get(0).replaceAll("deferred_mv4", "deferred_mv4_copy");
         currentState.createMaterializedView(
                 (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(copySql, ctx));
+        String meta = starRocksAssert.query("select inspect_mv_meta('deferred_mv4')").explainQuery();
+        Assert.assertTrue(meta, meta.contains("\"refreshScheme\":{\"moment\":\"DEFERRED\",\"type\":\"MANUAL\""));
     }
 
     @Test
@@ -478,9 +480,9 @@ public class ShowCreateMaterializedViewStmtTest {
                 "DISTRIBUTED BY HASH(`k1`) BUCKETS 10 \n" +
                 "REFRESH MANUAL\n" +
                 "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
                 "\"replicated_storage\" = \"true\",\n" +
                 "\"mv_rewrite_staleness_second\" = \"60\",\n" +
+                "\"replication_num\" = \"1\",\n" +
                 "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
                 "AS SELECT `tbl1`.`k1`, `tbl1`.`k2`\nFROM `test`.`tbl1`;");

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -1051,9 +1051,8 @@ public class ShowExecutorTest {
                 "DISTRIBUTED BY HASH(`col1`) BUCKETS 10 \n" +
                 "REFRESH ASYNC\n" +
                 "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\",\n" +
-                "\"storage_medium\" = \"SSD\",\n" +
-                "\"storage_cooldown_time\" = \"1970-01-01 08:00:00\"\n" +
+                "\"storage_cooldown_time\" = \"1970-01-01 08:00:00\",\n" +
+                "\"storage_medium\" = \"SSD\"\n" +
                 ")\n" +
                 "AS select col1, col2 from table1;";
 

--- a/test/sql/test_materialized_view/R/test_show_materialized_view
+++ b/test/sql/test_materialized_view/R/test_show_materialized_view
@@ -17,8 +17,8 @@ user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH MANUAL
 PROPERTIES (
-"replication_num" = "1",
 "replicated_storage" = "true",
+"replication_num" = "1",
 "storage_medium" = "HDD"
 )
 AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
@@ -31,8 +31,8 @@ user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH MANUAL
 PROPERTIES (
-"replication_num" = "1",
 "replicated_storage" = "true",
+"replication_num" = "1",
 "storage_medium" = "HDD"
 )
 AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
@@ -51,11 +51,11 @@ user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH MANUAL
 PROPERTIES (
-"replication_num" = "1",
 "replicated_storage" = "true",
 "mv_rewrite_staleness_second" = "3600",
-"storage_medium" = "HDD",
-"session.query_timeout" = "3600"
+"replication_num" = "1",
+"session.query_timeout" = "3600",
+"storage_medium" = "HDD"
 )
 AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
 FROM `test_show_materialized_view`.`user_tags`
@@ -67,11 +67,11 @@ user_tags_mv1	CREATE MATERIALIZED VIEW `user_tags_mv1` (`user_id`, `bitmap_union
 DISTRIBUTED BY HASH(`user_id`)
 REFRESH MANUAL
 PROPERTIES (
-"replication_num" = "1",
 "replicated_storage" = "true",
 "mv_rewrite_staleness_second" = "3600",
-"storage_medium" = "HDD",
-"session.query_timeout" = "3600"
+"replication_num" = "1",
+"session.query_timeout" = "3600",
+"storage_medium" = "HDD"
 )
 AS SELECT `user_tags`.`user_id`, bitmap_union(to_bitmap(`user_tags`.`tag_id`)) AS `bitmap_union(to_bitmap(tag_id))`
 FROM `test_show_materialized_view`.`user_tags`


### PR DESCRIPTION
Fixes #


1. Persist and display the `ORDER BY` clause of materialized view
2. Simplify the `show create materialized view` implementation
3. Fix the `REFRESH DEFERRED` semantic


Sort key of MV:
- Sort key of table: implicit for duplicate key, explicit for primary key, so there's no unified syntax and metadata
- Sort key of MV: could be explicited specified by ORDER BY, or chosen automatically
- Why recording the mvSortKeys metadata here? Because there's no syntax or metadata to specify the sort key of a duplicated key table.
- When would it record the mvSortKeys? Only if explicitly specify the ORDER BY

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [ ] 2.4
