### PR TITLE
[BugFix] generated column can not resloved in View(#31514)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -199,13 +199,15 @@ public class QueryAnalyzer {
             sourceScope.setParent(scope);
 
             Map<Expr, SlotRef> generatedExprToColumnRef = new HashMap<>();
-            new AstTraverser<Void, Void>() {
-                @Override
-                public Void visitTable(TableRelation tableRelation, Void context) {
-                    generatedExprToColumnRef.putAll(tableRelation.getGeneratedExprToColumnRef());
-                    return null;
-                }
-            }.visit(resolvedRelation);
+            if (!(resolvedRelation instanceof ViewRelation)) {
+                new AstTraverser<Void, Void>() {
+                    @Override
+                    public Void visitTable(TableRelation tableRelation, Void context) {
+                        generatedExprToColumnRef.putAll(tableRelation.getGeneratedExprToColumnRef());
+                        return null;
+                    }
+                }.visit(resolvedRelation);
+            }
             analyzeState.setGeneratedExprToColumnRef(generatedExprToColumnRef);
 
             SelectAnalyzer selectAnalyzer = new SelectAnalyzer(session);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/GeneratedColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/GeneratedColumnTest.java
@@ -53,6 +53,10 @@ public class GeneratedColumnTest extends PlanTestBase {
                 "\"replicated_storage\" = \"false\",\n" +
                 "\"compression\" = \"LZ4\"\n" +
                 ")");
+
+        starRocksAssert.withView("create view view_1 as select v3 from tmc;");
+
+        starRocksAssert.withView("create view view_2 as select v3, v4 from tmc;");
     }
 
     @Test
@@ -140,5 +144,11 @@ public class GeneratedColumnTest extends PlanTestBase {
         sql = " select tmc.v1 + 1 from tmc as v,tmc2 as tmc";
         plan = getFragmentPlan(sql);
         assertContains(plan, "<slot 8> : 5: v1 + 1");
+
+        sql = " select * from view_1";
+        plan = getFragmentPlan(sql);
+
+        sql = " select * from view_2";
+        plan = getFragmentPlan(sql);
     }
 }


### PR DESCRIPTION
Problem:
In visitSelect, generated column refs will be set in analyzeState using the refs in TableRelation. It is unnecessnary to set for ViewRelation because the rewrite and be done throught normal TableRelation and if we set it for ViewRelation, plan will get resloved error cause by the different context between normal table and view.

Solution:
skip to setGeneratedExprToColumnRef for the ViewRelation

Fixes #31514

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
