### PR TITLE
[Feature] Substitute large decimal types with double/decimal

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -216,9 +216,11 @@ public class ScalarType extends Type implements Cloneable {
 
     public static ScalarType createDecimalV3Type(PrimitiveType type, int precision, int scale) {
         int maxPrecision = PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL128);
-        if (ConnectContext.get() == null ||
-                ConnectContext.get().getSessionVariable().getLargeDecimalUnderlyingType().equals(
-                        SessionVariableConstants.PANIC)) {
+        ConnectContext ctx = ConnectContext.get();
+        if (ctx == null ||
+                ctx.getSessionVariable() == null ||
+                ctx.getSessionVariable().getLargeDecimalUnderlyingType() == null ||
+                ctx.getSessionVariable().getLargeDecimalUnderlyingType().equals(SessionVariableConstants.PANIC)) {
             Preconditions.checkArgument(0 <= precision &&
                             precision <= PrimitiveType.getMaxPrecisionOfDecimal(type),
                     "DECIMAL's precision should range from 1 to 38");

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -41,7 +41,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.proto.PScalarType;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SessionVariableConstants;
 import com.starrocks.thrift.TColumnType;
 import com.starrocks.thrift.TPrimitiveType;
@@ -51,7 +50,6 @@ import com.starrocks.thrift.TTypeNode;
 import com.starrocks.thrift.TTypeNodeType;
 
 import java.util.Objects;
-import javax.naming.Context;
 
 /**
  * Describes a scalar type. For most types this class just wraps a PrimitiveType enum,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -393,6 +393,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_MATERIALIZED_VIEW_REWRITE = "enable_materialized_view_rewrite";
     public static final String ENABLE_MATERIALIZED_VIEW_UNION_REWRITE = "enable_materialized_view_union_rewrite";
 
+    public static final String LARGE_DECIMAL_UNDERLYING_TYPE = "large_decimal_underlying_type";
+
     public enum MaterializedViewRewriteMode {
         DISABLE,            // disable materialized view rewrite
         DEFAULT,            // default, choose the materialized view or not by cost optimizer
@@ -1355,6 +1357,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_PRUNE_ICEBERG_MANIFEST)
     private boolean enablePruneIcebergManifest = true;
+
+    @VarAttr(name = LARGE_DECIMAL_UNDERLYING_TYPE)
+    private String largeDecimalUnderlyingType = SessionVariableConstants.PANIC;
 
     public boolean isEnablePruneIcebergManifest() {
         return enablePruneIcebergManifest;
@@ -2562,6 +2567,21 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isAuditExecuteStmt() {
         return auditExecuteStmt;
+    }
+
+    public void setLargeDecimalUnderlyingType(String type) {
+        if (type.equals(SessionVariableConstants.PANIC) ||
+                type.equals(SessionVariableConstants.DECIMAL) ||
+                type.equals(SessionVariableConstants.DOUBLE)) {
+            largeDecimalUnderlyingType = type;
+        } else {
+            throw new IllegalArgumentException(
+                    "Legal values of large_decimal_underlying_type are panic|decimal|double");
+        }
+    }
+
+    public String getLargeDecimalUnderlyingType() {
+        return largeDecimalUnderlyingType;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2570,10 +2570,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public void setLargeDecimalUnderlyingType(String type) {
-        if (type.equals(SessionVariableConstants.PANIC) ||
-                type.equals(SessionVariableConstants.DECIMAL) ||
-                type.equals(SessionVariableConstants.DOUBLE)) {
-            largeDecimalUnderlyingType = type;
+        if (type.equalsIgnoreCase(SessionVariableConstants.PANIC) ||
+                type.equalsIgnoreCase(SessionVariableConstants.DECIMAL) ||
+                type.equalsIgnoreCase(SessionVariableConstants.DOUBLE)) {
+            largeDecimalUnderlyingType = type.toLowerCase();
         } else {
             throw new IllegalArgumentException(
                     "Legal values of large_decimal_underlying_type are panic|decimal|double");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -25,4 +25,10 @@ public class SessionVariableConstants {
     public static final String FORCE_PREAGGREGATION = "force_preaggregation";
 
     public static final String LIMITED = "limited";
+
+    public static final String PANIC = "panic";
+
+    public static final String DOUBLE = "double";
+
+    public static final String DECIMAL = "decimal";
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -20,14 +20,20 @@ import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.JoinOperator;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.qe.VariableMgr;
+import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.utframe.UtFrameUtils;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -162,6 +168,79 @@ class ParserTest {
             Assert.assertEquals(JoinOperator.INNER_JOIN, bottomJoinRelation.getJoinOp());
         } catch (Exception e) {
             fail("sql should success. errMsg: " +  e.getMessage());
+        }
+    }
+
+    @Test
+    void testParseLargeDecimal() {
+        String sql = "select cast(1 as decimal(65,0))";
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setThreadLocalInfo();
+        SessionVariable sessionVariable = ctx.getSessionVariable();
+        try {
+            sessionVariable.setSqlDialect("sr");
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+            Assert.fail();
+        } catch (Throwable err) {
+            Assert.assertTrue(err.getMessage().contains("DECIMAL's precision should range from 1 to 38"));
+        }
+
+        try {
+            sessionVariable.setSqlDialect("trino");
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+            Assert.fail();
+        } catch (Throwable err) {
+            Assert.assertTrue(err.getMessage().contains("DECIMAL's precision should range from 1 to 38"));
+        }
+
+        try {
+            sessionVariable.setSqlDialect("sr");
+            sessionVariable.setLargeDecimalUnderlyingType("double");
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+            Analyzer.analyze(stmt, ctx);
+            Type type = stmt.getQueryRelation().getOutputExpression().get(0).getType();
+            Assert.assertTrue(type.isDouble());
+        } catch (Throwable err) {
+            Assert.fail(err.getMessage());
+        }
+
+        try {
+            sessionVariable.setSqlDialect("trino");
+            sessionVariable.setLargeDecimalUnderlyingType("double");
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+            Analyzer.analyze(stmt, ctx);
+            Type type = stmt.getQueryRelation().getOutputExpression().get(0).getType();
+            Assert.assertTrue(type.isDouble());
+        } catch (Throwable err) {
+            Assert.fail(err.getMessage());
+        }
+
+        try {
+            sessionVariable.setSqlDialect("sr");
+            sessionVariable.setLargeDecimalUnderlyingType("decimal");
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+            Analyzer.analyze(stmt, ctx);
+            Type type = stmt.getQueryRelation().getOutputExpression().get(0).getType();
+            Assert.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
+        } catch (Throwable err) {
+            Assert.fail(err.getMessage());
+        }
+
+        try {
+            sessionVariable.setSqlDialect("trino");
+            sessionVariable.setLargeDecimalUnderlyingType("decimal");
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+            Analyzer.analyze(stmt, ctx);
+            Type type = stmt.getQueryRelation().getOutputExpression().get(0).getType();
+            Assert.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
+        } catch (Throwable err) {
+            Assert.fail(err.getMessage());
+        }
+        try {
+            sessionVariable.setLargeDecimalUnderlyingType("foobar");
+            Assert.fail();
+        } catch (Throwable error) {
+
         }
     }
 


### PR DESCRIPTION
For query such as "select cast(1.0 as decimal(65,0))" that introduces large decimal(means precision exceeds 38), parser will panic or use double|decimal(38,s) as underlying type. 

Session variable  large_decimal_underlying_type ="panic"|"double"|"decimal" controls the behavior:
1. "panic",  it is current behavior,  FE panic when encountering large decimal types;
2. "double", use the double instead;
3. "decimal", use the decimal(38,s) instead.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
