### PR TITLE
【BugFix】The fragment_instance_id should be deleted when cancel

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -490,7 +490,11 @@ Status FragmentMgr::cancel(const TUniqueId& id, const PPlanFragmentCancelReason&
     auto s_tracker = exec_state->runtime_state()->instance_mem_tracker_ptr();
     exec_state->cancel(reason);
     exec_state.reset();
-
+    {
+        // Remove the exec state added
+        std::lock_guard<std::mutex> lock(_lock);
+        _fragment_map.erase(id);
+    }
     return Status::OK();
 }
 


### PR DESCRIPTION
Fixes [#issue](https://github.com/StarRocks/starrocks/issues/31074)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
