### PR TITLE
[Enhancement] support transmit runtime filter via http

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -841,6 +841,9 @@ CONF_Int64(deliver_broadcast_rf_passthrough_bytes_limit, "131072");
 // in passthrough style, the number of inflight RPCs of parallel deliveries are issued is not exceeds this limit.
 CONF_Int64(deliver_broadcast_rf_passthrough_inflight_num, "10");
 CONF_Int64(send_rpc_runtime_filter_timeout_ms, "1000");
+// if runtime filter size is larger than send_runtime_filter_via_http_rpc_min_size, be will transmit runtime filter via http protocol.
+// this is a default value, maybe changed by global_runtime_filter_rpc_http_min_size in session variable.
+CONF_Int64(send_runtime_filter_via_http_rpc_min_size, "67108864");
 
 CONF_Int32(max_batch_publish_latency_ms, "100");
 

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -47,15 +47,29 @@ static inline std::shared_ptr<MemTracker> get_mem_tracker(const PUniqueId& query
     }
 }
 
-static void send_rpc_runtime_filter(doris::PBackendService_Stub* stub, RuntimeFilterRpcClosure* rpc_closure,
-                                    int timeout_ms, const PTransmitRuntimeFilterParams& request) {
+static void send_rpc_runtime_filter(TNetworkAddress dest, RuntimeFilterRpcClosure* rpc_closure, int timeout_ms,
+                                    int64_t http_min_size, const PTransmitRuntimeFilterParams& request) {
+    doris::PBackendService_Stub* stub = nullptr;
+    bool via_http = request.data().size() >= http_min_size;
+    if (via_http) {
+        if (auto res = BrpcStubCache::create_http_stub(dest); res.ok()) {
+            stub = res.value().release();
+        }
+    } else {
+        stub = ExecEnv::GetInstance()->brpc_stub_cache()->get_stub(dest);
+    }
+    if (stub == nullptr) {
+        LOG(WARNING) << strings::Substitute("The brpc stub of {}: {} is null.", dest.hostname, dest.port);
+        return;
+    }
+
     rpc_closure->ref();
     rpc_closure->cntl.Reset();
     rpc_closure->cntl.set_timeout_ms(timeout_ms);
-    // as the attachment is empty, the http rpc also can do like the following interface.
-    // create a http rpc stub: http_stub
-    // http_stub->transmit_runtime_filter(&rpc_closure->cntl, &request, &rpc_closure->result, rpc_closure);
     stub->transmit_runtime_filter(&rpc_closure->cntl, &request, &rpc_closure->result, rpc_closure);
+    if (via_http) {
+        delete stub;
+    }
 }
 
 void RuntimeFilterPort::add_listener(RuntimeFilterProbeDescriptor* rf_desc) {
@@ -94,6 +108,11 @@ void RuntimeFilterPort::publish_runtime_filters(std::list<RuntimeFilterBuildDesc
     int timeout_ms = config::send_rpc_runtime_filter_timeout_ms;
     if (state->query_options().__isset.runtime_filter_send_timeout_ms) {
         timeout_ms = state->query_options().runtime_filter_send_timeout_ms;
+    }
+
+    int64_t rpc_http_min_size = config::send_runtime_filter_via_http_rpc_min_size;
+    if (state->query_options().__isset.runtime_filter_rpc_http_min_size) {
+        rpc_http_min_size = state->query_options().runtime_filter_rpc_http_min_size;
     }
 
     for (auto* rf_desc : rf_descs) {
@@ -150,11 +169,11 @@ void RuntimeFilterPort::publish_runtime_filters(std::list<RuntimeFilterBuildDesc
                                      [](const auto& a, const auto& b) { return a.lo < b.lo; });
             if (passthrough_delivery || *sender_id == state->fragment_instance_id()) {
                 state->exec_env()->runtime_filter_worker()->send_broadcast_runtime_filter(
-                        std::move(params), rf_desc->broadcast_grf_destinations(), timeout_ms);
+                        std::move(params), rf_desc->broadcast_grf_destinations(), timeout_ms, rpc_http_min_size);
             }
         } else {
-            state->exec_env()->runtime_filter_worker()->send_part_runtime_filter(std::move(params),
-                                                                                 rf_desc->merge_nodes(), timeout_ms);
+            state->exec_env()->runtime_filter_worker()->send_part_runtime_filter(
+                    std::move(params), rf_desc->merge_nodes(), timeout_ms, rpc_http_min_size);
         }
     }
 }
