### PR TITLE
[Enhancement] disable aws sdk curl init

### DIFF
--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -191,8 +191,16 @@ int main(int argc, char** argv) {
     // read range of source code for inject errors.
     starrocks::Status::access_directory_of_inject();
 #endif
+    // Initialize libcurl here to avoid concurrent initialization.
+    auto curl_ret = curl_global_init(CURL_GLOBAL_ALL);
+    if (curl_ret != 0) {
+        LOG(FATAL) << "fail to initialize libcurl, curl_ret=" << curl_ret;
+        exit(-1);
+    }
 
     Aws::SDKOptions aws_sdk_options;
+    // it is already initialized beforehead
+    aws_sdk_options.httpOptions.initAndCleanupCurl = false;
     if (starrocks::config::aws_sdk_logging_trace_enabled) {
         auto level = parse_aws_sdk_log_level(starrocks::config::aws_sdk_logging_trace_level);
         std::cerr << "enable aws sdk logging trace. log level = " << Aws::Utils::Logging::GetLogLevelName(level)
@@ -237,12 +245,6 @@ int main(int argc, char** argv) {
         }
     }
 
-    // Initilize libcurl here to avoid concurrent initialization.
-    auto curl_ret = curl_global_init(CURL_GLOBAL_ALL);
-    if (curl_ret != 0) {
-        LOG(FATAL) << "fail to initialize libcurl, curl_ret=" << curl_ret;
-        exit(-1);
-    }
     // Add logger for thrift internal.
     apache::thrift::GlobalOutput.setOutputFunction(starrocks::thrift_output);
 


### PR DESCRIPTION
* curl init is already done alone in starrocks_main

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
