### PR TITLE
[BugFix] Fix compaction jobs getting stuck when abortCompaction RPC fails

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionTask.java
@@ -53,10 +53,6 @@ public class CompactionTask {
         return nodeId;
     }
 
-    public Future<CompactResponse> getResponseFuture() {
-        return responseFuture;
-    }
-
     public boolean isDone() {
         return responseFuture != null && responseFuture.isDone();
     }
@@ -116,10 +112,15 @@ public class CompactionTask {
 
     public void abort() {
         if (!isCompleted()) {
-            LOG.info("abort compaction task, txn_id: {}, node: {}", request.txnId, nodeId);
             AbortCompactionRequest abortRequest = new AbortCompactionRequest();
             abortRequest.txnId = request.txnId;
-            Future<AbortCompactionResponse> ignored = rpcChannel.abortCompaction(abortRequest);
+            try {
+                Future<AbortCompactionResponse> ignored = rpcChannel.abortCompaction(abortRequest);
+                LOG.info("aborted compaction task, txn_id: {}, node: {}", request.txnId, nodeId);
+            } catch (Exception e) {
+                LOG.warn("fail to abort compaction task, txn_id: {}, node: {} error: {}", request.txnId,
+                        nodeId, e.getMessage());
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionTaskTest.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.compaction;
+
+import com.starrocks.proto.AbortCompactionRequest;
+import com.starrocks.proto.CompactRequest;
+import com.starrocks.rpc.LakeService;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class CompactionTaskTest {
+
+
+    @Test
+    public void testAbortThrowException(@Mocked LakeService lakeService) {
+        CompactRequest request = new CompactRequest();
+        request.tabletIds = Arrays.asList(1L);
+        request.txnId = 1000L;
+        request.version = 10L;
+        CompactionTask task = new CompactionTask(10043, lakeService, request);
+        new Expectations() {
+            {
+                lakeService.abortCompaction((AbortCompactionRequest) any);
+                result = new RuntimeException("channel inactive error");
+            }
+        };
+
+        task.abort();
+    }
+
+    @Test
+    public void testAbort(@Mocked LakeService lakeService) {
+        CompactRequest request = new CompactRequest();
+        request.tabletIds = Arrays.asList(1L);
+        request.txnId = 1000L;
+        request.version = 10L;
+        CompactionTask task = new CompactionTask(10043, lakeService, request);
+        new Expectations() {
+            {
+                lakeService.abortCompaction((AbortCompactionRequest) any);
+                result = null; // unused
+            }
+        };
+
+        task.abort();
+    }
+}


### PR DESCRIPTION
Fix compaction jobs getting stuck when LakeService.abortCompaction throwed exception

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
