### PR TITLE
[Refactor] Replan the insert to get rid of the metadata inconsistent between plan() and beginTransaction()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2444,4 +2444,7 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static long mv_plan_cache_max_size = 1000;
+
+    @ConfField(mutable = true)
+    public static boolean replan_on_insert = false;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -203,7 +203,7 @@ public class Coordinator {
     private PQueryStatistics auditStatistics;
 
     private Supplier<RuntimeProfile> topProfileSupplier;
-    private ExecPlan execPlanSupplier;
+    private ExecPlan execPlan;
     private final AtomicLong lastRuntimeProfileUpdateTime = new AtomicLong(System.currentTimeMillis());
 
     // only used for sync stream load profile
@@ -487,8 +487,8 @@ public class Coordinator {
         this.topProfileSupplier = topProfileSupplier;
     }
 
-    public void setExecPlanSupplier(ExecPlan execPlanSupplier) {
-        this.execPlanSupplier = execPlanSupplier;
+    public void setExecPlan(ExecPlan execPlan) {
+        this.execPlan = execPlan;
     }
 
     public boolean isUsingBackend(Long backendID) {
@@ -1531,7 +1531,7 @@ public class Coordinator {
         // current batch, the previous reported state will be synchronized to the profile manager.
         long now = System.currentTimeMillis();
         long lastTime = lastRuntimeProfileUpdateTime.get();
-        if (topProfileSupplier != null && execPlanSupplier != null && connectContext != null &&
+        if (topProfileSupplier != null && execPlan != null && connectContext != null &&
                 connectContext.getSessionVariable().isEnableProfile() &&
                 // If it's the last done report, avoiding duplicate trigger
                 (!execState.done || profileDoneSignal.getLeftMarks().size() > 1) &&
@@ -1539,7 +1539,7 @@ public class Coordinator {
                 now - lastTime > (connectContext.getSessionVariable().getRuntimeProfileReportInterval() * 950L) &&
                 lastRuntimeProfileUpdateTime.compareAndSet(lastTime, now)) {
             RuntimeProfile profile = topProfileSupplier.get();
-            ExecPlan plan = execPlanSupplier;
+            ExecPlan plan = execPlan;
             profile.addChild(buildMergedQueryProfile());
             ProfilingExecPlan profilingPlan = plan == null ? null : plan.getProfilingPlan();
             ProfileManager.getInstance().pushProfile(profilingPlan, profile);
@@ -1913,8 +1913,8 @@ public class Coordinator {
         Counter querySpillBytes = newQueryProfile.addCounter("QuerySpillBytes", TUnit.BYTES, null);
         querySpillBytes.setValue(maxQuerySpillBytes);
 
-        if (execPlanSupplier != null) {
-            newQueryProfile.addInfoString("Topology", execPlanSupplier.getProfilingPlan().toTopologyJson());
+        if (execPlan != null) {
+            newQueryProfile.addInfoString("Topology", execPlan.getProfilingPlan().toTopologyJson());
         }
         Counter processTimer =
                 newQueryProfile.addCounter("FrontendProfileMergeTime", TUnit.TIME_NS, null);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/Coordinator.java
@@ -203,7 +203,7 @@ public class Coordinator {
     private PQueryStatistics auditStatistics;
 
     private Supplier<RuntimeProfile> topProfileSupplier;
-    private Supplier<ExecPlan> execPlanSupplier;
+    private ExecPlan execPlanSupplier;
     private final AtomicLong lastRuntimeProfileUpdateTime = new AtomicLong(System.currentTimeMillis());
 
     // only used for sync stream load profile
@@ -487,7 +487,7 @@ public class Coordinator {
         this.topProfileSupplier = topProfileSupplier;
     }
 
-    public void setExecPlanSupplier(Supplier<ExecPlan> execPlanSupplier) {
+    public void setExecPlanSupplier(ExecPlan execPlanSupplier) {
         this.execPlanSupplier = execPlanSupplier;
     }
 
@@ -1539,7 +1539,7 @@ public class Coordinator {
                 now - lastTime > (connectContext.getSessionVariable().getRuntimeProfileReportInterval() * 950L) &&
                 lastRuntimeProfileUpdateTime.compareAndSet(lastTime, now)) {
             RuntimeProfile profile = topProfileSupplier.get();
-            ExecPlan plan = execPlanSupplier.get();
+            ExecPlan plan = execPlanSupplier;
             profile.addChild(buildMergedQueryProfile());
             ProfilingExecPlan profilingPlan = plan == null ? null : plan.getProfilingPlan();
             ProfileManager.getInstance().pushProfile(profilingPlan, profile);
@@ -1914,7 +1914,7 @@ public class Coordinator {
         querySpillBytes.setValue(maxQuerySpillBytes);
 
         if (execPlanSupplier != null) {
-            newQueryProfile.addInfoString("Topology", execPlanSupplier.get().getProfilingPlan().toTopologyJson());
+            newQueryProfile.addInfoString("Topology", execPlanSupplier.getProfilingPlan().toTopologyJson());
         }
         Counter processTimer =
                 newQueryProfile.addCounter("FrontendProfileMergeTime", TUnit.TIME_NS, null);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1625,7 +1625,9 @@ public class StmtExecutor {
             // So we need to get txn first, to make the dropping tablet procedure to wait.
             // This is the re-plan of the insert to fix the issue
 
-            execPlan = StatementPlanner.plan(stmt, context);
+            if (Config.replan_on_insert) {
+                execPlan = StatementPlanner.plan(stmt, context);
+            }
 
             // add table indexes to transaction state
             txnState = GlobalStateMgr.getCurrentGlobalTransactionMgr()

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1619,6 +1619,7 @@ public class StmtExecutor {
                             FrontendOptions.getLocalHostAddress()),
                     sourceType,
                     context.getSessionVariable().getQueryTimeoutS());
+            execPlan = StatementPlanner.plan(stmt, context);
 
             // add table indexes to transaction state
             txnState = GlobalStateMgr.getCurrentGlobalTransactionMgr()
@@ -1700,7 +1701,7 @@ public class StmtExecutor {
             QeProcessorImpl.INSTANCE.registerQuery(context.getExecutionId(), queryInfo);
             coord.exec();
             coord.setTopProfileSupplier(this::buildTopLevelProfile);
-            coord.setExecPlanSupplier(() -> execPlan);
+            coord.setExecPlanSupplier(execPlan);
 
             long jobDeadLineMs = System.currentTimeMillis() + context.getSessionVariable().getQueryTimeoutS() * 1000;
             coord.join(context.getSessionVariable().getQueryTimeoutS());


### PR DESCRIPTION
The metadata may be changed between plan() and beginTransaction(). When to beginTransaction(), the plan is not ready and the tablet is dropped by balanced. So we need to get txn first, to make the dropping tablet procedure to wait.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
