### PR TITLE
[Enhancement] Avoid using page cache when collecting statistics (#21801)

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -149,7 +149,7 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
     _params.skip_aggregation = skip_aggregation;
     _params.profile = _runtime_profile;
     _params.runtime_state = _runtime_state;
-    _params.use_page_cache = !config::disable_storage_page_cache;
+    _params.use_page_cache = _runtime_state->use_page_cache();
     _params.use_pk_index = thrift_olap_scan_node.use_pk_index;
     if (thrift_olap_scan_node.__isset.sorted_by_keys_per_tablet) {
         _params.sorted_by_keys_per_tablet = thrift_olap_scan_node.sorted_by_keys_per_tablet;

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -125,8 +125,7 @@ Status TabletScanner::_init_reader_params(const std::vector<OlapScanRange*>* key
     // we will not call agg object finalize method in scan node,
     // to avoid the unnecessary SerDe and improve query performance
     _params.need_agg_finalize = _need_agg_finalize;
-    _params.use_page_cache = !config::disable_storage_page_cache;
-
+    _params.use_page_cache = _runtime_state->use_page_cache();
     auto parser = _pool.add(new PredicateParser(_tablet->tablet_schema()));
     std::vector<PredicatePtr> preds;
     RETURN_IF_ERROR(_parent->_conjuncts_manager.get_column_predicates(parser, &preds));

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -230,6 +230,16 @@ void RuntimeState::get_unreported_errors(std::vector<std::string>* new_errors) {
     }
 }
 
+bool RuntimeState::use_page_cache() {
+    if (config::disable_storage_page_cache) {
+        return false;
+    }
+    if (_query_options.__isset.use_page_cache) {
+        return _query_options.use_page_cache;
+    }
+    return true;
+}
+
 Status RuntimeState::set_mem_limit_exceeded(MemTracker* tracker, int64_t failed_allocation_size,
                                             const std::string* msg) {
     DCHECK_GE(failed_allocation_size, 0);

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -339,6 +339,8 @@ public:
                _query_options.enable_collect_table_level_scan_stats;
     }
 
+    bool use_page_cache();
+
 private:
     // Set per-query state.
     void _init(const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -79,6 +79,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String QUERY_TIMEOUT = "query_timeout";
 
+    /* 
+     * When FE does not set the pagecache parameter, we expect a query to follow the pagecache policy of BE.
+     * If pagecache is set by FE, a query whether to use pagecache follows the policy specified by FE.
+     */
+    public static final String USE_PAGE_CACHE = "use_page_cache";
+
     public static final String QUERY_DELIVERY_TIMEOUT = "query_delivery_timeout";
     public static final String MAX_EXECUTION_TIME = "max_execution_time";
     public static final String IS_REPORT_SUCCESS = "is_report_success";
@@ -501,6 +507,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // query timeout in second.
     @VariableMgr.VarAttr(name = QUERY_TIMEOUT)
     private int queryTimeoutS = 300;
+
+    @VariableMgr.VarAttr(name = USE_PAGE_CACHE)
+    private boolean usePageCache = true;
 
     // Execution of a query contains two phase.
     // 1. Deliver all the fragment instances to BEs.
@@ -1198,6 +1207,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setLoadMemLimit(long loadMemLimit) {
         this.loadMemLimit = loadMemLimit;
+    }
+
+    public void setUsePageCache(boolean usePageCache) {
+        this.usePageCache = usePageCache;
     }
 
     public void setQueryTimeoutS(int queryTimeoutS) {
@@ -1977,6 +1990,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setConnector_scan_use_query_mem_ratio(connectorScanUseQueryMemRatio);
         tResult.setScan_use_query_mem_ratio(scanUseQueryMemRatio);
         tResult.setEnable_collect_table_level_scan_stats(enableCollectTableLevelScanStats);
+
+        tResult.setUse_page_cache(usePageCache);
         return tResult;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -22,6 +22,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QueryState;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.InsertStmt;
@@ -133,6 +134,10 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
     public void collectStatisticSync(String sql, ConnectContext context) throws Exception {
         LOG.debug("statistics collect sql : " + sql);
         StatisticExecutor executor = new StatisticExecutor();
+        SessionVariable sessionVariable = context.getSessionVariable();
+        // Full table scan is performed for full statistics collecting. In this case, 
+        // we do not need to use pagecache.
+        sessionVariable.setUsePageCache(false);
         List<TStatisticData> dataList = executor.executeStatisticDQL(context, sql);
 
         String tableName = StringEscapeUtils.escapeSql(db.getOriginName() + "." + table.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -93,6 +93,10 @@ public abstract class StatisticsCollectJob {
             StmtExecutor executor = new StmtExecutor(context, parsedStmt);
             SessionVariable sessionVariable = context.getSessionVariable();
             sessionVariable.setEnableMaterializedViewRewrite(false);
+            // Statistics collecting is not user-specific, which means response latency is not that important.
+            // Normally, if the page cache is enabled, the page cache must be full. Page cache is used for query 
+            // acceleration, then page cache is better filled with the user's data. 
+            sessionVariable.setUsePageCache(false);
             context.setExecutor(executor);
             context.setQueryId(UUIDUtil.genUUID());
             context.setStartTime();


### PR DESCRIPTION
Currently, BE scans segment files using pagecache when collecting statistics, which is a waste of resources. In addition, when large-scale data is continuously imported, if the amount of new data to be imported reaches a certain proportion, full statistics collection will be triggered, and page cache will fill up when the segment file is read. As a result, the imported memory will easily exceed the limit. This PR adds a field to queryoptions that allows FE to determine whether a query uses page cache. For collecting statistics, we use this field to tell BE not to use page cache when executing the query. ----
Signed-off-by: Zaorang Yang <zaorangy@gmail.com>

