### PR TITLE
[Enhancement] support batch get pk index when partial update by column

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1040,6 +1040,9 @@ CONF_Int32(default_mv_resource_group_cpu_limit, "1");
 // Max size of key columns size of primary key table, default value is 128 bytes
 CONF_mInt32(primary_key_limit_size, "128");
 
+// used for control the max memory cost when batch get pk index in each tablet
+CONF_mInt64(primary_key_batch_get_index_memory_limit, "104857600"); // 100MB
+
 // If your sort key cardinality is very high,
 // You could enable this config to speed up the point lookup query,
 // otherwise, StarRocks will use zone map for one column filter

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -63,28 +63,18 @@ Status RowsetColumnUpdateState::load(Tablet* tablet, Rowset* rowset, MemTracker*
     return _status;
 }
 
-// check if we have memory to preload update data
-void RowsetColumnUpdateState::_check_if_preload_column_mode_update_data(Rowset* rowset,
-                                                                        MemTracker* update_mem_tracker) {
-    if (update_mem_tracker->limit_exceeded() ||
-        update_mem_tracker->consumption() + rowset->total_update_row_size() >= update_mem_tracker->limit()) {
-        _enable_preload_column_mode_update_data = false;
-    } else {
-        _enable_preload_column_mode_update_data = true;
+void RowsetColumnUpdateState::_release_upserts(uint32_t start_idx, uint32_t end_idx) {
+    for (uint32_t idx = start_idx; idx < _upserts.size() && idx < end_idx; idx++) {
+        if (_upserts[idx] != nullptr) {
+            if (_upserts[idx]->is_last(idx)) {
+                _memory_usage -= _upserts[idx]->upserts->memory_usage();
+            }
+            _upserts[idx].reset();
+        }
     }
 }
 
-void RowsetColumnUpdateState::_release_upserts(uint32_t idx) {
-    if (idx >= _upserts.size()) {
-        return;
-    }
-    if (_upserts[idx] != nullptr) {
-        _memory_usage -= _upserts[idx]->memory_usage();
-        _upserts[idx].reset();
-    }
-}
-
-Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t idx) {
+Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t start_idx, uint32_t* end_idx) {
     RowsetReleaseGuard guard(rowset->shared_from_this());
     if (_upserts.size() == 0) {
         _upserts.resize(rowset->num_update_files());
@@ -94,11 +84,14 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t idx) {
         DCHECK(_upserts.size() == rowset->num_update_files());
         DCHECK(_update_chunk_cache.size() == rowset->num_update_files());
     }
-    if (_upserts.size() == 0 || _upserts[idx] != nullptr) {
+    if (_upserts.size() == 0) {
+        return Status::OK();
+    }
+    if (_upserts[start_idx] != nullptr) {
+        *end_idx = _upserts[start_idx]->end_idx;
         return Status::OK();
     }
 
-    const int64_t DEFAULT_CONTAINER_SIZE = 4096;
     OlapReaderStatistics stats;
     auto& schema = rowset->schema();
     vector<uint32_t> pk_columns;
@@ -106,17 +99,14 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t idx) {
         pk_columns.push_back((uint32_t)i);
     }
     std::vector<uint32_t> update_columns;
-    std::vector<uint32_t> update_columns_with_keys;
     const auto& txn_meta = rowset->rowset_meta()->get_meta_pb().txn_meta();
     for (uint32_t cid : txn_meta.partial_update_column_ids()) {
-        update_columns_with_keys.push_back(cid);
         if (cid >= schema->num_key_columns()) {
             update_columns.push_back(cid);
         }
     }
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
     Schema update_schema = ChunkHelper::convert_schema(schema, update_columns);
-    Schema update_schema_with_keys = ChunkHelper::convert_schema(schema, update_columns_with_keys);
     std::unique_ptr<Column> pk_column;
     if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
         std::string err_msg = fmt::format("create column for primary key encoder failed, tablet_id: {}", _tablet_id);
@@ -124,20 +114,9 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t idx) {
         return Status::InternalError(err_msg);
     }
 
+    std::shared_ptr<Chunk> chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, DEFAULT_CHUNK_SIZE);
     // iterators for each update segments;
