### PR TITLE
[BugFix] Catch exception when plugin close failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/plugin/DynamicPluginLoader.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/DynamicPluginLoader.java
@@ -155,7 +155,11 @@ public class DynamicPluginLoader extends PluginLoader {
     public void uninstall() throws IOException, UserException {
         if (plugin != null) {
             pluginUninstallValid();
-            plugin.close();
+            try {
+                plugin.close();
+            } catch (Throwable t) {
+                LOG.warn("close plugin failed", t);
+            }
         }
 
         if (null != installPath && Files.exists(installPath)


### PR DESCRIPTION
Fixes 
```java
2023-09-19 19:26:54,231 INFO (starrocks-mysql-nio-pool-1227|11447) [AuditLogPlugin.close():110] closing auditlog plugin
2023-09-19 19:26:54,231 WARN (starrocks-mysql-nio-pool-1227|11447) [StmtExecutor.handleDdlStmt():1417] DDL statement (UNINSTALL PLUGIN  AuditLog) process failed.
java.lang.NullPointerException: null
        at com.airbnb.di.starrocks.auditlog.AuditLogPlugin.close(AuditLogPlugin.java:112) ~[?:?]
        at com.starrocks.plugin.DynamicPluginLoader.uninstall(DynamicPluginLoader.java:158) ~[starrocks-fe.jar:?]
        at com.starrocks.plugin.PluginMgr.uninstallPlugin(PluginMgr.java:190) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.uninstallPlugin(GlobalStateMgr.java:3879) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.lambda$visitUninstallPluginStatement$56(DDLStmtExecutor.java:701) ~[starrocks-fe.jar:?]
        at com.starrocks.common.ErrorReport.wrapWithRuntimeException(ErrorReport.java:112) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitUninstallPluginStatement(DDLStmtExecutor.java:699) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitUninstallPluginStatement(DDLStmtExecutor.java:150) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.UninstallPluginStmt.accept(UninstallPluginStmt.java:45) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor.execute(DDLStmtExecutor.java:136) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:1391) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:616) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:363) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:477) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:747) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_74]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_74]
        at java.lang.Thread.run(Thread.java:745) ~[?:1.8.0_74]
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
