### PR TITLE
[Feature][Cherry-Pick] Unload data via table function (backport #30544)

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -189,6 +189,7 @@ set(EXEC_FILES
     pipeline/scan/schema_scan_context.cpp
     pipeline/sink/iceberg_table_sink_operator.cpp
     pipeline/sink/hive_table_sink_operator.cpp
+    pipeline/sink/table_function_table_sink_operator.cpp
     pipeline/scan/morsel.cpp
     pipeline/scan/chunk_buffer_limiter.cpp
     pipeline/sink/file_sink_operator.cpp

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -54,6 +54,7 @@
 #include "runtime/result_sink.h"
 #include "runtime/runtime_state.h"
 #include "runtime/schema_table_sink.h"
+#include "runtime/table_function_table_sink.h"
 
 namespace starrocks {
 
@@ -158,6 +159,13 @@ Status DataSink::create_data_sink(RuntimeState* state, const TDataSink& thrift_s
             return Status::InternalError("Missing hive table sink");
         }
         *sink = std::make_unique<HiveTableSink>(state->obj_pool(), output_exprs);
+        break;
+    }
+    case TDataSinkType::TABLE_FUNCTION_TABLE_SINK: {
+        if (!thrift_sink.__isset.table_function_table_sink) {
+            return Status::InternalError("Missing table function table sink");
+        }
+        *sink = std::make_unique<TableFunctionTableSink>(state->obj_pool(), output_exprs);
         break;
     }
 

--- a/be/src/exec/parquet_writer.cpp
+++ b/be/src/exec/parquet_writer.cpp
@@ -123,12 +123,14 @@ bool RollingAsyncParquetWriter::closed() {
     }
 
     if (_writer != nullptr) {
-        return _writer->closed();
-    }
+        if (!_writer->closed()) {
+            return false;
+        }
 
-    auto st = _writer->get_io_status();
-    if (!st.ok()) {
-        set_io_status(st);
+        auto st = _writer->get_io_status();
+        if (!st.ok()) {
+            set_io_status(st);
+        }
     }
 
     return true;

--- a/be/src/exec/parquet_writer.cpp
+++ b/be/src/exec/parquet_writer.cpp
@@ -29,6 +29,7 @@ RollingAsyncParquetWriter::RollingAsyncParquetWriter(
         std::function<void(starrocks::parquet::AsyncFileWriter*, RuntimeState*)> commit_func, RuntimeState* state,
         int32_t driver_id)
         : _table_info(std::move(tableInfo)),
+          _max_file_size(_table_info.max_file_size),
           _output_expr_ctxs(output_expr_ctxs),
           _parent_profile(parent_profile),
           _commit_func(std::move(commit_func)),
@@ -75,11 +76,13 @@ Status RollingAsyncParquetWriter::_new_file_writer() {
 }
 
 Status RollingAsyncParquetWriter::append_chunk(Chunk* chunk, RuntimeState* state) {
+    RETURN_IF_ERROR(get_io_status());
+
     if (_writer == nullptr) {
         RETURN_IF_ERROR(_new_file_writer());
     }
     // exceed file size
-    if (_writer->file_size() > _max_file_size) {
+    if (_max_file_size != -1 && _writer->file_size() > _max_file_size) {
         RETURN_IF_ERROR(close_current_writer(state));
         RETURN_IF_ERROR(_new_file_writer());
     }
@@ -109,16 +112,23 @@ Status RollingAsyncParquetWriter::close(RuntimeState* state) {
 
 bool RollingAsyncParquetWriter::closed() {
     for (auto& writer : _pending_commits) {
-        if (writer != nullptr && writer->closed()) {
-            writer = nullptr;
-        }
-        if (writer != nullptr && (!writer->closed())) {
+        if (!writer->closed()) {
             return false;
+        }
+
+        auto st = writer->get_io_status();
+        if (!st.ok()) {
+            set_io_status(st);
         }
     }
 
     if (_writer != nullptr) {
         return _writer->closed();
+    }
+
+    auto st = _writer->get_io_status();
+    if (!st.ok()) {
+        set_io_status(st);
     }
 
     return true;

--- a/be/src/exec/parquet_writer.h
+++ b/be/src/exec/parquet_writer.h
@@ -42,6 +42,7 @@ struct TableInfo {
     bool enable_dictionary = true;
     std::string partition_location = "";
     std::shared_ptr<::parquet::schema::GroupNode> schema;
+    int64_t max_file_size = 1024 * 1024 * 1024; // 1GB
     TCloudConfiguration cloud_conf;
 };
 
@@ -60,6 +61,14 @@ public:
     bool writable() const { return _writer == nullptr || _writer->writable(); }
     bool closed();
 
+    void set_io_status(const Status& status) {
+        if (_io_status.ok()) {
+            _io_status = status;
+        }
+    }
+
+    Status get_io_status() const { return _io_status; }
+
 private:
     std::string _new_file_location();
 
@@ -75,8 +84,9 @@ private:
     TableInfo _table_info;
     int32_t _file_cnt = 0;
     std::string _outfile_location;
+    Status _io_status;
     std::vector<std::shared_ptr<starrocks::parquet::AsyncFileWriter>> _pending_commits;
-    int64_t _max_file_size = 1 * 1024 * 1024 * 1024; // 1GB
+    int64_t _max_file_size;
     std::vector<ExprContext*> _output_expr_ctxs;
     RuntimeProfile* _parent_profile;
     std::function<void(starrocks::parquet::AsyncFileWriter*, RuntimeState*)> _commit_func;

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -39,6 +39,7 @@
 #include "exec/pipeline/sink/iceberg_table_sink_operator.h"
 #include "exec/pipeline/sink/memory_scratch_sink_operator.h"
 #include "exec/pipeline/sink/mysql_table_sink_operator.h"
+#include "exec/pipeline/sink/table_function_table_sink_operator.h"
 #include "exec/pipeline/stream_pipeline_driver.h"
 #include "exec/scan_node.h"
 #include "exec/tablet_sink.h"
@@ -59,6 +60,7 @@
 #include "runtime/result_sink.h"
 #include "runtime/stream_load/stream_load_context.h"
 #include "runtime/stream_load/transaction_mgr.h"
+#include "runtime/table_function_table_sink.h"
 #include "util/debug/query_trace.h"
 #include "util/pretty_printer.h"
 #include "util/runtime_profile.h"
@@ -968,6 +970,64 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
             context->maybe_interpolate_local_key_partition_exchange_for_sink(
                     runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, hive_table_sink_op,
                     partition_expr_ctxs, source_operator_dop, desired_hive_sink_dop);
+        }
+    } else if (typeid(*datasink) == typeid(starrocks::TableFunctionTableSink)) {
+        DCHECK(thrift_sink.table_function_table_sink.__isset.target_table);
+        DCHECK(thrift_sink.table_function_table_sink.__isset.cloud_configuration);
+
+        const auto& target_table = thrift_sink.table_function_table_sink.target_table;
+        DCHECK(target_table.__isset.path);
+        DCHECK(target_table.__isset.file_format);
+        DCHECK(target_table.__isset.columns);
+        DCHECK(target_table.__isset.write_single_file);
+        DCHECK(target_table.columns.size() == output_exprs.size());
+
+        std::vector<std::string> column_names;
+        for (const auto& column : target_table.columns) {
+            column_names.push_back(column.column_name);
+        }
+
+        std::vector<TExpr> partition_exprs;
+        std::vector<std::string> partition_column_names;
+        if (target_table.__isset.partition_column_ids) {
+            for (auto id : target_table.partition_column_ids) {
+                partition_exprs.push_back(output_exprs[id]);
+                partition_column_names.push_back(target_table.columns[id].column_name);
+            }
+        }
+        std::vector<ExprContext*> partition_expr_ctxs;
+        RETURN_IF_ERROR(Expr::create_expr_trees(runtime_state->obj_pool(), partition_exprs, &partition_expr_ctxs,
+                                                runtime_state));
+
+        std::vector<ExprContext*> output_expr_ctxs;
+        RETURN_IF_ERROR(
+                Expr::create_expr_trees(runtime_state->obj_pool(), output_exprs, &output_expr_ctxs, runtime_state));
+
+        auto op = std::make_shared<TableFunctionTableSinkOperatorFactory>(
+                context->next_operator_id(), target_table.path, target_table.file_format, target_table.compression_type,
+                output_expr_ctxs, partition_expr_ctxs, column_names, partition_column_names,
+                target_table.write_single_file, thrift_sink.table_function_table_sink.cloud_configuration,
+                fragment_ctx);
+
+        size_t source_dop = fragment_ctx->pipelines().back()->source_operator_factory()->degree_of_parallelism();
+        size_t sink_dop = request.pipeline_sink_dop();
+
+        if (target_table.write_single_file) {
+            sink_dop = 1;
+        }
+
+        if (partition_expr_ctxs.empty()) {
+            if (sink_dop != source_dop) {
+                context->maybe_interpolate_local_passthrough_exchange_for_sink(
+                        runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, std::move(op), source_dop,
+                        sink_dop);
+            } else {
+                fragment_ctx->pipelines().back()->get_op_factories().emplace_back(std::move(op));
+            }
+        } else {
+            context->maybe_interpolate_local_key_partition_exchange_for_sink(
+                    runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, op, partition_expr_ctxs, source_dop,
+                    sink_dop);
         }
     }
 

--- a/be/src/exec/pipeline/sink/hive_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/hive_table_sink_operator.cpp
@@ -17,42 +17,10 @@
 #include <utility>
 
 #include "exec/parquet_builder.h"
+#include "table_function_table_sink_operator.h"
 #include "util/path_util.h"
-#include "util/url_coding.h"
 
 namespace starrocks::pipeline {
-
-StatusOr<std::string> column_to_string(const TypeDescriptor& type_desc, const ColumnPtr& column) {
-    auto datum = column->get(0);
-
-    switch (type_desc.type) {
-    case TYPE_BOOLEAN: {
-        return datum.get_uint8() ? "true" : "false";
-    }
-    case TYPE_TINYINT: {
-        return std::to_string(datum.get_int8());
-    }
-    case TYPE_SMALLINT: {
-        return std::to_string(datum.get_int16());
-    }
-    case TYPE_INT: {
-        return std::to_string(datum.get_int32());
-    }
-    case TYPE_BIGINT: {
-        return std::to_string(datum.get_int64());
-    }
-    case TYPE_DATE: {
-        return datum.get_date().to_string();
-    }
-    case TYPE_CHAR:
-    case TYPE_VARCHAR: {
-        return url_encode(datum.get_slice().to_string());
-    }
-    default: {
-        return Status::InvalidArgument("unsupported partition column type" + type_desc.debug_string());
-    }
-    }
-}
 
 static const std::string HIVE_UNPARTITIONED_TABLE_LOCATION = "hive_unpartitioned_table_fake_location";
 

--- a/be/src/exec/pipeline/sink/table_function_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/table_function_table_sink_operator.cpp
@@ -1,0 +1,240 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "table_function_table_sink_operator.h"
+
+#include "formats/parquet/file_writer.h"
+#include "glog/logging.h"
+#include "util/url_coding.h"
+
+namespace starrocks::pipeline {
+
+// TODO(letian-jiang): optimize
+StatusOr<std::string> column_to_string(const TypeDescriptor& type_desc, const ColumnPtr& column) {
+    auto datum = column->get(0);
+    if (datum.is_null()) {
+        return "null";
+    }
+
+    switch (type_desc.type) {
+    case TYPE_BOOLEAN: {
+        return datum.get_uint8() ? "true" : "false";
+    }
+    case TYPE_TINYINT: {
+        return std::to_string(datum.get_int8());
+    }
+    case TYPE_SMALLINT: {
+        return std::to_string(datum.get_int16());
+    }
+    case TYPE_INT: {
+        return std::to_string(datum.get_int32());
+    }
+    case TYPE_BIGINT: {
+        return std::to_string(datum.get_int64());
+    }
+    case TYPE_DATE: {
+        return datum.get_date().to_string();
+    }
+    case TYPE_DATETIME: {
+        return url_encode(datum.get_timestamp().to_string());
+    }
+    case TYPE_CHAR:
+    case TYPE_VARCHAR: {
+        return url_encode(datum.get_slice().to_string());
+    }
+    default: {
+        return Status::InvalidArgument("unsupported partition column type" + type_desc.debug_string());
+    }
+    }
+}
+
+inline std::string get_partition_location(const string& path, const std::vector<std::string>& names,
+                                          const std::vector<std::string>& values) {
+    std::string partition_location = path;
+    for (size_t i = 0; i < names.size(); i++) {
+        partition_location += names[i] + "=" + values[i] + "/";
+    }
+    partition_location += "data_";
+    return partition_location;
+}
+
+Status TableFunctionTableSinkOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+    return Status::OK();
+}
+
+void TableFunctionTableSinkOperator::close(RuntimeState* state) {
+    for (const auto& writer : _partition_writers) {
+        if (!writer.second->closed()) {
+            writer.second->close(state);
+        }
+    }
+    Operator::close(state);
+}
+
+bool TableFunctionTableSinkOperator::need_input() const {
+    for (const auto& writer : _partition_writers) {
+        if (!writer.second->writable()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool TableFunctionTableSinkOperator::is_finished() const {
+    if (_partition_writers.size() == 0) {
+        return _is_finished.load();
+    }
+    for (const auto& writer : _partition_writers) {
+        if (!writer.second->closed()) {
+            return false;
+        }
+
+        auto st = writer.second->get_io_status();
+        if (!st.ok()) {
+            LOG(WARNING) << "cancel fragment: " << st.message();
+            _fragment_ctx->cancel(st);
+        }
+    }
+
+    return true;
+}
+
+Status TableFunctionTableSinkOperator::set_finishing(RuntimeState* state) {
+    for (const auto& writer : _partition_writers) {
+        if (!writer.second->closed()) {
+            writer.second->close(state);
+        }
+    }
+
+    if (_partition_writers.size() == 0) {
+        _is_finished = true;
+    }
+    return Status::OK();
+}
+
+bool TableFunctionTableSinkOperator::pending_finish() const {
+    return !is_finished();
+}
+
+Status TableFunctionTableSinkOperator::set_cancelled(RuntimeState* state) {
+    return Status::OK();
+}
+
+StatusOr<ChunkPtr> TableFunctionTableSinkOperator::pull_chunk(RuntimeState* state) {
+    return Status::InternalError("Shouldn't pull chunk from table function table sink operator");
+}
+
+Status TableFunctionTableSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    if (_partition_exprs.empty()) {
+        if (_partition_writers.empty()) {
+            auto writer = std::make_unique<RollingAsyncParquetWriter>(_make_table_info(_path), _output_exprs,
+                                                                      _common_metrics.get(), add_commit_info, state,
+                                                                      _driver_sequence);
+            RETURN_IF_ERROR(writer->init());
+            _partition_writers.insert({"default writer", std::move(writer)});
+        }
+        return _partition_writers["default writer"]->append_chunk(chunk.get(), state);
+    }
+
+    // compute partition values and correspondent location
+    std::vector<std::string> partition_column_values(_partition_exprs.size());
+    for (size_t i = 0; i < _partition_exprs.size(); ++i) {
+        ASSIGN_OR_RETURN(auto column, _partition_exprs[i]->evaluate(chunk.get()));
+        ASSIGN_OR_RETURN(partition_column_values[i], column_to_string(_partition_exprs[i]->root()->type(), column))
+    }
+    string partition_location = get_partition_location(_path, _partition_column_names, partition_column_values);
+
+    auto partition_writer = _partition_writers.find(partition_location);
+    // create writer for current partition if not exists
+    if (partition_writer == _partition_writers.end()) {
+        auto writer = std::make_unique<RollingAsyncParquetWriter>(_make_table_info(partition_location), _output_exprs,
+                                                                  _common_metrics.get(), add_commit_info, state,
+                                                                  _driver_sequence);
+        RETURN_IF_ERROR(writer->init());
+        RETURN_IF_ERROR(writer->append_chunk(chunk.get(), state));
+        _partition_writers.insert({partition_location, std::move(writer)});
+        return Status::OK();
+    }
+
+    return _partition_writers[partition_location]->append_chunk(chunk.get(), state);
+}
+
+TableInfo TableFunctionTableSinkOperator::_make_table_info(const string& partition_location) const {
+    TableInfo tableInfo;
+    tableInfo.partition_location = partition_location;
+    tableInfo.schema = _parquet_file_schema;
+    tableInfo.compress_type = _compression_type;
+    tableInfo.cloud_conf = _cloud_conf;
+    if (_write_single_file) {
+        tableInfo.max_file_size = -1;
+    }
+    return tableInfo;
+}
+
+TableFunctionTableSinkOperatorFactory::TableFunctionTableSinkOperatorFactory(
+        const int32_t id, const string& path, const string& file_format, const TCompressionType::type& compression_type,
+        const std::vector<ExprContext*>& output_exprs, const std::vector<ExprContext*>& partition_exprs,
+        const std::vector<std::string>& column_names, const std::vector<std::string>& partition_column_names,
+        bool write_single_file, const TCloudConfiguration& cloud_conf, FragmentContext* fragment_ctx)
+        : OperatorFactory(id, "table_function_table_sink", Operator::s_pseudo_plan_node_id_for_final_sink),
+          _path(path),
+          _file_format(file_format),
+          _compression_type(compression_type),
+          _output_exprs(output_exprs),
+          _partition_exprs(partition_exprs),
+          _column_names(column_names),
+          _partition_column_names(partition_column_names),
+          _write_single_file(write_single_file),
+          _cloud_conf(cloud_conf),
+          _fragment_ctx(fragment_ctx) {}
+
+Status TableFunctionTableSinkOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorFactory::prepare(state));
+
+    RETURN_IF_ERROR(Expr::prepare(_output_exprs, state));
+    RETURN_IF_ERROR(Expr::open(_output_exprs, state));
+
+    RETURN_IF_ERROR(Expr::prepare(_partition_exprs, state));
+    RETURN_IF_ERROR(Expr::open(_partition_exprs, state));
+
+    if (_file_format == "parquet") {
+        auto result = parquet::ParquetBuildHelper::make_schema(
+                _column_names, _output_exprs, std::vector<parquet::FileColumnId>(_output_exprs.size()));
+        if (!result.ok()) {
+            return Status::NotSupported(result.status().message());
+        }
+        _parquet_file_schema = result.ValueOrDie();
+    } else {
+        return Status::InternalError("unsupported file format" + _file_format);
+    }
+
+    return Status::OK();
+}
+
+OperatorPtr TableFunctionTableSinkOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
+    return std::make_shared<TableFunctionTableSinkOperator>(
+            this, _id, _plan_node_id, driver_sequence, _path, _file_format, _compression_type, _output_exprs,
+            _partition_exprs, _partition_column_names, _write_single_file, _cloud_conf, _fragment_ctx,
+            _parquet_file_schema);
+}
+
+void TableFunctionTableSinkOperatorFactory::close(RuntimeState* state) {
+    Expr::close(_partition_exprs, state);
+    Expr::close(_output_exprs, state);
+    OperatorFactory::close(state);
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sink/table_function_table_sink_operator.h
+++ b/be/src/exec/pipeline/sink/table_function_table_sink_operator.h
@@ -1,0 +1,133 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <gen_cpp/DataSinks_types.h>
+#include <parquet/arrow/writer.h>
+
+#include <utility>
+
+#include "common/logging.h"
+#include "exec/parquet_writer.h"
+#include "exec/pipeline/fragment_context.h"
+#include "exec/pipeline/operator.h"
+#include "fs/fs.h"
+
+namespace starrocks::pipeline {
+
+class TableFunctionTableSinkOperator final : public Operator {
+public:
+    TableFunctionTableSinkOperator(OperatorFactory* factory, const int32_t id, const int32_t plan_node_id,
+                                   const int32_t driver_sequence, const string& path, const string& file_format,
+                                   const TCompressionType::type& compression_type,
+                                   const std::vector<ExprContext*>& output_exprs,
+                                   const std::vector<ExprContext*>& partition_exprs,
+                                   const std::vector<std::string>& partition_column_names, bool write_single_file,
+                                   const TCloudConfiguration& cloud_conf, FragmentContext* fragment_ctx,
+                                   std::shared_ptr<::parquet::schema::GroupNode> parquet_file_schema)
+            : Operator(factory, id, "table_function_table_sink", plan_node_id, false, driver_sequence),
+              _path(path),
+              _file_format(file_format),
+              _compression_type(compression_type),
+              _output_exprs(output_exprs),
+              _partition_exprs(partition_exprs),
+              _partition_column_names(partition_column_names),
+              _write_single_file(write_single_file),
+              _cloud_conf(cloud_conf),
+              _fragment_ctx(fragment_ctx),
+              _parquet_file_schema(std::move(parquet_file_schema)) {}
+
+    ~TableFunctionTableSinkOperator() override = default;
+
+    Status prepare(RuntimeState* state) override;
+
+    void close(RuntimeState* state) override;
+
+    bool has_output() const override { return false; }
+
+    bool need_input() const override;
+
+    bool is_finished() const override;
+
+    Status set_finishing(RuntimeState* state) override;
+
+    bool pending_finish() const override;
+
+    Status set_cancelled(RuntimeState* state) override;
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
+
+private:
+    TableInfo _make_table_info(const string& partition_location) const;
+
+    static void add_commit_info(starrocks::parquet::AsyncFileWriter* writer, RuntimeState* state) {
+        if (writer->metadata()) {
+            state->update_num_rows_load_sink(writer->metadata()->num_rows());
+        }
+    }
+
+private:
+    const std::string _path;
+    const std::string _file_format;
+    const TCompressionType::type _compression_type;
+    const std::vector<ExprContext*> _output_exprs;
+    const std::vector<ExprContext*> _partition_exprs;
+    const std::vector<std::string> _partition_column_names;
+    const bool _write_single_file;
+    const TCloudConfiguration _cloud_conf;
+    mutable FragmentContext* _fragment_ctx;
+
+    const std::shared_ptr<::parquet::schema::GroupNode> _parquet_file_schema;
+    std::unordered_map<std::string, std::unique_ptr<starrocks::RollingAsyncParquetWriter>> _partition_writers;
+    std::atomic<bool> _is_finished = false;
+};
+
+class TableFunctionTableSinkOperatorFactory final : public OperatorFactory {
+public:
+    TableFunctionTableSinkOperatorFactory(const int32_t id, const string& path, const string& file_format,
+                                          const TCompressionType::type& compression_type,
+                                          const std::vector<ExprContext*>& output_exprs,
+                                          const std::vector<ExprContext*>& partition_exprs,
+                                          const std::vector<std::string>& column_names,
+                                          const std::vector<std::string>& partition_column_names,
+                                          bool write_single_file, const TCloudConfiguration& cloud_conf,
+                                          FragmentContext* fragment_ctx);
+
+    ~TableFunctionTableSinkOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override;
+
+    Status prepare(RuntimeState* state) override;
+
+    void close(RuntimeState* state) override;
+
+private:
+    const std::string _path;
+    const std::string _file_format;
+    const TCompressionType::type _compression_type;
+    const std::vector<ExprContext*> _output_exprs;
+    const std::vector<ExprContext*> _partition_exprs;
+    const std::vector<std::string> _column_names;
+    const std::vector<std::string> _partition_column_names;
+    const bool _write_single_file;
+    const TCloudConfiguration _cloud_conf;
+    FragmentContext* _fragment_ctx;
+
+    std::shared_ptr<::parquet::schema::GroupNode> _parquet_file_schema;
+};
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/sink/table_function_table_sink_operator.h
+++ b/be/src/exec/pipeline/sink/table_function_table_sink_operator.h
@@ -27,6 +27,8 @@
 
 namespace starrocks::pipeline {
 
+StatusOr<std::string> column_to_string(const TypeDescriptor& type_desc, const ColumnPtr& column);
+
 class TableFunctionTableSinkOperator final : public Operator {
 public:
     TableFunctionTableSinkOperator(OperatorFactory* factory, const int32_t id, const int32_t plan_node_id,

--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -158,6 +158,7 @@ arrow::Result<std::shared_ptr<::parquet::schema::GroupNode>> ParquetBuildHelper:
             ::parquet::schema::GroupNode::Make("table", ::parquet::Repetition::REQUIRED, std::move(fields)));
 }
 
+// for UT only
 arrow::Result<std::shared_ptr<::parquet::schema::GroupNode>> ParquetBuildHelper::make_schema(
         const std::vector<std::string>& file_column_names, const std::vector<TypeDescriptor>& type_descs,
         const std::vector<FileColumnId>& file_column_ids) {
@@ -432,7 +433,12 @@ Status AsyncFileWriter::_flush_row_group() {
     bool ok = _executor_pool->try_offer([&]() {
         SCOPED_TIMER(_io_timer);
         if (_chunk_writer != nullptr) {
-            _chunk_writer->close();
+            try {
+                _chunk_writer->close();
+            } catch (const ::parquet::ParquetStatusException& e) {
+                LOG(WARNING) << "flush row group error: " << e.what();
+                set_io_status(Status::IOError(fmt::format("{}: {}", "flush rowgroup error", e.what())));
+            }
             _chunk_writer = nullptr;
         }
         {
@@ -464,25 +470,37 @@ Status AsyncFileWriter::close(RuntimeState* state,
             auto lock = std::unique_lock(_m);
             _cv.wait(lock, [&] { return !_rg_writer_closing; });
         }
-        _writer->Close();
+
+        DeferOp defer([&]() {
+            // set closed to true anyway
+            _closed.store(true);
+        });
+
+        try {
+            _writer->Close();
+        } catch (const ::parquet::ParquetStatusException& e) {
+            LOG(WARNING) << "close writer error: " << e.what();
+            set_io_status(Status::IOError(fmt::format("{}: {}", "close writer error", e.what())));
+        }
         _chunk_writer = nullptr;
+
         _file_metadata = _writer->metadata();
         auto st = _outstream->Close();
         if (!st.ok()) {
-            return Status::InternalError("Close outstream failed");
+            LOG(WARNING) << "close output stream error: " << st.message();
+            set_io_status(Status::IOError(fmt::format("{}: {}", "close output stream error", st.message())));
         }
 
         if (cb != nullptr) {
             cb(this, state);
         }
-        _closed.store(true);
-        return Status::OK();
     });
 
-    if (ret) {
-        return Status::OK();
+    if (!ret) {
+        return Status::InternalError("Submit close file task error");
     }
-    return Status::InternalError("Submit close file error");
+
+    return Status::OK();
 }
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/file_writer.h
+++ b/be/src/formats/parquet/file_writer.h
@@ -199,12 +199,27 @@ public:
 
     std::string partition_location() const { return _partition_location; }
 
+    void set_io_status(const Status& status) {
+        std::unique_lock l(_io_status_mutex);
+        if (_io_status.ok()) {
+            _io_status = status;
+        }
+    }
+
+    Status get_io_status() const {
+        std::shared_lock l(_io_status_mutex);
+        return _io_status;
+    }
+
 private:
     Status _flush_row_group() override;
 
     std::string _file_location;
     std::string _partition_location;
     std::atomic<bool> _closed = false;
+
+    mutable std::shared_mutex _io_status_mutex;
+    Status _io_status;
 
     PriorityThreadPool* _executor_pool;
 

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -94,6 +94,7 @@ set(RUNTIME_FILES
     command_executor.cpp
     iceberg_table_sink.cpp
     hive_table_sink.cpp
+    table_function_table_sink.cpp
 )
 
 set(RUNTIME_FILES ${RUNTIME_FILES}

--- a/be/src/runtime/table_function_table_sink.cpp
+++ b/be/src/runtime/table_function_table_sink.cpp
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "table_function_table_sink.h"
+
+#include "exprs/expr.h"
+#include "glog/logging.h"
+#include "runtime/runtime_state.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks {
+
+TableFunctionTableSink::TableFunctionTableSink(ObjectPool* pool, const std::vector<TExpr>& t_exprs)
+        : _pool(pool), _t_output_expr(t_exprs) {}
+
+TableFunctionTableSink::~TableFunctionTableSink() = default;
+
+Status TableFunctionTableSink::init(const TDataSink& thrift_sink, RuntimeState* state) {
+    RETURN_IF_ERROR(DataSink::init(thrift_sink, state));
+    RETURN_IF_ERROR(prepare(state));
+    RETURN_IF_ERROR(open(state));
+    return Status::OK();
+}
+
+Status TableFunctionTableSink::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(DataSink::prepare(state));
+    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state));
+    std::stringstream title;
+    title << "TableFunctionTableSink (frag_id=" << state->fragment_instance_id() << ")";
+    _profile = _pool->add(new RuntimeProfile(title.str()));
+    return Status::OK();
+}
+
+Status TableFunctionTableSink::open(RuntimeState* state) {
+    RETURN_IF_ERROR(Expr::open(_output_expr_ctxs, state));
+    return Status::OK();
+}
+
+Status TableFunctionTableSink::send_chunk(RuntimeState* state, Chunk* chunk) {
+    return Status::OK();
+}
+
+Status TableFunctionTableSink::close(RuntimeState* state, Status exec_status) {
+    Expr::close(_output_expr_ctxs, state);
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/runtime/table_function_table_sink.h
+++ b/be/src/runtime/table_function_table_sink.h
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common/logging.h"
+#include "exec/data_sink.h"
+
+namespace starrocks {
+
+class ExprContext;
+
+class TableFunctionTableSink : public DataSink {
+public:
+    TableFunctionTableSink(ObjectPool* pool, const std::vector<TExpr>& t_exprs);
+
+    ~TableFunctionTableSink() override;
+
+    Status init(const TDataSink& thrift_sink, RuntimeState* state) override;
+
+    Status prepare(RuntimeState* state) override;
+
+    Status open(RuntimeState* state) override;
+
+    Status send_chunk(RuntimeState* state, Chunk* chunk) override;
+
+    Status close(RuntimeState* state, Status exec_status) override;
+
+    RuntimeProfile* profile() override { return _profile; }
+
+    std::vector<TExpr> get_output_expr() const { return _t_output_expr; }
+
+private:
+    ObjectPool* _pool;
+    const std::vector<TExpr>& _t_output_expr;
+    std::vector<ExprContext*> _output_expr_ctxs;
+    RuntimeProfile* _profile = nullptr;
+};
+
+} // namespace starrocks

--- a/be/src/util/url_coding.cpp
+++ b/be/src/util/url_coding.cpp
@@ -154,6 +154,7 @@ bool base64_decode(const std::string& in, std::string* out) {
     return true;
 }
 
+// refers to https://stackoverflow.com/questions/154536/encode-decode-urls-in-c
 std::string url_encode(const std::string& decoded) {
     const auto encoded_value = curl_easy_escape(nullptr, decoded.c_str(), static_cast<int>(decoded.length()));
     std::string result(encoded_value);

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
@@ -80,7 +80,7 @@ public class OutFileClause implements ParseNode {
         PARQUET_COMPRESSION_TYPE_MAP.put("lzo", TCompressionType.LZO);
         PARQUET_COMPRESSION_TYPE_MAP.put("bz2", TCompressionType.BZIP2);
         PARQUET_COMPRESSION_TYPE_MAP.put("zlib", TCompressionType.ZLIB);
-        PARQUET_COMPRESSION_TYPE_MAP.put("default", TCompressionType.DEFAULT_COMPRESSION);
+        PARQUET_COMPRESSION_TYPE_MAP.put("uncompressed", TCompressionType.NO_COMPRESSION);
     }
 
     public static final Set<PrimitiveType> PARQUET_SUPPORTED_PRIMITIVE_TYPES = ImmutableSet.of(

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -346,6 +346,10 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
         return type == TableType.JDBC;
     }
 
+    public boolean isTableFunctionTable() {
+        return type == TableType.TABLE_FUNCTION;
+    }
+
     // for create table
     public boolean isOlapOrCloudNativeTable() {
         return isOlapTable() || isCloudNativeTable();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -55,6 +55,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Verify.verify;
+import static com.starrocks.analysis.OutFileClause.PARQUET_COMPRESSION_TYPE_MAP;
 
 public class TableFunctionTable extends Table {
 
@@ -70,6 +75,10 @@ public class TableFunctionTable extends Table {
     private String format;
     private Map<String, String> properties;
     private List<String> columnsFromPath = new ArrayList<>();
+    private String compressionType;
+    @Nullable
+    private List<Integer> partitionColumnIDs;
+    private boolean writeSingleFile;
 
     private List<TBrokerFileStatus> fileStatuses = Lists.newArrayList();
 
@@ -96,6 +105,27 @@ public class TableFunctionTable extends Table {
         setNewFullSchema(columns);
     }
 
+    // Ctor for unload data via table function
+    public TableFunctionTable(String path, String format, String compressionType, List<Column> columns,
+                              @Nullable List<Integer> partitionColumnIDs, boolean writeSingleFile,
+                              Map<String, String> properties) {
+        super(TableType.TABLE_FUNCTION);
+        verify(!Strings.isNullOrEmpty(path), "path is null or empty");
+        verify(!(partitionColumnIDs != null && writeSingleFile));
+        this.path = path;
+        this.format = format;
+        this.compressionType = compressionType;
+        this.partitionColumnIDs = partitionColumnIDs;
+        this.writeSingleFile = writeSingleFile;
+        this.properties = properties;
+        super.setNewFullSchema(columns);
+    }
+
+    @Override
+    public boolean supportInsert() {
+        return true;
+    }
+
     public List<TBrokerFileStatus> fileList() {
         return fileStatuses;
     }
@@ -107,20 +137,26 @@ public class TableFunctionTable extends Table {
 
     @Override
     public TTableDescriptor toThrift(List<DescriptorTable.ReferencedPartitionInfo> partitions) {
-        TTableFunctionTable tTbl = new TTableFunctionTable();
-        tTbl.setPath(path);
-
-        List<TColumn> tColumns = Lists.newArrayList();
-
-        for (Column column : getBaseSchema()) {
-            tColumns.add(column.toThrift());
-        }
-        tTbl.setColumns(tColumns);
-
         TTableDescriptor tTableDescriptor = new TTableDescriptor(id, TTableType.TABLE_FUNCTION_TABLE, fullSchema.size(),
                 0, "_table_function_table", "_table_function_db");
-        tTableDescriptor.setTableFunctionTable(tTbl);
+
+        TTableFunctionTable tTableFunctionTable = this.toTTableFunctionTable();
+        tTableDescriptor.setTableFunctionTable(tTableFunctionTable);
         return tTableDescriptor;
+    }
+
+    public TTableFunctionTable toTTableFunctionTable() {
+        TTableFunctionTable tTableFunctionTable = new TTableFunctionTable();
+        List<TColumn> tColumns = getFullSchema().stream().map(Column::toThrift).collect(Collectors.toList());
+        tTableFunctionTable.setPath(path);
+        tTableFunctionTable.setColumns(tColumns);
+        tTableFunctionTable.setFile_format(format);
+        tTableFunctionTable.setWrite_single_file(writeSingleFile);
+        tTableFunctionTable.setCompression_type(PARQUET_COMPRESSION_TYPE_MAP.get(compressionType));
+        if (partitionColumnIDs != null) {
+            tTableFunctionTable.setPartition_column_ids(partitionColumnIDs);
+        }
+        return tTableFunctionTable;
     }
 
     public String getFormat() {
@@ -317,5 +353,17 @@ public class TableFunctionTable extends Table {
     @Override
     public boolean isSupported() {
         return true;
+    }
+
+    @Override
+    public List<String> getPartitionColumnNames() {
+        if (partitionColumnIDs == null) {
+            return new ArrayList<>();
+        }
+        return partitionColumnIDs.stream().map(id -> fullSchema.get(id).getName()).collect(Collectors.toList());
+    }
+
+    public boolean isWriteSingleFile() {
+        return writeSingleFile;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataSink.java
@@ -39,6 +39,7 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.thrift.TDataSink;
@@ -97,6 +98,8 @@ public abstract class DataSink {
         } else if (table instanceof IcebergTable) {
             return true;
         } else if (table instanceof HiveTable) {
+            return true;
+        } else if (table instanceof TableFunctionTable) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -157,6 +157,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     private boolean hasOlapTableSink = false;
     private boolean hasIcebergTableSink = false;
     private boolean hasHiveTableSink = false;
+    private boolean hasTableFunctionTableSink = false;
 
     private boolean forceSetTableSinkDop = false;
     private boolean forceAssignScanRangesPerDriverSeq = false;
@@ -260,7 +261,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     }
 
     public boolean hasTableSink() {
-        return hasIcebergTableSink() || hasOlapTableSink() || hasHiveTableSink();
+        return hasIcebergTableSink() || hasOlapTableSink() || hasHiveTableSink() || hasTableFunctionTableSink();
     }
 
     public boolean hasOlapTableSink() {
@@ -285,6 +286,14 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public void setHasHiveTableSink() {
         this.hasHiveTableSink = true;
+    }
+
+    public boolean hasTableFunctionTableSink() {
+        return this.hasTableFunctionTableSink;
+    }
+
+    public void setHasTableFunctionTableSink() {
+        this.hasTableFunctionTableSink = true;
     }
 
     public boolean forceSetTableSinkDop() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/TableFunctionTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/TableFunctionTableSink.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.TableFunctionTable;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.thrift.TCloudConfiguration;
+import com.starrocks.thrift.TDataSink;
+import com.starrocks.thrift.TDataSinkType;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TTableFunctionTableSink;
+
+public class TableFunctionTableSink extends DataSink {
+    private final TableFunctionTable table;
+    private final CloudConfiguration cloudConfiguration;
+
+    public TableFunctionTableSink(TableFunctionTable targetTable) {
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(
+                targetTable.getProperties());
+        this.table = targetTable;
+        this.cloudConfiguration = cloudConfiguration;
+    }
+
+    @Override
+    public String getExplainString(String prefix, TExplainLevel explainLevel) {
+        return prefix + "TABLE FUNCTION TABLE SINK\n" +
+                prefix + "  PATH: " + table.getPath() + "\n" +
+                prefix + "  FORMAT: " + table.getFormat() + "\n" +
+                prefix + "  PARTITION BY: " + table.getPartitionColumnNames() + "\n" +
+                prefix + "  SINGLE: " + table.isWriteSingleFile() + "\n" +
+                prefix + "  " + DataPartition.RANDOM.getExplainString(explainLevel);
+    }
+
+    @Override
+    protected TDataSink toThrift() {
+        TTableFunctionTableSink tTableFunctionTableSink = new TTableFunctionTableSink();
+        tTableFunctionTableSink.setTarget_table(table.toTTableFunctionTable());
+        TCloudConfiguration tCloudConfiguration = new TCloudConfiguration();
+        cloudConfiguration.toThrift(tCloudConfiguration);
+        tTableFunctionTableSink.setCloud_configuration(tCloudConfiguration);
+        TDataSink tDataSink = new TDataSink(TDataSinkType.TABLE_FUNCTION_TABLE_SINK);
+        tDataSink.setTable_function_table_sink(tTableFunctionTableSink);
+        return tDataSink;
+    }
+
+    @Override
+    public PlanNodeId getExchNodeId() {
+        return null;
+    }
+
+    @Override
+    public DataPartition getOutputPartition() {
+        return null;
+    }
+
+    @Override
+    public boolean canUsePipeLine() {
+        return true;
+    }
+
+    @Override
+    public boolean canUseRuntimeAdaptiveDop() {
+        return true;
+    }
+
+    public boolean isWriteSingleFile() { return table.isWriteSingleFile(); }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
@@ -23,6 +23,7 @@ import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanFragmentId;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.ScanNode;
+import com.starrocks.planner.TableFunctionTableSink;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.scheduler.ExplainBuilder;
 import com.starrocks.sql.optimizer.Utils;
@@ -298,7 +299,8 @@ public class FragmentInstance {
 
         DataSink dataSink = fragment.getSink();
         int dop = fragment.getPipelineDop();
-        if (!(dataSink instanceof IcebergTableSink || dataSink instanceof HiveTableSink)) {
+        if (!(dataSink instanceof IcebergTableSink || dataSink instanceof HiveTableSink
+                || dataSink instanceof TableFunctionTableSink)) {
             return dop;
         } else {
             int sessionVarSinkDop = ConnectContext.get().getSessionVariable().getPipelineSinkDop();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -34,6 +34,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
@@ -45,6 +46,7 @@ import com.starrocks.planner.IcebergTableSink;
 import com.starrocks.planner.MysqlTableSink;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.TableFunctionTableSink;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.AnalyzeState;
 import com.starrocks.sql.analyzer.ExpressionAnalyzer;
@@ -267,13 +269,15 @@ public class InsertPlanner {
             } else if (targetTable instanceof HiveTable) {
                 dataSink = new HiveTableSink((HiveTable) targetTable, tupleDesc,
                         isKeyPartitionStaticInsert(insertStmt, queryRelation), session.getSessionVariable());
+            } else if (targetTable instanceof TableFunctionTable) {
+                dataSink = new TableFunctionTableSink((TableFunctionTable) targetTable);
             } else {
                 throw new SemanticException("Unknown table type " + insertStmt.getTargetTable().getType());
             }
 
             PlanFragment sinkFragment = execPlan.getFragments().get(0);
             if (canUsePipeline && (targetTable instanceof OlapTable || targetTable.isIcebergTable() ||
-                    targetTable.isHiveTable())) {
+                    targetTable.isHiveTable() || targetTable.isTableFunctionTable())) {
                 if (shuffleServiceEnable) {
                     // For shuffle insert into, we only support tablet sink dop = 1
                     // because for tablet sink dop > 1, local passthourgh exchange will influence the order of sending,
@@ -296,6 +300,8 @@ public class InsertPlanner {
                     sinkFragment.setHasHiveTableSink();
                 } else if (targetTable.isIcebergTable()) {
                     sinkFragment.setHasIcebergTableSink();
+                } else if (targetTable.isTableFunctionTable()) {
+                    sinkFragment.setHasTableFunctionTableSink();
                 }
 
                 sinkFragment.disableRuntimeAdaptiveDop();
@@ -604,8 +610,9 @@ public class InsertPlanner {
             return new PhysicalPropertySet(distributionProperty);
         }
 
-        if (insertStmt.getTargetTable() instanceof IcebergTable) {
-            IcebergTable icebergTable = (IcebergTable) insertStmt.getTargetTable();
+        Table targetTable = insertStmt.getTargetTable();
+        if (targetTable instanceof IcebergTable) {
+            IcebergTable icebergTable = (IcebergTable) targetTable;
             SortOrder sortOrder = icebergTable.getNativeTable().sortOrder();
 
             if (sortOrder.isUnsorted()) {
@@ -627,11 +634,18 @@ public class InsertPlanner {
             }
         }
 
-        if (!(insertStmt.getTargetTable() instanceof OlapTable)) {
+
+        if (targetTable instanceof TableFunctionTable && ((TableFunctionTable) targetTable).isWriteSingleFile()) {
+            DistributionProperty distributionProperty = new DistributionProperty(new GatherDistributionSpec());
+            return new PhysicalPropertySet(distributionProperty);
+        }
+
+
+        if (!(targetTable instanceof OlapTable)) {
             return new PhysicalPropertySet();
         }
 
-        OlapTable table = (OlapTable) insertStmt.getTargetTable();
+        OlapTable table = (OlapTable) targetTable;
 
         if (KeysType.DUP_KEYS.equals(table.getKeysType())) {
             return new PhysicalPropertySet();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -22,11 +22,20 @@ import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.TableFunctionTable;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.analyzer.Field;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.starrocks.analysis.OutFileClause.PARQUET_COMPRESSION_TYPE_MAP;
 
 /**
  * Insert into is performed to load data from the result of query stmt.
@@ -81,6 +90,10 @@ public class InsertStmt extends DmlStmt {
      */
     private boolean forCTAS = false;
 
+    // tableFunctionAsTargetTable is true if insert statement is parsed from INSERT INTO FILES(..)
+    private final boolean tableFunctionAsTargetTable;
+    private final Map<String, String> tableFunctionProperties;
+
     public InsertStmt(TableName tblName, PartitionNames targetPartitionNames, String label, List<String> cols,
                       QueryStatement queryStatement, boolean isOverwrite) {
         this(tblName, targetPartitionNames, label, cols, queryStatement, isOverwrite, NodePosition.ZERO);
@@ -95,6 +108,8 @@ public class InsertStmt extends DmlStmt {
         this.queryStatement = queryStatement;
         this.targetColumnNames = cols;
         this.isOverwrite = isOverwrite;
+        this.tableFunctionAsTargetTable = false;
+        this.tableFunctionProperties = null;
     }
 
     // Ctor for CreateTableAsSelectStmt
@@ -106,6 +121,19 @@ public class InsertStmt extends DmlStmt {
         this.targetColumnNames = null;
         this.queryStatement = queryStatement;
         this.forCTAS = true;
+        this.tableFunctionAsTargetTable = false;
+        this.tableFunctionProperties = null;
+    }
+
+    // Ctor for INSERT INTO FILES(...)
+    public InsertStmt(Map<String, String> tableFunctionProperties, QueryStatement queryStatement, NodePosition pos) {
+        super(pos);
+        this.tblName = new TableName("table_function_catalog", "table_function_db", "table_function_table");
+        this.targetColumnNames = null;
+        this.targetPartitionNames = null;
+        this.queryStatement = queryStatement;
+        this.tableFunctionAsTargetTable = true;
+        this.tableFunctionProperties = tableFunctionProperties;
     }
 
     public Table getTargetTable() {
@@ -231,5 +259,106 @@ public class InsertStmt extends DmlStmt {
 
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitInsertStatement(this, context);
+    }
+
+    public boolean useTableFunctionAsTargetTable() {
+        return tableFunctionAsTargetTable;
+    }
+
+    public Map<String, String> getTableFunctionProperties() {
+        return tableFunctionProperties;
+    }
+
+    public Table makeTableFunctionTable() {
+        checkState(tableFunctionAsTargetTable, "tableFunctionAsTargetTable is false");
+        // fetch schema from query
+        QueryRelation query = getQueryStatement().getQueryRelation();
+        List<Field> allFields = query.getRelationFields().getAllFields();
+        List<Column> columns = allFields.stream().filter(Field::isVisible).map(field -> new Column(field.getName(),
+                field.getType(), field.isNullable())).collect(Collectors.toList());
+
+        // parse table function properties
+        Map<String, String> props = getTableFunctionProperties();
+        boolean writeSingleFile = Boolean.parseBoolean(props.get("single"));
+        String path = props.get("path");
+        String format = props.get("format");
+        String partitionBy = props.get("partition_by");
+        String compressionType = props.get("compression");
+
+        // validate properties
+        if (path == null) {
+            throw new SemanticException(
+                    "path is a mandatory property. \"path\" = \"s3://path/to/your/location/\"");
+        }
+
+        if (format == null) {
+            throw new SemanticException("format is a mandatory property. " +
+                    "Use \"path\" = \"parquet\" as only parquet format is supported now");
+        }
+
+        if (!format.equalsIgnoreCase("parquet")) {
+            throw new SemanticException("use \"path\" = \"parquet\", as only parquet format is supported now");
+        }
+
+        if (compressionType == null) {
+            throw new SemanticException("compression is a mandatory property. " +
+                    "Use \"compression\" = \"your_chosen_compression_type\". Supported compression types are" +
+                    "(uncompressed, gzip, brotli, zstd, lz4, lzo, bz2).");
+        }
+
+        if (!PARQUET_COMPRESSION_TYPE_MAP.containsKey(compressionType)) {
+            throw new SemanticException("compression type " + compressionType + " is not supported. " +
+                    "Use any of (uncompressed, gzip, brotli, zstd, lz4, lzo, bz2).");
+        }
+
+        if (writeSingleFile && partitionBy != null) {
+            throw new SemanticException("cannot use partition_by and single simultaneously.");
+        }
+
+        if (writeSingleFile) {
+            return new TableFunctionTable(path, format, compressionType, columns, null, true, props);
+        }
+
+        if (partitionBy == null) {
+            // prepend `data_` if path ends with forward slash
+            if (path.endsWith("/")) {
+                path += "data_";
+            }
+            return new TableFunctionTable(path, format, compressionType, columns, null, false, props);
+        }
+
+        // extra validation for using partitionBy
+        if (!path.endsWith("/")) {
+            throw new SemanticException(
+                    "If partition_by is used, path should be a directory ends with forward slash(/).");
+        }
+
+        List<String> columnNames = columns.stream().map(Column::getName).collect(Collectors.toList());
+
+        // parse and validate partition columns
+        List<String> partitionColumnNames = Arrays.asList(partitionBy.split(","));
+        partitionColumnNames.replaceAll(String::trim);
+        partitionColumnNames = partitionColumnNames.stream().distinct().collect(Collectors.toList());
+
+        List<String> unmatchedPartitionColumnNames = partitionColumnNames.stream().filter(col ->
+                !columnNames.contains(col)).collect(Collectors.toList());
+        if (!unmatchedPartitionColumnNames.isEmpty()) {
+            throw new SemanticException("partition columns expected to be a subset of " + columnNames +
+                    ", but got extra columns: " + unmatchedPartitionColumnNames);
+        }
+
+        List<Integer> partitionColumnIDs = partitionColumnNames.stream().map(columnNames::indexOf).collect(
+                Collectors.toList());
+
+        for (Integer partitionColumnID : partitionColumnIDs) {
+            Column partitionColumn = columns.get(partitionColumnID);
+            Type type = partitionColumn.getType();
+            if (type.isBoolean() || type.isIntegerType() || type.isDateType() || type.isStringType()) {
+                continue;
+            }
+            throw new SemanticException("partition column does not support type of " + type);
+        }
+
+        return new TableFunctionTable(path, format, compressionType, columns, partitionColumnIDs, false, props);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1679,13 +1679,6 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     // ------------------------------------------- DML Statement -------------------------------------------------------
     @Override
     public ParseNode visitInsertStatement(StarRocksParser.InsertStatementContext context) {
-        QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
-        TableName targetTableName = qualifiedNameToTableName(qualifiedName);
-        PartitionNames partitionNames = null;
-        if (context.partitionNames() != null) {
-            partitionNames = (PartitionNames) visit(context.partitionNames());
-        }
-
         QueryStatement queryStatement;
         if (context.VALUES() != null) {
             List<ValueList> rowValues = visit(context.expressionsWithDefault(), ValueList.class);
@@ -1706,10 +1699,23 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             queryStatement.setIsExplain(true, getExplainType(context.explainDesc()));
         }
 
-        return new InsertStmt(targetTableName, partitionNames,
-                context.label == null ? null : ((Identifier) visit(context.label)).getValue(),
-                getColumnNames(context.columnAliases()), queryStatement, context.OVERWRITE() != null,
-                createPos(context));
+        if (context.qualifiedName() != null) {
+            QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
+            TableName targetTableName = qualifiedNameToTableName(qualifiedName);
+            PartitionNames partitionNames = null;
+            if (context.partitionNames() != null) {
+                partitionNames = (PartitionNames) visit(context.partitionNames());
+            }
+
+            return new InsertStmt(targetTableName, partitionNames,
+                    context.label == null ? null : ((Identifier) visit(context.label)).getValue(),
+                    getColumnNames(context.columnAliases()), queryStatement, context.OVERWRITE() != null,
+                    createPos(context));
+        }
+
+        // INSERT INTO FILES(...)
+        Map<String, String> tableFunctionProperties = getPropertyList(context.propertyList());
+        return new InsertStmt(tableFunctionProperties, queryStatement, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1018,7 +1018,7 @@ partitionRenameClause
 // ------------------------------------------- DML Statement -----------------------------------------------------------
 
 insertStatement
-    : explainDesc? INSERT (INTO | OVERWRITE) qualifiedName partitionNames?
+    : explainDesc? INSERT (INTO | OVERWRITE) (qualifiedName | (FILES propertyList)) partitionNames?
         (WITH LABEL label=identifier)? columnAliases?
         (queryStatement | (VALUES expressionsWithDefault (',' expressionsWithDefault)*))
     ;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/TableFunctionTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TableFunctionTableSinkTest.java
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.TableFunctionTable;
+import com.starrocks.catalog.Type;
+import com.starrocks.thrift.TDataSink;
+import com.starrocks.thrift.TDataSinkType;
+import com.starrocks.thrift.TExplainLevel;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TableFunctionTableSinkTest {
+    @Test
+    public void testTableFunctionTableSink() {
+        TableFunctionTable tableFunctionTable = new TableFunctionTable("s3://path/to/directory/", "parquet",
+                "uncompressed", ImmutableList.of(new Column("k1", Type.INT)), null, false,
+                ImmutableMap.of());
+
+        TableFunctionTableSink tableFunctionTableSink = new TableFunctionTableSink(tableFunctionTable);
+
+        assertTrue(tableFunctionTableSink.canUsePipeLine());
+        assertTrue(tableFunctionTableSink.canUseRuntimeAdaptiveDop());
+        assertFalse(tableFunctionTableSink.isWriteSingleFile());
+
+        assertEquals("TABLE FUNCTION TABLE SINK\n" +
+                "  PATH: s3://path/to/directory/\n" +
+                "  FORMAT: parquet\n" +
+                "  PARTITION BY: []\n" +
+                "  SINGLE: false\n" +
+                "  RANDOM\n", tableFunctionTableSink.getExplainString("", TExplainLevel.NORMAL));
+        TDataSink tDataSink = tableFunctionTableSink.toThrift();
+        assertEquals(tDataSink.getType(), TDataSinkType.TABLE_FUNCTION_TABLE_SINK);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -213,4 +213,102 @@ public class AnalyzeInsertTest {
         analyzeFail("insert into iceberg_catalog.db.tbl select 1, 2, \"2023-01-01 12:34:45\"",
                 "Unsupported partition column type [DATETIME] for ICEBERG table sink.");
     }
+
+    @Test
+    public void testTableFunctionTable() {
+        analyzeSuccess("insert into files ( \n" +
+                "\t\"path\" = \"s3://path/to/directory/\", \n" +
+                "\t\"format\"=\"parquet\", \n" +
+                "\t\"compression\" = \"uncompressed\" ) \n" +
+                "select \"abc\" as k1");
+
+        analyzeFail("insert into files ( \n" +
+                "\t\"format\"=\"parquet\", \n" +
+                "\t\"compression\" = \"uncompressed\" ) \n" +
+                "select \"abc\" as k1",
+                "path is a mandatory property. \"path\" = \"s3://path/to/your/location/\".");
+
+        analyzeFail("insert into files ( \n" +
+                        "\t\"path\" = \"s3://path/to/directory/\", \n" +
+                        "\t\"compression\" = \"uncompressed\" ) \n" +
+                        "select \"abc\" as k1",
+                "format is a mandatory property. " +
+                        "Use \"path\" = \"parquet\" as only parquet format is supported now");
+
+        analyzeFail("insert into files ( \n" +
+                "\t\"path\" = \"s3://path/to/directory/\", \n" +
+                "\t\"format\"=\"orc\", \n" +
+                "\t\"compression\" = \"uncompressed\" ) \n" +
+                "select \"abc\" as k1",
+                "use \"path\" = \"parquet\", as only parquet format is supported now");
+
+        analyzeFail("insert into files ( \n" +
+                        "\t\"path\" = \"s3://path/to/directory/\", \n" +
+                        "\t\"format\"=\"parquet\" ) \n" +
+                        "select \"abc\" as k1",
+                "compression is a mandatory property. " +
+                "Use \"compression\" = \"your_chosen_compression_type\". Supported compression types are" +
+                "(uncompressed, gzip, brotli, zstd, lz4, lzo, bz2).");
+
+        analyzeFail("insert into files ( \n" +
+                        "\t\"path\" = \"s3://path/to/directory/\", \n" +
+                        "\t\"format\"=\"parquet\", \n" +
+                        "\t\"compression\" = \"unknown\" ) \n" +
+                        "select \"abc\" as k1",
+                "compression type unknown is not supported. " +
+                        "Use any of (uncompressed, gzip, brotli, zstd, lz4, lzo, bz2).");
+
+        analyzeFail("insert into files ( \n" +
+                        "\t\"path\" = \"oss://starrocks-dla-data-zhangjiakou/jiangletian/unload/test_partby_varchar/\", \n" +
+                        "\t\"format\"=\"parquet\", \n" +
+                        "\t\"compression\" = \"uncompressed\", \n" +
+                        "\t\"partition_by\"=\"k1\",\n" +
+                        "\t\"single\"=\"true\" ) \n" +
+                        "select \"abc\" as k1",
+                "cannot use partition_by and single simultaneously.");
+
+        analyzeSuccess("insert into files ( \n" +
+                        "\t\"path\" = \"s3://path/to/directory/\", \n" +
+                        "\t\"format\"=\"parquet\", \n" +
+                        "\t\"compression\" = \"uncompressed\", \n" +
+                        "\t\"partition_by\"=\"k1\" ) \n" +
+                        "select \"abc\" as k1");
+
+        analyzeFail("insert into files ( \n" +
+                "\t\"path\" = \"s3://path/to/directory/prefix\", \n" +
+                "\t\"format\"=\"parquet\", \n" +
+                "\t\"compression\" = \"uncompressed\", \n" +
+                "\t\"partition_by\"=\"k1\" ) \n" +
+                "select \"abc\" as k1",
+                "If partition_by is used, path should be a directory ends with forward slash(/).");
+
+        analyzeSuccess("insert into files ( \n" +
+                "\t\"path\" = \"s3://path/to/directory/\", \n" +
+                "\t\"format\"=\"parquet\", \n" +
+                "\t\"compression\" = \"uncompressed\", \n" +
+                "\t\"partition_by\"=\"k1, k2\" ) \n" +
+                "select \"abc\" as k1, 123 as k2");
+
+        analyzeFail("insert into files ( \n" +
+                "\t\"path\" = \"s3://path/to/directory/\", \n" +
+                "\t\"format\"=\"parquet\", \n" +
+                "\t\"compression\" = \"uncompressed\", \n" +
+                "\t\"partition_by\"=\"k3\" ) \n" +
+                "select \"abc\" as k1, 123 as k2",
+                "partition columns expected to be a subset of [k1, k2], but got extra columns: [k3]");
+
+        analyzeSuccess("insert into files ( \n" +
+                "\t\"path\" = \"s3://path/to/directory/\", \n" +
+                "\t\"format\"=\"parquet\", \n" +
+                "\t\"compression\" = \"uncompressed\", \n" +
+                "\t\"single\"=\"true\" ) \n" +
+                "select \"abc\" as k1, 123 as k2");
+
+        analyzeFail("insert into files ( \n" +
+                "\t\"path\" = \"s3://path/to/directory/\", \n" +
+                "\t\"format\"=\"parquet\", \n" +
+                "\t\"compression\" = \"uncompressed\", \n" +
+                "\t\"partition_by\"=\"k1\" ) \n" +
+                "select 1.23 as k1", "partition column does not support type of DECIMAL32(3,2).");
+    }
 }

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -53,7 +53,8 @@ enum TDataSinkType {
     MULTI_CAST_DATA_STREAM_SINK,
     SCHEMA_TABLE_SINK,
     ICEBERG_TABLE_SINK,
-    HIVE_TABLE_SINK
+    HIVE_TABLE_SINK,
+    TABLE_FUNCTION_TABLE_SINK
 }
 
 enum TResultSinkType {
@@ -241,6 +242,11 @@ struct THiveTableSink {
     7: optional CloudConfiguration.TCloudConfiguration cloud_configuration
 }
 
+struct TTableFunctionTableSink {
+    1: optional Descriptors.TTableFunctionTable target_table
+    2: optional CloudConfiguration.TCloudConfiguration cloud_configuration
+}
+
 struct TDataSink {
   1: required TDataSinkType type
   2: optional TDataStreamSink stream_sink
@@ -253,4 +259,5 @@ struct TDataSink {
   10: optional TSchemaTableSink schema_table_sink
   11: optional TIcebergTableSink iceberg_table_sink
   12: optional THiveTableSink hive_table_sink
+  13: optional TTableFunctionTableSink table_function_table_sink
 }

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -380,6 +380,18 @@ struct TTableFunctionTable {
 
     // Schema columns
     2: optional list<TColumn> columns
+
+    // File format
+    3: optional string file_format;
+
+    // Compression type
+    4: optional Types.TCompressionType compression_type
+
+    // Partition column ids, set if partition_by used in table function
+    5: optional list<i32> partition_column_ids
+
+    // Write single file
+    6: optional bool write_single_file
 }
 
 struct TIcebergSchema {


### PR DESCRIPTION
This PR gives users a new way to unload data to remote storage, especially when data partitioning is required.

```sql
# Unpartitioned Data
INSERT INTO 
FILES(
    "path" = "s3://my_bucket/path/parquet_file/",
    "format" = "parquet",
    "compression" = "zstd"
) 
SELECT * FROM SOURCE;

# Partitioned Data
INSERT INTO 
FILES(
    "path" = "s3://my_bucket/path/parquet_file/",
    "format" = "parquet",
    "compression" = "zstd",
    "partition_by" = "dt"
) 
SELECT * FROM SOURCE;

# Single DataFile
INSERT INTO 
FILES(
    "path" = "s3://my_bucket/path/parquet_file/",
    "format" = "parquet",
    "compression" = "zstd"
    "single" = "true"
) 
SELECT * FROM SOURCE;
```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
