### PR TITLE
[BugFix] fix current thread exit crash

### DIFF
--- a/be/src/runtime/current_thread.cpp
+++ b/be/src/runtime/current_thread.cpp
@@ -20,8 +20,7 @@
 namespace starrocks {
 
 CurrentThread::~CurrentThread() {
-    StorageEngine* storage_engine = StorageEngine::instance();
-    if (UNLIKELY(storage_engine != nullptr && storage_engine->bg_worker_stopped())) {
+    if (!GlobalEnv::is_init()) {
         tls_is_thread_status_init = false;
         return;
     }
@@ -30,12 +29,14 @@ CurrentThread::~CurrentThread() {
 }
 
 starrocks::MemTracker* CurrentThread::mem_tracker() {
-    if (UNLIKELY(tls_mem_tracker == nullptr)) {
-        if (GlobalEnv::is_init()) {
+    if (LIKELY(GlobalEnv::is_init())) {
+        if (UNLIKELY(tls_mem_tracker == nullptr)) {
             tls_mem_tracker = GlobalEnv::GetInstance()->process_mem_tracker();
         }
+        return tls_mem_tracker;
+    } else {
+        return nullptr;
     }
-    return tls_mem_tracker;
 }
 
 starrocks::MemTracker* CurrentThread::operator_mem_tracker() {


### PR DESCRIPTION
* CurrentThread instance is saved in tls, which may be after the execution of main() where the GlobalEnv already stopped
* skip committing its stats if GlobalEnv is stopped
* provide nullptr for the mem_tracker() if GlobaEnv is stopped

```
*** Aborted at 1695110294 (unix time) try "date -d @1695110294" if you are using GNU date ***
PC: @          0xb6c1818 starrocks::MemTracker::release()
*** SIGSEGV (@0x0) received by PID 60894 (TID 0x7f11421fe700) from PID 0; stack trace: ***
    @         0x116b6702 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f128bd18630 (unknown)
    @          0xb6c1818 starrocks::MemTracker::release()
    @          0xffd0cd8 starrocks::CurrentThread::mem_release_without_cache()
    @          0xffceb61 free
    @         0x13b1e687 (anonymous namespace)::run()
    @     0x7f128bd10ca2 __nptl_deallocate_tsd
    @     0x7f128bd10eb3 start_thread
    @     0x7f128b835b0d __clone
    @                0x0 (unknown)
```

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
