### PR TITLE
[Enhancement] Support decimal/decimal(precision) declaration for mysql compatibility

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -179,12 +179,14 @@ public class ScalarType extends Type implements Cloneable {
     /**
      * Unified decimal is used for parser, which creating default decimal from name
      */
-    public static ScalarType createUnifiedDecimalType() throws AnalysisException {
-        throw decimalParseError("both precision and scale are absent");
+    public static ScalarType createUnifiedDecimalType() {
+        // for mysql compatibility
+        return createUnifiedDecimalType(10, 0);
     }
 
-    public static ScalarType createUnifiedDecimalType(int precision) throws AnalysisException {
-        throw decimalParseError("scale is absent");
+    public static ScalarType createUnifiedDecimalType(int precision) {
+        // for mysql compatibility
+        return createUnifiedDecimalType(precision, 0);
     }
 
     public static ScalarType createUnifiedDecimalType(int precision, int scale) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -6733,11 +6733,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 if (scale != null) {
                     return ScalarType.createUnifiedDecimalType(precision, scale);
                 }
-                try {
-                    return ScalarType.createUnifiedDecimalType(precision);
-                } catch (AnalysisException e) {
-                    throw new SemanticException(e.getMessage());
-                }
+                return ScalarType.createUnifiedDecimalType(precision);
             }
             return ScalarType.createUnifiedDecimalType(10, 0);
         } else if (context.DECIMAL32() != null || context.DECIMAL64() != null || context.DECIMAL128() != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableWithDecimalTypesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateTableWithDecimalTypesTest.java
@@ -39,7 +39,7 @@ public class CreateTableWithDecimalTypesTest {
         starRocksAssert.withDatabase("db1").useDatabase("db1");
     }
 
-    public void createTableFail(boolean enableDecimalV3, String columnType) throws Exception {
+    public void createTable(boolean enableDecimalV3, String columnType) throws Exception {
         if (enableDecimalV3) {
             Config.enable_decimal_v3 = true;
         } else {
@@ -63,56 +63,54 @@ public class CreateTableWithDecimalTypesTest {
 
     @Test(expected = Exception.class)
     public void createTableWithDecimalV3p39s12() throws Exception {
-        createTableFail(true, "DECIMAL(39, 12)");
+        createTable(true, "DECIMAL(39, 12)");
         Assert.fail("should throw an exception");
     }
 
     @Test(expected = Exception.class)
     public void createTableWithDecimalV3p9s10() throws Exception {
-        createTableFail(true, "DECIMAL(9, 10)");
+        createTable(true, "DECIMAL(9, 10)");
         Assert.fail("should throw an exception");
     }
 
     @Test(expected = Exception.class)
     public void createTableWithDecimalV3p0s1() throws Exception {
-        createTableFail(true, "DECIMAL(0, 1)");
+        createTable(true, "DECIMAL(0, 1)");
         Assert.fail("should throw an exception");
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void createTableWithDecimalV3ScaleAbsent() throws Exception {
-        createTableFail(true, "DECIMAL(9)");
-        Assert.fail("should throw an exception");
+        createTable(true, "DECIMAL(9)");
     }
 
     @Test(expected = Exception.class)
     public void createTableWithDecimalV2p28s9() throws Exception {
-        createTableFail(false, "DECIMAL(28, 9)");
+        createTable(false, "DECIMAL(28, 9)");
         Assert.fail("should throw an exception");
     }
 
     @Test(expected = Exception.class)
     public void createTableWithDecimalV2p27s10() throws Exception {
-        createTableFail(false, "DECIMAL(27, 10)");
+        createTable(false, "DECIMAL(27, 10)");
         Assert.fail("should throw an exception");
     }
 
     @Test(expected = Exception.class)
     public void createTableWithDecimalV2p9s10() throws Exception {
-        createTableFail(false, "DECIMAL(9, 10)");
+        createTable(false, "DECIMAL(9, 10)");
         Assert.fail("should throw an exception");
     }
 
     @Test(expected = Exception.class)
     public void createTableWithDecimalV2p0s1() throws Exception {
-        createTableFail(false, "DECIMAL(0, 1)");
+        createTable(false, "DECIMAL(0, 1)");
         Assert.fail("should throw an exception");
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void createTableWithDecimalV2ScaleAbsent() throws Exception {
-        createTableFail(false, "DECIMAL(9)");
-        Assert.fail("should throw an exception");
+        createTable(false, "DECIMAL(9)");
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ScalarTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ScalarTypeTest.java
@@ -26,16 +26,14 @@ import java.util.List;
 
 public class ScalarTypeTest {
 
-    @Test(expected = AnalysisException.class)
+    @Test
     public void createUnifiedDecimalTypeWithoutPrecisionAndScale() throws AnalysisException {
         ScalarType.createUnifiedDecimalType();
-        Assert.fail("should throw an exception");
     }
 
-    @Test(expected = AnalysisException.class)
+    @Test
     public void testCreateUnifiedDecimalTypeWithoutScale() throws AnalysisException {
         ScalarType.createUnifiedDecimalType(18);
-        Assert.fail("should throw an exception");
     }
 
     @Test


### PR DESCRIPTION
For mysql compatiblity: bare decimal and deicmal(p) type declarations are legal:
1. for decimal, use decimal(10,0) instead;
2. for decimal(p),use decimal(p,0) instead.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
