### PR TITLE
[BugFix] fix be crash when upgrading column type

### DIFF
--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -88,6 +88,8 @@ public:
 
     KeysType keys_type() const { return static_cast<KeysType>(_keys_type); }
 
+    void init_sort_key_idxes() { _init_sort_key_idxes(); }
+
 private:
     void _build_index_map(const Fields& fields);
     void _init_sort_key_idxes() {

--- a/be/src/storage/convert_helper.cpp
+++ b/be/src/storage/convert_helper.cpp
@@ -1761,6 +1761,8 @@ std::unique_ptr<Chunk> ChunkConverter::copy_convert(const Chunk& from) const {
         auto c = _converters[i]->copy_convert(*from.get_column_by_id(f->id()));
         dest->append_column(std::move(c), f);
     }
+    // Make sure schema in chunk contains valid sort key idx
+    dest->schema()->init_sort_key_idxes();
     return dest;
 }
 
@@ -1773,6 +1775,8 @@ std::unique_ptr<Chunk> ChunkConverter::move_convert(Chunk* from) const {
         auto c = _converters[i]->move_convert(from->get_column_by_id(f->id()).get());
         dest->append_column(std::move(c), f);
     }
+    // Make sure schema in chunk contains valid sort key idx
+    dest->schema()->init_sort_key_idxes();
     return dest;
 }
 


### PR DESCRIPTION
Need to build sort key idx when using `ChunkConverter` to build chunk, or be will crash when do vertical compaction.

```
0x4cb6cdd starrocks::MergeEntry<>::next()
    @          0x4cc7161 starrocks::RowsetMergerImpl<>::_do_merge_horizontally()
    @          0x4cc8a4d starrocks::RowsetMergerImpl<>::_do_merge_vertically()
    @          0x4ccaa04 starrocks::RowsetMergerImpl<>::do_merge()
    @          0x4cb043f starrocks::compaction_merge_rowsets()
    @          0x4b5cefa starrocks::TabletUpdates::_do_compaction()
```

Because sort key idx must exist in schema, in `rowset_merger.cpp` : 
```
chunk_pk_column = chunk->get_column_by_index(chunk->schema()->sort_key_idxes()[0]);
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
