### PR TITLE
[BugFix] Fix complex distinct query use CTE error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CTEUtils.java
@@ -88,11 +88,9 @@ public class CTEUtils {
             LogicalCTEProduceOperator produce = (LogicalCTEProduceOperator) expression.getOp();
 
             // costs
-            if (context.getCteContext().isForceCTE(produce.getCteId())) {
-                OptExpression opt = root.extractLogicalTree();
-                calculateStatistics(opt, context);
-                context.getCteContext().addCTEStatistics(produce.getCteId(), opt.getStatistics());
-            }
+            OptExpression opt = root.extractLogicalTree();
+            calculateStatistics(opt, context);
+            context.getCteContext().addCTEStatistics(produce.getCteId(), opt.getStatistics());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -797,4 +797,29 @@ public class CTEPlanTest extends PlanTestBase {
         assertContains(plan, "9:SELECT\n" +
                 "  |  predicates: 26: v2 > 0, 28: v4 = 123");
     }
+
+    @Test
+    public void testCTEForceUseUnForce() throws Exception {
+        String sql = "with " +
+                "x1 as (select * from t0),\n" +
+                "y1 as (select count(distinct v1, v2), count(distinct v2, v3) from x1)," +
+                "y2 as (select count(distinct v3, v2), count(distinct v1, v3) from x1)" +
+                "select * " +
+                "from y1 join y2" +
+                "        join t3";
+        connectContext.getSessionVariable().setMaxTransformReorderJoins(1);
+        defaultCTEReuse();
+        String plan = getFragmentPlan(sql);
+        connectContext.getSessionVariable().setMaxTransformReorderJoins(8);
+        assertContains(plan, "  MultiCastDataSinks\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 01\n" +
+                "    RANDOM\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 21\n" +
+                "    RANDOM\n" +
+                "\n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t0");
+    }
 }


### PR DESCRIPTION
Fixes #issue

LIKE SQL:
```
with x1 as (select * from t0),
    y1 as (select count(distinct v1, v2), count(distinct v2, v3) from x1),
    y2 as (select count(distinct v3, v2), count(distinct v1, v3) from x1)
select * 
from y1 join y2
        join t3
```

`y1`, `y2` rewrite to force CTE, and them use CTE-1, when execute Greedy JoinRerorder, only collect force CTE statistics, but `y1` and `y2` dependent on CTE-1's statisitc

```
LogicalCTEAnchorOperator{cteId='1'}
->  LogicalCTEProduceOperator{cteId='1'}
    ->  LogicalOlapScanOperator {table=10006, selectedPartitionId=[], outputColumns=[1: v1, 2: v2, 3: v3], predicate=null, limit=-1}
->  LOGICAL_JOIN {CROSS JOIN, onPredicate = null , Predicate = null}
    ->  LOGICAL_JOIN {CROSS JOIN, onPredicate = null , Predicate = null}
        ->  LogicalCTEAnchorOperator{cteId='3'}
            ->  LogicalCTEProduceOperator{cteId='3'}
                ->  LogicalCTEConsumeOperator{cteId='1', limit=-1, predicate=null}
                    ->  LogicalOlapScanOperator {table=10006, selectedPartitionId=[], outputColumns=[14: v1, 15: v2, 16: v3], predicate=null, limit=-1}
            ->  LOGICAL_JOIN {CROSS JOIN, onPredicate = null , Predicate = null}
                ->  LogicalAggregation {type=GLOBAL ,aggregations={17: count=count(distinct 31: v1, 32: v2)} ,groupKeys=[]}
                    ->  LogicalCTEConsumeOperator{cteId='3', limit=-1, predicate=null}
                ->  LogicalAggregation {type=GLOBAL ,aggregations={18: count=count(distinct 33: v2, 34: v3)} ,groupKeys=[]}
                    ->  LogicalCTEConsumeOperator{cteId='3', limit=-1, predicate=null}
        ->  LogicalCTEAnchorOperator{cteId='2'}
            ->  LogicalCTEProduceOperator{cteId='2'}
                ->  LogicalCTEConsumeOperator{cteId='1', limit=-1, predicate=null}
                    ->  LogicalOlapScanOperator {table=10006, selectedPartitionId=[], outputColumns=[19: v1, 20: v2, 21: v3], predicate=null, limit=-1}
            ->  LOGICAL_JOIN {CROSS JOIN, onPredicate = null , Predicate = null}
                ->  LogicalAggregation {type=GLOBAL ,aggregations={22: count=count(distinct 28: v3, 27: v2)} ,groupKeys=[]}
                    ->  LogicalCTEConsumeOperator{cteId='2', limit=-1, predicate=null}
                ->  LogicalAggregation {type=GLOBAL ,aggregations={23: count=count(distinct 29: v1, 30: v3)} ,groupKeys=[]}
                    ->  LogicalCTEConsumeOperator{cteId='2', limit=-1, predicate=null}
    ->  LogicalOlapScanOperator {table=10033, selectedPartitionId=[], outputColumns=[24: v10, 25: v11, 26: v12], predicate=null, limit=-1}
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
