### PR TITLE
[Enhancement] Rename `block_cache` configurations to `data_cache` and support configuring data cache size by different expression.

### DIFF
--- a/be/src/block_cache/CMakeLists.txt
+++ b/be/src/block_cache/CMakeLists.txt
@@ -25,6 +25,7 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/block_cache")
 set(CACHE_FILES
   block_cache.cpp
   io_buffer.cpp
+  cache_options.cpp
 )
 
 if (${WITH_CACHELIB} STREQUAL "ON")

--- a/be/src/block_cache/cache_options.cpp
+++ b/be/src/block_cache/cache_options.cpp
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "block_cache/cache_options.h"
+
+#include <filesystem>
+
+#include "common/logging.h"
+#include "util/parse_util.h"
+
+namespace starrocks {
+
+int64_t parse_mem_size(const std::string& mem_size_str, int64_t mem_limit) {
+    return ParseUtil::parse_mem_spec(mem_size_str, mem_limit);
+}
+
+int64_t parse_disk_size(const std::string& disk_path, const std::string& disk_size_str, int64_t disk_limit) {
+    if (disk_limit == -1) {
+        std::filesystem::path dpath(disk_path);
+        // The datacache directory may be created automatically later.
+        if (!std::filesystem::exists(dpath)) {
+            if (!dpath.has_parent_path()) {
+                LOG(ERROR) << "invalid disk path for datacache, disk_path: " << disk_path;
+                return -1;
+            }
+            dpath = dpath.parent_path();
+        }
+
+        std::error_code ec;
+        auto space_info = std::filesystem::space(dpath, ec);
+        if (ec) {
+            LOG(ERROR) << "fail to get disk space info, path: " << dpath << ", error: " << ec.message();
+            return -1;
+        }
+        disk_limit = space_info.capacity;
+    }
+    return ParseUtil::parse_mem_spec(disk_size_str, disk_limit);
+}
+
+} // namespace starrocks

--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -36,9 +36,11 @@ struct CacheOptions {
     bool enable_direct_io;
     std::string engine;
     size_t max_concurrent_inserts;
-    // The following options are only valid for cachelib engine currently
-    size_t max_parcel_memory_mb;
-    uint8_t lru_insertion_point;
+    size_t max_flying_memory_mb;
 };
+
+int64_t parse_mem_size(const std::string& mem_size_str, int64_t mem_limit = -1);
+
+int64_t parse_disk_size(const std::string& disk_path, const std::string& disk_size_str, int64_t disk_limit = -1);
 
 } // namespace starrocks

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -42,13 +42,13 @@ Status CacheLibWrapper::init(const CacheOptions& options) {
         }
         nvmConfig.navyConfig.blockCache().setRegionSize(16 * 1024 * 1024);
         nvmConfig.navyConfig.blockCache().setDataChecksum(options.enable_checksum);
-        nvmConfig.navyConfig.setMaxParcelMemoryMB(options.max_parcel_memory_mb);
+        nvmConfig.navyConfig.setMaxParcelMemoryMB(options.max_flying_memory_mb);
         nvmConfig.navyConfig.setMaxConcurrentInserts(options.max_concurrent_inserts);
         config.enableNvmCache(nvmConfig);
     }
 
     Cache::MMConfig mm_config;
-    mm_config.lruInsertionPointSpec = options.lru_insertion_point;
+    mm_config.lruInsertionPointSpec = 1;
     _cache = std::make_unique<Cache>(config);
     _default_pool = _cache->addPool("default pool", _cache->getCacheMemoryStats().cacheSize, {}, mm_config);
     _meta_path = options.meta_path;

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -946,29 +946,39 @@ CONF_Int64(max_length_for_to_base64, "200000");
 // Used by bitmap functions
 CONF_Int64(max_length_for_bitmap_function, "1000000");
 
+// Configuration items for datacache
+CONF_mBool(datacache_enable, "false");
+CONF_mString(datacache_mem_size, "10%");
+CONF_mString(datacache_disk_size, "0");
+CONF_mString(datacache_disk_path, "${STARROCKS_HOME}/datacache/");
+CONF_String(datacache_meta_path, "${STARROCKS_HOME}/datacache/");
+CONF_Int64(datacache_block_size, "262144"); // 256K
+CONF_Bool(datacache_checksum_enable, "false");
+CONF_Bool(datacache_direct_io_enable, "false");
+// Maximum number of concurrent inserts we allow globally for datacache.
+// 0 means unlimited.
+CONF_Int64(datacache_max_concurrent_inserts, "1500000");
+// Total memory limit for in-flight cache jobs.
+// Once this is reached, cache populcation will be rejected until the flying memory usage gets under the limit.
+CONF_Int64(datacache_max_flying_memory_mb, "256");
+// DataCache engines, alternatives: cachelib, starcache.
+// Set the default value empty to indicate whether it is manully configured by users.
+// If not, we need to adjust the default engine based on build switches like "WITH_CACHELIB" and "WITH_STARCACHE".
+CONF_String(datacache_engine, "");
+
+// The following configurations will be deprecated, and we use the `datacache` prefix instead.
+// But it is temporarily necessary to keep them for a period of time to be compatible with
+// the old configuration files.
 CONF_Bool(block_cache_enable, "false");
 CONF_Int64(block_cache_disk_size, "0");
 CONF_String(block_cache_disk_path, "${STARROCKS_HOME}/block_cache/");
 CONF_String(block_cache_meta_path, "${STARROCKS_HOME}/block_cache/");
 CONF_Int64(block_cache_block_size, "262144");   // 256K
 CONF_Int64(block_cache_mem_size, "2147483648"); // 2GB
