### PR TITLE
[Enhancement] return more accurate logs when accessing hdfs fails

### DIFF
--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -56,7 +56,8 @@ public:
                 if (errno == ENOENT) {
                     return Status::RemoteFileNotFound(fmt::format("hdfsOpenFile failed, file={}", _path));
                 } else {
-                    return Status::InternalError(fmt::format("hdfsOpenFile failed, file={}", _path));
+                    return Status::InternalError(
+                            fmt::format("hdfsOpenFile failed, file={}. err_msg: {}", _path, get_hdfs_err_msg()));
                 }
             }
         }
@@ -601,7 +602,8 @@ StatusOr<std::unique_ptr<WritableFile>> HdfsFileSystem::new_writable_file(const 
         if (errno == ENOENT) {
             return Status::RemoteFileNotFound(fmt::format("hdfsOpenFile failed, file={}", path));
         } else {
-            return Status::InternalError(fmt::format("hdfsOpenFile failed, file={}", path));
+            return Status::InternalError(
+                    fmt::format("hdfsOpenFile failed, file={}. err_msg: {}", path, get_hdfs_err_msg()));
         }
     }
     return std::make_unique<HDFSWritableFile>(hdfs_client->hdfs_fs, file, path, 0);


### PR DESCRIPTION
Fixes #issue
add more accurate logs like the box
![image](https://github.com/StarRocks/starrocks/assets/91597003/55ea352a-c9ce-4245-8976-c15093d47b4a)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
