### PR TITLE
[Enhancement] allow statitics window funtion using order by and window clause

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
@@ -130,15 +130,10 @@ public class AnalyticAnalyzer {
             }
         }
 
-        if (isStatisticFn(analyticFunction.getFn()) && (!analyticExpr.getOrderByElements().isEmpty())) {
-            throw new SemanticException("order by not allowed with '" + analyticFunction.toSql() + "'",
-                    analyticExpr.getPos());
-        }
 
         if (analyticExpr.getWindow() != null) {
             if ((isRankingFn(analyticFunction.getFn()) || isCumeFn(analyticFunction.getFn()) ||
-                    isOffsetFn(analyticFunction.getFn()) || isHllAggFn(analyticFunction.getFn())) ||
-                    isStatisticFn(analyticFunction.getFn())) {
+                    isOffsetFn(analyticFunction.getFn()) || isHllAggFn(analyticFunction.getFn()))) {
                 throw new SemanticException("Windowing clause not allowed with '" + analyticFunction.toSql() + "'",
                         analyticExpr.getPos());
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -290,12 +290,14 @@ public class WindowTest extends PlanTestBase {
     @Test
     public void testStatisticWindowFunction() throws Exception {
         String sql = "select CORR(t1e,t1f) over (partition by t1a order by t1b) from test_all_type";
-        starRocksAssert.query(sql)
-                .analysisError("order by not allowed with");
-        sql = "select CORR(t1e,t1f) over (partition by t1a " +
+
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
+
+        sql = "select CORR(t1e,t1f) over (partition by t1a order by t1b " +
                 "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) from test_all_type";
-        starRocksAssert.query(sql)
-                .analysisError("Windowing clause not allowed with");
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW");
     }
 
     @Test


### PR DESCRIPTION
allow statitics window funtion using order by and window clause

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
