### PR TITLE
[Refactor] hive sink use the same get_partition_value_string with table function table sink

### DIFF
--- a/be/src/exec/pipeline/sink/hive_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/hive_table_sink_operator.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "exec/parquet_builder.h"
+#include "table_function_table_sink_operator.h"
 #include "util/path_util.h"
 
 namespace starrocks::pipeline {
@@ -104,22 +105,14 @@ Status HiveTableSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& ch
     } else if (_is_static_partition_insert && !_partition_writers.empty()) {
         _partition_writers.begin()->second->append_chunk(chunk.get(), state);
     } else {
-        Columns partitions_columns;
-        partitions_columns.resize(_partition_expr.size());
-        for (size_t i = 0; i < partitions_columns.size(); ++i) {
-            ASSIGN_OR_RETURN(partitions_columns[i], _partition_expr[i]->evaluate(chunk.get()));
-            DCHECK(partitions_columns[i] != nullptr);
-        }
-
-        std::vector<std::string> partition_column_values;
-        for (const ColumnPtr& column : partitions_columns) {
+        std::vector<std::string> partition_column_values(_partition_expr.size());
+        for (int i = 0; i < _partition_expr.size(); ++i) {
+            ASSIGN_OR_RETURN(ColumnPtr column, _partition_expr[i]->evaluate(chunk.get()));
+            DCHECK(column != nullptr);
             if (column->has_null()) {
                 return Status::NotSupported("Partition value can't be null.");
             }
-
-            std::string partition_value;
-            RETURN_IF_ERROR(partition_value_to_string(ColumnHelper::get_data_column(column.get()), partition_value));
-            partition_column_values.emplace_back(partition_value);
+            ASSIGN_OR_RETURN(partition_column_values[i], column_to_string(_partition_expr[i]->root()->type(), column))
         }
 
         DCHECK(_partition_column_names.size() == partition_column_values.size());
@@ -149,42 +142,6 @@ std::string HiveTableSinkOperator::_get_partition_location(const std::vector<std
         partition_location += _partition_column_names[i] + "=" + values[i] + "/";
     }
     return partition_location;
-}
-
-Status HiveTableSinkOperator::partition_value_to_string(Column* column, std::string& partition_value) {
-    auto v = column->get(0);
-    if (column->is_date()) {
-        partition_value = v.get_date().to_string();
-        return Status::OK();
-    }
-
-    bool not_support = false;
-    v.visit([&](auto& variant) {
-        std::visit(
-                [&](auto&& arg) {
-                    using T = std::decay_t<decltype(arg)>;
-                    if constexpr (std::is_same_v<T, Slice>) {
-                        partition_value = arg.to_string();
-                    } else if constexpr (std::is_same_v<T, uint8_t> || std::is_same_v<T, int16_t> ||
-                                         std::is_same_v<T, uint16_t> || std::is_same_v<T, uint24_t> ||
-                                         std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t> ||
-                                         std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t>) {
-                        partition_value = std::to_string(arg);
-                    } else if constexpr (std::is_same_v<T, int8_t>) {
-                        // iceberg has no smallint type. we can safely use int8 as boolean.
-                        partition_value = arg == 0 ? "false" : "true";
-                    } else {
-                        not_support = true;
-                    }
-                },
-                variant);
-    });
-
-    if (not_support) {
-        return Status::NotSupported(fmt::format("Partition value can't be {}", column->get_name()));
-    }
-
-    return Status::OK();
 }
 
 HiveTableSinkOperatorFactory::HiveTableSinkOperatorFactory(int32_t id, FragmentContext* fragment_ctx,

--- a/be/src/exec/pipeline/sink/hive_table_sink_operator.h
+++ b/be/src/exec/pipeline/sink/hive_table_sink_operator.h
@@ -74,8 +74,6 @@ public:
 
     static void add_hive_commit_info(starrocks::parquet::AsyncFileWriter* writer, RuntimeState* state);
 
-    static Status partition_value_to_string(Column* column, std::string& partition_value);
-
 private:
     std::string _get_partition_location(const std::vector<std::string>& values);
 

--- a/be/src/exec/pipeline/sink/table_function_table_sink_operator.h
+++ b/be/src/exec/pipeline/sink/table_function_table_sink_operator.h
@@ -27,6 +27,8 @@
 
 namespace starrocks::pipeline {
 
+StatusOr<std::string> column_to_string(const TypeDescriptor& type_desc, const ColumnPtr& column);
+
 class TableFunctionTableSinkOperator final : public Operator {
 public:
     TableFunctionTableSinkOperator(OperatorFactory* factory, const int32_t id, const int32_t plan_node_id,


### PR DESCRIPTION


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
