### PR TITLE
[Enhancement]optimize scan dop when shared scan

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -792,6 +792,8 @@ CONF_Int32(pipeline_analytic_removable_chunk_num, "128");
 CONF_Bool(pipeline_analytic_enable_streaming_process, "true");
 CONF_Bool(pipeline_analytic_enable_removable_cumulative_process, "true");
 CONF_Int32(pipline_limit_max_delivery, "4096");
+
+CONF_mBool(use_default_dop_when_shared_scan, "true");
 /// For parallel scan on the single tablet.
 // These three configs are used to calculate the minimum number of rows picked up from a segment at one time.
 // It is `splitted_scan_bytes/scan_row_bytes` and restricted in the range [min_splitted_scan_rows, max_splitted_scan_rows].

--- a/be/src/connector/connector.cpp
+++ b/be/src/connector/connector.cpp
@@ -110,7 +110,7 @@ void DataSource::update_profile(const Profile& profile) {
 StatusOr<pipeline::MorselQueuePtr> DataSourceProvider::convert_scan_range_to_morsel_queue(
         const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
         bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
-        size_t num_total_scan_ranges, size_t scan_dop) {
+        size_t num_total_scan_ranges, size_t scan_parallelism) {
     peek_scan_ranges(scan_ranges);
 
     pipeline::Morsels morsels;
@@ -144,8 +144,8 @@ StatusOr<pipeline::MorselQueuePtr> DataSourceProvider::convert_scan_range_to_mor
     }
 
     auto morsel_queue = std::make_unique<pipeline::DynamicMorselQueue>(std::move(morsels));
-    if (scan_dop > 0) {
-        morsel_queue->set_max_degree_of_parallelism(scan_dop);
+    if (scan_parallelism > 0) {
+        morsel_queue->set_max_degree_of_parallelism(scan_parallelism);
     }
     return morsel_queue;
 }

--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -171,7 +171,7 @@ public:
     virtual StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
             const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
             bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
-            size_t num_total_scan_ranges, size_t scan_dop = 0);
+            size_t num_total_scan_ranges, size_t scan_parallelism = 0);
 
     int64_t get_scan_dop() const { return scan_dop; }
 

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -195,7 +195,7 @@ public:
     StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
             const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
             bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
-            size_t num_total_scan_ranges, size_t scan_dop = 0) override;
+            size_t num_total_scan_ranges, size_t scan_parallelism = 0) override;
 
     // for ut
     void set_lake_tablet_manager(lake::TabletManager* tablet_manager) { _tablet_manager = tablet_manager; }

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -488,7 +488,7 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
                          scan_node->convert_scan_range_to_morsel_queue_factory(
                                  scan_ranges, scan_ranges_per_driver_seq, scan_node->id(), group_execution_scan_dop,
                                  _is_in_colocate_exec_group(scan_node->id()), enable_tablet_internal_parallel,
-                                 tablet_internal_parallel_mode));
+                                 tablet_internal_parallel_mode, enable_shared_scan));
         scan_node->enable_shared_scan(enable_shared_scan && morsel_queue_factory->is_shared());
         morsel_queue_factories.emplace(scan_node->id(), std::move(morsel_queue_factory));
     }

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -87,7 +87,7 @@ public:
             const std::vector<TScanRangeParams>& scan_ranges,
             const std::map<int32_t, std::vector<TScanRangeParams>>& scan_ranges_per_driver_seq, int node_id,
             int pipeline_dop, bool in_colocate_exec_group, bool enable_tablet_internal_parallel,
-            TTabletInternalParallelMode::type tablet_internal_parallel_mode);
+            TTabletInternalParallelMode::type tablet_internal_parallel_mode, bool enable_shared_scan = false);
     virtual StatusOr<pipeline::MorselQueuePtr> convert_scan_range_to_morsel_queue(
             const std::vector<TScanRangeParams>& scan_ranges, int node_id, int32_t pipeline_dop,
             bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,

--- a/test/sql/test_external_file/R/test_parquet_read_range
+++ b/test/sql/test_external_file/R/test_parquet_read_range
@@ -150,6 +150,13 @@ select count(*) from read_range_test a join[broadcast] read_range_big_page_test 
 -- result:
 800
 -- !result
+set enable_shared_scan = true;
+-- result:
+-- !result
+select count(distinct c2) from read_range_big_page_test;
+-- result:
+90
+-- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_external_file/test_parquet_read_range/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0

--- a/test/sql/test_external_file/T/test_parquet_read_range
+++ b/test/sql/test_external_file/T/test_parquet_read_range
@@ -87,4 +87,8 @@ select * from read_range_test where c0 in (1, 4000);
 -- test runtime in filter string type
 select count(*) from read_range_test a join[broadcast] read_range_big_page_test b on a.c2 = b.c2 where b.c0 < 5;
 
+-- test enable_shared_scan
+set enable_shared_scan = true;
+select count(distinct c2) from read_range_big_page_test;
+
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_external_file/test_parquet_read_range/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
Fixes #issue
What i'm doing?
1. Refactor scan_dop's logic of LakeDataSource, only decide scan_parallism, not scan_dop, 
    scan_dop is decided in scan_node.cpp.
2. when enable shared scan, use the default pipeline_dop, even there is only a few scan_ranges,
     we can use multi pipeline.
3. only enable 2 when morsel queue is fixed or dynamic and morsel factory is shared, to avoid
     impacting other case.  

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
