### PR TITLE
[BugFix] fix mv on non-partitioned jdbc table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -231,30 +231,22 @@ public class PartitionUtil {
     }
 
     public static List<String> getPartitionNames(Table table) {
+        if (table.isUnPartitioned()) {
+            return Lists.newArrayList(table.getName());
+        }
         List<String> partitionNames = null;
         if (table.isHiveTable() || table.isHudiTable()) {
             HiveMetaStoreTable hmsTable = (HiveMetaStoreTable) table;
-            if (hmsTable.isUnPartitioned()) {
-                // return table name if table is unpartitioned
-                return Lists.newArrayList(hmsTable.getTableName());
-            }
             partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
                     .listPartitionNames(hmsTable.getCatalogName(), hmsTable.getDbName(), hmsTable.getTableName());
         } else if (table.isIcebergTable()) {
             IcebergTable icebergTable = (IcebergTable) table;
-            if (icebergTable.isUnPartitioned()) {
-                // return table name if table is unpartitioned
-                return Lists.newArrayList(icebergTable.getRemoteTableName());
-            }
             partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
                     icebergTable.getCatalogName(), icebergTable.getRemoteDbName(), icebergTable.getRemoteTableName());
         } else if (table.isJDBCTable()) {
             JDBCTable jdbcTable = (JDBCTable) table;
             partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
                     jdbcTable.getCatalogName(), jdbcTable.getDbName(), jdbcTable.getJdbcTable());
-            if (partitionNames.size() == 0) {
-                return Lists.newArrayList(jdbcTable.getJdbcTable());
-            }
         } else {
             Preconditions.checkState(false, "Do not support get partition names and columns for" +
                     "table type %s", table.getType());

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import org.jetbrains.annotations.NotNull;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -180,18 +181,15 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
 
     public List<Partition> getPartitions(Connection connection, Table table) {
         JDBCTable jdbcTable = (JDBCTable) table;
-        String partitionsQuery = "SELECT PARTITION_DESCRIPTION, " +
-                "IF(UPDATE_TIME IS NULL, CREATE_TIME, UPDATE_TIME) AS MODIFIED_TIME " +
-                "FROM INFORMATION_SCHEMA.PARTITIONS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? " +
-                "AND PARTITION_NAME IS NOT NULL";
-        try (PreparedStatement ps = connection.prepareStatement(partitionsQuery)) {
+        String query = getPartitionQuery(table);
+        try (PreparedStatement ps = connection.prepareStatement(query)) {
             ps.setString(1, jdbcTable.getDbName());
             ps.setString(2, jdbcTable.getJdbcTable());
             ResultSet rs = ps.executeQuery();
             ImmutableList.Builder<Partition> list = ImmutableList.builder();
             if (null != rs) {
                 while (rs.next()) {
-                    String[] partitionNames = rs.getString("PARTITION_DESCRIPTION").
+                    String[] partitionNames = rs.getString("NAME").
                             replace("'", "").split(",");
                     long createTime = rs.getDate("MODIFIED_TIME").getTime();
                     for (String partitionName : partitionNames) {
@@ -205,5 +203,17 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
         } catch (SQLException | NullPointerException e) {
             throw new StarRocksConnectorException(e.getMessage());
         }
+    }
+
+    @NotNull
+    private static String getPartitionQuery(Table table) {
+        final String partitionsQuery = "SELECT PARTITION_DESCRIPTION AS NAME, " +
+                "IF(UPDATE_TIME IS NULL, CREATE_TIME, UPDATE_TIME) AS MODIFIED_TIME " +
+                "FROM INFORMATION_SCHEMA.PARTITIONS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? " +
+                "AND PARTITION_NAME IS NOT NULL";
+        final String nonPartitionQuery = "SELECT TABLE_NAME AS NAME, " +
+                "IF(UPDATE_TIME IS NULL, CREATE_TIME, UPDATE_TIME) AS MODIFIED_TIME " +
+                "FROM INFORMATION_SCHEMA.PARTITIONS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? ";
+        return table.isUnPartitioned() ? nonPartitionQuery : partitionsQuery;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -131,7 +131,8 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
 
     @Override
     public List<String> listPartitionNames(Connection connection, String databaseName, String tableName) {
-        String partitionNamesQuery = "SELECT PARTITION_DESCRIPTION FROM INFORMATION_SCHEMA.PARTITIONS WHERE TABLE_SCHEMA = ? " +
+        String partitionNamesQuery =
+                "SELECT PARTITION_DESCRIPTION as NAME FROM INFORMATION_SCHEMA.PARTITIONS WHERE TABLE_SCHEMA = ? " +
                 "AND TABLE_NAME = ? AND PARTITION_NAME IS NOT NULL";
         try (PreparedStatement ps = connection.prepareStatement(partitionNamesQuery)) {
             ps.setString(1, databaseName);
@@ -140,7 +141,7 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
             ImmutableList.Builder<String> list = ImmutableList.builder();
             if (null != rs) {
                 while (rs.next()) {
-                    String[] partitionNames = rs.getString("PARTITION_DESCRIPTION").
+                    String[] partitionNames = rs.getString("NAME").
                             replace("'", "").split(",");
                     for (String partitionName : partitionNames) {
                         list.add(partitionName);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -15,11 +15,13 @@
 
 package com.starrocks.connector.jdbc;
 
+import com.google.common.collect.Lists;
 import com.mockrunner.mock.jdbc.MockResultSet;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.DdlException;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
@@ -57,7 +59,7 @@ public class MysqlSchemaResolverTest {
     @Before
     public void setUp() throws SQLException {
         partitionsResult = new MockResultSet("partitions");
-        partitionsResult.addColumn("PARTITION_DESCRIPTION", Arrays.asList("'20230810'"));
+        partitionsResult.addColumn("NAME", Arrays.asList("'20230810'"));
         partitionsResult.addColumn("PARTITION_EXPRESSION", Arrays.asList("`d`"));
         partitionsResult.addColumn("MODIFIED_TIME", Arrays.asList("2023-08-01"));
         properties = new HashMap<>();
@@ -159,6 +161,16 @@ public class MysqlSchemaResolverTest {
             System.out.println(e.getMessage());
             Assert.fail();
         }
+    }
+
+    @Test
+    public void testGetPartitions_NonPartitioned() throws DdlException {
+        JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+        List<Column> columns = Arrays.asList(new Column("d", Type.VARCHAR));
+        JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", columns, Lists.newArrayList(),
+                "test", "catalog", properties);
+        int size = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
+        Assert.assertEquals(1, size);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
+import com.starrocks.connector.PartitionUtil;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
@@ -171,6 +172,8 @@ public class MysqlSchemaResolverTest {
                 "test", "catalog", properties);
         int size = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
         Assert.assertEquals(1, size);
+        List<String> partitionNames = PartitionUtil.getPartitionNames(jdbcTable);
+        Assert.assertEquals(Arrays.asList("tbl1"), partitionNames);
     }
 
     @Test


### PR DESCRIPTION
Fixes #issue

For non-partitioned mysql external table, its `partition_name` is null in MySQL schema, we should consider it individually.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
