### PR TITLE
[Enhancement] prefetch append_selective() large binary column to improve perfomance

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -67,8 +67,12 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
     const auto& src_offsets = src_column.get_offset();
     const auto& src_bytes = src_column.get_bytes();
 
+    // enable prefetch if
+    // 1) the input size is large enough
+    // 2) the src col is large enough
+    // 3) not only long strings.
     bool need_prefetch =
-            (size > SEQUENTIAL_DISTINCT * 2) && (src_offsets.back() > (1 << 22)) && src_offsets.size() > 64;
+            (size > SEQUENTIAL_DISTINCT * 2) && (src_offsets.back() > (1 << 22)) && src_offsets.size() > 512;
 
     size_t cur_row_count = _offsets.size() - 1;
     size_t cur_byte_size = _bytes.size();

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -72,7 +72,7 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
     // 2) the src col is large enough
     // 3) not only long strings.
     bool need_prefetch =
-            (size > SEQUENTIAL_DISTINCT * 2) && (src_offsets.back() > (1 << 26)) && src_offsets.size() > 512;
+            (size > SEQUENTIAL_DISTINCT * 2) && (src_offsets.back() > (1 << 23)) && src_offsets.size() > 512;
 
     size_t cur_row_count = _offsets.size() - 1;
     size_t cur_byte_size = _bytes.size();

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -72,7 +72,7 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
     // 2) the src col is large enough
     // 3) not only long strings.
     bool need_prefetch =
-            (size > SEQUENTIAL_DISTINCT * 2) && (src_offsets.back() > (1 << 22)) && src_offsets.size() > 512;
+            (size > SEQUENTIAL_DISTINCT * 2) && (src_offsets.back() > (1 << 26)) && src_offsets.size() > 512;
 
     size_t cur_row_count = _offsets.size() - 1;
     size_t cur_byte_size = _bytes.size();

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "simd/simd.h"
+#include "util/prefetch.h"
 
 #define JOIN_HASH_MAP_TPP
 
@@ -947,13 +948,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_impl(RuntimeState* state,
         }                                                                                                             \
         _probe_state->build_index.swap(new_order);                                                                    \
     }
-
-#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86)) /* _mm_prefetch() not defined outside of x86/x64 */
-#include <mmintrin.h> /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
-#define XXH_PREFETCH(ptr) _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
-#elif defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
-#define XXH_PREFETCH(ptr) __builtin_prefetch((ptr), 0 /* rw==read */, 3 /* locality */)
-#endif
 
 #define PREFETCH_AND_COWAIT(x, y) \
     XXH_PREFETCH(x);              \

--- a/be/src/util/prefetch.h
+++ b/be/src/util/prefetch.h
@@ -19,6 +19,9 @@
 #define XXH_PREFETCH(ptr) _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
 #elif defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
 #define XXH_PREFETCH(ptr) __builtin_prefetch((ptr), 0 /* rw==read */, 3 /* locality */)
+#else
+#define XXH_PREFETCH(ptr) (void)(ptr) /* disabled */
 #endif
+
 #define SEQUENTIAL_DISTINCT 16L
 #define SEQUENTIAL_PREFETCH(x) XXH_PREFETCH(x);

--- a/be/src/util/prefetch.h
+++ b/be/src/util/prefetch.h
@@ -1,0 +1,24 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86)) /* _mm_prefetch() not defined outside of x86/x64 */
+#include <mmintrin.h> /* https://msdn.microsoft.com/fr-fr/library/84szxsww(v=vs.90).aspx */
+#define XXH_PREFETCH(ptr) _mm_prefetch((const char*)(ptr), _MM_HINT_T0)
+#elif defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
+#define XXH_PREFETCH(ptr) __builtin_prefetch((ptr), 0 /* rw==read */, 3 /* locality */)
+#endif
+#define SEQUENTIAL_DISTINCT 16L
+#define SEQUENTIAL_PREFETCH(x) XXH_PREFETCH(x);


### PR DESCRIPTION
prefetch data during append_selective() for large binary column, reducing total query cost time from 24s to 19s, the time of copying build side column decreases from 7s421ms to 2s945ms.
```
select count(*) from lineitem join orders on left(o_comment,64) = left(l_comment,64) and l_orderkey < 100000000;
```

on concurrency tests, query parallelism = 2 or 3, the cost time is increased by 2 or 3 times, keeping faster than baseline.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
