### PR TITLE
[Enhancement][BugFix][CherryPick] optimize mv plan cache by using lru cache for 2.5 (#30361)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvPlanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvPlanContext.java
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+
+import java.util.List;
+
+// MvPlanContext is a item that stores metadata related to the materialized view rewrite context.
+// This cache is used during the FE's lifecycle to improve the performance of materialized view
+// rewriting operations.
+// By caching the metadata related to the materialized view rewrite context,
+// subsequent materialized view rewriting operations can avoid recomputing this metadata,
+// which can save time and resources.
+public class MvPlanContext {
+    // mv's logical plan
+    private final OptExpression logicalPlan;
+
+    // mv plan's output columns, used for mv rewrite
+    private final List<ColumnRefOperator> outputColumns;
+
+    // column ref factory used when compile mv plan
+    private final ColumnRefFactory refFactory;
+
+    // indicate whether this mv is a SPJG plan
+    // if not, we do not store other fields to save memory,
+    // because we will not use other fields
+    private boolean isValidMvPlan;
+
+    public MvPlanContext() {
+        this.logicalPlan = null;
+        this.outputColumns = null;
+        this.refFactory = null;
+        this.isValidMvPlan = false;
+    }
+
+    public MvPlanContext(
+            OptExpression logicalPlan,
+            List<ColumnRefOperator> outputColumns,
+            ColumnRefFactory refFactory) {
+        this.logicalPlan = logicalPlan;
+        this.outputColumns = outputColumns;
+        this.refFactory = refFactory;
+        this.isValidMvPlan = true;
+    }
+
+    public OptExpression getLogicalPlan() {
+        return logicalPlan;
+    }
+
+    public List<ColumnRefOperator> getOutputColumns() {
+        return outputColumns;
+    }
+
+    public ColumnRefFactory getRefFactory() {
+        return refFactory;
+    }
+
+    public boolean isValidMvPlan() {
+        return isValidMvPlan;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2100,4 +2100,16 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static int catalog_metadata_cache_size = 500;
+
+    /**
+     * mv plan cache expire interval in seconds
+     */
+    @ConfField(mutable = true)
+    public static long mv_plan_cache_expire_interval_sec = 24L * 60L * 60L;
+
+    /**
+     * mv plan cache expire interval in seconds
+     */
+    @ConfField(mutable = true)
+    public static long mv_plan_cache_max_size = 1000;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -360,6 +360,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String QUERY_EXCLUDING_MV_NAMES = "query_excluding_mv_names";
     public static final String QUERY_INCLUDING_MV_NAMES = "query_including_mv_names";
 
+    public static final String ENABLE_MATERIALIZED_VIEW_PLAN_CACHE = "enable_materialized_view_plan_cache";
+
     public static final String ENABLE_PRUNE_COMPLEX_TYPES = "enable_prune_complex_types";
 
     public static final String GROUP_CONCAT_MAX_LEN = "group_concat_max_len";
@@ -942,6 +944,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     //      try to rewrite by single table mvs and is determined by rule rather than by cost.
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_SINGLE_TABLE_VIEW_DELTA_REWRITE, flag = VariableMgr.INVISIBLE)
     private boolean enableMaterializedViewSingleTableViewDeltaRewrite = false;
+
+    // whether to use materialized view plan context cache to reduce mv rewrite time cost
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_PLAN_CACHE, flag = VariableMgr.INVISIBLE)
+    private boolean enableMaterializedViewPlanCache = true;
 
     @VarAttr(name = QUERY_EXCLUDING_MV_NAMES, flag = VariableMgr.INVISIBLE)
     private String queryExcludingMVNames = "";
@@ -1804,6 +1810,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public void setEnableMaterializedViewSingleTableViewDeltaRewrite(
             boolean enableMaterializedViewSingleTableViewDeltaRewrite) {
         this.enableMaterializedViewSingleTableViewDeltaRewrite = enableMaterializedViewSingleTableViewDeltaRewrite;
+    }
+
+    public void setEnableMaterializedViewPlanCache(boolean enableMaterializedViewPlanCache) {
+        this.enableMaterializedViewPlanCache = enableMaterializedViewPlanCache;
+    }
+
+    public boolean isEnableMaterializedViewPlanCache() {
+        return this.enableMaterializedViewPlanCache;
     }
 
     public String getQueryExcludingMVNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -188,6 +188,7 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.common.SyncPartitionUtils;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.system.Backend;
@@ -3563,7 +3564,9 @@ public class LocalMetastore implements ConnectorMetadata {
             db.readUnlock();
         }
         if (table instanceof MaterializedView) {
+            MaterializedView mv = (MaterializedView) table;
             db.dropTable(table.getName(), stmt.isSetIfExists(), true);
+            CachingMvPlanContextBuilder.getInstance().invalidateFromCache(mv);
             List<BaseTableInfo> baseTableInfos = ((MaterializedView) table).getBaseTableInfos();
             if (baseTableInfos != null) {
                 for (BaseTableInfo baseTableInfo : baseTableInfos) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
+import com.starrocks.catalog.MvPlanContext;
+import com.starrocks.common.Config;
+
+import java.util.concurrent.TimeUnit;
+
+public class CachingMvPlanContextBuilder {
+    private static final CachingMvPlanContextBuilder INSTANCE = new CachingMvPlanContextBuilder();
+
+    private Cache<MvId, MvPlanContext> mvPlanContextCache = Caffeine.newBuilder()
+            .expireAfterAccess(Config.mv_plan_cache_expire_interval_sec, TimeUnit.SECONDS)
+            .maximumSize(Config.mv_plan_cache_max_size)
+            .build();
+
+    private CachingMvPlanContextBuilder() {
+
+    }
+
+    public static CachingMvPlanContextBuilder getInstance() {
+        return INSTANCE;
+    }
+
+    public MvPlanContext getPlanContext(MaterializedView mv, boolean useCache) {
+        MvId mvId = new MvId(mv.getDbId(), mv.getId());
+        MvPlanContext result = useCache ? mvPlanContextCache.getIfPresent(mvId) : null;
+        if (result == null) {
+            MvPlanContextBuilder builder = new MvPlanContextBuilder();
+            result = builder.getPlanContext(mv);
+            if (result.isValidMvPlan()) {
+                mvPlanContextCache.put(mvId, result);
+                mv.setPlanMode(MaterializedView.PlanMode.VALID);
+            }
+        }
+
+        return result;
+    }
+
+    @VisibleForTesting
+    public boolean contains(MaterializedView mv) {
+        return mvPlanContextCache.asMap().containsKey(new MvId(mv.getDbId(), mv.getId()));
+    }
+
+    public void invalidateFromCache(MaterializedView mv) {
+        mvPlanContextCache.invalidate(new MvId(mv.getDbId(), mv.getId()));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializedViewOptimizer.java
@@ -3,7 +3,7 @@
 package com.starrocks.sql.optimizer;
 
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.MaterializedView.MVRewriteContextCache;
+import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -11,9 +11,9 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 
 public class MaterializedViewOptimizer {
-    public MVRewriteContextCache optimize(MaterializedView mv,
-                                          ConnectContext connectContext,
-                                          OptimizerConfig optimizerConfig) {
+    public MvPlanContext optimize(MaterializedView mv,
+                                  ConnectContext connectContext,
+                                  OptimizerConfig optimizerConfig) {
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
         String mvSql = mv.getViewDefineSql();
         Pair<OptExpression, LogicalPlan> plans =
@@ -23,10 +23,10 @@ public class MaterializedViewOptimizer {
         }
         OptExpression mvPlan = plans.first;
         if (!MvUtils.isValidMVPlan(mvPlan)) {
-            return new MVRewriteContextCache();
+            return new MvPlanContext();
         }
-        MVRewriteContextCache mvRewriteContext =
-                new MVRewriteContextCache(mvPlan, plans.second.getOutputColumn(), columnRefFactory);
+        MvPlanContext mvRewriteContext =
+                new MvPlanContext(mvPlan, plans.second.getOutputColumn(), columnRefFactory);
         return mvRewriteContext;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
@@ -1,0 +1,35 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.rule.RuleSetType;
+import com.starrocks.sql.optimizer.rule.RuleType;
+
+public class MvPlanContextBuilder {
+    public MvPlanContext getPlanContext(MaterializedView mv) {
+        // build mv query logical plan
+        MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();
+        // optimize the sql by rule and disable rule based materialized view rewrite
+        OptimizerConfig optimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerAlgorithm.RULE_BASED);
+        optimizerConfig.disableRuleSet(RuleSetType.PARTITION_PRUNE);
+        optimizerConfig.disableRuleSet(RuleSetType.SINGLE_TABLE_MV_REWRITE);
+        optimizerConfig.disableRule(RuleType.TF_REWRITE_GROUP_BY_COUNT_DISTINCT);
+        optimizerConfig.setMVRewritePlan(true);
+        return mvOptimizer.optimize(mv, new ConnectContext(), optimizerConfig);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -16,6 +16,7 @@ import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
@@ -29,8 +30,6 @@ import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rule.RuleSetType;
-import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -90,6 +89,10 @@ public class MvRewritePreprocessor {
 
         Set<ColumnRefOperator> originQueryColumns = Sets.newHashSet(queryColumnRefFactory.getColumnRefs());
         for (MaterializedView mv : relatedMvs) {
+            if (!mv.isValidPlan()) {
+                // skip to process unsupported plan tree
+                continue;
+            }
             try {
                 preprocessMv(mv, queryTables, originQueryColumns);
             } catch (Exception e) {
@@ -116,23 +119,20 @@ public class MvRewritePreprocessor {
             return;
         }
 
-        MaterializedView.MVRewriteContextCache mvRewriteContextCache = mv.getPlanContext();
-        if (mvRewriteContextCache == null) {
-            // build mv query logical plan
-            MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();
-            // optimize the sql by rule and disable rule based materialized view rewrite
-            OptimizerConfig optimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerAlgorithm.RULE_BASED);
-            optimizerConfig.disableRuleSet(RuleSetType.PARTITION_PRUNE);
-            optimizerConfig.disableRuleSet(RuleSetType.SINGLE_TABLE_MV_REWRITE);
-            optimizerConfig.disableRule(RuleType.TF_REWRITE_GROUP_BY_COUNT_DISTINCT);
-            optimizerConfig.setMVRewritePlan(true);
-
-            mvRewriteContextCache = mvOptimizer.optimize(mv, connectContext, optimizerConfig);
-            mv.setPlanContext(mvRewriteContextCache);
+        MvPlanContext mvPlanContext = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv,
+                connectContext.getSessionVariable().isEnableMaterializedViewPlanCache());
+        if (mvPlanContext == null) {
+            logMVPrepare(connectContext, mv, "MV plan is not valid: {}, cannot generate plan for rewrite", mv.getName());
+            return;
         }
-        if (!mvRewriteContextCache.isValidMvPlan()) {
-            logMVPrepare(connectContext, "MV plan is not valid: %s, plan:\n %s",
-                    mv.getName(), mvRewriteContextCache.getLogicalPlan().explain());
+        if (!mvPlanContext.isValidMvPlan()) {
+            mv.setPlanMode(MaterializedView.PlanMode.INVALID);
+            if (mvPlanContext.getLogicalPlan() != null) {
+                logMVPrepare(connectContext, mv, "MV plan is not valid: {}, plan:\n {}",
+                        mv.getName(), mvPlanContext.getLogicalPlan().explain());
+            } else {
+                logMVPrepare(connectContext, mv, "MV plan is not valid: {}", mv.getName());
+            }
             return;
         }
 
@@ -162,7 +162,10 @@ public class MvRewritePreprocessor {
             return;
         }
 
-        OptExpression mvPlan = mvRewriteContextCache.getLogicalPlan();
+        Preconditions.checkState(mvPlanContext != null);
+        OptExpression mvPlan = mvPlanContext.getLogicalPlan();
+        Preconditions.checkState(mvPlan != null);
+
         ScalarOperator mvPartialPartitionPredicates = null;
         if (mv.getPartitionInfo() instanceof ExpressionRangePartitionInfo && !partitionNamesToRefresh.isEmpty()) {
             // when mv is partitioned and there are some refreshed partitions,
@@ -185,9 +188,9 @@ public class MvRewritePreprocessor {
         List<Table> intersectingTables = baseTables.stream().filter(queryTables::contains).collect(Collectors.toList());
         MaterializationContext materializationContext =
                 new MaterializationContext(context, mv, mvPlan, queryColumnRefFactory,
-                        mv.getPlanContext().getRefFactory(), partitionNamesToRefresh,
+                        mvPlanContext.getRefFactory(), partitionNamesToRefresh,
                         baseTables, originQueryColumns, intersectingTables, mvPartialPartitionPredicates);
-        List<ColumnRefOperator> mvOutputColumns = mv.getPlanContext().getOutputColumns();
+        List<ColumnRefOperator> mvOutputColumns = mvPlanContext.getOutputColumns();
         // generate scan mv plan here to reuse it in rule applications
         LogicalOlapScanOperator scanMvOp = createScanMvOperator(materializationContext, partitionNamesToRefresh);
         materializationContext.setScanMvOperator(scanMvOp);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -1,0 +1,73 @@
+// This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvPlanContext;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MvRewriteTest extends MvRewriteTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MvRewriteTestBase.beforeClass();
+    }
+
+    @Test
+    public void testPlanCache() throws Exception {
+        {
+            String mvSql = "create materialized view agg_join_mv_1" +
+                    " distributed by hash(v1) as SELECT t0.v1 as v1," +
+                    " test_all_type.t1d, sum(test_all_type.t1c) as total_sum, count(test_all_type.t1c) as total_num" +
+                    " from t0 join test_all_type on t0.v1 = test_all_type.t1d" +
+                    " where t0.v1 < 100" +
+                    " group by v1, test_all_type.t1d";
+            starRocksAssert.withMaterializedView(mvSql);
+
+            MaterializedView mv = getMv("test", "agg_join_mv_1");
+            MvPlanContext planContext = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, true);
+            Assert.assertNotNull(planContext);
+            Assert.assertTrue(CachingMvPlanContextBuilder.getInstance().contains(mv));
+            planContext = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, false);
+            Assert.assertNotNull(planContext);
+            starRocksAssert.dropMaterializedView("agg_join_mv_1");
+        }
+
+        {
+            String mvSql = "create materialized view mv_with_window" +
+                    " distributed by hash(t1d) as" +
+                    " SELECT test_all_type.t1d, row_number() over (partition by t1c)" +
+                    " from test_all_type";
+            starRocksAssert.withMaterializedView(mvSql);
+
+            MaterializedView mv = getMv("test", "mv_with_window");
+            MvPlanContext planContext = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, true);
+            Assert.assertNotNull(planContext);
+            Assert.assertFalse(CachingMvPlanContextBuilder.getInstance().contains(mv));
+            starRocksAssert.dropMaterializedView("mv_with_window");
+        }
+
+        {
+            for (int i = 0; i < 1010; i++) {
+                String mvName = "plan_cache_mv_" + i;
+                String mvSql = String.format("create materialized view %s" +
+                        " distributed by hash(v1) as SELECT t0.v1 as v1," +
+                        " test_all_type.t1d, sum(test_all_type.t1c) as total_sum, count(test_all_type.t1c) as total_num" +
+                        " from t0 join test_all_type on t0.v1 = test_all_type.t1d" +
+                        " where t0.v1 < 100" +
+                        " group by v1, test_all_type.t1d", mvName);
+                starRocksAssert.withMaterializedView(mvSql);
+
+                MaterializedView mv = getMv("test", mvName);
+                MvPlanContext planContext = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv, true);
+                Assert.assertNotNull(planContext);
+            }
+            for (int i = 0; i < 1010; i++) {
+                String mvName = "plan_cache_mv_" + i;
+                starRocksAssert.dropMaterializedView(mvName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
* optimize mv plan cache by using lru cache

Fixes #30361 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
