### PR TITLE
[Feature] Substitute large decimal types with double/decimal (backport #31171)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -39,6 +39,8 @@ import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariableConstants;
 import com.starrocks.thrift.TColumnType;
 import com.starrocks.thrift.TScalarType;
 import com.starrocks.thrift.TTypeDesc;
@@ -190,11 +192,27 @@ public class ScalarType extends Type implements Cloneable {
     }
 
     public static ScalarType createDecimalV3Type(PrimitiveType type, int precision, int scale) {
-        Preconditions.checkArgument(0 <= precision && precision <= PrimitiveType.getMaxPrecisionOfDecimal(type),
-                "DECIMAL's precision should range from 1 to 38");
-        Preconditions.checkArgument(0 <= scale && scale <= precision,
-                "DECIMAL(P[,S]) type P must be greater than or equal to the value of S");
-
+        int maxPrecision = PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL128);
+        ConnectContext ctx = ConnectContext.get();
+        if (ctx == null ||
+                ctx.getSessionVariable() == null ||
+                ctx.getSessionVariable().getLargeDecimalUnderlyingType() == null ||
+                ctx.getSessionVariable().getLargeDecimalUnderlyingType().equals(SessionVariableConstants.PANIC)) {
+            Preconditions.checkArgument(0 <= precision &&
+                            precision <= PrimitiveType.getMaxPrecisionOfDecimal(type),
+                    "DECIMAL's precision should range from 1 to 38");
+            Preconditions.checkArgument(0 <= scale && scale <= precision,
+                    "DECIMAL(P[,S]) type P must be greater than or equal to the value of S");
+        }
+        if (precision > maxPrecision) {
+            String underlyingType = ConnectContext.get().getSessionVariable().getLargeDecimalUnderlyingType();
+            if (underlyingType.equals(SessionVariableConstants.DOUBLE)) {
+                return ScalarType.DOUBLE;
+            } else {
+                precision = maxPrecision;
+                type = PrimitiveType.DECIMAL128;
+            }
+        }
         ScalarType scalarType = new ScalarType(type);
         scalarType.precision = Math.max(precision, 1);
         scalarType.scale = scale;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -363,6 +363,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_MATERIALIZED_VIEW_REWRITE = "enable_materialized_view_rewrite";
     public static final String ENABLE_MATERIALIZED_VIEW_UNION_REWRITE = "enable_materialized_view_union_rewrite";
 
+    public static final String LARGE_DECIMAL_UNDERLYING_TYPE = "large_decimal_underlying_type";
+
     public enum MaterializedViewRewriteMode {
         DISABLE,            // disable materialized view rewrite
         DEFAULT,            // default, choose the materialized view or not by cost optimizer
@@ -1180,6 +1182,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableExprPrunePartition = true;
 
     private int exprChildrenLimit = -1;
+
+    @VarAttr(name = LARGE_DECIMAL_UNDERLYING_TYPE)
+    private String largeDecimalUnderlyingType = SessionVariableConstants.PANIC;
 
     public int getExprChildrenLimit() {
         return exprChildrenLimit;
@@ -2248,6 +2253,21 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableExprPrunePartition(boolean enableExprPrunePartition) {
         this.enableExprPrunePartition = enableExprPrunePartition;
+    }
+
+    public void setLargeDecimalUnderlyingType(String type) {
+        if (type.equalsIgnoreCase(SessionVariableConstants.PANIC) ||
+                type.equalsIgnoreCase(SessionVariableConstants.DECIMAL) ||
+                type.equalsIgnoreCase(SessionVariableConstants.DOUBLE)) {
+            largeDecimalUnderlyingType = type.toLowerCase();
+        } else {
+            throw new IllegalArgumentException(
+                    "Legal values of large_decimal_underlying_type are panic|decimal|double");
+        }
+    }
+
+    public String getLargeDecimalUnderlyingType() {
+        return largeDecimalUnderlyingType;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+public class SessionVariableConstants {
+
+    private SessionVariableConstants() {}
+
+    public static final String AUTO = "auto";
+
+    public static final String FORCE_STREAMING = "force_streaming";
+
+    public static final String FORCE_PREAGGREGATION = "force_preaggregation";
+
+    public static final String LIMITED = "limited";
+
+    public static final String PANIC = "panic";
+
+    public static final String DOUBLE = "double";
+
+    public static final String DECIMAL = "decimal";
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -19,12 +19,18 @@ import com.google.common.collect.Lists;
 import com.starrocks.analysis.CompoundPredicate;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.Pair;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.SqlModeHelper;
+import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.SelectList;
 import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.utframe.UtFrameUtils;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -116,6 +122,79 @@ class ParserTest {
     }
 
     @Test
+    void testParseLargeDecimal() {
+        String sql = "select cast(1 as decimal(65,0))";
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setThreadLocalInfo();
+        SessionVariable sessionVariable = ctx.getSessionVariable();
+        try {
+            sessionVariable.setSqlDialect("sr");
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+            Assert.fail();
+        } catch (Throwable err) {
+            Assert.assertTrue(err.getMessage().contains("DECIMAL's precision should range from 1 to 38"));
+        }
+
+        try {
+            sessionVariable.setSqlDialect("trino");
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+            Assert.fail();
+        } catch (Throwable err) {
+            Assert.assertTrue(err.getMessage().contains("DECIMAL's precision should range from 1 to 38"));
+        }
+
+        try {
+            sessionVariable.setSqlDialect("sr");
+            sessionVariable.setLargeDecimalUnderlyingType("double");
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+            Analyzer.analyze(stmt, ctx);
+            Type type = stmt.getQueryRelation().getOutputExpression().get(0).getType();
+            Assert.assertTrue(type.isDouble());
+        } catch (Throwable err) {
+            Assert.fail(err.getMessage());
+        }
+
+        try {
+            sessionVariable.setSqlDialect("trino");
+            sessionVariable.setLargeDecimalUnderlyingType("double");
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+            Analyzer.analyze(stmt, ctx);
+            Type type = stmt.getQueryRelation().getOutputExpression().get(0).getType();
+            Assert.assertTrue(type.isDouble());
+        } catch (Throwable err) {
+            Assert.fail(err.getMessage());
+        }
+
+        try {
+            sessionVariable.setSqlDialect("sr");
+            sessionVariable.setLargeDecimalUnderlyingType("decimal");
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+            Analyzer.analyze(stmt, ctx);
+            Type type = stmt.getQueryRelation().getOutputExpression().get(0).getType();
+            Assert.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
+        } catch (Throwable err) {
+            Assert.fail(err.getMessage());
+        }
+
+        try {
+            sessionVariable.setSqlDialect("trino");
+            sessionVariable.setLargeDecimalUnderlyingType("decimal");
+            QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
+            Analyzer.analyze(stmt, ctx);
+            Type type = stmt.getQueryRelation().getOutputExpression().get(0).getType();
+            Assert.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
+        } catch (Throwable err) {
+            Assert.fail(err.getMessage());
+        }
+        try {
+            sessionVariable.setLargeDecimalUnderlyingType("foobar");
+            Assert.fail();
+        } catch (Throwable error) {
+
+        }
+    }
+
+    @Test
     void testSettingSqlMode() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(2);
         Object lock = new Object();
@@ -189,5 +268,3 @@ class ParserTest {
         return sqls.stream().map(e -> Arguments.of(e.first, e.second));
     }
 }
-
-


### PR DESCRIPTION
For query such as "select cast(1.0 as decimal(65,0))" that introduces large decimal(means precision exceeds 38), parser will panic or use double|decimal(38,s) as underlying type.

Session variable  large_decimal_underlying_type ="panic"|"double"|"decimal" controls the behavior:
1. "panic",  it is current behavior,  FE panic when encountering large decimal types;
2. "double", use the double instead;
3. "decimal", use the decimal(38,s) instead.

----
Signed-off-by: satanson <ranpanf@gmail.com>

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
