### PR TITLE
[BugFix] in cgroupv2 k8s env,  memory.max is in /sys/fs/cgroup/kubepods

### DIFF
--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -139,7 +139,8 @@ void MemInfo::set_memlimit_if_container() {
         // cgroup v2
         // Read from /sys/fs/cgroup/memory/memory.max
         std::string memory_max;
-        if (!FileUtil::read_whole_content("/sys/fs/cgroup/memory.max", memory_max)) {
+        if (!FileUtil::read_whole_content("/sys/fs/cgroup/memory.max", memory_max) ||
+            !FileUtil::read_whole_content("/sys/fs/cgroup/kubepods/memory.max", memory_max)) {
             return;
         }
         _s_physical_mem = StringParser::string_to_int<int64_t>(memory_max.data(), memory_max.size(), &result);

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -88,9 +88,14 @@ export_mem_limit_from_conf() {
     fi
 
     if [ -f /.dockerenv ] && [ "$cgroup_version" == "cgroup2fs" ]; then
-        mem_limit=$(cat /sys/fs/cgroup/memory.max | awk '{printf $1}')
+        if [ -f /sys/fs/cgroup/memory.max ]; then
+            mem_limit=$(cat /sys/fs/cgroup/memory.max | awk '{printf $1}')
+        fi
+        if [ -f /sys/fs/cgroup/kubepods/memory.max ]; then
+            mem_limit=$(cat /sys/fs/cgroup/kubepods/memory.max | awk '{printf $1}')
+        fi
         if [ "$mem_limit" == "" ]; then
-            echo "can't get mem info from /sys/fs/cgroup/memory.max"
+            echo "can't get mem info from /sys/fs/cgroup/memory.max or /sys/fs/cgroup/kubepods/memory.max"
             return 1
         fi
         if [ "$mem_limit" != "max" ]; then


### PR DESCRIPTION
Fixes #issue
In cgroupv2 k8s env,  memory.max is in /sys/fs/cgroup/kubepods.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
