### PR TITLE
[Enhancement] Support empty kafka commit

### DIFF
--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -85,6 +85,7 @@ private:
     void exec_task(StreamLoadContext* ctx, DataConsumerPool* pool, const ExecFinishCallback& cb);
 
     void err_handler(StreamLoadContext* ctx, const Status& st, const std::string& err_msg);
+    void kafka_commit(StreamLoadContext* ctx, bool move_forward);
 
     ExecEnv* _exec_env;
     std::unique_ptr<ThreadPool> _thread_pool;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1428,6 +1428,13 @@ public class Config extends ConfigBase {
     public static int max_tolerable_backend_down_num = 0;
 
     /**
+     * This value should be not less than the Kafka broke config offsets.retention.minutes.
+     * https://kafka.apache.org/documentation/#brokerconfigs_offsets.retention.minutes
+    */
+    @ConfField(mutable = true)
+    public static long routine_load_kafka_offset_retention_minutes = 10080;
+
+    /**
      * a period for auto resume routine load
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -102,6 +102,11 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         }
 
         KafkaRoutineLoadJob kafkaRoutineLoadJob = (KafkaRoutineLoadJob) routineLoadJob;
+
+        if (kafkaRoutineLoadJob.needSchedule()) {
+            return true;
+        }
+
         Map<Integer, Long> latestOffsets = KafkaUtil.getLatestOffsets(kafkaRoutineLoadJob.getBrokerList(),
                 kafkaRoutineLoadJob.getTopic(),
                 ImmutableMap.copyOf(kafkaRoutineLoadJob.getConvertedCustomProperties()),


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/31233
This PR supports the empty kafka commit. When the routine load job is not actually scheduled more than FE config `routine_load_kafka_offset_retention_minutes`, an empty kafka commit would be launched. In this way, the consumer group of this routine load job on kafka would not be cleared.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [] 3.2
  - [] 3.1
  - [] 3.0
  - [] 2.5