-    std::vector<ChunkIteratorPtr> itrs;
-
-    std::shared_ptr<Chunk> chunk_shared_ptr;
-    // if we want to preload update cache, create chunk with update columns
-    if (_enable_preload_column_mode_update_data) {
-        _update_chunk_cache[idx] = ChunkHelper::new_chunk(update_schema, DEFAULT_CONTAINER_SIZE);
-        chunk_shared_ptr = ChunkHelper::new_chunk(update_schema_with_keys, DEFAULT_CONTAINER_SIZE);
-        ASSIGN_OR_RETURN(itrs, rowset->get_update_file_iterators(update_schema_with_keys, &stats));
-    } else {
-        _update_chunk_cache[idx] = ChunkHelper::new_chunk(update_schema, 0);
-        chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, DEFAULT_CONTAINER_SIZE);
-        ASSIGN_OR_RETURN(itrs, rowset->get_update_file_iterators(pkey_schema, &stats));
-    }
+    ASSIGN_OR_RETURN(std::vector<ChunkIteratorPtr> itrs, rowset->get_update_file_iterators(pkey_schema, &stats));
 
     if (itrs.size() != rowset->num_update_files()) {
         std::string err_msg = fmt::format("itrs.size {} != num_update_files {}, tablet_id: {}", itrs.size(),
@@ -145,40 +124,53 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t idx) {
         DCHECK(false) << err_msg;
         return Status::InternalError(err_msg);
     }
-    auto chunk = chunk_shared_ptr.get();
-    auto& dest = _upserts[idx];
-    auto& dest_chunk = _update_chunk_cache[idx];
-    auto col = pk_column->clone();
-    auto itr = itrs[idx].get();
-    if (itr != nullptr) {
-        col->reserve(DEFAULT_CONTAINER_SIZE);
-        while (true) {
-            chunk->reset();
-            auto st = itr->get_next(chunk);
-            if (st.is_end_of_file()) {
-                break;
-            } else if (!st.ok()) {
-                return st;
-            } else {
-                PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
-                if (_enable_preload_column_mode_update_data) {
-                    for (int i = pk_columns.size(); i < update_columns_with_keys.size(); i++) {
-                        _memory_usage += chunk->columns()[i]->byte_size();
-                        dest_chunk->columns()[i - pk_columns.size()]->append(*chunk->columns()[i]);
-                    }
+
+    // alloc first BatchPKsPtr
+    auto header_ptr = std::make_shared<BatchPKs>();
+    header_ptr->upserts = pk_column->clone();
+    header_ptr->start_idx = start_idx;
+    for (uint32_t idx = start_idx; idx < rowset->num_update_files(); idx++) {
+        _update_chunk_cache[idx] = ChunkHelper::new_chunk(update_schema, 0);
+        header_ptr->offsets.push_back(header_ptr->upserts->size());
+        auto chunk = chunk_shared_ptr.get();
+        auto col = pk_column->clone();
+        auto itr = itrs[idx].get();
+        if (itr != nullptr) {
+            col->reserve(DEFAULT_CHUNK_SIZE);
+            while (true) {
+                chunk->reset();
+                auto st = itr->get_next(chunk);
+                if (st.is_end_of_file()) {
+                    break;
+                } else if (!st.ok()) {
+                    return st;
+                } else {
+                    PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), col.get());
                 }
             }
         }
+        // merge pk column into BatchPKs
+        header_ptr->upserts->append(*col);
+        // all idx share same ptr with start idx
+        _upserts[idx] = header_ptr;
+        *end_idx = idx + 1;
+        // quit merge PK into BatchPKs when hiting memory limit
+        if (header_ptr->upserts->memory_usage() + _memory_usage > config::primary_key_batch_get_index_memory_limit) {
+            break;
+        }
     }
-    for (const auto& itr : itrs) {
-        itr->close();
-    }
-    dest = std::move(col);
+    // push end offset
+    header_ptr->offsets.push_back(header_ptr->upserts->size());
+    header_ptr->end_idx = *end_idx;
+    DCHECK(header_ptr->offsets.size() == header_ptr->end_idx - header_ptr->start_idx + 1);
     // This is a little bit trick. If pk column is a binary column, we will call function `raw_data()` in the following
     // And the function `raw_data()` will build slice of pk column which will increase the memory usage of pk column
     // So we try build slice in advance in here to make sure the correctness of memory statistics
-    dest->raw_data();
-    _memory_usage += dest != nullptr ? dest->memory_usage() : 0;
+    header_ptr->upserts->raw_data();
+    _memory_usage += header_ptr->upserts->memory_usage();
+    for (const auto& itr : itrs) {
+        itr->close();
+    }
 
     return Status::OK();
 }
@@ -187,15 +179,17 @@ Status RowsetColumnUpdateState::_do_load(Tablet* tablet, Rowset* rowset) {
     auto span = Tracer::Instance().start_trace_txn_tablet("rowset_column_update_state_load", rowset->txn_id(),
                                                           tablet->tablet_id());
     if (rowset->num_update_files() > 0) {
-        RETURN_IF_ERROR(_load_upserts(rowset, 0));
-        RETURN_IF_ERROR(_prepare_partial_update_states(tablet, rowset, 0, true));
+        uint32_t end_idx = 0;
+        RETURN_IF_ERROR(_load_upserts(rowset, 0, &end_idx));
+        DCHECK(end_idx > 0);
+        RETURN_IF_ERROR(_prepare_partial_update_states(tablet, rowset, 0, end_idx, true));
     }
 
     return Status::OK();
 }
 
-Status RowsetColumnUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t idx,
-                                                               bool need_lock) {
+Status RowsetColumnUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t start_idx,
+                                                               uint32_t end_idx, bool need_lock) {
     if (_partial_update_states.size() == 0) {
         _partial_update_states.resize(rowset->num_update_files());
     } else {
@@ -203,76 +197,87 @@ Status RowsetColumnUpdateState::_prepare_partial_update_states(Tablet* tablet, R
         DCHECK(_partial_update_states.size() == rowset->num_update_files());
     }
 
-    if (_partial_update_states[idx].inited) {
+    if (_partial_update_states[start_idx].inited) {
+        // assume that states between [start_idx, end_idx) should be inited
+        CHECK(_partial_update_states[end_idx - 1].inited);
         return Status::OK();
     }
 
+    EditVersion read_version;
+    _upserts[start_idx]->src_rss_rowids.resize(_upserts[start_idx]->upserts_size());
     int64_t t_start = MonotonicMillis();
-
-    _partial_update_states[idx].src_rss_rowids.resize(_upserts[idx]->size());
-
-    int64_t t_read_rss = MonotonicMillis();
     if (need_lock) {
-        RETURN_IF_ERROR(tablet->updates()->get_rss_rowids_by_pk(tablet, *_upserts[idx],
-                                                                &(_partial_update_states[idx].read_version),
-                                                                &(_partial_update_states[idx].src_rss_rowids)));
+        RETURN_IF_ERROR(tablet->updates()->get_rss_rowids_by_pk(tablet, *(_upserts[start_idx]->upserts), &read_version,
+                                                                &(_upserts[start_idx]->src_rss_rowids)));
     } else {
-        RETURN_IF_ERROR(tablet->updates()->get_rss_rowids_by_pk_unlock(tablet, *_upserts[idx],
-                                                                       &(_partial_update_states[idx].read_version),
-                                                                       &(_partial_update_states[idx].src_rss_rowids)));
+        RETURN_IF_ERROR(tablet->updates()->get_rss_rowids_by_pk_unlock(
+                tablet, *(_upserts[start_idx]->upserts), &read_version, &(_upserts[start_idx]->src_rss_rowids)));
     }
-    // build `rss_rowid_to_update_rowid`
-    _partial_update_states[idx].build_rss_rowid_to_update_rowid();
+    int64_t t_read_rss = MonotonicMillis();
+
+    for (uint32_t idx = start_idx; idx < end_idx; idx++) {
+        _upserts[idx]->split_src_rss_rowids(idx, _partial_update_states[idx].src_rss_rowids);
+        // build `rss_rowid_to_update_rowid`
+        _partial_update_states[idx].read_version = read_version;
+        _partial_update_states[idx].build_rss_rowid_to_update_rowid();
+        _partial_update_states[idx].inited = true;
+    }
     int64_t t_end = MonotonicMillis();
 
-    _partial_update_states[idx].inited = true;
-
     LOG(INFO) << strings::Substitute(
-            "prepare ColumnPartialUpdateState tablet:$0 segment:$1 "
-            "time:$2ms(src_rss:$3)",
-            _tablet_id, idx, t_end - t_start, t_end - t_read_rss);
+            "prepare ColumnPartialUpdateState tablet:$0 segment:[$1, $2) "
+            "time:$3ms(src_rss:$4)",
+            _tablet_id, start_idx, end_idx, t_end - t_start, t_read_rss - t_start);
     return Status::OK();
 }
 
-Status RowsetColumnUpdateState::_resolve_conflict(Tablet* tablet, uint32_t rowset_id, uint32_t segment_id,
-                                                  EditVersion latest_applied_version, const PrimaryIndex& index) {
+Status RowsetColumnUpdateState::_resolve_conflict(Tablet* tablet, uint32_t rowset_id, uint32_t start_idx,
+                                                  uint32_t end_idx, EditVersion latest_applied_version,
+                                                  const PrimaryIndex& index) {
     int64_t t_start = MonotonicMillis();
     // rebuild src_rss_rowids;
-    DCHECK(_upserts[segment_id]->size() == _partial_update_states[segment_id].src_rss_rowids.size());
-    index.get(*_upserts[segment_id], &_partial_update_states[segment_id].src_rss_rowids);
+    _upserts[start_idx]->src_rss_rowids.resize(_upserts[start_idx]->upserts_size(), 0);
+    index.get(*(_upserts[start_idx]->upserts), &(_upserts[start_idx]->src_rss_rowids));
     int64_t t_read_index = MonotonicMillis();
-    // rebuild rss_rowid_to_update_rowid
-    _partial_update_states[segment_id].build_rss_rowid_to_update_rowid();
+    for (uint32_t idx = start_idx; idx < end_idx; idx++) {
+        _partial_update_states[idx].src_rss_rowids.clear();
+        _upserts[idx]->split_src_rss_rowids(idx, _partial_update_states[idx].src_rss_rowids);
+        // rebuild rss_rowid_to_update_rowid
+        _partial_update_states[idx].build_rss_rowid_to_update_rowid();
+    }
     int64_t t_end = MonotonicMillis();
     LOG(INFO) << strings::Substitute(
-            "_resolve_conflict_column_mode tablet:$0 rowset:$1 segment:$2 version:($3 $4) "
-            "time:$5ms(index:$6/build:$7)",
-            tablet->tablet_id(), rowset_id, segment_id, _partial_update_states[segment_id].read_version.to_string(),
-            latest_applied_version.to_string(), t_end - t_start, t_read_index - t_start, t_end - t_read_index);
+            "_resolve_conflict_column_mode tablet:$0 rowset:$1 segment:[$2, $3) version:($4 $5) "
+            "time:$6ms(index:$7/build:$8)",
+            tablet->tablet_id(), rowset_id, start_idx, end_idx,
+            _partial_update_states[start_idx].read_version.to_string(), latest_applied_version.to_string(),
+            t_end - t_start, t_read_index - t_start, t_end - t_read_index);
 
     return Status::OK();
 }
 
-Status RowsetColumnUpdateState::_check_and_resolve_conflict(Tablet* tablet, uint32_t rowset_id, uint32_t segment_id,
-                                                            EditVersion latest_applied_version,
+Status RowsetColumnUpdateState::_check_and_resolve_conflict(Tablet* tablet, uint32_t rowset_id, uint32_t start_idx,
+                                                            uint32_t end_idx, EditVersion latest_applied_version,
                                                             const PrimaryIndex& index) {
-    if (_partial_update_states.size() <= segment_id || !_partial_update_states[segment_id].inited) {
+    if (_partial_update_states.size() < end_idx || !_partial_update_states[start_idx].inited ||
+        !_partial_update_states[end_idx - 1].inited) {
         std::string msg = strings::Substitute(
-                "_check_and_reslove_conflict tablet:$0 rowset:$1 segment:$2 failed, partial_update_states size:$3",
-                tablet->tablet_id(), rowset_id, segment_id, _partial_update_states.size());
+                "_check_and_reslove_conflict tablet:$0 rowset:$1 segment:[$2, $3) failed, partial_update_states "
+                "size:$4",
+                tablet->tablet_id(), rowset_id, start_idx, end_idx, _partial_update_states.size());
         LOG(WARNING) << msg;
         return Status::InternalError(msg);
     }
 
     VLOG(2) << "latest_applied_version is " << latest_applied_version.to_string() << " read version is "
-            << _partial_update_states[segment_id].read_version.to_string();
-    if (latest_applied_version == _partial_update_states[segment_id].read_version) {
+            << _partial_update_states[start_idx].read_version.to_string();
+    if (latest_applied_version == _partial_update_states[start_idx].read_version) {
         // _read_version is equal to latest_applied_version which means there is no other rowset is applied.
         // skip resolve conflict
         return Status::OK();
     }
 
-    return _resolve_conflict(tablet, rowset_id, segment_id, latest_applied_version, index);
+    return _resolve_conflict(tablet, rowset_id, start_idx, end_idx, latest_applied_version, index);
 }
 
 Status RowsetColumnUpdateState::_finalize_partial_update_state(Tablet* tablet, Rowset* rowset,
@@ -284,17 +289,20 @@ Status RowsetColumnUpdateState::_finalize_partial_update_state(Tablet* tablet, R
         return Status::OK();
     }
     RETURN_IF_ERROR(_init_rowset_seg_id(tablet));
-    for (uint32_t i = 0; i < rowset->num_update_files(); i++) {
-        RETURN_IF_ERROR(_load_upserts(rowset, i));
+    for (uint32_t i = 0; i < rowset->num_update_files();) {
+        uint32_t end_idx = 0;
+        RETURN_IF_ERROR(_load_upserts(rowset, i, &end_idx));
+        DCHECK(end_idx > i);
         // check and resolve conflict
         if (_partial_update_states.size() == 0 || !_partial_update_states[i].inited) {
-            RETURN_IF_ERROR(_prepare_partial_update_states(tablet, rowset, i, false));
+            RETURN_IF_ERROR(_prepare_partial_update_states(tablet, rowset, i, end_idx, false));
         } else {
             // reslove conflict
-            RETURN_IF_ERROR(_check_and_resolve_conflict(tablet, rowset->rowset_meta()->get_rowset_seg_id(), i,
+            RETURN_IF_ERROR(_check_and_resolve_conflict(tablet, rowset->rowset_meta()->get_rowset_seg_id(), i, end_idx,
                                                         latest_applied_version, index));
         }
-        _release_upserts(i);
+        _release_upserts(i, end_idx);
+        i = end_idx;
     }
 
     return Status::OK();
@@ -392,18 +400,13 @@ Status RowsetColumnUpdateState::_read_chunk_from_update(const RowidsToUpdateRowi
             batch_append_rowids.push_back(each.second.second);
         } else {
             // meet different update file, handle this round.
-            if (!_enable_preload_column_mode_update_data) {
-                _update_chunk_cache[cur_update_file_id]->reserve(4096);
-                // if already read from this update file, iterator will return end of file, and continue
-                RETURN_IF_ERROR(read_chunk_from_update_file(update_iterators[cur_update_file_id],
-                                                            _update_chunk_cache[cur_update_file_id]));
-                DCHECK(_update_chunk_cache[cur_update_file_id]->num_rows() >= batch_append_rowids.size());
-                result_chunk->append_selective(*_update_chunk_cache[cur_update_file_id], batch_append_rowids.data(), 0,
-                                               batch_append_rowids.size());
-            } else {
-                result_chunk->append_selective(*_update_chunk_cache[cur_update_file_id], batch_append_rowids.data(), 0,
-                                               batch_append_rowids.size());
-            }
+            _update_chunk_cache[cur_update_file_id]->reserve(DEFAULT_CHUNK_SIZE);
+            // if already read from this update file, iterator will return end of file, and continue
+            RETURN_IF_ERROR(read_chunk_from_update_file(update_iterators[cur_update_file_id],
+                                                        _update_chunk_cache[cur_update_file_id]));
+            DCHECK(_update_chunk_cache[cur_update_file_id]->num_rows() >= batch_append_rowids.size());
+            result_chunk->append_selective(*_update_chunk_cache[cur_update_file_id], batch_append_rowids.data(), 0,
+                                           batch_append_rowids.size());
             cur_update_file_id = each.second.first;
             batch_append_rowids.clear();
             batch_append_rowids.push_back(each.second.second);
@@ -411,18 +414,13 @@ Status RowsetColumnUpdateState::_read_chunk_from_update(const RowidsToUpdateRowi
     }
     if (!batch_append_rowids.empty()) {
         // finish last round.
-        if (!_enable_preload_column_mode_update_data) {
-            _update_chunk_cache[cur_update_file_id]->reserve(4096);
-            // if already read from this update file, iterator will return end of file, and continue
-            RETURN_IF_ERROR(read_chunk_from_update_file(update_iterators[cur_update_file_id],
-                                                        _update_chunk_cache[cur_update_file_id]));
-            DCHECK(_update_chunk_cache[cur_update_file_id]->num_rows() >= batch_append_rowids.size());
-            result_chunk->append_selective(*_update_chunk_cache[cur_update_file_id], batch_append_rowids.data(), 0,
-                                           batch_append_rowids.size());
-        } else {
-            result_chunk->append_selective(*_update_chunk_cache[cur_update_file_id], batch_append_rowids.data(), 0,
-                                           batch_append_rowids.size());
-        }
+        _update_chunk_cache[cur_update_file_id]->reserve(DEFAULT_CHUNK_SIZE);
+        // if already read from this update file, iterator will return end of file, and continue
+        RETURN_IF_ERROR(read_chunk_from_update_file(update_iterators[cur_update_file_id],
+                                                    _update_chunk_cache[cur_update_file_id]));
+        DCHECK(_update_chunk_cache[cur_update_file_id]->num_rows() >= batch_append_rowids.size());
+        result_chunk->append_selective(*_update_chunk_cache[cur_update_file_id], batch_append_rowids.data(), 0,
+                                       batch_append_rowids.size());
     }
     return Status::OK();
 }
@@ -553,7 +551,7 @@ Status RowsetColumnUpdateState::_insert_new_rows(const TabletSchemaCSPtr& tablet
         if (_partial_update_states[upt_id].insert_rowids.size() > 0) {
             // 1. generate segment file
             auto chunk_ptr = ChunkHelper::new_chunk(schema, _partial_update_states[upt_id].insert_rowids.size());
-            ChunkPtr partial_chunk_ptr = ChunkHelper::new_chunk(partial_schema, 4096);
+            ChunkPtr partial_chunk_ptr = ChunkHelper::new_chunk(partial_schema, DEFAULT_CHUNK_SIZE);
             ASSIGN_OR_RETURN(auto writer, _prepare_segment_writer(rowset, tablet_schema, segid));
             RETURN_IF_ERROR(read_chunk_from_update_file(update_iterators[upt_id], partial_chunk_ptr));
             for (uint32_t column_id : read_update_column_ids.second) {

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -79,13 +79,40 @@ struct ColumnPartialUpdateState {
     }
 };
 
+using ColumnUniquePtr = std::unique_ptr<Column>;
+
+// It contains multi segment's pk list, segment's id is between [start_idx, end_idx)
+struct BatchPKs {
+    ColumnUniquePtr upserts;
+    uint32_t start_idx;
+    uint32_t end_idx;
+    std::vector<uint64_t> src_rss_rowids;
+    // use offsets to record each segment's position in upserts and src_rss_rowids
+    // Last item of offsets is equal to upserts size
+    std::vector<size_t> offsets;
+
+    // if this idx is last of this BatchPKs
+    bool is_last(uint32_t idx) const { return idx == end_idx - 1; }
+
+    // get src_ress_rowids by idx, and set it to `target_src_rss_rowids`
+    void split_src_rss_rowids(uint32_t idx, std::vector<uint64_t>& target_src_rss_rowids) {
+        DCHECK(idx - start_idx + 1 < offsets.size());
+        target_src_rss_rowids.insert(target_src_rss_rowids.begin(), src_rss_rowids.begin() + offsets[idx - start_idx],
+                                     src_rss_rowids.begin() + offsets[idx - start_idx + 1]);
+    }
+
+    size_t upserts_size(uint32_t idx) const { return offsets[idx + 1] - offsets[idx]; }
+    size_t upserts_size() const { return upserts->size(); }
+};
+
+using BatchPKsPtr = std::shared_ptr<BatchPKs>;
+
 // `RowsetColumnUpdateState` is used for maintain the middle state when handling partial update in column mode.
 // It will be maintain in update_manager by `DynamicCache<string, RowsetColumnUpdateState>`, mapped from each rowset to it.
 // It is created when new rowset is generated, and released when rowset apply finished.
 // Because each tablet do apply in one thread, so it wouldn't be updated by multi threads.
 class RowsetColumnUpdateState {
 public:
-    using ColumnUniquePtr = std::unique_ptr<Column>;
     using DeltaColumnGroupPtr = std::shared_ptr<DeltaColumnGroup>;
     // rowid -> <update file id, update_rowids>
     using RowidsToUpdateRowids = std::map<uint32_t, std::pair<uint32_t, uint32_t>>;
@@ -112,8 +139,6 @@ public:
     Status finalize(Tablet* tablet, Rowset* rowset, uint32_t rowset_id, PersistentIndexMetaPB& index_meta,
                     vector<std::pair<uint32_t, DelVectorPtr>>& delvecs, PrimaryIndex& index);
 
-    const std::vector<ColumnUniquePtr>& upserts() const { return _upserts; }
-
     std::size_t memory_usage() const { return _memory_usage; }
 
     std::string to_string() const;
@@ -122,10 +147,13 @@ public:
 
     const std::map<uint32_t, DeltaColumnGroupPtr>& delta_column_groups() const { return _rssid_to_delta_column_group; }
 
-private:
-    Status _load_upserts(Rowset* rowset, uint32_t upsert_id);
+    // For UT test now
+    const std::vector<BatchPKsPtr>& upserts() const { return _upserts; }
 
-    void _release_upserts(uint32_t upsert_id);
+private:
+    Status _load_upserts(Rowset* rowset, uint32_t start_idx, uint32_t* end_idx);
+
+    void _release_upserts(uint32_t start_idx, uint32_t end_idx);
 
     Status _do_load(Tablet* tablet, Rowset* rowset);
 
@@ -137,17 +165,18 @@ private:
     Status _finalize_partial_update_state(Tablet* tablet, Rowset* rowset, EditVersion latest_applied_version,
                                           const PrimaryIndex& index);
 
-    Status _check_and_resolve_conflict(Tablet* tablet, uint32_t rowset_id, uint32_t segment_id,
+    Status _check_and_resolve_conflict(Tablet* tablet, uint32_t rowset_id, uint32_t start_idx, uint32_t end_idx,
                                        EditVersion latest_applied_version, const PrimaryIndex& index);
 
     StatusOr<std::unique_ptr<SegmentWriter>> _prepare_delta_column_group_writer(
             Rowset* rowset, const std::shared_ptr<TabletSchema>& tschema, uint32_t rssid, int64_t ver);
 
     // to build `_partial_update_states`
-    Status _prepare_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t idx, bool need_lock);
+    Status _prepare_partial_update_states(Tablet* tablet, Rowset* rowset, uint32_t start_idx, uint32_t end_idx,
+                                          bool need_lock);
 
     // rebuild src_rss_rowids and rss_rowid_to_update_rowid
-    Status _resolve_conflict(Tablet* tablet, uint32_t rowset_id, uint32_t segment_id,
+    Status _resolve_conflict(Tablet* tablet, uint32_t rowset_id, uint32_t start_idx, uint32_t end_idx,
                              EditVersion latest_applied_version, const PrimaryIndex& index);
 
     /// To reduce memory usage in primary index, we use 32-bit rssid as value.
@@ -161,8 +190,6 @@ private:
     Status _read_chunk_from_update(const RowidsToUpdateRowids& rowid_to_update_rowid,
                                    std::vector<ChunkIteratorPtr>& update_iterators, std::vector<uint32_t>& rowids,
                                    Chunk* result_chunk);
-
-    void _check_if_preload_column_mode_update_data(Rowset* rowset, MemTracker* update_mem_tracker);
 
     StatusOr<std::unique_ptr<SegmentWriter>> _prepare_segment_writer(Rowset* rowset,
                                                                      const TabletSchemaCSPtr& tablet_schema,
@@ -186,8 +213,7 @@ private:
     std::once_flag _load_once_flag;
     Status _status;
     // it contains primary key seriable column for each update segment file
-    std::vector<ColumnUniquePtr> _upserts;
-    // cache chunks read from update segment files
+    std::vector<BatchPKsPtr> _upserts;
     std::vector<ChunkPtr> _update_chunk_cache;
     // total memory usage in current state.
     // it will not record the temp memory usage.
@@ -202,9 +228,6 @@ private:
     // when generate delta column group finish, these fields will be filled
     bool _finalize_finished = false;
     std::map<uint32_t, DeltaColumnGroupPtr> _rssid_to_delta_column_group;
-
-    // if need to pre load update data from rowset
-    bool _enable_preload_column_mode_update_data = false;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const RowsetColumnUpdateState& o) {

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -40,11 +40,13 @@
 #include "testutil/assert.h"
 
 namespace starrocks {
-class RowsetColumnPartialUpdateTest : public ::testing::Test {
+
+class RowsetColumnPartialUpdateTest : public ::testing::Test, testing::WithParamInterface<int64_t> {
 public:
     void SetUp() override {
         _compaction_mem_tracker = std::make_unique<MemTracker>(-1);
         _update_mem_tracker = std::make_unique<MemTracker>();
+        config::primary_key_batch_get_index_memory_limit = GetParam();
     }
 
     void TearDown() override {
@@ -402,7 +404,7 @@ static void prepare_tablet(RowsetColumnPartialUpdateTest* self, const TabletShar
     }
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, partial_update_and_check) {
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_and_check) {
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
@@ -450,7 +452,7 @@ TEST_F(RowsetColumnPartialUpdateTest, partial_update_and_check) {
     }));
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, normal_partial_update_and_check) {
+TEST_P(RowsetColumnPartialUpdateTest, normal_partial_update_and_check) {
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
@@ -482,7 +484,7 @@ TEST_F(RowsetColumnPartialUpdateTest, normal_partial_update_and_check) {
     }));
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, partial_update_diff_column_and_check) {
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_diff_column_and_check) {
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
@@ -520,7 +522,7 @@ TEST_F(RowsetColumnPartialUpdateTest, partial_update_diff_column_and_check) {
     ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, partial_update_multi_segment_and_check) {
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_segment_and_check) {
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
@@ -559,7 +561,7 @@ TEST_F(RowsetColumnPartialUpdateTest, partial_update_multi_segment_and_check) {
     ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, partial_update_multi_segment_preload_and_check) {
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_segment_preload_and_check) {
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
@@ -568,7 +570,7 @@ TEST_F(RowsetColumnPartialUpdateTest, partial_update_multi_segment_preload_and_c
     prepare_tablet(this, tablet, version, version_before_partial_update, N);
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, partial_update_compaction_and_check) {
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_compaction_and_check) {
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
@@ -586,7 +588,7 @@ TEST_F(RowsetColumnPartialUpdateTest, partial_update_compaction_and_check) {
     }
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, test_full_clone) {
+TEST_P(RowsetColumnPartialUpdateTest, TEST_Pull_clone) {
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
@@ -596,7 +598,7 @@ TEST_F(RowsetColumnPartialUpdateTest, test_full_clone) {
 
     {
         // clone from _tablet to new_tablet
-        auto new_tablet = create_tablet(2000, 2000);
+        auto new_tablet = create_tablet(rand(), rand());
         ASSERT_EQ(1, new_tablet->updates()->version_history_count());
         ASSERT_OK(full_clone(tablet, version, new_tablet));
         ASSERT_TRUE(check_tablet(new_tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
@@ -606,7 +608,7 @@ TEST_F(RowsetColumnPartialUpdateTest, test_full_clone) {
 
     {
         // clone from _tablet to new_tablet with version before partial update
-        auto new_tablet = create_tablet(3000, 3000);
+        auto new_tablet = create_tablet(rand(), rand());
         ASSERT_EQ(1, new_tablet->updates()->version_history_count());
         ASSERT_OK(full_clone(tablet, version_before_partial_update, new_tablet));
         ASSERT_TRUE(check_tablet(new_tablet, version_before_partial_update, N, [](int64_t k1, int64_t v1, int32_t v2) {
@@ -616,7 +618,7 @@ TEST_F(RowsetColumnPartialUpdateTest, test_full_clone) {
 
     {
         // clone from _tablet to new_tablet with version just after first partial update
-        auto new_tablet = create_tablet(4000, 4000);
+        auto new_tablet = create_tablet(rand(), rand());
         ASSERT_EQ(1, new_tablet->updates()->version_history_count());
         ASSERT_OK(full_clone(tablet, version_before_partial_update + 1, new_tablet));
         ASSERT_TRUE(
@@ -626,7 +628,7 @@ TEST_F(RowsetColumnPartialUpdateTest, test_full_clone) {
     }
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, test_increment_clone) {
+TEST_P(RowsetColumnPartialUpdateTest, test_increment_clone) {
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
@@ -636,7 +638,7 @@ TEST_F(RowsetColumnPartialUpdateTest, test_increment_clone) {
 
     {
         // 1. full clone with version before partial update
-        auto new_tablet = create_tablet(5000, 5000);
+        auto new_tablet = create_tablet(rand(), rand());
         ASSERT_EQ(1, new_tablet->updates()->version_history_count());
         ASSERT_OK(full_clone(tablet, version_before_partial_update, new_tablet));
         ASSERT_TRUE(check_tablet(new_tablet, version_before_partial_update, N, [](int64_t k1, int64_t v1, int32_t v2) {
@@ -657,7 +659,7 @@ TEST_F(RowsetColumnPartialUpdateTest, test_increment_clone) {
     }
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, test_schema_change) {
+TEST_P(RowsetColumnPartialUpdateTest, test_schema_change) {
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
@@ -667,7 +669,7 @@ TEST_F(RowsetColumnPartialUpdateTest, test_schema_change) {
 
     {
         // create table with add column, test link_from
-        auto new_tablet = create_tablet(6000, 6000, true);
+        auto new_tablet = create_tablet(rand(), rand(), true);
         new_tablet->set_tablet_state(TABLET_NOTREADY);
         auto chunk_changer = std::make_unique<ChunkChanger>(new_tablet->tablet_schema());
         ASSERT_TRUE(new_tablet->updates()->link_from(tablet.get(), version, chunk_changer.get()).ok());
@@ -678,7 +680,7 @@ TEST_F(RowsetColumnPartialUpdateTest, test_schema_change) {
     }
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, test_full_clone2) {
+TEST_P(RowsetColumnPartialUpdateTest, TEST_Pull_clone2) {
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
@@ -699,7 +701,9 @@ TEST_F(RowsetColumnPartialUpdateTest, test_full_clone2) {
     }
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, test_dcg_gc) {
+TEST_P(RowsetColumnPartialUpdateTest, test_dcg_gc) {
+    // Only run one parameter here
+    if (GetParam() != 104857600) return;
     fs::remove_all(get_stores()->path());
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
@@ -756,7 +760,7 @@ TEST_F(RowsetColumnPartialUpdateTest, test_dcg_gc) {
     }));
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, test_get_column_values) {
+TEST_P(RowsetColumnPartialUpdateTest, test_get_column_values) {
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
@@ -787,7 +791,7 @@ TEST_F(RowsetColumnPartialUpdateTest, test_get_column_values) {
     }
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, test_upsert) {
+TEST_P(RowsetColumnPartialUpdateTest, test_upsert) {
     const int N = 100;
     auto tablet = create_tablet(rand(), rand());
     ASSERT_EQ(1, tablet->updates()->version_history_count());
@@ -830,7 +834,7 @@ TEST_F(RowsetColumnPartialUpdateTest, test_upsert) {
     }
 }
 
-TEST_F(RowsetColumnPartialUpdateTest, partial_update_two_rowset_and_check) {
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_two_rowset_and_check) {
     const int N = 100;
     const int M = N / 2;
     auto tablet = create_tablet(rand(), rand());
@@ -884,5 +888,8 @@ TEST_F(RowsetColumnPartialUpdateTest, partial_update_two_rowset_and_check) {
         return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
     }));
 }
+
+INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,
+                         ::testing::Values(1, 1024, 104857600));
 
 } // namespace starrocks

--- a/be/test/storage/rowset_column_update_state_test.cpp
+++ b/be/test/storage/rowset_column_update_state_test.cpp
@@ -122,7 +122,7 @@ public:
 
     RowsetSharedPtr create_partial_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
                                           std::vector<int32_t>& column_indexes,
-                                          const std::shared_ptr<TabletSchema>& partial_schema) {
+                                          const std::shared_ptr<TabletSchema>& partial_schema, int segment_num) {
         // create partial rowset
         RowsetWriterContext writer_context;
         RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
@@ -151,7 +151,9 @@ public:
             cols[0]->append_datum(Datum(key));
             cols[1]->append_datum(Datum((int16_t)(key % 100 + 3)));
         }
-        CHECK_OK(writer->flush_chunk(*chunk));
+        for (int i = 0; i < segment_num; i++) {
+            CHECK_OK(writer->flush_chunk(*chunk));
+        }
         RowsetSharedPtr partial_rowset = *writer->build();
 
         return partial_rowset;
@@ -238,7 +240,7 @@ TEST_F(RowsetColumnUpdateStateTest, prepare_partial_update_states) {
     std::vector<int32_t> column_indexes = {0, 1};
     {
         std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(_tablet->tablet_schema(), column_indexes);
-        RowsetSharedPtr partial_rowset = create_partial_rowset(_tablet, keys, column_indexes, partial_schema);
+        RowsetSharedPtr partial_rowset = create_partial_rowset(_tablet, keys, column_indexes, partial_schema, 1);
         // check data of write column
         RowsetColumnUpdateState state;
         state.load(_tablet.get(), partial_rowset.get(), _update_tracker.get());
@@ -258,7 +260,8 @@ TEST_F(RowsetColumnUpdateStateTest, prepare_partial_update_states) {
         for (int i = 0; i < N; i++) {
             keys_no_exist[i] = i + N;
         }
-        RowsetSharedPtr partial_rowset = create_partial_rowset(_tablet, keys_no_exist, column_indexes, partial_schema);
+        RowsetSharedPtr partial_rowset =
+                create_partial_rowset(_tablet, keys_no_exist, column_indexes, partial_schema, 1);
         // check data of write column
         RowsetColumnUpdateState state;
         state.load(_tablet.get(), partial_rowset.get(), _update_tracker.get());
@@ -266,6 +269,81 @@ TEST_F(RowsetColumnUpdateStateTest, prepare_partial_update_states) {
         ASSERT_EQ(parital_update_states.size(), 1);
         ASSERT_EQ(parital_update_states[0].src_rss_rowids.size(), N);
         ASSERT_EQ(parital_update_states[0].rss_rowid_to_update_rowid.size(), 0);
+    }
+}
+
+TEST_F(RowsetColumnUpdateStateTest, partial_update_states_batch_get_index) {
+    const int N = 100;
+    _tablet = create_tablet(rand(), rand());
+    ASSERT_EQ(1, _tablet->updates()->version_history_count());
+
+    // create full rowsets first
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.reserve(10);
+    for (int i = 0; i < 10; i++) {
+        rowsets.emplace_back(create_rowset(_tablet, keys));
+    }
+    auto pool = StorageEngine::instance()->update_manager()->apply_thread_pool();
+    for (int i = 0; i < rowsets.size(); i++) {
+        auto version = i + 2;
+        auto st = _tablet->rowset_commit(version, rowsets[i], 0);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        // Ensure that there is at most one thread doing the version apply job.
+        ASSERT_LE(pool->num_threads(), 1);
+        ASSERT_EQ(version, _tablet->updates()->max_version());
+        ASSERT_EQ(version, _tablet->updates()->version_history_count());
+    }
+    ASSERT_EQ(N, read_tablet(_tablet, rowsets.size()));
+
+    std::vector<int32_t> column_indexes = {0, 1};
+    for (size_t seg_cnt = 2; seg_cnt <= 10; seg_cnt++) {
+        // Rowset contains many segments, and memory is enough
+        std::shared_ptr<TabletSchema> partial_schema = TabletSchema::create(_tablet->tablet_schema(), column_indexes);
+        RowsetSharedPtr partial_rowset = create_partial_rowset(_tablet, keys, column_indexes, partial_schema, seg_cnt);
+        // check data of write column
+        RowsetColumnUpdateState state;
+        // assume that state will load all segments at once
+        state.load(_tablet.get(), partial_rowset.get(), _update_tracker.get());
+        const std::vector<ColumnPartialUpdateState>& parital_update_states = state.parital_update_states();
+        ASSERT_EQ(parital_update_states.size(), seg_cnt);
+        ASSERT_EQ(parital_update_states[0].src_rss_rowids.size(), N);
+        ASSERT_EQ(parital_update_states[0].rss_rowid_to_update_rowid.size(), N);
+        for (int upt_id = 0; upt_id < parital_update_states[0].src_rss_rowids.size(); upt_id++) {
+            uint64_t src_rss_rowid = parital_update_states[0].src_rss_rowids[upt_id];
+            ASSERT_EQ(parital_update_states[0].rss_rowid_to_update_rowid.find(src_rss_rowid)->second, upt_id);
+        }
+        // check upserts
+        std::vector<BatchPKsPtr> upserts = state.upserts();
+        ASSERT_EQ(upserts.size(), seg_cnt);
+        auto ptr = upserts[0].get();
+        for (size_t i = 0; i < seg_cnt; i++) {
+            ASSERT_EQ(upserts[i].get(), ptr);
+        }
+        for (size_t i = 0; i < seg_cnt - 1; i++) {
+            ASSERT_FALSE(upserts[i]->is_last(i));
+        }
+        ASSERT_TRUE(upserts[seg_cnt - 1]->is_last(seg_cnt - 1));
+        ASSERT_EQ(upserts[0]->upserts->size(), seg_cnt * N);
+        ASSERT_EQ(upserts[0]->start_idx, 0);
+        ASSERT_EQ(upserts[0]->end_idx, seg_cnt);
+        for (size_t i = 0; i < seg_cnt; i++) {
+            ASSERT_EQ(upserts[0]->offsets[i], i * N);
+        }
+        for (size_t i = 0; i < seg_cnt; i++) {
+            std::vector<uint64_t> target_src_rss_rowids;
+            upserts[0]->split_src_rss_rowids(i, target_src_rss_rowids);
+            uint32_t sid = 0;
+            for (const uint64_t id : target_src_rss_rowids) {
+                auto rssid = (uint32_t)(id >> 32);
+                auto rowid = (uint32_t)(id & ROWID_MASK);
+                ASSERT_EQ(rssid, 9);
+                ASSERT_EQ(rowid, sid++);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #20436
Merge multi-segment files' PK at once, and batch get index to reduce read IO amplification. And also control memory usage under config `primary_key_batch_get_index_memory_limit`. 

Test Result:
87 segment files generated when data loading, we compare the latency of getting from the index, under different batch get key size.
|      primary_key_batch_get_index_memory_limit size     | Time  |
| --------- | ----- |
| No batch  | 82s   |
| 100MB     | 54s   |
| 1000MB    | 27s   |
| 10000MB   | 10s   |

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
