### PR TITLE
[BugFix] Fix synchronized materialized view with upper column names

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
@@ -459,7 +459,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         Type type = defineExpr.getType();
         String columnName;
         if (defineExpr instanceof SlotRef) {
-            columnName = ((SlotRef) defineExpr).getColumnName().toLowerCase();
+            columnName = ((SlotRef) defineExpr).getColumnName();
         } else {
             if (Strings.isNullOrEmpty(selectListItem.getAlias())) {
                 throw new SemanticException("Create materialized view non-slot ref expression should have an alias:" +
@@ -468,8 +468,8 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             columnName = MVUtils.getMVColumnName(selectListItem.getAlias());
             type = AnalyzerUtils.transformTableColumnType(type, false);
         }
-        Set<String> baseColumnNames = baseSlotRefs.stream().map(slot -> slot.getColumnName().toLowerCase()).
-                collect(Collectors.toSet());
+        Set<String> baseColumnNames = baseSlotRefs.stream().map(slot -> slot.getColumnName())
+                        .collect(Collectors.toSet());
         return new MVColumnItem(columnName, type, null, false, defineExpr,
                 defineExpr.isNullable(),  baseColumnNames);
     }
@@ -486,7 +486,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         Type type;
         String mvColumnName = null;
         if (defineExpr instanceof SlotRef) {
-            String baseColumName = baseSlotRefs.get(0).getColumnName().toLowerCase();
+            String baseColumName = baseSlotRefs.get(0).getColumnName();
             mvColumnName = MVUtils.getMVAggColumnName(functionName, baseColumName);
         } else {
             if (defineExpr instanceof FunctionCallExpr) {
@@ -497,7 +497,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                     case FunctionSet.HLL_HASH:
                     case FunctionSet.PERCENTILE_HASH: {
                         if (argFunc.getChild(0) instanceof SlotRef) {
-                            String baseColumName = baseSlotRefs.get(0).getColumnName().toLowerCase();
+                            String baseColumName = baseSlotRefs.get(0).getColumnName();
                             mvColumnName = MVUtils.getMVAggColumnName(functionName, baseColumName);
                         }
                         break;
@@ -557,8 +557,8 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             throw new SemanticException(
                     String.format("Invalid aggregate function '%s' for '%s'", mvAggregateType, type));
         }
-        Set<String> baseColumnNames = baseSlotRefs.stream().map(slot -> slot.getColumnName().toLowerCase()).
-                collect(Collectors.toSet());
+        Set<String> baseColumnNames = baseSlotRefs.stream().map(slot -> slot.getColumnName())
+                        .collect(Collectors.toSet());
         return new MVColumnItem(mvColumnName, type, mvAggregateType, false,
                 defineExpr, functionCallExpr.isNullable(), baseColumnNames);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -119,6 +119,19 @@ public class CreateMaterializedViewTest {
                         ")\n" +
                         "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
                         "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE test.TBL1 \n" +
+                        "(\n" +
+                        "    K1 date,\n" +
+                        "    K2 int,\n" +
+                        "    V1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(K1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2020-01-01'),('2020-02-01')),\n" +
+                        "    PARTITION p2 values [('2020-02-01'),('2020-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(K2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
                 .withTable("CREATE TABLE `aggregate_table_with_null` (\n" +
                         "`k1` date,\n" +
                         "`v2` datetime MAX,\n" +
@@ -3024,6 +3037,78 @@ public class CreateMaterializedViewTest {
                     "in table tbl1"));
         }
         starRocksAssert.dropMaterializedView("sync_mv1");
+    }
+
+    @Test
+    public void testCreateSyncMV_WithUpperColumn() throws Exception {
+        // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
+        String sql = "create materialized view UPPER_MV1 as select K1, sum(V1) from TBL1 group by K1;";
+        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+
+        waitingRollupJobV2Finish();
+        {
+            sql = "select * from UPPER_MV1 [_SYNC_MV_];";
+            Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+            String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
+            // output columns should be same with the base table.
+            Assert.assertTrue(explainString.contains("PLAN FRAGMENT 0\n" +
+                    " OUTPUT EXPRS:1: K1 | 2: mv_sum_V1\n" +
+                    "  PARTITION: UNPARTITIONED"));
+        }
+        {
+            sql = "select K1, sum(V1) from TBL1 group by K1";
+            Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+            String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
+            Assert.assertTrue(explainString.contains("1:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  output: sum(4: mv_sum_V1)\n" +
+                    "  |  group by: 1: K1\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: TBL1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=2/2\n" +
+                    "     rollup: UPPER_MV1"));
+        }
+        starRocksAssert.dropMaterializedView("UPPER_MV1");
+    }
+
+    @Test
+    public void testCreateSyncMV_WithLowerColumn() throws Exception {
+        // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
+        String sql = "create materialized view lower_mv1 as select k1, sum(v1) from tbl1 group by K1;";
+        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+
+        waitingRollupJobV2Finish();
+        {
+            sql = "select * from lower_mv1 [_SYNC_MV_];";
+            Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+            String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
+            // output columns should be same with the base table.
+            Assert.assertTrue(explainString.contains("PLAN FRAGMENT 0\n" +
+                    " OUTPUT EXPRS:1: k1 | 2: mv_sum_v1\n" +
+                    "  PARTITION: UNPARTITIONED"));
+        }
+        {
+            sql = "select K1, sum(v1) from tbl1 group by K1";
+            Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+            String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
+            Assert.assertTrue(explainString.contains("1:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  output: sum(4: mv_sum_v1)\n" +
+                    "  |  group by: 1: k1\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: tbl1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=2/2\n" +
+                    "     rollup: lower_mv1"));
+        }
+        starRocksAssert.dropMaterializedView("lower_mv1");
     }
 
     @Test

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view2
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view2
@@ -1,4 +1,4 @@
--- name: test_sync_materialized_view
+-- name: test_sync_materialized_view2
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view2
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view2
@@ -1,4 +1,4 @@
--- name: test_sync_materialized_view2
+-- name: test_sync_materialized_view
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
 -- result:
 -- !result
@@ -148,4 +148,53 @@ drop materialized view test_ce_mv1;
 2	a	2	None
 4	b	2	None
 6	None	None	None
+-- !result
+CREATE TABLE UPPER_TBL1 
+(
+    K1 date,
+    K2 int,
+    V1 int sum
+)
+PARTITION BY RANGE(K1)
+(
+    PARTITION p1 values [('2020-01-01'),('2020-02-01')),
+    PARTITION p2 values [('2020-02-01'),('2020-03-01'))
+)
+DISTRIBUTED BY HASH(K2) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into UPPER_TBL1 values ('2020-01-01', 1, 1), ('2020-01-01', 1, 1), ('2020-01-01', 1, 2),  ('2020-01-01', 2, 1);
+-- result:
+-- !result
+create materialized view UPPER_MV1 as select K1, sum(V1) from UPPER_TBL1 group by K1;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+select * from UPPER_MV1 [_SYNC_MV_] order by K1, mv_sum_V1;
+-- result:
+2020-01-01	1
+2020-01-01	4
+-- !result
+select K1, sum(V1) from UPPER_TBL1 group by K1;
+-- result:
+2020-01-01	5
+-- !result
+insert into UPPER_TBL1 values ('2020-01-01', 1, 1), ('2020-01-01', 1, 1), ('2020-01-01', 1, 2),  ('2020-01-01', 2, 1);
+-- result:
+-- !result
+select * from UPPER_MV1 [_SYNC_MV_] order by K1, mv_sum_V1;
+-- result:
+2020-01-01	2
+2020-01-01	8
+-- !result
+select K1, sum(V1) from UPPER_TBL1 group by K1;
+-- result:
+2020-01-01	10
+-- !result
+drop materialized view UPPER_MV1;
+-- result:
 -- !result

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view2
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view2
@@ -72,3 +72,28 @@ insert into tbl1 values (1, 'a', 1, 'aa'), (2, 'b', 1, NULL), (3, NULL, NULL, NU
 select * from tbl1 order by k1;
 select * from test_ce_mv1 [_SYNC_MV_] order by mv_k1_2; 
 drop materialized view test_ce_mv1;
+
+-- table with upper case
+CREATE TABLE UPPER_TBL1 
+(
+    K1 date,
+    K2 int,
+    V1 int sum
+)
+PARTITION BY RANGE(K1)
+(
+    PARTITION p1 values [('2020-01-01'),('2020-02-01')),
+    PARTITION p2 values [('2020-02-01'),('2020-03-01'))
+)
+DISTRIBUTED BY HASH(K2) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+insert into UPPER_TBL1 values ('2020-01-01', 1, 1), ('2020-01-01', 1, 1), ('2020-01-01', 1, 2),  ('2020-01-01', 2, 1);
+create materialized view UPPER_MV1 as select K1, sum(V1) from UPPER_TBL1 group by K1;
+function: wait_materialized_view_finish()
+select * from UPPER_MV1 [_SYNC_MV_] order by K1, mv_sum_V1;
+select K1, sum(V1) from UPPER_TBL1 group by K1;
+insert into UPPER_TBL1 values ('2020-01-01', 1, 1), ('2020-01-01', 1, 1), ('2020-01-01', 1, 2),  ('2020-01-01', 2, 1);
+select * from UPPER_MV1 [_SYNC_MV_] order by K1, mv_sum_V1;
+select K1, sum(V1) from UPPER_TBL1 group by K1;
+drop materialized view UPPER_MV1;

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view2
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view2
@@ -1,4 +1,4 @@
--- name: test_sync_materialized_view
+-- name: test_sync_materialized_view2
 
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
 insert into user_tags values('2023-04-13', 1, 'a', 1), ('2023-04-13', 1, 'b', 2), ('2023-04-13', 1, 'c', 3), ('2023-04-13', 1, 'd', 4), ('2023-04-13', 1, 'e', 5), ('2023-04-13', 2, 'e', 5), ('2023-04-13', 3, 'e', 6);


### PR DESCRIPTION
Fix #31504 

- synchronized materialized view should be case sensitive for base table's column names.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
