### PR TITLE
[BugFix] Unmatched tablet schema

### DIFF
--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -448,9 +448,9 @@ TEST_F(LakeTabletManagerTest, create_from_base_tablet) {
         ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(65536));
         ASSIGN_OR_ABORT(auto schema, tablet.get_schema());
         ASSERT_EQ(0, schema->column(0).unique_id());
-        ASSERT_EQ(3, schema->column(1).unique_id());
-        ASSERT_EQ(1, schema->column(2).unique_id());
-        ASSERT_EQ(2, schema->column(3).unique_id());
+        ASSERT_EQ(1, schema->column(1).unique_id());
+        ASSERT_EQ(2, schema->column(2).unique_id());
+        ASSERT_EQ(3, schema->column(3).unique_id());
         ASSERT_EQ(4, schema->next_column_unique_id());
 
         ASSERT_EQ("c0", schema->column(0).name());
@@ -491,9 +491,9 @@ TEST_F(LakeTabletManagerTest, create_from_base_tablet) {
         ASSIGN_OR_ABORT(auto tablet, _tablet_manager->get_tablet(65537));
         ASSIGN_OR_ABORT(auto schema, tablet.get_schema());
         ASSERT_EQ(0, schema->column(0).unique_id());
-        ASSERT_EQ(3, schema->column(1).unique_id());
+        ASSERT_EQ(1, schema->column(1).unique_id());
         ASSERT_EQ(2, schema->column(2).unique_id());
-        ASSERT_EQ(4, schema->next_column_unique_id());
+        ASSERT_EQ(3, schema->next_column_unique_id());
 
         ASSERT_EQ("c0", schema->column(0).name());
         ASSERT_EQ("c3", schema->column(1).name());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -340,16 +340,13 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                             throw new AlterCancelException("No alive backend");
                         }
                         countDownLatch.addMark(backendId, shadowTabletId);
+                        // No need to set base tablet id for CreateReplicaTask
                         CreateReplicaTask createReplicaTask = new CreateReplicaTask(backendId, dbId, tableId, partitionId,
                                 shadowIdxId, shadowTabletId, shadowShortKeyColumnCount, 0, Partition.PARTITION_INIT_VERSION,
                                 originKeysType, TStorageType.COLUMN, storageMedium, copiedShadowSchema, bfColumns, bfFpp,
                                 countDownLatch, indexes, table.isInMemory(), table.enablePersistentIndex(), 
                                 table.primaryIndexCacheExpireSec(), TTabletType.TABLET_TYPE_LAKE, table.getCompressionType(), 
                                 copiedSortKeyIdxes);
-
-                        Long baseTabletId = partitionIndexTabletMap.row(partitionId).get(shadowIdxId).get(shadowTabletId);
-                        assert baseTabletId != null;
-                        createReplicaTask.setBaseTablet(baseTabletId, 0/*unused*/);
                         batchTask.addTask(createReplicaTask);
                     }
                 }


### PR DESCRIPTION
Ignore base_tablet_id when create tablet to guarantee schema consistency. 

if column unique ids were set for new tablets based on the base tablet
like in share-nothing tables during schema change, these tablets created
from the base tablet would end up with different column unique ids
compared to tablets created after schema change ends. This is because
tablets created after schema change do not have a base tablet.
This may lead to inconsistency between tablet schema and the schema file.
Inconsistency between the tablet schema and schema file may result in
reading incorrect column data when loading segment files. This could
lead to wrong query results or process crashes.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
