### PR TITLE
[BugFix] fix prune expr partition yield empty range

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
@@ -123,27 +123,11 @@ public class PartitionColPredicateEvaluator {
                     Range<PartitionKey> newRange;
                     if (!range.hasUpperBound() || range.upperEndpoint().getKeys().get(0) instanceof MaxLiteral) {
                         newRange = createFullScopeRange(returnType);
-                    } else if (!range.hasLowerBound()) {
-                        PartitionKey lowerKey = new PartitionKey();
-                        PartitionKey upperKey = new PartitionKey();
-
-                        LiteralExpr lowerBound = createInfinity(partitionColumn.getType(), false);
-
-                        Optional<LiteralExpr> mappingLowerBound = mapRangeBoundValue(call, lowerBound);
-                        Optional<LiteralExpr> mappingUpperBound = mapRangeBoundValue(call,
-                                range.upperEndpoint().getKeys().get(0));
-                        if (mappingLowerBound.isPresent() && mappingUpperBound.isPresent()) {
-                            lowerKey.pushColumn(mappingLowerBound.get(), returnType);
-                            upperKey.pushColumn(mappingUpperBound.get(), returnType);
-                            newRange = Range.range(lowerKey, BoundType.CLOSED, upperKey, BoundType.OPEN);
-                        } else {
-                            newRange = createFullScopeRange(call.getType().getPrimitiveType());
-                        }
                     } else {
                         PartitionKey lowerKey = new PartitionKey();
                         PartitionKey upperKey = new PartitionKey();
-
-                        LiteralExpr lowerBound = range.lowerEndpoint().getKeys().get(0);
+                        LiteralExpr lowerBound = range.hasLowerBound() ? range.lowerEndpoint().getKeys().get(0)
+                                : createInfinity(partitionColumn.getType(), false);
                         LiteralExpr upperBound = range.upperEndpoint().getKeys().get(0);
                         Optional<LiteralExpr> mappingLowerBound = mapRangeBoundValue(call, lowerBound);
                         Optional<LiteralExpr> mappingUpperBound = mapRangeBoundValue(call, upperBound);
@@ -158,7 +142,7 @@ public class PartitionColPredicateEvaluator {
                             }
                             lowerKey.pushColumn(newLowerBound, returnType);
                             upperKey.pushColumn(newUpperBound, returnType);
-                            newRange = Range.range(lowerKey, BoundType.CLOSED, upperKey, BoundType.OPEN);
+                            newRange = Range.range(lowerKey, BoundType.CLOSED, upperKey, BoundType.CLOSED);
                         } else {
                             newRange = createFullScopeRange(call.getType().getPrimitiveType());
                         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
@@ -449,6 +449,10 @@ class FurtherPartitionPruneTest extends PlanTestBase {
         sqlList.add("select * from less_than_tbl where k1 < str_to_date('20200801', '%Y%m%d')");
         sqlList.add("select * from less_than_tbl where k1 < '2020-08-01' and k1 is not null");
         sqlList.add("select * from less_than_tbl where k1 < '2020-08-01' and k1 is null");
+        sqlList.add("select * from ptest where date_trunc('year', d2) = '2020-01-01'");
+        sqlList.add("select * from less_than_tbl where date_trunc('year', k1) < '2020-08-01'");
+        sqlList.add("select * from less_than_tbl where datediff('2020-08-01', k1) = 1");
+
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 
@@ -467,7 +471,6 @@ class FurtherPartitionPruneTest extends PlanTestBase {
 
     private static Stream<Arguments> exprPrunePartitionSqls() {
         List<String> sqlList = Lists.newArrayList();
-        sqlList.add("select * from less_than_tbl where date_trunc('year', k1) < '2020-08-01'");
         sqlList.add("select * from less_than_tbl where date_trunc('year', k1) is null");
         sqlList.add(
                 "select * from less_than_tbl where date_trunc('year', k1) is null or k1 in " +

--- a/test/sql/test_partition_by_expr/R/test_expr_prune_partition
+++ b/test/sql/test_partition_by_expr/R/test_expr_prune_partition
@@ -13,7 +13,8 @@ PARTITION BY RANGE(`d2`)
 (PARTITION p202001 VALUES [('1000-01-01'), ('2020-01-01')),
 PARTITION p202004 VALUES [('2020-01-01'), ('2020-04-01')),
 PARTITION p202007 VALUES [('2020-04-01'), ('2020-07-01')),
-PARTITION p202012 VALUES [('2020-07-01'), (MAXVALUE)))
+PARTITION p202008 VALUES [('2020-07-01'), ('2020-07-29')),
+PARTITION p202012 VALUES [('2020-08-01'), (MAXVALUE)))
 DISTRIBUTED BY HASH(`k1`) BUCKETS 10
 PROPERTIES (
 "replication_num" = "1",
@@ -108,6 +109,10 @@ select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by 
 select k1, d2 from ptest where datediff('2020-08-01', d2) < 0 order by k1;
 -- result:
 14	2050-01-05
+-- !result
+select k1, d2 from ptest where date_trunc('month', d2) = '2020-07-01' order by k1;
+-- result:
+14	2020-07-01
 -- !result
 select k1, d2 from ptest_expr where date_trunc('day', d2) is null order by k1;
 -- result:

--- a/test/sql/test_partition_by_expr/T/test_expr_prune_partition
+++ b/test/sql/test_partition_by_expr/T/test_expr_prune_partition
@@ -13,7 +13,8 @@ PARTITION BY RANGE(`d2`)
 (PARTITION p202001 VALUES [('1000-01-01'), ('2020-01-01')),
 PARTITION p202004 VALUES [('2020-01-01'), ('2020-04-01')),
 PARTITION p202007 VALUES [('2020-04-01'), ('2020-07-01')),
-PARTITION p202012 VALUES [('2020-07-01'), (MAXVALUE)))
+PARTITION p202008 VALUES [('2020-07-01'), ('2020-07-29')),
+PARTITION p202012 VALUES [('2020-08-01'), (MAXVALUE)))
 DISTRIBUTED BY HASH(`k1`) BUCKETS 10
 PROPERTIES (
 "replication_num" = "1",
@@ -53,6 +54,9 @@ select k1, d2 from ptest where date_trunc('day', date_trunc('day', d2)) in ('202
 select k1, d2 from ptest where (days_add(d2, 1) in ('1000-01-02', '1999-03-22') or d2 > '2020-07-01') and v2 is null and v3 is null order by k1;
 select k1, d2 from ptest where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
 select k1, d2 from ptest where datediff('2020-08-01', d2) < 0 order by k1;
+select k1, d2 from ptest where date_trunc('month', d2) = '2020-07-01' order by k1;
+
+
 
 select k1, d2 from ptest_expr where date_trunc('day', d2) is null order by k1;
 select k1, d2 from ptest_expr where date_trunc('day', d2) in ('2020-01-01', '2020-06-30') order by k1;
@@ -62,5 +66,7 @@ select k1, d2 from ptest_expr where date_trunc('day', date_trunc('day', d2)) in 
 select k1, d2 from ptest_expr where (days_add(d2, 1) in ('1000-01-02', '1999-03-22') or d2 > '2020-07-01') and v2 is null and v3 is null order by k1;
 select k1, d2 from ptest_expr where date_trunc('day', d2) > days_sub(d2, 4) order by k1;
 select k1, d2 from ptest_expr where datediff('2020-08-01', d2) < 0 order by k1;
+
+
 
 


### PR DESCRIPTION
Fixes #issue

For sql like `select * from tbl where '2021-01-01' =date_trunc('month', partition_col)`, if the table with a parition ['2021-01-01', '2021-01-29'). When we applied the date_trunc to the parition range, the old code yields a new range ['2021-01-01', '2021-01-01') which actually is an empty range, it should be ['2021-01-01', '2021-01-01']. So to ensure the correcteness, the new mapping range is a both left and right closed range.  

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
