### PR TITLE
[Enhancement] add timeout for clear expire state in primary key

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1054,4 +1054,8 @@ CONF_mBool(dump_metrics_with_bvar, "true");
 
 CONF_mBool(enable_drop_tablet_if_unfinished_txn, "true");
 
+// control the timeout of clearing expire state in primary key
+// 0 means no timeout
+CONF_mInt64(clear_expire_primary_key_state_timeout_millis, "0");
+
 } // namespace starrocks::config


### PR DESCRIPTION
If so many expired entries in dynamic cache, and we want to clear them at once, which will hold `_lock` in dynamic cache for a long time. We use  dynamic cache to store primary index, so if clear expire index cost too much time, it will make data loading hang, and waiting for `_lock` in dynamic cache.
So I add config `clear_expire_primary_key_state_timeout_millis` here to control the timeout of clear expire entries in dynamic cache, no timeout by default.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
