### PR TITLE
[Enhancement] Refine profile to support visualization refactor(4)

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -27,9 +27,8 @@ Status ExchangeMergeSortSourceOperator::prepare(RuntimeState* state) {
     auto query_statistic_recv = state->query_recv();
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
-            config::exchg_node_buffer_size_bytes, _unique_metrics, true, query_statistic_recv, true,
-            // ExchangeMergeSort will never perform pipeline level shuffle
-            DataStreamRecvr::INVALID_DOP_FOR_NON_PIPELINE_LEVEL_SHUFFLE, true);
+            config::exchg_node_buffer_size_bytes, true, query_statistic_recv, true, 1, true);
+    _stream_recvr->bind_profile(_driver_sequence, _unique_metrics.get());
     return _stream_recvr->create_merger_for_pipeline(state, _sort_exec_exprs, &_is_asc_order, &_nulls_first);
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.h
@@ -100,7 +100,7 @@ public:
 
     void close(RuntimeState* state) override;
 
-    DataStreamRecvr* get_stream_recvr(RuntimeState* state, const std::shared_ptr<RuntimeProfile>& profile);
+    DataStreamRecvr* get_stream_recvr(RuntimeState* state);
     merge_path::MergePathCascadeMerger* get_merge_path_merger(RuntimeState* state);
     void close_stream_recvr();
 

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -203,6 +203,7 @@ Status ExchangeSinkOperator::Channel::add_rows_selective(Chunk* chunk, int32_t d
     {
         SCOPED_TIMER(_parent->_shuffle_chunk_append_timer);
         _chunks[driver_sequence]->append_selective(*chunk, indexes, from, size);
+        COUNTER_UPDATE(_parent->_shuffle_chunk_append_counter, 1);
     }
     return Status::OK();
 }
