### PR TITLE
[BugFix] Fix concurrency issues when creating colocate tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColocateTableIndex.java
@@ -182,7 +182,7 @@ public class ColocateTableIndex implements Writable {
     }
 
     public boolean addTableToGroup(Database db,
-                                OlapTable olapTable, String colocateGroup, boolean expectLakeTable)
+                                   OlapTable olapTable, String colocateGroup, boolean expectLakeTable)
             throws DdlException {
         if (Strings.isNullOrEmpty(colocateGroup)) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/CountingLatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/CountingLatch.java
@@ -1,0 +1,90 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util.concurrent;
+
+import com.google.common.base.Preconditions;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.AbstractQueuedSynchronizer;
+
+/**
+ * CountDownLatch with extra counting up functionality.
+ */
+public class CountingLatch {
+    /**
+     * Synchronization control for CountingLatch.
+     * Uses AQS state to represent count.
+     */
+    private static final class Sync extends AbstractQueuedSynchronizer {
+        private Sync() {
+        }
+
+        private Sync(final int initialState) {
+            setState(initialState);
+        }
+
+        int getCount() {
+            return getState();
+        }
+
+        protected int tryAcquireShared(final int acquires) {
+            return getState() == 0 ? 1 : -1;
+        }
+
+        protected boolean tryReleaseShared(final int delta) {
+            // Decrement count; signal when transition to zero
+            while (true) {
+                final int st = getState();
+                final int nextSt = st + delta;
+                Preconditions.checkState(nextSt >= 0);
+                if (compareAndSetState(st, nextSt)) {
+                    return nextSt == 0;
+                }
+            }
+        }
+    }
+
+    private final Sync sync;
+
+    public CountingLatch() {
+        sync = new Sync();
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    public CountingLatch(final int initialCount) {
+        sync = new Sync(initialCount);
+    }
+
+    public void increment() {
+        sync.releaseShared(1);
+    }
+
+    public int getCount() {
+        return sync.getCount();
+    }
+
+    public void decrement() {
+        sync.releaseShared(-1);
+    }
+
+    public void awaitZero() throws InterruptedException {
+        sync.acquireSharedInterruptibly(1);
+    }
+
+    public boolean awaitZero(final long timeout,
+                             final TimeUnit timeUnit) throws InterruptedException {
+        return sync.tryAcquireSharedNanos(1, timeUnit.toNanos(timeout));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -118,6 +118,7 @@ import com.starrocks.common.util.DynamicPartitionUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.Util;
+import com.starrocks.common.util.concurrent.CountingLatch;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.ConnectorTableInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -278,6 +279,13 @@ public class LocalMetastore implements ConnectorMetadata {
     private final GlobalStateMgr stateMgr;
     private final CatalogRecycleBin recycleBin;
     private ColocateTableIndex colocateTableIndex;
+    /**
+     * Concurrent colocate table creation process have dependency on each other
+     * (even in different databases), but we do not want to affect the performance
+     * of non-colocate table creation, so here we use a separate latch to
+     * synchronize only the creation of colocate tables.
+     */
+    private final CountingLatch colocateTableCreateSyncer = new CountingLatch(0);
 
     public LocalMetastore(GlobalStateMgr globalStateMgr, CatalogRecycleBin recycleBin,
                           ColocateTableIndex colocateTableIndex) {
@@ -2306,89 +2314,124 @@ public class LocalMetastore implements ConnectorMetadata {
         List<List<Long>> backendsPerBucketSeq = null;
         ColocateTableIndex.GroupId groupId = null;
         boolean initBucketSeqWithSameOrigNameGroup = false;
-        if (colocateTableIndex.isColocateTable(tabletMeta.getTableId())) {
-            // if this is a colocate table, try to get backend seqs from colocation index.
-            Database db = getDb(tabletMeta.getDbId());
-            groupId = colocateTableIndex.getGroup(tabletMeta.getTableId());
-            // Use db write lock here to make sure the backendsPerBucketSeq is
-            // consistent when the backendsPerBucketSeq is updating.
-            // This lock will release very fast.
-            db.writeLock();
-            try {
-                backendsPerBucketSeq = colocateTableIndex.getBackendsPerBucketSeq(groupId);
-                if (backendsPerBucketSeq.isEmpty()) {
-                    List<ColocateTableIndex.GroupId> colocateWithGroupsInOtherDb =
-                            colocateTableIndex.getColocateWithGroupsInOtherDb(groupId);
-                    if (!colocateWithGroupsInOtherDb.isEmpty()) {
-                        backendsPerBucketSeq =
-                                colocateTableIndex.getBackendsPerBucketSeq(colocateWithGroupsInOtherDb.get(0));
-                        initBucketSeqWithSameOrigNameGroup = true;
-                    }
-                }
-            } finally {
-                db.writeUnlock();
-            }
-        }
-
+        boolean isColocateTable = colocateTableIndex.isColocateTable(tabletMeta.getTableId());
         // chooseBackendsArbitrary is true, means this may be the first table of colocation group,
         // or this is just a normal table, and we can choose backends arbitrary.
         // otherwise, backends should be chosen from backendsPerBucketSeq;
-        boolean chooseBackendsArbitrary = backendsPerBucketSeq == null || backendsPerBucketSeq.isEmpty();
-        if (chooseBackendsArbitrary) {
-            backendsPerBucketSeq = Lists.newArrayList();
-        }
-        for (int i = 0; i < distributionInfo.getBucketNum(); ++i) {
-            // create a new tablet with random chosen backends
-            LocalTablet tablet = new LocalTablet(getNextId());
+        boolean chooseBackendsArbitrary;
 
-            // add tablet to inverted index first
-            index.addTablet(tablet, tabletMeta);
-            tabletIdSet.add(tablet.getId());
-
-            // get BackendIds
-            List<Long> chosenBackendIds;
-            if (chooseBackendsArbitrary) {
-                // This is the first colocate table in the group, or just a normal table,
-                // randomly choose backends
-                if (Config.enable_strict_storage_medium_check) {
-                    chosenBackendIds =
-                            chosenBackendIdBySeq(replicationNum, tabletMeta.getStorageMedium());
-                } else {
-                    try {
-                        chosenBackendIds = chosenBackendIdBySeq(replicationNum);
-                    } catch (DdlException ex) {
-                        throw new DdlException(String.format("%s, table=%s, default_replication_num=%d",
-                                ex.getMessage(), table.getName(), Config.default_replication_num));
+        // We should synchronize the creation of colocate tables, otherwise it can have concurrent issues.
+        // Considering the following situation,
+        // T1: P1 issues `create colocate table` and finds that there isn't a bucket sequence associated
+        //     with the colocate group, so it will initialize the bucket sequence for the first time
+        // T2: P2 do the same thing as P1
+        // T3: P1 set the bucket sequence for colocate group stored in `ColocateTableIndex`
+        // T4: P2 also set the bucket sequence, hence overwrite what P1 just wrote
+        // T5: After P1 creates the colocate table, the actual tablet distribution won't match the bucket sequence
+        //     of the colocate group, and balancer will create a lot of COLOCATE_MISMATCH tasks which shouldn't exist.
+        if (isColocateTable) {
+            try {
+                // Optimization: wait first time, before global lock
+                colocateTableCreateSyncer.awaitZero();
+                // Since we have supported colocate tables in different databases,
+                // we should use global lock, not db lock.
+                tryLock(false);
+                try {
+                    // Wait again, for safety
+                    // We are in global lock, we should have timeout in case holding lock for too long
+                    colocateTableCreateSyncer.awaitZero(Config.catalog_try_lock_timeout_ms, TimeUnit.MILLISECONDS);
+                    // if this is a colocate table, try to get backend seqs from colocation index.
+                    groupId = colocateTableIndex.getGroup(tabletMeta.getTableId());
+                    backendsPerBucketSeq = colocateTableIndex.getBackendsPerBucketSeq(groupId);
+                    if (backendsPerBucketSeq.isEmpty()) {
+                        List<ColocateTableIndex.GroupId> colocateWithGroupsInOtherDb =
+                                colocateTableIndex.getColocateWithGroupsInOtherDb(groupId);
+                        if (!colocateWithGroupsInOtherDb.isEmpty()) {
+                            backendsPerBucketSeq =
+                                    colocateTableIndex.getBackendsPerBucketSeq(colocateWithGroupsInOtherDb.get(0));
+                            initBucketSeqWithSameOrigNameGroup = true;
+                        }
                     }
+                    chooseBackendsArbitrary = backendsPerBucketSeq == null || backendsPerBucketSeq.isEmpty();
+                    if (chooseBackendsArbitrary) {
+                        colocateTableCreateSyncer.increment();
+                    }
+                } finally {
+                    unlock();
                 }
-                backendsPerBucketSeq.add(chosenBackendIds);
-            } else {
-                // get backends from existing backend sequence
-                chosenBackendIds = backendsPerBucketSeq.get(i);
+            } catch (InterruptedException e) {
+                LOG.warn("wait for concurrent colocate table creation finish failed, msg: {}",
+                        e.getMessage(), e);
+                Thread.currentThread().interrupt();
+                throw new DdlException("wait for concurrent colocate table creation finish failed", e);
             }
-
-            // create replicas
-            for (long backendId : chosenBackendIds) {
-                long replicaId = getNextId();
-                Replica replica = new Replica(replicaId, backendId, replicaState, version,
-                        tabletMeta.getOldSchemaHash());
-                tablet.addReplica(replica);
-            }
-            Preconditions.checkState(chosenBackendIds.size() == replicationNum,
-                    chosenBackendIds.size() + " vs. " + replicationNum);
+        } else {
+            chooseBackendsArbitrary = true;
         }
 
-        // In the following two situations, we should set the bucket seq for colocate group and persist the info,
-        //   1. This is the first time we add a table to colocate group, and it doesn't have the same original name
-        //      with colocate group in other database.
-        //   2. It's indeed the first time, but it should colocate with group in other db
-        //      (because of having the same original name), we should use the bucket
-        //      seq of other group to initialize our own.
-        if ((groupId != null && chooseBackendsArbitrary) || initBucketSeqWithSameOrigNameGroup) {
-            colocateTableIndex.addBackendsPerBucketSeq(groupId, backendsPerBucketSeq);
-            ColocatePersistInfo info =
-                    ColocatePersistInfo.createForBackendsPerBucketSeq(groupId, backendsPerBucketSeq);
-            GlobalStateMgr.getCurrentState().getEditLog().logColocateBackendsPerBucketSeq(info);
+
+
+        try {
+            if (chooseBackendsArbitrary) {
+                backendsPerBucketSeq = Lists.newArrayList();
+            }
+            for (int i = 0; i < distributionInfo.getBucketNum(); ++i) {
+                // create a new tablet with random chosen backends
+                LocalTablet tablet = new LocalTablet(getNextId());
+
+                // add tablet to inverted index first
+                index.addTablet(tablet, tabletMeta);
+                tabletIdSet.add(tablet.getId());
+
+                // get BackendIds
+                List<Long> chosenBackendIds;
+                if (chooseBackendsArbitrary) {
+                    // This is the first colocate table in the group, or just a normal table,
+                    // randomly choose backends
+                    if (Config.enable_strict_storage_medium_check) {
+                        chosenBackendIds =
+                                chosenBackendIdBySeq(replicationNum, tabletMeta.getStorageMedium());
+                    } else {
+                        try {
+                            chosenBackendIds = chosenBackendIdBySeq(replicationNum);
+                        } catch (DdlException ex) {
+                            throw new DdlException(String.format("%s, table=%s, default_replication_num=%d",
+                                    ex.getMessage(), table.getName(), Config.default_replication_num));
+                        }
+                    }
+                    backendsPerBucketSeq.add(chosenBackendIds);
+                } else {
+                    // get backends from existing backend sequence
+                    chosenBackendIds = backendsPerBucketSeq.get(i);
+                }
+
+                // create replicas
+                for (long backendId : chosenBackendIds) {
+                    long replicaId = getNextId();
+                    Replica replica = new Replica(replicaId, backendId, replicaState, version,
+                            tabletMeta.getOldSchemaHash());
+                    tablet.addReplica(replica);
+                }
+                Preconditions.checkState(chosenBackendIds.size() == replicationNum,
+                        chosenBackendIds.size() + " vs. " + replicationNum);
+            }
+
+            // In the following two situations, we should set the bucket seq for colocate group and persist the info,
+            //   1. This is the first time we add a table to colocate group, and it doesn't have the same original name
+            //      with colocate group in other database.
+            //   2. It's indeed the first time, but it should colocate with group in other db
+            //      (because of having the same original name), we should use the bucket
+            //      seq of other group to initialize our own.
+            if ((groupId != null && chooseBackendsArbitrary) || initBucketSeqWithSameOrigNameGroup) {
+                colocateTableIndex.addBackendsPerBucketSeq(groupId, backendsPerBucketSeq);
+                ColocatePersistInfo info =
+                        ColocatePersistInfo.createForBackendsPerBucketSeq(groupId, backendsPerBucketSeq);
+                GlobalStateMgr.getCurrentState().getEditLog().logColocateBackendsPerBucketSeq(info);
+            }
+        } finally {
+            if (isColocateTable && chooseBackendsArbitrary) {
+                colocateTableCreateSyncer.decrement();
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/concurrent/CountingLatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/concurrent/CountingLatchTest.java
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.common.util.concurrent;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+
+public class CountingLatchTest {
+    @Test
+    public void testCountUpAndDown() throws InterruptedException {
+        CountingLatch customCounter = new CountingLatch(0);
+
+        // Create a CountDownLatch to synchronize the start of all threads
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        // Create and start multiple threads
+        int numThreads = 5;
+        Thread[] threads = new Thread[numThreads];
+
+        for (int i = 0; i < numThreads; i++) {
+            threads[i] = new Thread(() -> {
+                try {
+                    startLatch.await(); // Wait until all threads are ready to start
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+
+                Random random = new Random();
+                // Simulate some work (e.g., incrementing and decrementing)
+                for (int idx = 0; idx < 100; idx++) {
+                    customCounter.increment();
+                    try {
+                        int time = random.nextInt(100) + 1;
+                        Thread.sleep(time);
+                        // System.out.println("thread sleeps for " + time + "ms");
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    customCounter.decrement();
+                }
+            });
+            threads[i].start();
+        }
+
+        // Start all threads concurrently
+        startLatch.countDown();
+
+        // Wait for all threads to finish
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        // Ensure that the count reaches zero
+        customCounter.awaitZero();
+        Assert.assertEquals(0, customCounter.getCount());
+        System.out.println("Count reached zero.");
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/server/ConcurrentDDLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/ConcurrentDDLTest.java
@@ -1,0 +1,115 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.server;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+
+public class ConcurrentDDLTest {
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+
+        // create connect context
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test");
+
+        // add extra backends
+        UtFrameUtils.addMockBackend(10002);
+        UtFrameUtils.addMockBackend(10003);
+        UtFrameUtils.addMockBackend(10004);
+        UtFrameUtils.addMockBackend(10005);
+
+        Config.tablet_sched_disable_colocate_balance = true;
+        Config.tablet_sched_repair_delay_factor_second = 1000000;
+    }
+
+    @Test
+    public void testConcurrentCreatingColocateTables() throws InterruptedException {
+        // Create a CountDownLatch to synchronize the start of all threads
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        // Create and start multiple threads
+        int numThreads = 3;
+        Thread[] threads = new Thread[numThreads];
+
+        for (int i = 0; i < numThreads; i++) {
+            threads[i] = new Thread(() -> {
+                try {
+                    startLatch.await(); // Wait until all threads are ready to start
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+
+                try {
+                    System.out.println("start to create table");
+                    starRocksAssert.withTable("create table test.test_tbl_" + Thread.currentThread().getId() +
+                            " (id int) duplicate key (id)" +
+                            " distributed by hash(id) buckets 5183 " +
+                            "properties(\"replication_num\"=\"1\", \"colocate_with\"=\"test_cg_001\");");
+                    System.out.println("end to create table");
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            threads[i].start();
+        }
+
+        List<Long> threadIds = Arrays.stream(threads).map(Thread::getId).collect(Collectors.toList());
+
+        // Start all threads concurrently
+        startLatch.countDown();
+
+        // Wait for all threads to finish, table creation finish
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        Database db = GlobalStateMgr.getServingState().getDb("test");
+        Table table = db.getTable("test_tbl_" + threadIds.get(0));
+
+        List<List<Long>> bucketSeq = GlobalStateMgr.getCurrentState().getColocateTableIndex().getBackendsPerBucketSeq(
+                GlobalStateMgr.getCurrentState().getColocateTableIndex().getGroup(table.getId()));
+        System.out.println(bucketSeq);
+        // check all created colocate tables has same tablet distribution as the bucket seq in colocate group
+        for (long threadId : threadIds) {
+            table = db.getTable("test_tbl_" + threadId);
+            List<Long> tablets = table.getPartitions().stream().findFirst().get().getBaseIndex().getTabletIdsInOrder();
+            List<Long> backendIdList = tablets.stream()
+                    .map(id -> GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getReplicasByTabletId(id))
+                    .map(replicaList -> replicaList.get(0).getBackendId())
+                    .collect(Collectors.toList());
+            System.out.println(backendIdList);
+            Assert.assertEquals(bucketSeq, backendIdList.stream().map(Arrays::asList).collect(Collectors.toList()));
+        }
+    }
+}


### PR DESCRIPTION
Fixes SR-20855

We should synchronize the creation of colocate tables, otherwise, it can have concurrent issues.
Considering the following situation,
T1: P1 issues `create colocate table` and finds that there isn't a bucket sequence associated
 with the colocate group, so it will initialize the bucket sequence for the first time
T2: P2 do the same thing as P1
T3: P1 set the bucket sequence for the colocate group stored in `ColocateTableIndex`
T4: P2 also set the bucket sequence, hence overwrite what P1 just wrote
T5: After P1 creates the colocate table, the actual tablet distribution won't match the bucket sequence
of the colocate group, and the balancer will create a lot of COLOCATE_MISMATCH tasks that shouldn't exist.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
