### PR TITLE
[Enhancement] Avoid using page cache when collecting statistics (#21801)

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -157,7 +157,7 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
     _params.skip_aggregation = skip_aggregation;
     _params.profile = _runtime_profile;
     _params.runtime_state = _runtime_state;
-    _params.use_page_cache = !config::disable_storage_page_cache;
+    _params.use_page_cache = _runtime_state->use_page_cache();
     _morsel->init_tablet_reader_params(&_params);
 
     PredicateParser parser(_tablet->tablet_schema());

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -125,7 +125,7 @@ Status TabletScanner::_init_reader_params(const std::vector<OlapScanRange*>* key
     // we will not call agg object finalize method in scan node,
     // to avoid the unnecessary SerDe and improve query performance
     _params.need_agg_finalize = _need_agg_finalize;
-    _params.use_page_cache = !config::disable_storage_page_cache;
+    _params.use_page_cache = _runtime_state->use_page_cache();
 
     PredicateParser parser(_tablet->tablet_schema());
     std::vector<PredicatePtr> preds;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -223,6 +223,16 @@ void RuntimeState::get_unreported_errors(std::vector<std::string>* new_errors) {
     }
 }
 
+bool RuntimeState::use_page_cache() {
+    if (config::disable_storage_page_cache) {
+        return false;
+    }
+    if (_query_options.__isset.use_page_cache) {
+        return _query_options.use_page_cache;
+    }
+    return true;
+}
+
 Status RuntimeState::set_mem_limit_exceeded(MemTracker* tracker, int64_t failed_allocation_size,
                                             const std::string* msg) {
     DCHECK_GE(failed_allocation_size, 0);

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -286,6 +286,8 @@ public:
                _query_options.enable_collect_table_level_scan_stats;
     }
 
+    bool use_page_cache();
+
 private:
     // Set per-query state.
     void _init(const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -71,6 +71,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String QUERY_TIMEOUT = "query_timeout";
 
+    /* 
+     * When FE does not set the pagecache parameter, we expect a query to follow the pagecache policy of BE.
+     * If pagecache is set by FE, a query whether to use pagecache follows the policy specified by FE.
+     */
+    public static final String USE_PAGE_CACHE = "use_page_cache";
+
     public static final String QUERY_DELIVERY_TIMEOUT = "query_delivery_timeout";
     public static final String MAX_EXECUTION_TIME = "max_execution_time";
     public static final String IS_REPORT_SUCCESS = "is_report_success";
@@ -280,6 +286,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // query timeout in second.
     @VariableMgr.VarAttr(name = QUERY_TIMEOUT)
     private int queryTimeoutS = 300;
+
+    @VariableMgr.VarAttr(name = USE_PAGE_CACHE)
+    private boolean usePageCache = true;
 
     // Execution of a query contains two phase.
     // 1. Deliver all the fragment instances to BEs.
@@ -723,6 +732,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setLoadMemLimit(long loadMemLimit) {
         this.loadMemLimit = loadMemLimit;
+    }
+
+    public void setUsePageCache(boolean usePageCache) {
+        this.usePageCache = usePageCache;
     }
 
     public void setQueryTimeoutS(int queryTimeoutS) {
@@ -1180,6 +1193,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setEnable_tablet_internal_parallel(enableTabletInternalParallel);
         tResult.setEnable_pipeline_query_statistic(enablePipelineQueryStatistic);
         tResult.setEnable_collect_table_level_scan_stats(enableCollectTableLevelScanStats);
+        tResult.setUse_page_cache(usePageCache);
         return tResult;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -23,6 +23,7 @@ import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.RowBatch;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
@@ -238,6 +239,10 @@ public class StatisticExecutor {
             LOG.debug("Collect statistic SQL: {}", sql);
 
             ConnectContext context = StatisticUtils.buildConnectContext();
+            SessionVariable sessionVariable = context.getSessionVariable();
+            // Full table scan is performed for full statistics collecting. In this case, 
+            // we do not need to use pagecache.
+            sessionVariable.setUsePageCache(false);
             StatementBase parsedStmt = parseSQL(sql, context);
             StmtExecutor executor = new StmtExecutor(context, parsedStmt);
             executor.execute();

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -172,6 +172,7 @@ struct TQueryOptions {
 
   67: optional bool enable_pipeline_query_statistic = false;
 
+  91: optional bool use_page_cache;
 
   102: optional bool enable_collect_table_level_scan_stats;
   // The following params only exist on 2.2 2.3, to avoid upgrade inconsistency


### PR DESCRIPTION
Currently, BE scans segment files using pagecache when collecting statistics, which is a waste of resources. In addition, when large-scale data is continuously imported, if the amount of new data to be imported reaches a certain proportion, full statistics collection will be triggered, and page cache will fill up when the segment file is read. As a result, the imported memory will easily exceed the limit. This PR adds a field to queryoptions that allows FE to determine whether a query uses page cache. For collecting statistics, we use this field to tell BE not to use page cache when executing the query. ----
Signed-off-by: Zaorang Yang <zaorangy@gmail.com>
