### PR TITLE
[BugFix] fix build.sh error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,7 +55,7 @@ if [ -z $STARROCKS_VERSION ]; then
     fi
 fi
 
-if [ -z $STARROCKS_COMMIT_HASH]; then
+if [ -z $STARROCKS_COMMIT_HASH ] ; then
     export STARROCKS_COMMIT_HASH=$(git rev-parse --short=7 HEAD)
 fi
 


### PR DESCRIPTION
* fix the following error

```
./build.sh: line 58: [: missing `]'
```

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
