### PR TITLE
[Refactor] Add a new config enable_drop_tablet_if_unfinished_txn when dropping tablet

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -163,18 +163,26 @@ void run_drop_tablet_task(const std::shared_ptr<DropTabletAgentTaskRequest>& age
         if (!config::enable_drop_tablet_if_unfinished_txn) {
             int64_t partition_id;
             std::set<int64_t> transaction_ids;
-            StorageEngine::instance()->txn_manager()->get_tablet_related_txns(
-                    drop_tablet_req.tablet_id, drop_tablet_req.schema_hash, dropped_tablet->tablet_uid(), &partition_id,
-                    &transaction_ids);
+            {
+                std::lock_guard push_lock(dropped_tablet->get_push_lock());
+                StorageEngine::instance()->txn_manager()->get_tablet_related_txns(
+                        drop_tablet_req.tablet_id, drop_tablet_req.schema_hash, dropped_tablet->tablet_uid(),
+                        &partition_id, &transaction_ids);
+            }
             if (!transaction_ids.empty()) {
                 std::stringstream ss;
-                ss << "Failed to drop tablet when there is unfinished txns. tablet_id:" << drop_tablet_req.tablet_id;
-                LOG(WARNING) << ss.c_str();
-                error_msgs.emplace_back(ss.c_str());
+                ss << "Failed to drop tablet when there is unfinished txns."
+                   << "tablet_id: " << drop_tablet_req.tablet_id << ", txn_ids: ";
+                for (auto itr = transaction_ids.begin(); itr != transaction_ids.end(); itr++) {
+                    ss << *itr;
+                    if (std::next(itr) != transaction_ids.end()) {
+                        ss << ",";
+                    }
+                }
+                LOG(WARNING) << ss.str();
+                error_msgs.emplace_back(ss.str());
                 status_code = TStatusCode::RUNTIME_ERROR;
-                unify_finish_agent_task(status_code, error_msgs,
-                                        agent_task_req->task_type,
-                                        agent_task_req->signature);
+                unify_finish_agent_task(status_code, error_msgs, agent_task_req->task_type, agent_task_req->signature);
                 return;
             }
         }

--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -160,6 +160,25 @@ void run_drop_tablet_task(const std::shared_ptr<DropTabletAgentTaskRequest>& age
 
     auto dropped_tablet = StorageEngine::instance()->tablet_manager()->get_tablet(drop_tablet_req.tablet_id);
     if (dropped_tablet != nullptr) {
+        if (!config::enable_drop_tablet_if_unfinished_txn) {
+            int64_t partition_id;
+            std::set<int64_t> transaction_ids;
+            StorageEngine::instance()->txn_manager()->get_tablet_related_txns(
+                    drop_tablet_req.tablet_id, drop_tablet_req.schema_hash, dropped_tablet->tablet_uid(), &partition_id,
+                    &transaction_ids);
+            if (!transaction_ids.empty()) {
+                std::stringstream ss;
+                ss << "Failed to drop tablet when there is unfinished txns. tablet_id:" << drop_tablet_req.tablet_id;
+                LOG(WARNING) << ss.c_str();
+                error_msgs.emplace_back(ss.c_str());
+                status_code = TStatusCode::RUNTIME_ERROR;
+                unify_finish_agent_task(status_code, error_msgs,
+                                        agent_task_req->task_type,
+                                        agent_task_req->signature);
+                return;
+            }
+        }
+
         TabletDropFlag flag = force_drop ? kDeleteFiles : kMoveFilesToTrash;
         auto st = StorageEngine::instance()->tablet_manager()->drop_tablet(drop_tablet_req.tablet_id, flag);
         if (!st.ok()) {

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1052,4 +1052,6 @@ CONF_mInt32(get_txn_status_internal_sec, "30");
 
 CONF_mBool(dump_metrics_with_bvar, "true");
 
+CONF_mBool(enable_drop_tablet_if_unfinished_txn, "true");
+
 } // namespace starrocks::config


### PR DESCRIPTION
When dropping tablet, there is some tablet still running with txns. The FE balance may drop the tablet, but the tablet still has txns. There is a sequence where the tablet will still receive the txn.
```
1. Drop the tablet
2. Receive a new query and plan
3. Begin a transaction
```
The BeginTransaction is after the query plan, it will make the ingestion can not get the accurate tablet state. But the ingestion will fail, and throw an
```
no delete vector found tablet
```
This config is just a temporary mechanism before changing the txn mechanism in the FE. 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
