### PR TITLE
[Enhancement] prune iceberg manifests with limit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -154,6 +154,10 @@ public class IcebergTable extends Table {
         return indexes;
     }
 
+    public boolean isV2Format() {
+        return ((BaseTable) getNativeTable()).operations().current().formatVersion() > 1;
+    }
+
     public boolean isUnPartitioned() {
         return getPartitionColumns().size() == 0;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -118,8 +118,8 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys, long snapshotId,
-                                                   ScalarOperator predicate, List<String> fieldNames) {
-        return normal.getRemoteFileInfos(table, partitionKeys, snapshotId, predicate, fieldNames);
+                                                   ScalarOperator predicate, List<String> fieldNames, long limit) {
+        return normal.getRemoteFileInfos(table, partitionKeys, snapshotId, predicate, fieldNames, limit);
     }
 
     @Override
@@ -129,8 +129,8 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
 
     @Override
     public Statistics getTableStatistics(OptimizerContext session, Table table, Map<ColumnRefOperator, Column> columns,
-                                         List<PartitionKey> partitionKeys, ScalarOperator predicate) {
-        return normal.getTableStatistics(session, table, columns, partitionKeys, predicate);
+                                         List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit) {
+        return normal.getTableStatistics(session, table, columns, partitionKeys, predicate, limit);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -134,10 +134,13 @@ public interface ConnectorMetadata {
      * @param snapshotId selected snapshot id
      * @param predicate used to filter metadata for iceberg, etc
      * @param fieldNames all selected columns (including partition columns)
+     * @param limit scan limit nums if needed
+     *
      * @return the remote file information of the query to scan.
      */
     default List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
-                                                    long snapshotId, ScalarOperator predicate, List<String> fieldNames) {
+                                                    long snapshotId, ScalarOperator predicate,
+                                                    List<String> fieldNames, long limit) {
         return Lists.newArrayList();
     }
 
@@ -153,13 +156,16 @@ public interface ConnectorMetadata {
      * @param columns selected columns
      * @param partitionKeys selected partition keys
      * @param predicate used to filter metadata for iceberg, etc
+     * @param limit scan limit if needed, default value is -1
+     *
      * @return the table statistics for the table.
      */
     default Statistics getTableStatistics(OptimizerContext session,
                                           Table table,
                                           Map<ColumnRefOperator, Column> columns,
                                           List<PartitionKey> partitionKeys,
-                                          ScalarOperator predicate) {
+                                          ScalarOperator predicate,
+                                          long limit) {
         return Statistics.builder().build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -174,7 +174,8 @@ public class HiveMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
-                                                   long snapshotId, ScalarOperator predicate, List<String> fieldNames) {
+                                                   long snapshotId, ScalarOperator predicate,
+                                                   List<String> fieldNames, long limit) {
         ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
         HiveMetaStoreTable hmsTbl = (HiveMetaStoreTable) table;
 
@@ -221,7 +222,8 @@ public class HiveMetadata implements ConnectorMetadata {
                                          Table table,
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
-                                         ScalarOperator predicate) {
+                                         ScalarOperator predicate,
+                                         long limit) {
         Statistics statistics = null;
         List<ColumnRefOperator> columnRefOperators = Lists.newArrayList(columns.keySet());
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -124,7 +124,8 @@ public class HudiMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
-                                                   long snapshotId, ScalarOperator predicate, List<String> fieldNames) {
+                                                   long snapshotId, ScalarOperator predicate,
+                                                   List<String> fieldNames, long limit) {
         ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
         HiveMetaStoreTable hmsTbl = (HiveMetaStoreTable) table;
 
@@ -152,7 +153,7 @@ public class HudiMetadata implements ConnectorMetadata {
                                          Table table,
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
-                                         ScalarOperator predicate) {
+                                         ScalarOperator predicate, long limit) {
         Statistics statistics = null;
         List<ColumnRefOperator> columnRefOperators = Lists.newArrayList(columns.keySet());
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -264,6 +264,9 @@ public class IcebergMetadata implements ConnectorMetadata {
                     scan.planFiles(), scan.targetSplitSize());
             CloseableIterator<FileScanTask> fileScanTaskIterator = fileScanTaskIterable.iterator();
             Iterator<FileScanTask> fileScanTasks;
+
+            // Under the condition of ensuring that the data is correct, we disabled the limit optimization when table has
+            // partition evolution because this may cause data diff.
             boolean canPruneManifests = limit != -1 && !table.isV2Format() && onlyHasPartitionPredicate(table, predicate)
                     && limit < Integer.MAX_VALUE && table.getNativeTable().spec().specId() == 0 && enablePruneManifest();
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -265,7 +265,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             CloseableIterator<FileScanTask> fileScanTaskIterator = fileScanTaskIterable.iterator();
             Iterator<FileScanTask> fileScanTasks;
             boolean canPruneManifests = limit != -1 && !table.isV2Format() && onlyHasPartitionPredicate(table, predicate)
-                    && limit < Integer.MAX_VALUE && enablePruneManifest();
+                    && limit < Integer.MAX_VALUE && table.getNativeTable().spec().specId() == 0 && enablePruneManifest();
 
             if (canPruneManifests) {
                 // After iceberg uses partition predicate plan files, each manifests entry must have at least one row of data.

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -57,10 +57,10 @@ public class IcebergStatisticProvider {
     }
 
     public Statistics getTableStatistics(IcebergTable icebergTable, ScalarOperator predicate,
-                                         Map<ColumnRefOperator, Column> colRefToColumnMetaMap) {
+                                         Map<ColumnRefOperator, Column> colRefToColumnMetaMap, long limit) {
         LOG.debug("Begin to make iceberg table statistics!");
         Table nativeTable = icebergTable.getNativeTable();
-        IcebergFileStats icebergFileStats = generateIcebergFileStats(icebergTable, predicate);
+        IcebergFileStats icebergFileStats = generateIcebergFileStats(icebergTable, predicate, limit);
 
         Statistics.Builder statisticsBuilder = Statistics.builder();
         double recordCount = Math.max(icebergFileStats == null ? 0 : icebergFileStats.getRecordCount(), 1);
@@ -70,7 +70,7 @@ public class IcebergStatisticProvider {
         return statisticsBuilder.build();
     }
 
-    private IcebergFileStats generateIcebergFileStats(IcebergTable icebergTable, ScalarOperator icebergPredicate) {
+    private IcebergFileStats generateIcebergFileStats(IcebergTable icebergTable, ScalarOperator icebergPredicate, long limit) {
         Optional<Snapshot> snapshot = Optional.ofNullable(icebergTable.getNativeTable().currentSnapshot());
         if (!snapshot.isPresent()) {
             return null;
@@ -81,7 +81,7 @@ public class IcebergStatisticProvider {
         String catalogName = icebergTable.getCatalogName();
 
         List<RemoteFileInfo> splits = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
-                catalogName, icebergTable, null, snapshotId, icebergPredicate, null);
+                catalogName, icebergTable, null, snapshotId, icebergPredicate, null, limit);
 
         if (splits.isEmpty()) {
             return new IcebergFileStats(1);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -172,7 +172,8 @@ public class PaimonMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
-                                                   long snapshotId, ScalarOperator predicate, List<String> fieldNames) {
+                                                   long snapshotId, ScalarOperator predicate,
+                                                   List<String> fieldNames, long limit) {
         RemoteFileInfo remoteFileInfo = new RemoteFileInfo();
         PaimonTable paimonTable = (PaimonTable) table;
         PaimonFilter filter = new PaimonFilter(paimonTable.getDbName(), paimonTable.getTableName(), predicate, fieldNames);
@@ -200,7 +201,8 @@ public class PaimonMetadata implements ConnectorMetadata {
                                          Table table,
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
-                                         ScalarOperator predicate) {
+                                         ScalarOperator predicate,
+                                         long limit) {
         Statistics.Builder builder = Statistics.builder();
         for (ColumnRefOperator columnRefOperator : columns.keySet()) {
             builder.addColumnStatistic(columnRefOperator, ColumnStatistic.unknown());
@@ -208,7 +210,7 @@ public class PaimonMetadata implements ConnectorMetadata {
 
         List<String> fieldNames = columns.keySet().stream().map(ColumnRefOperator::getName).collect(Collectors.toList());
         List<RemoteFileInfo> fileInfos = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
-                catalogName, table, null, -1, predicate, fieldNames);
+                catalogName, table, null, -1, predicate, fieldNames, limit);
         RemoteFileDesc remoteFileDesc = fileInfos.get(0).getFiles().get(0);
         List<Split> splits = remoteFileDesc.getPaimonSplitsInfo().getPaimonSplits();
         long rowCount = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -131,9 +131,9 @@ public class UnifiedMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys, long snapshotId,
-                                                   ScalarOperator predicate, List<String> fieldNames) {
+                                                   ScalarOperator predicate, List<String> fieldNames, long limit) {
         ConnectorMetadata metadata = metadataOfTable(table);
-        return metadata.getRemoteFileInfos(table, partitionKeys, snapshotId, predicate, fieldNames);
+        return metadata.getRemoteFileInfos(table, partitionKeys, snapshotId, predicate, fieldNames, limit);
     }
 
     @Override
@@ -144,9 +144,9 @@ public class UnifiedMetadata implements ConnectorMetadata {
 
     @Override
     public Statistics getTableStatistics(OptimizerContext session, Table table, Map<ColumnRefOperator, Column> columns,
-                                         List<PartitionKey> partitionKeys, ScalarOperator predicate) {
+                                         List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit) {
         ConnectorMetadata metadata = metadataOfTable(table);
-        return metadata.getTableStatistics(session, table, columns, partitionKeys, predicate);
+        return metadata.getTableStatistics(session, table, columns, partitionKeys, predicate, limit);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -199,7 +199,7 @@ public class IcebergScanNode extends ScanNode {
         long snapshotId = snapshot.get().snapshotId();
 
         List<RemoteFileInfo> splits = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
-                catalogName, srIcebergTable, null, snapshotId, predicate, null);
+                catalogName, srIcebergTable, null, snapshotId, predicate, null, -1);
 
         if (splits.isEmpty()) {
             LOG.warn("There is no scan tasks after planFies on {}.{} and predicate: [{}]",

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -111,7 +111,7 @@ public class PaimonScanNode extends ScanNode {
         List<String> fieldNames =
                 tupleDescriptor.getSlots().stream().map(s -> s.getColumn().getName()).collect(Collectors.toList());
         List<RemoteFileInfo> fileInfos = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
-                paimonTable.getCatalogName(), paimonTable, null, -1, predicate, fieldNames);
+                paimonTable.getCatalogName(), paimonTable, null, -1, predicate, fieldNames, -1);
         RemoteFileDesc remoteFileDesc = fileInfos.get(0).getFiles().get(0);
         PaimonSplitsInfo splitsInfo = remoteFileDesc.getPaimonSplitsInfo();
         String predicateInfo = encodeObjectToString(splitsInfo.getPredicate());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -317,6 +317,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ALLOW_DEFAULT_PARTITION = "allow_default_partition";
 
+    public static final String ENABLE_PRUNE_ICEBERG_MANIFEST = "enable_prune_iceberg_manifest";
+
     public static final String ENABLE_HIVE_COLUMN_STATS = "enable_hive_column_stats";
 
     public static final String ENABLE_HIVE_METADATA_CACHE_WITH_INSERT = "enable_hive_metadata_cache_with_insert";
@@ -1331,6 +1333,17 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public SessionVariable setHiveTempStagingDir(String hiveTempStagingDir) {
         this.hiveTempStagingDir = hiveTempStagingDir;
         return this;
+    }
+
+    @VarAttr(name = ENABLE_PRUNE_ICEBERG_MANIFEST)
+    private boolean enablePruneIcebergManifest = true;
+
+    public boolean isEnablePruneIcebergManifest() {
+        return enablePruneIcebergManifest;
+    }
+
+    public void setEnablePruneIcebergManifest(boolean enablePruneIcebergManifest) {
+        this.enablePruneIcebergManifest = enablePruneIcebergManifest;
     }
 
     public boolean isCboPredicateSubfieldPath() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -286,7 +286,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         if (context.getStatistics() == null) {
             String catalogName = ((IcebergTable) table).getCatalogName();
             Statistics stats = GlobalStateMgr.getCurrentState().getMetadataMgr().getTableStatistics(
-                    optimizerContext, catalogName, table, colRefToColumnMetaMap, null, node.getPredicate());
+                    optimizerContext, catalogName, table, colRefToColumnMetaMap, null, node.getPredicate(), node.getLimit());
             context.setStatistics(stats);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -175,10 +175,10 @@ public class CatalogConnectorMetadataTest {
                 connectorMetadata.createTable(null);
                 connectorMetadata.createDb("test_db");
                 connectorMetadata.dropDb("test_db", false);
-                connectorMetadata.getRemoteFileInfos(null, null, 0, null, null);
+                connectorMetadata.getRemoteFileInfos(null, null, 0, null, null, -1);
                 connectorMetadata.getPartitions(null, null);
                 connectorMetadata.getMaterializedViewIndex("test_db", "test_tbl");
-                connectorMetadata.getTableStatistics(null, null, null, null, null);
+                connectorMetadata.getTableStatistics(null, null, null, null, null, -1);
             }
         };
 
@@ -210,9 +210,9 @@ public class CatalogConnectorMetadataTest {
         catalogConnectorMetadata.createTable(null);
         catalogConnectorMetadata.createDb("test_db");
         catalogConnectorMetadata.dropDb("test_db", false);
-        catalogConnectorMetadata.getRemoteFileInfos(null, null, 0, null, null);
+        catalogConnectorMetadata.getRemoteFileInfos(null, null, 0, null, null, -1);
         catalogConnectorMetadata.getPartitions(null, null);
         catalogConnectorMetadata.getMaterializedViewIndex("test_db", "test_tbl");
-        catalogConnectorMetadata.getTableStatistics(null, null, null, null, null);
+        catalogConnectorMetadata.getTableStatistics(null, null, null, null, null, -1);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -188,7 +188,7 @@ public class HiveMetadataTest {
                 Lists.newArrayList("2"), hiveTable.getPartitionColumns());
 
         List<RemoteFileInfo> remoteFileInfos = hiveMetadata.getRemoteFileInfos(
-                hiveTable, Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), -1, null, null);
+                hiveTable, Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), -1, null, null, -1);
         Assert.assertEquals(2, remoteFileInfos.size());
 
         RemoteFileInfo fileInfo = remoteFileInfos.get(0);
@@ -238,7 +238,7 @@ public class HiveMetadataTest {
         columns.put(partColumnRefOperator, null);
         columns.put(dataColumnRefOperator, null);
         Statistics statistics = hiveMetadata.getTableStatistics(optimizerContext, hiveTable, columns,
-                Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), null);
+                Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), null, -1);
         Assert.assertEquals(1, statistics.getOutputRowCount(), 0.001);
         Assert.assertEquals(2, statistics.getColumnStatistics().size());
         Assert.assertTrue(statistics.getColumnStatistics().get(partColumnRefOperator).isUnknown());
@@ -258,14 +258,14 @@ public class HiveMetadataTest {
         columns.put(partColumnRefOperator, null);
         columns.put(dataColumnRefOperator, null);
 
-        Statistics statistics = hiveMetadata.getTableStatistics(optimizerContext, hiveTable, columns,
-                Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), null);
-        Assert.assertEquals(1, statistics.getOutputRowCount(), 0.001);
+        Statistics statistics = hiveMetadata.getTableStatistics(
+                optimizerContext, hiveTable, columns, Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), null, -1);
+        Assert.assertEquals(1,  statistics.getOutputRowCount(), 0.001);
         Assert.assertEquals(2, statistics.getColumnStatistics().size());
 
         cachingHiveMetastore.getPartitionStatistics(hiveTable, Lists.newArrayList("col1=1", "col1=2"));
         statistics = hiveMetadata.getTableStatistics(optimizerContext, hiveTable, columns,
-                Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), null);
+                Lists.newArrayList(hivePartitionKey1, hivePartitionKey2), null, -1);
 
         Assert.assertEquals(100, statistics.getOutputRowCount(), 0.001);
         Map<ColumnRefOperator, ColumnStatistic> columnStatistics = statistics.getColumnStatistics();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -163,7 +163,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
     @Override
     public Statistics getTableStatistics(OptimizerContext session, com.starrocks.catalog.Table table,
                                          Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
-                                         ScalarOperator predicate) {
+                                         ScalarOperator predicate, long limit) {
         HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) table;
         String hiveDb = hmsTable.getDbName();
         String tblName = hmsTable.getTableName();
@@ -185,7 +185,8 @@ public class MockedHiveMetadata implements ConnectorMetadata {
 
     @Override
     public List<RemoteFileInfo> getRemoteFileInfos(com.starrocks.catalog.Table table, List<PartitionKey> partitionKeys,
-                                                   long snapshotId, ScalarOperator predicate, List<String> fieldNames) {
+                                                   long snapshotId, ScalarOperator predicate,
+                                                   List<String> fieldNames, long limit) {
         HiveMetaStoreTable hmsTbl = (HiveMetaStoreTable) table;
         int size = partitionKeys.size();
         readLock();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
@@ -54,6 +54,14 @@ public class TableTestBase {
                     .withRecordCount(2)
                     .build();
 
+    public static final DataFile FILE_B =
+            DataFiles.builder(SPEC)
+                    .withPath("/path/to/data-b.parquet")
+                    .withFileSizeInBytes(10)
+                    .withPartitionPath("data_bucket=1") // easy way to set partition data for now
+                    .withRecordCount(1)
+                    .build();
+
     static final FileIO FILE_IO = new TestTables.LocalFileIO();
 
     @Rule

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
@@ -63,7 +63,7 @@ public class IcebergStatisticProviderTest extends TableTestBase {
         colRefToColumnMetaMap.put(columnRefOperator1, new Column("id", Type.INT));
         colRefToColumnMetaMap.put(columnRefOperator2, new Column("data", Type.STRING));
 
-        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, null, colRefToColumnMetaMap);
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, null, colRefToColumnMetaMap, -1);
         Assert.assertEquals(2.0, statistics.getOutputRowCount(), 0.001);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -169,7 +169,7 @@ public class PaimonMetadataTest {
         };
         PaimonTable paimonTable = (PaimonTable) metadata.getTable("db1", "tbl1");
         List<String> requiredNames = Lists.newArrayList("f2", "dt");
-        List<RemoteFileInfo> result = metadata.getRemoteFileInfos(paimonTable, null, -1, null, requiredNames);
+        List<RemoteFileInfo> result = metadata.getRemoteFileInfos(paimonTable, null, -1, null, requiredNames, -1);
         Assert.assertEquals(1, result.size());
         Assert.assertEquals(1, result.get(0).getFiles().size());
         Assert.assertEquals(2, result.get(0).getFiles().get(0).getPaimonSplitsInfo().getPaimonSplits().size());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -143,7 +143,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                hiveMetadata.getRemoteFileInfos(hiveTable, ImmutableList.of(), -1, null, null);
+                hiveMetadata.getRemoteFileInfos(hiveTable, ImmutableList.of(), -1, null, null, -1);
                 result = ImmutableList.of();
                 times = 1;
             }
@@ -173,7 +173,8 @@ public class UnifiedMetadataTest {
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
-        List<RemoteFileInfo> remoteFileInfos = unifiedMetadata.getRemoteFileInfos(hiveTable, ImmutableList.of(), -1, null, null);
+        List<RemoteFileInfo> remoteFileInfos = unifiedMetadata.getRemoteFileInfos(
+                hiveTable, ImmutableList.of(), -1, null, null, -1);
         assertEquals(ImmutableList.of(), remoteFileInfos);
         List<PartitionInfo> partitionInfos = unifiedMetadata.getPartitions(hiveTable, ImmutableList.of());
         assertEquals(ImmutableList.of(), partitionInfos);
@@ -214,7 +215,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                icebergMetadata.getRemoteFileInfos(icebergTable, ImmutableList.of(), -1, null, null);
+                icebergMetadata.getRemoteFileInfos(icebergTable, ImmutableList.of(), -1, null, null, -1);
                 result = ImmutableList.of();
                 times = 1;
             }
@@ -245,7 +246,7 @@ public class UnifiedMetadataTest {
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         List<RemoteFileInfo> remoteFileInfos = unifiedMetadata.getRemoteFileInfos(icebergTable, ImmutableList.of(),
-                -1, null, null);
+                -1, null, null, -1);
         assertEquals(ImmutableList.of(), remoteFileInfos);
         List<PartitionInfo> partitionInfos = unifiedMetadata.getPartitions(icebergTable, ImmutableList.of());
         assertEquals(ImmutableList.of(), partitionInfos);
@@ -281,7 +282,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                hudiMetadata.getRemoteFileInfos(hudiTable, ImmutableList.of(), -1, null, null);
+                hudiMetadata.getRemoteFileInfos(hudiTable, ImmutableList.of(), -1, null, null, -1);
                 result = ImmutableList.of();
                 times = 1;
             }
@@ -311,7 +312,8 @@ public class UnifiedMetadataTest {
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
-        List<RemoteFileInfo> remoteFileInfos = unifiedMetadata.getRemoteFileInfos(hudiTable, ImmutableList.of(), -1, null, null);
+        List<RemoteFileInfo> remoteFileInfos = unifiedMetadata.getRemoteFileInfos(
+                hudiTable, ImmutableList.of(), -1, null, null, -1);
         assertEquals(ImmutableList.of(), remoteFileInfos);
         List<PartitionInfo> partitionInfos = unifiedMetadata.getPartitions(hudiTable, ImmutableList.of());
         assertEquals(ImmutableList.of(), partitionInfos);
@@ -352,7 +354,7 @@ public class UnifiedMetadataTest {
                 times = 1;
             }
             {
-                deltaLakeMetadata.getRemoteFileInfos(deltaLakeTable, ImmutableList.of(), -1, null, null);
+                deltaLakeMetadata.getRemoteFileInfos(deltaLakeTable, ImmutableList.of(), -1, null, null, -1);
                 result = ImmutableList.of();
                 times = 1;
             }
@@ -383,7 +385,7 @@ public class UnifiedMetadataTest {
         partitionNames = unifiedMetadata.listPartitionNamesByValue("test_db", "test_tbl", ImmutableList.of());
         assertEquals(ImmutableList.of("test_part1", "test_part2"), partitionNames);
         List<RemoteFileInfo> remoteFileInfos = unifiedMetadata.getRemoteFileInfos(deltaLakeTable, ImmutableList.of(),
-                -1, null, null);
+                -1, null, null, -1);
         assertEquals(ImmutableList.of(), remoteFileInfos);
         List<PartitionInfo> partitionInfos = unifiedMetadata.getPartitions(deltaLakeTable, ImmutableList.of());
         assertEquals(ImmutableList.of(), partitionInfos);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -5,19 +5,12 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.DescriptorTable;
-import com.starrocks.analysis.Expr;
-import com.starrocks.analysis.TableRef;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
-import com.starrocks.sql.optimizer.base.ColumnRefFactory;
-import com.starrocks.sql.optimizer.operator.physical.PhysicalIcebergScanOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.THdfsScanRange;
 import com.starrocks.thrift.TIcebergDeleteFile;
@@ -29,8 +22,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
-import org.apache.iceberg.BaseCombinedScanTask;
-import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.BaseFileScanTask;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DataTableScan;
@@ -40,16 +32,14 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.RuntimeIOException;
-import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,9 +48,10 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.apache.iceberg.TableProperties.SPLIT_SIZE_DEFAULT;
 
 public class IcebergScanNodeTest {
     private String dbName;
@@ -107,12 +98,13 @@ public class IcebergScanNodeTest {
         }
     }
 
-    class TestFileScanTask implements FileScanTask {
+    class TestFileScanTask extends BaseFileScanTask {
         private DataFile data;
 
         private DeleteFile[] deletes;
 
         public TestFileScanTask(DataFile data, DeleteFile[] deletes) {
+            super(data, deletes, null, null, null);
             this.data = data;
             this.deletes = deletes;
         }
@@ -136,24 +128,11 @@ public class IcebergScanNodeTest {
             return 0;
         }
 
-        @Override
-        public long length() {
-            return 0;
-        }
-
-        @Override
-        public Expression residual() {
-            return null;
-        }
-
-        @Override
-        public Iterable<FileScanTask> split(long l) {
-            return null;
-        }
     }
 
     private void setUpMock(boolean isPosDelete, com.starrocks.catalog.IcebergTable table,
                            Table iTable, Snapshot snapshot, DataTableScan dataTableScan) {
+
         new MockUp<DataTableScan>() {
             @Mock
             public DataTableScan useSnapshot(long var1) {
@@ -161,8 +140,8 @@ public class IcebergScanNodeTest {
             }
 
             @Mock
-            public CloseableIterable<CombinedScanTask> planTasks() {
-                List<CombinedScanTask> tasks = new ArrayList<CombinedScanTask>();
+            public CloseableIterable<FileScanTask> planFiles()  {
+                List<FileScanTask> tasks = new ArrayList<FileScanTask>();
                 DataFile data = DataFiles.builder(PartitionSpec.unpartitioned())
                         .withInputFile(new LocalFileIO().newInputFile("input.orc"))
                         .withRecordCount(1)
@@ -186,7 +165,7 @@ public class IcebergScanNodeTest {
 
 
                 FileScanTask scanTask = new TestFileScanTask(data, new DeleteFile[]{delete});
-                tasks.add(new BaseCombinedScanTask(scanTask));
+                tasks.add(scanTask);
 
                 return CloseableIterable.withNoopClose(tasks);
             }
@@ -207,6 +186,14 @@ public class IcebergScanNodeTest {
                 result = dataTableScan;
             }
         };
+
+        new Expectations(dataTableScan) {
+            {
+                dataTableScan.targetSplitSize();
+                result = SPLIT_SIZE_DEFAULT;
+            }
+        };
+
     }
 
     @Before
@@ -237,6 +224,35 @@ public class IcebergScanNodeTest {
         setUpMock(true, table, iTable, snapshot, dataTableScan);
 
         IcebergScanNode scanNode = new IcebergScanNode(new PlanNodeId(0), tupleDesc, "IcebergScanNode");
+
+        new MockUp<SnapshotScan>() {
+            @Mock
+            public CloseableIterable<FileScanTask> planFiles()  {
+                List<FileScanTask> tasks = new ArrayList<>();
+                DataFile data = DataFiles.builder(PartitionSpec.unpartitioned())
+                        .withInputFile(new LocalFileIO().newInputFile("input.orc"))
+                        .withRecordCount(1)
+                        .withFileSizeInBytes(1024)
+                        .withFormat(FileFormat.ORC)
+                        .build();
+
+                FileMetadata.Builder builder;
+                    builder = FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+                            .ofPositionDeletes();
+                DeleteFile delete = builder.withPath("delete.orc")
+                        .withFileSizeInBytes(1024)
+                        .withRecordCount(1)
+                        .withFormat(FileFormat.ORC)
+                        .build();
+
+
+                FileScanTask scanTask = new TestFileScanTask(data, new DeleteFile[]{delete});
+                tasks.add(scanTask);
+
+                return CloseableIterable.withNoopClose(tasks);
+            }
+        };
+
         scanNode.setupScanRangeLocations();
 
         List<TScanRangeLocations> result = scanNode.getScanRangeLocations(1);
@@ -249,27 +265,5 @@ public class IcebergScanNodeTest {
         TIcebergDeleteFile deleteFile = hdfsScanRange.delete_files.get(0);
         Assert.assertEquals("delete.orc", deleteFile.full_path);
         Assert.assertEquals(TIcebergFileContent.POSITION_DELETES, deleteFile.file_content);
-    }
-
-    @Test
-    public void testGetScanRangeLocationsWithEquality(@Mocked com.starrocks.catalog.IcebergTable table,
-                                                      @Mocked Table iTable,
-                                                      @Mocked Snapshot snapshot,
-                                                      @Mocked DataTableScan dataTableScan) throws Exception {
-        Analyzer analyzer = new Analyzer(GlobalStateMgr.getCurrentState(), new ConnectContext());
-        DescriptorTable descTable = analyzer.getDescTbl();
-        TupleDescriptor tupleDesc = descTable.createTupleDescriptor("DestTableTuple");
-        tupleDesc.setTable(table);
-
-        setUpMock(false, table, iTable, snapshot, dataTableScan);
-
-        IcebergScanNode scanNode = new IcebergScanNode(new PlanNodeId(0), tupleDesc, "IcebergScanNode");
-        scanNode.setupScanRangeLocations();
-
-        List<TScanRangeLocations> result = scanNode.getScanRangeLocations(1);
-        TScanRange scanRange = result.get(0).scan_range;
-        THdfsScanRange hdfsScanRange = scanRange.hdfs_scan_range;
-        TIcebergDeleteFile deleteFile = hdfsScanRange.delete_files.get(0);
-        Assert.assertEquals(TIcebergFileContent.EQUALITY_DELETES, deleteFile.file_content);
     }
 }


### PR DESCRIPTION
Fixes #issue

When the user iceberg metadata is particularly large, even if we currently cache the manifests file input stream, it is time-consuming to decode the manifests avro file. This patch mainly prune manifest entry by limit. This optimization can be used if the following conditions are met:
- iceberg v1 format
- limit != -1
- only has partition predicate in query
- session var `enable_prune_iceberg_manifest=true`. default value is true.

A 56MB manifests file with limit 10 test :
base 70s
patched 1s

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
