### PR TITLE
[Enhancement] Add a check about assessible of BE ports before remove the blacklist

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/NetUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/NetUtils.java
@@ -40,6 +40,7 @@ import org.apache.commons.validator.routines.InetAddressValidator;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.Socket;
 import java.net.SocketException;
@@ -96,5 +97,19 @@ public class NetUtils {
             fqdn = host;
         }
         return new Pair<>(ip, fqdn);
+    }
+
+    public static boolean checkAccessibleForAllPorts(String host, List<Integer> ports) {
+        boolean accessible = true;
+        int timeout = 1000; // Timeout in milliseconds
+        for (Integer port : ports) {
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress(host, port), timeout);
+            } catch (IOException e) {
+                accessible = false;
+                break;
+            }
+        }
+        return accessible;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SimpleScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SimpleScheduler.java
@@ -39,8 +39,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.common.Reference;
+import com.starrocks.common.util.NetUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
+import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TNetworkAddress;
@@ -49,6 +51,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -203,6 +206,19 @@ public class SimpleScheduler {
         }
     }
 
+    // The function is used for unit test
+    public static boolean removeFromBlacklist(Long backendID) {
+        if (backendID == null) {
+            return true;
+        }
+        lock.lock();
+        try {
+            return blacklistBackends.remove(backendID) != null;
+        } finally {
+            lock.unlock();
+        }
+    }
+
     private static class UpdateBlacklistThread implements Runnable {
         private static final Logger LOG = LogManager.getLogger(UpdateBlacklistThread.class);
         private static Thread thread;
@@ -231,23 +247,30 @@ public class SimpleScheduler {
                             Map.Entry<Long, Integer> entry = iterator.next();
                             Long backendId = entry.getKey();
 
-                            // remove from blacklist if
-                            // 1. backend does not exist anymore
-                            // 2. backend is alive
-                            if (clusterInfoService.getBackend(backendId) == null
-                                    || clusterInfoService.checkBackendAvailable(backendId)) {
+                            // 1. If the backend is null, means that the backend has been removed.
+                            // 2. check the all ports of the backend
+                            // 3. retry three times
+                            // If both of the above conditions are met, the backend is removed from the blacklist
+                            Backend backend = clusterInfoService.getBackend(backendId);
+                            if (backend == null) {
                                 iterator.remove();
-                                LOG.debug("remove backendID {} which is alive", backendId);
+                                LOG.warn("remove backendID {} from blacklist", backendId);
+                            } else if (clusterInfoService.checkBackendAvailable(backendId)) {
+                                String host = backend.getHost();
+                                List<Integer> ports = new ArrayList<Integer>();
+                                Collections.addAll(ports, backend.getBePort(), backend.getBrpcPort(), backend.getHttpPort());
+                                if (NetUtils.checkAccessibleForAllPorts(host, ports)) {
+                                    iterator.remove();
+                                    LOG.warn("remove backendID {} from blacklist", backendId);;
+                                }
                             } else {
-                                // 3. max try time is reach
                                 Integer retryTimes = entry.getValue();
                                 retryTimes = retryTimes - 1;
                                 if (retryTimes <= 0) {
                                     iterator.remove();
-                                    LOG.warn("remove backendID {}. reach max try time", backendId);
+                                    LOG.warn("remove backendID {} from blacklist", backendId);
                                 } else {
                                     entry.setValue(retryTimes);
-                                    LOG.debug("blacklistBackends backendID={} retryTimes={}", backendId, retryTimes);
                                 }
                             }
                         }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SimpleSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SimpleSchedulerTest.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.common.Reference;
+import com.starrocks.common.util.NetUtils;
 import com.starrocks.persist.EditLog;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -53,6 +54,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -247,6 +249,33 @@ public class SimpleSchedulerTest {
         // no backend can work
         address = SimpleScheduler.getBackendHost(immutableThreeBackends, ref);
         Assert.assertNull(address);
+    }
+
+
+    @Test
+    public void testRemoveBackendFromBlackList() {
+        Config.heartbeat_timeout_second = Integer.MAX_VALUE;
+        TNetworkAddress address = null;
+
+        Backend backendA = new Backend(100, "addressA", 0);
+        backendA.updateOnce(0, 0, 0);
+        Map<Long, Backend> backends = Maps.newHashMap();
+        backends.put((long) 100, backendA);
+        ImmutableMap<Long, ComputeNode> immutableBackends = ImmutableMap.copyOf(backends);
+
+        SimpleScheduler.addToBlacklist(Long.valueOf(100));
+        address = SimpleScheduler.getBackendHost(immutableBackends, ref);
+        Assert.assertNull(address);
+
+        String host = backendA.getHost();
+        List<Integer> ports = new ArrayList<Integer>();
+        Collections.addAll(ports, backendA.getBePort(), backendA.getBrpcPort(), backendA.getHttpPort());
+        boolean accessible = NetUtils.checkAccessibleForAllPorts(host, ports);
+        Assert.assertFalse(accessible);
+
+        SimpleScheduler.removeFromBlacklist(Long.valueOf(100));
+        address = SimpleScheduler.getBackendHost(immutableBackends, ref);
+        Assert.assertEquals(address.hostname, "addressA");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/GetNextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/GetNextTest.java
@@ -34,7 +34,6 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TUniqueId;
 import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
-import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -46,7 +45,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.starrocks.utframe.MockedBackend.MockPBackendService;
@@ -117,6 +115,10 @@ public class GetNextTest extends SchedulerTestBase {
             }
         });
 
+        SimpleScheduler.removeFromBlacklist(BACKEND1_ID);
+        SimpleScheduler.removeFromBlacklist(backend2.getId());
+        SimpleScheduler.removeFromBlacklist(backend3.getId());
+
         String sql = "select count(1) from lineitem";
         DefaultCoordinator scheduler = startScheduling(sql);
 
@@ -140,9 +142,6 @@ public class GetNextTest extends SchedulerTestBase {
         DefaultCoordinator scheduler = startScheduling(sql);
 
         Assert.assertThrows("rpc failed: test runtime exception", RpcException.class, scheduler::getNext);
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() ->
-                !SimpleScheduler.isInBlacklist(BACKEND1_ID) && !SimpleScheduler.isInBlacklist(backend2.getId()) &&
-                        !SimpleScheduler.isInBlacklist(backend3.getId()));
     }
 
     @Test
