### PR TITLE
[BugFix] fix lake mv constructor not called properly when start

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeMaterializedView.java
@@ -52,6 +52,10 @@ public class LakeMaterializedView extends MaterializedView {
 
     private static final Logger LOG = LogManager.getLogger(LakeMaterializedView.class);
 
+    public LakeMaterializedView() {
+        this.type = TableType.CLOUD_NATIVE_MATERIALIZED_VIEW;
+    }
+
     public LakeMaterializedView(long id, long dbId, String mvName, List<Column> baseSchema, KeysType keysType,
                                 PartitionInfo partitionInfo, DistributionInfo defaultDistributionInfo,
                                 MvRefreshScheme refreshScheme) {


### PR DESCRIPTION
LakeMaterializedView extends MaterializedView, when fe starts, if not use a default constructor, some fields in MaterializedView are not initialized, such as `MaterializedView.planMode`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
