### PR TITLE
[Enhancement] Change the parquet footer init read size to 48KB

### DIFF
--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -37,7 +37,7 @@ namespace starrocks::parquet {
 
 // contains magic number (4 bytes) and footer length (4 bytes)
 constexpr static const uint32_t PARQUET_FOOTER_SIZE = 8;
-constexpr static const uint64_t DEFAULT_FOOTER_BUFFER_SIZE = 64 * 1024;
+constexpr static const uint64_t DEFAULT_FOOTER_BUFFER_SIZE = 48 * 1024;
 constexpr static const char* PARQUET_MAGIC_NUMBER = "PAR1";
 constexpr static const char* PARQUET_EMAIC_NUMBER = "PARE";
 


### PR DESCRIPTION
Make the footer init read size the same as Trino

<img width="874" alt="image" src="https://github.com/StarRocks/starrocks/assets/18729228/63c64cb9-b5a6-434b-88ae-df31ba46e7fe">


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
