### PR TITLE
[BugFix] Fix upgrade NPE bug where default value of Task is null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
@@ -72,6 +72,8 @@ public class Task implements Writable {
     @SerializedName("createUser")
     private String createUser = AuthenticationMgr.ROOT_USER;
 
+    public Task() {}
+
     public Task(String name) {
         this.name = name;
         this.createTime = System.currentTimeMillis();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskTest.java
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.authentication.AuthenticationMgr;
+import com.starrocks.persist.gson.GsonUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TaskTest {
+
+    @Test
+    public void testDeserialize() {
+        Task task = GsonUtils.GSON.fromJson("{}", Task.class);
+        Assert.assertEquals(Constants.TaskSource.CTAS, task.getSource());
+        Assert.assertEquals(AuthenticationMgr.ROOT_USER, task.getCreateUser());
+        Assert.assertEquals(Constants.TaskState.UNKNOWN, task.getState());
+        Assert.assertEquals(Constants.TaskType.MANUAL, task.getType());
+    }
+}


### PR DESCRIPTION
Fixes 
upgrade from 2.3
```java
2023-09-16 12:02:04,536 WARN (replayer|66) [GlobalStateMgr.replayJournalInner():1963] catch exception when replaying 87,
com.starrocks.journal.JournalInconsistentException: failed to load journal type 10081
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:967) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.replayJournalInner(GlobalStateMgr.java:1952) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$5.runOneCycle(GlobalStateMgr.java:1809) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:115) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$5.run(GlobalStateMgr.java:1874) ~[starrocks-fe.jar:?]
Caused by: java.lang.NullPointerException
        at com.starrocks.scheduler.TaskRunBuilder.build(TaskRunBuilder.java:37) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.TaskManager.replayCreateTaskRun(TaskManager.java:597) ~[starrocks-fe.jar:?]
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:669) ~[starrocks-fe.jar:?]
        ... 4 more
2023-09-16 12:02:04,567 WARN (replayer|66) [GlobalStateMgr$5.runOneCycle():1812] got interrupt exception or inconsistent exception when replay journal 87, will exit,
com.starrocks.journal.JournalInconsistentException: failed to load journal type 10081
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:967) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.replayJournalInner(GlobalStateMgr.java:1952) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$5.runOneCycle(GlobalStateMgr.java:1809) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:115) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$5.run(GlobalStateMgr.java:1874) ~[starrocks-fe.jar:?]
Caused by: java.lang.NullPointerException
        at com.starrocks.scheduler.TaskRunBuilder.build(TaskRunBuilder.java:37) ~[starrocks-fe.jar:?]
        at com.starrocks.scheduler.TaskManager.replayCreateTaskRun(TaskManager.java:597) ~[starrocks-fe.jar:?]
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:669) ~[starrocks-fe.jar:?]
```
The property `source` is newly added in Task, and the default value is set to `CTAS`. But the default value will be set to null when deserializing, because there is no empty constructor. To fix this bug, add the empty constructor.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
