### PR TITLE
[BugFix] Fix the invalid skip distance when coping io buffer in datacache.

### DIFF
--- a/be/src/block_cache/io_buffer.cpp
+++ b/be/src/block_cache/io_buffer.cpp
@@ -29,12 +29,13 @@ size_t IOBuffer::copy_to(void* data, ssize_t size, size_t pos) const {
                 skip -= sp.size();
                 continue;
             }
-            size_t to_cp = std::min(sp.size(), bytes_to_copy - bytes_copied);
+            size_t to_cp = std::min(sp.size() - skip, bytes_to_copy - bytes_copied);
             strings::memcpy_inlined((char*)data + bytes_copied, sp.data() + skip, to_cp);
             bytes_copied += to_cp;
             if (bytes_copied >= size) {
                 break;
             }
+            skip = 0;
         }
     }
     return bytes_copied;

--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -78,6 +78,34 @@ TEST_F(BlockCacheTest, auto_create_disk_cache_path) {
     cache->shutdown();
 }
 
+TEST_F(BlockCacheTest, copy_to_iobuf) {
+    // Create an iobuffer which contains 3 blocks
+    const size_t buf_block_size = 100;
+    void* data1 = malloc(buf_block_size);
+    void* data2 = malloc(buf_block_size);
+    void* data3 = malloc(buf_block_size);
+    memset(data1, 1, buf_block_size);
+    memset(data2, 2, buf_block_size);
+    memset(data3, 3, buf_block_size);
+
+    IOBuffer buffer;
+    buffer.append_user_data(data1, buf_block_size, nullptr);
+    buffer.append_user_data(data2, buf_block_size, nullptr);
+    buffer.append_user_data(data3, buf_block_size, nullptr);
+
+    // Copy the last 150 bytes of iobuffer to a target buffer
+    const off_t offset = 150;
+    const size_t size = 150;
+    char result[size] = {0};
+    buffer.copy_to(result, size, offset);
+
+    // Check the target buffer content
+    char expect[size] = {0};
+    memset(expect, 2, 50);
+    memset(expect + 50, 3, 100);
+    ASSERT_EQ(memcmp(result, expect, size), 0);
+}
+
 #ifdef WITH_STARCACHE
 TEST_F(BlockCacheTest, hybrid_cache) {
     std::unique_ptr<BlockCache> cache(new BlockCache);


### PR DESCRIPTION
We don't reset skip value in `IOBuffer::copy_to`. For an io buffer which contains multiple buffer blocks (not common in our scenarios), if we copy it after skiping multiple buffer blocks, the result may be unexpected. 
 
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
