### PR TITLE
[BugFix] Fix some daily test bug

### DIFF
--- a/be/src/storage/rowset/bitshuffle_page.h
+++ b/be/src/storage/rowset/bitshuffle_page.h
@@ -302,10 +302,6 @@ public:
 
     [[nodiscard]] Status seek_to_position_in_page(uint32_t pos) override {
         DCHECK(_parsed) << "Must call init()";
-        if (PREDICT_FALSE(_num_elements == 0)) {
-            DCHECK_EQ(0, pos);
-        }
-
         DCHECK_LE(pos, _num_elements);
         if (pos > _num_elements) {
             std::string msg = strings::Substitute("invalid pos:$0, num_elements:$1", pos, _num_elements);

--- a/be/src/storage/rowset/bitshuffle_page.h
+++ b/be/src/storage/rowset/bitshuffle_page.h
@@ -304,10 +304,13 @@ public:
         DCHECK(_parsed) << "Must call init()";
         if (PREDICT_FALSE(_num_elements == 0)) {
             DCHECK_EQ(0, pos);
-            return Status::InvalidArgument("invalid pos");
         }
 
         DCHECK_LE(pos, _num_elements);
+        if (pos > _num_elements) {
+            std::string msg = strings::Substitute("invalid pos:$0, num_elements:$1", pos, _num_elements);
+            return Status::InternalError(msg);
+        }
         _cur_index = pos;
         return Status::OK();
     }

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -352,6 +352,7 @@ std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchemaCSPtr& src_
         }
         cid++;
     }
+    partial_tablet_schema_pb.mutable_sort_key_idxes()->Add(sort_key_idxes.begin(), sort_key_idxes.end());
     return std::make_shared<TabletSchema>(partial_tablet_schema_pb);
 }
 

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -327,6 +327,10 @@ std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchemaPB& schema_
     return std::make_shared<TabletSchema>(schema_pb, schema_map);
 }
 
+// Be careful
+// When you use this function to create a new partial tablet schema, please make sure `referenced_column_ids` include
+// all sort key column index of `src_tablet_schema`. Otherwise you need to recalculate the short key columns of the
+// partial tablet schema
 std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchemaCSPtr& src_tablet_schema,
                                                    const std::vector<int32_t>& referenced_column_ids) {
     TabletSchemaPB partial_tablet_schema_pb;
@@ -348,7 +352,6 @@ std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchemaCSPtr& src_
         }
         cid++;
     }
-    partial_tablet_schema_pb.mutable_sort_key_idxes()->Add(sort_key_idxes.begin(), sort_key_idxes.end());
     return std::make_shared<TabletSchema>(partial_tablet_schema_pb);
 }
 

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -291,8 +291,14 @@ public:
     // segment file will be rewrite to col file after apply. So these function are used to modify
     // the sort_key_idxes and short_key_column_num in partial tablet schema to avoid BE crash so far.
     void set_sort_key_idxes(std::vector<ColumnId> sort_key_idxes) {
+        for (auto idx : _sort_key_idxes) {
+            _cols[idx].set_is_sort_key(false);
+        }
         _sort_key_idxes.clear();
         _sort_key_idxes.assign(sort_key_idxes.begin(), sort_key_idxes.end());
+        for (auto idx : _sort_key_idxes) {
+            _cols[idx].set_is_sort_key(true);
+        }
     }
     void set_num_short_key_columns(uint16_t num_short_key_columns) { _num_short_key_columns = num_short_key_columns; }
 

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update
@@ -43,8 +43,8 @@ insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
 select * from tab1;
 -- result:
 200	k2_200	200	200	200	v4_200	v5_200
-100	k2_100	100	100	100	v4_100	v5_100
 300	k3_300	300	300	300	v4_300	v5_300
+100	k2_100	100	100	100	v4_100	v5_100
 -- !result
 insert into tab2 values (100, 100, 100, 100);
 -- result:
@@ -67,17 +67,17 @@ E: (1064, 'Getting analyzing error. Detail message: must specify where clause to
 -- !result
 select * from tab1;
 -- result:
-200	k2_200	200	200	200	v4_200	v5_200
-100	k2_100	100	100	100	v4_100	v5_100
 300	k3_300	300	300	300	v4_300	v5_300
+100	k2_100	100	100	100	v4_100	v5_100
+200	k2_200	200	200	200	v4_200	v5_200
 -- !result
 update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2) where k1 = 100;
 -- result:
 -- !result
 select * from tab1;
 -- result:
-100	k2_100	600	600	100	v4_100	v5_100
 300	k3_300	300	300	300	v4_300	v5_300
+100	k2_100	600	600	100	v4_100	v5_100
 200	k2_200	200	200	200	v4_200	v5_200
 -- !result
 update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2);
@@ -85,7 +85,49 @@ update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) 
 -- !result
 select * from tab1;
 -- result:
-200	k2_200	600	600	200	v4_200	v5_200
 100	k2_100	600	600	100	v4_100	v5_100
+200	k2_200	600	600	200	v4_200	v5_200
 300	k3_300	600	600	300	v4_300	v5_300
+-- !result
+CREATE table tab3 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+ORDER BY (`v1`, `v2`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab3 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+-- result:
+-- !result
+insert into tab3 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+-- result:
+-- !result
+insert into tab3 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+-- result:
+-- !result
+select * from tab3;
+-- result:
+300	k3_300	300	300	300	v4_300	v5_300
+100	k2_100	100	100	100	v4_100	v5_100
+200	k2_200	200	200	200	v4_200	v5_200
+-- !result
+update tab3 set v1 = 1111, v2 = (select sum(tab2.v2) from tab2);
+-- result:
+-- !result
+select * from tab3;
+-- result:
+300	k3_300	1111	600	300	v4_300	v5_300
+100	k2_100	1111	600	100	v4_100	v5_100
+200	k2_200	1111	600	200	v4_200	v5_200
 -- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update
@@ -41,3 +41,28 @@ update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) 
 select * from tab1;
 update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2);
 select * from tab1;
+
+
+CREATE table tab3 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+ORDER BY (`v1`, `v2`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into tab3 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+insert into tab3 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+insert into tab3 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+select * from tab3;
+
+update tab3 set v1 = 1111, v2 = (select sum(tab2.v2) from tab2);
+select * from tab3;


### PR DESCRIPTION
This pr fix two bugs: https://github.com/StarRocks/starrocks/issues/31333, https://github.com/StarRocks/starrocks/issues/31642

1. First issue(https://github.com/StarRocks/starrocks/issues/31333) is when we create a scalar type column and all value is null. In order to save disk usage, we don't write data in data page but only write null flags. And the scalar column type column encoded type is BITSHUFFLE by default right now. When we try to read data page, we will find the data page is empty and `bitshuffle_page_reader` will return error but this could be reasonable.
2. Second issue(https://github.com/StarRocks/starrocks/issues/31642) is when we do update sql for primary key table which primary key and sort key is separated, if we update sort key column which is not primary key column, the update sql will failed. The reason is when we do column mode partial update, we modify the `sort_key_idx` of partial table schema but ignore the sort key property in `TabletColumn`. So the following check in `SegmentWriter` will fail.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
