### PR TITLE
[Feature] Files() support columns from path

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/BrokerFileGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/BrokerFileGroup.java
@@ -143,7 +143,7 @@ public class BrokerFileGroup implements Writable {
         this.fileFieldNames = new ArrayList<>();
 
         this.columnExprList = table.getColumnExprList();
-        this.columnsFromPath = new ArrayList<>();
+        this.columnsFromPath = table.getColumnsFromPath();
     }
 
     public BrokerFileGroup(DataDescription dataDescription) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TableFunctionTableTest {
+    @Test
+    public void testNormal() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("path", "fake://some_bucket/some_path/*");
+        properties.put("format", "ORC");
+        properties.put("columns_from_path", "col_path1, col_path2,   col_path3");
+
+        Assertions.assertDoesNotThrow(() -> {
+            TableFunctionTable table = new TableFunctionTable(properties);
+            List<Column> schema = table.getFullSchema();
+            Assertions.assertEquals(5, schema.size());
+            Assertions.assertEquals(new Column("col_int", Type.INT), schema.get(0));
+            Assertions.assertEquals(new Column("col_string", Type.VARCHAR), schema.get(1));
+            Assertions.assertEquals(new Column("col_path1", ScalarType.createDefaultString(), true), schema.get(2));
+            Assertions.assertEquals(new Column("col_path2", ScalarType.createDefaultString(), true), schema.get(3));
+            Assertions.assertEquals(new Column("col_path3", ScalarType.createDefaultString(), true), schema.get(4));
+        });
+    }
+}


### PR DESCRIPTION
This PR adds the support of `columns from path` to `FILES()`. The column type inferred from the file path is in string.
```
MySQL [db0]> select * from  files("path"="hdfs://127.0.0.1:9000/column-from-path/year=2023/*/*/*","format"="parquet", "columns_from_path"="year, month, day");
+----------+------+------+-------+------+
| name     | age  | year | month | day  |
+----------+------+------+-------+------+
| mark835  |   28 | 2023 | 7     | 12   |
| jack611  |    9 | 2023 | 7     | 12   |
| alice335 |   21 | 2023 | 7     | 12   |
| jack1004 |   30 | 2023 | 7     | 12   |
| rose800  |   20 | 2023 | 7     | 12   |
| mark1021 |   14 | 2023 | 7     | 12   |
| rose305  |   27 | 2023 | 7     | 12   |
| alice387 |   37 | 2023 | 7     | 12   |
| rose312  |   10 | 2023 | 7     | 12   |
| jack841  |   22 | 2023 | 7     | 12   |
| mark835  |   28 | 2023 | 8     | 12   |
| jack611  |    9 | 2023 | 8     | 12   |
| alice335 |   21 | 2023 | 8     | 12   |
| jack1004 |   30 | 2023 | 8     | 12   |
| rose800  |   20 | 2023 | 8     | 12   |
| mark1021 |   14 | 2023 | 8     | 12   |
| rose305  |   27 | 2023 | 8     | 12   |
| alice387 |   37 | 2023 | 8     | 12   |
| rose312  |   10 | 2023 | 8     | 12   |
| jack841  |   22 | 2023 | 8     | 12   |
| mark835  |   28 | 2023 | 9     | 13   |
| jack611  |    9 | 2023 | 9     | 13   |
| alice335 |   21 | 2023 | 9     | 13   |
| jack1004 |   30 | 2023 | 9     | 13   |
| rose800  |   20 | 2023 | 9     | 13   |
| mark1021 |   14 | 2023 | 9     | 13   |
| rose305  |   27 | 2023 | 9     | 13   |
| alice387 |   37 | 2023 | 9     | 13   |
| rose312  |   10 | 2023 | 9     | 13   |
| jack841  |   22 | 2023 | 9     | 13   |
+----------+------+------+-------+------+
30 rows in set (0.044 sec)


```


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
