### PR TITLE
[Enhancement] modify columns_desc of TOlapTableIndexSchema from required to optional

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -304,7 +304,8 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
     _tablet_schema = TabletSchema::copy(tablet_schema_ptr);
 
     // if column_desc come from fe, reset tablet schema
-    if (!_scan_node->thrift_olap_scan_node().columns_desc.empty() &&
+    if (_scan_node->thrift_olap_scan_node().__isset.columns_desc &&
+        !_scan_node->thrift_olap_scan_node().columns_desc.empty() &&
         _scan_node->thrift_olap_scan_node().columns_desc[0].col_unique_id >= 0) {
         _tablet_schema->clear_columns();
         for (const auto& column_desc : _scan_node->thrift_olap_scan_node().columns_desc) {

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -108,10 +108,12 @@ Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema) {
                 index->slots.emplace_back(it->second);
             }
         }
-        for (auto& tcolumn_desc : t_index.columns_desc) {
-            TabletColumn* tc = _obj_pool.add(new TabletColumn());
-            tc->init_from_thrift(tcolumn_desc);
-            index->columns.emplace_back(tc);
+        if (t_index.__isset.columns_desc) {
+            for (auto& tcolumn_desc : t_index.columns_desc) {
+                TabletColumn* tc = _obj_pool.add(new TabletColumn());
+                tc->init_from_thrift(tcolumn_desc);
+                index->columns.emplace_back(tc);
+            }
         }
         _indexes.emplace_back(index);
     }

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -52,7 +52,8 @@ Status TabletScanner::init(RuntimeState* runtime_state, const TabletScannerParam
     _tablet_schema = TabletSchema::copy(tablet_schema_ptr);
 
     // if column_desc come from fe, reset tablet schema
-    if (!_parent->_olap_scan_node.columns_desc.empty() && _parent->_olap_scan_node.columns_desc[0].col_unique_id >= 0) {
+    if (_parent->_olap_scan_node.__isset.columns_desc && !_parent->_olap_scan_node.columns_desc.empty() &&
+        _parent->_olap_scan_node.columns_desc[0].col_unique_id >= 0) {
         _tablet_schema->clear_columns();
         for (const auto& column_desc : _parent->_olap_scan_node.columns_desc) {
             _tablet_schema->append_column(TabletColumn(column_desc));

--- a/be/src/storage/push_handler.cpp
+++ b/be/src/storage/push_handler.cpp
@@ -103,7 +103,8 @@ Status PushHandler::_do_streaming_ingestion(TabletSharedPtr tablet, const TPushR
             DeleteConditionHandler del_cond_handler;
             tablet_var.tablet->obtain_header_rdlock();
             auto tablet_schema = TabletSchema::copy(tablet_var.tablet->thread_safe_get_tablet_schema());
-            if (!request.columns_desc.empty() && request.columns_desc[0].col_unique_id >= 0) {
+            if (request.__isset.columns_desc && !request.columns_desc.empty() &&
+                request.columns_desc[0].col_unique_id >= 0) {
                 tablet_schema->clear_columns();
                 for (const auto& column_desc : request.columns_desc) {
                     tablet_schema->append_column(TabletColumn(column_desc));
@@ -121,7 +122,7 @@ Status PushHandler::_do_streaming_ingestion(TabletSharedPtr tablet, const TPushR
     }
 
     auto tablet_schema = std::shared_ptr<TabletSchema>(TabletSchema::copy(tablet_vars->at(0).tablet->tablet_schema()));
-    if (!request.columns_desc.empty() && request.columns_desc[0].col_unique_id >= 0) {
+    if (request.__isset.columns_desc && !request.columns_desc.empty() && request.columns_desc[0].col_unique_id >= 0) {
         tablet_schema->clear_columns();
         for (const auto& column_desc : request.columns_desc) {
             tablet_schema->append_column(TabletColumn(column_desc));

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -289,7 +289,8 @@ public class OlapTableSink extends DataSink {
                 columns.add(Load.LOAD_OP_COLUMN);
             }
             TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(pair.getKey(), columns,
-                    indexMeta.getSchemaHash(), columnsDesc);
+                    indexMeta.getSchemaHash());
+            indexSchema.setColumns_desc(columnsDesc);
             schemaParam.addToIndexes(indexSchema);
         }
         return schemaParam;

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -259,7 +259,7 @@ struct TOlapTableIndexSchema {
     1: required i64 id
     2: required list<string> columns
     3: required i32 schema_hash
-    4: required list<TColumn> columns_desc
+    4: optional list<TColumn> columns_desc
 }
 
 struct TOlapTableSchemaParam {


### PR DESCRIPTION
The item `column_desc` is introduced by lightSchemaChange(https://github.com/StarRocks/starrocks/pull/26246).

Defining it as required will cause some compatibility issues during the upgrade and rollback process. This function is only available on 3.2+ and has not been released yet.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
