### PR TITLE
[Refactor] Replan the insert to get rid of the metadata inconsistent between plan() and beginTransaction() (#31351)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2547,4 +2547,7 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static long mv_plan_cache_max_size = 1000;
+
+    @ConfField(mutable = true)
+    public static boolean replan_on_insert = false;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -373,8 +373,8 @@ public class DefaultCoordinator extends Coordinator {
     }
 
     @Override
-    public void setExecPlanSupplier(Supplier<ExecPlan> execPlanSupplier) {
-        queryProfile.setExecPlanSupplier(execPlanSupplier);
+    public void setExecPlan(ExecPlan execPlan) {
+        queryProfile.setExecPlan(execPlan);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -948,7 +948,7 @@ public class StmtExecutor {
 
         coord.exec();
         coord.setTopProfileSupplier(this::buildTopLevelProfile);
-        coord.setExecPlanSupplier(() -> execPlan);
+        coord.setExecPlan(execPlan);
 
         RowBatch batch;
         boolean isOutfileQuery = false;
@@ -1766,6 +1766,15 @@ public class StmtExecutor {
                     sourceType,
                     context.getSessionVariable().getQueryTimeoutS());
 
+            // The metadata may be changed between plan() and beginTransaction().
+            // When to beginTransaction(), the plan is not ready and the tablet is dropped by balance.
+            // So we need to get txn first, to make the dropping tablet procedure to wait.
+            // This is the re-plan of the insert to fix the issue
+
+            if (Config.replan_on_insert) {
+                execPlan = StatementPlanner.plan(stmt, context);
+            }
+
             // add table indexes to transaction state
             txnState = transactionMgr.getTransactionState(database.getId(), transactionId);
             if (txnState == null) {
@@ -1850,7 +1859,7 @@ public class StmtExecutor {
 
             coord.exec();
             coord.setTopProfileSupplier(this::buildTopLevelProfile);
-            coord.setExecPlanSupplier(() -> execPlan);
+            coord.setExecPlan(execPlan);
 
             long jobDeadLineMs = System.currentTimeMillis() + context.getSessionVariable().getQueryTimeoutS() * 1000;
             coord.join(context.getSessionVariable().getQueryTimeoutS());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -156,7 +156,7 @@ public abstract class Coordinator {
 
     public abstract void setTopProfileSupplier(Supplier<RuntimeProfile> topProfileSupplier);
 
-    public abstract void setExecPlanSupplier(Supplier<ExecPlan> execPlanSupplier);
+    public abstract void setExecPlan(ExecPlan execPlan);
 
     public abstract RuntimeProfile buildMergedQueryProfile();
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -85,7 +85,7 @@ public class QueryRuntimeProfile {
     private MarkedCountDownLatch<TUniqueId, Long> profileDoneSignal = null;
 
     private Supplier<RuntimeProfile> topProfileSupplier;
-    private Supplier<ExecPlan> execPlanSupplier;
+    private ExecPlan execPlan;
     private final AtomicLong lastRuntimeProfileUpdateTime = new AtomicLong(System.currentTimeMillis());
 
     // ------------------------------------------------------------------------------------
@@ -163,8 +163,8 @@ public class QueryRuntimeProfile {
         this.topProfileSupplier = topProfileSupplier;
     }
 
-    public void setExecPlanSupplier(Supplier<ExecPlan> execPlanSupplier) {
-        this.execPlanSupplier = execPlanSupplier;
+    public void setExecPlan(ExecPlan execPlan) {
+        this.execPlan = execPlan;
     }
 
     public void clearExportStatus() {
@@ -242,7 +242,7 @@ public class QueryRuntimeProfile {
         // current batch, the previous reported state will be synchronized to the profile manager.
         long now = System.currentTimeMillis();
         long lastTime = lastRuntimeProfileUpdateTime.get();
-        if (topProfileSupplier != null && execPlanSupplier != null && connectContext != null &&
+        if (topProfileSupplier != null && execPlan != null && connectContext != null &&
                 connectContext.getSessionVariable().isEnableProfile() &&
                 // If it's the last done report, avoiding duplicate trigger
                 (!execState.isFinished() || profileDoneSignal.getLeftMarks().size() > 1) &&
@@ -250,7 +250,7 @@ public class QueryRuntimeProfile {
                 now - lastTime > (connectContext.getSessionVariable().getRuntimeProfileReportInterval() * 950L) &&
                 lastRuntimeProfileUpdateTime.compareAndSet(lastTime, now)) {
             RuntimeProfile profile = topProfileSupplier.get();
-            ExecPlan plan = execPlanSupplier.get();
+            ExecPlan plan = execPlan;
             profile.addChild(buildMergedQueryProfile());
             ProfilingExecPlan profilingPlan = plan == null ? null : plan.getProfilingPlan();
             ProfileManager.getInstance().pushProfile(profilingPlan, profile);
@@ -489,8 +489,8 @@ public class QueryRuntimeProfile {
         Counter querySpillBytes = newQueryProfile.addCounter("QuerySpillBytes", TUnit.BYTES, null);
         querySpillBytes.setValue(maxQuerySpillBytes);
 
-        if (execPlanSupplier != null) {
-            newQueryProfile.addInfoString("Topology", execPlanSupplier.get().getProfilingPlan().toTopologyJson());
+        if (execPlan != null) {
+            newQueryProfile.addInfoString("Topology", execPlan.getProfilingPlan().toTopologyJson());
         }
         Counter processTimer =
                 newQueryProfile.addCounter("FrontendProfileMergeTime", TUnit.TIME_NS, null);


### PR DESCRIPTION
The metadata may be changed between plan() and beginTransaction(). When to beginTransaction(), the plan is not ready and the tablet is dropped by balanced. So we need to get txn first, to make the dropping tablet procedure wait.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
