### PR TITLE
[BugFix] Fix workgroup_token released before query finished

### DIFF
--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -184,7 +184,7 @@ void FragmentContext::set_stream_load_contexts(const std::vector<StreamLoadConte
 }
 
 void FragmentContext::cancel(const Status& status) {
-    if (_runtime_state != nullptr && _runtime_state->query_ctx() != nullptr) {
+    if (!status.ok() && _runtime_state != nullptr && _runtime_state->query_ctx() != nullptr) {
         _runtime_state->query_ctx()->release_workgroup_token_once();
     }
 


### PR DESCRIPTION
When a query starts, the number of running queries of the related resource group is increased. 
When it finishes, the number is decreased.

`FragmentContext::cancel` decreases the number of running queries intermediately, since the query is cancelled.
However, `FragmentContext::finish`  also calls `cancel(Status::OK())`.

Therefore, `FragmentContext::cancel` should decrease the number of running queries intermediately, only when the parameter `status` is not OK.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