-CONF_Bool(block_cache_checksum_enable, "false");
-// Maximum number of concurrent inserts we allow globally for block cache.
-// 0 means unlimited.
 CONF_Int64(block_cache_max_concurrent_inserts, "1500000");
-// Total memory limit for in-flight parcels.
-// Once this is reached, requests will be rejected until the parcel memory usage gets under the limit.
-CONF_Int64(block_cache_max_parcel_memory_mb, "256");
-CONF_Bool(block_cache_report_stats, "false");
-// This essentially turns the LRU into a two-segmented LRU. Setting this to 1 means every new insertion
-// will be inserted 1/2 from the end of the LRU, 2 means 1/4 from the end of the LRU, and so on.
-// It is only useful for the cachelib engine currently.
-CONF_Int64(block_cache_lru_insertion_point, "1");
-// Block cache engines, alternatives: cachelib, starcache.
-// Set the default value empty to indicate whether it is manully configured by users.
-// If not, we need to adjust the default engine based on build switches like "WITH_CACHELIB" and "WITH_STARCACHE".
-CONF_String(block_cache_engine, "");
+CONF_Bool(block_cache_checksum_enable, "false");
 CONF_Bool(block_cache_direct_io_enable, "false");
+CONF_String(block_cache_engine, "");
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -90,17 +90,17 @@ Status HiveDataSource::open(RuntimeState* state) {
     }
     RETURN_IF_ERROR(_check_all_slots_nullable());
 