@@ -448,6 +449,7 @@ Status ExchangeSinkOperator::prepare(RuntimeState* state) {
 
     _serialize_chunk_timer = ADD_TIMER(_unique_metrics, "SerializeChunkTime");
     _shuffle_hash_timer = ADD_TIMER(_unique_metrics, "ShuffleHashTime");
+    _shuffle_chunk_append_counter = ADD_COUNTER(_unique_metrics, "ShuffleChunkAppendCounter", TUnit::UNIT);
     _shuffle_chunk_append_timer = ADD_TIMER(_unique_metrics, "ShuffleChunkAppendTime");
     _compress_timer = ADD_TIMER(_unique_metrics, "CompressTime");
     _pass_through_buffer_peak_mem_usage = _unique_metrics->AddHighWaterMarkCounter(

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -174,6 +174,7 @@ private:
 
     RuntimeProfile::Counter* _serialize_chunk_timer = nullptr;
     RuntimeProfile::Counter* _shuffle_hash_timer = nullptr;
+    RuntimeProfile::Counter* _shuffle_chunk_append_counter = nullptr;
     RuntimeProfile::Counter* _shuffle_chunk_append_timer = nullptr;
     RuntimeProfile::Counter* _compress_timer = nullptr;
     RuntimeProfile::Counter* _bytes_pass_through_counter = nullptr;

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.h
@@ -174,6 +174,7 @@ private:
 
     RuntimeProfile::Counter* _serialize_chunk_timer = nullptr;
     RuntimeProfile::Counter* _shuffle_hash_timer = nullptr;
+    RuntimeProfile::Counter* _shuffle_chunk_append_timer = nullptr;
     RuntimeProfile::Counter* _compress_timer = nullptr;
     RuntimeProfile::Counter* _bytes_pass_through_counter = nullptr;
     RuntimeProfile::Counter* _sender_input_bytes_counter = nullptr;

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -23,7 +23,8 @@
 namespace starrocks::pipeline {
 Status ExchangeSourceOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(SourceOperator::prepare(state));
-    _stream_recvr = static_cast<ExchangeSourceOperatorFactory*>(_factory)->create_stream_recvr(state, _unique_metrics);
+    _stream_recvr = static_cast<ExchangeSourceOperatorFactory*>(_factory)->create_stream_recvr(state);
+    _stream_recvr->bind_profile(_driver_sequence, _unique_metrics.get());
     return Status::OK();
 }
 
@@ -50,16 +51,15 @@ StatusOr<ChunkPtr> ExchangeSourceOperator::pull_chunk(RuntimeState* state) {
     return std::move(chunk);
 }
 
-std::shared_ptr<DataStreamRecvr> ExchangeSourceOperatorFactory::create_stream_recvr(
-        RuntimeState* state, const std::shared_ptr<RuntimeProfile>& profile) {
+std::shared_ptr<DataStreamRecvr> ExchangeSourceOperatorFactory::create_stream_recvr(RuntimeState* state) {
     if (_stream_recvr != nullptr) {
         return _stream_recvr;
     }
     auto query_statistic_recv = state->query_recv();
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
-            config::exchg_node_buffer_size_bytes, profile, false, query_statistic_recv, true, _degree_of_parallelism,
-            false);
+            config::exchg_node_buffer_size_bytes, false, query_statistic_recv, true, _degree_of_parallelism, false);
+
     return _stream_recvr;
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.h
@@ -65,8 +65,7 @@ public:
     bool could_local_shuffle() const override;
     TPartitionType::type partition_type() const override;
 
-    std::shared_ptr<DataStreamRecvr> create_stream_recvr(RuntimeState* state,
-                                                         const std::shared_ptr<RuntimeProfile>& profile);
+    std::shared_ptr<DataStreamRecvr> create_stream_recvr(RuntimeState* state);
     void close_stream_recvr();
 
     SourceOperatorFactory::AdaptiveState adaptive_state() const override { return AdaptiveState::ACTIVE; }

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -157,12 +157,10 @@ void SinkBuffer::update_profile(RuntimeProfile* profile) {
     COUNTER_SET(bytes_sent_counter, _bytes_sent);
     COUNTER_SET(request_sent_counter, _request_sent);
 
-    if (_bytes_enqueued - _bytes_sent > 0) {
-        auto* bytes_unsent_counter = ADD_COUNTER(profile, "BytesUnsent", TUnit::BYTES);
-        auto* request_unsent_counter = ADD_COUNTER(profile, "RequestUnsent", TUnit::UNIT);
-        COUNTER_SET(bytes_unsent_counter, _bytes_enqueued - _bytes_sent);
-        COUNTER_SET(request_unsent_counter, _request_enqueued - _request_sent);
-    }
+    auto* bytes_unsent_counter = ADD_COUNTER(profile, "BytesUnsent", TUnit::BYTES);
+    auto* request_unsent_counter = ADD_COUNTER(profile, "RequestUnsent", TUnit::UNIT);
+    COUNTER_SET(bytes_unsent_counter, _bytes_enqueued - _bytes_sent);
+    COUNTER_SET(request_unsent_counter, _request_enqueued - _request_sent);
 
     profile->add_derived_counter(
             "NetworkBandwidth", TUnit::BYTES_PER_SECOND,

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -57,16 +57,15 @@ inline uint32_t DataStreamMgr::get_bucket(const TUniqueId& fragment_instance_id)
 
 std::shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(
         RuntimeState* state, const RowDescriptor& row_desc, const TUniqueId& fragment_instance_id,
-        PlanNodeId dest_node_id, int num_senders, int buffer_size, const std::shared_ptr<RuntimeProfile>& profile,
-        bool is_merging, std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr, bool is_pipeline,
+        PlanNodeId dest_node_id, int num_senders, int buffer_size, bool is_merging,
+        std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr, bool is_pipeline,
         int32_t degree_of_parallelism, bool keep_order) {
-    DCHECK(profile != nullptr);
     VLOG_FILE << "creating receiver for fragment=" << fragment_instance_id << ", node=" << dest_node_id;
     PassThroughChunkBuffer* pass_through_chunk_buffer = get_pass_through_chunk_buffer(state->query_id());
     DCHECK(pass_through_chunk_buffer != nullptr);
     std::shared_ptr<DataStreamRecvr> recvr(
             new DataStreamRecvr(this, state, row_desc, fragment_instance_id, dest_node_id, num_senders, is_merging,
-                                buffer_size, profile, std::move(sub_plan_query_statistics_recvr), is_pipeline,
+                                buffer_size, std::move(sub_plan_query_statistics_recvr), is_pipeline,
                                 degree_of_parallelism, keep_order, pass_through_chunk_buffer));
 
     uint32_t bucket = get_bucket(fragment_instance_id);

--- a/be/src/runtime/data_stream_mgr.h
+++ b/be/src/runtime/data_stream_mgr.h
@@ -93,8 +93,7 @@ public:
     // caller.
     std::shared_ptr<DataStreamRecvr> create_recvr(RuntimeState* state, const RowDescriptor& row_desc,
                                                   const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id,
-                                                  int num_senders, int buffer_size,
-                                                  const std::shared_ptr<RuntimeProfile>& profile, bool is_merging,
+                                                  int num_senders, int buffer_size, bool is_merging,
                                                   std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr,
                                                   bool is_pipeline, int32_t degree_of_parallelism, bool keep_order);
 

--- a/be/src/runtime/data_stream_recvr.cpp
+++ b/be/src/runtime/data_stream_recvr.cpp
@@ -209,8 +209,7 @@ void DataStreamRecvr::bind_profile(int32_t driver_sequence, RuntimeProfile* prof
     statistics.deserialize_chunk_timer = ADD_TIMER(profile, "DeserializeChunkTime");
     statistics.decompress_chunk_timer = ADD_TIMER(profile, "DecompressChunkTime");
     statistics.process_total_timer = ADD_TIMER(profile, "ReceiverProcessTotalTime");
-    statistics.sender_total_timer = ADD_TIMER(profile, "SenderTotalTime");
-    statistics.sender_wait_lock_timer = ADD_TIMER(profile, "SenderWaitLockTime");
+    statistics.wait_lock_timer = ADD_TIMER(profile, "WaitLockTime");
     statistics.buffer_unplug_counter = ADD_COUNTER(profile, "BufferUnplugCount", TUnit::UNIT);
     statistics.peak_buffer_mem_bytes = profile->AddHighWaterMarkCounter(
             "PeakBufferMemoryBytes", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TUnit::BYTES));
@@ -243,7 +242,6 @@ Status DataStreamRecvr::add_chunks(const PTransmitChunkParams& request, ::google
 
     auto& metrics = get_metrics_round_robin();
     SCOPED_TIMER(metrics.process_total_timer);
-    SCOPED_TIMER(metrics.sender_total_timer);
     COUNTER_UPDATE(metrics.request_received_counter, 1);
     int use_sender_id = _is_merging ? request.sender_id() : 0;
     // Add all batches to the same queue if _is_merging is false.

--- a/be/src/runtime/data_stream_recvr.cpp
+++ b/be/src/runtime/data_stream_recvr.cpp
@@ -273,7 +273,12 @@ void DataStreamRecvr::close() {
     _chunks_merger.reset();
     _cascade_merger.reset();
 
-    _closure_block_timer->update(_closure_block_timer->value() / std::max(1, _degree_of_parallelism));
+    ADD_CHILD_TIMER(_profile, "ClosureBlockTimeAvg", "ClosureBlockTime")
+            ->update(_closure_block_timer->value() / std::max(1, _degree_of_parallelism));
+    ADD_CHILD_TIMER(_profile, "DeserializeChunkTimeAvg", "DeserializeChunkTime")
+            ->update(_deserialize_chunk_timer->value() / std::max(1, _degree_of_parallelism));
+    ADD_CHILD_TIMER(_profile, "DecompressChunkTimeAvg", "DecompressChunkTime")
+            ->update(_decompress_chunk_timer->value() / std::max(1, _degree_of_parallelism));
     _close = true;
 }
 

--- a/be/src/runtime/data_stream_recvr.cpp
+++ b/be/src/runtime/data_stream_recvr.cpp
@@ -64,8 +64,8 @@ using std::make_pair;
 
 namespace starrocks {
 
-Status DataStreamRecvr::create_merger(RuntimeState* state, const SortExecExprs* exprs, const std::vector<bool>* is_asc,
-                                      const std::vector<bool>* is_null_first) {
+Status DataStreamRecvr::create_merger(RuntimeState* state, RuntimeProfile* profile, const SortExecExprs* exprs,
+                                      const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first) {
     DCHECK(_is_merging);
     _chunks_merger = std::make_unique<SortedChunksMerger>(state, _keep_order);
     ChunkSuppliers chunk_suppliers;
@@ -89,7 +89,7 @@ Status DataStreamRecvr::create_merger(RuntimeState* state, const SortExecExprs* 
 
     RETURN_IF_ERROR(_chunks_merger->init(chunk_suppliers, chunk_probe_suppliers, chunk_has_suppliers,
                                          &(exprs->lhs_ordering_expr_ctxs()), is_asc, is_null_first));
-    _chunks_merger->set_profile(_profile.get());
+    _chunks_merger->set_profile(profile);
     return Status::OK();
 }
 
@@ -153,7 +153,7 @@ std::vector<merge_path::MergePathChunkProvider> DataStreamRecvr::create_merge_pa
 
 DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtime_state, const RowDescriptor& row_desc,
                                  const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders,
-                                 bool is_merging, int total_buffer_limit, std::shared_ptr<RuntimeProfile> profile,
+                                 bool is_merging, int total_buffer_limit,
                                  std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr,
                                  bool is_pipeline, int32_t degree_of_parallelism, bool keep_order,
                                  PassThroughChunkBuffer* pass_through_chunk_buffer)
@@ -164,52 +164,56 @@ DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtim
           _row_desc(row_desc),
           _is_merging(is_merging),
           _num_buffered_bytes(0),
-          _profile(std::move(profile)),
           _instance_profile(runtime_state->runtime_profile_ptr()),
           _query_mem_tracker(runtime_state->query_mem_tracker_ptr()),
           _instance_mem_tracker(runtime_state->instance_mem_tracker_ptr()),
           _sub_plan_query_statistics_recvr(std::move(sub_plan_query_statistics_recvr)),
           _is_pipeline(is_pipeline),
-          _degree_of_parallelism(degree_of_parallelism),
           _keep_order(keep_order),
           _pass_through_context(pass_through_chunk_buffer, fragment_instance_id, dest_node_id) {
     // Create one queue per sender if is_merging is true.
     int num_queues = is_merging ? num_senders : 1;
     _sender_queues.reserve(num_queues);
     int num_sender_per_queue = is_merging ? 1 : num_senders;
+    DCHECK_GE(degree_of_parallelism, 1);
     for (int i = 0; i < num_queues; ++i) {
         SenderQueue* queue = nullptr;
         if (_is_pipeline) {
             queue = _sender_queue_pool.add(
-                    new PipelineSenderQueue(this, num_sender_per_queue, _is_merging ? 1 : _degree_of_parallelism));
+                    new PipelineSenderQueue(this, num_sender_per_queue, _is_merging ? 1 : degree_of_parallelism));
         } else {
             queue = _sender_queue_pool.add(new NonPipelineSenderQueue(this, num_sender_per_queue));
         }
         _sender_queues.push_back(queue);
     }
 
-    // Initialize the counters
-    _bytes_received_counter = ADD_COUNTER(_profile, "BytesReceived", TUnit::BYTES);
-    _bytes_pass_through_counter = ADD_COUNTER(_profile, "BytesPassThrough", TUnit::BYTES);
-    _request_received_counter = ADD_COUNTER(_profile, "RequestReceived", TUnit::UNIT);
-    _closure_block_timer = ADD_TIMER(_profile, "ClosureBlockTime");
-    _closure_block_counter = ADD_COUNTER(_profile, "ClosureBlockCount", TUnit::UNIT);
-    _deserialize_chunk_timer = ADD_TIMER(_profile, "DeserializeChunkTime");
-    _decompress_chunk_timer = ADD_TIMER(_profile, "DecompressChunkTime");
-    _process_total_timer = ADD_TIMER(_profile, "ReceiverProcessTotalTime");
-
-    _sender_total_timer = ADD_TIMER(_profile, "SenderTotalTime");
-    _sender_wait_lock_timer = ADD_TIMER(_profile, "SenderWaitLockTime");
-
-    _buffer_unplug_counter = ADD_COUNTER(_profile, "BufferUnplugCount", TUnit::UNIT);
-
-    _peak_buffer_mem_bytes = _profile->AddHighWaterMarkCounter("PeakBufferMemoryBytes", TUnit::BYTES,
-                                                               RuntimeProfile::Counter::create_strategy(TUnit::BYTES));
+    _metrics.resize(degree_of_parallelism);
 
     _pass_through_context.init();
     if (runtime_state->query_options().__isset.transmission_encode_level) {
         _encode_level = runtime_state->query_options().transmission_encode_level;
     }
+}
+
+void DataStreamRecvr::bind_profile(int32_t driver_sequence, RuntimeProfile* profile) {
+    DCHECK(profile != nullptr);
+    DCHECK_GE(driver_sequence, 0);
+    DCHECK_LT(driver_sequence, _metrics.size());
+    auto& statistics = _metrics[driver_sequence];
+
+    statistics.bytes_received_counter = ADD_COUNTER(profile, "BytesReceived", TUnit::BYTES);
+    statistics.bytes_pass_through_counter = ADD_COUNTER(profile, "BytesPassThrough", TUnit::BYTES);
+    statistics.request_received_counter = ADD_COUNTER(profile, "RequestReceived", TUnit::UNIT);
+    statistics.closure_block_timer = ADD_TIMER(profile, "ClosureBlockTime");
+    statistics.closure_block_counter = ADD_COUNTER(profile, "ClosureBlockCount", TUnit::UNIT);
+    statistics.deserialize_chunk_timer = ADD_TIMER(profile, "DeserializeChunkTime");
+    statistics.decompress_chunk_timer = ADD_TIMER(profile, "DecompressChunkTime");
+    statistics.process_total_timer = ADD_TIMER(profile, "ReceiverProcessTotalTime");
+    statistics.sender_total_timer = ADD_TIMER(profile, "SenderTotalTime");
+    statistics.sender_wait_lock_timer = ADD_TIMER(profile, "SenderWaitLockTime");
+    statistics.buffer_unplug_counter = ADD_COUNTER(profile, "BufferUnplugCount", TUnit::UNIT);
+    statistics.peak_buffer_mem_bytes = profile->AddHighWaterMarkCounter(
+            "PeakBufferMemoryBytes", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TUnit::BYTES));
 }
 
 Status DataStreamRecvr::get_next(ChunkPtr* chunk, bool* eos) {
@@ -237,17 +241,18 @@ Status DataStreamRecvr::add_chunks(const PTransmitChunkParams& request, ::google
     MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(_instance_mem_tracker.get());
     DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
-    SCOPED_TIMER(_process_total_timer);
-    SCOPED_TIMER(_sender_total_timer);
-    COUNTER_UPDATE(_request_received_counter, 1);
+    auto& metrics = get_metrics_round_robin();
+    SCOPED_TIMER(metrics.process_total_timer);
+    SCOPED_TIMER(metrics.sender_total_timer);
+    COUNTER_UPDATE(metrics.request_received_counter, 1);
     int use_sender_id = _is_merging ? request.sender_id() : 0;
     // Add all batches to the same queue if _is_merging is false.
 
     if (_keep_order) {
         DCHECK(_is_pipeline);
-        return _sender_queues[use_sender_id]->add_chunks_and_keep_order(request, done);
+        return _sender_queues[use_sender_id]->add_chunks_and_keep_order(request, metrics, done);
     } else {
-        return _sender_queues[use_sender_id]->add_chunks(request, done);
+        return _sender_queues[use_sender_id]->add_chunks(request, metrics, done);
     }
 }
 
@@ -272,13 +277,6 @@ void DataStreamRecvr::close() {
     _mgr = nullptr;
     _chunks_merger.reset();
     _cascade_merger.reset();
-
-    ADD_CHILD_TIMER(_profile, "ClosureBlockTimeAvg", "ClosureBlockTime")
-            ->update(_closure_block_timer->value() / std::max(1, _degree_of_parallelism));
-    ADD_CHILD_TIMER(_profile, "DeserializeChunkTimeAvg", "DeserializeChunkTime")
-            ->update(_deserialize_chunk_timer->value() / std::max(1, _degree_of_parallelism));
-    ADD_CHILD_TIMER(_profile, "DecompressChunkTimeAvg", "DecompressChunkTime")
-            ->update(_decompress_chunk_timer->value() / std::max(1, _degree_of_parallelism));
     _close = true;
 }
 

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -232,7 +232,7 @@ private:
     // concurrency of the brpc threads, so we let the size of _metrics to be the same as the pipeline's dop,
     // and use round-robin to choose the metrics for each brpc thread.
     std::vector<Metrics> _metrics;
-    int32_t _rpc_round_roubin_index = 0;
+    std::atomic<size_t> _rpc_round_roubin_index = 0;
 
     // Sub plan query statistics receiver.
     std::shared_ptr<QueryStatisticsRecvr> _sub_plan_query_statistics_recvr;

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -86,10 +86,8 @@ class SortExecExprs;
 // recvr instance from the tracking structure of its DataStreamMgr in all cases.
 class DataStreamRecvr {
 public:
-    const static int32_t INVALID_DOP_FOR_NON_PIPELINE_LEVEL_SHUFFLE = 0;
-
-public:
     ~DataStreamRecvr();
+    void bind_profile(int32_t driver_sequence, RuntimeProfile* profile);
 
     Status get_chunk(std::unique_ptr<Chunk>* chunk);
     Status get_chunk_for_pipeline(std::unique_ptr<Chunk>* chunk, const int32_t driver_sequence);
@@ -100,8 +98,8 @@ public:
     // Create a SortedRunMerger instance to merge rows from multiple sender according to the
     // specified row comparator. Fetches the first batches from the individual sender
     // queues. The exprs used in less_than must have already been prepared and opened.
-    Status create_merger(RuntimeState* state, const SortExecExprs* exprs, const std::vector<bool>* is_asc,
-                         const std::vector<bool>* is_null_first);
+    Status create_merger(RuntimeState* state, RuntimeProfile* profile, const SortExecExprs* exprs,
+                         const std::vector<bool>* is_asc, const std::vector<bool>* is_null_first);
     Status create_merger_for_pipeline(RuntimeState* state, const SortExecExprs* exprs, const std::vector<bool>* is_asc,
                                       const std::vector<bool>* is_null_first);
 
@@ -137,12 +135,13 @@ private:
     class SenderQueue;
     class NonPipelineSenderQueue;
     class PipelineSenderQueue;
+    struct Metrics;
 
     DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtime_state, const RowDescriptor& row_desc,
                     const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders, bool is_merging,
-                    int total_buffer_limit, std::shared_ptr<RuntimeProfile> profile,
-                    std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr, bool is_pipeline,
-                    int32_t degree_of_parallelism, bool keep_order, PassThroughChunkBuffer* pass_through_chunk_buffer);
+                    int total_buffer_limit, std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr,
+                    bool is_pipeline, int32_t degree_of_parallelism, bool keep_order,
+                    PassThroughChunkBuffer* pass_through_chunk_buffer);
 
     // If receive queue is full, done is enqueue pending, and return with *done is nullptr
     Status add_chunks(const PTransmitChunkParams& request, ::google::protobuf::Closure** done);
@@ -157,6 +156,9 @@ private:
     // Return true if the addition of a new batch of size 'chunk_size' would exceed the
     // total buffer limit.
     bool exceeds_limit(int chunk_size) { return _num_buffered_bytes + chunk_size > _total_buffer_limit; }
+
+    // Return a metrics for current rpc in round-robin manner.
+    Metrics& get_metrics_round_robin() { return _metrics[_rpc_round_roubin_index++ % _metrics.size()]; }
 
     // DataStreamMgr instance used to create this recvr. (Not owned)
     DataStreamMgr* _mgr;
@@ -193,44 +195,48 @@ private:
     // Pool of sender queues.
     ObjectPool _sender_queue_pool;
 
-    // Runtime profile storing the counters below.
-    std::shared_ptr<RuntimeProfile> _profile;
-
     // instance profile and mem_tracker
     std::shared_ptr<RuntimeProfile> _instance_profile;
     std::shared_ptr<MemTracker> _query_mem_tracker;
     std::shared_ptr<MemTracker> _instance_mem_tracker;
 
-    // Number of bytes received
-    RuntimeProfile::Counter* _bytes_received_counter;
-    RuntimeProfile::Counter* _bytes_pass_through_counter;
+    struct Metrics {
+        // Number of bytes received
+        RuntimeProfile::Counter* bytes_received_counter = nullptr;
+        RuntimeProfile::Counter* bytes_pass_through_counter = nullptr;
 
-    // Time series of number of bytes received, samples _bytes_received_counter
-    // RuntimeProfile::TimeSeriesCounter* _bytes_received_time_series_counter;
-    RuntimeProfile::Counter* _deserialize_chunk_timer;
-    RuntimeProfile::Counter* _decompress_chunk_timer;
-    RuntimeProfile::Counter* _request_received_counter;
+        // Time series of number of bytes received, samples _bytes_received_counter
+        // RuntimeProfile::TimeSeriesCounter* _bytes_received_time_series_counter;
+        RuntimeProfile::Counter* deserialize_chunk_timer = nullptr;
+        RuntimeProfile::Counter* decompress_chunk_timer = nullptr;
+        RuntimeProfile::Counter* request_received_counter = nullptr;
 
-    // Average time of closure stayed in the buffer
-    // Formula is: cumulative_time / _degree_of_parallelism, so the estimation may
-    // not be that accurate, but enough to expose problems in profile analysis
-    RuntimeProfile::Counter* _closure_block_timer;
-    RuntimeProfile::Counter* _closure_block_counter;
-    RuntimeProfile::Counter* _process_total_timer = nullptr;
+        // Average time of closure stayed in the buffer
+        RuntimeProfile::Counter* closure_block_timer = nullptr;
+        RuntimeProfile::Counter* closure_block_counter = nullptr;
+        RuntimeProfile::Counter* process_total_timer = nullptr;
 
-    // Total spent for senders putting data in the queue
-    // TODO(hcf) remove these two metrics after non-pipeline offlined
-    RuntimeProfile::Counter* _sender_total_timer = nullptr;
-    RuntimeProfile::Counter* _sender_wait_lock_timer = nullptr;
+        // Total spent for senders putting data in the queue
+        RuntimeProfile::Counter* sender_total_timer = nullptr;
+        RuntimeProfile::Counter* sender_wait_lock_timer = nullptr;
 
-    RuntimeProfile::Counter* _buffer_unplug_counter = nullptr;
-    RuntimeProfile::HighWaterMarkCounter* _peak_buffer_mem_bytes = nullptr;
+        RuntimeProfile::Counter* buffer_unplug_counter = nullptr;
+        RuntimeProfile::HighWaterMarkCounter* peak_buffer_mem_bytes = nullptr;
+    };
+
+    // One DataStreamRecvr will be shared by a group of ExchangeSourceOperator
+    // And the whole process at the receiver side can be split into to parts:
+    //     Part one: Put chunk to queue, which is performed at the brpc thread
+    //     Part two: Get chunk from queue, which is performed at the pipeline's working thread
+    // We know excatly about the parallelism of the pipeline's working threads, but we cannot know the
+    // concurrency of the brpc threads, so we let the size of _metrics to be the same as the pipeline's dop,
+    // and use round-robin to choose the metrics for each brpc thread.
+    std::vector<Metrics> _metrics;
+    int32_t _rpc_round_roubin_index = 0;
 
     // Sub plan query statistics receiver.
     std::shared_ptr<QueryStatisticsRecvr> _sub_plan_query_statistics_recvr;
     bool _is_pipeline;
-    // Invalid if _is_pipeline is false
-    int32_t _degree_of_parallelism;
 
     // Invalid if _is_pipeline is false
     // Pipeline will send packets out-of-order

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -217,8 +217,7 @@ private:
         RuntimeProfile::Counter* process_total_timer = nullptr;
 
         // Total spent for senders putting data in the queue
-        RuntimeProfile::Counter* sender_total_timer = nullptr;
-        RuntimeProfile::Counter* sender_wait_lock_timer = nullptr;
+        RuntimeProfile::Counter* wait_lock_timer = nullptr;
 
         RuntimeProfile::Counter* buffer_unplug_counter = nullptr;
         RuntimeProfile::HighWaterMarkCounter* peak_buffer_mem_bytes = nullptr;

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -95,10 +95,10 @@ Status DataStreamRecvr::SenderQueue::_build_chunk_meta(const ChunkPB& pb_chunk) 
     return Status::OK();
 }
 
-Status DataStreamRecvr::SenderQueue::_deserialize_chunk(const ChunkPB& pchunk, Chunk* chunk,
+Status DataStreamRecvr::SenderQueue::_deserialize_chunk(const ChunkPB& pchunk, Chunk* chunk, Metrics& metrics,
                                                         faststring* uncompressed_buffer) {
     if (pchunk.compress_type() == CompressionTypePB::NO_COMPRESSION) {
-        SCOPED_TIMER(_recvr->_deserialize_chunk_timer);
+        SCOPED_TIMER(metrics.deserialize_chunk_timer);
         TRY_CATCH_BAD_ALLOC({
             serde::ProtobufChunkDeserializer des(_chunk_meta, &pchunk, _recvr->get_encode_level());
             ASSIGN_OR_RETURN(*chunk, des.deserialize(pchunk.data()));
@@ -106,7 +106,7 @@ Status DataStreamRecvr::SenderQueue::_deserialize_chunk(const ChunkPB& pchunk, C
     } else {
         size_t uncompressed_size = 0;
         {
-            SCOPED_TIMER(_recvr->_decompress_chunk_timer);
+            SCOPED_TIMER(metrics.decompress_chunk_timer);
             const BlockCompressionCodec* codec = nullptr;
             RETURN_IF_ERROR(get_block_compression_codec(pchunk.compress_type(), &codec));
             uncompressed_size = pchunk.uncompressed_size();
@@ -115,7 +115,7 @@ Status DataStreamRecvr::SenderQueue::_deserialize_chunk(const ChunkPB& pchunk, C
             RETURN_IF_ERROR(codec->decompress(pchunk.data(), &output));
         }
         {
-            SCOPED_TIMER(_recvr->_deserialize_chunk_timer);
+            SCOPED_TIMER(metrics.deserialize_chunk_timer);
             TRY_CATCH_BAD_ALLOC({
                 std::string_view buff(reinterpret_cast<const char*>(uncompressed_buffer->data()), uncompressed_size);
                 serde::ProtobufChunkDeserializer des(_chunk_meta, &pchunk, _recvr->get_encode_level());
@@ -149,13 +149,14 @@ Status DataStreamRecvr::NonPipelineSenderQueue::get_chunk(Chunk** chunk, const i
     *chunk = _chunk_queue.front().chunk_ptr.release();
     auto* closure = _chunk_queue.front().closure;
     auto queue_enter_time = _chunk_queue.front().queue_enter_time;
+    auto& metrics = _recvr->_metrics[0];
 
     _recvr->_num_buffered_bytes -= _chunk_queue.front().chunk_bytes;
     VLOG_ROW << "DataStreamRecvr fetched #rows=" << (*chunk)->num_rows();
     _chunk_queue.pop_front();
 
     if (closure != nullptr) {
-        _recvr->_closure_block_timer->update(MonotonicNanos() - queue_enter_time);
+        COUNTER_UPDATE(metrics.closure_block_timer, MonotonicNanos() - queue_enter_time);
         // When the execution thread is blocked and the Chunk queue exceeds the memory limit,
         // the execution thread will hold done and will not return, block brpc from sending packets,
         // and the execution thread will call run() to let brpc continue to send packets,
@@ -199,33 +200,35 @@ bool DataStreamRecvr::NonPipelineSenderQueue::try_get_chunk(Chunk** chunk) {
         _recvr->_num_buffered_bytes -= _chunk_queue.front().chunk_bytes;
         auto* closure = _chunk_queue.front().closure;
         auto queue_enter_time = _chunk_queue.front().queue_enter_time;
+        auto& metrics = _recvr->get_metrics_round_robin();
         VLOG_ROW << "DataStreamRecvr fetched #rows=" << (*chunk)->num_rows();
         _chunk_queue.pop_front();
         if (closure != nullptr) {
-            _recvr->_closure_block_timer->update(MonotonicNanos() - queue_enter_time);
+            COUNTER_UPDATE(metrics.closure_block_timer, MonotonicNanos() - queue_enter_time);
             closure->Run();
         }
         return true;
     }
 }
 
-Status DataStreamRecvr::NonPipelineSenderQueue::add_chunks(const PTransmitChunkParams& request,
+Status DataStreamRecvr::NonPipelineSenderQueue::add_chunks(const PTransmitChunkParams& request, Metrics& metrics,
                                                            ::google::protobuf::Closure** done) {
-    return add_chunks<false>(request, done);
+    return add_chunks<false>(request, metrics, done);
 }
 
 Status DataStreamRecvr::NonPipelineSenderQueue::add_chunks_and_keep_order(const PTransmitChunkParams& request,
+                                                                          Metrics& metrics,
                                                                           ::google::protobuf::Closure** done) {
-    return add_chunks<true>(request, done);
+    return add_chunks<true>(request, metrics, done);
 }
 
 template <bool keep_order>
-Status DataStreamRecvr::NonPipelineSenderQueue::add_chunks(const PTransmitChunkParams& request,
+Status DataStreamRecvr::NonPipelineSenderQueue::add_chunks(const PTransmitChunkParams& request, Metrics& metrics,
                                                            ::google::protobuf::Closure** done) {
     DCHECK(request.chunks_size() > 0);
     int32_t be_number = request.be_number();
     int64_t sequence = request.sequence();
-    ScopedTimer<MonotonicStopWatch> wait_timer(_recvr->_sender_wait_lock_timer);
+    ScopedTimer<MonotonicStopWatch> wait_timer(metrics.sender_wait_lock_timer);
     {
         std::lock_guard<Mutex> l(_lock);
         wait_timer.stop();
@@ -265,7 +268,7 @@ Status DataStreamRecvr::NonPipelineSenderQueue::add_chunks(const PTransmitChunkP
         }
         // We only need to build chunk meta on first chunk
         if (_chunk_meta.types.empty()) {
-            SCOPED_TIMER(_recvr->_deserialize_chunk_timer);
+            SCOPED_TIMER(metrics.deserialize_chunk_timer);
             auto& pchunk = request.chunks(0);
             RETURN_IF_ERROR(_build_chunk_meta(pchunk));
         }
@@ -279,12 +282,12 @@ Status DataStreamRecvr::NonPipelineSenderQueue::add_chunks(const PTransmitChunkP
         auto& pchunk = request.chunks().Get(i);
         int64_t chunk_bytes = pchunk.data().size();
         ChunkUniquePtr chunk = std::make_unique<Chunk>();
-        RETURN_IF_ERROR(_deserialize_chunk(pchunk, chunk.get(), &uncompressed_buffer));
+        RETURN_IF_ERROR(_deserialize_chunk(pchunk, chunk.get(), metrics, &uncompressed_buffer));
         ChunkItem item{chunk_bytes, std::move(chunk), nullptr};
         chunks.emplace_back(std::move(item));
         total_chunk_bytes += chunk_bytes;
     }
-    COUNTER_UPDATE(_recvr->_bytes_received_counter, total_chunk_bytes);
+    COUNTER_UPDATE(metrics.bytes_received_counter, total_chunk_bytes);
 
     wait_timer.start();
     {
@@ -306,7 +309,7 @@ Status DataStreamRecvr::NonPipelineSenderQueue::add_chunks(const PTransmitChunkP
             if (has_new_chunks && done != nullptr && _recvr->exceeds_limit(total_chunk_bytes)) {
                 _chunk_queue.back().closure = *done;
                 _chunk_queue.back().queue_enter_time = MonotonicNanos();
-                COUNTER_UPDATE(_recvr->_closure_block_counter, 1);
+                COUNTER_UPDATE(metrics.closure_block_counter, 1);
                 *done = nullptr;
             }
             _recvr->_num_buffered_bytes += total_chunk_bytes;
@@ -317,7 +320,7 @@ Status DataStreamRecvr::NonPipelineSenderQueue::add_chunks(const PTransmitChunkP
             if (!chunks.empty() && done != nullptr && _recvr->exceeds_limit(total_chunk_bytes)) {
                 chunks.back().closure = *done;
                 chunks.back().queue_enter_time = MonotonicNanos();
-                COUNTER_UPDATE(_recvr->_closure_block_counter, 1);
+                COUNTER_UPDATE(metrics.closure_block_counter, 1);
                 *done = nullptr;
             }
 
@@ -397,9 +400,10 @@ void DataStreamRecvr::NonPipelineSenderQueue::close() {
 }
 
 void DataStreamRecvr::NonPipelineSenderQueue::clean_buffer_queues() {
+    auto& metrics = _recvr->_metrics[0];
     for (auto& item : _chunk_queue) {
         if (item.closure != nullptr) {
-            _recvr->_closure_block_timer->update(MonotonicNanos() - item.queue_enter_time);
+            COUNTER_UPDATE(metrics.closure_block_timer, MonotonicNanos() - item.queue_enter_time);
             item.closure->Run();
         }
     }
@@ -435,6 +439,7 @@ Status DataStreamRecvr::PipelineSenderQueue::get_chunk(Chunk** chunk, const int3
     size_t index = _is_pipeline_level_shuffle ? driver_sequence : 0;
     auto& chunk_queue = _chunk_queues[index];
     auto& chunk_queue_state = _chunk_queue_states[index];
+    auto& metrics = _recvr->_metrics[driver_sequence];
 
     ChunkItem item;
     if (!chunk_queue.try_dequeue(item)) {
@@ -450,7 +455,7 @@ Status DataStreamRecvr::PipelineSenderQueue::get_chunk(Chunk** chunk, const int3
                     tls_thread_status.set_mem_tracker(GlobalEnv::GetInstance()->process_mem_tracker());
             DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 #endif
-            _recvr->_closure_block_timer->update(MonotonicNanos() - item.queue_enter_time);
+            COUNTER_UPDATE(metrics.closure_block_timer, MonotonicNanos() - item.queue_enter_time);
             closure->Run();
             chunk_queue_state.blocked_closure_num--;
         }
@@ -459,7 +464,7 @@ Status DataStreamRecvr::PipelineSenderQueue::get_chunk(Chunk** chunk, const int3
     if (item.chunk_ptr == nullptr) {
         ChunkUniquePtr chunk_ptr = std::make_unique<Chunk>();
         faststring uncompressed_buffer;
-        RETURN_IF_ERROR(_deserialize_chunk(item.pchunk, chunk_ptr.get(), &uncompressed_buffer));
+        RETURN_IF_ERROR(_deserialize_chunk(item.pchunk, chunk_ptr.get(), metrics, &uncompressed_buffer));
         *chunk = chunk_ptr.release();
     } else {
         *chunk = item.chunk_ptr.release();
@@ -468,7 +473,7 @@ Status DataStreamRecvr::PipelineSenderQueue::get_chunk(Chunk** chunk, const int3
 
     _total_chunks--;
     _recvr->_num_buffered_bytes -= item.chunk_bytes;
-    COUNTER_ADD(_recvr->_peak_buffer_mem_bytes, -item.chunk_bytes);
+    COUNTER_ADD(metrics.peak_buffer_mem_bytes, -item.chunk_bytes);
     return Status::OK();
 }
 
@@ -488,6 +493,7 @@ bool DataStreamRecvr::PipelineSenderQueue::try_get_chunk(Chunk** chunk) {
     }
     auto& chunk_queue = _chunk_queues[0];
     auto& chunk_queue_state = _chunk_queue_states[0];
+    auto& metrics = _recvr->get_metrics_round_robin();
     ChunkItem item;
     if (!chunk_queue.try_dequeue(item)) {
         return false;
@@ -497,24 +503,25 @@ bool DataStreamRecvr::PipelineSenderQueue::try_get_chunk(Chunk** chunk) {
     VLOG_ROW << "DataStreamRecvr fetched #rows=" << (*chunk)->num_rows();
     auto* closure = item.closure;
     if (closure != nullptr) {
-        _recvr->_closure_block_timer->update(MonotonicNanos() - item.queue_enter_time);
+        COUNTER_UPDATE(metrics.closure_block_timer, MonotonicNanos() - item.queue_enter_time);
         closure->Run();
         chunk_queue_state.blocked_closure_num--;
     }
     _total_chunks--;
     _recvr->_num_buffered_bytes -= item.chunk_bytes;
-    COUNTER_ADD(_recvr->_peak_buffer_mem_bytes, -item.chunk_bytes);
+    COUNTER_ADD(metrics.peak_buffer_mem_bytes, -item.chunk_bytes);
     return true;
 }
 
-Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkParams& request,
+Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkParams& request, Metrics& metrics,
                                                         ::google::protobuf::Closure** done) {
-    return add_chunks<false>(request, done);
+    return add_chunks<false>(request, metrics, done);
 }
 
 Status DataStreamRecvr::PipelineSenderQueue::add_chunks_and_keep_order(const PTransmitChunkParams& request,
+                                                                       Metrics& metrics,
                                                                        ::google::protobuf::Closure** done) {
-    return add_chunks<true>(request, done);
+    return add_chunks<true>(request, metrics, done);
 }
 
 void DataStreamRecvr::PipelineSenderQueue::decrement_senders(int be_number) {
@@ -544,6 +551,7 @@ void DataStreamRecvr::PipelineSenderQueue::close() {
 
 void DataStreamRecvr::PipelineSenderQueue::clean_buffer_queues() {
     std::lock_guard<Mutex> l(_lock);
+    auto& metrics = _recvr->_metrics[0];
     for (size_t i = 0; i < _chunk_queues.size(); i++) {
         auto& chunk_queue = _chunk_queues[i];
         auto& chunk_queue_state = _chunk_queue_states[i];
@@ -551,13 +559,13 @@ void DataStreamRecvr::PipelineSenderQueue::clean_buffer_queues() {
         while (chunk_queue.size_approx() > 0) {
             if (chunk_queue.try_dequeue(item)) {
                 if (item.closure != nullptr) {
-                    _recvr->_closure_block_timer->update(MonotonicNanos() - item.queue_enter_time);
+                    COUNTER_UPDATE(metrics.closure_block_timer, MonotonicNanos() - item.queue_enter_time);
                     item.closure->Run();
                     chunk_queue_state.blocked_closure_num--;
                 }
                 --_total_chunks;
                 _recvr->_num_buffered_bytes -= item.chunk_bytes;
-                COUNTER_ADD(_recvr->_peak_buffer_mem_bytes, -item.chunk_bytes);
+                COUNTER_ADD(metrics.peak_buffer_mem_bytes, -item.chunk_bytes);
             }
         }
     }
@@ -566,7 +574,7 @@ void DataStreamRecvr::PipelineSenderQueue::clean_buffer_queues() {
         for (auto& [_, chunk_queue] : chunk_queues) {
             for (auto& item : chunk_queue) {
                 if (item.closure != nullptr) {
-                    _recvr->_closure_block_timer->update(MonotonicNanos() - item.queue_enter_time);
+                    COUNTER_UPDATE(metrics.closure_block_timer, MonotonicNanos() - item.queue_enter_time);
                     item.closure->Run();
                 }
             }
@@ -574,7 +582,8 @@ void DataStreamRecvr::PipelineSenderQueue::clean_buffer_queues() {
     }
 }
 
-Status DataStreamRecvr::PipelineSenderQueue::try_to_build_chunk_meta(const PTransmitChunkParams& request) {
+Status DataStreamRecvr::PipelineSenderQueue::try_to_build_chunk_meta(const PTransmitChunkParams& request,
+                                                                     Metrics& metrics) {
     // We only need to build chunk meta on first chunk and not use_pass_through
     // By using pass through, chunks are transmitted in shared memory without ser/deser
     // So there is no need to build chunk meta.
@@ -585,7 +594,7 @@ Status DataStreamRecvr::PipelineSenderQueue::try_to_build_chunk_meta(const PTran
         return Status::OK();
     }
 
-    ScopedTimer<MonotonicStopWatch> wait_timer(_recvr->_sender_wait_lock_timer);
+    ScopedTimer<MonotonicStopWatch> wait_timer(metrics.sender_wait_lock_timer);
     std::lock_guard<Mutex> l(_lock);
     wait_timer.stop();
 
@@ -593,7 +602,7 @@ Status DataStreamRecvr::PipelineSenderQueue::try_to_build_chunk_meta(const PTran
         return Status::OK();
     }
 
-    SCOPED_TIMER(_recvr->_deserialize_chunk_timer);
+    SCOPED_TIMER(metrics.deserialize_chunk_timer);
     auto& pchunk = request.chunks(0);
     RETURN_IF_ERROR(_build_chunk_meta(pchunk));
     _is_chunk_meta_built = true;
@@ -625,7 +634,7 @@ DataStreamRecvr::PipelineSenderQueue::get_chunks_from_pass_through(int32_t sende
 
 template <bool need_deserialization>
 StatusOr<DataStreamRecvr::PipelineSenderQueue::ChunkList> DataStreamRecvr::PipelineSenderQueue::get_chunks_from_request(
-        const PTransmitChunkParams& request, size_t& total_chunk_bytes) {
+        const PTransmitChunkParams& request, Metrics& metrics, size_t& total_chunk_bytes) {
     ChunkList chunks;
     faststring uncompressed_buffer;
     for (auto i = 0; i < request.chunks().size(); i++) {
@@ -634,7 +643,7 @@ StatusOr<DataStreamRecvr::PipelineSenderQueue::ChunkList> DataStreamRecvr::Pipel
         int64_t chunk_bytes = pchunk.data().size();
         if constexpr (need_deserialization) {
             ChunkUniquePtr chunk = std::make_unique<Chunk>();
-            RETURN_IF_ERROR(_deserialize_chunk(pchunk, chunk.get(), &uncompressed_buffer));
+            RETURN_IF_ERROR(_deserialize_chunk(pchunk, chunk.get(), metrics, &uncompressed_buffer));
             chunks.emplace_back(chunk_bytes, driver_sequence, nullptr, std::move(chunk));
         } else {
             chunks.emplace_back(chunk_bytes, driver_sequence, nullptr, pchunk);
@@ -645,7 +654,7 @@ StatusOr<DataStreamRecvr::PipelineSenderQueue::ChunkList> DataStreamRecvr::Pipel
 }
 
 template <bool keep_order>
-Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkParams& request,
+Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkParams& request, Metrics& metrics,
                                                         ::google::protobuf::Closure** done) {
     if (keep_order) {
         DCHECK(!request.has_is_pipeline_level_shuffle() && !request.is_pipeline_level_shuffle());
@@ -657,7 +666,7 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
         return Status::OK();
     }
 
-    RETURN_IF_ERROR(try_to_build_chunk_meta(request));
+    RETURN_IF_ERROR(try_to_build_chunk_meta(request, metrics));
 
     size_t total_chunk_bytes = 0;
     _is_pipeline_level_shuffle = request.has_is_pipeline_level_shuffle() && request.is_pipeline_level_shuffle();
@@ -666,11 +675,12 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
     // there is no chance to handle deserialize error, so the lazy deserialization is not supported now,
     // we can change related interface's defination to do this later.
     ChunkList chunks;
-    ASSIGN_OR_RETURN(chunks, use_pass_through
-                                     ? get_chunks_from_pass_through(request.sender_id(), total_chunk_bytes)
-                                     : (keep_order ? get_chunks_from_request<true>(request, total_chunk_bytes)
-                                                   : get_chunks_from_request<false>(request, total_chunk_bytes)));
-    COUNTER_UPDATE(use_pass_through ? _recvr->_bytes_pass_through_counter : _recvr->_bytes_received_counter,
+    ASSIGN_OR_RETURN(chunks,
+                     use_pass_through
+                             ? get_chunks_from_pass_through(request.sender_id(), total_chunk_bytes)
+                             : (keep_order ? get_chunks_from_request<true>(request, metrics, total_chunk_bytes)
+                                           : get_chunks_from_request<false>(request, metrics, total_chunk_bytes)));
+    COUNTER_UPDATE(use_pass_through ? metrics.bytes_pass_through_counter : metrics.bytes_received_counter,
                    total_chunk_bytes);
 
     if (_is_cancelled) {
@@ -680,7 +690,7 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
     if (keep_order) {
         const int32_t be_number = request.be_number();
         const int32_t sequence = request.sequence();
-        ScopedTimer<MonotonicStopWatch> wait_timer(_recvr->_sender_wait_lock_timer);
+        ScopedTimer<MonotonicStopWatch> wait_timer(metrics.sender_wait_lock_timer);
         std::lock_guard<Mutex> l(_lock);
         wait_timer.stop();
 
@@ -700,7 +710,7 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
         if (!chunks.empty() && done != nullptr && _recvr->exceeds_limit(total_chunk_bytes)) {
             chunks.back().closure = *done;
             chunks.back().queue_enter_time = MonotonicNanos();
-            COUNTER_UPDATE(_recvr->_closure_block_counter, 1);
+            COUNTER_UPDATE(metrics.closure_block_counter, 1);
             *done = nullptr;
         }
 
@@ -726,7 +736,7 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
                 _chunk_queue_states[0].blocked_closure_num += closure != nullptr;
                 _total_chunks++;
                 _recvr->_num_buffered_bytes += chunk_bytes;
-                COUNTER_ADD(_recvr->_peak_buffer_mem_bytes, chunk_bytes);
+                COUNTER_ADD(metrics.peak_buffer_mem_bytes, chunk_bytes);
             }
 
             chunk_queues.erase(it);
@@ -753,7 +763,7 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
         if (!chunks.empty() && done != nullptr && _recvr->exceeds_limit(total_chunk_bytes)) {
             chunks.back().closure = *done;
             chunks.back().queue_enter_time = MonotonicNanos();
-            COUNTER_UPDATE(_recvr->_closure_block_counter, 1);
+            COUNTER_UPDATE(metrics.closure_block_counter, 1);
             *done = nullptr;
         }
 
@@ -769,7 +779,7 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
                 short_circuit(index);
             }
             _recvr->_num_buffered_bytes += chunk_bytes;
-            COUNTER_ADD(_recvr->_peak_buffer_mem_bytes, chunk_bytes);
+            COUNTER_ADD(metrics.peak_buffer_mem_bytes, chunk_bytes);
         }
     }
 
@@ -778,6 +788,7 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
 
 void DataStreamRecvr::PipelineSenderQueue::short_circuit(const int32_t driver_sequence) {
     auto& chunk_queue_state = _chunk_queue_states[driver_sequence];
+    auto& metrics = _recvr->_metrics[driver_sequence];
     chunk_queue_state.is_short_circuited.store(true, std::memory_order_relaxed);
     if (_is_pipeline_level_shuffle) {
         auto& chunk_queue = _chunk_queues[driver_sequence];
@@ -785,13 +796,13 @@ void DataStreamRecvr::PipelineSenderQueue::short_circuit(const int32_t driver_se
         while (chunk_queue.size_approx() > 0) {
             if (chunk_queue.try_dequeue(item)) {
                 if (item.closure != nullptr) {
-                    _recvr->_closure_block_timer->update(MonotonicNanos() - item.queue_enter_time);
+                    COUNTER_UPDATE(metrics.closure_block_timer, MonotonicNanos() - item.queue_enter_time);
                     item.closure->Run();
                     chunk_queue_state.blocked_closure_num--;
                 }
                 --_total_chunks;
                 _recvr->_num_buffered_bytes -= item.chunk_bytes;
-                COUNTER_ADD(_recvr->_peak_buffer_mem_bytes, item.chunk_bytes);
+                COUNTER_ADD(metrics.peak_buffer_mem_bytes, item.chunk_bytes);
             }
         }
     }
@@ -805,6 +816,7 @@ bool DataStreamRecvr::PipelineSenderQueue::has_output(const int32_t driver_seque
     size_t index = _is_pipeline_level_shuffle ? driver_sequence : 0;
     size_t chunk_num = _chunk_queues[index].size_approx();
     auto& chunk_queue_state = _chunk_queue_states[index];
+    auto& metrics = _recvr->_metrics[driver_sequence];
     // introduce an unplug mechanism similar to scan operator to reduce scheduling overhead
 
     // 1. in the unplug state, return true if there is a chunk, otherwise return false and exit the unplug state
@@ -818,7 +830,7 @@ bool DataStreamRecvr::PipelineSenderQueue::has_output(const int32_t driver_seque
     // 2. if this queue is not in the unplug state, try to batch as much chunk as possible before returning
     // @TODO need an adaptive strategy to determin this threshold
     if (chunk_num >= kUnplugBufferThreshold) {
-        COUNTER_UPDATE(_recvr->_buffer_unplug_counter, 1);
+        COUNTER_UPDATE(metrics.buffer_unplug_counter, 1);
         chunk_queue_state.unpluging = true;
         return true;
     }

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -228,7 +228,7 @@ Status DataStreamRecvr::NonPipelineSenderQueue::add_chunks(const PTransmitChunkP
     DCHECK(request.chunks_size() > 0);
     int32_t be_number = request.be_number();
     int64_t sequence = request.sequence();
-    ScopedTimer<MonotonicStopWatch> wait_timer(metrics.sender_wait_lock_timer);
+    ScopedTimer<MonotonicStopWatch> wait_timer(metrics.wait_lock_timer);
     {
         std::lock_guard<Mutex> l(_lock);
         wait_timer.stop();
@@ -594,7 +594,7 @@ Status DataStreamRecvr::PipelineSenderQueue::try_to_build_chunk_meta(const PTran
         return Status::OK();
     }
 
-    ScopedTimer<MonotonicStopWatch> wait_timer(metrics.sender_wait_lock_timer);
+    ScopedTimer<MonotonicStopWatch> wait_timer(metrics.wait_lock_timer);
     std::lock_guard<Mutex> l(_lock);
     wait_timer.stop();
 
@@ -690,7 +690,7 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
     if (keep_order) {
         const int32_t be_number = request.be_number();
         const int32_t sequence = request.sequence();
-        ScopedTimer<MonotonicStopWatch> wait_timer(metrics.sender_wait_lock_timer);
+        ScopedTimer<MonotonicStopWatch> wait_timer(metrics.wait_lock_timer);
         std::lock_guard<Mutex> l(_lock);
         wait_timer.stop();
 

--- a/be/src/runtime/sender_queue.h
+++ b/be/src/runtime/sender_queue.h
@@ -43,11 +43,12 @@ public:
     virtual bool try_get_chunk(Chunk** chunk) = 0;
 
     // add chunks to this sender queue if this stream has not been cancelled
-    virtual Status add_chunks(const PTransmitChunkParams& request, ::google::protobuf::Closure** done) = 0;
+    virtual Status add_chunks(const PTransmitChunkParams& request, Metrics& metrics,
+                              ::google::protobuf::Closure** done) = 0;
 
     // add chunks to this sender queue if this stream has not been cancelled
     // Process data in strict accordance with the order of the sequence
-    virtual Status add_chunks_and_keep_order(const PTransmitChunkParams& request,
+    virtual Status add_chunks_and_keep_order(const PTransmitChunkParams& request, Metrics& metrics,
                                              ::google::protobuf::Closure** done) = 0;
 
     // Decrement the number of remaining senders for this queue
@@ -60,7 +61,7 @@ public:
 protected:
     Status _build_chunk_meta(const ChunkPB& pb_chunk);
 
-    Status _deserialize_chunk(const ChunkPB& pchunk, Chunk* chunk, faststring* uncompressed_buffer);
+    Status _deserialize_chunk(const ChunkPB& pchunk, Chunk* chunk, Metrics& metrics, faststring* uncompressed_buffer);
 
     DataStreamRecvr* _recvr = nullptr;
 
@@ -78,9 +79,11 @@ public:
 
     bool try_get_chunk(Chunk** chunk) override;
 
-    Status add_chunks(const PTransmitChunkParams& request, ::google::protobuf::Closure** done) override;
+    Status add_chunks(const PTransmitChunkParams& request, Metrics& metrics,
+                      ::google::protobuf::Closure** done) override;
 
-    Status add_chunks_and_keep_order(const PTransmitChunkParams& request, ::google::protobuf::Closure** done) override;
+    Status add_chunks_and_keep_order(const PTransmitChunkParams& request, Metrics& metrics,
+                                     ::google::protobuf::Closure** done) override;
 
     void decrement_senders(int be_number) override;
 
@@ -92,7 +95,7 @@ private:
     void clean_buffer_queues();
 
     template <bool keep_order>
-    Status add_chunks(const PTransmitChunkParams& request, ::google::protobuf::Closure** done);
+    Status add_chunks(const PTransmitChunkParams& request, Metrics& metrics, ::google::protobuf::Closure** done);
 
     struct ChunkItem {
         int64_t chunk_bytes = 0;
@@ -152,9 +155,11 @@ public:
 
     bool try_get_chunk(Chunk** chunk) override;
 
-    Status add_chunks(const PTransmitChunkParams& request, ::google::protobuf::Closure** done) override;
+    Status add_chunks(const PTransmitChunkParams& request, Metrics& metrics,
+                      ::google::protobuf::Closure** done) override;
 
-    Status add_chunks_and_keep_order(const PTransmitChunkParams& request, ::google::protobuf::Closure** done) override;
+    Status add_chunks_and_keep_order(const PTransmitChunkParams& request, Metrics& metrics,
+                                     ::google::protobuf::Closure** done) override;
 
     void decrement_senders(int be_number) override;
 
@@ -208,12 +213,13 @@ private:
     StatusOr<ChunkList> get_chunks_from_pass_through(const int32_t sender_id, size_t& total_chunk_bytes);
 
     template <bool need_deserialization>
-    StatusOr<ChunkList> get_chunks_from_request(const PTransmitChunkParams& request, size_t& total_chunk_bytes);
+    StatusOr<ChunkList> get_chunks_from_request(const PTransmitChunkParams& request, Metrics& metrics,
+                                                size_t& total_chunk_bytes);
 
-    Status try_to_build_chunk_meta(const PTransmitChunkParams& request);
+    Status try_to_build_chunk_meta(const PTransmitChunkParams& request, Metrics& metrics);
 
     template <bool keep_order>
-    Status add_chunks(const PTransmitChunkParams& request, ::google::protobuf::Closure** done);
+    Status add_chunks(const PTransmitChunkParams& request, Metrics& metrics, ::google::protobuf::Closure** done);
 
     typedef moodycamel::ConcurrentQueue<ChunkItem> ChunkQueue;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
@@ -17,6 +17,7 @@ package com.starrocks.common.util;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.starrocks.analysis.AggregateInfo;
 import com.starrocks.analysis.Expr;
@@ -51,7 +52,6 @@ import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.plan.ExecPlan;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
-import org.glassfish.jersey.internal.guava.Sets;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -93,7 +94,7 @@ public class ProfilingExecPlan {
         private final Class<?> clazz;
         private final List<ProfilingElement> children = Lists.newArrayList();
         private final List<Integer> multiSinkIds = Lists.newArrayList();
-        private final List<String> titleAttributes = Lists.newArrayList();
+        private final TreeSet<String> titleAttributes = Sets.newTreeSet();
         private final Map<String, String> uniqueInfos = Maps.newLinkedHashMap();
 
         private String displayName;
@@ -134,8 +135,12 @@ public class ProfilingExecPlan {
             return multiSinkIds;
         }
 
-        public List<String> getTitleAttributes() {
+        public Set<String> getTitleAttributes() {
             return titleAttributes;
+        }
+
+        public void addTitleAttribute(String attribute) {
+            titleAttributes.add(attribute);
         }
 
         public Map<String, String> getUniqueInfos() {
@@ -174,10 +179,6 @@ public class ProfilingExecPlan {
 
         private void addMultiSinkIds(List<Integer> ids) {
             multiSinkIds.addAll(ids);
-        }
-
-        private void addTitleAttribute(String attribute) {
-            titleAttributes.add(attribute);
         }
 
         private void addInfo(String name, String content) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
@@ -188,6 +188,8 @@ public class ExplainAnalyzer {
         String queryState = summaryProfile.getInfoString("Query State");
         if (Objects.equals(queryState, "Running")) {
             isRuntimeProfile = true;
+        } else {
+            checkIdentical();
         }
 
         for (int i = 0; i < executionProfile.getChildList().size(); i++) {
@@ -288,6 +290,23 @@ public class ExplainAnalyzer {
         cumulativeScanTime = executionProfile.getCounter("QueryCumulativeScanTime");
         cumulativeNetworkTime = executionProfile.getCounter("QueryCumulativeNetworkTime");
         scheduleTime = executionProfile.getCounter("QueryPeakScheduleTime");
+    }
+
+    private void checkIdentical() {
+        Queue<RuntimeProfile> queue = Lists.newLinkedList();
+        queue.offer(executionProfile);
+        while (!queue.isEmpty()) {
+            int size = queue.size();
+            for (int i = 0; i < size; i++) {
+                RuntimeProfile top = queue.poll();
+                Preconditions.checkState(top != null);
+                Preconditions.checkState(!top.containsInfoString("NotIdentical"), "Profile is not identical");
+
+                for (RuntimeProfile child : top.getChildMap().values()) {
+                    queue.offer(child);
+                }
+            }
+        }
     }
 
     private void appendSummaryInfo() {


### PR DESCRIPTION
This pr is an continuation work of #29063, #30381 and #30975, and the main objectives of this pr are:

1. Using groups of metrics that each group will attach to individual ExchangeSourceOperator, so the time, like `DecompressChunkTime` and `DeserializeChunkTime`, can be treated as wall time after thir pr instead of cumulative time.
2. Support MV lables for `HitMaterializedViews` in text-based profile analysis.
3. Adjust the output numbers of ExchangeNode working in `broadcast` mode.
4. Add `ShuffleChunkAppendTime`
5. Fix the bug for metrics `BytesUnsent` and `RequestUnsent`(Fixes https://github.com/StarRocks/starrocks/issues/31558), this issue is introduced by runtime profiling, when the query is still under processing, there may be some requests in the sender's buffer, so the metrics `BytesUnsent` and `RequestUnsent` is updated. But when the query is finished, the sender's buffer is emtpy, and it won't update the metrics `BytesUnsent` and `RequestUnsent`, so the final profile will show the previous value, which lead to the problem.
6. Text-baed profile will show the subordinatory operators.


## Result

3be,1fe tpch-1g,

```sql
explain analyze select * from lineitem a join lineitem b on a.L_ORDERKEY=b.L_ORDERKEY;
```

Before this pr:

```
          UniqueMetrics:
             - BufferUnplugCount: 1
             - BytesPassThrough: 2.099 GB
             - BytesReceived: 1.710 GB
             - ClosureBlockCount: 5.367K (5367)
             - ClosureBlockTime: 1h11m
             - DecompressChunkTime: 0ns
             - DeserializeChunkTime: 1s435ms
             - PeakBufferMemoryBytes: 337.983 MB
             - ReceiverProcessTotalTime: 376.063ms
             - RequestReceived: 7.230K (7230)
             - SenderTotalTime: 374.950ms
             - SenderWaitLockTime: 182ns
```

After this pr:

```
            UniqueMetrics:
             - BufferUnplugCount: 1
               - __MAX_OF_BufferUnplugCount: 1
               - __MIN_OF_BufferUnplugCount: 0
             - BytesPassThrough: 2.099 GB
               - __MAX_OF_BytesPassThrough: 323.068 MB
               - __MIN_OF_BytesPassThrough: 210.815 MB
             - BytesReceived: 1.710 GB
               - __MAX_OF_BytesReceived: 221.580 MB
               - __MIN_OF_BytesReceived: 214.748 MB
             - ClosureBlockCount: 5.371K (5371)
               - __MAX_OF_ClosureBlockCount: 676
               - __MIN_OF_ClosureBlockCount: 665
             - ClosureBlockTime: 6m31s
               - __MAX_OF_ClosureBlockTime: 7m39s
               - __MIN_OF_ClosureBlockTime: 5m27s
             - DecompressChunkTime: 0ns
             - DeserializeChunkTime: 175.463ms
               - __MAX_OF_DeserializeChunkTime: 181.618ms
               - __MIN_OF_DeserializeChunkTime: 168.038ms
             - PeakBufferMemoryBytes: 499.565 MB
               - __MAX_OF_PeakBufferMemoryBytes: 100.848 MB
               - __MIN_OF_PeakBufferMemoryBytes: 7.883 MB
             - ReceiverProcessTotalTime: 47.307ms
               - __MAX_OF_ReceiverProcessTotalTime: 49.546ms
               - __MIN_OF_ReceiverProcessTotalTime: 45.226ms
             - RequestReceived: 7.239K (7239)
               - __MAX_OF_RequestReceived: 905
               - __MIN_OF_RequestReceived: 904
             - SenderTotalTime: 47.138ms
               - __MAX_OF_SenderTotalTime: 49.343ms
               - __MIN_OF_SenderTotalTime: 45.070ms
             - SenderWaitLockTime: 12ns
               - __MAX_OF_SenderWaitLockTime: 100ns
               - __MIN_OF_SenderWaitLockTime: 0ns
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
