### PR TITLE
[BugFix] fix subquery check in join on predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -445,6 +445,32 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         extractConjunctsImpl(cpe.getChild(1), conjuncts);
     }
 
+    public static List<Expr> flattenPredicate(Expr root) {
+        List<Expr> children = Lists.newArrayList();
+        if (null == root) {
+            return children;
+        }
+
+        flattenPredicate(root, children);
+        return children;
+    }
+
+    private static void flattenPredicate(Expr root, List<Expr> children) {
+        if (!(root instanceof CompoundPredicate)) {
+            children.add(root);
+            return;
+        }
+
+        CompoundPredicate cpe = (CompoundPredicate) root;
+        if (CompoundPredicate.Operator.AND.equals(cpe.getOp()) || CompoundPredicate.Operator.OR.equals(cpe.getOp())) {
+            extractConjunctsImpl(cpe.getChild(0), children);
+            extractConjunctsImpl(cpe.getChild(1), children);
+        } else {
+            children.add(root);
+        }
+    }
+
+
     public static Expr compoundAnd(Collection<Expr> conjuncts) {
         return createCompound(CompoundPredicate.Operator.AND, conjuncts);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
@@ -208,4 +208,7 @@ public interface ParserErrorMsg {
 
     @BaseMessage("Conflicted options {0} and {1}")
     String conflictedOptions(String a0, String a1);
+
+    @BaseMessage("Not support ''{0}'' {1}")
+    String unsupportedSubquery(String a0, String a1);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -203,7 +203,7 @@ public class OptExpression {
         StringBuilder sb = new StringBuilder();
         sb.append(headlinePrefix).append(op.accept(new DebugOperatorTracer(), null));
         limitLine -= 1;
-        if (limitLine <= 0 || inputs.isEmpty()) {
+        if (limitLine <= 0) {
             return sb.toString();
         }
         sb.append('\n');

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownApplyAggFilterRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PushDownApplyAggFilterRule.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.collect.Lists;
@@ -39,39 +38,41 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * Push down ApplyNode and AggregationNode as a whole
- * Pattern:
- * ApplyNode
- * /      \
- * LEFT     Aggregation(scalar aggregation)
- * \
- * Filter
- * \
- * ....
- * Before:
- * ApplyNode
- * /      \
- * LEFT     Aggregate(scalar aggregation)
- * \
- * Filter
- * \
- * ....
- * After:
- * ApplyNode
- * /      \
- * LEFT      Filter(correlation)
- * \
- * Aggregate(vector aggregation, group by correlation columns)
- * \
- * Project(correlation columns: expression)[optional]
- * \
- * Filter(un-correlation)[optional]
- * \
- * ....
- * Requirements:
- * 1. All predicate is Binary.EQ in correlation filter
- */
+// Push down ApplyNode and AggregationNode as a whole
+// Pattern:
+//      ApplyNode
+//      /      \
+//  LEFT     Aggregation(scalar aggregation)
+//               \
+//               Filter
+//                 \
+//                 ....
+//
+// Before:
+//      ApplyNode
+//      /      \
+//  LEFT     Aggregate(scalar aggregation)
+//               \
+//               Filter
+//                 \
+//                 ....
+//
+// After:
+//      ApplyNode
+//      /      \
+//  LEFT      Filter(correlation)
+//               \
+//            Aggregate(vector aggregation, group by correlation columns)
+//                 \
+//              Project(correlation columns: expression)[optional]
+//                   \
+//               Filter(un-correlation)[optional]
+//                     \
+//                      ....
+//
+// Requirements:
+// 1. All predicate is Binary.EQ in correlation filter
+//
 public class PushDownApplyAggFilterRule extends TransformationRule {
     public PushDownApplyAggFilterRule() {
         super(RuleType.TF_PUSH_DOWN_APPLY_AGG, Pattern.create(OperatorType.LOGICAL_APPLY).addChildren(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -242,7 +242,6 @@ public final class SqlToScalarOperatorTranslator {
                 if (num > 0) {
                     return num;
                 }
-
                 if (child instanceof Subquery) {
                     num++;
                 } else {
@@ -794,9 +793,9 @@ public final class SqlToScalarOperatorTranslator {
             ColumnRefSet outerUsedColumns = new ColumnRefSet();
             if (subqueryPlan.getCorrelation().isEmpty()) {
                 for (Expr outer : context.outerExprs) {
-                    outerUsedColumns.union(SqlToScalarOperatorTranslator
-                            .translate(outer, builder.getExpressionMapping(), columnRefFactory)
-                            .getUsedColumns());
+                    outerUsedColumns.union(
+                            SqlToScalarOperatorTranslator.translate(outer, expressionMapping, columnRefFactory)
+                                    .getUsedColumns());
                 }
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonTypeTest.java
@@ -225,7 +225,7 @@ public class JsonTypeTest extends PlanTestBase {
                 "CAST(json_array(CAST(1 AS JSON), CAST(2 AS JSON), CAST(3 AS JSON)) AS ARRAY<JSON>)");
 
         // Multi-dimension array casting is not supported
-        assertExceptionMessage("select cast(json_array(1,2,3) as array<array<int>>)",
+        assertExceptionMsgContains("select cast(json_array(1,2,3) as array<array<int>>)",
                 "Getting analyzing error from line 1, column 7 to line 1, column 50. Detail message: " +
                         "Invalid type cast from json to array<array<int(11)>> in sql `json_array(1, 2, 3)`.");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -610,12 +610,12 @@ public class PlanTestNoneDBBase {
         }
     }
 
-    protected void assertExceptionMessage(String sql, String message) {
+    protected void assertExceptionMsgContains(String sql, String message) {
         try {
             getFragmentPlan(sql);
             throw new Error();
         } catch (Exception e) {
-            Assert.assertEquals(message, e.getMessage());
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains(message));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -24,6 +24,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static org.junit.Assert.fail;
+
 public class SubqueryTest extends PlanTestBase {
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
@@ -1181,25 +1183,21 @@ public class SubqueryTest extends PlanTestBase {
 
     @Test
     public void testOnClauseNotSupportedCases() {
-        assertExceptionMessage("select * from t0 " +
+        assertExceptionMsgContains("select * from t0 " +
                         "join t1 on (select v1 from t0 where t0.v2 = t1.v5) = (select v4 from t1 where t0.v2 = t1.v5)",
-                "Not support ON Clause conjunct contains more than one subquery");
+                "contains more than one subquery");
 
-        assertExceptionMessage("select * from t0 " +
-                        "join t1 on t0.v1 + t1.v4 = (select count(*) from t0)",
-                "Not support ON Clause un-correlated subquery referencing columns of more than one table");
-
-        assertExceptionMessage("select * from t0 " +
+        assertExceptionMsgContains("select * from t0 " +
                         "join t1 on 1 = (select count(*) from t2 where t0.v1 = t2.v7 and t1.v4 = t2.v7)",
-                "Not support ON Clause correlated subquery referencing columns of more than one table");
+                "referencing columns from more than one table");
 
-        assertExceptionMessage("select * from t0 " +
+        assertExceptionMsgContains("select * from t0 " +
                         "join t1 on 1 = (select count(*) from t2 where t0.v1 = t2.v7 and t1.v4 = t2.v7)",
-                "Not support ON Clause correlated subquery referencing columns of more than one table");
+                "referencing columns from more than one table");
 
-        assertExceptionMessage("select * from t0 " +
+        assertExceptionMsgContains("select * from t0 " +
                         "join t1 on t0.v1 in (select t2.v7 from t2 where t1.v5 = t2.v8)",
-                "Not support ON Clause correlated in-subquery referencing columns of more than one table");
+                "referencing columns from more than one table");
     }
 
     @Test
@@ -1783,7 +1781,7 @@ public class SubqueryTest extends PlanTestBase {
     @Test
     public void testNestSubquery() throws Exception {
         String sql = "select * from t0 where exists (select * from t1 where t0.v1 in (select v7 from t2));";
-        assertExceptionMessage(sql, "Getting analyzing error. Detail message: Unsupported complex nested in-subquery.");
+        assertExceptionMsgContains(sql, "Getting analyzing error. Detail message: Unsupported complex nested in-subquery.");
 
         sql = "select * from t0 where exists (select * from t1 where t0.v1 = (select v7 from t2));";
         String plan = getFragmentPlan(sql);
@@ -1885,6 +1883,36 @@ public class SubqueryTest extends PlanTestBase {
                     () -> getFragmentPlan(sql));
         } finally {
             connectContext.getSessionVariable().setSqlMode(sqlMode);
+        }
+    }
+
+    @Test
+    public void testUnsupportedInSubquery() {
+        String sql = "select * from t0 left join t1 on v1 in (select v7 from t2 where v4 = v8) or v1 < v5;";
+        try {
+            getFragmentPlan(sql);
+            fail("sql should fail");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("referencing columns from more than one table"));
+        }
+
+        sql = "select * from t0 left join t1 on v1 + v4 in (select v7 from t2) or v1 < v5;";
+        try {
+            getFragmentPlan(sql);
+            fail("sql should fail");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("referencing columns from more than one table"));
+        }
+    }
+
+    @Test
+    public void testUnsupportedExistSubquery() {
+        String sql = "select * from t0 left join t1 on exists (select v7 from t2 where v1 = v4) or v1 < v5;";
+        try {
+            getFragmentPlan(sql);
+            fail("sql should fail");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("referencing columns from more than one table"));
         }
     }
 }

--- a/test/sql/test_join/R/test_apply_to_join
+++ b/test/sql/test_join/R/test_apply_to_join
@@ -1,0 +1,97 @@
+-- name: test_apply_to_join
+CREATE TABLE `t0` (
+  `v1` bigint NULL COMMENT "",
+  `v2` bigint NULL COMMENT "",
+  `v3` bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`, `v2`, v3)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false"
+);
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `v4` bigint NULL COMMENT "",
+  `v5` bigint NULL COMMENT "",
+  `v6` bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v4`, `v5`, v6)
+DISTRIBUTED BY HASH(`v4`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false"
+);
+-- result:
+-- !result
+CREATE TABLE `t2` (
+  `v7` bigint NULL COMMENT "",
+  `v8` bigint NULL COMMENT "",
+  `v9` bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v7`, `v8`, v9)
+DISTRIBUTED BY HASH(`v7`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false"
+);
+-- result:
+-- !result
+insert into t0 values (null, 1, 1), (2, null, null), (3, 3, null), (4, 4, 4), (5, 5, 5), (6, 6, 6), (null, null, null), (7, 7, 7), (8, 8, 8);
+-- result:
+-- !result
+insert into t1 values (null, 1, 1), (2, null, null), (3, 3, null), (4, 4, 4), (5, 5, 5), (6, 6, 6), (null, null, null), (7, 7, 7), (8, 8, 8);
+-- result:
+-- !result
+insert into t2 values (null, 1, 1), (2, null, null), (3, 3, null), (4, 4, 4), (5, 5, 5), (6, 6, 6), (null, null, null), (7, 7, 7), (8, 8, 8);
+-- result:
+-- !result
+select count(*) from t0 left join t1 on v1 in (select v7 from t2) or v1 < v5;
+-- result:
+65
+-- !result
+select count(*) from t0 left join t1 on v1 in (select v7 from t2 where v2 = v8) or v1 < v5;
+-- result:
+62
+-- !result
+select count(*) from t0 left join t1 on v4 in (select v7 from t2) or v1 < v5;
+-- result:
+63
+-- !result
+select count(*) from t0 left join t1 on v4 in (select v7 from t2 where v5 = v8) or v1 < v5;
+-- result:
+54
+-- !result
+select count(*) from t0 left join t1 on exists (select v7 from t2) or v1 < v5;
+-- result:
+81
+-- !result
+select count(*) from t0 left join t1 on exists (select v7 from t2 where v8 = v1) or v1 < v5;
+-- result:
+62
+-- !result
+select count(*) from t0 left join t1 on exists (select v7 from t2 where v8 = v4) or v1 < v5;
+-- result:
+54
+-- !result
+select count(*) from t0 left join t1 on (select count(*) from t2 where v4 = v7) > 0;
+-- result:
+63
+-- !result
+select count(*) from t0 left join t1 on (select count(*) from t2 where v4 = v7) > 0 or v1 > v4;
+-- result:
+63
+-- !result
+select count(*) from t0 left join t1 on (select count(*) from t2 where v4 = v7) > v1 + v5 or v1 > v4;
+-- result:
+24
+-- !result
+select count(*) from t0 left join t1 on (select count(*) from t2) > 0 or v1 + v4 = v2 + v5;
+-- result:
+81
+-- !result
+select count(*) from t0 left join t1 on (select count(*) from t2) > v1 + v4 or v1 < v4;
+-- result:
+33
+-- !result

--- a/test/sql/test_join/T/test_apply_to_join
+++ b/test/sql/test_join/T/test_apply_to_join
@@ -1,0 +1,56 @@
+-- name: test_apply_to_join
+CREATE TABLE `t0` (
+  `v1` bigint NULL COMMENT "",
+  `v2` bigint NULL COMMENT "",
+  `v3` bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`, `v2`, v3)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false"
+);
+
+CREATE TABLE `t1` (
+  `v4` bigint NULL COMMENT "",
+  `v5` bigint NULL COMMENT "",
+  `v6` bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v4`, `v5`, v6)
+DISTRIBUTED BY HASH(`v4`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false"
+);
+
+CREATE TABLE `t2` (
+  `v7` bigint NULL COMMENT "",
+  `v8` bigint NULL COMMENT "",
+  `v9` bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v7`, `v8`, v9)
+DISTRIBUTED BY HASH(`v7`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false"
+);
+
+insert into t0 values (null, 1, 1), (2, null, null), (3, 3, null), (4, 4, 4), (5, 5, 5), (6, 6, 6), (null, null, null), (7, 7, 7), (8, 8, 8);
+insert into t1 values (null, 1, 1), (2, null, null), (3, 3, null), (4, 4, 4), (5, 5, 5), (6, 6, 6), (null, null, null), (7, 7, 7), (8, 8, 8);
+insert into t2 values (null, 1, 1), (2, null, null), (3, 3, null), (4, 4, 4), (5, 5, 5), (6, 6, 6), (null, null, null), (7, 7, 7), (8, 8, 8);
+
+select count(*) from t0 left join t1 on v1 in (select v7 from t2) or v1 < v5;
+select count(*) from t0 left join t1 on v1 in (select v7 from t2 where v2 = v8) or v1 < v5;
+select count(*) from t0 left join t1 on v4 in (select v7 from t2) or v1 < v5;
+select count(*) from t0 left join t1 on v4 in (select v7 from t2 where v5 = v8) or v1 < v5;
+
+select count(*) from t0 left join t1 on exists (select v7 from t2) or v1 < v5;
+select count(*) from t0 left join t1 on exists (select v7 from t2 where v8 = v1) or v1 < v5;
+select count(*) from t0 left join t1 on exists (select v7 from t2 where v8 = v4) or v1 < v5;
+
+select count(*) from t0 left join t1 on (select count(*) from t2 where v4 = v7) > 0;
+select count(*) from t0 left join t1 on (select count(*) from t2 where v4 = v7) > 0 or v1 > v4;
+select count(*) from t0 left join t1 on (select count(*) from t2 where v4 = v7) > v1 + v5 or v1 > v4;
+select count(*) from t0 left join t1 on (select count(*) from t2) > 0 or v1 + v4 = v2 + v5;
+select count(*) from t0 left join t1 on (select count(*) from t2) > v1 + v4 or v1 < v4;
+


### PR DESCRIPTION
Fixes #issue
```
select * from t0 left join t1 on (select count(*) from t2 where v4 = v7) > 0;
```
failed to pass `Preconditions.checkState(isJoinLeftCorrelated || isJoinRightCorrelated);` because of not implement equals method in field.

The root casue is subquery in join on predicate is a little different from it in other position, because we need to define which node in the join operator is the outer node in apply operator.
- scalar subquery
   If uncorrelated, just choose the right node in the join op, else choose the correlated node. If the correlated relationship ref cols from both nodes in the join, throw unsupported exception.
- exists subquery
   the same as scalar subquery.
- in subquery
   It's a little different becuase the `expr in subquery` has implied a correlated realtionship. So just choose the correlated node. If the correlated relationship ref cols from both nodes in the join, throw unsupported exception.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
