### PR TITLE
[Enhancement] Replace the RPC call for fetching partition names from HMS to avoid HMS timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -276,8 +276,16 @@ public class CachingHiveMetastore implements IHiveMetastore {
     }
 
     private List<String> loadPartitionKeys(HivePartitionValue hivePartitionValue) {
-        return metastore.getPartitionKeysByValue(hivePartitionValue.getHiveTableName().getDatabaseName(),
-                hivePartitionValue.getHiveTableName().getTableName(), hivePartitionValue.getPartitionValues());
+        String dbName = hivePartitionValue.getHiveTableName().getDatabaseName();
+        String tableName = hivePartitionValue.getHiveTableName().getTableName();
+        List<Optional<String>> partitionValues = hivePartitionValue.getPartitionValues();
+        if (hivePartitionValue.getPartitionValues().isEmpty()) {
+            HiveTableName hiveTableName = HiveTableName.of(dbName, tableName);
+            Table table = loadTable(hiveTableName);
+            partitionValues = table.getPartitionColumnNames().stream()
+                    .map(columnName -> Optional.of("")).collect(Collectors.toList());
+        }
+        return metastore.getPartitionKeysByValue(dbName, tableName, partitionValues);
     }
 
     public Database getDb(String dbName) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.transport.TTransportException;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -158,6 +159,11 @@ public class HiveMetaClient {
             argClasses = argClasses == null ? ClassUtils.getCompatibleParamClasses(args) : argClasses;
             Method method = client.hiveClient.getClass().getDeclaredMethod(methodName, argClasses);
             return (T) method.invoke(client.hiveClient, args);
+        } catch (InvocationTargetException e) {
+            LOG.error(messageIfError, e);
+            connectionException = new StarRocksConnectorException(messageIfError + ", msg: " +
+                    e.getTargetException().getMessage(), e.getTargetException());
+            throw connectionException;
         } catch (Throwable e) {
             LOG.error(messageIfError, e);
             connectionException = new StarRocksConnectorException(messageIfError + ", msg: " + e.getMessage(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -217,16 +217,10 @@ public class OptExternalPartitionPruner {
                 // check if the partition predicate could be used for filter partition names
                 List<Optional<ScalarOperator>> effectivePartitionPredicate =
                         getEffectivePartitionPredicate(operator, partitionColumns, operator.getPredicate());
-                if (effectivePartitionPredicate.stream().anyMatch(Optional::isPresent)) {
-                    List<Optional<String>> partitionValues = getPartitionValue(effectivePartitionPredicate);
-                    partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                            .listPartitionNamesByValue(hmsTable.getCatalogName(), hmsTable.getDbName(),
-                                    hmsTable.getTableName(), partitionValues);
-                } else {
-                    partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                            .listPartitionNames(hmsTable.getCatalogName(), hmsTable.getDbName(),
-                                    hmsTable.getTableName());
-                }
+                List<Optional<String>> partitionValues = getPartitionValue(effectivePartitionPredicate);
+                partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                        .listPartitionNamesByValue(hmsTable.getCatalogName(), hmsTable.getDbName(),
+                                hmsTable.getTableName(), partitionValues);
 
                 List<PartitionKey> keys = new ArrayList<>();
                 for (String partName : partitionNames) {


### PR DESCRIPTION
Fixes #issue

Why is it needed?
listPartitionNames causes HMS timeout when fetching millions of partition names from HMS, as the corresponding RPC call submits a query containing "order by partitionName asc". By replacing this method with listPartitionNamesByValue may avoid the order by action. 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
