### PR TITLE
[BugFix] BE crash in ASAN mode when we do column mode partial update for primary key table which separate primary keys and sort keys

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -199,8 +199,7 @@ Status DeltaWriter::_init() {
     _build_current_tablet_schema(_opt.index_id, _opt.ptable_schema_param, _tablet->tablet_schema());
 
     // maybe partial update, change to partial tablet schema
-    if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS &&
-        partial_cols_num < _tablet_schema->num_columns()) {
+    if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && partial_cols_num < _tablet_schema->num_columns()) {
         writer_context.referenced_column_ids.reserve(partial_cols_num);
         for (auto i = 0; i < partial_cols_num; ++i) {
             const auto& slot_col_name = (*_opt.slots)[i]->col_name();
@@ -235,7 +234,7 @@ Status DeltaWriter::_init() {
             writer_context.merge_condition = _opt.merge_condition;
         }
         auto partial_update_schema = TabletSchema::create(_tablet_schema, writer_context.referenced_column_ids);
-        // In column mode partial update, we need to modify sort key idxes and short key column num in partial 
+        // In column mode partial update, we need to modify sort key idxes and short key column num in partial
         // tablet schema
         if (_opt.partial_update_mode == PartialUpdateMode::COLUMN_UPSERT_MODE ||
             _opt.partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -338,10 +338,17 @@ std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchemaCSPtr& src_
     if (src_tablet_schema->has_bf_fpp()) {
         partial_tablet_schema_pb.set_bf_fpp(src_tablet_schema->bf_fpp());
     }
+    std::vector<ColumnId> sort_key_idxes;
+    uint32_t cid = 0;
     for (const auto referenced_column_id : referenced_column_ids) {
         auto* tablet_column = partial_tablet_schema_pb.add_column();
         src_tablet_schema->column(referenced_column_id).to_schema_pb(tablet_column);
+        if (src_tablet_schema->column(referenced_column_id).is_sort_key()) {
+            sort_key_idxes.emplace_back(cid);
+        }
+        cid++;
     }
+    partial_tablet_schema_pb.mutable_sort_key_idxes()->Add(sort_key_idxes.begin(), sort_key_idxes.end());
     return std::make_shared<TabletSchema>(partial_tablet_schema_pb);
 }
 
@@ -422,7 +429,7 @@ void TabletSchema::_init_from_pb(const TabletSchemaPB& schema) {
         for (auto i = 0; i < schema.sort_key_idxes_size(); ++i) {
             _sort_key_idxes.push_back(schema.sort_key_idxes(i));
             _sort_key_idxes_set.emplace(schema.sort_key_idxes(i));
-        }
+        }\
     }
     for (auto cid : _sort_key_idxes) {
         _cols[cid].set_is_sort_key(true);

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -429,7 +429,7 @@ void TabletSchema::_init_from_pb(const TabletSchemaPB& schema) {
         for (auto i = 0; i < schema.sort_key_idxes_size(); ++i) {
             _sort_key_idxes.push_back(schema.sort_key_idxes(i));
             _sort_key_idxes_set.emplace(schema.sort_key_idxes(i));
-        }\
+        }
     }
     for (auto cid : _sort_key_idxes) {
         _cols[cid].set_is_sort_key(true);

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -263,9 +263,11 @@ public:
     const TabletColumn& column(size_t ordinal) const;
     const std::vector<TabletColumn>& columns() const;
     const std::vector<ColumnId> sort_key_idxes() const { return _sort_key_idxes; }
+
     size_t num_columns() const { return _cols.size(); }
     size_t num_key_columns() const { return _num_key_columns; }
     size_t num_short_key_columns() const { return _num_short_key_columns; }
+    
     size_t num_rows_per_row_block() const { return _num_rows_per_row_block; }
     KeysType keys_type() const { return static_cast<KeysType>(_keys_type); }
     size_t next_column_unique_id() const { return _next_column_unique_id; }
@@ -277,6 +279,24 @@ public:
     int32_t schema_version() const { return _schema_version; }
     void clear_columns();
     void copy_from(const std::shared_ptr<const TabletSchema>& tablet_schema);
+
+    // Please call the following function with caution. Most of the time, 
+    // the following two functions should not be called explicitly.
+    // When we do column partial update for primary key table which seperate primary keys
+    // and sort keys, we will create a partial tablet schema for rowset writer. However,
+    // the sort key columns maybe not exist in the partial tablet schema and the partial tablet
+    // schema will keep a wrong sort key idxes and short key column num. So BE will crash in ASAN
+    // mode. However, the sort_key_idxes and short_key_column_num in partial tablet schema is not
+    // important actually, because the update segment file does not depend on it and the update
+    // segment file will be rewrite to col file after apply. So these function are used to modify
+    // the sort_key_idxes and short_key_column_num in partial tablet schema to avoid BE crash so far.
+    void set_sort_key_idxes(std::vector<ColumnId> sort_key_idxes) {
+        _sort_key_idxes.clear();
+        _sort_key_idxes.assign(sort_key_idxes.begin(), sort_key_idxes.end());
+    }
+    void set_num_short_key_columns(uint16_t num_short_key_columns) { 
+        _num_short_key_columns = num_short_key_columns; 
+    }
 
     std::string debug_string() const;
 

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -267,7 +267,7 @@ public:
     size_t num_columns() const { return _cols.size(); }
     size_t num_key_columns() const { return _num_key_columns; }
     size_t num_short_key_columns() const { return _num_short_key_columns; }
-    
+
     size_t num_rows_per_row_block() const { return _num_rows_per_row_block; }
     KeysType keys_type() const { return static_cast<KeysType>(_keys_type); }
     size_t next_column_unique_id() const { return _next_column_unique_id; }
@@ -280,7 +280,7 @@ public:
     void clear_columns();
     void copy_from(const std::shared_ptr<const TabletSchema>& tablet_schema);
 
-    // Please call the following function with caution. Most of the time, 
+    // Please call the following function with caution. Most of the time,
     // the following two functions should not be called explicitly.
     // When we do column partial update for primary key table which seperate primary keys
     // and sort keys, we will create a partial tablet schema for rowset writer. However,
@@ -294,9 +294,7 @@ public:
         _sort_key_idxes.clear();
         _sort_key_idxes.assign(sort_key_idxes.begin(), sort_key_idxes.end());
     }
-    void set_num_short_key_columns(uint16_t num_short_key_columns) { 
-        _num_short_key_columns = num_short_key_columns; 
-    }
+    void set_num_short_key_columns(uint16_t num_short_key_columns) { _num_short_key_columns = num_short_key_columns; }
 
     std::string debug_string() const;
 


### PR DESCRIPTION
When we do a column partial update for the primary key table which separates primary keys and sort keys, we will create a partial tablet schema for the rowset writer. However, the sort key columns may not exist in the partial tablet schema and the partial tablet schema will keep a wrong sort key idxes and short key column num. So BE will crash in ASAN mode. However, the sort_key_idxes and short_key_column_num in partial tablet schema are not important because the update segment file does not depend on it and the update segment file will be rewritten to a col file after apply. So we should modify the sort key idxes and short key column num in column mode partial update.
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
