### PR TITLE
[BugFix] fix AppIO Bytes Read exceed FSIO Bytes Read

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -328,7 +328,7 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
                 ADD_CHILD_COUNTER(_runtime_profile, "AppIOBytesRead", TUnit::BYTES, prefix);
         _profile.app_io_timer = ADD_CHILD_TIMER(_runtime_profile, "AppIOTime", prefix);
         _profile.app_io_counter = ADD_CHILD_COUNTER(_runtime_profile, "AppIOCounter", TUnit::UNIT, prefix);
-        _profile.fs_bytes_read_counter = ADD_CHILD_COUNTER(_runtime_profile, "FSBytesRead", TUnit::BYTES, prefix);
+        _profile.fs_bytes_read_counter = ADD_CHILD_COUNTER(_runtime_profile, "FSIOBytesRead", TUnit::BYTES, prefix);
         _profile.fs_io_counter = ADD_CHILD_COUNTER(_runtime_profile, "FSIOCounter", TUnit::UNIT, prefix);
         _profile.fs_io_timer = ADD_CHILD_TIMER(_runtime_profile, "FSIOTime", prefix);
     }

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -47,9 +47,13 @@ public:
     }
 
     StatusOr<std::string_view> peek(int64_t count) override {
+        if (count < 0) {
+            _stats->bytes_read += count;
+            return Status::OK();
+        }
+
         auto st = _stream->peek(count);
         if (st.ok()) {
-            _stats->io_count += 1;
             _stats->bytes_read += count;
         }
         return st;

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -21,7 +21,6 @@
 #include "util/compression/stream_compression.h"
 
 static constexpr int64_t ROW_FORMAT_ESTIMATED_MEMORY_USAGE = 32LL * 1024 * 1024;
-
 namespace starrocks {
 
 class CountedSeekableInputStream : public io::SeekableInputStreamWrapper {
@@ -47,15 +46,7 @@ public:
     }
 
     StatusOr<std::string_view> peek(int64_t count) override {
-        if (count < 0) {
-            _stats->bytes_read += count;
-            return Status::OK();
-        }
-
         auto st = _stream->peek(count);
-        if (st.ok()) {
-            _stats->bytes_read += count;
-        }
         return st;
     }
 

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -28,9 +28,6 @@
 #include "runtime/runtime_state.h"
 #include "util/runtime_profile.h"
 
-namespace starrocks::parquet {
-class FileReader;
-}
 namespace starrocks {
 
 class RuntimeFilterProbeCollector;

--- a/be/src/exec/hdfs_scanner_parquet.h
+++ b/be/src/exec/hdfs_scanner_parquet.h
@@ -17,6 +17,9 @@
 #include "exec/hdfs_scanner.h"
 
 namespace starrocks {
+namespace parquet {
+class FileReader;
+}
 
 class HdfsParquetScanner final : public HdfsScanner {
 public:

--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -46,7 +46,8 @@ Status ColumnChunkReader::init(int chunk_size) {
     }
     int64_t size = metadata().total_compressed_size;
     int64_t num_values = metadata().num_values;
-    _page_reader = std::make_unique<PageReader>(_opts.file->stream().get(), start_offset, size, num_values);
+    _stream = _opts.file->stream().get();
+    _page_reader = std::make_unique<PageReader>(_stream, start_offset, size, num_values, _opts);
 
     // seek to the first page
     RETURN_IF_ERROR(_page_reader->seek_to_offset(start_offset));
@@ -148,6 +149,7 @@ Status ColumnChunkReader::_read_and_decompress_page_data(uint32_t compressed_siz
     Slice read_data;
     auto ret = _page_reader->peek(read_size);
     if (ret.ok() && ret.value().size() == read_size) {
+        _opts.stats->bytes_read += read_size;
         // peek dos not advance offset.
         RETURN_IF_ERROR(_page_reader->skip_bytes(read_size));
         read_data = Slice(ret.value().data(), read_size);

--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -47,7 +47,7 @@ Status ColumnChunkReader::init(int chunk_size) {
     int64_t size = metadata().total_compressed_size;
     int64_t num_values = metadata().num_values;
     _stream = _opts.file->stream().get();
-    _page_reader = std::make_unique<PageReader>(_stream, start_offset, size, num_values, _opts);
+    _page_reader = std::make_unique<PageReader>(_stream, start_offset, size, num_values, _opts.stats);
 
     // seek to the first page
     RETURN_IF_ERROR(_page_reader->seek_to_offset(start_offset));

--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -138,6 +138,7 @@ private:
     const ColumnReaderOptions& _opts;
     std::unique_ptr<PageReader> _page_reader;
     const BlockCompressionCodec* _compress_codec = nullptr;
+    io::SeekableInputStream* _stream;
 
     LevelDecoder _def_level_decoder;
     LevelDecoder _rep_level_decoder;

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -29,8 +29,8 @@ static constexpr size_t kDefaultPageHeaderSize = 16 * 1024;
 static constexpr size_t kMaxPageHeaderSize = 16 * 1024 * 1024;
 
 PageReader::PageReader(io::SeekableInputStream* stream, uint64_t start_offset, uint64_t length, uint64_t num_values,
-                       const ColumnReaderOptions& opts)
-        : _stream(stream), _finish_offset(start_offset + length), _num_values_total(num_values), _opts(opts) {}
+                       HdfsScanStats* stats)
+        : _stream(stream), _finish_offset(start_offset + length), _num_values_total(num_values), _stats(stats) {}
 
 Status PageReader::next_header() {
     if (_offset != _next_header_pos) {
@@ -70,7 +70,7 @@ Status PageReader::next_header() {
                 page_buf = page_buffer.data();
                 st = _stream->peek(allowed_page_size);
                 if (st.ok()) {
-                    _opts.stats->bytes_read -= allowed_page_size;
+                    _stats->bytes_read -= allowed_page_size;
                     peek_mode = true;
                 }
             }
@@ -81,7 +81,7 @@ Status PageReader::next_header() {
 
         if (st.ok()) {
             if (peek_mode) {
-                _opts.stats->bytes_read += header_length;
+                _stats->bytes_read += header_length;
             }
             break;
         }

--- a/be/src/formats/parquet/page_reader.h
+++ b/be/src/formats/parquet/page_reader.h
@@ -22,10 +22,13 @@
 
 namespace starrocks::parquet {
 
+class ColumnReaderOptions;
+
 // Used to parse page header of column chunk. This class don't parse page's type.
 class PageReader {
 public:
-    PageReader(io::SeekableInputStream* stream, size_t start, size_t length, size_t num_values);
+    PageReader(io::SeekableInputStream* stream, size_t start, size_t length, size_t num_values,
+               const ColumnReaderOptions& opts);
 
     ~PageReader() = default;
 
@@ -70,6 +73,7 @@ private:
 
     uint64_t _num_values_read = 0;
     const uint64_t _num_values_total = 0;
+    const ColumnReaderOptions& _opts;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/page_reader.h
+++ b/be/src/formats/parquet/page_reader.h
@@ -20,15 +20,15 @@
 #include "gen_cpp/parquet_types.h"
 #include "io/seekable_input_stream.h"
 
+namespace starrocks {
+class HdfsScanStats;
+}
 namespace starrocks::parquet {
-
-class ColumnReaderOptions;
 
 // Used to parse page header of column chunk. This class don't parse page's type.
 class PageReader {
 public:
-    PageReader(io::SeekableInputStream* stream, size_t start, size_t length, size_t num_values,
-               const ColumnReaderOptions& opts);
+    PageReader(io::SeekableInputStream* stream, size_t start, size_t length, size_t num_values, HdfsScanStats* stats);
 
     ~PageReader() = default;
 
@@ -73,7 +73,7 @@ private:
 
     uint64_t _num_values_read = 0;
     const uint64_t _num_values_total = 0;
-    const ColumnReaderOptions& _opts;
+    HdfsScanStats* _stats;
 };
 
 } // namespace starrocks::parquet

--- a/be/test/formats/parquet/page_reader_test.cpp
+++ b/be/test/formats/parquet/page_reader_test.cpp
@@ -18,12 +18,12 @@
 
 #include <iostream>
 
+#include "exec/hdfs_scanner.h"
 #include "fs/fs_memory.h"
 #include "gen_cpp/parquet_types.h"
 #include "io/shared_buffered_input_stream.h"
 #include "io/string_input_stream.h"
 #include "util/thrift_util.h"
-
 namespace starrocks::parquet {
 
 class ParquetPageReaderTest : public testing::Test {
@@ -34,6 +34,7 @@ public:
 
 TEST_F(ParquetPageReaderTest, Normal) {
     std::string buffer;
+    HdfsScanStats stats;
 
     std::vector<uint8_t> read_buffer;
     read_buffer.reserve(1024);
@@ -80,7 +81,7 @@ TEST_F(ParquetPageReaderTest, Normal) {
 
     io::SharedBufferedInputStream stream(file.stream(), file.filename(), file.get_size().value());
 
-    PageReader reader(&stream, 0, total_size, 30);
+    PageReader reader(&stream, 0, total_size, 30, &stats);
 
     // read page 1
     auto st = reader.next_header();
@@ -106,6 +107,7 @@ TEST_F(ParquetPageReaderTest, Normal) {
 
 TEST_F(ParquetPageReaderTest, ExtraBytes) {
     std::string buffer;
+    HdfsScanStats stats;
 
     std::vector<uint8_t> read_buffer;
     read_buffer.reserve(1024);
@@ -154,7 +156,7 @@ TEST_F(ParquetPageReaderTest, ExtraBytes) {
 
     io::SharedBufferedInputStream stream(file.stream(), file.filename(), file.get_size().value());
 
-    PageReader reader(&stream, 0, total_size, 30);
+    PageReader reader(&stream, 0, total_size, 30, &stats);
 
     // read page 1
     auto st = reader.next_header();


### PR DESCRIPTION
Fixes #issue

It's about the `parse_header` part. Since we don't know the exact size of this header, we initially read 64KB and double it if necessary. However, in practice:
- If the actual header is only 20KB, then the app ends up reading an extra 44KB.
- If the 64KB header isn't sufficient, then the app ends up reading an additional 64KB in one go.

So, this can easily lead to the app reading more than it needs to.

![9da2c39e-fc88-41f1-87ff-846b24a1934c](https://github.com/StarRocks/starrocks/assets/1081215/02fb1bf3-5453-4d20-a854-45cb05cdc3f0)


And fix this problem, we have to check
- when `read_at_fully` from stream, is this data already in shared buffer
- if not, it means shared buffer does not hold data. Means it actually trigger FS read
- otherwise, it means we only need to read data that we need (thrift header length)


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
