### PR TITLE
[Refactor] Refactoring the timing of memory release on partial column updates (backport #30683)

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -905,12 +905,13 @@ void TabletUpdates::_apply_column_partial_update_commit(const EditVersionInfo& v
             strings::Substitute("$0_$1", tablet_id, rowset->rowset_id().to_string()));
     state_entry->update_expire_time(MonotonicMillis() + manager->get_cache_expire_ms());
     // when failure happen, remove state cache and record error msg
-    auto failure_handler = [&](const std::string& str, Status st) {
-        manager->update_column_state_cache().remove(state_entry);
+    auto failure_handler = [&](const std::string& str, const Status& st) {
         std::string msg = strings::Substitute("$0: $1 $2", str, st.to_string(), debug_string());
         LOG(ERROR) << msg;
         _set_error(msg);
     };
+    // remove state entry when function end
+    DeferOp state_defer([&]() { manager->update_column_state_cache().remove(state_entry); });
     auto& state = state_entry->value();
     auto st = state.load(&_tablet, rowset.get(), manager->mem_tracker());
     manager->update_column_state_cache().update_object_size(state_entry, state.memory_usage());
@@ -924,17 +925,24 @@ void TabletUpdates::_apply_column_partial_update_commit(const EditVersionInfo& v
     auto index_entry = manager->index_cache().get_or_create(tablet_id);
     index_entry->update_expire_time(MonotonicMillis() + manager->get_cache_expire_ms());
     auto& index = index_entry->value();
+    bool enable_persistent_index = index.enable_persistent_index();
+    // release or remove index entry when function end
+    DeferOp index_defer([&]() {
+        if (enable_persistent_index ^ _tablet.get_enable_persistent_index()) {
+            manager->index_cache().remove(index_entry);
+        } else {
+            manager->index_cache().release(index_entry);
+        }
+    });
     // empty rowset does not need to load in-memory primary index, so skip it
     if (rowset->has_data_files() || _tablet.get_enable_persistent_index()) {
         auto st = index.load(&_tablet);
         manager->index_cache().update_object_size(index_entry, index.memory_usage());
         if (!st.ok()) {
-            manager->index_cache().remove(index_entry);
             failure_handler("load primary index failed", st);
             return;
         }
     }
-    bool enable_persistent_index = index.enable_persistent_index();
     PersistentIndexMetaPB index_meta;
     if (enable_persistent_index) {
         st = TabletMetaManager::get_persistent_index_meta(_tablet.data_dir(), _tablet.tablet_id(), &index_meta);
@@ -1015,13 +1023,6 @@ void TabletUpdates::_apply_column_partial_update_commit(const EditVersionInfo& v
         return;
     }
 
-    // 6. clear state and index cache
-    manager->update_column_state_cache().remove(state_entry);
-    if (enable_persistent_index ^ _tablet.get_enable_persistent_index()) {
-        manager->index_cache().remove(index_entry);
-    } else {
-        manager->index_cache().release(index_entry);
-    }
     _update_total_stats(version_info.rowsets, nullptr, nullptr);
 }
 

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -138,6 +138,10 @@ public:
         return Status::OK();
     }
 
+    // Used in UT only
+    bool TEST_update_state_exist(Tablet* tablet, Rowset* rowset);
+    bool TEST_primary_index_refcnt(int64_t tablet_id, uint32_t expected_cnt);
+
 private:
     // default 6min
     int64_t _cache_expire_ms = 360000;

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -368,6 +368,12 @@ static void prepare_tablet(RowsetColumnPartialUpdateTest* self, const TabletShar
         ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
             return (int16_t)(k1 % 100 + 1) == v1 && (int32_t)(k1 % 1000 + 2) == v2;
         }));
+        // check refcnt
+        for (const auto& rs_ptr : rowsets) {
+            ASSERT_FALSE(
+                    StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get()));
+        }
+        ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
         version_before_partial_update = version;
     }
 
@@ -390,6 +396,12 @@ static void prepare_tablet(RowsetColumnPartialUpdateTest* self, const TabletShar
         ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
             return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
         }));
+        // check refcnt
+        for (const auto& rs_ptr : rowsets) {
+            ASSERT_FALSE(
+                    StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get()));
+        }
+        ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
     }
 }
 
@@ -504,6 +516,11 @@ TEST_F(RowsetColumnPartialUpdateTest, partial_update_diff_column_and_check) {
     ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
         return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
     }));
+    // check refcnt
+    for (const auto& rs_ptr : rowsets) {
+        ASSERT_FALSE(StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get()));
+    }
+    ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
 }
 
 TEST_F(RowsetColumnPartialUpdateTest, partial_update_multi_segment_and_check) {
@@ -538,6 +555,11 @@ TEST_F(RowsetColumnPartialUpdateTest, partial_update_multi_segment_and_check) {
     ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
         return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
     }));
+    // check refcnt
+    for (const auto& rs_ptr : rowsets) {
+        ASSERT_FALSE(StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get()));
+    }
+    ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
 }
 
 TEST_F(RowsetColumnPartialUpdateTest, partial_update_multi_segment_preload_and_check) {
@@ -802,6 +824,12 @@ TEST_F(RowsetColumnPartialUpdateTest, test_upsert) {
         ASSERT_TRUE(check_tablet(tablet, version, 2 * N, [](int64_t k1, int64_t v1, int32_t v2) {
             return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
         }));
+        // check refcnt
+        for (const auto& rs_ptr : rowsets) {
+            ASSERT_FALSE(
+                    StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get()));
+        }
+        ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
     }
 }
 


### PR DESCRIPTION

Refactoring the timing of memory release on partial column updates, and also fix the potential pk index leak after an error status.

Fixes #30683

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
