### PR TITLE
[BugFix] Fix bucket optimize not work with spill AGG

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -33,11 +33,13 @@ void SpillableAggregateBlockingSourceOperator::close(RuntimeState* state) {
 }
 
 bool SpillableAggregateBlockingSourceOperator::has_output() const {
-    if (AggregateBlockingSourceOperator::has_output()) {
+    bool has_spilled = _aggregator->spiller()->spilled();
+
+    if (!has_spilled && AggregateBlockingSourceOperator::has_output()) {
         return true;
     }
 
-    if (!_aggregator->spiller()->spilled()) {
+    if (!has_spilled) {
         return false;
     }
     if (_accumulator.has_output()) {
@@ -96,6 +98,12 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::pull_chunk(RuntimeS
     }
 
     return res;
+}
+
+Status SpillableAggregateBlockingSourceOperator::reset_state(RuntimeState* state,
+                                                             const std::vector<ChunkPtr>& refill_chunks) {
+    _accumulator.reset_state();
+    return Status::OK();
 }
 
 StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::_pull_spilled_chunk(RuntimeState* state) {

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.h
@@ -44,6 +44,7 @@ public:
     void close(RuntimeState* state) override;
 
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
+    Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
 
 private:
     StatusOr<ChunkPtr> _pull_spilled_chunk(RuntimeState* state);

--- a/be/src/exec/pipeline/bucket_process_operator.cpp
+++ b/be/src/exec/pipeline/bucket_process_operator.cpp
@@ -50,6 +50,11 @@ Status BucketProcessSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr
     if (!chunk->is_empty()) {
         RETURN_IF_ERROR(_ctx->sink->push_chunk(state, chunk));
     }
+    // short-circuit case. such as group by limit
+    if (_ctx->sink->is_finished()) {
+        _ctx->all_input_finishing = true;
+        return Status::OK();
+    }
     if (info.is_last_chunk()) {
         RETURN_IF_ERROR(_ctx->sink->set_finishing(state));
         _ctx->current_bucket_sink_finished = true;

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -116,6 +116,7 @@ Status Spiller::reset_state(RuntimeState* state) {
     _spilled_append_rows = 0;
     _restore_read_rows = 0;
     _block_group->clear();
+    RETURN_IF_ERROR(prepare(state));
     return Status::OK();
 }
 

--- a/test/sql/test_agg/R/test_bucket_agg
+++ b/test/sql/test_agg/R/test_bucket_agg
@@ -77,6 +77,10 @@ select count(*) from (select c0, c1, sum(c2) from t0 group by c0, c1) tb;
 -- result:
 4096
 -- !result
+select count(*) from (select distinct c0 from t0 limit 100) tb;
+-- result:
+100
+-- !result
 set tablet_internal_parallel_mode="auto";
 -- result:
 -- !result
@@ -135,4 +139,8 @@ select count(*) from (select distinct c0 from t0) tb;
 select count(*) from (select c0, c1, sum(c2) from t0 group by c0, c1) tb;
 -- result:
 4096
+-- !result
+select count(*) from (select distinct c0 from t0 limit 100) tb;
+-- result:
+100
 -- !result

--- a/test/sql/test_agg/T/test_bucket_agg
+++ b/test/sql/test_agg/T/test_bucket_agg
@@ -27,6 +27,8 @@ select sum(c1), max(c2) from t0 group by c0 order by 1, 2 limit 5;
 
 select count(*) from (select distinct c0 from t0) tb;
 select count(*) from (select c0, c1, sum(c2) from t0 group by c0, c1) tb;
+-- distinct with limit
+select count(*) from (select distinct c0 from t0 limit 100) tb;
 
 set tablet_internal_parallel_mode="auto";
 
@@ -39,3 +41,5 @@ select sum(c1), max(c2) from t0 group by c0 order by 1, 2 limit 5;
 
 select count(*) from (select distinct c0 from t0) tb;
 select count(*) from (select c0, c1, sum(c2) from t0 group by c0, c1) tb;
+-- distinct with limit
+select count(*) from (select distinct c0 from t0 limit 100) tb;

--- a/test/sql/test_spill/R/test_spill_aggregate
+++ b/test/sql/test_spill/R/test_spill_aggregate
@@ -1,4 +1,4 @@
--- name: test_spill_agg_with_empty_agg_operator
+-- name: test_spill_agg
 set enable_spill=true;
 -- result:
 -- !result
@@ -28,4 +28,38 @@ insert into t2 select sum(k1),k2 from t1 group by k2;
 select * from t2;
 -- result:
 1	1
+-- !result
+set spill_mode="force";
+-- result:
+-- !result
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+insert into t0 select * from t0;
+-- result:
+-- !result
+insert into t0 select * from t0;
+-- result:
+-- !result
+select max(sl) from (select sum(c1) sl from t0 group by c0) tb;
+-- result:
+16380
+-- !result
+select avg(sl) from (select sum(c1) sl from t0 group by c0) tb;
+-- result:
+8190.0
+-- !result
+select count(sl) from (select sum(c1) sl from t0 group by c0) tb;
+-- result:
+4096
+-- !result
+select count(sl) from (select count(c1) sl from t0 group by c0) tb;
+-- result:
+4096
 -- !result

--- a/test/sql/test_spill/T/test_spill_aggregate
+++ b/test/sql/test_spill/T/test_spill_aggregate
@@ -1,8 +1,8 @@
--- name: test_spill_agg_with_empty_agg_operator
--- for issue: https://github.com/StarRocks/starrocks/issues/23491
+-- name: test_spill_agg
 set enable_spill=true;
 set spill_mode="auto";
 -- 
+-- for issue: https://github.com/StarRocks/starrocks/issues/23491
 CREATE TABLE t1 (
     k1 INT,
     k2 VARCHAR(20))
@@ -16,3 +16,18 @@ DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
 insert into t1 values (1,"1");
 insert into t2 select sum(k1),k2 from t1 group by k2;
 select * from t2;
+--
+-- spill colocate bucket agg
+set spill_mode="force";
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+insert into t0 select * from t0;
+insert into t0 select * from t0;
+
+select max(sl) from (select sum(c1) sl from t0 group by c0) tb;
+select avg(sl) from (select sum(c1) sl from t0 group by c0) tb;
+select count(sl) from (select sum(c1) sl from t0 group by c0) tb;
+select count(sl) from (select count(c1) sl from t0 group by c0) tb;


### PR DESCRIPTION
Fix 
https://github.com/StarRocks/StarRocksBenchmark/issues/452
and 
```
tracker:consistency consumption: 0
*** Aborted at 1693811613 (unix time) try "date -d @1693811613" if you are using GNU date ***
PC: @     0x7f2b31eff387 __GI_raise
*** SIGABRT (@0x3e800004f23) received by PID 20259 (TID 0x7f2a84351700) from PID 20259; stack trace: ***
    @          0x60d6d62 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f2b329b4630 (unknown)
    @     0x7f2b31eff387 __GI_raise
    @     0x7f2b31f00a78 __GI_abort
    @          0x28fadce starrocks::failure_function()
    @          0x60ca73d google::LogMessage::Fail()
    @          0x60ccbaf google::LogMessage::SendToLog()
    @          0x60ca28e google::LogMessage::Flush()
    @          0x60cd1b9 google::LogMessageFatal::~LogMessageFatal()
    @          0x33b65f7 starrocks::materialize_column_by_permutation()
    @          0x33b6805 starrocks::materialize_by_permutation()
    @          0x32f8b11 starrocks::MergeTwoCursor::merge_sorted_intersected_cursor()
    @          0x32fbb05 starrocks::MergeTwoCursor::merge_sorted_cursor_two_way()
    @          0x32fc8fc starrocks::MergeTwoCursor::next()
    @          0x32fc9a2 _ZNSt17_Function_handlerIFbPSt10unique_ptrIN9starrocks5ChunkESt14default_deleteIS2_EEPbEZNS1_14MergeTwoCursorC4ERKNS1_9SortDescsEOS0_INS1_21SimpleChunkSortCursorES3_ISD_EESG_EUlS6_S7_E_E9_M_invokeERKSt9_Any_dataOS6_OS7_
    @          0x2ac272a starrocks::SimpleChunkSortCursor::try_get_next()
    @          0x32f7cd1 starrocks::MergeCursorsCascade::try_get_next()
    @          0x2aa8805 starrocks::CascadeChunkMerger::get_next()
    @          0x3529199 starrocks::spill::OrderedInputStream::get_next()
    @          0x34b7208 starrocks::spill::SpillerReader::restore<>()
    @          0x34b7717 starrocks::spill::Spiller::restore<>()
    @          0x34afe6b starrocks::pipeline::SpillableAggregateBlockingSourceOperator::_pull_spilled_chunk()
    @          0x34b0389 starrocks::pipeline::SpillableAggregateBlockingSourceOperator::pull_chunk()
    @          0x34bccae starrocks::pipeline::BucketProcessSourceOperator::pull_chunk()
    @          0x348143e starrocks::pipeline::PipelineDriver::process()
    @          0x34736ce starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x2b784da starrocks::ThreadPool::dispatch_thread()
    @          0x2b72faa starrocks::Thread::supervise_thread()
    @     0x7f2b329acea5 start_thread
    @     0x7f2b31fc7b0d __clone
    @                0x0 (unknown)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
