### PR TITLE
[Enhancement] Add prepare timer for fragment instance and scan operator

### DIFF
--- a/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_prepare_operator.cpp
@@ -39,7 +39,12 @@ Status OlapScanPrepareOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(SourceOperator::prepare(state));
 
     RETURN_IF_ERROR(_ctx->prepare(state));
-    RETURN_IF_ERROR(_ctx->capture_tablet_rowsets(_morsel_queue->olap_scan_ranges()));
+
+    auto* capture_tablet_rowsets_timer = ADD_TIMER(_unique_metrics, "CaptureTabletRowsetsTime");
+    {
+        SCOPED_TIMER(capture_tablet_rowsets_timer);
+        RETURN_IF_ERROR(_ctx->capture_tablet_rowsets(_morsel_queue->olap_scan_ranges()));
+    }
 
     return Status::OK();
 }

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -85,7 +85,7 @@ Status ScanOperator::prepare(RuntimeState* state) {
             "PeakIOTasks", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG));
 
     _prepare_chunk_source_timer = ADD_TIMER(_unique_metrics, "PrepareChunkSourceTime");
-    _submit_io_task_timer = ADD_TIMER(_unique_metrics, "SubmitIOTaskTime");
+    _submit_io_task_timer = ADD_TIMER(_unique_metrics, "SubmitTaskTime");
 
     RETURN_IF_ERROR(do_prepare(state));
     return Status::OK();

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -195,6 +195,9 @@ private:
     // The total number of the original tablets in this fragment instance.
     RuntimeProfile::Counter* _tablets_counter = nullptr;
     RuntimeProfile::HighWaterMarkCounter* _peak_io_tasks_counter = nullptr;
+
+    RuntimeProfile::Counter* _prepare_chunk_source_timer = nullptr;
+    RuntimeProfile::Counter* _submit_io_task_timer = nullptr;
 };
 
 class ScanOperatorFactory : public SourceOperatorFactory {


### PR DESCRIPTION
- `FragmentInstancePrepareTime` should also consider the driver prepare time.
- Add `FragmentInstancePrepareTime.prepare-pipeline-driver`.
- Add `CaptureTabletRowsetsTime` to OlapScanPrepareOperator.
- Add `PrepareChunkSourceTime` and `SubmitTaskTime` to ScanOperator, since these two metrics are pretty high with ingestion task or too many small i/o tasks.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
