### PR TITLE
[Enhancement] Avoid using page cache when collecting statistics (#21801)

### DIFF
--- a/be/src/exec/pipeline/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/olap_chunk_source.cpp
@@ -187,7 +187,7 @@ Status OlapChunkSource::_init_reader_params(const std::vector<OlapScanRange*>& k
     _params.skip_aggregation = skip_aggregation;
     _params.profile = _runtime_profile;
     _params.runtime_state = _runtime_state;
-    _params.use_page_cache = !config::disable_storage_page_cache;
+    _params.use_page_cache = _runtime_state->use_page_cache();
     _decide_chunk_size();
 
     PredicateParser parser(_tablet->tablet_schema());

--- a/be/src/exec/vectorized/tablet_scanner.cpp
+++ b/be/src/exec/vectorized/tablet_scanner.cpp
@@ -126,7 +126,7 @@ Status TabletScanner::_init_reader_params(const std::vector<OlapScanRange*>* key
     // we will not call agg object finalize method in scan node,
     // to avoid the unnecessary SerDe and improve query performance
     _params.need_agg_finalize = _need_agg_finalize;
-    _params.use_page_cache = !config::disable_storage_page_cache;
+    _params.use_page_cache = _runtime_state->use_page_cache();
 
     PredicateParser parser(_tablet->tablet_schema());
     std::vector<PredicatePtr> preds;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -240,6 +240,16 @@ void RuntimeState::get_unreported_errors(std::vector<std::string>* new_errors) {
     }
 }
 
+bool RuntimeState::use_page_cache() {
+    if (config::disable_storage_page_cache) {
+        return false;
+    }
+    if (_query_options.__isset.use_page_cache) {
+        return _query_options.use_page_cache;
+    }
+    return true;
+}
+
 Status RuntimeState::set_mem_limit_exceeded(MemTracker* tracker, int64_t failed_allocation_size,
                                             const std::string* msg) {
     DCHECK_GE(failed_allocation_size, 0);

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -283,6 +283,8 @@ public:
     void set_func_version(int func_version) { this->_func_version = func_version; }
     int func_version() const { return this->_func_version; }
 
+    bool use_page_cache();
+
 private:
     Status create_error_log_file();
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -49,6 +49,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String EXEC_MEM_LIMIT = "exec_mem_limit";
     public static final String QUERY_TIMEOUT = "query_timeout";
 
+    /* 
+     * When FE does not set the pagecache parameter, we expect a query to follow the pagecache policy of BE.
+     * If pagecache is set by FE, a query whether to use pagecache follows the policy specified by FE.
+     */
+    public static final String USE_PAGE_CACHE = "use_page_cache";
+
     public static final String QUERY_DELIVERY_TIMEOUT = "query_delivery_timeout";
     public static final String MAX_EXECUTION_TIME = "max_execution_time";
     public static final String IS_REPORT_SUCCESS = "is_report_success";
@@ -227,6 +233,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // query timeout in second.
     @VariableMgr.VarAttr(name = QUERY_TIMEOUT)
     private int queryTimeoutS = 300;
+
+    @VariableMgr.VarAttr(name = USE_PAGE_CACHE)
+    private boolean usePageCache = true;
 
     // Execution of a query contains two phase.
     // 1. Deliver all the fragment instances to BEs.
@@ -636,6 +645,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.loadMemLimit = loadMemLimit;
     }
 
+    public void setUsePageCache(boolean usePageCache) {
+        this.usePageCache = usePageCache;
+    }
+
     public void setQueryTimeoutS(int queryTimeoutS) {
         this.queryTimeoutS = queryTimeoutS;
     }
@@ -1021,6 +1034,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
                 tResult.setPipeline_profile_level(TPipelineProfileLevel.CORE_METRICS);
                 break;
         }
+
+        tResult.setUse_page_cache(usePageCache);
         return tResult;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -23,6 +23,7 @@ import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.RowBatch;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
@@ -236,6 +237,10 @@ public class StatisticExecutor {
             LOG.debug("Collect statistic SQL: {}", sql);
 
             ConnectContext context = StatisticUtils.buildConnectContext();
+            SessionVariable sessionVariable = context.getSessionVariable();
+            // Full table scan is performed for full statistics collecting. In this case, 
+            // we do not need to use pagecache.
+            sessionVariable.setUsePageCache(false);
             StatementBase parsedStmt = parseSQL(sql, context);
             StmtExecutor executor = new StmtExecutor(context, parsedStmt);
             executor.execute();

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -164,11 +164,35 @@ struct TQueryOptions {
 
   60: optional i32 query_delivery_timeout;
 
+<<<<<<< HEAD
   // The following params only exist on 2.2 2.3, to avoid upgrade inconsistency
   //  (if start from a low number, say 80, this id may be used by another param in the new version),
   // start from 1000
   1000: optional i32 parallel_exec_instance_num;
   1001: optional i32 max_parallel_scan_instance_num;
+=======
+  70: optional bool allow_throw_exception = 0;
+
+  71: optional bool hudi_mor_force_jni_reader;
+
+  72: optional i64 rpc_http_min_size;
+
+  // some experimental parameter for spill
+  73: optional i32 spill_mem_table_size;
+  74: optional i32 spill_mem_table_num;
+  75: optional double spill_mem_limit_threshold;
+  76: optional i64 spill_operator_min_bytes;
+  77: optional i64 spill_operator_max_bytes;
+  85: optional TSpillMode spill_mode;
+  
+  86: optional i32 io_tasks_per_scan_operator = 4;
+  87: optional i32 connector_io_tasks_per_scan_operator = 16;
+  88: optional double runtime_filter_early_return_selectivity = 0.05;
+
+  90: optional i64 log_rejected_record_num = 0;
+
+  91: optional bool use_page_cache;
+>>>>>>> b0d0533f3e... [Enhancement] Avoid using page cache when collecting statistics (#21801)
 }
 
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -164,35 +164,13 @@ struct TQueryOptions {
 
   60: optional i32 query_delivery_timeout;
 
-<<<<<<< HEAD
+  91: optional bool use_page_cache;
+
   // The following params only exist on 2.2 2.3, to avoid upgrade inconsistency
   //  (if start from a low number, say 80, this id may be used by another param in the new version),
   // start from 1000
   1000: optional i32 parallel_exec_instance_num;
   1001: optional i32 max_parallel_scan_instance_num;
-=======
-  70: optional bool allow_throw_exception = 0;
-
-  71: optional bool hudi_mor_force_jni_reader;
-
-  72: optional i64 rpc_http_min_size;
-
-  // some experimental parameter for spill
-  73: optional i32 spill_mem_table_size;
-  74: optional i32 spill_mem_table_num;
-  75: optional double spill_mem_limit_threshold;
-  76: optional i64 spill_operator_min_bytes;
-  77: optional i64 spill_operator_max_bytes;
-  85: optional TSpillMode spill_mode;
-  
-  86: optional i32 io_tasks_per_scan_operator = 4;
-  87: optional i32 connector_io_tasks_per_scan_operator = 16;
-  88: optional double runtime_filter_early_return_selectivity = 0.05;
-
-  90: optional i64 log_rejected_record_num = 0;
-
-  91: optional bool use_page_cache;
->>>>>>> b0d0533f3e... [Enhancement] Avoid using page cache when collecting statistics (#21801)
 }
 
 


### PR DESCRIPTION
Currently, BE scans segment files using pagecache when collecting statistics, which is a waste of resources. In addition, when large-scale data is continuously imported, if the amount of new data to be imported reaches a certain proportion, full statistics collection will be triggered, and page cache will fill up when the segment file is read. As a result, the imported memory will easily exceed the limit. This PR adds a field to queryoptions that allows FE to determine whether a query uses page cache. For collecting statistics, we use this field to tell BE not to use page cache when executing the query. ----
Signed-off-by: Zaorang Yang <zaorangy@gmail.com>

