### PR TITLE
[Enhancement] Remove the get schema call in TabletReader.

### DIFF
--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -127,14 +127,7 @@ StatusOr<std::shared_ptr<const TabletSchema>> Tablet::get_schema() {
 
 StatusOr<std::vector<RowsetPtr>> Tablet::get_rowsets(int64_t version) {
     ASSIGN_OR_RETURN(auto tablet_metadata, get_metadata(version));
-    std::vector<RowsetPtr> rowsets;
-    rowsets.reserve(tablet_metadata->rowsets_size());
-    for (int i = 0, size = tablet_metadata->rowsets_size(); i < size; ++i) {
-        const auto& rowset_metadata = tablet_metadata->rowsets(i);
-        auto rowset = std::make_shared<Rowset>(this, std::make_shared<const RowsetMetadata>(rowset_metadata), i);
-        rowsets.emplace_back(std::move(rowset));
-    }
-    return rowsets;
+    return get_rowsets(*tablet_metadata);
 }
 
 StatusOr<std::vector<RowsetPtr>> Tablet::get_rowsets(const TabletMetadata& metadata) {

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -32,6 +32,7 @@
 #include "storage/rowset/rowid_range_option.h"
 #include "storage/rowset/rowset_options.h"
 #include "storage/seek_range.h"
+#include "storage/tablet_schema_map.h"
 #include "storage/types.h"
 #include "storage/union_iterator.h"
 
@@ -71,9 +72,14 @@ TabletReader::~TabletReader() {
 }
 
 Status TabletReader::prepare() {
-    ASSIGN_OR_RETURN(_tablet_schema, _tablet.get_schema());
+    ASSIGN_OR_RETURN(_tablet_metadata, _tablet.get_metadata(_version));
+    CHECK_EQ(_version, _tablet_metadata->version());
+    _tablet_schema = GlobalTabletSchemaMap::Instance()->emplace(_tablet_metadata->schema()).first;
+    if (UNLIKELY(_tablet_schema == nullptr)) {
+        return Status::InternalError("failed to construct tablet schema");
+    }
     if (!_rowsets_inited) {
-        ASSIGN_OR_RETURN(_rowsets, enhance_error_prompt(_tablet.get_rowsets(_version)));
+        ASSIGN_OR_RETURN(_rowsets, enhance_error_prompt(_tablet.get_rowsets(*_tablet_metadata)));
         _rowsets_inited = true;
     }
     _stats.rowsets_read_count += _rowsets.size();
@@ -158,11 +164,12 @@ Status TabletReader::init_predicates(const TabletReaderParams& params) {
 }
 
 Status TabletReader::init_delete_predicates(const TabletReaderParams& params, DeletePredicates* dels) {
+    CHECK(_tablet_metadata != nullptr) << "_tablet_metadata is null";
+    CHECK(_tablet_schema != nullptr) << "_tablet_schema is null";
     PredicateParser pred_parser(_tablet_schema);
-    ASSIGN_OR_RETURN(auto tablet_metadata, enhance_error_prompt(_tablet.get_metadata(_version)));
 
-    for (int index = 0, size = tablet_metadata->rowsets_size(); index < size; ++index) {
-        const auto& rowset_metadata = tablet_metadata->rowsets(index);
+    for (int index = 0, size = _tablet_metadata->rowsets_size(); index < size; ++index) {
+        const auto& rowset_metadata = _tablet_metadata->rowsets(index);
         if (!rowset_metadata.has_delete_predicate()) {
             continue;
         }

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -164,8 +164,12 @@ Status TabletReader::init_predicates(const TabletReaderParams& params) {
 }
 
 Status TabletReader::init_delete_predicates(const TabletReaderParams& params, DeletePredicates* dels) {
-    CHECK(_tablet_metadata != nullptr) << "_tablet_metadata is null";
-    CHECK(_tablet_schema != nullptr) << "_tablet_schema is null";
+    if (UNLIKELY(_tablet_metadata == nullptr)) {
+        return Status::InternalError("tablet metadata is null. forget or fail to call prepare()");
+    }
+    if (UNLIKELY(_tablet_schema == nullptr)) {
+        return Status::InternalError("tablet schema is null. forget or fail to call prepare()");
+    }
     PredicateParser pred_parser(_tablet_schema);
 
     for (int index = 0, size = _tablet_metadata->rowsets_size(); index < size; ++index) {

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -95,8 +95,9 @@ private:
                                    MemPool* mempool);
 
     Tablet _tablet;
-    std::shared_ptr<const TabletSchema> _tablet_schema;
     int64_t _version;
+    std::shared_ptr<const TabletMetadataPB> _tablet_metadata;
+    std::shared_ptr<const TabletSchema> _tablet_schema;
 
     // _rowsets is specified in the constructor when compaction
     bool _rowsets_inited = false;


### PR DESCRIPTION
This patch first fetches the tablet metadata, and then obtains the tablet schema from it, avoiding extra gets of the tablet schema. This also prevents duplicate fetching of the tablet schema.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