@@ -159,6 +158,10 @@ public class GetNextTest extends SchedulerTestBase {
                 });
             }
         });
+
+        SimpleScheduler.removeFromBlacklist(BACKEND1_ID);
+        SimpleScheduler.removeFromBlacklist(backend2.getId());
+        SimpleScheduler.removeFromBlacklist(backend3.getId());
 
         String sql = "select count(1) from lineitem";
         DefaultCoordinator scheduler;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/StartSchedulingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/StartSchedulingTest.java
@@ -157,6 +157,7 @@ public class StartSchedulingTest extends SchedulerTestBase {
         String sql = "select count(1) from lineitem";
 
         Assert.assertThrows("test runtime exception", RpcException.class, () -> startScheduling(sql));
+        SimpleScheduler.removeFromBlacklist(backend3.getId());
         Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> !SimpleScheduler.isInBlacklist(backend3.getId()));
     }
 
@@ -184,6 +185,7 @@ public class StartSchedulingTest extends SchedulerTestBase {
         deployFuture.setRef(
                 mockFutureWithException(new ExecutionException("test execution exception", new Exception())));
         Assert.assertThrows("test execution exception", RpcException.class, () -> startScheduling(sql));
+        SimpleScheduler.removeFromBlacklist(backend3.getId());
         Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> !SimpleScheduler.isInBlacklist(backend3.getId()));
 
         isFirstFragmentToDeploy.set(true);
@@ -334,6 +336,9 @@ public class StartSchedulingTest extends SchedulerTestBase {
         // Shouldn't block by the failed cancelled instance.
         Assert.assertTrue(scheduler.isDone());
 
+        SimpleScheduler.removeFromBlacklist(BACKEND1_ID);
+        SimpleScheduler.removeFromBlacklist(backend2.getId());
+        SimpleScheduler.removeFromBlacklist(backend3.getId());
         Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() ->
                 !SimpleScheduler.isInBlacklist(BACKEND1_ID) && !SimpleScheduler.isInBlacklist(backend2.getId()) &&
                         !SimpleScheduler.isInBlacklist(backend3.getId()));


### PR DESCRIPTION
Currently, the backend will be added to the blacklist when encountering any RPC error. But removing it from the blacklist only takes the Heartbeat port into consideration. This pull request adds a check for all ports(BE port, BE BRPC port, BE HTTP port). If one of the ports is not accessible, it will not be removed from the blacklist.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
