### PR TITLE
[Feature] add support for partition_ttl  on materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.UniqueConstraint;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.DynamicPartitionUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.persist.AlterMaterializedViewStatusLog;
@@ -52,6 +53,7 @@ import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.optimizer.Utils;
 import org.apache.commons.lang3.StringUtils;
+import org.threeten.extra.PeriodDuration;
 
 import java.util.List;
 import java.util.Map;
@@ -88,7 +90,11 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         propClone.putAll(properties);
         int partitionTTL = INVALID;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER)) {
-            partitionTTL = PropertyAnalyzer.analyzePartitionTimeToLive(properties);
+            partitionTTL = PropertyAnalyzer.analyzePartitionTTLNumber(properties);
+        }
+        Pair<String, PeriodDuration> ttlDuration = null;
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)) {
+            ttlDuration = PropertyAnalyzer.analyzePartitionTTL(properties);
         }
         int partitionRefreshNumber = INVALID;
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)) {
@@ -158,7 +164,12 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
 
         boolean isChanged = false;
         Map<String, String> curProp = materializedView.getTableProperty().getProperties();
-        if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER) &&
+        if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL) && ttlDuration != null &&
+                !materializedView.getTableProperty().getPartitionTTL().equals(ttlDuration.second)) {
+            curProp.put(PropertyAnalyzer.PROPERTIES_PARTITION_TTL, ttlDuration.first);
+            materializedView.getTableProperty().setPartitionTTL(ttlDuration.second);
+            isChanged = true;
+        } else if (propClone.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER) &&
                 materializedView.getTableProperty().getPartitionTTLNumber() != partitionTTL) {
             curProp.put(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER, String.valueOf(partitionTTL));
             materializedView.getTableProperty().setPartitionTTLNumber(partitionTTL);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1253,6 +1253,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         NEED_SHOW_PROPS = new ImmutableSet.Builder<String>()
                 .add(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME)
                 .add(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER)
+                .add(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)
                 .add(PropertyAnalyzer.PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT)
                 .add(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER)
                 .add(PropertyAnalyzer.PROPERTIES_EXCLUDED_TRIGGER_TABLES)

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -122,6 +122,8 @@ public class TableProperty implements Writable, GsonPostProcessable {
     // partition time to live number, -1 means no ttl
     private int partitionTTLNumber = INVALID;
 
+    private PeriodDuration partitionTTL = PeriodDuration.ZERO;
+
     // This property only applies to materialized views
     // It represents the maximum number of partitions that will be refreshed by a TaskRun refresh
     private int partitionRefreshNumber = INVALID;
@@ -612,6 +614,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     public int getPartitionTTLNumber() {
         return partitionTTLNumber;
+    }
+
+    public void setPartitionTTL(PeriodDuration ttlDuration) {
+        this.partitionTTL = ttlDuration;
+    }
+
+    public PeriodDuration getPartitionTTL() {
+        return partitionTTL;
     }
 
     public int getAutoRefreshPartitionsLimit() {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -62,6 +62,7 @@ import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.RangeUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.DropPartitionClause;
@@ -72,6 +73,7 @@ import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.statistic.StatsConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.threeten.extra.PeriodDuration;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -481,7 +483,8 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
             }
 
             int ttlNumber = olapTable.getTableProperty().getPartitionTTLNumber();
-            if (Objects.equals(ttlNumber, INVALID)) {
+            PeriodDuration ttlDuration = olapTable.getTableProperty().getPartitionTTL();
+            if (Objects.equals(ttlNumber, INVALID) && ttlDuration.isZero()) {
                 iterator.remove();
                 LOG.warn("database={}, table={} have no ttl. remove it from scheduler", dbId, tableId);
                 continue;
@@ -489,7 +492,11 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
 
             ArrayList<DropPartitionClause> dropPartitionClauses = null;
             try {
-                dropPartitionClauses = getDropPartitionClauseByTTL(olapTable, ttlNumber);
+                if (!ttlDuration.isZero()) {
+                    dropPartitionClauses = buildDropPartitionClauseByTTL(olapTable, ttlDuration);
+                } else {
+                    dropPartitionClauses = getDropPartitionClauseByTTL(olapTable, ttlNumber);
+                }
             } catch (AnalysisException e) {
                 LOG.warn("database={}, table={} Failed to generate drop statement.", dbId, tableId, e);
             }
@@ -511,6 +518,51 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
             }
 
         }
+    }
+
+    /**
+     * Build drop partitions by TTL.
+     * Drop the partition if partition upper endpoint less than TTL lower bound
+     */
+    private ArrayList<DropPartitionClause> buildDropPartitionClauseByTTL(OlapTable olapTable,
+                                                                         PeriodDuration ttlDuration)
+            throws AnalysisException {
+        if (ttlDuration.isZero()) {
+            return Lists.newArrayList();
+        }
+        ArrayList<DropPartitionClause> dropPartitionClauses = new ArrayList<>();
+        RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) (olapTable.getPartitionInfo());
+        List<Column> partitionColumns = rangePartitionInfo.getPartitionColumns();
+        Preconditions.checkArgument(partitionColumns.size() == 1);
+        Type partitionType = partitionColumns.get(0).getType();
+        PartitionKey ttlLowerBound = null;
+
+        LocalDateTime ttlTime = LocalDateTime.now().minus(ttlDuration);
+        if (partitionType.isDatetime()) {
+            ttlLowerBound = PartitionKey.ofDateTime(ttlTime);
+        } else if (partitionType.isDate()) {
+            ttlLowerBound = PartitionKey.ofDate(ttlTime.toLocalDate());
+        } else {
+            throw new SemanticException("partition_ttl not support partition type: " + partitionType);
+        }
+
+        PartitionKey shadowPartitionKey = PartitionKey.createShadowPartitionKey(partitionColumns);
+
+        Map<Long, Range<PartitionKey>> idToRange = rangePartitionInfo.getIdToRange(false);
+        for (Map.Entry<Long, Range<PartitionKey>> partitionRange : idToRange.entrySet()) {
+            PartitionKey left = partitionRange.getValue().lowerEndpoint();
+            if (left.compareTo(shadowPartitionKey) == 0) {
+                continue;
+            }
+
+            PartitionKey right = partitionRange.getValue().upperEndpoint();
+            if (right.compareTo(ttlLowerBound) <= 0) {
+                long partitionId = partitionRange.getKey();
+                String dropPartitionName = olapTable.getPartition(partitionId).getName();
+                dropPartitionClauses.add(new DropPartitionClause(true, dropPartitionName, false, true));
+            }
+        }
+        return dropPartitionClauses;
     }
 
     private ArrayList<DropPartitionClause> getDropPartitionClauseByTTL(OlapTable olapTable, int ttlNumber)

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
@@ -267,8 +267,9 @@ public class DynamicPartitionUtil {
     }
 
     public static void registerOrRemovePartitionTTLTable(long dbId, OlapTable olapTable) {
-        if (olapTable.getTableProperty() != null
-                && olapTable.getTableProperty().getPartitionTTLNumber() > 0) {
+        TableProperty tableProperty = olapTable.getTableProperty();
+        if (tableProperty != null &&
+                (tableProperty.getPartitionTTLNumber() > 0 || !tableProperty.getPartitionTTL().isZero())) {
             GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler()
                     .registerTtlPartitionTable(dbId, olapTable.getId());
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -160,6 +160,7 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_ENABLE_ASYNC_WRITE_BACK = "enable_async_write_back";
     public static final String PROPERTIES_PARTITION_TTL_NUMBER = "partition_ttl_number";
+    public static final String PROPERTIES_PARTITION_TTL = "partition_ttl";
     public static final String PROPERTIES_PARTITION_LIVE_NUMBER = "partition_live_number";
     public static final String PROPERTIES_AUTO_REFRESH_PARTITIONS_LIMIT = "auto_refresh_partitions_limit";
     public static final String PROPERTIES_PARTITION_REFRESH_NUMBER = "partition_refresh_number";
@@ -307,7 +308,7 @@ public class PropertyAnalyzer {
         return shortKeyColumnCount;
     }
 
-    public static int analyzePartitionTimeToLive(Map<String, String> properties) {
+    public static int analyzePartitionTTLNumber(Map<String, String> properties) {
         int partitionTimeToLive = INVALID;
         if (properties != null && properties.containsKey(PROPERTIES_PARTITION_TTL_NUMBER)) {
             try {
@@ -321,6 +322,21 @@ public class PropertyAnalyzer {
             properties.remove(PROPERTIES_PARTITION_TTL_NUMBER);
         }
         return partitionTimeToLive;
+    }
+
+    public static Pair<String, PeriodDuration> analyzePartitionTTL(Map<String, String> properties) {
+        if (properties != null && properties.containsKey(PROPERTIES_PARTITION_TTL)) {
+            String ttlStr = properties.get(PROPERTIES_PARTITION_TTL);
+            PeriodDuration duration;
+            try {
+                duration = TimeUtils.parseHumanReadablePeriodOrDuration(ttlStr);
+            } catch (NumberFormatException e) {
+                throw new SemanticException(String.format("illegal %s: %s", PROPERTIES_PARTITION_TTL, e.getMessage()));
+            }
+            properties.remove(PROPERTIES_PARTITION_TTL);
+            return Pair.create(ttlStr, duration);
+        }
+        return Pair.create(null, PeriodDuration.ZERO);
     }
 
     public static int analyzePartitionLiveNumber(Map<String, String> properties,

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -249,6 +249,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.threeten.extra.PeriodDuration;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -3202,9 +3203,22 @@ public class LocalMetastore implements ConnectorMetadata {
                         .put(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TIME,
                                 String.valueOf(dataProperty.getCooldownTimeMs()));
             }
+            // partition ttl
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL)) {
+                if (isNonPartitioned) {
+                    throw new AnalysisException(PropertyAnalyzer.PROPERTIES_PARTITION_TTL
+                            + " is only supported by partitioned materialized-view");
+                }
+
+                Pair<String, PeriodDuration> ttlDuration = PropertyAnalyzer.analyzePartitionTTL(properties);
+                materializedView.getTableProperty().getProperties()
+                        .put(PropertyAnalyzer.PROPERTIES_PARTITION_TTL, ttlDuration.first);
+                materializedView.getTableProperty().setPartitionTTL(ttlDuration.second);
+            }
+
             // partition ttl number
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER)) {
-                int number = PropertyAnalyzer.analyzePartitionTimeToLive(properties);
+                int number = PropertyAnalyzer.analyzePartitionTTLNumber(properties);
                 materializedView.getTableProperty().getProperties()
                         .put(PropertyAnalyzer.PROPERTIES_PARTITION_TTL_NUMBER, String.valueOf(number));
                 materializedView.getTableProperty().setPartitionTTLNumber(number);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.analysis;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.LocalTablet;
@@ -45,6 +46,8 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.time.LocalDate;
+import java.time.Period;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -669,5 +672,104 @@ public class RefreshMaterializedViewTest {
             .useDatabase("test")
             .dropMaterializedView("mv_with_partition")
             .dropTable("tbl_with_partition");
+    }
+
+    private void buildTimePartitions(String tableName, OlapTable tbl, int partitionCount) throws Exception {
+        LocalDate currentDate = LocalDate.now();
+        for (int i = 0; i < partitionCount; i++) {
+            LocalDate lowerBound = currentDate.minus(Period.ofMonths(i + 1));
+            LocalDate upperBound = currentDate.minus(Period.ofMonths(i));
+            String partitionName = String.format("p_%d_%d", lowerBound.getYear(), lowerBound.getMonthValue());
+            String addPartition = String.format("alter table %s add partition p%s values [('%s'), ('%s')) ",
+                    tableName, partitionName, lowerBound.toString(), upperBound);
+            starRocksAssert.getCtx().executeSql(addPartition);
+        }
+    }
+
+    @Test
+    public void testMaterializedViewPartitionTTL() throws Exception {
+        String tableName = "test.tbl1";
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE " + tableName +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    v1 int \n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values less than('2022-06-01'),\n" +
+                        "    PARTITION p2 values less than('2022-07-01'),\n" +
+                        "    PARTITION p3 values less than('2022-08-01'),\n" +
+                        "    PARTITION p4 values less than('2022-09-01')\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH (k1) BUCKETS 3\n" +
+                        "PROPERTIES\n" +
+                        "(\n" +
+                        "    'replication_num' = '1'\n" +
+                        ");");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test.mv_ttl_mv1\n" +
+                " REFRESH ASYNC " +
+                " PARTITION BY k1\n" +
+                " PROPERTIES('partition_ttl'='2 month')" +
+                " AS SELECT k1, v1 FROM test.tbl1");
+
+        DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
+                .getDynamicPartitionScheduler();
+        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        OlapTable tbl = (OlapTable) db.getTable("mv_ttl_mv1");
+        buildTimePartitions(tableName, tbl, 10);
+
+        // initial partitions should consider the ttl
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        Assert.assertEquals(ImmutableSet.of("pp_2023_8", "pp_2023_9"), tbl.getPartitionNames());
+
+        // normal ttl
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='2 month')");
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        dynamicPartitionScheduler.runOnceForTest();
+        Assert.assertEquals(ImmutableSet.of("pp_2023_8", "pp_2023_9"), tbl.getPartitionNames());
+
+        // large ttl
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='10 year')");
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        dynamicPartitionScheduler.runOnceForTest();
+        Assert.assertEquals(tbl.getRangePartitionMap().toString(), 14, tbl.getPartitions().size());
+
+        // tiny ttl
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='1 day')");
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        dynamicPartitionScheduler.runOnceForTest();
+        Assert.assertEquals(ImmutableSet.of("pp_2023_9"), tbl.getPartitionNames());
+
+        // zero ttl
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='0 day')");
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        dynamicPartitionScheduler.runOnceForTest();
+        Assert.assertEquals(tbl.getRangePartitionMap().toString(), 14, tbl.getPartitions().size());
+        Assert.assertEquals("PT0S", tbl.getTableProperty().getPartitionTTL().toString());
+
+        // tiny ttl
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='24 hour')");
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        dynamicPartitionScheduler.runOnceForTest();
+        Assert.assertEquals(tbl.getRangePartitionMap().toString(), 1, tbl.getPartitions().size());
+        Assert.assertEquals(ImmutableSet.of("pp_2023_9"), tbl.getPartitionNames());
+
+        // the ttl cross two partitions
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='32 day')");
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        dynamicPartitionScheduler.runOnceForTest();
+        Assert.assertEquals(ImmutableSet.of("pp_2023_8", "pp_2023_9"), tbl.getPartitionNames());
+        Assert.assertEquals(tbl.getRangePartitionMap().toString(), 2, tbl.getPartitions().size());
+
+        // corner cases
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='error')");
+        Assert.assertEquals("P32D", tbl.getTableProperty().getPartitionTTL().toString());
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='day')");
+        Assert.assertEquals("P32D", tbl.getTableProperty().getPartitionTTL().toString());
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='0')");
+        Assert.assertEquals("P32D", tbl.getTableProperty().getPartitionTTL().toString());
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='0 day')");
+        Assert.assertEquals("PT0S", tbl.getTableProperty().getPartitionTTL().toString());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DynamicPartitionSchedulerTest.java
@@ -27,15 +27,20 @@ import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Period;
 import java.util.Map;
 
 public class DynamicPartitionSchedulerTest {
 
+    private static final Logger LOG = LogManager.getLogger(DynamicPartitionSchedulerTest.class);
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
 
@@ -213,5 +218,101 @@ public class DynamicPartitionSchedulerTest {
         Assert.assertTrue(rangePartitionMap.containsKey("p20230329"));
         Assert.assertTrue(rangePartitionMap.containsKey("p20230330"));
         Assert.assertTrue(rangePartitionMap.containsKey("p99991230"));
+    }
+
+    private void buildTimePartitions(String tableName, OlapTable tbl, int partitionCount) throws Exception {
+        LocalDate currentDate = LocalDate.now();
+        for (int i = 0; i < partitionCount; i++) {
+            LocalDate lowerBound = currentDate.minus(Period.ofMonths(i + 1));
+            LocalDate upperBound = currentDate.minus(Period.ofMonths(i));
+            String partitionName = String.format("p_%d_%d", lowerBound.getYear(), lowerBound.getMonthValue());
+            String addPartition = String.format("alter table %s add partition p%s values [('%s'), ('%s')) ",
+                    tableName, partitionName, lowerBound.toString(), upperBound);
+            starRocksAssert.getCtx().executeSql(addPartition);
+        }
+        LOG.info("table partitions: {}", tbl.getRangePartitionMap());
+    }
+
+    @Test
+    public void testMaterializedViewPartitionTTL() throws Exception {
+        String tableName = "test.tbl1";
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE " + tableName +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    v1 int \n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values less than('2022-06-01'),\n" +
+                        "    PARTITION p2 values less than('2022-07-01'),\n" +
+                        "    PARTITION p3 values less than('2022-08-01'),\n" +
+                        "    PARTITION p4 values less than('2022-09-01')\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH (k1) BUCKETS 3\n" +
+                        "PROPERTIES\n" +
+                        "(\n" +
+                        "    'replication_num' = '1'\n" +
+                        ");");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test.mv_ttl_mv1\n" +
+                " REFRESH ASYNC " +
+                " PARTITION BY k1\n" +
+                " PROPERTIES('partition_ttl'='2 month')" +
+                " AS SELECT k1, v1 FROM test.tbl1");
+
+        DynamicPartitionScheduler dynamicPartitionScheduler = GlobalStateMgr.getCurrentState()
+                .getDynamicPartitionScheduler();
+
+        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        OlapTable tbl = (OlapTable) db.getTable("mv_ttl_mv1");
+
+        buildTimePartitions(tableName, tbl, 10);
+
+        // normal ttl
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='2 month')");
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        dynamicPartitionScheduler.runAfterCatalogReady();
+        Assert.assertEquals(tbl.getRangePartitionMap().toString(), 2, tbl.getPartitions().size());
+
+        // large ttl
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='10 year')");
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        dynamicPartitionScheduler.runAfterCatalogReady();
+        Assert.assertEquals(tbl.getRangePartitionMap().toString(), 14, tbl.getPartitions().size());
+
+        // tiny ttl
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='1 day')");
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        dynamicPartitionScheduler.runAfterCatalogReady();
+        Assert.assertEquals(tbl.getRangePartitionMap().toString(), 1, tbl.getPartitions().size());
+
+        // zero ttl
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='0 day')");
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        dynamicPartitionScheduler.runAfterCatalogReady();
+        Assert.assertEquals(tbl.getRangePartitionMap().toString(), 14, tbl.getPartitions().size());
+        Assert.assertEquals("PT0S", tbl.getTableProperty().getPartitionTTL().toString());
+
+        // tiny ttl
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='24 hour')");
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        dynamicPartitionScheduler.runAfterCatalogReady();
+        Assert.assertEquals(tbl.getRangePartitionMap().toString(), 1, tbl.getPartitions().size());
+
+        // the ttl cross two partitions
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='32 day')");
+        starRocksAssert.getCtx().executeSql("refresh materialized view test.mv_ttl_mv1 with sync mode");
+        dynamicPartitionScheduler.runAfterCatalogReady();
+        Assert.assertEquals(tbl.getRangePartitionMap().toString(), 2, tbl.getPartitions().size());
+
+        // corner cases
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='error')");
+        Assert.assertEquals("P32D", tbl.getTableProperty().getPartitionTTL().toString());
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='day')");
+        Assert.assertEquals("P32D", tbl.getTableProperty().getPartitionTTL().toString());
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='0')");
+        Assert.assertEquals("P32D", tbl.getTableProperty().getPartitionTTL().toString());
+        starRocksAssert.getCtx().executeSql("alter materialized view test.mv_ttl_mv1 set ('partition_ttl'='0 day')");
+        Assert.assertEquals("PT0S", tbl.getTableProperty().getPartitionTTL().toString());
     }
 }


### PR DESCRIPTION
Fixes #issue

Introduce the `partition_ttl` property for Materialized View:
```sql
CREATE MATERIALIZED VIEW test.mv_ttl_mv1
 REFRESH ASYNC 
 PARTITION BY k1
 PROPERTIES('partition_ttl'='2 month')
 AS SELECT k1, v1 FROM test.tbl1
```

The `partition_ttl='2 month'` means, retain partitions whose data is within two months.

At the meantime, the `partition_ttl_number` is not recommended.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