@@ -364,6 +383,10 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int rf_version, int32_t fil
     if (_query_options.__isset.runtime_filter_send_timeout_ms) {
         timeout_ms = _query_options.runtime_filter_send_timeout_ms;
     }
+    int64_t rpc_http_min_size = config::send_runtime_filter_via_http_rpc_min_size;
+    if (_query_options.__isset.runtime_filter_rpc_http_min_size) {
+        rpc_http_min_size = _query_options.runtime_filter_rpc_http_min_size;
+    }
 
     int64_t now = UnixMillis();
     status->broadcast_filter_ts = now;
@@ -416,11 +439,6 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int rf_version, int32_t fil
     while (index < size) {
         auto& t = targets[index];
         bool is_local = (local == t.first);
-        auto* stub = _exec_env->brpc_stub_cache()->get_stub(t.first);
-        if (UNLIKELY(stub == nullptr)) {
-            LOG(WARNING) << strings::Substitute("The brpc stub of {}:{} is null.", t.first.hostname, t.first.port);
-            return;
-        }
         request.clear_probe_finst_ids();
         request.clear_forward_targets();
         for (const auto& inst : t.second) {
@@ -460,7 +478,7 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int rf_version, int32_t fil
         rpc_closures.push_back(new RuntimeFilterRpcClosure);
         auto* closure = rpc_closures.back();
         closure->ref();
-        send_rpc_runtime_filter(stub, closure, timeout_ms, request);
+        send_rpc_runtime_filter(t.first, closure, timeout_ms, rpc_http_min_size, request);
     }
 
     // we don't need to hold rf any more.
@@ -493,6 +511,7 @@ public:
     std::vector<TNetworkAddress> transmit_addrs;
     std::vector<TRuntimeFilterDestination> destinations;
     int transmit_timeout_ms;
+    int64_t transmit_via_http_min_size = 64L * 1024 * 1024;
 
     /// For SEND_PART_RF, RECEIVE_PART_RF, and RECEIVE_TOTAL_RF.
     PTransmitRuntimeFilterParams transmit_rf_request;
@@ -530,11 +549,13 @@ void RuntimeFilterWorker::close_query(const TUniqueId& query_id) {
 }
 
 void RuntimeFilterWorker::send_part_runtime_filter(PTransmitRuntimeFilterParams&& params,
-                                                   const std::vector<TNetworkAddress>& addrs, int timeout_ms) {
+                                                   const std::vector<TNetworkAddress>& addrs, int timeout_ms,
+                                                   int64_t rpc_http_min_size) {
     _exec_env->add_rf_event({params.query_id(), params.filter_id(), "", "SEND_PART_RF"});
     RuntimeFilterWorkerEvent ev;
     ev.type = SEND_PART_RF;
     ev.transmit_timeout_ms = timeout_ms;
+    ev.transmit_via_http_min_size = rpc_http_min_size;
     ev.transmit_addrs = addrs;
     ev.transmit_rf_request = std::move(params);
     _queue.put(std::move(ev));
@@ -542,11 +563,12 @@ void RuntimeFilterWorker::send_part_runtime_filter(PTransmitRuntimeFilterParams&
 
 void RuntimeFilterWorker::send_broadcast_runtime_filter(PTransmitRuntimeFilterParams&& params,
                                                         const std::vector<TRuntimeFilterDestination>& destinations,
-                                                        int timeout_ms) {
+                                                        int timeout_ms, int64_t rpc_http_min_size) {
     _exec_env->add_rf_event({params.query_id(), params.filter_id(), "", "SEND_BROADCAST_RF"});
     RuntimeFilterWorkerEvent ev;
     ev.type = SEND_BROADCAST_GRF;
     ev.transmit_timeout_ms = timeout_ms;
+    ev.transmit_via_http_min_size = rpc_http_min_size;
     ev.destinations = destinations;
     ev.transmit_rf_request = std::move(params);
     _queue.put(std::move(ev));
@@ -670,11 +692,6 @@ void RuntimeFilterWorker::_receive_total_runtime_filter(PTransmitRuntimeFilterPa
         TNetworkAddress addr;
         addr.hostname = t.host();
         addr.port = t.port();
-        auto* stub = _exec_env->brpc_stub_cache()->get_stub(addr);
-        if (UNLIKELY(stub == nullptr)) {
-            LOG(WARNING) << strings::Substitute("The brpc stub of {}:{} is null.", addr.hostname, addr.port);
-            return;
-        }
 
         request.clear_probe_finst_ids();
         request.clear_forward_targets();
@@ -700,12 +717,14 @@ void RuntimeFilterWorker::_receive_total_runtime_filter(PTransmitRuntimeFilterPa
         rpc_closures.push_back(new RuntimeFilterRpcClosure());
         auto* closure = rpc_closures.back();
         closure->ref();
-        send_rpc_runtime_filter(stub, closure, config::send_rpc_runtime_filter_timeout_ms, request);
+        send_rpc_runtime_filter(addr, closure, config::send_rpc_runtime_filter_timeout_ms,
+                                config::send_runtime_filter_via_http_rpc_min_size, request);
     }
 }
 
 void RuntimeFilterWorker::_process_send_broadcast_runtime_filter_event(
-        PTransmitRuntimeFilterParams&& params, std::vector<TRuntimeFilterDestination>&& destinations, int timeout_ms) {
+        PTransmitRuntimeFilterParams&& params, std::vector<TRuntimeFilterDestination>&& destinations, int timeout_ms,
+        int64_t rpc_http_min_size) {
     auto mem_tracker = get_mem_tracker(params.query_id(), params.is_pipeline());
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker.get());
 
@@ -738,15 +757,17 @@ void RuntimeFilterWorker::_process_send_broadcast_runtime_filter_event(
 
     auto passthrough_delivery = params.data().size() <= config::deliver_broadcast_rf_passthrough_bytes_limit;
     if (passthrough_delivery) {
-        _deliver_broadcast_runtime_filter_passthrough(std::move(params), std::move(destinations), timeout_ms);
+        _deliver_broadcast_runtime_filter_passthrough(std::move(params), std::move(destinations), timeout_ms,
+                                                      rpc_http_min_size);
     } else {
-        _deliver_broadcast_runtime_filter_relay(std::move(params), std::move(destinations), timeout_ms);
+        _deliver_broadcast_runtime_filter_relay(std::move(params), std::move(destinations), timeout_ms,
+                                                rpc_http_min_size);
     }
 }
 
 void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_relay(PTransmitRuntimeFilterParams&& request,
                                                                   std::vector<TRuntimeFilterDestination>&& destinations,
-                                                                  int timeout_ms) {
+                                                                  int timeout_ms, int64_t rpc_http_min_size) {
     DCHECK(!destinations.empty());
     request.clear_probe_finst_ids();
     request.clear_forward_targets();
@@ -770,20 +791,15 @@ void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_relay(PTransmitRunti
 
     auto* rpc_closure = new RuntimeFilterRpcClosure();
     SingleClosureJoinAndClean join_and_join(rpc_closure);
-    auto* stub = _exec_env->brpc_stub_cache()->get_stub(first_dest.address);
-    if (UNLIKELY(stub == nullptr)) {
-        LOG(WARNING) << strings::Substitute("The brpc stub of $0:$1 is null.", first_dest.address.hostname,
-                                            first_dest.address.port);
-        return;
-    }
     _exec_env->add_rf_event(
             {request.query_id(), request.filter_id(), first_dest.address.hostname, "DELIVER_BROADCAST_RF_RELAY"});
     rpc_closure->ref();
-    send_rpc_runtime_filter(stub, rpc_closure, timeout_ms, request);
+    send_rpc_runtime_filter(first_dest.address, rpc_closure, timeout_ms, rpc_http_min_size, request);
 }
 
 void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_passthrough(
-        PTransmitRuntimeFilterParams&& params, std::vector<TRuntimeFilterDestination>&& destinations, int timeout_ms) {
+        PTransmitRuntimeFilterParams&& params, std::vector<TRuntimeFilterDestination>&& destinations, int timeout_ms,
+        int64_t rpc_http_min_size) {
     DCHECK(!destinations.empty());
 
     size_t k = 0;
@@ -798,12 +814,6 @@ void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_passthrough(
         for (auto i = 0; i < num_inflight; ++i) {
             auto request = params;
             auto& dest = destinations[start_idx + i];
-            auto* stub = _exec_env->brpc_stub_cache()->get_stub(dest.address);
-            if (UNLIKELY(stub == nullptr)) {
-                LOG(WARNING) << strings::Substitute("The brpc stub of $0:$1 is null.", dest.address.hostname,
-                                                    dest.address.port);
-                return;
-            }
             request.clear_probe_finst_ids();
             request.clear_forward_targets();
             for (const auto& id : dest.finstance_ids) {
@@ -817,7 +827,7 @@ void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_passthrough(
             rpc_closures.push_back(new RuntimeFilterRpcClosure());
             auto* closure = rpc_closures.back();
             closure->ref();
-            send_rpc_runtime_filter(stub, closure, timeout_ms, request);
+            send_rpc_runtime_filter(dest.address, closure, timeout_ms, rpc_http_min_size, request);
         }
     }
 }
@@ -836,21 +846,17 @@ void RuntimeFilterWorker::_deliver_broadcast_runtime_filter_local(PTransmitRunti
 }
 
 void RuntimeFilterWorker::_deliver_part_runtime_filter(std::vector<TNetworkAddress>&& transmit_addrs,
-                                                       PTransmitRuntimeFilterParams&& params, int transmit_timeout_ms) {
+                                                       PTransmitRuntimeFilterParams&& params, int transmit_timeout_ms,
+                                                       int64_t rpc_http_min_size) {
     RuntimeFilterRpcClosures rpc_closures;
     rpc_closures.reserve(transmit_addrs.size());
     BatchClosuresJoinAndClean join_and_clean(rpc_closures);
     for (const auto& addr : transmit_addrs) {
-        auto* stub = _exec_env->brpc_stub_cache()->get_stub(addr);
-        if (UNLIKELY(stub == nullptr)) {
-            LOG(WARNING) << strings::Substitute("The brpc stub of {}:{} is null.", addr.hostname, addr.port);
-            return;
-        }
         _exec_env->add_rf_event({params.query_id(), params.filter_id(), addr.hostname, "SEND_PART_RF_RPC"});
         rpc_closures.push_back(new RuntimeFilterRpcClosure());
         auto* closure = rpc_closures.back();
         closure->ref();
-        send_rpc_runtime_filter(stub, closure, transmit_timeout_ms, params);
+        send_rpc_runtime_filter(addr, closure, transmit_timeout_ms, rpc_http_min_size, params);
     }
 }
 
@@ -906,12 +912,12 @@ void RuntimeFilterWorker::execute() {
 
         case SEND_PART_RF: {
             _deliver_part_runtime_filter(std::move(ev.transmit_addrs), std::move(ev.transmit_rf_request),
-                                         ev.transmit_timeout_ms);
+                                         ev.transmit_timeout_ms, ev.transmit_via_http_min_size);
             break;
         }
         case SEND_BROADCAST_GRF: {
             _process_send_broadcast_runtime_filter_event(std::move(ev.transmit_rf_request), std::move(ev.destinations),
-                                                         ev.transmit_timeout_ms);
+                                                         ev.transmit_timeout_ms, ev.transmit_via_http_min_size);
             break;
         }
 

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -62,14 +62,16 @@ static void send_rpc_runtime_filter(TNetworkAddress dest, RuntimeFilterRpcClosur
         LOG(WARNING) << strings::Substitute("The brpc stub of {}: {} is null.", dest.hostname, dest.port);
         return;
     }
+    DeferOp defer([&] () {
+        if(via_http) {
+            delete stub;
+        }
+    });
 
     rpc_closure->ref();
     rpc_closure->cntl.Reset();
     rpc_closure->cntl.set_timeout_ms(timeout_ms);
     stub->transmit_runtime_filter(&rpc_closure->cntl, &request, &rpc_closure->result, rpc_closure);
-    if (via_http) {
-        delete stub;
-    }
 }
 
 void RuntimeFilterPort::add_listener(RuntimeFilterProbeDescriptor* rf_desc) {

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -47,7 +47,7 @@ static inline std::shared_ptr<MemTracker> get_mem_tracker(const PUniqueId& query
     }
 }
 
-static void send_rpc_runtime_filter(TNetworkAddress dest, RuntimeFilterRpcClosure* rpc_closure, int timeout_ms,
+static void send_rpc_runtime_filter(const TNetworkAddress& dest, RuntimeFilterRpcClosure* rpc_closure, int timeout_ms,
                                     int64_t http_min_size, const PTransmitRuntimeFilterParams& request) {
     doris::PBackendService_Stub* stub = nullptr;
     bool via_http = request.data().size() >= http_min_size;

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -62,8 +62,8 @@ static void send_rpc_runtime_filter(TNetworkAddress dest, RuntimeFilterRpcClosur
         LOG(WARNING) << strings::Substitute("The brpc stub of {}: {} is null.", dest.hostname, dest.port);
         return;
     }
-    DeferOp defer([&] () {
-        if(via_http) {
+    DeferOp defer([&]() {
+        if (via_http) {
             delete stub;
         }
     });

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -134,25 +134,29 @@ public:
     void receive_runtime_filter(const PTransmitRuntimeFilterParams& params);
     void execute();
     void send_part_runtime_filter(PTransmitRuntimeFilterParams&& params,
-                                  const std::vector<starrocks::TNetworkAddress>& addrs, int timeout_ms);
+                                  const std::vector<starrocks::TNetworkAddress>& addrs, int timeout_ms,
+                                  int64_t rpc_http_min_size);
     void send_broadcast_runtime_filter(PTransmitRuntimeFilterParams&& params,
-                                       const std::vector<TRuntimeFilterDestination>& destinations, int timeout_ms);
+                                       const std::vector<TRuntimeFilterDestination>& destinations, int timeout_ms,
+                                       int64_t rpc_http_min_size);
 
 private:
     void _receive_total_runtime_filter(PTransmitRuntimeFilterParams& params);
     void _process_send_broadcast_runtime_filter_event(PTransmitRuntimeFilterParams&& params,
                                                       std::vector<TRuntimeFilterDestination>&& destinations,
-                                                      int timeout_ms);
+                                                      int timeout_ms, int64_t rpc_http_min_size);
     void _deliver_broadcast_runtime_filter_passthrough(PTransmitRuntimeFilterParams&& params,
                                                        std::vector<TRuntimeFilterDestination>&& destinations,
-                                                       int timeout_ms);
+                                                       int timeout_ms, int64_t rpc_http_min_size);
     void _deliver_broadcast_runtime_filter_relay(PTransmitRuntimeFilterParams&& params,
-                                                 std::vector<TRuntimeFilterDestination>&& destinations, int timeout_ms);
+                                                 std::vector<TRuntimeFilterDestination>&& destinations, int timeout_ms,
+                                                 int64_t rpc_http_min_size);
     void _deliver_broadcast_runtime_filter_local(PTransmitRuntimeFilterParams& params,
                                                  const TRuntimeFilterDestination& destinations);
 
     void _deliver_part_runtime_filter(std::vector<TNetworkAddress>&& transmit_addrs,
-                                      PTransmitRuntimeFilterParams&& params, int transmit_timeout_ms);
+                                      PTransmitRuntimeFilterParams&& params, int transmit_timeout_ms,
+                                      int64_t rpc_http_min_size);
 
     UnboundedBlockingQueue<RuntimeFilterWorkerEvent> _queue;
     std::unordered_map<TUniqueId, RuntimeFilterMerger> _mergers;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -322,6 +322,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String GLOBAL_RUNTIME_FILTER_RPC_TIMEOUT = "global_runtime_filter_rpc_timeout";
     public static final String RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY = "runtime_filter_early_return_selectivity";
     public static final String ENABLE_TOPN_RUNTIME_FILTER = "enable_topn_runtime_filter";
+    public static final String GLOBAL_RUNTIME_FILTER_RPC_TIMEOUT = "global_runtime_filter_rpc_timeout";
+    public static final String GLOBAL_RUNTIME_FILTER_RPC_HTTP_MIN_SIZE = "global_runtime_filter_rpc_http_min_size";
 
     public static final String ENABLE_PIPELINE_LEVEL_MULTI_PARTITIONED_RF =
             "enable_pipeline_level_multi_partitioned_rf";
@@ -1037,6 +1039,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int globalRuntimeFilterRpcTimeout = 400;
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY, flag = VariableMgr.INVISIBLE)
     private float runtimeFilterEarlyReturnSelectivity = 0.05f;
+    @VariableMgr.VarAttr(name = GLOBAL_RUNTIME_FILTER_RPC_TIMEOUT, flag = VariableMgr.INVISIBLE)
+    private int globalRuntimeFilterRpcTimeout = 400;
+    @VariableMgr.VarAttr(name = GLOBAL_RUNTIME_FILTER_RPC_HTTP_MIN_SIZE, flag = VariableMgr.INVISIBLE)
+    private long globalRuntimeFilterRpcHttpMinSize = 64L * 1024 * 1024;
 
     @VarAttr(name = ENABLE_PIPELINE_LEVEL_MULTI_PARTITIONED_RF)
     private boolean enablePipelineLevelMultiPartitionedRf = false;
@@ -2825,6 +2831,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setRuntime_filter_wait_timeout_ms(globalRuntimeFilterWaitTimeout);
         tResult.setRuntime_filter_send_timeout_ms(globalRuntimeFilterRpcTimeout);
         tResult.setRuntime_filter_scan_wait_time_ms(runtimeFilterScanWaitTime);
+        tResult.setRuntime_filter_rpc_http_min_size(globalRuntimeFilterRpcHttpMinSize);
         tResult.setPipeline_dop(pipelineDop);
         if (pipelineProfileLevel == 2) {
             tResult.setPipeline_profile_level(TPipelineProfileLevel.DETAIL);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -322,7 +322,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String GLOBAL_RUNTIME_FILTER_RPC_TIMEOUT = "global_runtime_filter_rpc_timeout";
     public static final String RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY = "runtime_filter_early_return_selectivity";
     public static final String ENABLE_TOPN_RUNTIME_FILTER = "enable_topn_runtime_filter";
-    public static final String GLOBAL_RUNTIME_FILTER_RPC_TIMEOUT = "global_runtime_filter_rpc_timeout";
     public static final String GLOBAL_RUNTIME_FILTER_RPC_HTTP_MIN_SIZE = "global_runtime_filter_rpc_http_min_size";
 
     public static final String ENABLE_PIPELINE_LEVEL_MULTI_PARTITIONED_RF =
@@ -1039,8 +1038,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int globalRuntimeFilterRpcTimeout = 400;
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY, flag = VariableMgr.INVISIBLE)
     private float runtimeFilterEarlyReturnSelectivity = 0.05f;
-    @VariableMgr.VarAttr(name = GLOBAL_RUNTIME_FILTER_RPC_TIMEOUT, flag = VariableMgr.INVISIBLE)
-    private int globalRuntimeFilterRpcTimeout = 400;
     @VariableMgr.VarAttr(name = GLOBAL_RUNTIME_FILTER_RPC_HTTP_MIN_SIZE, flag = VariableMgr.INVISIBLE)
     private long globalRuntimeFilterRpcHttpMinSize = 64L * 1024 * 1024;
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -231,6 +231,7 @@ struct TQueryOptions {
 
   106: optional bool enable_agg_spill_preaggregation;
   107: optional i64 global_runtime_filter_build_max_size;
+  108: optional i64 runtime_filter_rpc_http_min_size;
 }
 
 


### PR DESCRIPTION
currently, we use brpc protocol to transmit runtime filter, brpc protocol will use single connection by default, which means all brpc requests transmit data via a single connection.

if the runtime filter is very large, the server will spent a lot of time to handle response (probably more than a few hundred milliseconds).data on the connection may not be processed in time, and the query is likely to encounter a `server is overcrowded` error.

for http protocol, brpc will use a seperate connection to transmit data.

so, in this pr, I support transmiting large runtime filter via http protocol, to avoid the impact of large runtime filter on exchange operator.

I test the following query on tpcds 10t data set, it will generate 500+MB partial runtime filter.
without my change, it will fail stably and return the error `transmit chunk rpc failed`. With my changes, it can be executed successfully.
```sql
set global_runtime_filter_build_max_size=1073741824;
with tmp as (select x as ss_customer_sk from table(generate_series(1000000000,2000000000,1)) t(x)) select count(store_sales.ss_sold_date_sk),count(store_sales.ss_customer_sk),count(store_sales.ss_wholesale_cost) from store_sales join[shuffle] tmp on tmp.ss_customer_sk <=> store_sales.ss_customer_sk;
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
