### PR TITLE
[Cherry-pick][Branch-3.1][Enhancement] optimize the re-balance strategy for backend scan range(#28468)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteScanRangeLocations.java
@@ -85,18 +85,10 @@ public class RemoteScanRangeLocations {
         long length = blockDesc.getLength();
         long offset = blockDesc.getOffset();
         do {
-            if (remainingBytes <= splitSize) {
+            if (remainingBytes < 2 * splitSize) {
                 createScanRangeLocationsForSplit(partitionId, partition, fileDesc,
                         blockDesc, offset + length - remainingBytes,
                         remainingBytes);
-                remainingBytes = 0;
-            } else if (remainingBytes <= 2 * splitSize) {
-                long mid = (remainingBytes + 1) / 2;
-                createScanRangeLocationsForSplit(partitionId, partition, fileDesc,
-                        blockDesc, offset + length - remainingBytes, mid);
-                createScanRangeLocationsForSplit(partitionId, partition, fileDesc,
-                        blockDesc, offset + length - remainingBytes + mid,
-                        remainingBytes - mid);
                 remainingBytes = 0;
             } else {
                 createScanRangeLocationsForSplit(partitionId, partition, fileDesc,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -87,7 +87,9 @@ public class HDFSBackendSelector implements BackendSelector {
     private boolean chooseComputeNode;
     private boolean shuffleScanRange;
     private final int kCandidateNumber = 3;
-    private final int kMaxImbalanceRatio = 3;
+    // After testing, this value can ensure that the scan range size assigned to each BE is as uniform as possible,
+    // and the largest scan data is not more than 1.1 times of the average value
+    private final double kMaxImbalanceRatio = 1.1;
     public static final int CONSISTENT_HASH_RING_VIRTUAL_NUMBER = 32;
 
     class HdfsScanRangeHasher {
@@ -161,30 +163,24 @@ public class HDFSBackendSelector implements BackendSelector {
         this.shuffleScanRange = shuffleScanRange;
     }
 
-    private ComputeNode selectLeastScanBytesComputeNode(List<ComputeNode> backends, long maxImbalanceBytes) {
+    // re-balance scan ranges for compute node if needed, return the compute node which scan range is assigned to
+    private ComputeNode reBalanceScanRangeForComputeNode(List<ComputeNode> backends, long avgNodeScanRangeBytes,
+                                                         TScanRangeLocations scanRangeLocations) {
         if (backends == null || backends.isEmpty()) {
             return null;
         }
 
         ComputeNode node = null;
-        long minAssignedScanRanges = Long.MAX_VALUE;
+        long addedScans = scanRangeLocations.scan_range.hdfs_scan_range.length;
         for (ComputeNode backend : backends) {
             long assignedScanRanges = assignedScansPerComputeNode.get(backend);
-            if (assignedScanRanges < minAssignedScanRanges) {
-                minAssignedScanRanges = assignedScanRanges;
-                node = backend;
-            }
-        }
-        if (maxImbalanceBytes == 0) {
-            return node;
-        }
-
-        for (ComputeNode backend : backends) {
-            long assignedScanRanges = assignedScansPerComputeNode.get(backend);
-            if (assignedScanRanges < (minAssignedScanRanges + maxImbalanceBytes)) {
+            if (assignedScanRanges + addedScans < avgNodeScanRangeBytes * kMaxImbalanceRatio) {
                 node = backend;
                 break;
             }
+        }
+        if (node == null) {
+            node = backends.get(0);
         }
         return node;
     }
@@ -222,12 +218,12 @@ public class HDFSBackendSelector implements BackendSelector {
         return hashRing;
     }
 
-    private long computeAverageScanRangeBytes() {
+    private long computeTotalSize() {
         long size = 0;
         for (TScanRangeLocations scanRangeLocations : locations) {
             size += scanRangeLocations.scan_range.hdfs_scan_range.getLength();
         }
-        return size / (locations.size() + 1);
+        return size;
     }
 
     @Override
@@ -236,8 +232,8 @@ public class HDFSBackendSelector implements BackendSelector {
             return;
         }
 
-        long avgScanRangeBytes = computeAverageScanRangeBytes();
-        long maxImbalanceBytes = avgScanRangeBytes * kMaxImbalanceRatio;
+        long totalSize = computeTotalSize();
+        long avgNodeScanRangeBytes = totalSize / Math.max(computeNodes.size(), 1) + 1;
 
         // exclude non-alive or in-blacklist compute nodes.
         for (ComputeNode computeNode : computeNodes) {
@@ -267,7 +263,7 @@ public class HDFSBackendSelector implements BackendSelector {
                     }
                     backends.addAll(servers);
                 }
-                ComputeNode node = selectLeastScanBytesComputeNode(backends, 0);
+                ComputeNode node = reBalanceScanRangeForComputeNode(backends, avgNodeScanRangeBytes, scanRangeLocations);
                 if (node == null) {
                     remoteScanRangeLocations.add(scanRangeLocations);
                 } else {
@@ -290,7 +286,7 @@ public class HDFSBackendSelector implements BackendSelector {
         for (int i = 0; i < remoteScanRangeLocations.size(); ++i) {
             TScanRangeLocations scanRangeLocations = remoteScanRangeLocations.get(i);
             List<ComputeNode> backends = hashRing.get(scanRangeLocations, kCandidateNumber);
-            ComputeNode node = selectLeastScanBytesComputeNode(backends, maxImbalanceBytes);
+            ComputeNode node = reBalanceScanRangeForComputeNode(backends, avgNodeScanRangeBytes, scanRangeLocations);
             if (node == null) {
                 throw new RuntimeException("Failed to find backend to execute");
             }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/HDFSBackendSelectorTest.java
@@ -52,7 +52,7 @@ public class HDFSBackendSelectorTest {
     final int computeNodePort = 9030;
     final String hostFormat = "Host%02d";
 
-    private List<TScanRangeLocations> createScanRanges(int number, int size) {
+    private List<TScanRangeLocations> createScanRanges(long number, long size) {
         List<TScanRangeLocations> ans = new ArrayList<>();
 
         for (int i = 0; i < number; i++) {


### PR DESCRIPTION


Fixes #issue
optimize the re-balance strategy for backend scan range **before:**
tpch q1:

![img_v2_2c795289-f568-4f20-9306-d526dec37f6g](https://github.com/StarRocks/starrocks/assets/9495145/eeeac209-fd9f-49a6-8b18-2ff171affe44)

backend 1 re-balance bytes: 609M+
backend 2 re-balance bytes: 3.8G+
backend 3 re-balance bytes: 811M+

tpch q2:

![image](https://github.com/StarRocks/starrocks/assets/9495145/73e31b13-6bcb-47d2-88f6-c9c97f6fff63)

For partsupp
backend 1 re-balance bytes:  536M+
backend 2 re-balance bytes: 1.2G+
backend 3 re-balance bytes: 0

**now :**
tpch q1:

![img_v2_964962bb-3d29-4a8a-b579-b3bbe57ff43g](https://github.com/StarRocks/starrocks/assets/9495145/c3771648-256f-4684-9cf6-043538bb2b39)

backend 1 re-balance bytes: 0
backend 2 re-balance bytes : 1.0G+
backend 3 re-balance bytes: 134M

tpch q2:

![64c433c9-35e5-42fa-9d5b-c471d0a3f253](https://github.com/StarRocks/starrocks/assets/9495145/bc1b4734-db61-4703-91a8-77350b08dae7)

For partsupp
backend 1 re-balance bytes:  391M+
backend 2 re-balance bytes: 930M+
backend 3 re-balance bytes: 0

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
