### PR TITLE
[BugFix] BugFix AccessPath construction

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
@@ -66,9 +66,7 @@ public class PruneSubfieldRule extends TransformationRule {
 
         // normalize access path
         SubfieldAccessPathNormalizer normalizer = new SubfieldAccessPathNormalizer();
-        for (ScalarOperator expr : allSubfieldExpr) {
-            expr.accept(normalizer, null);
-        }
+        normalizer.collect(allSubfieldExpr);
 
         List<ColumnAccessPath> accessPaths = Lists.newArrayList();
         for (ColumnRefOperator ref : scan.getColRefToColumnMetaMap().keySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -171,6 +171,11 @@ public class SubfieldAccessPathNormalizer {
             }
             Optional<AccessPath> currentPath = scalarOperator.accept(this, childAccessPaths);
             AccessPath path = currentPath.orElse(null);
+            // When an AccessPath from offspring ScalarOperators can be extended to a longer AccessPath
+            // in current ScalarOperator would not gathered until it can not be extended.
+            // Since AccessPath is extended by appending path component in-place, so AccessPaths in
+            // childAccessPaths that is not identical to AccessPath of the current ScalarOperator is
+            // non-extendable.
             childAccessPaths.stream().filter(p -> p.isPresent() && p.get() != path)
                     .map(Optional::get).forEach(accessPaths::add);
             return currentPath;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -25,17 +25,17 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.thrift.TAccessPathType;
 
+import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /*
  * normalize expression to ColumnAccessPath
  */
-public class SubfieldAccessPathNormalizer extends ScalarOperatorVisitor<Void, Void> {
+public class SubfieldAccessPathNormalizer {
     private final Deque<AccessPath> allAccessPaths = Lists.newLinkedList();
-
-    private AccessPath currentPath = null;
 
     private static class AccessPath {
         private final ScalarOperator root;
@@ -49,6 +49,11 @@ public class SubfieldAccessPathNormalizer extends ScalarOperatorVisitor<Void, Vo
         public AccessPath appendPath(String path, TAccessPathType pathType) {
             paths.add(path);
             pathTypes.add(pathType);
+            return this;
+        }
+
+        public AccessPath appendFieldNames(Collection<String> fieldNames) {
+            fieldNames.forEach(fld -> appendPath(fld, TAccessPathType.FIELD));
             return this;
         }
 
@@ -98,84 +103,81 @@ public class SubfieldAccessPathNormalizer extends ScalarOperatorVisitor<Void, Vo
         return allAccessPaths.stream().anyMatch(path -> path.root().equals(root));
     }
 
-    public void add(ScalarOperator operator) {
-        if (operator == null) {
-            return;
+    public static class Collector extends ScalarOperatorVisitor<Optional<AccessPath>, List<Optional<AccessPath>>> {
+        @Override
+        public Optional<AccessPath> visit(ScalarOperator scalarOperator,
+                                          List<Optional<AccessPath>> childrenAccessPaths) {
+            return Optional.empty();
         }
-        operator.accept(this, null);
-    }
 
-    @Override
-    public Void visit(ScalarOperator scalarOperator, Void context) {
-        for (ScalarOperator child : scalarOperator.getChildren()) {
-            child.accept(this, context);
-            if (currentPath != null) {
-                allAccessPaths.push(currentPath);
-                currentPath = null;
+        @Override
+        public Optional<AccessPath> visitVariableReference(ColumnRefOperator variable,
+                                                           List<Optional<AccessPath>> childrenAccessPaths) {
+            if (variable.getType().isComplexType()) {
+                return Optional.of(new AccessPath(variable));
             }
-        }
-        return null;
-    }
-
-    @Override
-    public Void visitVariableReference(ColumnRefOperator variable, Void context) {
-        if (variable.getType().isComplexType()) {
-            currentPath = new AccessPath(variable);
-            allAccessPaths.push(currentPath);
-        }
-        return null;
-    }
-
-    @Override
-    public Void visitSubfield(SubfieldOperator subfieldOperator, Void context) {
-        subfieldOperator.getChild(0).accept(this, context);
-        if (currentPath != null) {
-            subfieldOperator.getFieldNames()
-                    .forEach(p -> currentPath.appendPath(p, TAccessPathType.FIELD));
-        }
-        return null;
-    }
-
-    @Override
-    public Void visitCollectionElement(CollectionElementOperator collectionElementOp, Void context) {
-        if (!collectionElementOp.getChild(1).isConstant()) {
-            collectionElementOp.getChild(1).accept(this, context);
+            return Optional.empty();
         }
 
-        collectionElementOp.getChild(0).accept(this, context);
-        if (currentPath == null) {
-            return null;
+        @Override
+        public Optional<AccessPath> visitSubfield(SubfieldOperator subfieldOperator,
+                                                  List<Optional<AccessPath>> childAccessPaths) {
+            return childAccessPaths.get(0).map(parent -> parent.appendFieldNames(subfieldOperator.getFieldNames()));
         }
 
-        if (!collectionElementOp.getChild(1).isConstant()) {
-            currentPath.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.ALL);
-            return null;
-        }
-        currentPath.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.INDEX);
-        return null;
-    }
-
-    @Override
-    public Void visitCall(CallOperator call, Void context) {
-        if (!PruneSubfieldRule.SUPPORT_FUNCTIONS.contains(call.getFnName())) {
-            return visit(call, context);
-        }
-
-        if (call.getFnName().equals(FunctionSet.MAP_KEYS)) {
-            call.getChild(0).accept(this, context);
-            if (currentPath != null) {
-                currentPath.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.KEY);
+        @Override
+        public Optional<AccessPath> visitCollectionElement(CollectionElementOperator collectionElementOp,
+                                                           List<Optional<AccessPath>> childrenAccessPaths) {
+            Optional<AccessPath> parent = childrenAccessPaths.get(0);
+            if (!parent.isPresent()) {
+                return Optional.empty();
             }
-            return null;
-        } else if (FunctionSet.MAP_SIZE.equals(call.getFnName())
-                || FunctionSet.CARDINALITY.equals(call.getFnName())
-                || FunctionSet.ARRAY_LENGTH.equals(call.getFnName())) {
-            call.getChild(0).accept(this, context);
-            if (currentPath != null) {
-                currentPath.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.OFFSET);
+
+            if (!collectionElementOp.getChild(1).isConstant()) {
+                return parent.map(p -> p.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.ALL));
+            } else {
+                return parent.map(p -> p.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.INDEX));
             }
         }
 
-        return null;
+        @Override
+        public Optional<AccessPath> visitCall(CallOperator call, List<Optional<AccessPath>> childrenAccessPaths) {
+            if (!PruneSubfieldRule.SUPPORT_FUNCTIONS.contains(call.getFnName())) {
+                return Optional.empty();
+            }
+
+            if (call.getFnName().equals(FunctionSet.MAP_KEYS)) {
+                return childrenAccessPaths.get(0)
+                        .map(p -> p.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.KEY));
+            } else if (FunctionSet.MAP_SIZE.equals(call.getFnName())
+                    || FunctionSet.CARDINALITY.equals(call.getFnName())
+                    || FunctionSet.ARRAY_LENGTH.equals(call.getFnName())) {
+                return childrenAccessPaths.get(0)
+                        .map(p -> p.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.OFFSET));
+            }
+
+            return Optional.empty();
+        }
+
+        public Optional<AccessPath> process(ScalarOperator scalarOperator, Deque<AccessPath> accessPaths) {
+            // process children in post-order
+            List<Optional<AccessPath>> childAccessPaths = scalarOperator.getChildren().stream()
+                    .map(child -> process(child, accessPaths))
+                    .collect(Collectors.toList());
+            // no AccessPaths gathered from children of intermediate ScalarOperator means current
+            // scalar operator contains not nested types.
+            if (!childAccessPaths.isEmpty() && childAccessPaths.stream().noneMatch(Optional::isPresent)) {
+                return Optional.empty();
+            }
+            childAccessPaths.forEach(p -> p.ifPresent(accessPaths::add));
+            return scalarOperator.accept(this, childAccessPaths);
+        }
+    }
+
+    public void collect(List<ScalarOperator> scalarOperators) {
+        Collector collector = new Collector();
+        List<Optional<AccessPath>> paths =
+                scalarOperators.stream().map(op -> collector.process(op, allAccessPaths)).collect(Collectors.toList());
+        paths.forEach(p -> p.ifPresent(allAccessPaths::add));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -673,7 +673,7 @@ public class PlanFragmentBuilder {
 
             List<ColumnAccessPath> paths = Lists.newArrayList();
             SubfieldAccessPathNormalizer normalizer = new SubfieldAccessPathNormalizer();
-            collector.getComplexExpressions().forEach(normalizer::add);
+            normalizer.collect(collector.getComplexExpressions());
 
             for (ColumnRefOperator key : scan.getColRefToColumnMetaMap().keySet()) {
                 if (!key.getType().isComplexType()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -656,6 +656,37 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                     "     ColumnAccessPath: [/st3/sa3]\n" +
                     "     cardinality: 1\n");
         }
+    }
 
+    @Test
+    public void testCommonPathMerge() throws Exception {
+        {
+            String sql = "select pc0.a1[0],pc0.a1[1] from pc0 where (([]) is not NULL)";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  0:OlapScanNode\n" +
+                    "     table: pc0, rollup: pc0\n" +
+                    "     preAggregation: on\n" +
+                    "     Predicates: array_length([]) IS NOT NULL\n" +
+                    "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
+                    "     tabletList=\n" +
+                    "     actualRows=0, avgRowSize=3.0\n" +
+                    "     Pruned type: 7 <-> [ARRAY<INT>]\n" +
+                    "     ColumnAccessPath: [/a1/INDEX]\n" +
+                    "     cardinality: 1");
+        }
+        {
+            String sql = "select st3.sa3[0], array_length(st3.sa3) from sc0 where (([1,2,3]) is NOT NULL)";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  0:OlapScanNode\n" +
+                    "     table: sc0, rollup: sc0\n" +
+                    "     preAggregation: on\n" +
+                    "     Predicates: array_length([1,2,3]) IS NOT NULL\n" +
+                    "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
+                    "     tabletList=\n" +
+                    "     actualRows=0, avgRowSize=3.0\n" +
+                    "     Pruned type: 4 <-> [struct<s1 int(11), s2 int(11), sa3 array<int(11)>>]\n" +
+                    "     ColumnAccessPath: [/st3/sa3/ALL]\n" +
+                    "     cardinality: 1\n");
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -625,4 +625,37 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                         "  |  <slot 16> : array_map(<slot 15> -> CAST(<slot 15> AS BIGINT) + 8: v1, 7: a1)\n" +
                         "  |  <slot 27> : 27: expr");
     }
+
+    @Test
+    public void testLiteralArrayPredicates() throws Exception {
+        {
+            String sql = "select pc0.a1 from pc0 where (([]) is not NULL)";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  0:OlapScanNode\n" +
+                    "     table: pc0, rollup: pc0\n" +
+                    "     preAggregation: on\n" +
+                    "     Predicates: array_length([]) IS NOT NULL\n" +
+                    "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
+                    "     tabletList=\n" +
+                    "     actualRows=0, avgRowSize=1.0\n" +
+                    "     Pruned type: 7 <-> [ARRAY<INT>]\n" +
+                    "     cardinality: 1");
+
+        }
+        {
+            String sql = "select st3.sa3, array_length(st3.sa3) from sc0 where (([1,2,3]) is NOT NULL)";
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  0:OlapScanNode\n" +
+                    "     table: sc0, rollup: sc0\n" +
+                    "     preAggregation: on\n" +
+                    "     Predicates: array_length([1,2,3]) IS NOT NULL\n" +
+                    "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
+                    "     tabletList=\n" +
+                    "     actualRows=0, avgRowSize=3.0\n" +
+                    "     Pruned type: 4 <-> [struct<s1 int(11), s2 int(11), sa3 array<int(11)>>]\n" +
+                    "     ColumnAccessPath: [/st3/sa3]\n" +
+                    "     cardinality: 1\n");
+        }
+
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/StarRocks/StarRocksTest/issues/3814

1. ColumnAccessPath's extraction and normalization processes (([]) IS NOT NULL) mistakenly,  it generate a wrong ColumnAccessPath /array/OFFSET

```
mysql> explain costs SELECT t1_126.c_1_10 FROM t1_1 AS t1_126 WHERE (([]) IS NOT NULL);
+--------------------------------------------------------------+
| Explain String                                               |
+--------------------------------------------------------------+
| PLAN FRAGMENT 0(F00)                                         |
|   Output Exprs:11: c_1_10                                    |
|   Input Partition: RANDOM                                    |
|   RESULT SINK                                                |
|                                                              |
|   0:OlapScanNode                                             |
|      table: t1_1, rollup: t1_1                               |
|      preAggregation: on                                      |
|      Predicates: array_length([]) IS NOT NULL                |
|      partitionsRatio=1/1, tabletsRatio=1/1                   |
|      tabletList=2641283                                      |
|      actualRows=4, avgRowSize=1.0                            |
|      Pruned type: 11 <-> [ARRAY<INT>]                        |
|      ColumnAccessPath: [/c_1_10/OFFSET]                      |
|      cardinality: 4                                          |
|      column statistics:                                      |
|      * c_1_10-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN |
+--------------------------------------------------------------+
```
2. BE considers that it only needs offsets column of array column when it counters /array/OFFSET, so it just appends default values(NULL) whose number is equivalent to the number of  array elements instead of reading real values.

```cpp

 _access_values = false;

Status ArrayColumnIterator::init(const ColumnIteratorOptions& opts) {
    if (_null_iterator != nullptr) {
        RETURN_IF_ERROR(_null_iterator->init(opts));
    }
    RETURN_IF_ERROR(_array_size_iterator->init(opts));
    RETURN_IF_ERROR(_element_iterator->init(opts));

    // only offset
    if (_path != nullptr && _path->children().size() == 1 && _path->children()[0]->is_offset()) {
        _access_values = false;
    }
    return Status::OK();
}
```

```cpp
    // 3. Read elements
    if (_access_values) {
        RETURN_IF_ERROR(_element_iterator->next_batch(&num_to_read, array_column->elements_column().get()));
    } else {
        array_column->elements_column()->append_default(num_to_read);
    }
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
  - [ ] 2.4
