### PR TITLE
[BugFix] Fail to refresh MV in share_data cluster

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -28,7 +28,6 @@ import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.lake.CommitRateLimiter;
-import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.Utils;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.proto.AbortTxnRequest;
@@ -51,7 +50,7 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
     private static final Logger LOG = LogManager.getLogger(LakeTableTxnStateListener.class);
     private final DatabaseTransactionMgr dbTxnMgr;
     // lake table or lake materialized view
-    private final LakeTable table;
+    private final OlapTable table;
 
     private Set<Long> dirtyPartitionSet;
     private Set<String> invalidDictCacheColumns;
@@ -60,8 +59,10 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
 
     public LakeTableTxnStateListener(@NotNull DatabaseTransactionMgr dbTxnMgr, @NotNull OlapTable table) {
         this.dbTxnMgr = Objects.requireNonNull(dbTxnMgr, "dbTxnMgr is null");
-        this.table = (LakeTable) Objects.requireNonNull(table, "table is null");
+        this.table = Objects.requireNonNull(table, "table is null");
         this.compactionMgr = GlobalStateMgr.getCurrentState().getCompactionMgr();
+        Preconditions.checkState(this.table.isCloudNativeTableOrMaterializedView(),
+                "expect LakeTable or LakeMaterializedView but real type is " + this.table.getClass().getName());
     }
 
     @Override


### PR DESCRIPTION
The `table` parameter of class LakeTableTxnStateListener can be `LakeTable` or `LakeMaterializedView`, since `LakeMaterializedView` is not a subclass of `LakeTable`, cannot cast the `table` parameter to `LakeTable`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
