### PR TITLE
[Enhancement] move memory release out of lock in DynamicCache iterate operation

### DIFF
--- a/be/test/util/dynamic_cache_test.cpp
+++ b/be/test/util/dynamic_cache_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <vector>
 
 #include "util/logging.h"
 
@@ -66,6 +67,22 @@ TEST(DynamicCacheTest, cache) {
     cache.clear_expired();
     ASSERT_EQ(4, cache.size());
     ASSERT_TRUE(cache.get(19) == nullptr);
+}
+
+TEST(DynamicCacheTest, cache2) {
+    int N = 1000;
+    DynamicCache<int32_t, int64_t> cache(N);
+    for (int i = 0; i < N; i++) {
+        auto e = cache.get_or_create(i);
+        cache.update_object_size(e, 1);
+        cache.release(e);
+    }
+    std::vector<DynamicCache<int32_t, int64_t>::Entry*> entry_list;
+    ASSERT_TRUE(cache.TEST_evict(0, &entry_list));
+    ASSERT_EQ(entry_list.size(), N);
+    for (DynamicCache<int32_t, int64_t>::Entry* entry : entry_list) {
+        delete entry;
+    }
 }
 
 } // namespace starrocks


### PR DESCRIPTION
Release memory while holding DynamicCache's lock may cause other operation hang. Move it out of lock..

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
