### PR TITLE
[BugFix] Fix UserPrivilegeCollectionV2 was not compatible bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/UserPrivilegeCollectionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/UserPrivilegeCollectionInfo.java
@@ -19,12 +19,17 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.privilege.ObjectTypeDeprecate;
+import com.starrocks.privilege.PrivilegeEntry;
+import com.starrocks.privilege.UserPrivilegeCollection;
 import com.starrocks.privilege.UserPrivilegeCollectionV2;
 import com.starrocks.sql.ast.UserIdentity;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 public class UserPrivilegeCollectionInfo implements Writable {
 
@@ -72,6 +77,32 @@ public class UserPrivilegeCollectionInfo implements Writable {
 
     public static UserPrivilegeCollectionInfo read(DataInput in) throws IOException {
         String json = Text.readString(in);
-        return GsonUtils.GSON.fromJson(json, UserPrivilegeCollectionInfo.class);
+        try {
+            return GsonUtils.GSON.fromJson(json, UserPrivilegeCollectionInfo.class);
+        } catch (Exception e) {
+            /*
+             * Because 3.0.3 introduced a bug, the upgrade of UserPrivilegeCollectionV2
+             * was not compatible and the original SerializedName "p" was used directly,
+             * resulting in inconsistent types after the upgrade.
+             * Fault tolerance code has been added here.
+             * If UserPrivilegeCollectionV2 cannot be parsed correctly,
+             * need to use UserPrivilegeCollectionInfoDeprecated to parse.
+             */
+            UserPrivilegeCollectionInfoDeprecated deprecated
+                    = GsonUtils.GSON.fromJson(json, UserPrivilegeCollectionInfoDeprecated.class);
+
+            UserPrivilegeCollection collectionDeprecate = deprecated.getPrivilegeCollection();
+            UserPrivilegeCollectionV2 collection = new UserPrivilegeCollectionV2();
+            collection.grantRoles(collectionDeprecate.getAllRoles());
+            collection.setDefaultRoleIds(collectionDeprecate.getDefaultRoleIds());
+
+            Map<ObjectTypeDeprecate, List<PrivilegeEntry>> m = collectionDeprecate.getTypeToPrivilegeEntryList();
+            for (Map.Entry<ObjectTypeDeprecate, List<PrivilegeEntry>> entry : m.entrySet()) {
+                collection.getTypeToPrivilegeEntryList().put(entry.getKey().toObjectType(), entry.getValue());
+            }
+
+            return new UserPrivilegeCollectionInfo(deprecated.getUserIdentity(), collection,
+                    deprecated.pluginId, deprecated.pluginVersion);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/UserPrivilegeCollectionInfoDeprecated.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/UserPrivilegeCollectionInfoDeprecated.java
@@ -1,0 +1,76 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.privilege.UserPrivilegeCollection;
+import com.starrocks.sql.ast.UserIdentity;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class UserPrivilegeCollectionInfoDeprecated implements Writable {
+
+    @SerializedName(value = "i")
+    public short pluginId;
+    @SerializedName(value = "v")
+    public short pluginVersion;
+    @SerializedName(value = "u")
+    private UserIdentity userIdentity;
+
+    @SerializedName(value = "p")
+    private UserPrivilegeCollection privilegeCollection;
+
+    public UserPrivilegeCollectionInfoDeprecated(
+            UserIdentity userIdentity,
+            UserPrivilegeCollection userPrivilegeCollection,
+            short pluginId,
+            short pluginVersion) {
+        this.userIdentity = userIdentity;
+        this.privilegeCollection = userPrivilegeCollection;
+        this.pluginId = pluginId;
+        this.pluginVersion = pluginVersion;
+    }
+
+    public UserIdentity getUserIdentity() {
+        return userIdentity;
+    }
+
+    public UserPrivilegeCollection getPrivilegeCollection() {
+        return privilegeCollection;
+    }
+
+    public short getPluginId() {
+        return pluginId;
+    }
+
+    public short getPluginVersion() {
+        return pluginVersion;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        Text.writeString(out, GsonUtils.GSON.toJson(this));
+    }
+
+    public static UserPrivilegeCollectionInfoDeprecated read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, UserPrivilegeCollectionInfoDeprecated.class);
+    }
+}


### PR DESCRIPTION
Fixes #29368

Because 3.0.3 introduced a bug, the upgrade of UserPrivilegeCollectionV2 was not compatible and the original SerializedName "p" was used directly, resulting in inconsistent types after the upgrade. Fault tolerance code has been added here. If UserPrivilegeCollectionV2 cannot be parsed correctly, you need to use UserPrivilegeCollectionInfoDeprecated to parse.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