-    _use_block_cache = config::block_cache_enable;
-    if (state->query_options().__isset.use_scan_block_cache) {
-        _use_block_cache &= state->query_options().use_scan_block_cache;
+    _use_datacache = config::datacache_enable;
+    if (state->query_options().__isset.enable_scan_datacache) {
+        _use_datacache &= state->query_options().enable_scan_datacache;
     }
-    if (state->query_options().__isset.enable_populate_block_cache) {
-        _enable_populate_block_cache = state->query_options().enable_populate_block_cache;
+    if (state->query_options().__isset.enable_populate_datacache) {
+        _enable_populate_datacache = state->query_options().enable_populate_datacache;
     }
-    // Don't use block cache when priority = -1
+    // Don't use datacache when priority = -1
     if (_scan_range.__isset.datacache_options && _scan_range.datacache_options.__isset.priority &&
         _scan_range.datacache_options.priority == -1) {
-        _use_block_cache = false;
+        _use_datacache = false;
     }
 
     RETURN_IF_ERROR(_init_conjunct_ctxs(state));
@@ -303,27 +303,26 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
         _profile.shared_buffered_direct_io_timer = ADD_CHILD_TIMER(_runtime_profile, "DirectIOTime", prefix);
     }
 
-    if (_use_block_cache) {
-        static const char* prefix = "BlockCache";
-        ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
-        _profile.block_cache_read_counter =
-                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheReadCounter", TUnit::UNIT, prefix);
-        _profile.block_cache_read_bytes =
-                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheReadBytes", TUnit::BYTES, prefix);
-        _profile.block_cache_read_timer = ADD_CHILD_TIMER(_runtime_profile, "BlockCacheReadTimer", prefix);
-        _profile.block_cache_write_counter =
-                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheWriteCounter", TUnit::UNIT, prefix);
-        _profile.block_cache_write_bytes =
-                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheWriteBytes", TUnit::BYTES, prefix);
-        _profile.block_cache_write_timer = ADD_CHILD_TIMER(_runtime_profile, "BlockCacheWriteTimer", prefix);
-        _profile.block_cache_write_fail_counter =
-                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheWriteFailCounter", TUnit::UNIT, prefix);
-        _profile.block_cache_write_fail_bytes =
-                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheWriteFailBytes", TUnit::BYTES, prefix);
-        _profile.block_cache_read_block_buffer_counter =
-                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheReadBlockBufferCounter", TUnit::UNIT, prefix);
-        _profile.block_cache_read_block_buffer_bytes =
-                ADD_CHILD_COUNTER(_runtime_profile, "BlockCacheReadBlockBufferBytes", TUnit::BYTES, prefix);
+    if (_use_datacache) {
+        static const char* prefix = "DataCache";
+        ADD_COUNTER(_runtime_profile, prefix, TUnit::UNIT);
+        _profile.datacache_read_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadCounter", TUnit::UNIT, prefix);
+        _profile.datacache_read_bytes = ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBytes", TUnit::BYTES, prefix);
+        _profile.datacache_read_timer = ADD_CHILD_TIMER(_runtime_profile, "DataCacheReadTimer", prefix);
+        _profile.datacache_write_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteCounter", TUnit::UNIT, prefix);
+        _profile.datacache_write_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteBytes", TUnit::BYTES, prefix);
+        _profile.datacache_write_timer = ADD_CHILD_TIMER(_runtime_profile, "DataCacheWriteTimer", prefix);
+        _profile.datacache_write_fail_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteFailCounter", TUnit::UNIT, prefix);
+        _profile.datacache_write_fail_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteFailBytes", TUnit::BYTES, prefix);
+        _profile.datacache_read_block_buffer_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBlockBufferCounter", TUnit::UNIT, prefix);
+        _profile.datacache_read_block_buffer_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBlockBufferBytes", TUnit::BYTES, prefix);
     }
 
     {
@@ -536,8 +535,8 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
         auto tbl = dynamic_cast<const IcebergTableDescriptor*>(_hive_table);
         scanner_params.iceberg_schema = tbl->get_iceberg_schema();
     }
-    scanner_params.use_block_cache = _use_block_cache;
-    scanner_params.enable_populate_block_cache = _enable_populate_block_cache;
+    scanner_params.use_datacache = _use_datacache;
+    scanner_params.enable_populate_datacache = _enable_populate_datacache;
     scanner_params.can_use_any_column = _can_use_any_column;
     scanner_params.can_use_min_max_count_opt = _can_use_min_max_count_opt;
 

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -89,8 +89,8 @@ private:
     ObjectPool _pool;
     RuntimeState* _runtime_state = nullptr;
     HdfsScanner* _scanner = nullptr;
-    bool _use_block_cache = false;
-    bool _enable_populate_block_cache = false;
+    bool _use_datacache = false;
+    bool _enable_populate_datacache = false;
 
     // ============ conjuncts =================
     std::vector<ExprContext*> _min_max_conjunct_ctxs;

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -240,10 +240,10 @@ Status HdfsScanner::open_random_access_file() {
         input_stream = _shared_buffered_input_stream;
 
         // input_stream = CacheInputStream(input_stream)
-        if (_scanner_params.use_block_cache) {
+        if (_scanner_params.use_datacache) {
             _cache_input_stream = std::make_shared<io::CacheInputStream>(_shared_buffered_input_stream, filename,
                                                                          file_size, _scanner_params.modification_time);
-            _cache_input_stream->set_enable_populate_cache(_scanner_params.enable_populate_block_cache);
+            _cache_input_stream->set_enable_populate_cache(_scanner_params.enable_populate_datacache);
             _shared_buffered_input_stream->set_align_size(_cache_input_stream->get_align_size());
             input_stream = _cache_input_stream;
         }
@@ -300,18 +300,18 @@ void HdfsScanner::update_counter() {
     COUNTER_UPDATE(profile->column_read_timer, _app_stats.column_read_ns);
     COUNTER_UPDATE(profile->column_convert_timer, _app_stats.column_convert_ns);
 
-    if (_scanner_params.use_block_cache && _cache_input_stream) {
+    if (_scanner_params.use_datacache && _cache_input_stream) {
         const io::CacheInputStream::Stats& stats = _cache_input_stream->stats();
-        COUNTER_UPDATE(profile->block_cache_read_counter, stats.read_cache_count);
-        COUNTER_UPDATE(profile->block_cache_read_bytes, stats.read_cache_bytes);
-        COUNTER_UPDATE(profile->block_cache_read_timer, stats.read_cache_ns);
-        COUNTER_UPDATE(profile->block_cache_write_counter, stats.write_cache_count);
-        COUNTER_UPDATE(profile->block_cache_write_bytes, stats.write_cache_bytes);
-        COUNTER_UPDATE(profile->block_cache_write_timer, stats.write_cache_ns);
-        COUNTER_UPDATE(profile->block_cache_write_fail_counter, stats.write_cache_fail_count);
-        COUNTER_UPDATE(profile->block_cache_write_fail_bytes, stats.write_cache_fail_bytes);
-        COUNTER_UPDATE(profile->block_cache_read_block_buffer_counter, stats.read_block_buffer_count);
-        COUNTER_UPDATE(profile->block_cache_read_block_buffer_bytes, stats.read_block_buffer_bytes);
+        COUNTER_UPDATE(profile->datacache_read_counter, stats.read_cache_count);
+        COUNTER_UPDATE(profile->datacache_read_bytes, stats.read_cache_bytes);
+        COUNTER_UPDATE(profile->datacache_read_timer, stats.read_cache_ns);
+        COUNTER_UPDATE(profile->datacache_write_counter, stats.write_cache_count);
+        COUNTER_UPDATE(profile->datacache_write_bytes, stats.write_cache_bytes);
+        COUNTER_UPDATE(profile->datacache_write_timer, stats.write_cache_ns);
+        COUNTER_UPDATE(profile->datacache_write_fail_counter, stats.write_cache_fail_count);
+        COUNTER_UPDATE(profile->datacache_write_fail_bytes, stats.write_cache_fail_bytes);
+        COUNTER_UPDATE(profile->datacache_read_block_buffer_counter, stats.read_block_buffer_count);
+        COUNTER_UPDATE(profile->datacache_read_block_buffer_bytes, stats.read_block_buffer_bytes);
     }
     if (_shared_buffered_input_stream) {
         COUNTER_UPDATE(profile->shared_buffered_shared_io_count, _shared_buffered_input_stream->shared_io_count());

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -93,16 +93,16 @@ struct HdfsScanProfile {
     RuntimeProfile::Counter* column_read_timer = nullptr;
     RuntimeProfile::Counter* column_convert_timer = nullptr;
 
-    RuntimeProfile::Counter* block_cache_read_counter = nullptr;
-    RuntimeProfile::Counter* block_cache_read_bytes = nullptr;
-    RuntimeProfile::Counter* block_cache_read_timer = nullptr;
-    RuntimeProfile::Counter* block_cache_write_counter = nullptr;
-    RuntimeProfile::Counter* block_cache_write_bytes = nullptr;
-    RuntimeProfile::Counter* block_cache_write_timer = nullptr;
-    RuntimeProfile::Counter* block_cache_write_fail_counter = nullptr;
-    RuntimeProfile::Counter* block_cache_write_fail_bytes = nullptr;
-    RuntimeProfile::Counter* block_cache_read_block_buffer_counter = nullptr;
-    RuntimeProfile::Counter* block_cache_read_block_buffer_bytes = nullptr;
+    RuntimeProfile::Counter* datacache_read_counter = nullptr;
+    RuntimeProfile::Counter* datacache_read_bytes = nullptr;
+    RuntimeProfile::Counter* datacache_read_timer = nullptr;
+    RuntimeProfile::Counter* datacache_write_counter = nullptr;
+    RuntimeProfile::Counter* datacache_write_bytes = nullptr;
+    RuntimeProfile::Counter* datacache_write_timer = nullptr;
+    RuntimeProfile::Counter* datacache_write_fail_counter = nullptr;
+    RuntimeProfile::Counter* datacache_write_fail_bytes = nullptr;
+    RuntimeProfile::Counter* datacache_read_block_buffer_counter = nullptr;
+    RuntimeProfile::Counter* datacache_read_block_buffer_bytes = nullptr;
 
     RuntimeProfile::Counter* shared_buffered_shared_io_count = nullptr;
     RuntimeProfile::Counter* shared_buffered_shared_io_bytes = nullptr;
@@ -180,8 +180,8 @@ struct HdfsScannerParams {
 
     bool is_lazy_materialization_slot(SlotId slot_id) const;
 
-    bool use_block_cache = false;
-    bool enable_populate_block_cache = false;
+    bool use_datacache = false;
+    bool enable_populate_datacache = false;
 
     std::atomic<int32_t>* lazy_column_coalesce_counter;
     bool can_use_any_column = false;

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -151,6 +151,9 @@ Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bo
 }
 
 void CacheInputStream::_deduplicate_shared_buffer(SharedBufferedInputStream::SharedBuffer* sb) {
+    if (sb->size == 0) {
+        return;
+    }
     int64_t end_offset = sb->offset + sb->size;
     int64_t start_block_id = sb->offset / _block_size;
     int64_t end_block_id = (end_offset - 1) / _block_size;

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -38,6 +38,7 @@
 #include "service/staros_worker.h"
 #include "storage/storage_engine.h"
 #include "util/logging.h"
+#include "util/mem_info.h"
 #include "util/thrift_rpc_helper.h"
 #include "util/thrift_server.h"
 
@@ -50,44 +51,67 @@ DECLARE_int64(socket_max_unwritten_bytes);
 
 namespace starrocks {
 
-void init_block_cache() {
+Status init_datacache(GlobalEnv* global_env) {
+    if (!config::datacache_enable && config::block_cache_enable) {
+        config::datacache_enable = true;
+        config::datacache_mem_size = std::to_string(config::block_cache_mem_size);
+        config::datacache_disk_size = std::to_string(config::block_cache_disk_size);
+        config::datacache_disk_path = config::block_cache_disk_path;
+        config::datacache_meta_path = config::block_cache_meta_path;
+        config::datacache_block_size = config::block_cache_block_size;
+        config::datacache_max_concurrent_inserts = config::block_cache_max_concurrent_inserts;
+        config::datacache_checksum_enable = config::block_cache_checksum_enable;
+        config::datacache_direct_io_enable = config::block_cache_direct_io_enable;
+        config::datacache_engine = config::block_cache_engine;
+        LOG(WARNING) << "The configuration items prefixed with `block_cache_` will be deprecated soon"
+                     << ", you'd better use the configuration items prefixed `datacache` instead!";
+    }
+
 #if !defined(WITH_CACHELIB) && !defined(WITH_STARCACHE)
-    if (config::block_cache_enable) {
-        config::block_cache_enable = false;
+    if (config::datacache_enable) {
+        config::datacache_enable = false;
     }
 #endif
 
-    if (config::block_cache_enable) {
+    if (config::datacache_enable) {
         BlockCache* cache = BlockCache::instance();
+
         CacheOptions cache_options;
-        cache_options.mem_space_size = config::block_cache_mem_size;
+        int64_t mem_limit = MemInfo::physical_mem();
+        if (global_env->process_mem_tracker()->has_limit()) {
+            mem_limit = global_env->process_mem_tracker()->limit();
+        }
+        cache_options.mem_space_size = parse_mem_size(config::datacache_mem_size, mem_limit);
 
         std::vector<std::string> paths;
-        EXIT_IF_ERROR(parse_conf_block_cache_paths(config::block_cache_disk_path, &paths));
-
+        RETURN_IF_ERROR(parse_conf_datacache_paths(config::datacache_disk_path, &paths));
         for (auto& p : paths) {
-            cache_options.disk_spaces.push_back(
-                    {.path = p, .size = static_cast<size_t>(config::block_cache_disk_size)});
+            int64_t disk_size = parse_disk_size(p, config::datacache_disk_size);
+            if (disk_size < 0) {
+                LOG(ERROR) << "invalid disk size for datacache: " << disk_size;
+                return Status::InvalidArgument("invalid disk size for datacache");
+            }
+            cache_options.disk_spaces.push_back({.path = p, .size = static_cast<size_t>(disk_size)});
         }
 
         // Adjust the default engine based on build switches.
-        if (config::block_cache_engine == "") {
+        if (config::datacache_engine == "") {
 #if defined(WITH_STARCACHE)
-            config::block_cache_engine = "starcache";
+            config::datacache_engine = "starcache";
 #else
-            config::block_cache_engine = "cachelib";
+            config::datacache_engine = "cachelib";
 #endif
         }
-        cache_options.meta_path = config::block_cache_meta_path;
-        cache_options.block_size = config::block_cache_block_size;
-        cache_options.max_parcel_memory_mb = config::block_cache_max_parcel_memory_mb;
-        cache_options.max_concurrent_inserts = config::block_cache_max_concurrent_inserts;
-        cache_options.lru_insertion_point = config::block_cache_lru_insertion_point;
-        cache_options.enable_checksum = config::block_cache_checksum_enable;
-        cache_options.enable_direct_io = config::block_cache_direct_io_enable;
-        cache_options.engine = config::block_cache_engine;
-        EXIT_IF_ERROR(cache->init(cache_options));
+        cache_options.meta_path = config::datacache_meta_path;
+        cache_options.block_size = config::datacache_block_size;
+        cache_options.max_flying_memory_mb = config::datacache_max_flying_memory_mb;
+        cache_options.max_concurrent_inserts = config::datacache_max_concurrent_inserts;
+        cache_options.enable_checksum = config::datacache_checksum_enable;
+        cache_options.enable_direct_io = config::datacache_direct_io_enable;
+        cache_options.engine = config::datacache_engine;
+        return cache->init(cache_options);
     }
+    return Status::OK();
 }
 
 StorageEngine* init_storage_engine(GlobalEnv* global_env, std::vector<StorePath> paths, bool as_cn) {
@@ -148,8 +172,11 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     LOG(INFO) << process_name << " start step" << start_step++ << ": staros worker init successfully";
 #endif
 
-    init_block_cache();
-    LOG(INFO) << process_name << " start step " << start_step++ << ": block cache init successfully";
+    if (!init_datacache(global_env).ok()) {
+        LOG(ERROR) << "Fail to init datacache";
+        exit(1);
+    }
+    LOG(INFO) << "BE start step " << start_step++ << ": datacache init successfully";
 
     // Start thrift server
     int thrift_port = config::be_port;
@@ -276,9 +303,9 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 #endif
 
 #if defined(WITH_CACHELIB) || defined(WITH_STARCACHE)
-    if (config::block_cache_enable) {
+    if (config::datacache_enable) {
         (void)BlockCache::instance()->shutdown();
-        LOG(INFO) << process_name << " exit step " << exit_step++ << ": block cache shutdown successfully";
+        LOG(INFO) << process_name << " exit step " << exit_step++ << ": datacache shutdown successfully";
     }
 #endif
 

--- a/be/src/storage/options.cpp
+++ b/be/src/storage/options.cpp
@@ -160,7 +160,7 @@ Status parse_conf_store_paths(const string& config_path, std::vector<StorePath>*
     return Status::OK();
 }
 
-Status parse_conf_block_cache_paths(const std::string& config_path, std::vector<std::string>* paths) {
+Status parse_conf_datacache_paths(const std::string& config_path, std::vector<std::string>* paths) {
     if (config_path.empty()) {
         return Status::OK();
     }
@@ -183,8 +183,8 @@ Status parse_conf_block_cache_paths(const std::string& config_path, std::vector<
         paths->emplace_back(local_path.string());
     }
     if ((path_vec.size() != paths->size() && !config::ignore_broken_disk)) {
-        LOG(WARNING) << "fail to parse block_cache_disk_path config. value=[" << config_path << "]";
-        return Status::InvalidArgument("fail to parse block_cache_disk_path");
+        LOG(WARNING) << "fail to parse datacache_disk_path config. value=[" << config_path << "]";
+        return Status::InvalidArgument("fail to parse datacache_disk_path");
     }
     return Status::OK();
 }

--- a/be/src/storage/options.h
+++ b/be/src/storage/options.h
@@ -57,7 +57,7 @@ Status parse_root_path(const std::string& root_path, StorePath* path);
 
 Status parse_conf_store_paths(const std::string& config_path, std::vector<StorePath>* path);
 
-Status parse_conf_block_cache_paths(const std::string& config_path, std::vector<std::string>* paths);
+Status parse_conf_datacache_paths(const std::string& config_path, std::vector<std::string>* paths);
 
 struct EngineOptions {
     // list paths that tablet will be put into.

--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <cstring>
+#include <filesystem>
 
 #include "common/logging.h"
 #include "common/statusor.h"
@@ -104,6 +105,37 @@ TEST_F(BlockCacheTest, copy_to_iobuf) {
     memset(expect, 2, 50);
     memset(expect + 50, 3, 100);
     ASSERT_EQ(memcmp(result, expect, size), 0);
+}
+
+TEST_F(BlockCacheTest, parse_cache_space_str) {
+    uint64_t mem_size = 10;
+    ASSERT_EQ(parse_mem_size("10"), mem_size);
+    mem_size *= 1024;
+    ASSERT_EQ(parse_mem_size("10K"), mem_size);
+    mem_size *= 1024;
+    ASSERT_EQ(parse_mem_size("10M"), mem_size);
+    mem_size *= 1024;
+    ASSERT_EQ(parse_mem_size("10G"), mem_size);
+    mem_size *= 1024;
+    ASSERT_EQ(parse_mem_size("10T"), mem_size);
+    ASSERT_EQ(parse_mem_size("10%", 10 * 1024), 1024);
+
+    std::string disk_path = "./ut_dir/block_disk_cache";
+    uint64_t disk_size = 10;
+    ASSERT_EQ(parse_disk_size(disk_path, "10"), disk_size);
+    disk_size *= 1024;
+    ASSERT_EQ(parse_disk_size(disk_path, "10K"), disk_size);
+    disk_size *= 1024;
+    ASSERT_EQ(parse_disk_size(disk_path, "10M"), disk_size);
+    disk_size *= 1024;
+    ASSERT_EQ(parse_disk_size(disk_path, "10G"), disk_size);
+    disk_size *= 1024;
+    ASSERT_EQ(parse_disk_size(disk_path, "10T"), disk_size);
+
+    disk_size = parse_disk_size(disk_path, "10%");
+    std::error_code ec;
+    auto space_info = std::filesystem::space(disk_path, ec);
+    ASSERT_EQ(disk_size, int64_t(10.0 / 100.0 * space_info.capacity));
 }
 
 #ifdef WITH_STARCACHE
@@ -205,8 +237,6 @@ TEST_F(BlockCacheTest, custom_lru_insertion_point) {
     options.block_size = block_size;
     options.max_concurrent_inserts = 100000;
     options.engine = "cachelib";
-    // insert in the 1/2 of the lru list
-    options.lru_insertion_point = 1;
     Status status = cache->init(options);
     ASSERT_TRUE(status.ok());
 

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -49,7 +49,8 @@ public:
 protected:
     void _create_runtime_state(const std::string& timezone);
     void _create_runtime_profile();
-    Status _init_block_cache(size_t mem_size, const std::string& engine);
+    HdfsScanProfile* _create_profile();
+    Status _init_datacache(size_t mem_size, const std::string& engine);
     HdfsScannerParams* _create_param(const std::string& file, THdfsScanRange* range, const TupleDescriptor* tuple_desc);
     void build_hive_column_names(HdfsScannerParams* params, const TupleDescriptor* tuple_desc,
                                  bool diff_case_sensitive = false);
@@ -69,6 +70,75 @@ void HdfsScannerTest::_create_runtime_profile() {
     _runtime_profile->set_metadata(1);
 }
 
+HdfsScanProfile* HdfsScannerTest::_create_profile() {
+    if (!_runtime_profile) {
+        _create_runtime_profile();
+    }
+    HdfsScanProfile* profile = _pool.add(new HdfsScanProfile());
+    profile->runtime_profile = _runtime_profile;
+    profile->rows_read_counter = ADD_COUNTER(_runtime_profile, "RowsRead", TUnit::UNIT);
+    profile->rows_skip_counter = ADD_COUNTER(_runtime_profile, "RowsSkip", TUnit::UNIT);
+    profile->scan_ranges_counter = ADD_COUNTER(_runtime_profile, "ScanRanges", TUnit::UNIT);
+
+    profile->reader_init_timer = ADD_TIMER(_runtime_profile, "ReaderInit");
+    profile->open_file_timer = ADD_TIMER(_runtime_profile, "OpenFile");
+    profile->expr_filter_timer = ADD_TIMER(_runtime_profile, "ExprFilterTime");
+
+    profile->column_read_timer = ADD_TIMER(_runtime_profile, "ColumnReadTime");
+    profile->column_convert_timer = ADD_TIMER(_runtime_profile, "ColumnConvertTime");
+
+    {
+        static const char* prefix = "SharedBuffered";
+        ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
+        profile->shared_buffered_shared_io_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "SharedIOBytes", TUnit::BYTES, prefix);
+        profile->shared_buffered_shared_io_count =
+                ADD_CHILD_COUNTER(_runtime_profile, "SharedIOCount", TUnit::UNIT, prefix);
+        profile->shared_buffered_shared_io_timer = ADD_CHILD_TIMER(_runtime_profile, "SharedIOTime", prefix);
+        profile->shared_buffered_direct_io_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "DirectIOBytes", TUnit::BYTES, prefix);
+        profile->shared_buffered_direct_io_count =
+                ADD_CHILD_COUNTER(_runtime_profile, "DirectIOCount", TUnit::UNIT, prefix);
+        profile->shared_buffered_direct_io_timer = ADD_CHILD_TIMER(_runtime_profile, "DirectIOTime", prefix);
+    }
+
+    {
+        static const char* prefix = "DataCache";
+        ADD_COUNTER(_runtime_profile, prefix, TUnit::UNIT);
+        profile->datacache_read_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadCounter", TUnit::UNIT, prefix);
+        profile->datacache_read_bytes = ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBytes", TUnit::BYTES, prefix);
+        profile->datacache_read_timer = ADD_CHILD_TIMER(_runtime_profile, "DataCacheReadTimer", prefix);
+        profile->datacache_write_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteCounter", TUnit::UNIT, prefix);
+        profile->datacache_write_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteBytes", TUnit::BYTES, prefix);
+        profile->datacache_write_timer = ADD_CHILD_TIMER(_runtime_profile, "DataCacheWriteTimer", prefix);
+        profile->datacache_write_fail_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteFailCounter", TUnit::UNIT, prefix);
+        profile->datacache_write_fail_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteFailBytes", TUnit::BYTES, prefix);
+        profile->datacache_read_block_buffer_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBlockBufferCounter", TUnit::UNIT, prefix);
+        profile->datacache_read_block_buffer_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBlockBufferBytes", TUnit::BYTES, prefix);
+    }
+
+    {
+        static const char* prefix = "InputStream";
+        ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
+        profile->app_io_bytes_read_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "AppIOBytesRead", TUnit::BYTES, prefix);
+        profile->app_io_timer = ADD_CHILD_TIMER(_runtime_profile, "AppIOTime", prefix);
+        profile->app_io_counter = ADD_CHILD_COUNTER(_runtime_profile, "AppIOCounter", TUnit::UNIT, prefix);
+        profile->fs_bytes_read_counter = ADD_CHILD_COUNTER(_runtime_profile, "FSIOBytesRead", TUnit::BYTES, prefix);
+        profile->fs_io_counter = ADD_CHILD_COUNTER(_runtime_profile, "FSIOCounter", TUnit::UNIT, prefix);
+        profile->fs_io_timer = ADD_CHILD_TIMER(_runtime_profile, "FSIOTime", prefix);
+    }
+
+    return profile;
+}
+
 void HdfsScannerTest::_create_runtime_state(const std::string& timezone) {
     TUniqueId fragment_id;
     TQueryOptions query_options;
@@ -80,12 +150,12 @@ void HdfsScannerTest::_create_runtime_state(const std::string& timezone) {
     _runtime_state->init_instance_mem_tracker();
 }
 
-Status HdfsScannerTest::_init_block_cache(size_t mem_size, const std::string& engine) {
+Status HdfsScannerTest::_init_datacache(size_t mem_size, const std::string& engine) {
     BlockCache* cache = BlockCache::instance();
     CacheOptions cache_options;
     cache_options.mem_space_size = mem_size;
-    cache_options.block_size = starrocks::config::block_cache_block_size;
-    cache_options.enable_checksum = starrocks::config::block_cache_checksum_enable;
+    cache_options.block_size = starrocks::config::datacache_block_size;
+    cache_options.enable_checksum = starrocks::config::datacache_checksum_enable;
     cache_options.max_concurrent_inserts = 1500000;
     cache_options.engine = engine;
     return cache->init(cache_options);
@@ -1604,14 +1674,15 @@ TEST_F(HdfsScannerTest, TestCSVWithoutEndDelemeter) {
         auto* range = _create_scan_range(small_file, 0, 0);
         auto* tuple_desc = _create_tuple_desc(csv_descs);
         auto* param = _create_param(small_file, range, tuple_desc);
+        param->profile = _create_profile();
 #if defined(WITH_STARCACHE)
-        status = _init_block_cache(50 * 1024 * 1024, "starcache"); // 50MB
+        status = _init_datacache(50 * 1024 * 1024, "starcache"); // 50MB
         ASSERT_TRUE(status.ok()) << status.get_error_msg();
-        param->use_block_cache = true;
+        param->use_datacache = true;
 #elif defined(WITH_CACHELIB)
-        status = _init_block_cache(50 * 1024 * 1024, "cachelib"); // 50MB
+        status = _init_datacache(50 * 1024 * 1024, "cachelib"); // 50MB
         ASSERT_TRUE(status.ok()) << status.get_error_msg();
-        param->use_block_cache = true;
+        param->use_datacache = true;
 #endif
         build_hive_column_names(param, tuple_desc, true);
         auto scanner = std::make_shared<HdfsTextScanner>();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -364,8 +364,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String WINDOW_PARTITION_MODE = "window_partition_mode";
 
-    public static final String ENABLE_SCAN_DATACACHE = "enable_scan_block_cache";
+    public static final String ENABLE_SCAN_DATACACHE = "enable_scan_datacache";
+    public static final String ENABLE_POPULATE_DATACACHE = "enable_populate_datacache";
+    // The following configurations will be deprecated, and we use the `datacache` suffix instead.
+    // But it is temporarily necessary to keep them for a period of time to be compatible with
+    // the old session variable names.
+    public static final String ENABLE_SCAN_BLOCK_CACHE = "enable_scan_block_cache";
     public static final String ENABLE_POPULATE_BLOCK_CACHE = "enable_populate_block_cache";
+
     public static final String HUDI_MOR_FORCE_JNI_READER = "hudi_mor_force_jni_reader";
     public static final String IO_TASKS_PER_SCAN_OPERATOR = "io_tasks_per_scan_operator";
     public static final String CONNECTOR_IO_TASKS_PER_SCAN_OPERATOR = "connector_io_tasks_per_scan_operator";
@@ -1145,8 +1151,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableParallelMerge = enableParallelMerge;
     }
 
-    @VariableMgr.VarAttr(name = ENABLE_SCAN_DATACACHE)
+    @VariableMgr.VarAttr(name = ENABLE_SCAN_DATACACHE, alias = ENABLE_SCAN_BLOCK_CACHE)
     private boolean enableScanDataCache = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_POPULATE_DATACACHE, alias = ENABLE_POPULATE_BLOCK_CACHE)
+    private boolean enablePopulateDataCache = true;
 
     @VariableMgr.VarAttr(name = IO_TASKS_PER_SCAN_OPERATOR)
     private int ioTasksPerScanOperator = 4;
@@ -1165,9 +1174,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = CONNECTOR_SCAN_USE_QUERY_MEM_RATIO)
     private double connectorScanUseQueryMemRatio = 0.3;
-
-    @VariableMgr.VarAttr(name = ENABLE_POPULATE_BLOCK_CACHE)
-    private boolean enablePopulateBlockCache = true;
 
     @VariableMgr.VarAttr(name = HUDI_MOR_FORCE_JNI_READER)
     private boolean hudiMORForceJNIReader = false;
@@ -2670,8 +2676,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
         tResult.setAllow_throw_exception((sqlMode & SqlModeHelper.MODE_ALLOW_THROW_EXCEPTION) != 0);
 
-        tResult.setUse_scan_block_cache(enableScanDataCache);
-        tResult.setEnable_populate_block_cache(enablePopulateBlockCache);
+        tResult.setEnable_scan_datacache(enableScanDataCache);
+        tResult.setEnable_populate_datacache(enablePopulateDataCache);
         tResult.setHudi_mor_force_jni_reader(hudiMORForceJNIReader);
         tResult.setIo_tasks_per_scan_operator(ioTasksPerScanOperator);
         tResult.setConnector_io_tasks_per_scan_operator(connectorIoTasksPerScanOperator);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -176,13 +176,13 @@ struct TQueryOptions {
 
   64: optional TLoadJobType load_job_type
 
-  66: optional bool use_scan_block_cache;
+  66: optional bool enable_scan_datacache;
 
   67: optional bool enable_pipeline_query_statistic = false;
 
   68: optional i32 transmission_encode_level;
   
-  69: optional bool enable_populate_block_cache;
+  69: optional bool enable_populate_datacache;
 
   70: optional bool allow_throw_exception = 0;
 


### PR DESCRIPTION
In this PR, we rename the old BE configuration items and FE session variables related to datacache from `block_cache` to `datacache`, to make it easier for users to understand. Also, we still keep the original items for compatibility with old versions, and they will be removed after some version iterations.

In addition, we support more flexible ways, such as space percentage, to configure datacache.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
