### PR TITLE
[BugFix] timezone for FILES()

### DIFF
--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -117,6 +117,13 @@ RuntimeState::RuntimeState(const TQueryGlobals& query_globals)
     TimezoneUtils::find_cctz_time_zone(_timezone, _timezone_obj);
 }
 
+RuntimeState::RuntimeState(ExecEnv* exec_env) : _exec_env(exec_env) {
+    _profile = std::make_shared<RuntimeProfile>("<unnamed>");
+    _query_options.batch_size = DEFAULT_CHUNK_SIZE;
+    _timezone = TimezoneUtils::default_time_zone;
+    _timestamp_ms = 0;
+}
+
 RuntimeState::~RuntimeState() {
     // close error log file
     if (_error_log_file != nullptr && _error_log_file->is_open()) {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -96,6 +96,8 @@ public:
     // RuntimeState for executing expr in fe-support.
     explicit RuntimeState(const TQueryGlobals& query_globals);
 
+    explicit RuntimeState(ExecEnv* exec_env);
+
     // Empty d'tor to avoid issues with std::unique_ptr.
     ~RuntimeState();
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -801,7 +801,7 @@ void PInternalServiceImplBase<T>::_get_file_schema(google::protobuf::RpcControll
         return;
     }
 
-    RuntimeState state{};
+    RuntimeState state(_exec_env);
     RuntimeProfile profile{"dummy_profile", false};
     ScannerCounter counter{};
     std::unique_ptr<FileScanner> p_scanner;


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/30982

When the `RuntimeState` is constructed by default constructor, the timezone of `RuntimeState` is empty. This would lead to failure in reading ORC file.
This PR sets the default timezone as `+08:00` for `RuntimeState` to fix the problem.
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
