### PR TITLE
[Feature] Add materialized view metrics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -72,9 +72,13 @@ public class MetricsAction extends RestBaseAction {
 
 
     public final class RequestParams {
+        // Whether to collect per table metrics
         private final boolean collectTableMetrics;
+        // Whether to collect per table metrics in minified mode, Ignore some heavy metrics if true
         private final boolean minifyTableMetrics;
+        // Whether to collect per materialized view metrics
         private final boolean collectMVMetrics;
+        // Whether to collect per materialized view metrics in minified mode, Ignore some heavy metrics if true
         private final boolean minifyMVMetrics;
         RequestParams(boolean collectTableMetrics, boolean minifyTableMetrics,
                       boolean collectMVMetrics, boolean minifyMVMetrics) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -61,12 +61,44 @@ public class MetricsAction extends RestBaseAction {
     // `with_table_metrics=minified` : without tables that have empty values
     // `with_table_metrics=all` : with all table metrics
     protected static final String WITH_TABLE_METRICS_PARAM = "with_table_metrics";
-    protected static final String WITH_TABLE_METRICS_MINIFIED = "minified";
-    protected static final String WITH_TABLE_METRICS_ALL = "all";
+    protected static final String WITH_MATERIALIZED_VIEW_METRICS_PARAM = "with_materialized_view_metrics";
+    protected static final String COLLECT_MODE_METRICS_MINIFIED = "minified";
+    protected static final String COLLECT_MODE_METRICS_ALL = "all";
     public static final String API_PATH = "/metrics";
 
     public MetricsAction(ActionController controller) {
         super(controller);
+    }
+
+
+    public final class RequestParams {
+        private final boolean collectTableMetrics;
+        private final boolean minifyTableMetrics;
+        private final boolean collectMVMetrics;
+        private final boolean minifyMVMetrics;
+        RequestParams(boolean collectTableMetrics, boolean minifyTableMetrics,
+                      boolean collectMVMetrics, boolean minifyMVMetrics) {
+            this.collectTableMetrics = collectTableMetrics;
+            this.minifyTableMetrics = minifyTableMetrics;
+            this.collectMVMetrics = collectMVMetrics;
+            this.minifyMVMetrics = minifyMVMetrics;
+        }
+
+        public boolean isCollectTableMetrics() {
+            return collectTableMetrics;
+        }
+
+        public boolean isMinifyTableMetrics() {
+            return minifyTableMetrics;
+        }
+
+        public boolean isCollectMVMetrics() {
+            return collectMVMetrics;
+        }
+
+        public boolean isMinifyMVMetrics() {
+            return minifyMVMetrics;
+        }
     }
 
     public static void registerAction(ActionController controller) throws IllegalArgException {
@@ -75,6 +107,7 @@ public class MetricsAction extends RestBaseAction {
 
     @Override
     public void execute(BaseRequest request, BaseResponse response) throws DdlException {
+        // parse visitor type
         String type = request.getSingleParameter(TYPE_PARAM);
         MetricVisitor visitor = null;
         if (!Strings.isNullOrEmpty(type) && type.equalsIgnoreCase("core")) {
@@ -84,27 +117,34 @@ public class MetricsAction extends RestBaseAction {
         } else {
             visitor = new PrometheusMetricVisitor("starrocks_fe");
         }
-        boolean collectTableMetrics = false;
-        boolean minifyTableMetrics = true;
+
+        // parse request params
+        RequestParams requestParams = parseRequestParams(request);
+
+        response.setContentType("text/plain");
+        response.getContent().append(MetricRepo.getMetric(visitor, requestParams));
+        sendResult(request, response);
+    }
+
+    private RequestParams parseRequestParams(BaseRequest request) {
         String withTableMetrics = request.getSingleParameter(WITH_TABLE_METRICS_PARAM);
-        UserIdentity currentUser = null;
-        if (WITH_TABLE_METRICS_MINIFIED.equalsIgnoreCase(withTableMetrics) ||
-                WITH_TABLE_METRICS_ALL.equalsIgnoreCase(withTableMetrics)) {
+        String withMaterializedViewsMetrics = request.getSingleParameter(WITH_MATERIALIZED_VIEW_METRICS_PARAM);
+        // check request authorization
+        if (Strings.isNullOrEmpty(withMaterializedViewsMetrics) || Strings.isNullOrEmpty(withTableMetrics)) {
+            UserIdentity currentUser = null;
             try {
                 ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
                 currentUser = checkPassword(authInfo);
                 checkUserOwnsAdminRole(currentUser);
-                collectTableMetrics = true;
-                if (WITH_TABLE_METRICS_ALL.equalsIgnoreCase(withTableMetrics)) {
-                    minifyTableMetrics = false;
-                }
             } catch (AccessDeniedException e) {
                 LOG.warn("Auth failure when getting table level metrics, current user: {}, error msg: {}",
                         currentUser, e.getMessage(), e);
             }
         }
-        response.setContentType("text/plain");
-        response.getContent().append(MetricRepo.getMetric(visitor, collectTableMetrics, minifyTableMetrics));
-        sendResult(request, response);
+        boolean collectTableMetrics = COLLECT_MODE_METRICS_MINIFIED.equalsIgnoreCase(withTableMetrics);
+        boolean minifyTableMetrics = COLLECT_MODE_METRICS_ALL.equalsIgnoreCase(withTableMetrics);
+        boolean collectMVMetrics = COLLECT_MODE_METRICS_ALL.equalsIgnoreCase(withMaterializedViewsMetrics);
+        boolean minifyMVMetrics = COLLECT_MODE_METRICS_MINIFIED.equalsIgnoreCase(withMaterializedViewsMetrics);
+        return new RequestParams(collectTableMetrics, minifyTableMetrics, collectMVMetrics, minifyMVMetrics);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsEntity.java
@@ -1,0 +1,273 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.metric;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.metric.Metric.MetricUnit;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.scheduler.PartitionBasedMvRefreshProcessor;
+import com.starrocks.scheduler.TaskBuilder;
+import com.starrocks.scheduler.TaskManager;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+public final class MaterializedViewMetricsEntity {
+    private static final Logger LOG = LogManager.getLogger(MaterializedViewMetricsEntity.class);
+
+
+    private final MvId mvId;
+    private final MetricRegistry metricRegistry;
+    private final List<Metric> metrics = Lists.newArrayList();
+
+    // refresh
+    public LongCounterMetric counterRefreshJobTotal;
+    public LongCounterMetric counterRefreshJobSuccessTotal;
+    public LongCounterMetric counterRefreshJobFailedTotal;
+    public LongCounterMetric counterRefreshJobEmptyTotal;
+    public LongCounterMetric counterRefreshJobRetryCheckChangedTotal;
+
+    // query
+    // only record when the materialized view is not contained before rewriting
+    public LongCounterMetric counterQueryHitTotal;
+    public LongCounterMetric counterQueryConsideredTotal;
+    public LongCounterMetric counterQueryMatchedTotal;
+    // record once the materialized view is used in the final plan
+    public LongCounterMetric counterQueryMaterializedViewTotal;
+
+    // gauge
+    public GaugeMetric<Long> counterRefreshPendingJobs;
+    public GaugeMetric<Long> counterRefreshRunningJobs;
+    public GaugeMetric<Long> counterRowNums;
+    public GaugeMetric<Long> counterStorageSize;
+
+    // histogram
+    public Histogram histRefreshJobDuration;
+
+    public MaterializedViewMetricsEntity(MetricRegistry metricRegistry, MvId mvId) {
+        this.metricRegistry = metricRegistry;
+        this.mvId = mvId;
+
+        initMaterializedViewMetrics();
+    }
+
+    public List<Metric> getMetrics() {
+        return metrics;
+    }
+
+    protected void initMaterializedViewMetrics() {
+        // refresh metrics
+        counterRefreshJobTotal = new LongCounterMetric("mv_refresh_jobs", MetricUnit.REQUESTS,
+                "total materialized view's refresh jobs");
+        metrics.add(counterRefreshJobTotal);
+        counterRefreshJobSuccessTotal = new LongCounterMetric("mv_refresh_total_success_jobs", MetricUnit.REQUESTS,
+                "total materialized view's refresh success jobs");
+        metrics.add(counterRefreshJobSuccessTotal);
+        counterRefreshJobFailedTotal = new LongCounterMetric("mv_refresh_total_failed_jobs", MetricUnit.REQUESTS,
+                "total materialized view's refresh failed jobs");
+        metrics.add(counterRefreshJobFailedTotal);
+        counterRefreshJobEmptyTotal = new LongCounterMetric("mv_refresh_total_empty_jobs", MetricUnit.REQUESTS,
+                "total materialized view's refresh empty jobs");
+        metrics.add(counterRefreshJobEmptyTotal);
+        counterRefreshJobRetryCheckChangedTotal = new LongCounterMetric("mv_refresh_total_retry_meta_count", MetricUnit.REQUESTS,
+                "total materialized view's retry to check table change count");
+        metrics.add(counterRefreshJobRetryCheckChangedTotal);
+
+        // query metrics
+        counterQueryMaterializedViewTotal = new LongCounterMetric("mv_query_total_count", MetricUnit.REQUESTS,
+                "total materialized view's query count");
+        metrics.add(counterQueryMaterializedViewTotal);
+        counterQueryHitTotal = new LongCounterMetric("mv_query_total_hit_count", MetricUnit.REQUESTS,
+                "total hit materialized view's query count");
+        metrics.add(counterQueryHitTotal);
+        counterQueryConsideredTotal = new LongCounterMetric("mv_query_total_considered_count", MetricUnit.REQUESTS,
+                "total considered materialized view's query count");
+        metrics.add(counterQueryConsideredTotal);
+        counterQueryMatchedTotal = new LongCounterMetric("mv_query_total_matched_count", MetricUnit.REQUESTS,
+                "total matched materialized view's query count");
+        metrics.add(counterQueryMatchedTotal);
+
+        // histogram metrics
+        try {
+            Database db = GlobalStateMgr.getCurrentState().getDb(mvId.getDbId());
+            MaterializedView mv = (MaterializedView) db.getTable(mvId.getId());
+            histRefreshJobDuration = metricRegistry.histogram(MetricRegistry.name("mv_refresh_duration",
+                    db.getFullName(), mv.getName()));
+        } catch (Exception e) {
+            LOG.warn("Ignore histogram metrics for materialized view: {}", mvId);
+        }
+
+        // gauge metrics
+        counterRefreshPendingJobs = new GaugeMetric<Long>("mv_refresh_pending_jobs", MetricUnit.NOUNIT,
+                "current materialized view pending refresh jobs number") {
+            @Override
+            public Long getValue() {
+                String mvTaskName = TaskBuilder.getMvTaskName(mvId.getId());
+                TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
+                if (taskManager == null) {
+                    return 0L;
+                }
+                if (!taskManager.containTask(mvTaskName)) {
+                    return 0L;
+                }
+                Long taskId = taskManager.getTask(mvTaskName).getId();
+                return taskManager.getTaskRunManager().getPendingTaskRunCount(taskId);
+            }
+        };
+        metrics.add(counterRefreshPendingJobs);
+
+        counterRefreshRunningJobs = new GaugeMetric<Long>("mv_refresh_running_jobs", MetricUnit.NOUNIT,
+                "current materialized view running refresh jobs number") {
+            @Override
+            public Long getValue() {
+                String mvTaskName = TaskBuilder.getMvTaskName(mvId.getId());
+                TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
+                if (taskManager == null) {
+                    return 0L;
+                }
+                if (!taskManager.containTask(mvTaskName)) {
+                    return 0L;
+                }
+                Long taskId = taskManager.getTask(mvTaskName).getId();
+                if (taskManager.getTaskRunManager().containsTaskInRunningTaskRunMap(taskId)) {
+                    return 1L;
+                } else {
+                    return 0L;
+                }
+            }
+        };
+        metrics.add(counterRefreshRunningJobs);
+
+        counterRowNums = new GaugeMetric<Long>("mv_row_count", MetricUnit.NOUNIT,
+                "current materialized view's row count") {
+            @Override
+            public Long getValue() {
+                Database db = GlobalStateMgr.getCurrentState().getDb(mvId.getDbId());
+                if (db == null) {
+                    return 0L;
+                }
+                Table table = db.getTable(mvId.getId());
+                if (!table.isMaterializedView()) {
+                    return 0L;
+                }
+
+                db.readLock();
+                try {
+                    MaterializedView mv = (MaterializedView) table;
+                    return mv.getRowCount();
+                } catch (Exception e) {
+                    return 0L;
+                } finally {
+                    db.readUnlock();
+                }
+            }
+        };
+        metrics.add(counterRowNums);
+
+        counterStorageSize = new GaugeMetric<Long>("mv_storage_size", MetricUnit.NOUNIT,
+                "current materialized view's storage size") {
+            @Override
+            public Long getValue() {
+                Database db = GlobalStateMgr.getCurrentState().getDb(mvId.getDbId());
+                if (db == null) {
+                    return 0L;
+                }
+                Table table = db.getTable(mvId.getId());
+                if (!table.isMaterializedView()) {
+                    return 0L;
+                }
+
+                db.readLock();
+                try {
+                    MaterializedView mv = (MaterializedView) table;
+                    return mv.getDataSize();
+                } catch (Exception e) {
+                    return 0L;
+                } finally {
+                    db.readUnlock();
+                }
+            }
+        };
+        metrics.add(counterStorageSize);
+    }
+
+    public static boolean isUpdateMaterializedViewMetrics(ConnectContext connectContext) {
+        if (connectContext == null) {
+            return false;
+        }
+        // ignore: explain queries
+        if (connectContext.getExplainLevel() != null) {
+            return false;
+        }
+        // ignore: queries that are not using materialized view rewrite(eg: stats jobs)
+        if (!connectContext.getSessionVariable().isEnableMaterializedViewRewrite() ||
+                !Config.enable_materialized_view) {
+            return false;
+        }
+        return true;
+    }
+
+    public void increaseQueryConsideredCount(long count) {
+        this.counterQueryConsideredTotal.increase(count);
+    }
+
+    public void increaseQueryMatchedCount(long count) {
+        this.counterQueryMatchedTotal.increase(count);
+    }
+
+    public void increaseQueryHitCount(long count) {
+        this.counterQueryHitTotal.increase(count);
+    }
+
+    public void increaseQueryMaterializedViewCount(long count) {
+        this.counterQueryMaterializedViewTotal.increase(count);
+    }
+
+    public void increaseRefreshJobStatus(PartitionBasedMvRefreshProcessor.RefreshJobStatus status) {
+        switch (status) {
+            case EMPTY:
+                this.counterRefreshJobEmptyTotal.increase(1L);
+                break;
+            case SUCCESS:
+                this.counterRefreshJobSuccessTotal.increase(1L);
+                break;
+            case FAILED:
+                this.counterRefreshJobFailedTotal.increase(1L);
+                break;
+            case TOTAL:
+                this.counterRefreshJobTotal.increase(1L);
+                break;
+        }
+    }
+
+    public void increaseRefreshRetryMetaCount(Long retryNum) {
+        this.counterRefreshJobRetryCheckChangedTotal.increase(retryNum);
+    }
+
+    public void updateRefreshDuration(long duration) {
+        this.histRefreshJobDuration.update(duration);
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MaterializedViewMetricsRegistry.java
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.metric;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
+import com.starrocks.common.ThreadPoolManager;
+import com.starrocks.server.GlobalStateMgr;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TimerTask;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class MaterializedViewMetricsRegistry {
+
+    private final MetricRegistry metricRegistry = new MetricRegistry();
+    private final Map<MvId, MaterializedViewMetricsEntity> idToMVMetrics;
+    private final ScheduledThreadPoolExecutor timer;
+    private static final MaterializedViewMetricsRegistry INSTANCE = new MaterializedViewMetricsRegistry();
+
+    private MaterializedViewMetricsRegistry() {
+        idToMVMetrics = Maps.newHashMap();
+        // clear all metrics everyday
+        timer = ThreadPoolManager.newDaemonScheduledThreadPool(1, "MaterializedView-Metrics-Cleaner", true);
+        timer.scheduleAtFixedRate(new MaterializedViewMetricsRegistry.MetricsCleaner(), 0, 1L, TimeUnit.DAYS);
+    }
+
+    public static MaterializedViewMetricsRegistry getInstance() {
+        return INSTANCE;
+    }
+
+    public synchronized MaterializedViewMetricsEntity getMetricsEntity(MvId mvId) {
+        return idToMVMetrics.computeIfAbsent(mvId, k -> new MaterializedViewMetricsEntity(metricRegistry, mvId));
+    }
+
+    private class MetricsCleaner extends TimerTask {
+        @Override
+        public void run() {
+            synchronized (MaterializedViewMetricsRegistry.this) {
+                idToMVMetrics.clear();
+            }
+        }
+    }
+
+    // collect materialized-view-level metrics
+    public static void collectMaterializedViewMetrics(MetricVisitor visitor, boolean minifyMetrics) {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        List<String> dbNames = globalStateMgr.getDbNames();
+        for (String dbName : dbNames) {
+            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+            if (null == db) {
+                continue;
+            }
+            db.readLock();
+            try {
+                for (MaterializedView mv : db.getMaterializedViews()) {
+                    MaterializedViewMetricsEntity mvEntity =
+                            MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
+
+                    for (Metric m : mvEntity.getMetrics()) {
+                        // minify metrics if needed
+                        if (minifyMetrics) {
+                            if (null == m.getValue()) {
+                                continue;
+                            }
+                            // GAUGE metrics is a bit heavy, skip it when in mini mode.
+                            if (Metric.MetricType.GAUGE == m.type) {
+                                continue;
+                            }
+                            if (Metric.MetricType.COUNTER == m.type && ((Long) m.getValue()).longValue() == 0L) {
+                                continue;
+                            }
+                        }
+                        m.addLabel(new MetricLabel("db_name", dbName))
+                                .addLabel(new MetricLabel("mv_name", mv.getName()))
+                                .addLabel(new MetricLabel("mv_id", String.valueOf(mv.getId())));
+                        visitor.visit(m);
+                    }
+                }
+
+                for (Map.Entry<String, Histogram> e : MaterializedViewMetricsRegistry.getInstance()
+                        .metricRegistry.getHistograms().entrySet()) {
+                    visitor.visitHistogram(e.getKey(), e.getValue());
+                }
+            } finally {
+                db.readUnlock();
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -55,6 +55,7 @@ import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.KafkaUtil;
 import com.starrocks.common.util.ProfileManager;
+import com.starrocks.http.rest.MetricsAction;
 import com.starrocks.load.EtlJobType;
 import com.starrocks.load.loadv2.JobState;
 import com.starrocks.load.loadv2.LoadMgr;
@@ -866,8 +867,7 @@ public final class MetricRepo {
         GAUGE_ROUTINE_LOAD_LAGS = routineLoadLags;
     }
 
-    public static synchronized String getMetric(MetricVisitor visitor, boolean collectTableMetrics,
-                                                boolean minifyTableMetrics) {
+    public static synchronized String getMetric(MetricVisitor visitor, MetricsAction.RequestParams requestParams) {
         if (!isInit) {
             return "";
         }
@@ -889,8 +889,13 @@ public final class MetricRepo {
         collectDatabaseMetrics(visitor);
 
         // table metrics
-        if (collectTableMetrics) {
-            collectTableMetrics(visitor, minifyTableMetrics);
+        if (requestParams.isCollectTableMetrics()) {
+            collectTableMetrics(visitor, requestParams.isMinifyTableMetrics());
+        }
+
+        // materialized view metrics
+        if (requestParams.isCollectMVMetrics()) {
+            MaterializedViewMetricsRegistry.collectMaterializedViewMetrics(visitor, requestParams.isMinifyMVMetrics());
         }
 
         // histogram

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -343,9 +343,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_MULTI_COLUMNS_ON_GLOBAL_RUNTIME_FILTER =
             "enable_multicolumn_global_runtime_filter";
 
-    public static final String ENABLE_OPTIMIZER_TRACE_LOG = "enable_optimizer_trace_log";
-    public static final String ENABLE_MV_OPTIMIZER_TRACE_LOG = "enable_mv_optimizer_trace_log";
-
     // command, file
     public static final String TRACE_LOG_MODE = "trace_log_mode";
     public static final String JOIN_IMPLEMENTATION_MODE = "join_implementation_mode";

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -57,12 +57,15 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.RangeUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.lake.LakeTable;
+import com.starrocks.metric.MaterializedViewMetricsEntity;
+import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.persist.ChangeMaterializedViewRefreshSchemeLog;
 import com.starrocks.planner.HdfsScanNode;
 import com.starrocks.planner.OlapScanNode;
@@ -148,6 +151,14 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
     private long oldTransactionVisibleWaitTimeout;
 
+    // represents the refresh job final job status
+    public enum RefreshJobStatus {
+        SUCCESS,
+        FAILED,
+        EMPTY,
+        TOTAL
+    }
+
     @VisibleForTesting
     public MvTaskRunContext getMvContext() {
         return mvContext;
@@ -166,16 +177,27 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     @Override
     public void processTaskRun(TaskRunContext context) throws Exception {
         Tracers.register();
+
         prepare(context);
+
+        Preconditions.checkState(materializedView != null);
+        MaterializedViewMetricsEntity mvEntity =
+                MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(materializedView.getMvId());
+        mvEntity.increaseRefreshJobStatus(RefreshJobStatus.TOTAL);
+
         try {
-            doMvRefresh(context);
+            RefreshJobStatus status = doMvRefresh(context, mvEntity);
+            mvEntity.increaseRefreshJobStatus(status);
+        } catch (Exception e) {
+            mvEntity.increaseRefreshJobStatus(RefreshJobStatus.FAILED);
+            throw e;
         } finally {
             postProcess();
             Tracers.close();
         }
     }
 
-    private void doMvRefresh(TaskRunContext context) throws Exception {
+    private RefreshJobStatus doMvRefresh(TaskRunContext context, MaterializedViewMetricsEntity mvEntity) throws Exception {
         InsertStmt insertStmt = null;
         ExecPlan execPlan = null;
         int retryNum = 0;
@@ -183,6 +205,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
         Map<Table, Set<String>> refTableRefreshPartitions = null;
         Set<String> mvToRefreshedPartitions = null;
+        long startRefreshTs = System.currentTimeMillis();
         while (!checked) {
             // sync partitions between materialized view and base tables out of lock
             // do it outside lock because it is a time-cost operation
@@ -208,11 +231,13 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                             materializedView.getName(), retryNum);
                     continue;
                 }
+                mvEntity.increaseRefreshRetryMetaCount((long) retryNum);
+
                 checked = true;
                 mvToRefreshedPartitions = getPartitionsToRefreshForMaterializedView(context.getProperties());
                 if (mvToRefreshedPartitions.isEmpty()) {
                     LOG.info("no partitions to refresh for materialized view {}", materializedView.getName());
-                    return;
+                    return RefreshJobStatus.EMPTY;
                 }
 
                 // Only refresh the first partition refresh number partitions, other partitions will generate new tasks
@@ -270,6 +295,15 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         if (mvContext.hasNextBatchPartition()) {
             generateNextTaskRun();
         }
+
+        {
+            long refreshDurationMs = System.currentTimeMillis() - startRefreshTs;
+            LOG.info("Refresh {} success, cost time(s): {}", materializedView.getName(),
+                    DebugUtil.DECIMAL_FORMAT_SCALE_3.format(refreshDurationMs / 1000));
+            mvEntity.updateRefreshDuration(refreshDurationMs);
+        }
+
+        return RefreshJobStatus.SUCCESS;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -260,6 +260,22 @@ public class TaskRunManager {
         return pendingTaskRunMap.size();
     }
 
+    public boolean containsTaskInRunningTaskRunMap(long taskId) {
+        return this.runningTaskRunMap.containsKey(taskId);
+    }
+
+    public long getPendingTaskRunCount(long taskId) {
+        taskRunLock.lock();
+        try {
+            return pendingTaskRunMap.containsKey(taskId) ? 0L :
+                    pendingTaskRunMap.get(taskId).size();
+        } catch (Exception e) {
+            return 0L;
+        } finally {
+            taskRunLock.unlock();
+        }
+    }
+
     public long getRunningTaskRunCount() {
         return runningTaskRunMap.size();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -217,9 +217,9 @@ public class Optimizer {
             // valid the final plan
             PlanValidator.getInstance().validatePlan(finalPlan, rootTaskContext);
             // validate mv and log tracer if needed
-            MVRewriteValidator.getInstance().validateMV(finalPlan);
-            // Audit the usage of materialized view
-            MVRewriteValidator.getInstance().auditMv(finalPlan, context);
+            MVRewriteValidator.getInstance().validateMV(connectContext, finalPlan, rootTaskContext);
+            // audit mv
+            MVRewriteValidator.getInstance().auditMv(connectContext, finalPlan, rootTaskContext);
             return finalPlan;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -159,13 +159,13 @@ public class MvUtils {
         }
     }
 
-    public static List<String> collectMaterializedViewNames(OptExpression optExpression) {
+    public static List<MaterializedView> collectMaterializedViews(OptExpression optExpression) {
         List<MaterializedView> mvs = new ArrayList<>();
-        collectMaterializedViewNames(optExpression, mvs);
-        return mvs.stream().map(Table::getName).collect(Collectors.toList());
+        collectMaterializedViews(optExpression, mvs);
+        return mvs;
     }
 
-    private static void collectMaterializedViewNames(OptExpression optExpression, List<MaterializedView> mvs) {
+    private static void collectMaterializedViews(OptExpression optExpression, List<MaterializedView> mvs) {
         if (optExpression == null) {
             return;
         }
@@ -178,7 +178,7 @@ public class MvUtils {
         }
 
         for (OptExpression child : optExpression.getInputs()) {
-            collectMaterializedViewNames(child, mvs);
+            collectMaterializedViews(child, mvs);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.optimizer.validate;
 
-import com.google.api.client.util.Lists;
 import com.google.common.base.Joiner;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.profile.Tracers;
@@ -34,6 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.metric.MaterializedViewMetricsEntity.isUpdateMaterializedViewMetrics;
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.collectMaterializedViews;
 
 public class MVRewriteValidator {
     private static final MVRewriteValidator INSTANCE = new MVRewriteValidator();
@@ -146,23 +146,6 @@ public class MVRewriteValidator {
             String logMessage = "Query has already been successfully rewritten by: "
                     + Joiner.on(",").join(mvNames) + ".";
             Tracers.log(Tracers.Module.MV, logMessage);
-        }
-    }
-
-    private static List<MaterializedView> collectMaterializedViews(OptExpression optExpression) {
-        List<MaterializedView> mvs = Lists.newArrayList();
-        collectMaterializedViews(optExpression, mvs);
-        return mvs;
-    }
-
-    private static void collectMaterializedViews(OptExpression optExpression, List<MaterializedView> mvs) {
-        if (optExpression == null) {
-            return;
-        }
-        collectMaterializedViews(optExpression, mvs);
-
-        for (OptExpression child : optExpression.getInputs()) {
-            collectMaterializedViews(child, mvs);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
@@ -137,8 +137,7 @@ public class MVRewriteValidator {
                 throw new IllegalArgumentException(errorMessage);
             } else {
                 String logMessage = hasRewriteSuccess ?
-                        "Query cannot be rewritten, please check the trace logs or " +
-                                "set enable_mv_optimizer_trace_log=on to find more information." :
+                        "Query cannot be rewritten, please check the trace logs to find more information." :
                         "Query has already been successfully rewritten, but it is not chosen as the best plan by cost.";
                 Tracers.log(Tracers.Module.MV, logMessage);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
@@ -16,18 +16,24 @@ package com.starrocks.sql.optimizer.validate;
 
 import com.google.api.client.util.Lists;
 import com.google.common.base.Joiner;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.profile.Tracers;
-import com.starrocks.common.profile.Var;
+import com.starrocks.metric.MaterializedViewMetricsEntity;
+import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import com.starrocks.sql.optimizer.task.TaskContext;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.starrocks.metric.MaterializedViewMetricsEntity.isUpdateMaterializedViewMetrics;
 
 public class MVRewriteValidator {
     private static final MVRewriteValidator INSTANCE = new MVRewriteValidator();
@@ -39,12 +45,12 @@ public class MVRewriteValidator {
     /**
      * Record the MV usage into audit log
      */
-    public void auditMv(OptExpression physicalPlan, OptimizerContext optimizerContext) {
-        ConnectContext connectContext = ConnectContext.get();
-        if (connectContext == null) {
+    public void auditMv(ConnectContext connectContext, OptExpression physicalPlan, TaskContext taskContext) {
+        if (!isUpdateMaterializedViewMetrics(connectContext)) {
             return;
         }
 
+        OptimizerContext optimizerContext = taskContext.getOptimizerContext();
         // Candidate MVs
         if (CollectionUtils.isNotEmpty(optimizerContext.getCandidateMvs())) {
             List<String> mvNames = optimizerContext.getCandidateMvs()
@@ -54,69 +60,110 @@ public class MVRewriteValidator {
         }
 
         // Rewritten MVs
-        List<String> mvNames = MvUtils.collectMaterializedViewNames(physicalPlan);
-        if (CollectionUtils.isNotEmpty(mvNames)) {
-            connectContext.getAuditEventBuilder().setHitMvs(mvNames);
+        List<MaterializedView> mvs = collectMaterializedViews(physicalPlan);
+        // To avoid queries that query the materialized view directly, only consider materialized views
+        // that are not used in rewriting before.
+        Set<Long> beforeTableIds = taskContext.getAllScanOperators().stream()
+                .map(op -> op.getTable().getId())
+                .collect(Collectors.toSet());
+        if (CollectionUtils.isNotEmpty(mvs)) {
+            List<String> rewrittenMVs = mvs.stream().filter(mv -> !beforeTableIds.contains(mv.getId()))
+                    .map(mv -> mv.getName())
+                    .collect(Collectors.toList());
+            connectContext.getAuditEventBuilder().setHitMvs(rewrittenMVs);
         }
     }
 
-    public void validateMV(OptExpression physicalPlan) {
-        ConnectContext connectContext = ConnectContext.get();
+    private void updateMaterializedViewMetricsIfNeeded(ConnectContext connectContext,
+                                                       OptimizerContext optimizerContext,
+                                                       List<MaterializedView> mvs,
+                                                       Set<Long> beforeTableIds) {
+        // ignore: explain queries
+        if (!isUpdateMaterializedViewMetrics(connectContext)) {
+            return;
+        }
+        // update considered metrics
+        if (CollectionUtils.isNotEmpty(optimizerContext.getCandidateMvs())) {
+            for (MaterializationContext mvContext : optimizerContext.getCandidateMvs()) {
+                MaterializedView mv = mvContext.getMv();
+                if (mv == null) {
+                    continue;
+                }
+                MaterializedViewMetricsEntity mvEntity =
+                        MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
+                mvEntity.increaseQueryConsideredCount(1L);
+            }
+        }
+        // update rewritten metrics
+        for (MaterializedView mv : mvs) {
+            // To avoid queries that query the materialized view directly, only consider materialized views
+            // that are not used in rewriting before.
+            MaterializedViewMetricsEntity mvEntity =
+                    MaterializedViewMetricsRegistry.getInstance().getMetricsEntity(mv.getMvId());
+            if (!beforeTableIds.contains(mv.getId())) {
+                mvEntity.increaseQueryHitCount(1L);
+            }
+            mvEntity.increaseQueryMaterializedViewCount(1L);
+        }
+    }
+
+    public void validateMV(ConnectContext connectContext, OptExpression physicalPlan, TaskContext taskContext) {
         if (connectContext == null) {
             return;
         }
 
-        List<String> mvNames = MvUtils.collectMaterializedViewNames(physicalPlan);
-        if (mvNames.isEmpty()) {
-            // Check whether plan has been rewritten success by rule.
+        List<MaterializedView> mvs = collectMaterializedViews(physicalPlan);
+        Set<Long> beforeTableIds = taskContext.getAllScanOperators().stream()
+                .map(op -> op.getTable().getId())
+                .collect(Collectors.toSet());
 
-            List<String> tracerNames = Lists.newArrayList();
-            for (Var<?> var : Tracers.getAllVars()) {
-                if (StringUtils.contains(var.getValue().toString(), MaterializedViewRewriter.REWRITE_SUCCESS)) {
-                    tracerNames.add(var.getName().replace("REWRITE ", ""));
-                }
-            }
+        updateMaterializedViewMetricsIfNeeded(connectContext, taskContext.getOptimizerContext(), mvs, beforeTableIds);
+
+        List<MaterializedView> diffMVs = mvs.stream()
+                .filter(mv -> !beforeTableIds.contains(mv.getId()))
+                .collect(Collectors.toList());
+        if (diffMVs.isEmpty()) {
+            boolean hasRewriteSuccess = Tracers.getAllVars().stream()
+                    .anyMatch(var -> StringUtils.contains(var.getValue().toString(),
+                            MaterializedViewRewriter.REWRITE_SUCCESS));
 
             if (connectContext.getSessionVariable().isEnableMaterializedViewRewriteOrError()) {
-                if (tracerNames.isEmpty()) {
-                    throw new IllegalArgumentException("no executable plan with materialized view for this sql in " +
-                            connectContext.getSessionVariable().getMaterializedViewRewriteMode() + " mode.");
-                } else {
-                    throw new IllegalArgumentException("no executable plan with materialized view for this sql in " +
-                            connectContext.getSessionVariable().getMaterializedViewRewriteMode() + " mode because of" +
-                            "cost.");
-                }
-            }
-
-            if (tracerNames.isEmpty()) {
-                Tracers.log(Tracers.Module.MV, "Query cannot be rewritten, please check the trace logs or " +
-                        "`set enable_mv_optimizer_trace_log=on` to find more infos.");
+                String errorMessage = hasRewriteSuccess ?
+                        "no executable plan with materialized view for this SQL in " +
+                                connectContext.getSessionVariable().getMaterializedViewRewriteMode() + " mode." :
+                        "no executable plan with materialized view for this SQL in " +
+                                connectContext.getSessionVariable().getMaterializedViewRewriteMode() + " mode " +
+                                "because of cost.";
+                throw new IllegalArgumentException(errorMessage);
             } else {
-                Tracers.log(Tracers.Module.MV,
-                        "Query has already been successfully rewritten by: " + Joiner.on(",").join(tracerNames)
-                                + ", but are not chosen as the best plan by cost.");
+                String logMessage = hasRewriteSuccess ?
+                        "Query cannot be rewritten, please check the trace logs or " +
+                                "set enable_mv_optimizer_trace_log=on to find more information." :
+                        "Query has already been successfully rewritten, but it is not chosen as the best plan by cost.";
+                Tracers.log(Tracers.Module.MV, logMessage);
             }
         } else {
-            // If final result contains materialized views, ho
-            if (connectContext.getSessionVariable().isEnableMaterializedViewRewriteOrError()) {
-                boolean hasRewriteSuccess = false;
-                for (Var<?> var : Tracers.getAllVars()) {
-                    if (StringUtils.contains(var.getValue().toString(), MaterializedViewRewriter.REWRITE_SUCCESS)) {
-                        hasRewriteSuccess = true;
-                        break;
-                    }
-                }
-
-                if (!hasRewriteSuccess) {
-                    throw new IllegalArgumentException("no executable plan with materialized view for this sql in " +
-                            connectContext.getSessionVariable().getMaterializedViewRewriteMode() + " mode.");
-                }
-            }
-
-            Tracers.log(Tracers.Module.MV,
-                    "Query has already been successfully rewritten by: " + Joiner.on(",").join(mvNames) + ".");
+            List<String> mvNames = diffMVs.stream().map(MaterializedView::getName).collect(Collectors.toList());
+            String logMessage = "Query has already been successfully rewritten by: "
+                    + Joiner.on(",").join(mvNames) + ".";
+            Tracers.log(Tracers.Module.MV, logMessage);
         }
     }
 
+    private static List<MaterializedView> collectMaterializedViews(OptExpression optExpression) {
+        List<MaterializedView> mvs = Lists.newArrayList();
+        collectMaterializedViews(optExpression, mvs);
+        return mvs;
+    }
 
+    private static void collectMaterializedViews(OptExpression optExpression, List<MaterializedView> mvs) {
+        if (optExpression == null) {
+            return;
+        }
+        collectMaterializedViews(optExpression, mvs);
+
+        for (OptExpression child : optExpression.getInputs()) {
+            collectMaterializedViews(child, mvs);
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
@@ -129,16 +129,16 @@ public class MVRewriteValidator {
 
             if (connectContext.getSessionVariable().isEnableMaterializedViewRewriteOrError()) {
                 String errorMessage = hasRewriteSuccess ?
-                        "no executable plan with materialized view for this SQL in " +
-                                connectContext.getSessionVariable().getMaterializedViewRewriteMode() + " mode." :
-                        "no executable plan with materialized view for this SQL in " +
+                        "no executable plan with materialized view for this sql in " +
                                 connectContext.getSessionVariable().getMaterializedViewRewriteMode() + " mode " +
-                                "because of cost.";
+                                "because of cost." :
+                        "no executable plan with materialized view for this sql in " +
+                                connectContext.getSessionVariable().getMaterializedViewRewriteMode() + " mode.";
                 throw new IllegalArgumentException(errorMessage);
             } else {
                 String logMessage = hasRewriteSuccess ?
-                        "Query cannot be rewritten, please check the trace logs to find more information." :
-                        "Query has already been successfully rewritten, but it is not chosen as the best plan by cost.";
+                        "Query has already been successfully rewritten, but it is not chosen as the best plan by cost.":
+                        "Query cannot be rewritten, please check the trace logs to find more information." ;
                 Tracers.log(Tracers.Module.MV, logMessage);
             }
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
@@ -137,8 +137,8 @@ public class MVRewriteValidator {
                 throw new IllegalArgumentException(errorMessage);
             } else {
                 String logMessage = hasRewriteSuccess ?
-                        "Query has already been successfully rewritten, but it is not chosen as the best plan by cost.":
-                        "Query cannot be rewritten, please check the trace logs to find more information." ;
+                        "Query has already been successfully rewritten, but it is not chosen as the best plan by cost." :
+                        "Query cannot be rewritten, please check the trace logs to find more information.";
                 Tracers.log(Tracers.Module.MV, logMessage);
             }
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -35,7 +35,6 @@ import com.starrocks.connector.iceberg.IcebergApiConverter;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QueryState;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.InsertStmt;
@@ -191,10 +190,10 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
     public void collectStatisticSync(String sql, ConnectContext context) throws Exception {
         LOG.debug("statistics collect sql : " + sql);
         StatisticExecutor executor = new StatisticExecutor();
-        SessionVariable sessionVariable = context.getSessionVariable();
-        // Full table scan is performed for full statistics collecting. In this case,
-        // we do not need to use pagecache.
-        sessionVariable.setUsePageCache(false);
+
+        // set default session variables for stats context
+        setDefaultSessionVariable(context);
+
         List<TStatisticData> dataList = executor.executeStatisticDQL(context, sql);
 
         for (TStatisticData data : dataList) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -32,7 +32,6 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QueryState;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.InsertStmt;
@@ -115,10 +114,10 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
     public void collectStatisticSync(String sql, ConnectContext context) throws Exception {
         LOG.debug("statistics collect sql : " + sql);
         StatisticExecutor executor = new StatisticExecutor();
-        SessionVariable sessionVariable = context.getSessionVariable();
-        // Full table scan is performed for full statistics collecting. In this case, 
-        // we do not need to use pagecache.
-        sessionVariable.setUsePageCache(false);
+
+        // set default session variables for stats context
+        setDefaultSessionVariable(context);
+
         List<TStatisticData> dataList = executor.executeStatisticDQL(context, sql);
 
         String tableName = StringEscapeUtils.escapeSql(db.getOriginName() + "." + table.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -110,6 +110,15 @@ public abstract class StatisticsCollectJob {
         return properties;
     }
 
+    protected void setDefaultSessionVariable(ConnectContext context) {
+        SessionVariable sessionVariable = context.getSessionVariable();
+        // Statistics collecting is not user-specific, which means response latency is not that important.
+        // Normally, if the page cache is enabled, the page cache must be full. Page cache is used for query
+        // acceleration, then page cache is better filled with the user's data.
+        sessionVariable.setUsePageCache(false);
+        sessionVariable.setEnableMaterializedViewRewrite(false);
+    }
+
     protected void collectStatisticSync(String sql, ConnectContext context) throws Exception {
         int count = 0;
         int maxRetryTimes = 5;
@@ -117,12 +126,10 @@ public abstract class StatisticsCollectJob {
             LOG.debug("statistics collect sql : {}", sql);
             StatementBase parsedStmt = SqlParser.parseOneWithStarRocksDialect(sql, context.getSessionVariable());
             StmtExecutor executor = new StmtExecutor(context, parsedStmt);
-            SessionVariable sessionVariable = context.getSessionVariable();
-            // Statistics collecting is not user-specific, which means response latency is not that important.
-            // Normally, if the page cache is enabled, the page cache must be full. Page cache is used for query 
-            // acceleration, then page cache is better filled with the user's data. 
-            sessionVariable.setUsePageCache(false);
-            sessionVariable.setEnableMaterializedViewRewrite(false);
+
+            // set default session variables for stats context
+            setDefaultSessionVariable(context);
+
             context.setExecutor(executor);
             context.setQueryId(UUIDUtil.genUUID());
             context.setStartTime();

--- a/test/sql/test_materialized_view/R/test_materialized_view_force_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_force_rewrite
@@ -124,7 +124,7 @@ None
 -- !result
 SELECT t1.t1_id, count(distinct t1.t1_age) FROM t1 INNER JOIN t2 ON t1.t1_t2_id=t2.t2_id INNER JOIN t3 ON t1.t1_t3_id=t3.t3_id group by t1.t1_id order by t1.t1_id;
 -- result:
-E: (1064, 'no executable plan with materialized view for this sql in default_or_error mode because ofcost.')
+E: (1064, 'no executable plan with materialized view for this sql in default_or_error mode because of cost.')
 -- !result
 SELECT t1.t1_id, bitmap_union_count(to_bitmap(t1.t1_age + 1)) FROM t1 INNER JOIN t2 ON t1.t1_t2_id=t2.t2_id INNER JOIN t3 ON t1.t1_t3_id=t3.t3_id group by t1.t1_id order by t1.t1_id;
 -- result:


### PR DESCRIPTION
### Changes

To be better to monitor materialized view's stats, add materialized view metrics to monitor or alert. 
Like table's metrics in `TableMetricsRegistry`,  materialized view's metrics are not collected by default.


### Materialized View Metrics

All these metrics are all per materialized view unit, you can monitor each materialized view as you want:
```
    // refresh
    // increased once the materialized view's refresh job is triggered.
    public LongCounterMetric counterRefreshJobTotal;
    // increased only if the materialized view's refresh job is success refreshed.
    public LongCounterMetric counterRefreshJobSuccessTotal;
    // increased once the materialized view's refresh job is failed.
    public LongCounterMetric counterRefreshJobFailedTotal;
    // increased once the materialized view's refresh job is not be triggered because of the refreshed data is empty.
    public LongCounterMetric counterRefreshJobEmptyTotal;
    // increased once the materialized view's refresh job checks whether the base table is changed or not.
    public LongCounterMetric counterRefreshJobRetryCheckChangedTotal;

    // query
    // increased if the materialized view is considered in the preprocess for one query.
    public LongCounterMetric counterQueryConsideredTotal;
    // increased if the materialized view is successes to be rewritten from query, but it may be missed in the
    // final plan because of the cost.
    public LongCounterMetric counterQueryMatchedTotal;
    // only increased if the materialized view is rewritten and not be queried directly
    public LongCounterMetric counterQueryHitTotal;
    // increased once the materialized view is used in the final plan no matter it is queried directly or rewritten.
    public LongCounterMetric counterQueryMaterializedViewTotal;

    // gauge
    // the current pending refresh jobs for the materialized view
    public GaugeMetric<Long> counterRefreshPendingJobs;
    // the current running refresh jobs for the materialized view
    public GaugeMetric<Long> counterRefreshRunningJobs;
    // the current materialized view's row count
    public GaugeMetric<Long> counterRowNums;
    // the current materialized view's storage size, unit: byte
    public GaugeMetric<Long> counterStorageSize;
    // the current materialized view is active or not, 0: active, 1: inactive
    public GaugeMetric<Integer> counterInactiveState;

    // the current materialized view's partition count, 0 if the materialized view is not partitioned
    public GaugeMetric<Integer> counterPartitionCount;

    // histogram
    // record the materialized view's refresh job duration only if it's refreshed successfully.
    public Histogram histRefreshJobDuration;
```

### Usage
In this pr, materialized view's metrics are not collected by default because extra metrics will add  the collect time.

You can control this by changing your prometheus config  like this:

cat prometheus.yml
```
# my global config
global:
....
scrape_configs:

  - job_name: 'dev' 
    metrics_path: '/metrics'    
    params:
      'with_materialized_view_metrics' : ['all']   
....
```

`with_materialized_view_metrics` can be:
- all: collect all metrics about materialized view
- minified : ignore metics which is 0 and gauge metrics(which need check frontend meta each request)
### Examples

`metrics` can be used in `prometheus`  and `grafana` , eg:

![image](https://github.com/StarRocks/starrocks/assets/5104975/2c740d40-3678-47b7-a279-d1871f017e52)

### Further

After this pr,  I will add a demo of materialized view grafana config template.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
  - [ ] 2.4
