### PR TITLE
[BugFix] fix crash issue caused by RewriteSumByAssociativeRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSumByAssociativeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSumByAssociativeRule.java
@@ -306,22 +306,19 @@ public class RewriteSumByAssociativeRule extends TransformationRule {
 
         private ScalarOperator createNewAggFunction(ScalarOperator arg0, ScalarOperator arg1, Type returnType) {
             if (arg0.isConstant()) {
-                // generate count() * arg0
+                // generate count(arg1) * arg0
+                List<ScalarOperator> countArguments = Lists.newArrayList(createColumnRefForAggArgument(arg1));
+                List<Type> argTypes = Lists.newArrayList(arg1.getType());
 
                 AggregateFunction countFunction = AggregateFunction.createBuiltin(
-                        FunctionSet.COUNT, Lists.newArrayList(arg1.getType()), Type.BIGINT, Type.BIGINT,
+                        FunctionSet.COUNT, argTypes, Type.BIGINT, Type.BIGINT,
                         false, true, true);
 
-                // if arg1 is nullable, we use count(arg1), otherwise use count()
-                List<ScalarOperator> countArguments = Lists.newArrayList();
-                if (arg1.isNullable()) {
-                    countArguments.add(createColumnRefForAggArgument(arg1));
-                }
                 CallOperator newAggFunction = new CallOperator(FunctionSet.COUNT,
                         Type.BIGINT, countArguments, countFunction);
 
                 ColumnRefOperator newAggRef = columnRefFactory.create(
-                        newAggFunction, newAggFunction.getType(), true);
+                        newAggFunction, newAggFunction.getType(), false);
                 newAggregations.put(newAggRef, newAggFunction);
 
                 // cast countOperator and constOperator to target type

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1882,7 +1882,6 @@ public class AggregateTest extends PlanTestBase {
     @Test
     public void testRewriteSumByAssociativeRule() throws Exception {
         // 1. different types
-        // 1.1 nullable
         String sql = "select sum(t1b+1),sum(t1c+1),sum(t1d+1),sum(t1e+1),sum(t1f+1),sum(t1g+1),sum(id_decimal+1)" +
                 " from test_all_type";
         String plan = getVerboseExplain(sql);
@@ -1942,23 +1941,6 @@ public class AggregateTest extends PlanTestBase {
                 "  |  <slot 10> : 10: id_decimal\n" +
                 "  |  \n" +
                 "  0:OlapScanNode");
-        // 1.2 not null
-        sql = "select sum(t1b+1),sum(t1c+1),sum(t1d+1),sum(t1e+1),sum(t1f+1),sum(t1g+1),sum(id_decimal+1)" +
-                " from test_all_type_not_null";
-        plan = getVerboseExplain(sql);
-        // for each sum(col + 1), should rewrite to sum(col) + count() * 1,
-        // so count() will be a common expression
-        assertContains(plan, "  3:Project\n" +
-                "  |  output columns:\n" +
-                "  |  18 <-> [25: sum, BIGINT, true] + [40: multiply, BIGINT, true]\n" +
-                "  |  19 <-> [27: sum, BIGINT, true] + [40: multiply, BIGINT, true]\n" +
-                "  |  20 <-> [29: sum, BIGINT, true] + [40: multiply, BIGINT, true]\n" +
-                "  |  21 <-> [32: sum, DOUBLE, true] + cast([33: count, BIGINT, true] as DOUBLE) * 1.0\n" +
-                "  |  22 <-> [34: sum, DOUBLE, true] + cast([35: count, BIGINT, true] as DOUBLE) * 1.0\n" +
-                "  |  23 <-> [36: sum, BIGINT, true] + [40: multiply, BIGINT, true]\n" +
-                "  |  24 <-> [38: sum, DECIMAL128(38,2), true] + cast([35: count, BIGINT, true] as DECIMAL128(18,0)) * 1\n" +
-                "  |  common expressions:\n" +
-                "  |  40 <-> [35: count, BIGINT, true] * 1");
 
         // 2. aggregate result reuse
         sql = "select sum(t1b), sum(t1b+1), sum(t1b+2) from test_all_type";
@@ -2032,6 +2014,25 @@ public class AggregateTest extends PlanTestBase {
                 "  |  17 <-> [18: sum, BIGINT, true] + [19: count, BIGINT, true] * 2 + 1");
         assertContains(plan, "  |  group by: [3: t1c, INT, true]\n" +
                 "  |  having: [18: sum, BIGINT, true] + [19: count, BIGINT, true] * 1 > 10");
+        // 5. agg after join
+        sql = "select sum(t2.t1b+1) from test_all_type as t1 join test_all_type_not_null as t2 " +
+                "on t1.t1c = t2.t1c";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  5:AGGREGATE (update serialize)\n" +
+                "  |  aggregate: sum[([12: t1b, SMALLINT, false]); " +
+                "args: SMALLINT; result: BIGINT; args nullable: false; result nullable: true], " +
+                "count[([12: t1b, SMALLINT, false]); " +
+                "args: SMALLINT; result: BIGINT; args nullable: false; result nullable: true]");
+        sql = "select sum(t2.t1b+1) from test_all_type as t1 left outer join test_all_type_not_null as t2 " +
+                "on t1.t1c = t2.t1c";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  6:AGGREGATE (update serialize)\n" +
+                "  |  aggregate: sum[([12: t1b, SMALLINT, true]); " +
+                "args: SMALLINT; result: BIGINT; args nullable: true; result nullable: true], " +
+                "count[([12: t1b, SMALLINT, true]); " +
+                "args: SMALLINT; result: BIGINT; args nullable: true; result nullable: true]\n" +
+                "  |  hasNullableGenerateChild: true");
+
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1599,7 +1599,7 @@ public class LowCardinalityTest extends PlanTestBase {
         sql = "select max(upper(S_ADDRESS)), min(upper(S_ADDRESS)), max(S_ADDRESS), sum(S_SUPPKEY + 1) from supplier";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
-                "  |  output: max(18: upper), min(18: upper), max(17: S_ADDRESS), sum(1: S_SUPPKEY), count(*)\n" +
+                "  |  output: max(18: upper), min(18: upper), max(17: S_ADDRESS), sum(1: S_SUPPKEY), count(1: S_SUPPKEY)\n" +
                 "  |  group by: \n" +
                 "  |  \n" +
                 "  1:Project\n" +

--- a/test/sql/test_sum_rewrite/R/test_sum_rewrite
+++ b/test/sql/test_sum_rewrite/R/test_sum_rewrite
@@ -1,0 +1,79 @@
+-- name: test_rewrite_sum_by_associative_rule
+create table t0 (
+    c0 int,
+    c1 int not null
+) duplicate key(c0) distributed by hash(c0) buckets 3 properties("replication_num" = "1");
+-- result:
+-- !result
+create table t1 (
+    c0 int,
+    c1 int not null
+) duplicate key(c0) distributed by hash(c0) buckets 3 properties("replication_num" = "1");
+-- result:
+-- !result
+insert into t0 values (1,1),(2,2),(3,3);
+-- result:
+-- !result
+insert into t1 values (1,1),(2,2),(NULL,4);
+-- result:
+-- !result
+select sum(c0),sum(c0+1),sum(c0+2) from t1;
+-- result:
+3	5	7
+-- !result
+select c1, sum(c0),sum(c0+1),sum(c0+2) from t1 group by c1 order by c1;
+-- result:
+1	1	2	3
+2	2	3	4
+4	None	None	None
+-- !result
+select sum(c1),sum(c1+1),sum(c1+2) from t1;
+-- result:
+7	10	13
+-- !result
+select c0, sum(c1),sum(c1+1),sum(c1+2) from t1 group by c0 order by c0;
+-- result:
+None	4	5	6
+1	1	2	3
+2	2	3	4
+-- !result
+select sum(t0.c0+1),sum(t0.c1+1) from t0 left outer join t1 on t0.c1 = t1.c1;
+-- result:
+9	9
+-- !result
+select t1.c0,sum(t0.c0+1),sum(t0.c1+1) from t0 left outer join t1 on t0.c1 = t1.c1 group by t1.c0 order by t1.c0;
+-- result:
+None	4	4
+1	2	2
+2	3	3
+-- !result
+select sum(t1.c0+1),sum(t1.c1+1) from t0 left outer join t1 on t0.c0 = t1.c0;
+-- result:
+5	5
+-- !result
+select t0.c0,sum(t1.c0+1),sum(t1.c1+1) from t0 left outer join t1 on t0.c0 = t1.c0 group by t0.c0 order by t0.c0;
+-- result:
+1	2	2
+2	3	3
+3	None	None
+-- !result
+select sum(t0.c0+1),sum(t0.c1+1) from t0 right outer join t1 on t0.c1 = t1.c1;
+-- result:
+5	5
+-- !result
+select t1.c0,sum(t0.c0+1),sum(t0.c1+1) from t0 right outer join t1 on t0.c1 = t1.c1 group by t1.c0 order by t1.c0;
+-- result:
+None	None	None
+1	2	2
+2	3	3
+-- !result
+select sum(t1.c0+1),sum(t1.c1+1) from t0 right outer join t1 on t0.c0 = t1.c0;
+-- result:
+5	10
+-- !result
+select t0.c0,sum(t1.c0+1),sum(t1.c1+1) from t0 right outer join t1 on t0.c0 = t1.c0 group by t0.c0 order by t0.c0;
+-- result:
+None	None	5
+1	2	2
+2	3	3
+-- !result

--- a/test/sql/test_sum_rewrite/T/test_sum_rewrite
+++ b/test/sql/test_sum_rewrite/T/test_sum_rewrite
@@ -1,0 +1,29 @@
+-- name: test_rewrite_sum_by_associative_rule
+create table t0 (
+    c0 int,
+    c1 int not null
+) duplicate key(c0) distributed by hash(c0) buckets 3 properties("replication_num" = "1");
+create table t1 (
+    c0 int,
+    c1 int not null
+) duplicate key(c0) distributed by hash(c0) buckets 3 properties("replication_num" = "1");
+
+insert into t0 values (1,1),(2,2),(3,3);
+insert into t1 values (1,1),(2,2),(NULL,4);
+
+select sum(c0),sum(c0+1),sum(c0+2) from t1;
+select c1, sum(c0),sum(c0+1),sum(c0+2) from t1 group by c1 order by c1;
+select sum(c1),sum(c1+1),sum(c1+2) from t1;
+select c0, sum(c1),sum(c1+1),sum(c1+2) from t1 group by c0 order by c0;
+
+select sum(t0.c0+1),sum(t0.c1+1) from t0 left outer join t1 on t0.c1 = t1.c1;
+select t1.c0,sum(t0.c0+1),sum(t0.c1+1) from t0 left outer join t1 on t0.c1 = t1.c1 group by t1.c0 order by t1.c0;
+select sum(t1.c0+1),sum(t1.c1+1) from t0 left outer join t1 on t0.c0 = t1.c0;
+select t0.c0,sum(t1.c0+1),sum(t1.c1+1) from t0 left outer join t1 on t0.c0 = t1.c0 group by t0.c0 order by t0.c0;
+
+select sum(t0.c0+1),sum(t0.c1+1) from t0 right outer join t1 on t0.c1 = t1.c1;
+select t1.c0,sum(t0.c0+1),sum(t0.c1+1) from t0 right outer join t1 on t0.c1 = t1.c1 group by t1.c0 order by t1.c0;
+select sum(t1.c0+1),sum(t1.c1+1) from t0 right outer join t1 on t0.c0 = t1.c0;
+select t0.c0,sum(t1.c0+1),sum(t1.c1+1) from t0 right outer join t1 on t0.c0 = t1.c0 group by t0.c0 order by t0.c0;
+
+


### PR DESCRIPTION
Fixes #31277

root cause:

if arg1 is not null, we will generate an invalid AggregateFunction which the count of arg types and the count of arg expr is not matched.
![image](https://github.com/StarRocks/starrocks/assets/3675229/d4b06c71-f5b0-4a6c-ad90-4fd0d7a217b5)

besides, for `sum(col+1)`, if col is not null, we will transform it to `sum(col) + count() * 1`, but if it is an aggregation after outer join, the nullable property of col may be changed and `count()` will get a wrong result.so ,we should always rewrite it to `sum(col)+count(col)*1`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
