### PR TITLE
[BugFix] in cgroupv2 k8s env, memory.max is in /sys/fs/cgroup/kubepods

### DIFF
--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -139,7 +139,8 @@ void MemInfo::set_memlimit_if_container() {
         // cgroup v2
         // Read from /sys/fs/cgroup/memory/memory.max
         std::string memory_max;
-        if (!FileUtil::read_whole_content("/sys/fs/cgroup/memory.max", memory_max)) {
+        if (!FileUtil::read_whole_content("/sys/fs/cgroup/memory.max", memory_max) ||
+            !FileUtil::read_whole_content("/sys/fs/cgroup/kubepods/memory.max", memory_max)) {
             return;
         }
         _s_physical_mem = StringParser::string_to_int<int64_t>(memory_max.data(), memory_max.size(), &result);


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
