### PR TITLE
[BugFix] skip collect subfield expr without referencing cols

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
@@ -52,18 +52,28 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
 
     @Override
     public Void visitCollectionElement(CollectionElementOperator collectionElementOp, Void context) {
+        if (collectionElementOp.getUsedColumns().isEmpty()) {
+            return null;
+        }
         complexExpressions.add(collectionElementOp);
         return null;
     }
 
     @Override
     public Void visitSubfield(SubfieldOperator subfieldOperator, Void context) {
+        if (subfieldOperator.getUsedColumns().isEmpty()) {
+            return null;
+        }
         complexExpressions.add(subfieldOperator);
         return null;
     }
 
     @Override
     public Void visitCall(CallOperator call, Void context) {
+        if (call.getUsedColumns().isEmpty()) {
+            return null;
+        }
+
         if (PruneSubfieldRule.SUPPORT_FUNCTIONS.contains(call.getFnName())) {
             complexExpressions.add(call);
             return null;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -689,4 +689,27 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                     "     cardinality: 1\n");
         }
     }
+
+    @Test
+    public void testSubfieldWithoutCols() throws Exception {
+        String sql = "select [1, 2, 3] is null from pc0 t1 right join sc0 t2 on t1.v1 = t2.v1;";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "5:Project\n" +
+                "  |  <slot 15> : array_length([1,2,3]) IS NULL");
+
+        sql = "select [1, 2, 3][1] is null from pc0 t1 right join sc0 t2 on t1.v1 = t2.v1;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "5:Project\n" +
+                "  |  <slot 15> : [1,2,3][1] IS NULL");
+
+        sql = "select map_keys(map{'a':1,'b':2}) is null from pc0 t1 right join sc0 t2 on t1.v1 = t2.v1;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "5:Project\n" +
+                "  |  <slot 15> : array_length(map_keys(map{'a':1,'b':2})) IS NULL");
+
+        sql = "select row(1,2,3).col2 is null from pc0 t1 right join sc0 t2 on t1.v1 = t2.v1;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "5:Project\n" +
+                "  |  <slot 15> : row(1, 2, 3).col2 IS NULL");
+    }
 }


### PR DESCRIPTION
Fixes #issue
For sql like
```
select [1, 2, 3][1] is null from pc0 t1 right join sc0 t2 on t1.v1 = t2.v1;
```
`[1, 2, 3][1]` has been pushed to the left table in this right join because of this expr refs empty cols leading `leftOutput.containsAll(subfieldUseColumns)` = true
```
if (leftOutput.containsAll(subfieldUseColumns)) {
                    leftContext.put(index, subfieldExpr);
                    childSubfieldOutputs.union(index);
                } else if (rightOutput.containsAll(subfieldUseColumns)) {
                    rightContext.put(index, subfieldExpr);
                    childSubfieldOutputs.union(index);
                } else {
                    localContext.put(index, subfieldExpr);
                }
```

So just skip collect subfield expr without referencing cols.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
