### PR TITLE
[Enhancement] Add session variables enable_table_prune_on_update

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -167,6 +167,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     // enable table pruning(CBO) in cardinality-preserving joins
     public static final String ENABLE_CBO_TABLE_PRUNE = "enable_cbo_table_prune";
+
+    // Table pruning on update statement is risky, so turn off in default.
+    public static final String ENABLE_TABLE_PRUNE_ON_UPDATE = "enable_table_prune_on_update";
+
     // if set to true, some of stmt will be forwarded to leader FE to get result
 
     // if set to true, some of stmt will be forwarded to leader FE to get result
@@ -859,6 +863,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_CBO_TABLE_PRUNE)
     private boolean enableCboTablePrune = false;
+
+    @VarAttr(name = ENABLE_TABLE_PRUNE_ON_UPDATE)
+    private boolean enableTablePruneOnUpdate = false;
     @VariableMgr.VarAttr(name = FORWARD_TO_LEADER, alias = FORWARD_TO_MASTER)
     private boolean forwardToLeader = false;
 
@@ -1705,6 +1712,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableCboTablePrune() {
         return enableCboTablePrune;
+    }
+
+    public void setEnableTablePruneOnUpdate(boolean on) {
+        this.enableTablePruneOnUpdate = on;
+    }
+
+    public boolean isEnableTablePruneOnUpdate() {
+        return enableTablePruneOnUpdate;
     }
 
     public int getSpillMemTableSize() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -57,6 +57,7 @@ import com.starrocks.sql.optimizer.rule.transformation.SeparateProjectRule;
 import com.starrocks.sql.optimizer.rule.transformation.SplitScanORToUnionRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.pruner.CboTablePruneRule;
+import com.starrocks.sql.optimizer.rule.transformation.pruner.PrimaryKeyUpdateTableRule;
 import com.starrocks.sql.optimizer.rule.transformation.pruner.RboTablePruneRule;
 import com.starrocks.sql.optimizer.rule.transformation.pruner.UniquenessBasedTablePruneRule;
 import com.starrocks.sql.optimizer.rule.tree.AddDecodeNodeForDictStringRule;
@@ -263,8 +264,10 @@ public class Optimizer {
             //  operations on the same tablets, pruning this bucket shuffle join make update statement performance
             //  regression, so we can turn on this rule after we put an bucket-shuffle exchange in front of
             //  OlapTableSink in future, at present we turn off this rule.
-            // tree = new PrimaryKeyUpdateTableRule().rewrite(tree, rootTaskContext);
-            // deriveLogicalProperty(tree);
+            if (rootTaskContext.getOptimizerContext().getSessionVariable().isEnableTablePruneOnUpdate()) {
+                tree = new PrimaryKeyUpdateTableRule().rewrite(tree, rootTaskContext);
+                deriveLogicalProperty(tree);
+            }
             tree = new RboTablePruneRule().rewrite(tree, rootTaskContext);
             ruleRewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
             rootTaskContext.setRequiredColumns(requiredColumns.clone());

--- a/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningCTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TablePruningCTETest.java
@@ -86,6 +86,7 @@ public class TablePruningCTETest extends TablePruningTestBase {
             Assert.assertTrue(createTableSql, createTableSql.contains(showAndResult[1]));
         }
         FeConstants.runningUnitTest = true;
+        ctx.getSessionVariable().setEnableTablePruneOnUpdate(true);
     }
 
     private static String replaceTableName(String createTableSql) {
@@ -93,7 +94,7 @@ public class TablePruningCTETest extends TablePruningTestBase {
         return createTableSql.replaceAll(pat.pattern(), "CREATE TABLE `$10`");
     }
 
-    // @Test
+    @Test
     public void testUpdate() {
         String sql = "WITH cte0 as (\n" +
                 "WITH cte1 as (\n" +
@@ -132,31 +133,31 @@ public class TablePruningCTETest extends TablePruningTestBase {
         checkHashJoinCountWithOnlyRBO(sql, 1);
     }
 
-    // @Test
+    @Test
     public void testUpdateCTEFullInlined() {
         String q = getSqlList("sql/tpch_pk_tables/", "q1").get(0);
         checkHashJoinCountWithOnlyRBO(q, 3);
     }
 
-    // @Test
+    @Test
     public void testUpdateCTENotFullInlined() {
         String q = getSqlList("sql/tpch_pk_tables/", "q2").get(0);
         checkHashJoinCountWithOnlyRBO(q, 3);
     }
 
-    // @Test
+    @Test
     public void testUpdateCTEInnerJoin() {
         String q = getSqlList("sql/tpch_pk_tables/", "q3").get(0);
         checkHashJoinCountWithOnlyRBO(q, 3);
     }
 
-    // @Test
+    @Test
     public void testUpdateAggregationPreventPruning() {
         String q = getSqlList("sql/tpch_pk_tables/", "q4").get(0);
         checkHashJoinCountWithOnlyRBO(q, 5);
     }
 
-    // @Test
+    @Test
     public void testUpdateWithPredicates() {
         String q = getSqlList("sql/tpch_pk_tables/", "q5").get(0);
         String plan = checkHashJoinCountWithOnlyRBO(q, 3);
@@ -170,7 +171,7 @@ public class TablePruningCTETest extends TablePruningTestBase {
                 "[l_orderkey, BIGINT, false] <= 1000"));
     }
 
-    // @Test
+    @Test
     public void testUpdateContainsRightJoin() {
         String q = getSqlList("sql/tpch_pk_tables/", "q6").get(0);
         checkHashJoinCountWithOnlyRBO(q, 3);


### PR DESCRIPTION
Add session variables enable_table_prune_on_update(false in default) to control on/off of table prune feature applying to update statment.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
