### PR TITLE
[BugFix] fix cloud native pk index not load when handle partial update

### DIFF
--- a/be/src/storage/lake/lake_local_persistent_index.cpp
+++ b/be/src/storage/lake/lake_local_persistent_index.cpp
@@ -297,7 +297,6 @@ Status LakeLocalPersistentIndex::load_from_lake_tablet(starrocks::lake::Tablet* 
                                                _l2_versions.size() > 0 ? _l2_versions[0] : EditVersion()));
     _dump_snapshot = false;
     _flushed = false;
-    _primary_index->update_data_version(base_version);
 
     LOG(INFO) << "build persistent index finish tablet: " << tablet->id() << " version:" << base_version
               << " #rowset:" << rowsets->size() << " #segment:" << total_segments << " data_size:" << total_data_size

--- a/be/src/storage/lake/lake_local_persistent_index.h
+++ b/be/src/storage/lake/lake_local_persistent_index.h
@@ -28,10 +28,7 @@ class LakePrimaryIndex;
 
 class LakeLocalPersistentIndex : public PersistentIndex {
 public:
-    explicit LakeLocalPersistentIndex(std::string path, LakePrimaryIndex* primary_index)
-            : PersistentIndex(path), _primary_index(primary_index) {
-        _path = path;
-    }
+    explicit LakeLocalPersistentIndex(std::string path) : PersistentIndex(path) { _path = path; }
 
     ~LakeLocalPersistentIndex() override {}
 
@@ -40,7 +37,6 @@ public:
 
 private:
     std::string _path;
-    LakePrimaryIndex* _primary_index;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -33,6 +33,11 @@ Status LakePrimaryIndex::lake_load(Tablet* tablet, const TabletMetadata& metadat
         return _status;
     }
     _status = _do_lake_load(tablet, metadata, base_version, builder);
+    if (_status.ok()) {
+        // update data version when memory index or persistent index load finish.
+        _data_version = base_version;
+    }
+    _tablet_id = tablet->id();
     _loaded = true;
     TRACE("end load pk index");
     if (!_status.ok()) {
@@ -80,7 +85,7 @@ Status LakePrimaryIndex::_do_lake_load(Tablet* tablet, const TabletMetadata& met
                     RETURN_IF_ERROR(
                             StorageEngine::instance()->get_persistent_index_store()->create_dir_if_path_not_exists(
                                     path));
-                    _persistent_index = std::make_unique<LakeLocalPersistentIndex>(path, this);
+                    _persistent_index = std::make_unique<LakeLocalPersistentIndex>(path);
                     return ((LakeLocalPersistentIndex*)_persistent_index.get())
                             ->load_from_lake_tablet(tablet, metadata, base_version, builder);
                 }
@@ -154,8 +159,6 @@ Status LakePrimaryIndex::_do_lake_load(Tablet* tablet, const TabletMetadata& met
             itr->close();
         }
     }
-    _tablet_id = tablet->id();
-    _data_version = base_version;
     auto cost_ns = watch.elapsed_time();
     g_load_pk_index_latency << cost_ns / 1000;
     LOG_IF(INFO, cost_ns >= /*10ms=*/10 * 1000 * 1000)

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -468,6 +468,59 @@ TEST_P(PartialUpdateTest, test_resolve_conflict_multi_segment) {
     }
 }
 
+TEST_P(PartialUpdateTest, test_write_with_index_reload) {
+    auto chunk0 = generate_data(kChunkSize, 0, false, 3);
+    auto chunk1 = generate_data(kChunkSize, 0, true, 3);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // normal write
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
+                                                _mem_tracker.get());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+
+    // remove pk index, to make it reload again
+    _update_mgr->remove_primary_index_cache(tablet_id);
+
+    // partial update
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
+                                                _mem_tracker.get());
+        delta_writer->TEST_set_partial_update(_partial_tablet_schema, _referenced_column_ids);
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        add_trash_files(tablet_id, txn_id);
+        // Publish version
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(PartialUpdateTest, PartialUpdateTest,
                          ::testing::Values(PrimaryKeyParam{true}, PrimaryKeyParam{false}));
 


### PR DESCRIPTION
Cloud native primary table with persistent index will fail with error message. 
```
Primary index not load yet, tablet_id xxx
```
That is because we haven't updated the persistent index's data version when load persistent index from disk. 
And in PR, I unify data version updates for different types of primary indexes into one path.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
