### PR TITLE
[BugFix] Use default filesystem to manipulate jdbc driver

### DIFF
--- a/be/src/runtime/jdbc_driver_manager.cpp
+++ b/be/src/runtime/jdbc_driver_manager.cpp
@@ -104,7 +104,8 @@ Status JDBCDriverManager::init(const std::string& driver_dir) {
             std::string checksum;
             int64_t first_access_ts;
             if (!_parse_from_file_name(file, &name, &checksum, &first_access_ts)) {
-                LOG(WARNING) << fmt::format("cannot parse jdbc driver info from file {}, try to remove it", target_file);
+                LOG(WARNING) << fmt::format("cannot parse jdbc driver info from file {}, try to remove it",
+                                            target_file);
                 RETURN_IF_ERROR(FileSystem::Default()->delete_file(target_file));
                 continue;
             }

--- a/be/src/runtime/jdbc_driver_manager.cpp
+++ b/be/src/runtime/jdbc_driver_manager.cpp
@@ -58,7 +58,7 @@ struct JDBCDriverEntry {
 JDBCDriverEntry::~JDBCDriverEntry() {
     if (should_delete.load()) {
         LOG(INFO) << fmt::format("try to delete jdbc driver {}", location);
-        WARN_IF_ERROR(fs::remove(location), "fail to delete jdbc driver");
+        WARN_IF_ERROR(FileSystem::Default()->delete_file(location), "fail to delete jdbc driver");
     }
 }
 
@@ -87,10 +87,15 @@ Status JDBCDriverManager::init(const std::string& driver_dir) {
     // load jdbc drivers from file
     for (auto& file : driver_files) {
         std::string target_file = fmt::format("{}/{}", _driver_dir, file);
-        // remove all tmporary files
+        ASSIGN_OR_RETURN(auto is_dir, FileSystem::Default()->is_directory(target_file));
+        if (is_dir) {
+            LOG(WARNING) << "there exists sub directory in jdbc driver folder: " << target_file;
+            continue;
+        }
+        // remove all temporary files
         if (boost::algorithm::ends_with(file, TMP_FILE_SUFFIX)) {
-            LOG(INFO) << fmt::format("try to remove tmporary file {}", target_file);
-            RETURN_IF_ERROR(fs::remove(target_file));
+            LOG(INFO) << fmt::format("try to remove temporary file {}", target_file);
+            RETURN_IF_ERROR(FileSystem::Default()->delete_file(target_file));
             continue;
         }
         // try to load drivers from jar file
@@ -99,8 +104,8 @@ Status JDBCDriverManager::init(const std::string& driver_dir) {
             std::string checksum;
             int64_t first_access_ts;
             if (!_parse_from_file_name(file, &name, &checksum, &first_access_ts)) {
-                LOG(WARNING) << fmt::format("cannot parse jdbc driver info from file {}, try to remove it", file);
-                RETURN_IF_ERROR(fs::remove(target_file));
+                LOG(WARNING) << fmt::format("cannot parse jdbc driver info from file {}, try to remove it", target_file);
+                RETURN_IF_ERROR(FileSystem::Default()->delete_file(target_file));
                 continue;
             }
 
@@ -134,7 +139,7 @@ Status JDBCDriverManager::init(const std::string& driver_dir) {
                 } else {
                     // this driver is old, just remove
                     LOG(INFO) << fmt::format("try to remove an old jdbc driver, name[{}], file[{}]", name, target_file);
-                    RETURN_IF_ERROR(fs::remove(target_file));
+                    RETURN_IF_ERROR(FileSystem::Default()->delete_file(target_file));
                 }
             }
         }


### PR DESCRIPTION
For files with `:` in filenames (e.g. `/path/to/jdbc_drivers/a:b.jar`), we will create an HDFS filesystem. 
But a local filesystem is expected. 

This is because of `is_posix_uri` returning false if filename contains `:`
```c++
inline bool is_posix_uri(std::string_view uri) {
    return (memchr(uri.data(), ':', uri.size()) == nullptr) || starts_with(uri, "posix://");
}
```

To resolve this issue, this PR uses default FS to conduct related operations.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
