### PR TITLE
[BugFix] Rename ChunkMerger to resolve name conflict and use virtual destructor

### DIFF
--- a/be/src/runtime/sorted_chunks_merger.h
+++ b/be/src/runtime/sorted_chunks_merger.h
@@ -95,7 +95,7 @@ private:
 class ChunkMerger {
 public:
     ChunkMerger(RuntimeState* state) : _state(state) {}
-    ~ChunkMerger() = default;
+    virtual ~ChunkMerger() = default;
 
     virtual Status init(const std::vector<ChunkProvider>& has_suppliers, const std::vector<ExprContext*>* sort_exprs,
                         const SortDescs& _sort_desc) = 0;

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -76,10 +76,10 @@ int compare_chunk_row(const ChunkRow& lhs, const ChunkRow& rhs, const std::vecto
 
 struct MergeElement;
 // TODO: optimize it with vertical sort
-class ChunkMerger {
+class HeapChunkMerger {
 public:
-    explicit ChunkMerger(TabletSharedPtr tablet, std::vector<ColumnId> sort_key_idxes);
-    virtual ~ChunkMerger();
+    explicit HeapChunkMerger(TabletSharedPtr tablet, std::vector<ColumnId> sort_key_idxes);
+    virtual ~HeapChunkMerger();
 
     Status merge(std::vector<ChunkPtr>& chunk_arr, RowsetWriter* rowset_writer);
     static void aggregate_chunk(ChunkAggregator& aggregator, ChunkPtr& chunk, RowsetWriter* rowset_writer);
@@ -103,7 +103,7 @@ struct MergeElement {
 
     Chunk* chunk;
     size_t row_index;
-    ChunkMerger* _merger;
+    HeapChunkMerger* _merger;
 };
 
 bool ChunkSorter::sort(ChunkPtr& chunk, const TabletSharedPtr& new_tablet) {
@@ -146,16 +146,16 @@ bool ChunkSorter::sort(ChunkPtr& chunk, const TabletSharedPtr& new_tablet) {
     return true;
 }
 
-ChunkMerger::ChunkMerger(TabletSharedPtr tablet, std::vector<ColumnId> sort_key_idxes)
+HeapChunkMerger::HeapChunkMerger(TabletSharedPtr tablet, std::vector<ColumnId> sort_key_idxes)
         : _tablet(std::move(tablet)), _aggregator(nullptr), _sort_key_idxes(std::move(sort_key_idxes)) {}
 
-ChunkMerger::~ChunkMerger() {
+HeapChunkMerger::~HeapChunkMerger() {
     if (_aggregator != nullptr) {
         _aggregator->close();
     }
 }
 
-void ChunkMerger::aggregate_chunk(ChunkAggregator& aggregator, ChunkPtr& chunk, RowsetWriter* rowset_writer) {
+void HeapChunkMerger::aggregate_chunk(ChunkAggregator& aggregator, ChunkPtr& chunk, RowsetWriter* rowset_writer) {
     aggregator.aggregate();
     while (aggregator.is_finish()) {
         (void)rowset_writer->add_chunk(*aggregator.aggregate_result());
@@ -174,7 +174,7 @@ void ChunkMerger::aggregate_chunk(ChunkAggregator& aggregator, ChunkPtr& chunk, 
     }
 }
 
-Status ChunkMerger::merge(std::vector<ChunkPtr>& chunk_arr, RowsetWriter* rowset_writer) {
+Status HeapChunkMerger::merge(std::vector<ChunkPtr>& chunk_arr, RowsetWriter* rowset_writer) {
     auto process_err = [this] {
         VLOG(3) << "merge chunk failed";
         while (!_heap.empty()) {
@@ -232,7 +232,7 @@ Status ChunkMerger::merge(std::vector<ChunkPtr>& chunk_arr, RowsetWriter* rowset
     return Status::OK();
 }
 
-bool ChunkMerger::_make_heap(std::vector<ChunkPtr>& chunk_arr) {
+bool HeapChunkMerger::_make_heap(std::vector<ChunkPtr>& chunk_arr) {
     for (const auto& chunk : chunk_arr) {
         MergeElement element;
         element.chunk = chunk.get();
@@ -245,7 +245,7 @@ bool ChunkMerger::_make_heap(std::vector<ChunkPtr>& chunk_arr) {
     return true;
 }
 
-void ChunkMerger::_pop_heap() {
+void HeapChunkMerger::_pop_heap() {
     MergeElement element = _heap.top();
     _heap.pop();
 
@@ -612,7 +612,7 @@ Status SchemaChangeWithSorting::_internal_sorting(std::vector<ChunkPtr>& chunk_a
         sort_key_idxes.resize(tablet->tablet_schema()->num_key_columns());
         std::iota(sort_key_idxes.begin(), sort_key_idxes.end(), 0);
     }
-    ChunkMerger merger(std::move(tablet), std::move(sort_key_idxes));
+    HeapChunkMerger merger(std::move(tablet), std::move(sort_key_idxes));
     if (auto st = merger.merge(chunk_arr, new_rowset_writer); !st.ok()) {
         LOG(WARNING) << "merge chunk arr failed";
         return st;


### PR DESCRIPTION
This PR fixes clang-tidy warning and potential bug for ChunkMerger and it's sub-classes

```
In file included from /opt/rh/gcc-toolset-10/root/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../include/c++/10.3.0/memory:83:
/opt/rh/gcc-toolset-10/root/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/../../../../include/c++/10.3.0/bits/unique_ptr.h:85:2: warning: delete called on non-final 'starrocks::ConstChunkMerger' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
delete __ptr;
^
```

It also fixes a classname duplication for ChunkMerger(same name both in schemachange.cpp and sorted_chunks_merger.cpp), it will mess up function names and cause wrong method invocations, sorted_chunks_merger.h calls into schema_change.cpp
```
==23368==ERROR: AddressSanitizer: attempting double-free on 0x6020000f3030 in thread T0:
    #0 0xb0dd267 in operator delete(void*) ../../.././libsanitizer/asan/asan_new_delete.cpp:160
    #1 0x1bf07af8 in __gnu_cxx::new_allocator<starrocks::MergeElement>::deallocate(starrocks::MergeElement*, unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/ext/new_allocator.h:133
    #2 0x1bf02905 in std::allocator<starrocks::MergeElement>::deallocate(starrocks::MergeElement*, unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/allocator.h:187
    #3 0x1bf02905 in std::allocator_traits<std::allocator<starrocks::MergeElement> >::deallocate(std::allocator<starrocks::MergeElement>&, starrocks::MergeElement*, unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/alloc_traits.h:492
    #4 0x1befc99b in std::_Vector_base<starrocks::MergeElement, std::allocator<starrocks::MergeElement> >::_M_deallocate(starrocks::MergeElement*, unsigned long) /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/stl_vector.h:354
    #5 0x1bef75f1 in std::_Vector_base<starrocks::MergeElement, std::allocator<starrocks::MergeElement> >::~_Vector_base() /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/stl_vector.h:335
    #6 0x1bef3a3e in std::vector<starrocks::MergeElement, std::allocator<starrocks::MergeElement> >::~vector() /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/stl_vector.h:683
    #7 0x1bef2eee in std::priority_queue<starrocks::MergeElement, std::vector<starrocks::MergeElement, std::allocator<starrocks::MergeElement> >, std::less<starrocks::MergeElement> >::~priority_queue() /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/bits/stl_queue.h:456
    #8 0x1bec2861 in starrocks::ChunkMerger::~ChunkMerger() /root/StarRocks/be/src/storage/schema_change.cpp:152
    #9 0x13f1b69f in starrocks::CascadeChunkMerger::~CascadeChunkMerger() /root/StarRocks/be/src/runtime/sorted_chunks_merger.h:117
``` 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
