### PR TITLE
[BugFix] Analyze non-function partition exprs in ExpressionRangePartitionInfo in deserialize

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.SlotRef;
@@ -33,13 +34,19 @@ import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PartitionExprAnalyzer;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.parser.SqlParser;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * ExpressionRangePartitionInfo replace columns with expressions
@@ -49,6 +56,9 @@ import static java.util.stream.Collectors.toList;
  */
 @Deprecated
 public class ExpressionRangePartitionInfo extends RangePartitionInfo implements GsonPreProcessable, GsonPostProcessable {
+
+    private static final Logger LOG = LogManager.getLogger(ExpressionRangePartitionInfo.class);
+
     public static final String AUTOMATIC_SHADOW_PARTITION_NAME = "$shadow_automatic_partition";
     public static final String SHADOW_PARTITION_PREFIX = "$";
 
@@ -83,19 +93,30 @@ public class ExpressionRangePartitionInfo extends RangePartitionInfo implements 
             }
         }
 
+        // Analyze partition expr
+        Map<String, Column> partitionNameColumnMap = partitionColumns.stream()
+                .collect(toMap(x -> x.getName(), Function.identity(), (e1, e2) -> e1, CaseInsensitiveMap::new));
+        SlotRef slotRef;
         for (Expr expr : partitionExprs) {
             if (expr instanceof FunctionCallExpr) {
-                SlotRef slotRef = AnalyzerUtils.getSlotRefFromFunctionCall(expr);
-                // TODO: Later, for automatically partitioned tables,
-                //  partitions of materialized views (also created automatically),
-                //  and partition by expr tables will use ExpressionRangePartitionInfoV2
-                for (Column partitionColumn : partitionColumns) {
-                    if (slotRef.getColumnName().equalsIgnoreCase(partitionColumn.getName())) {
-                        slotRef.setType(partitionColumn.getType());
-                        slotRef.setNullable(partitionColumn.isAllowNull());
-                        PartitionExprAnalyzer.analyzePartitionExpr(expr, slotRef);
-                    }
-                }
+                slotRef = AnalyzerUtils.getSlotRefFromFunctionCall(expr);
+            } else if (expr instanceof CastExpr) {
+                slotRef = AnalyzerUtils.getSlotRefFromCast(expr);
+            } else if (expr instanceof SlotRef) {
+                slotRef = (SlotRef) expr;
+            } else {
+                LOG.warn("Unknown expr type: {}", expr.toSql());
+                continue;
+            }
+
+            // TODO: Later, for automatically partitioned tables,
+            //  partitions of materialized views (also created automatically),
+            //  and partition by expr tables will use ExpressionRangePartitionInfoV2
+            if (partitionNameColumnMap.containsKey(slotRef.getColumnName())) {
+                Column partitionColumn = partitionNameColumnMap.get(slotRef.getColumnName());
+                slotRef.setType(partitionColumn.getType());
+                slotRef.setNullable(partitionColumn.isAllowNull());
+                PartitionExprAnalyzer.analyzePartitionExpr(expr, slotRef);
             }
         }
         this.partitionExprs = partitionExprs;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
@@ -440,7 +440,7 @@ public class ExpressionRangePartitionInfoTest {
     }
 
     @Test
-    public void testExpressionRangePartitionInfoSerialized() throws Exception {
+    public void testExpressionRangePartitionInfoSerialized_FunctionExpr() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE table_hitcount (\n" +
                 "databaseName varchar(200) NULL COMMENT \"\",\n" +
@@ -480,6 +480,52 @@ public class ExpressionRangePartitionInfoTest {
         List<Expr> readPartitionExprs = expressionRangePartitionInfo.getPartitionExprs();
         Function fn = readPartitionExprs.get(0).getFn();
         Assert.assertNotNull(fn);
+        starRocksAssert.dropTable("table_hitcount");
     }
 
+    @Test
+    public void testExpressionRangePartitionInfoSerialized_SlotRef() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE test_table (\n" +
+                "databaseName varchar(200) NULL COMMENT \"\",\n" +
+                "tableName varchar(200) NULL COMMENT \"\",\n" +
+                "queryTime varchar(50) NULL COMMENT \"\",\n" +
+                "queryId varchar(50) NULL COMMENT \"\",\n" +
+                "dt date NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(databaseName, tableName)\n" +
+                "PARTITION BY RANGE (`dt`)\n" +
+                "(\n" +
+                "    PARTITION p1 values less than('2021-02-01'),\n" +
+                "    PARTITION p2 values less than('2021-03-01')\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(databaseName) BUCKETS 1\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+
+        starRocksAssert.withMaterializedView("create materialized view test_mv1 " +
+                " DISTRIBUTED BY HASH(dt, queryId) BUCKETS 4\n" +
+                " PARTITION BY dt\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") as select dt, queryId, count(1) from test_table group by dt, queryId"
+        );
+        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        Table table = db.getTable("test_mv1");
+        // serialize
+        String json = GsonUtils.GSON.toJson(table);
+        // deserialize
+        OlapTable readTable = GsonUtils.GSON.fromJson(json, OlapTable.class);
+        ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) readTable.getPartitionInfo();
+        List<Expr> readPartitionExprs = expressionRangePartitionInfo.getPartitionExprs();
+        Assert.assertTrue(readPartitionExprs.get(0) instanceof SlotRef);
+        SlotRef slotRef = (SlotRef)  readPartitionExprs.get(0);
+        Assert.assertTrue(!slotRef.getType().isInvalid());
+        Assert.assertTrue(slotRef.getType().isDateType());
+        starRocksAssert.dropMaterializedView("test_mv1");
+        starRocksAssert.dropTable("test_table");
+    }
 }


### PR DESCRIPTION
Fixes #31354
- Slot ref should be analyzed in ExpressionRangePartitionInfo in deserialize, otherwise, the type will be invalid

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
