### PR TITLE
[Enhancement] No need to build_slice for get data from BinaryColumn

### DIFF
--- a/be/src/util/arrow/starrocks_column_to_arrow.cpp
+++ b/be/src/util/arrow/starrocks_column_to_arrow.cpp
@@ -46,7 +46,6 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvFloatAndIntegerGuard<LT, 
     using StarRocksCppType = RunTimeCppType<LT>;
     using StarRocksColumnType = RunTimeColumnType<LT>;
     using ArrowType = ArrowTypeIdToType<AT>;
-    using ArrowCppType = ArrowTypeIdToCppType<AT>;
     using ArrowBuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType;
     static inline arrow::Status convert(const ColumnPtr& column, arrow::MemoryPool* pool,
                                         std::shared_ptr<arrow::Array>& array) {
@@ -85,7 +84,6 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvDecimalGuard<LT, AT>> {
     using StarRocksCppType = RunTimeCppType<LT>;
     using StarRocksColumnType = RunTimeColumnType<LT>;
     using ArrowType = ArrowTypeIdToType<AT>;
-    using ArrowCppType = ArrowTypeIdToCppType<AT>;
     using ArrowBuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType;
 
     static inline arrow::Decimal128 convert_datum(const StarRocksCppType& datum) {
@@ -164,7 +162,6 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvBinaryGuard<LT, AT>> {
     using StarRocksCppType = RunTimeCppType<LT>;
     using StarRocksColumnType = RunTimeColumnType<LT>;
     using ArrowType = ArrowTypeIdToType<AT>;
-    using ArrowCppType = ArrowTypeIdToCppType<AT>;
     using ArrowBuilderType = typename arrow::TypeTraits<ArrowType>::BuilderType;
 
     static inline std::string convert_datum(const StarRocksCppType& datum, [[maybe_unused]] int precision,
@@ -197,33 +194,49 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvBinaryGuard<LT, AT>> {
             const auto* nullable_column = down_cast<NullableColumn*>(column.get());
             const auto* data_column = down_cast<StarRocksColumnType*>(nullable_column->data_column().get());
             const auto* null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
-            const auto& data = data_column->get_data();
-            [[maybe_unused]] int precision = -1;
-            [[maybe_unused]] int scale = -1;
-            if constexpr (lt_is_decimal<LT>) {
-                precision = data_column->precision();
-                scale = data_column->scale();
-            }
             const auto num_rows = null_column->size();
-            for (auto i = 0; i < num_rows; ++i) {
-                if (nullable_column->is_null(i)) {
-                    ARROW_RETURN_NOT_OK(builder->AppendNull());
-                } else {
-                    ARROW_RETURN_NOT_OK(builder->Append(convert_datum(data[i], precision, scale)));
+            if constexpr (lt_is_string<LT>) {
+                for (auto i = 0; i < num_rows; ++i) {
+                    if (nullable_column->is_null(i)) {
+                        ARROW_RETURN_NOT_OK(builder->AppendNull());
+                    } else {
+                        ARROW_RETURN_NOT_OK(builder->Append(convert_datum(data_column->get_slice(i), -1, -1)));
+                    }
+                }
+            } else {
+                const auto& data = data_column->get_data();
+                [[maybe_unused]] int precision = -1;
+                [[maybe_unused]] int scale = -1;
+                if constexpr (lt_is_decimal<LT>) {
+                    precision = data_column->precision();
+                    scale = data_column->scale();
+                }
+                for (auto i = 0; i < num_rows; ++i) {
+                    if (nullable_column->is_null(i)) {
+                        ARROW_RETURN_NOT_OK(builder->AppendNull());
+                    } else {
+                        ARROW_RETURN_NOT_OK(builder->Append(convert_datum(data[i], precision, scale)));
+                    }
                 }
             }
         } else {
             const auto* data_column = down_cast<StarRocksColumnType*>(column.get());
-            const auto& data = data_column->get_data();
             const auto num_rows = column->size();
-            [[maybe_unused]] int precision = -1;
-            [[maybe_unused]] int scale = -1;
-            if constexpr (lt_is_decimal<LT>) {
-                precision = data_column->precision();
-                scale = data_column->scale();
-            }
-            for (auto i = 0; i < num_rows; ++i) {
-                ARROW_RETURN_NOT_OK(builder->Append(convert_datum(data[i], precision, scale)));
+            if constexpr (lt_is_string<LT>) {
+                for (auto i = 0; i < num_rows; ++i) {
+                    ARROW_RETURN_NOT_OK(builder->Append(convert_datum(data_column->get_slice(i), -1, -1)));
+                }
+            } else {
+                const auto& data = data_column->get_data();
+                [[maybe_unused]] int precision = -1;
+                [[maybe_unused]] int scale = -1;
+                if constexpr (lt_is_decimal<LT>) {
+                    precision = data_column->precision();
+                    scale = data_column->scale();
+                }
+                for (auto i = 0; i < num_rows; ++i) {
+                    ARROW_RETURN_NOT_OK(builder->Append(convert_datum(data[i], precision, scale)));
+                }
             }
         }
         return builder->Finish(&array);
@@ -313,7 +326,7 @@ Status convert_chunk_to_arrow_batch(Chunk* chunk, std::vector<ExprContext*>& _ou
     std::vector<std::shared_ptr<arrow::Array>> arrays(result_num_column);
 
     for (auto i = 0; i < result_num_column; ++i) {
-        ASSIGN_OR_RETURN(ColumnPtr column, _output_expr_ctxs[i]->evaluate(chunk));
+        ASSIGN_OR_RETURN(ColumnPtr column, _output_expr_ctxs[i]->evaluate(chunk))
         Expr* expr = _output_expr_ctxs[i]->root();
         if (column->is_constant()) {
             column = ColumnHelper::unfold_const_column(expr->type(), chunk->num_rows(), column);

--- a/be/src/util/arrow/starrocks_column_to_arrow.cpp
+++ b/be/src/util/arrow/starrocks_column_to_arrow.cpp
@@ -196,11 +196,12 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvBinaryGuard<LT, AT>> {
             const auto* null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
             const auto num_rows = null_column->size();
             if constexpr (lt_is_string<LT>) {
+                const auto& data = data_column->get_proxy_data();
                 for (auto i = 0; i < num_rows; ++i) {
                     if (nullable_column->is_null(i)) {
                         ARROW_RETURN_NOT_OK(builder->AppendNull());
                     } else {
-                        ARROW_RETURN_NOT_OK(builder->Append(convert_datum(data_column->get_slice(i), -1, -1)));
+                        ARROW_RETURN_NOT_OK(builder->Append(convert_datum(data[i], -1, -1)));
                     }
                 }
             } else {
@@ -223,8 +224,9 @@ struct ColumnToArrowConverter<LT, AT, is_nullable, ConvBinaryGuard<LT, AT>> {
             const auto* data_column = down_cast<StarRocksColumnType*>(column.get());
             const auto num_rows = column->size();
             if constexpr (lt_is_string<LT>) {
+                const auto& data = data_column->get_proxy_data();
                 for (auto i = 0; i < num_rows; ++i) {
-                    ARROW_RETURN_NOT_OK(builder->Append(convert_datum(data_column->get_slice(i), -1, -1)));
+                    ARROW_RETURN_NOT_OK(builder->Append(convert_datum(data[i], -1, -1)));
                 }
             } else {
                 const auto& data = data_column->get_data();


### PR DESCRIPTION
Fixes #issue

There are two main purposes:

* Optimize the performance of Convert binary column to arrow format (https://github.com/StarRocks/starrocks/pull/30664)
* Convenient for the memory statistics for spark connector export (build slice will allocate additional memory for chunk)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
  - [x] 2.4
