### PR TITLE
[Enhancement] iceberg support global dict collect and rewrite query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.alter;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -775,7 +774,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
 
         for (Column column : table.getColumns()) {
             if (Type.VARCHAR.equals(column.getType())) {
-                IDictManager.getInstance().removeGlobalDict(table.getId(), column.getName());
+                IDictManager.getInstance().removeGlobalDict(table, column.getName());
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -506,9 +506,9 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                     List<Column> diffGeneratedColumnSchema = Lists.newArrayList();
                     if (originIdxId == tbl.getBaseIndexId()) {
                         List<String> originSchema = tbl.getSchemaByIndexId(originIdxId).stream().map(col ->
-                                                        new String(col.getName())).collect(Collectors.toList());
+                                new String(col.getName())).collect(Collectors.toList());
                         List<String> newSchema = tbl.getSchemaByIndexId(shadowIdxId).stream().map(col ->
-                                                    new String(col.getName())).collect(Collectors.toList());
+                                new String(col.getName())).collect(Collectors.toList());
 
                         if (originSchema.size() != 0 && newSchema.size() != 0) {
                             for (String colNameInNewSchema : newSchema) {
@@ -531,11 +531,11 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                         Map<String, SlotDescriptor> slotDescByName = new HashMap<>();
 
                         /*
-                          * The expression substitution is needed here, because all slotRefs in 
-                          * GeneratedColumnExpr are still is unAnalyzed. slotRefs get isAnalyzed == true
-                          * if it is init by SlotDescriptor. The slot information will be used by be to indentify
-                          * the column location in a chunk.
-                        */
+                         * The expression substitution is needed here, because all slotRefs in
+                         * GeneratedColumnExpr are still is unAnalyzed. slotRefs get isAnalyzed == true
+                         * if it is init by SlotDescriptor. The slot information will be used by be to indentify
+                         * the column location in a chunk.
+                         */
                         for (Column col : tbl.getFullSchema()) {
                             SlotDescriptor slotDesc = descTbl.addSlotDescriptor(tupleDesc);
                             slotDesc.setType(col.getType());
@@ -556,7 +556,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
                                 if (slotDesc == null) {
                                     throw new AlterCancelException("Expression for generated column can not find " +
-                                                                   "the ref column");
+                                            "the ref column");
                                 }
 
                                 SlotRef slotRef = new SlotRef(slotDesc);
@@ -569,24 +569,24 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                             // sourceScope must be set null tableName for its Field in RelationFields
                             // because we hope slotRef can not be resolved in sourceScope but can be
                             // resolved in outputScope to force to replace the node using outputExprs.
-                            Scope sourceScope = new Scope(RelationId.anonymous(), 
-                                                    new RelationFields(tbl.getBaseSchema().stream().map(col ->
-                                                        new Field(col.getName(), col.getType(), null, null))
-                                                            .collect(Collectors.toList())));
+                            Scope sourceScope = new Scope(RelationId.anonymous(),
+                                    new RelationFields(tbl.getBaseSchema().stream().map(col ->
+                                                    new Field(col.getName(), col.getType(), null, null))
+                                            .collect(Collectors.toList())));
 
-                            Scope outputScope = new Scope(RelationId.anonymous(), 
-                                                    new RelationFields(tbl.getBaseSchema().stream().map(col ->
-                                                        new Field(col.getName(), col.getType(), tableName, null))
-                                                            .collect(Collectors.toList())));
+                            Scope outputScope = new Scope(RelationId.anonymous(),
+                                    new RelationFields(tbl.getBaseSchema().stream().map(col ->
+                                                    new Field(col.getName(), col.getType(), tableName, null))
+                                            .collect(Collectors.toList())));
 
                             RewriteAliasVisitor visitor =
-                                                new RewriteAliasVisitor(sourceScope, outputScope,
-                                                    outputExprs, ConnectContext.get());
+                                    new RewriteAliasVisitor(sourceScope, outputScope,
+                                            outputExprs, ConnectContext.get());
 
                             ExpressionAnalyzer.analyzeExpression(expr, new AnalyzeState(), new Scope(RelationId.anonymous(),
-                                    new RelationFields(tbl.getBaseSchema().stream().map(col -> new Field(col.getName(),
-                                        col.getType(), tableName, null)).collect(Collectors.toList()))),
-                                            ConnectContext.get());
+                                            new RelationFields(tbl.getBaseSchema().stream().map(col -> new Field(col.getName(),
+                                                    col.getType(), tableName, null)).collect(Collectors.toList()))),
+                                    ConnectContext.get());
 
                             Expr generatedColumnExpr = expr.accept(visitor, null);
 
@@ -719,10 +719,10 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                     for (Tablet shadowTablet : shadowIdx.getTablets()) {
                         // Mark schema changed tablet not to move to trash.
                         long baseTabletId = partitionIndexTabletMap.get(
-                                                    partitionId, shadowIdxId).get(shadowTablet.getId());
+                                partitionId, shadowIdxId).get(shadowTablet.getId());
                         // NOTE: known for sure that only LocalTablet uses this SchemaChangeJobV2 class
                         GlobalStateMgr.getCurrentInvertedIndex().
-                                    markTabletForceDelete(baseTabletId, shadowTablet.getBackendIds());
+                                markTabletForceDelete(baseTabletId, shadowTablet.getBackendIds());
                         List<Replica> replicas = ((LocalTablet) shadowTablet).getImmutableReplicas();
                         int healthyReplicaNum = 0;
                         for (Replica replica : replicas) {
@@ -833,7 +833,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         // dictionary invalid after schema change.
         for (Column column : tbl.getColumns()) {
             if (column.getType().isVarchar()) {
-                IDictManager.getInstance().removeGlobalDict(tbl.getId(), column.getName());
+                IDictManager.getInstance().removeGlobalDict(tbl, column.getName());
             }
         }
         // replace the origin index with shadow index, set index state as NORMAL

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -196,6 +196,9 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
 
     protected Map<PartitionKey, Long> partitionKeyToId;
 
+    public String catalogName = "";
+    public String dbName = "";
+
     public Table(TableType type) {
         this.type = type;
         this.fullSchema = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadingTaskPlanner.java
@@ -124,10 +124,11 @@ public class LoadingTaskPlanner {
     private Boolean missAutoIncrementColumn = Boolean.FALSE;
 
     public LoadingTaskPlanner(Long loadJobId, long txnId, long dbId, OlapTable table,
-            BrokerDesc brokerDesc, List<BrokerFileGroup> brokerFileGroups,
-            boolean strictMode, String timezone, long timeoutS,
-            long startTime, boolean partialUpdate, Map<String, String> sessionVariables, String mergeConditionStr, 
-            TPartialUpdateMode partialUpdateMode) {
+                              BrokerDesc brokerDesc, List<BrokerFileGroup> brokerFileGroups,
+                              boolean strictMode, String timezone, long timeoutS,
+                              long startTime, boolean partialUpdate, Map<String, String> sessionVariables,
+                              String mergeConditionStr,
+                              TPartialUpdateMode partialUpdateMode) {
         this.loadJobId = loadJobId;
         this.txnId = txnId;
         this.dbId = dbId;
@@ -179,7 +180,7 @@ public class LoadingTaskPlanner {
                 }
                 List<Boolean> isMissAutoIncrementColumn = Lists.newArrayList();
                 destColumns = Load.getPartialUpateColumns(table, fileGroups.get(0).getColumnExprList(),
-                    isMissAutoIncrementColumn);
+                        isMissAutoIncrementColumn);
 
                 if (isMissAutoIncrementColumn.size() != 0) {
                     this.missAutoIncrementColumn = isMissAutoIncrementColumn.get(0);
@@ -198,9 +199,8 @@ public class LoadingTaskPlanner {
             slotDesc.setColumn(col);
             slotDesc.setIsNullable(col.isAllowNull());
 
-            if (col.getType().isVarchar() && IDictManager.getInstance().hasGlobalDict(table.getId(),
-                    col.getName())) {
-                Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(table.getId(), col.getName());
+            if (col.getType().isVarchar() && IDictManager.getInstance().hasGlobalDict(table, col.getName())) {
+                Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(table, col.getName());
                 dict.ifPresent(columnDict -> globalDicts.add(new Pair<>(slotDesc.getId().asInt(), columnDict)));
             }
         }
@@ -225,7 +225,7 @@ public class LoadingTaskPlanner {
     }
 
     public void buildDirectPlan(TUniqueId loadId, List<List<TBrokerFileStatus>> fileStatusesList,
-            int filesAdded, boolean forceReplicatedStorage)
+                                int filesAdded, boolean forceReplicatedStorage)
             throws UserException {
         // Generate plan trees
         // 1. Broker scan node
@@ -312,7 +312,7 @@ public class LoadingTaskPlanner {
             partitionExprs.add(new SlotRef(tupleDesc.getColumnSlot(column.getName())));
         });
 
-        DataPartition dataPartition = new DataPartition(TPartitionType.HASH_PARTITIONED, partitionExprs); 
+        DataPartition dataPartition = new DataPartition(TPartitionType.HASH_PARTITIONED, partitionExprs);
         ExchangeNode exchangeNode = new ExchangeNode(new PlanNodeId(nextNodeId++), scanFragment.getPlanRoot(),
                 dataPartition);
         PlanFragment sinkFragment = new PlanFragment(new PlanFragmentId(1), exchangeNode, dataPartition);

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.InternalErrorCode;
@@ -281,7 +282,11 @@ public class RoutineLoadMgr implements Writable {
         // add txn state callback in factory
         GlobalStateMgr.getCurrentGlobalTransactionMgr().getCallbackFactory().addCallback(routineLoadJob);
         if (!Config.enable_dict_optimize_routine_load) {
-            IDictManager.getInstance().disableGlobalDict(routineLoadJob.getTableId());
+            Optional<Table> t =
+                    GlobalStateMgr.getCurrentState().mayGetTable(routineLoadJob.getDbId(), routineLoadJob.getTableId());
+            if (t.isPresent()) {
+                IDictManager.getInstance().disableGlobalDict(t.get());
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/StreamLoadPlanner.java
@@ -38,10 +38,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.DescriptorTable;
-import com.starrocks.common.util.DebugUtil;
-import com.starrocks.qe.ConnectContext;
-import com.starrocks.service.FrontendOptions;
-import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.AggregateType;
@@ -57,9 +53,13 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.load.Load;
 import com.starrocks.load.streamload.StreamLoadInfo;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.FrontendOptions;
+import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.optimizer.statistics.ColumnDict;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.thrift.InternalServiceVersion;
@@ -160,9 +160,8 @@ public class StreamLoadPlanner {
             }
 
             if (col.getType().isVarchar() && Config.enable_dict_optimize_stream_load &&
-                    IDictManager.getInstance().hasGlobalDict(destTable.getId(),
-                            col.getName())) {
-                Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(destTable.getId(), col.getName());
+                    IDictManager.getInstance().hasGlobalDict(destTable, col.getName())) {
+                Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(destTable, col.getName());
                 dict.ifPresent(columnDict -> globalDicts.add(new Pair<>(slotDesc.getId().asInt(), columnDict)));
             }
         }
@@ -200,7 +199,8 @@ public class StreamLoadPlanner {
             olapTableSink.setMissAutoIncrementColumn();
         }
         olapTableSink.init(loadId, streamLoadInfo.getTxnId(), db.getId(), streamLoadInfo.getTimeout());
-        Load.checkMergeCondition(streamLoadInfo.getMergeConditionStr(), destTable, destColumns, olapTableSink.missAutoIncrementColumn());
+        Load.checkMergeCondition(streamLoadInfo.getMergeConditionStr(), destTable, destColumns,
+                olapTableSink.missAutoIncrementColumn());
         olapTableSink.setPartialUpdateMode(streamLoadInfo.getPartialUpdateMode());
         olapTableSink.complete(streamLoadInfo.getMergeConditionStr());
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -36,6 +36,7 @@ package com.starrocks.qe;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.DdlException;
@@ -76,6 +77,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.net.ssl.SSLContext;
 
 // When one client connect in, we create a connection context for it.
@@ -188,6 +190,7 @@ public class ConnectContext {
 
     // The related db ids for current sql
     protected Set<Long> currentSqlDbIds = Sets.newHashSet();
+    protected Set<Database> currentSqlDatabases = Sets.newHashSet();
 
     protected PlannerProfile plannerProfile;
     protected StatementBase.ExplainLevel explainLevel;
@@ -576,6 +579,15 @@ public class ConnectContext {
 
     public void setCurrentSqlDbIds(Set<Long> currentSqlDbIds) {
         this.currentSqlDbIds = currentSqlDbIds;
+    }
+
+    public Set<Database> getCurrentSqlDatabases() {
+        return currentSqlDatabases;
+    }
+
+    public void setCurrentSqlDatabases(Set<Database> currentSqlDatabases) {
+        currentSqlDbIds = currentSqlDatabases.stream().map(x -> x.getId()).collect(Collectors.toSet());
+        this.currentSqlDatabases = currentSqlDatabases;
     }
 
     public PlannerProfile getPlannerProfile() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3792,10 +3792,10 @@ public class LocalMetastore implements ConnectorMetadata {
                 olapTable.setHasForbitGlobalDict(isForbit);
                 if (isForbit) {
                     property.put(PropertyAnalyzer.ENABLE_LOW_CARD_DICT_TYPE, PropertyAnalyzer.DISABLE_LOW_CARD_DICT);
-                    IDictManager.getInstance().disableGlobalDict(olapTable.getId());
+                    IDictManager.getInstance().disableGlobalDict(olapTable);
                 } else {
                     property.put(PropertyAnalyzer.ENABLE_LOW_CARD_DICT_TYPE, PropertyAnalyzer.ABLE_LOW_CARD_DICT);
-                    IDictManager.getInstance().enableGlobalDict(olapTable.getId());
+                    IDictManager.getInstance().enableGlobalDict(olapTable);
                 }
                 ModifyTablePropertyOperationLog info =
                         new ModifyTablePropertyOperationLog(db.getId(), table.getId(), property);
@@ -3842,10 +3842,10 @@ public class LocalMetastore implements ConnectorMetadata {
                 if (olapTable != null) {
                     if (enAble.equals(PropertyAnalyzer.DISABLE_LOW_CARD_DICT)) {
                         olapTable.setHasForbitGlobalDict(true);
-                        IDictManager.getInstance().disableGlobalDict(olapTable.getId());
+                        IDictManager.getInstance().disableGlobalDict(olapTable);
                     } else {
                         olapTable.setHasForbitGlobalDict(false);
-                        IDictManager.getInstance().enableGlobalDict(olapTable.getId());
+                        IDictManager.getInstance().enableGlobalDict(olapTable);
                     }
                 }
             } else {
@@ -4358,7 +4358,8 @@ public class LocalMetastore implements ConnectorMetadata {
             //
             // So we can only discard this information, in this case, it is equivalent to losing the record of these operations.
             // But it doesn't matter, these records are currently only used to record whether a replica is in a bad state.
-            // This state has little effect on the system, and it can be restored after the system has processed the bad state replica.
+            // This state has little effect on the system, and it can be restored after the system has processed the bad state
+            // replica.
             for (Pair<Long, Integer> tabletInfo : tabletsWithSchemaHash) {
                 LOG.warn("find an old backendTabletsInfo for tablet {}, ignore it", tabletInfo.first);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.server;
 
 import com.google.common.base.Preconditions;
@@ -72,8 +71,10 @@ public class MetadataMgr {
         this.connectorTblMetaInfoMgr = connectorTblMetaInfoMgr;
     }
 
-    /** get ConnectorMetadata by catalog name
+    /**
+     * get ConnectorMetadata by catalog name
      * if catalog is null or empty will return localMetastore
+     *
      * @param catalogName catalog's name
      * @return ConnectorMetadata
      */
@@ -191,7 +192,7 @@ public class MetadataMgr {
             }
             return connectorMetadata.get().createTable(stmt);
         } else {
-            throw new  DdlException("Invalid catalog " + catalogName + " , ConnectorMetadata doesn't exist");
+            throw new DdlException("Invalid catalog " + catalogName + " , ConnectorMetadata doesn't exist");
         }
     }
 
@@ -228,6 +229,8 @@ public class MetadataMgr {
             // Load meta information from ConnectorTblMetaInfoMgr for each external table.
             connectorTblMetaInfoMgr.setTableInfoForConnectorTable(catalogName, dbName, connectorTable);
         }
+        connectorTable.catalogName = catalogName;
+        connectorTable.dbName = dbName;
         return connectorTable;
     }
 
@@ -258,7 +261,6 @@ public class MetadataMgr {
      * SQL ： select dt,hh,mm from tbl where hh = '12' and mm = '30';
      * the partition columns are [dt,hh,mm]
      * the partition values should be [empty,'12','30']
-     *
      */
     public List<String> listPartitionNamesByValue(String catalogName, String dbName, String tableName,
                                                   List<Optional<String>> partitionValues) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -201,8 +201,8 @@ public class InsertPlanner {
                 slotDescriptor.setColumn(column);
                 slotDescriptor.setIsNullable(column.isAllowNull());
                 if (column.getType().isVarchar() &&
-                        IDictManager.getInstance().hasGlobalDict(tableId, column.getName())) {
-                    Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(tableId, column.getName());
+                        IDictManager.getInstance().hasGlobalDict(targetTable, column.getName())) {
+                    Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(targetTable, column.getName());
                     dict.ifPresent(
                             columnDict -> globalDicts.add(new Pair<>(slotDescriptor.getId().asInt(), columnDict)));
                 }
@@ -320,8 +320,8 @@ public class InsertPlanner {
                 for (List<Expr> row : values.getRows()) {
                     if (isAutoIncrement && row.get(columnIdx).getType() == Type.NULL) {
                         throw new SemanticException(" `NULL` value is not supported for an AUTO_INCREMENT column: " +
-                                                     targetColumn.getName() + " You can use `default` for an" +
-                                                     " AUTO INCREMENT column");
+                                targetColumn.getName() + " You can use `default` for an" +
+                                " AUTO INCREMENT column");
                     }
                     if (row.get(columnIdx) instanceof DefaultValueExpr) {
                         if (isAutoIncrement) {
@@ -339,8 +339,8 @@ public class InsertPlanner {
                     for (List<Expr> row : values.getRows()) {
                         if (isAutoIncrement && row.get(idx).getType() == Type.NULL) {
                             throw new SemanticException(" `NULL` value is not supported for an AUTO_INCREMENT column: " +
-                                                        targetColumn.getName() + " You can use `default` for an" +
-                                                        " AUTO INCREMENT column");
+                                    targetColumn.getName() + " You can use `default` for an" +
+                                    " AUTO INCREMENT column");
                         }
                         if (row.get(idx) instanceof DefaultValueExpr) {
                             if (isAutoIncrement) {
@@ -411,8 +411,8 @@ public class InsertPlanner {
     }
 
     private OptExprBuilder fillGeneratedColumns(ColumnRefFactory columnRefFactory, InsertStmt insertStatement,
-                                                   List<ColumnRefOperator> outputColumns, OptExprBuilder root,
-                                                   ConnectContext session) {
+                                                List<ColumnRefOperator> outputColumns, OptExprBuilder root,
+                                                ConnectContext session) {
         List<Column> fullSchema = insertStatement.getTargetTable().getFullSchema();
         Set<Column> baseSchema = Sets.newHashSet(insertStatement.getTargetTable().getBaseSchema());
         Map<ColumnRefOperator, ScalarOperator> columnRefMap = new HashMap<>();
@@ -424,10 +424,10 @@ public class InsertPlanner {
                 // If fe restart and Insert INTO is executed, the re-analyze is needed.
                 Expr expr = targetColumn.generatedColumnExpr();
                 ExpressionAnalyzer.analyzeExpression(expr,
-                    new AnalyzeState(), new Scope(RelationId.anonymous(), new RelationFields(
-                        insertStatement.getTargetTable().getBaseSchema().stream().map(col -> new Field(col.getName(),
-                                col.getType(), insertStatement.getTableName(), null))
-                            .collect(Collectors.toList()))), session);
+                        new AnalyzeState(), new Scope(RelationId.anonymous(), new RelationFields(
+                                insertStatement.getTargetTable().getBaseSchema().stream().map(col -> new Field(col.getName(),
+                                                col.getType(), insertStatement.getTableName(), null))
+                                        .collect(Collectors.toList()))), session);
 
                 List<SlotRef> slots = new ArrayList<>();
                 expr.collect(SlotRef.class, slots);
@@ -494,7 +494,8 @@ public class InsertPlanner {
                 continue;
             }
 
-            // Target column which starts with "mv" should not be treated as materialized view column when this column exists in base schema,
+            // Target column which starts with "mv" should not be treated as materialized view column when this column exists
+            // in base schema,
             // this could be created by user.
             if (targetColumn.isNameWithPrefix(MATERIALIZED_VIEW_NAME_PREFIX) &&
                     !baseSchema.contains(targetColumn)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -354,9 +354,8 @@ public class LoadPlanner {
             }
 
             if (col.getType().isVarchar() && enableDictOptimize
-                    && IDictManager.getInstance().hasGlobalDict(destTable.getId(),
-                    col.getName())) {
-                Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(destTable.getId(), col.getName());
+                    && IDictManager.getInstance().hasGlobalDict(destTable, col.getName())) {
+                Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(destTable, col.getName());
                 dict.ifPresent(columnDict -> globalDicts.add(new Pair<>(slotDesc.getId().asInt(), columnDict)));
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -78,7 +78,7 @@ public class StatementPlanner {
                 OptimizerTraceUtil.logQueryStatement(session, "after analyze:\n%s", (QueryStatement) stmt);
             }
 
-            session.setCurrentSqlDbIds(dbs.values().stream().map(Database::getId).collect(Collectors.toSet()));
+            session.setCurrentSqlDatabases(dbs.values().stream().collect(Collectors.toSet()));
 
             // Note: we only could get the olap table after Analyzing phase
             boolean isOnlyOlapTableQueries = AnalyzerUtils.isOnlyHasOlapTables(stmt);
@@ -176,7 +176,7 @@ public class StatementPlanner {
 
             Set<OlapTable> olapTables = Sets.newHashSet();
             Map<String, Database> dbs = AnalyzerUtils.collectAllDatabase(session, queryStmt);
-            session.setCurrentSqlDbIds(dbs.values().stream().map(Database::getId).collect(Collectors.toSet()));
+            session.setCurrentSqlDatabases(dbs.values().stream().collect(Collectors.toSet()));
 
             try {
                 // Need lock to avoid olap table metas ConcurrentModificationException

--- a/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/UpdatePlanner.java
@@ -97,8 +97,8 @@ public class UpdatePlanner {
                 slotDescriptor.setColumn(column);
                 slotDescriptor.setIsNullable(column.isAllowNull());
                 if (column.getType().isVarchar() &&
-                        IDictManager.getInstance().hasGlobalDict(tableId, column.getName())) {
-                    Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(tableId, column.getName());
+                        IDictManager.getInstance().hasGlobalDict(table, column.getName())) {
+                    Optional<ColumnDict> dict = IDictManager.getInstance().getGlobalDict(table, column.getName());
                     dict.ifPresent(
                             columnDict -> globalDicts.add(new Pair<>(slotDescriptor.getId().asInt(), columnDict)));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -68,7 +68,6 @@ import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.privilege.PrivilegeType;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.PartitionMeasure;
 import com.starrocks.sql.ast.AddPartitionClause;
@@ -337,11 +336,7 @@ public class AnalyzerUtils {
                 return;
             }
 
-            if (!CatalogMgr.isInternalCatalog(catalog)) {
-                return;
-            }
-
-            Database db = session.getGlobalStateMgr().getDb(dbName);
+            Database db = session.getGlobalStateMgr().getMetadataMgr().getDb(catalog, dbName);
             if (db == null) {
                 return;
             }
@@ -1208,7 +1203,7 @@ public class AnalyzerUtils {
     }
 
     private static void checkPartitionColumnTypeValid(FunctionCallExpr expr, List<ColumnDef> columnDefs,
-                                               NodePosition pos, String partitionColumnName, String fmt) {
+                                                      NodePosition pos, String partitionColumnName, String fmt) {
         // For materialized views currently columnDefs == null
         if (columnDefs != null && "hour".equalsIgnoreCase(fmt)) {
             ColumnDef partitionDef = findPartitionDefByName(columnDefs, partitionColumnName);
@@ -1230,7 +1225,6 @@ public class AnalyzerUtils {
         }
         return null;
     }
-
 
     public static Expr resolveSlotRef(SlotRef slotRef, QueryStatement queryStatement) {
         AstVisitor<Expr, Void> slotRefResolver = new AstVisitor<Expr, Void>() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
@@ -80,8 +80,6 @@ public class TableRelation extends Relation {
 
     public void setTable(Table table) {
         this.table = table;
-        table.catalogName = this.name.getCatalog();
-        table.dbName = this.name.getDb();
     }
 
     public PartitionNames getPartitionNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TableRelation.java
@@ -80,6 +80,8 @@ public class TableRelation extends Relation {
 
     public void setTable(Table table) {
         this.table = table;
+        table.catalogName = this.name.getCatalog();
+        table.dbName = this.name.getDb();
     }
 
     public PartitionNames getPartitionNames() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnIdentifier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/base/ColumnIdentifier.java
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.base;
+
+import com.starrocks.catalog.Table;
 
 import java.util.Objects;
 
@@ -22,36 +23,22 @@ import java.util.Objects;
  * so we use table id + column name to identify one column
  */
 public final class ColumnIdentifier {
-    private final long tableId;
+    public final String catalogName;
+    public final String dbName;
+    public final String tableName;
     private final String columnName;
+    public final long tableId;
 
-    private long dbId = -1;
-
-    public ColumnIdentifier(long tableId, String columnName) {
-        this.tableId = tableId;
+    public ColumnIdentifier(Table t, String columnName) {
+        this.catalogName = t.catalogName;
+        this.dbName = t.dbName;
+        this.tableName = t.getName();
         this.columnName = columnName;
-    }
-
-    public ColumnIdentifier(long dbId, long tableId, String columnName) {
-        this.dbId = dbId;
-        this.tableId = tableId;
-        this.columnName = columnName;
-    }
-
-    public long getTableId() {
-        return tableId;
+        tableId = t.getId();
     }
 
     public String getColumnName() {
         return columnName;
-    }
-
-    public long getDbId() {
-        return dbId;
-    }
-
-    public void setDbId(long dbId) {
-        this.dbId = dbId;
     }
 
     @Override
@@ -64,11 +51,13 @@ public final class ColumnIdentifier {
         if (this == columnIdentifier) {
             return true;
         }
-        return tableId == columnIdentifier.tableId && columnName.equalsIgnoreCase(columnIdentifier.columnName);
+        return catalogName.equals(columnIdentifier.catalogName) &&
+                dbName.equals(columnIdentifier.dbName) && tableName.equals(columnIdentifier.tableName) &&
+                columnName.equalsIgnoreCase(columnIdentifier.columnName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tableId, columnName);
+        return Objects.hash(catalogName, dbName, tableName, columnName);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalIcebergScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalIcebergScanOperator.java
@@ -14,20 +14,42 @@
 
 package com.starrocks.sql.optimizer.operator.physical;
 
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
+import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnDict;
+
+import java.util.List;
+import java.util.Map;
 
 public class PhysicalIcebergScanOperator extends PhysicalScanOperator {
     private ScanOperatorPredicates predicates;
+    private List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
 
     public PhysicalIcebergScanOperator(LogicalIcebergScanOperator scanOperator) {
         super(OperatorType.PHYSICAL_ICEBERG_SCAN, scanOperator);
         this.predicates = scanOperator.getScanOperatorPredicates();
+    }
+
+    public PhysicalIcebergScanOperator(Table table,
+                                       Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+                                       long limit,
+                                       ScalarOperator predicate,
+                                       Projection projection,
+                                       ScanOperatorPredicates predicates) {
+        super(OperatorType.PHYSICAL_ICEBERG_SCAN, table, colRefToColumnMetaMap, limit, predicate, projection);
+        this.predicates = predicates;
     }
 
     @Override
@@ -59,4 +81,18 @@ public class PhysicalIcebergScanOperator extends PhysicalScanOperator {
         predicates.getMinMaxColumnRefMap().keySet().forEach(refs::union);
         return refs;
     }
+
+    public void setOutputColumns(List<ColumnRefOperator> outputColumns) {
+        this.outputColumns = outputColumns;
+    }
+
+    public List<Pair<Integer, ColumnDict>> getGlobalDicts() {
+        return globalDicts;
+    }
+
+    public void setGlobalDicts(
+            List<Pair<Integer, ColumnDict>> globalDicts) {
+        this.globalDicts = globalDicts;
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -339,8 +339,8 @@ public class OptExternalPartitionPruner {
             throws AnalysisException {
         ScanOperatorPredicates scanOperatorPredicates = operator.getScanOperatorPredicates();
         for (ScalarOperator scalarOperator : scanOperatorPredicates.getNonPartitionConjuncts()) {
-            if (isSupportedMinMaxConjuncts(scalarOperator)) {
-                addMinMaxConjuncts(scalarOperator, operator, context);
+            if (isSupportedMinMaxConjuncts(operator, scalarOperator)) {
+                addMinMaxConjuncts(scalarOperator, operator);
             }
         }
     }
@@ -349,11 +349,14 @@ public class OptExternalPartitionPruner {
      * Only conjuncts of the form <column> <op> <constant> and <column> in <constant> are supported,
      * and <op> must be one of LT, LE, GE, GT, or EQ.
      */
-    private static boolean isSupportedMinMaxConjuncts(ScalarOperator operator) {
+    private static boolean isSupportedMinMaxConjuncts(LogicalScanOperator scanOperator, ScalarOperator operator) {
         if (operator instanceof BinaryPredicateOperator) {
             ScalarOperator leftChild = operator.getChild(0);
             ScalarOperator rightChild = operator.getChild(1);
             if (!(leftChild.isColumnRef()) || !(rightChild.isConstantRef())) {
+                return false;
+            }
+            if (!scanOperator.getColRefToColumnMetaMap().containsKey((ColumnRefOperator) leftChild)) {
                 return false;
             }
             return !((ConstantOperator) rightChild).isNull();
@@ -364,6 +367,9 @@ public class OptExternalPartitionPruner {
             if (((InPredicateOperator) operator).isNotIn()) {
                 return false;
             }
+            if (!scanOperator.getColRefToColumnMetaMap().containsKey((ColumnRefOperator) operator.getChild(0))) {
+                return false;
+            }
             return ((InPredicateOperator) operator).allValuesMatch(ScalarOperator::isConstantRef) &&
                     !((InPredicateOperator) operator).hasAnyNullValues();
         } else {
@@ -371,20 +377,19 @@ public class OptExternalPartitionPruner {
         }
     }
 
-    private static void addMinMaxConjuncts(ScalarOperator scalarOperator, LogicalScanOperator operator,
-            OptimizerContext context) throws AnalysisException {
+    private static void addMinMaxConjuncts(ScalarOperator scalarOperator, LogicalScanOperator operator)
+            throws AnalysisException {
         List<ScalarOperator> minMaxConjuncts = operator.getScanOperatorPredicates().getMinMaxConjuncts();
         if (scalarOperator instanceof BinaryPredicateOperator) {
             BinaryPredicateOperator binaryPredicateOperator = (BinaryPredicateOperator) scalarOperator;
             ScalarOperator leftChild = binaryPredicateOperator.getChild(0);
             ScalarOperator rightChild = binaryPredicateOperator.getChild(1);
             if (binaryPredicateOperator.getBinaryType().isEqual()) {
-                minMaxConjuncts.add(buildMinMaxConjunct(BinaryType.LE, leftChild, rightChild, operator, context));
-                minMaxConjuncts.add(buildMinMaxConjunct(BinaryType.GE, leftChild, rightChild, operator, context));
+                minMaxConjuncts.add(buildMinMaxConjunct(BinaryType.LE, leftChild, rightChild, operator));
+                minMaxConjuncts.add(buildMinMaxConjunct(BinaryType.GE, leftChild, rightChild, operator));
             } else if (binaryPredicateOperator.getBinaryType().isRange()) {
                 minMaxConjuncts.add(
-                        buildMinMaxConjunct(binaryPredicateOperator.getBinaryType(), leftChild, rightChild, operator,
-                                context));
+                        buildMinMaxConjunct(binaryPredicateOperator.getBinaryType(), leftChild, rightChild, operator));
             }
         } else if (scalarOperator instanceof InPredicateOperator) {
             InPredicateOperator inPredicateOperator = (InPredicateOperator) scalarOperator;
@@ -402,19 +407,20 @@ public class OptExternalPartitionPruner {
             Preconditions.checkState(min != null);
 
             BinaryPredicateOperator minBound =
-                    buildMinMaxConjunct(BinaryType.GE, inPredicateOperator.getChild(0), min, operator, context);
+                    buildMinMaxConjunct(BinaryType.GE, inPredicateOperator.getChild(0), min, operator);
             BinaryPredicateOperator maxBound =
-                    buildMinMaxConjunct(BinaryType.LE, inPredicateOperator.getChild(0), max, operator, context);
+                    buildMinMaxConjunct(BinaryType.LE, inPredicateOperator.getChild(0), max, operator);
             minMaxConjuncts.add(minBound);
             minMaxConjuncts.add(maxBound);
         }
     }
 
     private static BinaryPredicateOperator buildMinMaxConjunct(BinaryType type, ScalarOperator left,
-            ScalarOperator right, LogicalScanOperator operator, OptimizerContext context) throws AnalysisException {
+            ScalarOperator right, LogicalScanOperator operator) throws AnalysisException {
         ScanOperatorPredicates scanOperatorPredicates = operator.getScanOperatorPredicates();
-        ColumnRefOperator newColumnRef = context.getColumnRefFactory().create(left, left.getType(), left.isNullable());
-        scanOperatorPredicates.getMinMaxColumnRefMap().put(newColumnRef, operator.getColRefToColumnMetaMap().get(left));
-        return new BinaryPredicateOperator(type, newColumnRef, right);
+        ColumnRefOperator columnRefOperator = (ColumnRefOperator) left;
+        scanOperatorPredicates.getMinMaxColumnRefMap().putIfAbsent(columnRefOperator,
+                operator.getColRefToColumnMetaMap().get(columnRefOperator));
+        return new BinaryPredicateOperator(type, columnRefOperator, right);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -917,9 +917,9 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                 }
 
                 // Condition 3: the varchar column has collected global dict
-                if (IDictManager.getInstance().hasGlobalDict(table.getId(), column.getName(), version)) {
+                if (IDictManager.getInstance().hasGlobalDict(table, column.getName(), version)) {
                     Optional<ColumnDict> dict =
-                            IDictManager.getInstance().getGlobalDict(table.getId(), column.getName());
+                            IDictManager.getInstance().getGlobalDict(table, column.getName());
                     // cache reaches capacity limit, randomly eliminate some keys
                     // then we will get an empty dictionary.
                     if (!dict.isPresent()) {
@@ -949,19 +949,20 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
                     continue;
                 }
 
-                ColumnStatistic columnStatistic =
-                        GlobalStateMgr.getCurrentStatisticStorage().getColumnStatistic(table, column.getName());
+                //                ColumnStatistic columnStatistic =
+                //                        GlobalStateMgr.getCurrentStatisticStorage().getColumnStatistic(table, column.getName());
                 // Condition 2: the varchar column is low cardinality string column
-                if (!FeConstants.USE_MOCK_DICT_MANAGER && (columnStatistic.isUnknown() ||
-                        columnStatistic.getDistinctValuesCount() > CacheDictManager.LOW_CARDINALITY_THRESHOLD)) {
-                    LOG.debug("{} isn't low cardinality string column", column.getName());
-                    continue;
-                }
+                //                if (!FeConstants.USE_MOCK_DICT_MANAGER && (columnStatistic.isUnknown() ||
+                //                        columnStatistic.getDistinctValuesCount() > CacheDictManager
+                //                        .LOW_CARDINALITY_THRESHOLD)) {
+                //                    LOG.debug("{} isn't low cardinality string column", column.getName());
+                //                    continue;
+                //                }
 
                 // Condition 3: the varchar column has collected global dict
-                if (IDictManager.getInstance().hasGlobalDict(table.getId(), column.getName(), 1)) {
+                if (IDictManager.getInstance().hasGlobalDict(table, column.getName(), 1)) {
                     Optional<ColumnDict> dict =
-                            IDictManager.getInstance().getGlobalDict(table.getId(), column.getName());
+                            IDictManager.getInstance().getGlobalDict(table, column.getName());
                     // cache reaches capacity limit, randomly eliminate some keys
                     // then we will get an empty dictionary.
                     if (!dict.isPresent()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheDictManager.java
@@ -19,11 +19,10 @@ import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.Status;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.base.ColumnIdentifier;
 import com.starrocks.thrift.TGlobalDict;
@@ -67,18 +66,16 @@ public class CacheDictManager implements IDictManager {
                         @NonNull Executor executor) {
                     return CompletableFuture.supplyAsync(() -> {
                         try {
-                            long tableId = columnIdentifier.getTableId();
-                            String columnName = columnIdentifier.getColumnName();
-                            Pair<List<TStatisticData>, Status> result = queryDictSync(columnIdentifier.getDbId(),
-                                    tableId, columnName);
+                            Pair<List<TStatisticData>, Status> result = queryDictSync(columnIdentifier);
                             if (result.second.isGlobalDictError()) {
-                                LOG.debug("{}-{} isn't low cardinality string column", tableId, columnName);
+                                LOG.debug("{}-{} isn't low cardinality string column", columnIdentifier.tableName,
+                                        columnIdentifier.getColumnName());
                                 NO_DICT_STRING_COLUMNS.add(columnIdentifier);
                                 return Optional.empty();
                             } else {
                                 // check TStatisticData is not empty, There may be no such column Statistics in BE
                                 if (!result.first.isEmpty()) {
-                                    return deserializeColumnDict(tableId, columnName, result.first.get(0));
+                                    return deserializeColumnDict(columnIdentifier, result.first.get(0));
                                 } else {
                                     return Optional.empty();
                                 }
@@ -104,7 +101,7 @@ public class CacheDictManager implements IDictManager {
             .maximumSize(Config.statistic_dict_columns)
             .buildAsync(dictLoader);
 
-    private Optional<ColumnDict> deserializeColumnDict(long tableId, String columnName, TStatisticData statisticData) {
+    private Optional<ColumnDict> deserializeColumnDict(ColumnIdentifier columnIdentifier, TStatisticData statisticData) {
         if (statisticData.dict == null) {
             throw new RuntimeException("Collect dict error in BE");
         }
@@ -114,7 +111,6 @@ public class CacheDictManager implements IDictManager {
             return Optional.empty();
         }
         int dictSize = tGlobalDict.getIdsSize();
-        ColumnIdentifier columnIdentifier = new ColumnIdentifier(tableId, columnName);
         if (dictSize > LOW_CARDINALITY_THRESHOLD) {
             NO_DICT_STRING_COLUMNS.add(columnIdentifier);
             return Optional.empty();
@@ -142,34 +138,20 @@ public class CacheDictManager implements IDictManager {
             dicts.put(tGlobalDict.strings.get(i), tGlobalDict.ids.get(i));
         }
         LOG.info("collected dictionary table:{} column:{}, version:{} size:{}",
-                tableId, columnName, statisticData.meta_version, dictSize);
+                columnIdentifier.tableName, columnIdentifier.getColumnName(), statisticData.meta_version, dictSize);
         return Optional.of(new ColumnDict(dicts.build(), statisticData.meta_version));
     }
 
     @Override
-    public boolean hasGlobalDict(long tableId, String columnName, long versionTime) {
-        ColumnIdentifier columnIdentifier = new ColumnIdentifier(tableId, columnName);
+    public boolean hasGlobalDict(Table t, String columnName, long versionTime) {
+        ColumnIdentifier columnIdentifier = new ColumnIdentifier(t, columnName);
         if (NO_DICT_STRING_COLUMNS.contains(columnIdentifier)) {
-            LOG.debug("{}-{} isn't low cardinality string column", tableId, columnName);
+            LOG.debug("{}-{} isn't low cardinality string column", columnIdentifier.tableId, columnName);
             return false;
         }
 
-        if (FORBIDDEN_DICT_TABLE_IDS.contains(tableId)) {
-            LOG.debug("table {} forbid low cardinality global dict", tableId);
-            return false;
-        }
-
-        Set<Long> dbIds = ConnectContext.get().getCurrentSqlDbIds();
-        for (Long id : dbIds) {
-            Database db = GlobalStateMgr.getCurrentState().getDb(id);
-            if (db != null && db.getTable(tableId) != null) {
-                columnIdentifier.setDbId(db.getId());
-                break;
-            }
-        }
-
-        if (columnIdentifier.getDbId() == -1) {
-            LOG.debug("{} couldn't find db id", columnName);
+        if (FORBIDDEN_DICT_TABLE_IDS.contains(columnIdentifier.tableId)) {
+            LOG.debug("table {} forbid low cardinality global dict", columnIdentifier.tableId);
             return false;
         }
 
@@ -179,7 +161,7 @@ public class CacheDictManager implements IDictManager {
             try {
                 realResult = result.get();
             } catch (Exception e) {
-                LOG.warn(String.format("get dict cache for %d: %s failed", tableId, columnName), e);
+                LOG.warn(String.format("get dict cache for %d: %s failed", columnIdentifier.tableId, columnName), e);
                 return false;
             }
             if (!realResult.isPresent()) {
@@ -197,15 +179,15 @@ public class CacheDictManager implements IDictManager {
     }
 
     @Override
-    public boolean hasGlobalDict(long tableId, String columnName) {
-        ColumnIdentifier columnIdentifier = new ColumnIdentifier(tableId, columnName);
+    public boolean hasGlobalDict(Table t, String columnName) {
+        ColumnIdentifier columnIdentifier = new ColumnIdentifier(t, columnName);
         if (NO_DICT_STRING_COLUMNS.contains(columnIdentifier)) {
             LOG.debug("{} isn't low cardinality string column", columnName);
             return false;
         }
 
-        if (FORBIDDEN_DICT_TABLE_IDS.contains(tableId)) {
-            LOG.debug("table {} forbid low cardinality global dict", tableId);
+        if (FORBIDDEN_DICT_TABLE_IDS.contains(columnIdentifier.tableId)) {
+            LOG.debug("table {} forbid low cardinality global dict", columnIdentifier.tableId);
             return false;
         }
 
@@ -213,8 +195,8 @@ public class CacheDictManager implements IDictManager {
     }
 
     @Override
-    public void removeGlobalDict(long tableId, String columnName) {
-        ColumnIdentifier columnIdentifier = new ColumnIdentifier(tableId, columnName);
+    public void removeGlobalDict(Table t, String columnName) {
+        ColumnIdentifier columnIdentifier = new ColumnIdentifier(t, columnName);
 
         // skip dictionary operator in checkpoint thread
         if (GlobalStateMgr.isCheckpointThread()) {
@@ -225,29 +207,29 @@ public class CacheDictManager implements IDictManager {
             return;
         }
 
-        LOG.info("remove dict for table:{} column:{}", tableId, columnName);
+        LOG.info("remove dict for table:{} column:{}", columnIdentifier.tableId, columnName);
         dictStatistics.synchronous().invalidate(columnIdentifier);
     }
 
     @Override
-    public void disableGlobalDict(long tableId) {
-        LOG.debug("disable dict optimize for table {}", tableId);
-        FORBIDDEN_DICT_TABLE_IDS.add(tableId);
+    public void disableGlobalDict(Table t) {
+        LOG.debug("disable dict optimize for table {}", t.getId());
+        FORBIDDEN_DICT_TABLE_IDS.add(t.getId());
     }
 
     @Override
-    public void enableGlobalDict(long tableId) {
-        FORBIDDEN_DICT_TABLE_IDS.remove(tableId);
+    public void enableGlobalDict(Table t) {
+        FORBIDDEN_DICT_TABLE_IDS.remove(t.getId());
     }
 
     @Override
-    public void updateGlobalDict(long tableId, String columnName, long collectVersion, long versionTime) {
+    public void updateGlobalDict(Table t, String columnName, long collectVersion, long versionTime) {
         // skip dictionary operator in checkpoint thread
         if (GlobalStateMgr.isCheckpointThread()) {
             return;
         }
 
-        ColumnIdentifier columnIdentifier = new ColumnIdentifier(tableId, columnName);
+        ColumnIdentifier columnIdentifier = new ColumnIdentifier(t, columnName);
         if (!dictStatistics.asMap().containsKey(columnIdentifier)) {
             return;
         }
@@ -263,28 +245,28 @@ public class CacheDictManager implements IDictManager {
                     long dictCollectVersion = columnDict.getCollectedVersionTime();
                     if (collectVersion != dictCollectVersion) {
                         LOG.info("remove dict by unmatched version {}:{}", collectVersion, dictCollectVersion);
-                        removeGlobalDict(tableId, columnName);
+                        removeGlobalDict(t, columnName);
                         return;
                     }
                     columnDict.updateVersionTime(versionTime);
-                    LOG.info("update dict for table {} column {} from version {} to {}", tableId, columnName,
+                    LOG.info("update dict for table {} column {} from version {} to {}", columnIdentifier.tableId, columnName,
                             lastVersion, versionTime);
                 }
             } catch (Exception e) {
-                LOG.warn(String.format("update dict cache for %d: %s failed", tableId, columnName), e);
+                LOG.warn(String.format("update dict cache for %d: %s failed", columnIdentifier.tableId, columnName), e);
             }
         }
     }
 
     @Override
-    public Optional<ColumnDict> getGlobalDict(long tableId, String columnName) {
-        ColumnIdentifier columnIdentifier = new ColumnIdentifier(tableId, columnName);
+    public Optional<ColumnDict> getGlobalDict(Table t, String columnName) {
+        ColumnIdentifier columnIdentifier = new ColumnIdentifier(t, columnName);
         CompletableFuture<Optional<ColumnDict>> columnFuture = dictStatistics.get(columnIdentifier);
         if (columnFuture.isDone()) {
             try {
                 return columnFuture.get();
             } catch (Exception e) {
-                LOG.warn(String.format("get dict cache for %d: %s failed", tableId, columnName), e);
+                LOG.warn(String.format("get dict cache for %d: %s failed", columnIdentifier.tableId, columnName), e);
             }
         }
         return Optional.empty();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/IDictManager.java
@@ -12,28 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.statistics;
 
+import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
 
 import java.util.Optional;
 
 public interface IDictManager {
-    boolean hasGlobalDict(long tableId, String columnName, long versionTime);
+    boolean hasGlobalDict(Table t, String columnName, long versionTime);
 
-    void updateGlobalDict(long tableId, String columnName, long collectedVersion, long versionTime);
+    void updateGlobalDict(Table t, String columnName, long collectedVersion, long versionTime);
 
-    boolean hasGlobalDict(long tableId, String columnName);
+    boolean hasGlobalDict(Table t, String columnName);
 
-    void removeGlobalDict(long tableId, String columnName);
+    void removeGlobalDict(Table t, String columnName);
 
-    void disableGlobalDict(long tableId);
+    void disableGlobalDict(Table t);
 
-    void enableGlobalDict(long tableId);
+    void enableGlobalDict(Table t);
 
     // You should call `hasGlobalDict` firstly to ensure the global dict exist
-    Optional<ColumnDict> getGlobalDict(long tableId, String columnName);
+    Optional<ColumnDict> getGlobalDict(Table t, String columnName);
 
     static IDictManager getInstance() {
         if (FeConstants.USE_MOCK_DICT_MANAGER) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/MockDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/MockDictManager.java
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Table;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -37,34 +37,34 @@ public class MockDictManager implements IDictManager {
     }
 
     @Override
-    public boolean hasGlobalDict(long tableId, String columnName, long versionTime) {
+    public boolean hasGlobalDict(Table t, String columnName, long versionTime) {
         return true;
     }
 
     @Override
-    public void updateGlobalDict(long tableId, String columnName,  long collectedVersion, long versionTime) {
+    public void updateGlobalDict(Table t, String columnName, long collectedVersion, long versionTime) {
     }
 
     @Override
-    public boolean hasGlobalDict(long tableId, String columnName) {
+    public boolean hasGlobalDict(Table t, String columnName) {
         return true;
     }
 
     @Override
-    public void removeGlobalDict(long tableId, String columnName) {
+    public void removeGlobalDict(Table t, String columnName) {
     }
 
     @Override
-    public void disableGlobalDict(long tableId) {
+    public void disableGlobalDict(Table t) {
     }
 
     @Override
-    public void enableGlobalDict(long tableId) {
+    public void enableGlobalDict(Table t) {
 
     }
 
     @Override
-    public Optional<ColumnDict> getGlobalDict(long tableId, String columnName) {
+    public Optional<ColumnDict> getGlobalDict(Table t, String columnName) {
         return Optional.of(COLUMN_DICT);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1211,6 +1211,7 @@ public class PlanFragmentBuilder {
 
             PlanFragment fragment =
                     new PlanFragment(context.getNextFragmentId(), icebergScanNode, DataPartition.RANDOM);
+            fragment.setQueryGlobalDicts(node.getGlobalDicts());
             context.getFragments().add(fragment);
             return fragment;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -929,7 +929,7 @@ public class PlanFragmentBuilder {
                     slotDescriptor.setIsNullable(column.isAllowNull());
                     slotDescriptor.setIsMaterialized(true);
                     context.getColRefToExpr()
-                            .put(columnRefOperator, new SlotRef(columnRefOperator.toString(), slotDescriptor));
+                            .putIfAbsent(columnRefOperator, new SlotRef(columnRefOperator.toString(), slotDescriptor));
                 }
             }
             minMaxTuple.computeMemLayout();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -18,7 +18,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
@@ -33,8 +33,8 @@ import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.ErrorType;
-import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.base.ColumnIdentifier;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TResultBatch;
@@ -151,27 +151,33 @@ public class StatisticExecutor {
     }
 
     // If you call this function, you must ensure that the db lock is added
-    public static Pair<List<TStatisticData>, Status> queryDictSync(Long dbId, Long tableId, String column)
+    public static Pair<List<TStatisticData>, Status> queryDictSync(ColumnIdentifier identifier)
             throws Exception {
-        if (dbId == -1) {
-            return Pair.create(Collections.emptyList(), Status.OK);
-        }
-
-        Database db = MetaUtils.getDatabase(dbId);
-        Table table = MetaUtils.getTable(dbId, tableId);
+        String column = identifier.getColumnName();
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                .getTable(identifier.catalogName, identifier.dbName, identifier.tableName);
         if (!(table.isOlapOrCloudNativeTable() || table.isMaterializedView() || table.isIcebergTable())) {
             throw new SemanticException("Table '%s' is not a OLAP table or LAKE table or Materialize View",
                     table.getName());
         }
 
-        OlapTable olapTable = (OlapTable) table;
-        long version = olapTable.getPartitions().stream().map(Partition::getVisibleVersionTime)
-                .max(Long::compareTo).orElse(0L);
-        String catalogName = InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
-        String sql = "select cast(" + StatsConstants.STATISTIC_DICT_VERSION + " as Int), " +
-                "cast(" + version + " as bigint), " +
-                "dict_merge(" + StatisticUtils.quoting(column) + ") as _dict_merge_" + column +
-                " from " + StatisticUtils.quoting(catalogName, db.getOriginName(), table.getName()) + " [_META_]";
+        String sql;
+        if (table.isIcebergTable()) {
+            IcebergTable icebergTable = (IcebergTable) table;
+            long version = icebergTable.getNativeTable().currentSnapshot().snapshotId();
+            sql = "select cast(" + StatsConstants.STATISTIC_DICT_VERSION + " as Int), " +
+                    "cast(" + version + " as bigint), " +
+                    "dict_merge(array<string>[" + StatisticUtils.quoting(column) + "]) as _dict_merge_" + column +
+                    " from " + StatisticUtils.quoting(table.catalogName, table.dbName, table.getName());
+        } else {
+            OlapTable olapTable = (OlapTable) table;
+            long version = olapTable.getPartitions().stream().map(Partition::getVisibleVersionTime)
+                    .max(Long::compareTo).orElse(0L);
+            sql = "select cast(" + StatsConstants.STATISTIC_DICT_VERSION + " as Int), " +
+                    "cast(" + version + " as bigint), " +
+                    "dict_merge(" + StatisticUtils.quoting(column) + ") as _dict_merge_" + column +
+                    " from " + StatisticUtils.quoting(table.catalogName, table.dbName, table.getName()) + " [_META_]";
+        }
 
         ConnectContext context = StatisticUtils.buildConnectContext();
         // The parallelism degree of low-cardinality dict collect task is uniformly set to 1 to

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -69,7 +69,7 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
 
             if (!partitionCommitInfo.getInvalidDictCacheColumns().isEmpty()) {
                 for (String column : partitionCommitInfo.getInvalidDictCacheColumns()) {
-                    IDictManager.getInstance().removeGlobalDict(tableId, column);
+                    IDictManager.getInstance().removeGlobalDict(table, column);
                 }
             }
             if (!partitionCommitInfo.getValidDictCacheColumns().isEmpty()) {
@@ -86,7 +86,7 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
                 String columnName = validDictCacheColumns.get(i);
                 long collectedVersion = dictCollectedVersions.get(i);
                 IDictManager.getInstance()
-                        .updateGlobalDict(tableId, columnName, collectedVersion, maxPartitionVersionTime);
+                        .updateGlobalDict(table, columnName, collectedVersion, maxPartitionVersionTime);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -144,7 +144,7 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
             partition.updateVisibleVersion(version, versionTime, txnState.getTransactionId());
             if (!partitionCommitInfo.getInvalidDictCacheColumns().isEmpty()) {
                 for (String column : partitionCommitInfo.getInvalidDictCacheColumns()) {
-                    IDictManager.getInstance().removeGlobalDict(tableId, column);
+                    IDictManager.getInstance().removeGlobalDict(table, column);
                 }
             }
             if (!partitionCommitInfo.getValidDictCacheColumns().isEmpty()) {
@@ -162,7 +162,7 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
                 String columnName = validDictCacheColumns.get(i);
                 long collectedVersion = dictCollectedVersions.get(i);
                 IDictManager.getInstance()
-                        .updateGlobalDict(tableId, columnName, collectedVersion, maxPartitionVersionTime);
+                        .updateGlobalDict(table, columnName, collectedVersion, maxPartitionVersionTime);
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PushDownMinMaxConjunctsRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PushDownMinMaxConjunctsRuleTest.java
@@ -15,8 +15,8 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
-import com.google.common.collect.Maps;
 import com.starrocks.analysis.BinaryType;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.Memo;
@@ -31,6 +31,9 @@ import com.starrocks.sql.optimizer.operator.scalar.PredicateOperator;
 import mockit.Mocked;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 
 public class PushDownMinMaxConjunctsRuleTest {
@@ -38,19 +41,38 @@ public class PushDownMinMaxConjunctsRuleTest {
     public void transformIceberg(@Mocked IcebergTable table) {
         ExternalScanPartitionPruneRule rule0 = ExternalScanPartitionPruneRule.ICEBERG_SCAN;
 
-        PredicateOperator binaryPredicateOperator = new BinaryPredicateOperator(
-                BinaryType.EQ, new ColumnRefOperator(1, Type.INT, "id", true),
+        ColumnRefOperator colRef = new ColumnRefOperator(1, Type.INT, "id", true);
+        Column col = new Column("id", Type.INT, true);
+        PredicateOperator binaryPredicateOperator = new BinaryPredicateOperator(BinaryType.EQ, colRef,
                 ConstantOperator.createInt(1));
 
+        Map<ColumnRefOperator, Column> colRefToColumnMetaMap = new HashMap<>();
+        Map<Column, ColumnRefOperator> columnMetaToColRefMap = new HashMap<>();
+        colRefToColumnMetaMap.put(colRef, col);
+        columnMetaToColRefMap.put(col, colRef);
         OptExpression scan =
-                new OptExpression(new LogicalIcebergScanOperator(table,
-                                Maps.newHashMap(), Maps.newHashMap(), -1, binaryPredicateOperator));
-        scan.getInputs().add(scan);
+                new OptExpression(new LogicalIcebergScanOperator(table, colRefToColumnMetaMap, columnMetaToColRefMap,
+                        -1, binaryPredicateOperator));
 
         assertEquals(0, ((LogicalIcebergScanOperator) scan.getOp()).getScanOperatorPredicates().getMinMaxConjuncts().size());
 
         rule0.transform(scan, new OptimizerContext(new Memo(), new ColumnRefFactory()));
 
         assertEquals(2, ((LogicalIcebergScanOperator) scan.getOp()).getScanOperatorPredicates().getMinMaxConjuncts().size());
+
+        PredicateOperator binaryPredicateOperatorNoPushDown = new BinaryPredicateOperator(BinaryType.EQ,
+                new ColumnRefOperator(2, Type.INT, "id_noexist", true), ConstantOperator.createInt(1));
+
+        OptExpression scanNoPushDown =
+                new OptExpression(new LogicalIcebergScanOperator(table, colRefToColumnMetaMap, columnMetaToColRefMap,
+                        -1, binaryPredicateOperatorNoPushDown));
+
+        assertEquals(0,
+                ((LogicalIcebergScanOperator) scanNoPushDown.getOp()).getScanOperatorPredicates().getMinMaxConjuncts().size());
+
+        rule0.transform(scanNoPushDown, new OptimizerContext(new Memo(), new ColumnRefFactory()));
+
+        assertEquals(0,
+                ((LogicalIcebergScanOperator) scanNoPushDown.getOp()).getScanOperatorPredicates().getMinMaxConjuncts().size());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -164,7 +164,7 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
         PlanTestBase.assertContains(plan1, "hive_union_mv_1");
         PlanTestBase.assertContains(plan1, "1:HdfsScanNode\n" +
                 "     TABLE: supplier\n" +
-                "     NON-PARTITION PREDICATES: 13: s_suppkey < 10, 13: s_suppkey >= 5");
+                "     NON-PARTITION PREDICATES: 12: s_suppkey < 10, 12: s_suppkey >= 5");
         dropMv("test", "hive_union_mv_1");
     }
 
@@ -186,8 +186,7 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
 
         String query1 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 10";
         String plan = getFragmentPlan(query1);
-        PlanTestBase.assertContains(plan, "TABLE: supplier", "NON-PARTITION PREDICATES: 1: s_suppkey < 10");
-
+        PlanTestBase.assertContains(plan, "TABLE: supplier", "NON-PARTITION PREDICATES: 18: s_suppkey < 10, 18: s_suppkey >= 5");
         connectContext.getSessionVariable().setUseNthExecPlan(0);
         dropMv("test", "hive_join_mv_1");
     }
@@ -267,9 +266,9 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
             String plan = getFragmentPlan(query);
             System.out.println(plan);
             PlanTestBase.assertContains(plan, "1:AGGREGATE (update serialize)\n" +
-                            "  |  STREAMING\n" +
-                            "  |  output: sum(21: sum(l_orderkey))\n" +
-                            "  |  group by: 19: l_suppkey");
+                    "  |  STREAMING\n" +
+                    "  |  output: sum(21: sum(l_orderkey))\n" +
+                    "  |  group by: 19: l_suppkey");
             PlanTestBase.assertContains(plan, "PREDICATES: 18: l_orderkey > 1\n" +
                     "     partitions=6/6\n" +
                     "     rollup: hive_partition_prune_mv1");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -392,9 +392,9 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
                 ImmutableList.of("l_shipdate=1998-01-02"));
         plan = getFragmentPlan(query);
         PlanTestBase.assertContains(plan, "hive_parttbl_mv_2", "lineitem_par",
-                "PARTITION PREDICATES: (((23: l_shipdate < '1998-01-03') OR (23: l_shipdate >= '1998-01-06'))" +
-                        " AND (23: l_shipdate >= '1998-01-02')) OR (23: l_shipdate IS NULL)",
-                "NON-PARTITION PREDICATES: 21: l_orderkey > 100");
+                "PARTITION PREDICATES: (((22: l_shipdate < '1998-01-03') OR (22: l_shipdate >= '1998-01-06'))" +
+                        " AND (22: l_shipdate >= '1998-01-02')) OR (22: l_shipdate IS NULL)",
+                "NON-PARTITION PREDICATES: 20: l_orderkey > 100");
 
         dropMv("test", "hive_parttbl_mv_2");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
@@ -45,7 +45,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
                 "     TABLE: t1\n" +
                 "     PARTITION PREDICATES: 4: par_col = 1\n" +
                 "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
-                "     MIN/MAX PREDICATES: 5: c1 <= 2, 6: c1 >= 2\n" +
+                "     MIN/MAX PREDICATES: 1: c1 <= 2, 1: c1 >= 2\n" +
                 "     partitions=1/3");
 
         sql = "select * from t1 where par_col = abs(-1) and c1 = 2";
@@ -55,7 +55,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
                 "     PARTITION PREDICATES: 4: par_col = CAST(abs(-1) AS INT)\n" +
                 "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
                 "     NO EVAL-PARTITION PREDICATES: 4: par_col = CAST(abs(-1) AS INT)\n" +
-                "     MIN/MAX PREDICATES: 5: c1 <= 2, 6: c1 >= 2\n" +
+                "     MIN/MAX PREDICATES: 1: c1 <= 2, 1: c1 >= 2\n" +
                 "     partitions=3/3");
 
         sql = "select * from t1 where par_col = 1+1 and c1 = 2";
@@ -64,7 +64,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
                 "     TABLE: t1\n" +
                 "     PARTITION PREDICATES: 4: par_col = 2\n" +
                 "     NON-PARTITION PREDICATES: 1: c1 = 2\n" +
-                "     MIN/MAX PREDICATES: 5: c1 <= 2, 6: c1 >= 2\n" +
+                "     MIN/MAX PREDICATES: 1: c1 <= 2, 1: c1 >= 2\n" +
                 "     partitions=1/3");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.catalog.Table;
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
@@ -1578,9 +1579,9 @@ public class LowCardinalityTest extends PlanTestBase {
 
         new Expectations(dictManager) {
             {
-                dictManager.hasGlobalDict(anyLong, "S_ADDRESS", anyLong);
+                dictManager.hasGlobalDict((Table) any, "S_ADDRESS", anyLong);
                 result = true;
-                dictManager.getGlobalDict(anyLong, "S_ADDRESS");
+                dictManager.getGlobalDict((Table) any, "S_ADDRESS");
                 result = Optional.empty();
             }
         };

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q1.sql
@@ -114,14 +114,14 @@ OutPut Exchange Id: 03
 |  7 <-> [7: l_discount, DECIMAL64(15,2), true]
 |  9 <-> [9: l_returnflag, VARCHAR, true]
 |  10 <-> [10: l_linestatus, VARCHAR, true]
-|  17 <-> [32: multiply, DECIMAL128(33,4), true]
-|  18 <-> [32: multiply, DECIMAL128(33,4), true] * cast(1 + [8: l_tax, DECIMAL64(15,2), true] as DECIMAL128(16,2))
+|  17 <-> [31: multiply, DECIMAL128(33,4), true]
+|  18 <-> [31: multiply, DECIMAL128(33,4), true] * cast(1 + [8: l_tax, DECIMAL64(15,2), true] as DECIMAL128(16,2))
 |  common expressions:
-|  32 <-> [28: cast, DECIMAL128(15,2), true] * [31: cast, DECIMAL128(18,2), true]
-|  28 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
-|  29 <-> [7: l_discount, DECIMAL64(15,2), true]
-|  30 <-> 1 - [29: cast, DECIMAL64(18,2), true]
-|  31 <-> cast([30: subtract, DECIMAL64(18,2), true] as DECIMAL128(18,2))
+|  27 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
+|  28 <-> [7: l_discount, DECIMAL64(15,2), true]
+|  29 <-> 1 - [28: cast, DECIMAL64(18,2), true]
+|  30 <-> cast([29: subtract, DECIMAL64(18,2), true] as DECIMAL128(18,2))
+|  31 <-> [27: cast, DECIMAL128(15,2), true] * [30: cast, DECIMAL128(18,2), true]
 |  cardinality: 600037902
 |  column statistics:
 |  * l_quantity-->[1.0, 50.0, 0.0, 8.0, 50.0] ESTIMATE
@@ -135,7 +135,7 @@ OutPut Exchange Id: 03
 0:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 11: l_shipdate <= '1998-12-01'
-MIN/MAX PREDICATES: 27: l_shipdate <= '1998-12-01'
+MIN/MAX PREDICATES: 11: l_shipdate <= '1998-12-01'
 partitions=1/1
 avgRowSize=70.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q10.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q10.sql
@@ -184,7 +184,7 @@ OutPut Exchange Id: 13
 6:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 26: l_returnflag = 'R'
-MIN/MAX PREDICATES: 40: l_returnflag <= 'R', 41: l_returnflag >= 'R'
+MIN/MAX PREDICATES: 26: l_returnflag <= 'R', 26: l_returnflag >= 'R'
 partitions=1/1
 avgRowSize=25.0
 numNodes=0
@@ -215,7 +215,7 @@ OutPut Exchange Id: 10
 8:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 13: o_orderdate >= '1994-05-01', 13: o_orderdate < '1994-08-01'
-MIN/MAX PREDICATES: 42: o_orderdate >= '1994-05-01', 43: o_orderdate < '1994-08-01'
+MIN/MAX PREDICATES: 13: o_orderdate >= '1994-05-01', 13: o_orderdate < '1994-08-01'
 partitions=1/1
 avgRowSize=20.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q11.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q11.sql
@@ -232,7 +232,7 @@ OutPut Exchange Id: 16
 14:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 32: n_name = 'PERU'
-MIN/MAX PREDICATES: 39: n_name <= 'PERU', 40: n_name >= 'PERU'
+MIN/MAX PREDICATES: 32: n_name <= 'PERU', 32: n_name >= 'PERU'
 partitions=1/1
 avgRowSize=29.0
 numNodes=0
@@ -348,7 +348,7 @@ OutPut Exchange Id: 04
 2:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 14: n_name = 'PERU'
-MIN/MAX PREDICATES: 41: n_name <= 'PERU', 42: n_name >= 'PERU'
+MIN/MAX PREDICATES: 14: n_name <= 'PERU', 14: n_name >= 'PERU'
 partitions=1/1
 avgRowSize=29.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q12.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q12.sql
@@ -147,7 +147,7 @@ OutPut Exchange Id: 03
 1:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 24: l_shipmode IN ('REG AIR', 'MAIL'), 21: l_commitdate < 22: l_receiptdate, 20: l_shipdate < 21: l_commitdate, 22: l_receiptdate >= '1997-01-01', 22: l_receiptdate < '1998-01-01'
-MIN/MAX PREDICATES: 30: l_shipmode >= 'MAIL', 31: l_shipmode <= 'REG AIR', 32: l_receiptdate >= '1997-01-01', 33: l_receiptdate < '1998-01-01'
+MIN/MAX PREDICATES: 24: l_shipmode >= 'MAIL', 24: l_shipmode <= 'REG AIR', 22: l_receiptdate >= '1997-01-01', 22: l_receiptdate < '1998-01-01'
 partitions=1/1
 avgRowSize=30.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q14.sql
@@ -44,7 +44,7 @@ OutPut Partition: UNPARTITIONED
 OutPut Exchange Id: 08
 
 7:AGGREGATE (update serialize)
-|  aggregate: sum[(if[(21: p_type LIKE 'PROMO%', [37: multiply, DECIMAL128(33,4), true], 0); args: BOOLEAN,DECIMAL128,DECIMAL128; result: DECIMAL128(33,4); args nullable: true; result nullable: true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true], sum[([27: expr, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
+|  aggregate: sum[(if[(21: p_type LIKE 'PROMO%', [35: multiply, DECIMAL128(33,4), true], 0); args: BOOLEAN,DECIMAL128,DECIMAL128; result: DECIMAL128(33,4); args nullable: true; result nullable: true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true], sum[([27: expr, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
 |  cardinality: 1
 |  column statistics:
 |  * sum-->[-Infinity, Infinity, 0.0, 16.0, 1.0] ESTIMATE
@@ -53,14 +53,14 @@ OutPut Exchange Id: 08
 6:Project
 |  output columns:
 |  21 <-> [21: p_type, VARCHAR, true]
-|  27 <-> [37: multiply, DECIMAL128(33,4), true]
-|  37 <-> [37: multiply, DECIMAL128(33,4), true]
+|  27 <-> [35: multiply, DECIMAL128(33,4), true]
+|  35 <-> [35: multiply, DECIMAL128(33,4), true]
 |  common expressions:
-|  33 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
-|  34 <-> [7: l_discount, DECIMAL64(15,2), true]
-|  35 <-> 1 - [34: cast, DECIMAL64(18,2), true]
-|  36 <-> cast([35: subtract, DECIMAL64(18,2), true] as DECIMAL128(18,2))
-|  37 <-> [33: cast, DECIMAL128(15,2), true] * [36: cast, DECIMAL128(18,2), true]
+|  32 <-> [7: l_discount, DECIMAL64(15,2), true]
+|  33 <-> 1 - [32: cast, DECIMAL64(18,2), true]
+|  34 <-> cast([33: subtract, DECIMAL64(18,2), true] as DECIMAL128(18,2))
+|  35 <-> [31: cast, DECIMAL128(15,2), true] * [34: cast, DECIMAL128(18,2), true]
+|  31 <-> cast([6: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
 |  cardinality: 6653886
 |  column statistics:
 |  * p_type-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
@@ -112,7 +112,7 @@ OutPut Exchange Id: 04
 2:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 11: l_shipdate >= '1997-02-01', 11: l_shipdate < '1997-03-01'
-MIN/MAX PREDICATES: 31: l_shipdate >= '1997-02-01', 32: l_shipdate < '1997-03-01'
+MIN/MAX PREDICATES: 11: l_shipdate >= '1997-02-01', 11: l_shipdate < '1997-03-01'
 partitions=1/1
 avgRowSize=28.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q15.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q15.sql
@@ -254,7 +254,7 @@ OutPut Exchange Id: 09
 6:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 36: l_shipdate >= '1995-07-01', 36: l_shipdate < '1995-10-01'
-MIN/MAX PREDICATES: 46: l_shipdate >= '1995-07-01', 47: l_shipdate < '1995-10-01'
+MIN/MAX PREDICATES: 36: l_shipdate >= '1995-07-01', 36: l_shipdate < '1995-10-01'
 partitions=1/1
 avgRowSize=40.0
 numNodes=0
@@ -293,7 +293,7 @@ OutPut Exchange Id: 04
 1:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 18: l_shipdate >= '1995-07-01', 18: l_shipdate < '1995-10-01'
-MIN/MAX PREDICATES: 48: l_shipdate >= '1995-07-01', 49: l_shipdate < '1995-10-01'
+MIN/MAX PREDICATES: 18: l_shipdate >= '1995-07-01', 18: l_shipdate < '1995-10-01'
 partitions=1/1
 avgRowSize=40.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q16.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q16.sql
@@ -200,7 +200,7 @@ OutPut Exchange Id: 03
 2:HdfsScanNode
 TABLE: part
 NON-PARTITION PREDICATES: 9: p_brand != 'Brand#43', NOT (10: p_type LIKE 'PROMO BURNISHED%'), 11: p_size IN (31, 43, 9, 6, 18, 11, 25, 1)
-MIN/MAX PREDICATES: 24: p_size >= 1, 25: p_size <= 43
+MIN/MAX PREDICATES: 11: p_size >= 1, 11: p_size <= 43
 partitions=1/1
 avgRowSize=47.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q17.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q17.sql
@@ -159,7 +159,7 @@ OutPut Exchange Id: 03
 1:HdfsScanNode
 TABLE: part
 NON-PARTITION PREDICATES: 20: p_brand = 'Brand#35', 23: p_container = 'JUMBO CASE'
-MIN/MAX PREDICATES: 48: p_brand <= 'Brand#35', 49: p_brand >= 'Brand#35', 50: p_container <= 'JUMBO CASE', 51: p_container >= 'JUMBO CASE'
+MIN/MAX PREDICATES: 20: p_brand <= 'Brand#35', 20: p_brand >= 'Brand#35', 23: p_container <= 'JUMBO CASE', 23: p_container >= 'JUMBO CASE'
 partitions=1/1
 avgRowSize=28.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q19.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q19.sql
@@ -109,7 +109,7 @@ OutPut Exchange Id: 04
 3:HdfsScanNode
 TABLE: part
 NON-PARTITION PREDICATES: 20: p_brand IN ('Brand#45', 'Brand#11', 'Brand#21'), 22: p_size <= 15, 23: p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG', 'MED BAG', 'MED BOX', 'MED PKG', 'MED PACK', 'LG CASE', 'LG BOX', 'LG PACK', 'LG PKG'), 22: p_size >= 1
-MIN/MAX PREDICATES: 28: p_brand >= 'Brand#11', 29: p_brand <= 'Brand#45', 30: p_size <= 15, 31: p_container >= 'LG BOX', 32: p_container <= 'SM PKG', 33: p_size >= 1
+MIN/MAX PREDICATES: 20: p_brand >= 'Brand#11', 20: p_brand <= 'Brand#45', 22: p_size <= 15, 23: p_container >= 'LG BOX', 23: p_container <= 'SM PKG', 22: p_size >= 1
 partitions=1/1
 avgRowSize=32.0
 numNodes=0
@@ -142,7 +142,7 @@ OutPut Exchange Id: 02
 0:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 5: l_quantity >= 5, 5: l_quantity <= 35, 15: l_shipmode IN ('AIR', 'AIR REG'), 14: l_shipinstruct = 'DELIVER IN PERSON'
-MIN/MAX PREDICATES: 34: l_quantity >= 5, 35: l_quantity <= 35, 36: l_shipmode >= 'AIR', 37: l_shipmode <= 'AIR REG', 38: l_shipinstruct <= 'DELIVER IN PERSON', 39: l_shipinstruct >= 'DELIVER IN PERSON'
+MIN/MAX PREDICATES: 5: l_quantity >= 5, 5: l_quantity <= 35, 15: l_shipmode >= 'AIR', 15: l_shipmode <= 'AIR REG', 14: l_shipinstruct <= 'DELIVER IN PERSON', 14: l_shipinstruct >= 'DELIVER IN PERSON'
 partitions=1/1
 avgRowSize=67.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q2.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q2.sql
@@ -297,7 +297,7 @@ OutPut Exchange Id: 14
 12:HdfsScanNode
 TABLE: part
 NON-PARTITION PREDICATES: 6: p_size = 12, 5: p_type LIKE '%COPPER'
-MIN/MAX PREDICATES: 53: p_size <= 12, 54: p_size >= 12
+MIN/MAX PREDICATES: 6: p_size <= 12, 6: p_size >= 12
 partitions=1/1
 avgRowSize=62.0
 numNodes=0
@@ -435,7 +435,7 @@ OutPut Exchange Id: 04
 2:HdfsScanNode
 TABLE: region
 NON-PARTITION PREDICATES: 27: r_name = 'AMERICA'
-MIN/MAX PREDICATES: 51: r_name <= 'AMERICA', 52: r_name >= 'AMERICA'
+MIN/MAX PREDICATES: 27: r_name <= 'AMERICA', 27: r_name >= 'AMERICA'
 partitions=1/1
 avgRowSize=10.8
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q20.sql
@@ -165,7 +165,7 @@ OutPut Exchange Id: 19
 17:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 9: n_name = 'ARGENTINA'
-MIN/MAX PREDICATES: 49: n_name <= 'ARGENTINA', 50: n_name >= 'ARGENTINA'
+MIN/MAX PREDICATES: 9: n_name <= 'ARGENTINA', 9: n_name >= 'ARGENTINA'
 partitions=1/1
 avgRowSize=29.0
 numNodes=0
@@ -342,7 +342,7 @@ OutPut Exchange Id: 03
 0:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 29: l_suppkey IS NOT NULL, 37: l_shipdate >= '1993-01-01', 37: l_shipdate < '1994-01-01'
-MIN/MAX PREDICATES: 47: l_shipdate >= '1993-01-01', 48: l_shipdate < '1994-01-01'
+MIN/MAX PREDICATES: 37: l_shipdate >= '1993-01-01', 37: l_shipdate < '1994-01-01'
 partitions=1/1
 avgRowSize=24.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q21.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q21.sql
@@ -317,7 +317,7 @@ OutPut Exchange Id: 13
 11:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 34: n_name = 'CANADA'
-MIN/MAX PREDICATES: 72: n_name <= 'CANADA', 73: n_name >= 'CANADA'
+MIN/MAX PREDICATES: 34: n_name <= 'CANADA', 34: n_name >= 'CANADA'
 partitions=1/1
 avgRowSize=29.0
 numNodes=0
@@ -342,7 +342,7 @@ OutPut Exchange Id: 07
 5:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 26: o_orderstatus = 'F'
-MIN/MAX PREDICATES: 74: o_orderstatus <= 'F', 75: o_orderstatus >= 'F'
+MIN/MAX PREDICATES: 26: o_orderstatus <= 'F', 26: o_orderstatus >= 'F'
 partitions=1/1
 avgRowSize=9.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q22.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q22.sql
@@ -205,7 +205,7 @@ OutPut Exchange Id: 06
 3:HdfsScanNode
 TABLE: customer
 NON-PARTITION PREDICATES: 14: c_acctbal > 0.00, substring(13: c_phone, 1, 2) IN ('21', '28', '24', '32', '35', '34', '37')
-MIN/MAX PREDICATES: 32: c_acctbal > 0.00
+MIN/MAX PREDICATES: 14: c_acctbal > 0.00
 partitions=1/1
 avgRowSize=23.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q3.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q3.sql
@@ -141,7 +141,7 @@ OutPut Exchange Id: 09
 3:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 13: o_orderdate < '1995-03-11'
-MIN/MAX PREDICATES: 37: o_orderdate < '1995-03-11'
+MIN/MAX PREDICATES: 13: o_orderdate < '1995-03-11'
 partitions=1/1
 avgRowSize=24.0
 numNodes=0
@@ -170,7 +170,7 @@ OutPut Exchange Id: 06
 4:HdfsScanNode
 TABLE: customer
 NON-PARTITION PREDICATES: 7: c_mktsegment = 'HOUSEHOLD'
-MIN/MAX PREDICATES: 38: c_mktsegment <= 'HOUSEHOLD', 39: c_mktsegment >= 'HOUSEHOLD'
+MIN/MAX PREDICATES: 7: c_mktsegment <= 'HOUSEHOLD', 7: c_mktsegment >= 'HOUSEHOLD'
 partitions=1/1
 avgRowSize=18.0
 numNodes=0
@@ -199,7 +199,7 @@ OutPut Exchange Id: 02
 0:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 28: l_shipdate > '1995-03-11'
-MIN/MAX PREDICATES: 36: l_shipdate > '1995-03-11'
+MIN/MAX PREDICATES: 28: l_shipdate > '1995-03-11'
 partitions=1/1
 avgRowSize=28.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q4.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q4.sql
@@ -122,7 +122,7 @@ OutPut Exchange Id: 05
 3:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 5: o_orderdate >= '1994-09-01', 5: o_orderdate < '1994-12-01'
-MIN/MAX PREDICATES: 28: o_orderdate >= '1994-09-01', 29: o_orderdate < '1994-12-01'
+MIN/MAX PREDICATES: 5: o_orderdate >= '1994-09-01', 5: o_orderdate < '1994-12-01'
 partitions=1/1
 avgRowSize=27.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q5.sql
@@ -184,7 +184,7 @@ OutPut Exchange Id: 17
 15:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 13: o_orderdate >= '1995-01-01', 13: o_orderdate < '1996-01-01'
-MIN/MAX PREDICATES: 52: o_orderdate >= '1995-01-01', 53: o_orderdate < '1996-01-01'
+MIN/MAX PREDICATES: 13: o_orderdate >= '1995-01-01', 13: o_orderdate < '1996-01-01'
 partitions=1/1
 avgRowSize=20.0
 numNodes=0
@@ -359,7 +359,7 @@ OutPut Exchange Id: 05
 3:HdfsScanNode
 TABLE: region
 NON-PARTITION PREDICATES: 46: r_name = 'AFRICA'
-MIN/MAX PREDICATES: 50: r_name <= 'AFRICA', 51: r_name >= 'AFRICA'
+MIN/MAX PREDICATES: 46: r_name <= 'AFRICA', 46: r_name >= 'AFRICA'
 partitions=1/1
 avgRowSize=10.8
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q6.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q6.sql
@@ -48,7 +48,7 @@ OutPut Exchange Id: 03
 0:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 11: l_shipdate >= '1995-01-01', 11: l_shipdate < '1996-01-01', 7: l_discount >= 0.02, 7: l_discount <= 0.04, 5: l_quantity < 24
-MIN/MAX PREDICATES: 19: l_shipdate >= '1995-01-01', 20: l_shipdate < '1996-01-01', 21: l_discount >= 0.02, 22: l_discount <= 0.04, 23: l_quantity < 24
+MIN/MAX PREDICATES: 11: l_shipdate >= '1995-01-01', 11: l_shipdate < '1996-01-01', 7: l_discount >= 0.02, 7: l_discount <= 0.04, 5: l_quantity < 24
 partitions=1/1
 avgRowSize=44.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q7.sql
@@ -263,7 +263,7 @@ OutPut Exchange Id: 14
 2:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 18: l_shipdate >= '1995-01-01', 18: l_shipdate <= '1996-12-31'
-MIN/MAX PREDICATES: 56: l_shipdate >= '1995-01-01', 57: l_shipdate <= '1996-12-31'
+MIN/MAX PREDICATES: 18: l_shipdate >= '1995-01-01', 18: l_shipdate <= '1996-12-31'
 partitions=1/1
 avgRowSize=32.0
 numNodes=0
@@ -351,7 +351,7 @@ OutPut Exchange Id: 08
 4:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 42: n_name IN ('CANADA', 'IRAN')
-MIN/MAX PREDICATES: 54: n_name >= 'CANADA', 55: n_name <= 'IRAN'
+MIN/MAX PREDICATES: 42: n_name >= 'CANADA', 42: n_name <= 'IRAN'
 partitions=1/1
 avgRowSize=29.0
 numNodes=0
@@ -369,7 +369,7 @@ OutPut Exchange Id: 06
 5:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 46: n_name IN ('IRAN', 'CANADA')
-MIN/MAX PREDICATES: 52: n_name >= 'CANADA', 53: n_name <= 'IRAN'
+MIN/MAX PREDICATES: 46: n_name >= 'CANADA', 46: n_name <= 'IRAN'
 partitions=1/1
 avgRowSize=29.0
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
@@ -110,14 +110,14 @@ OutPut Exchange Id: 34
 32:Project
 |  output columns:
 |  61 <-> year[([37: o_orderdate, DATE, true]); args: DATE; result: SMALLINT; args nullable: true; result nullable: true]
-|  62 <-> [77: multiply, DECIMAL128(33,4), true]
-|  63 <-> if[([55: n_name, VARCHAR, true] = 'IRAN', [77: multiply, DECIMAL128(33,4), true], 0); args: BOOLEAN,DECIMAL128,DECIMAL128; result: DECIMAL128(33,4); args nullable: true; result nullable: true]
+|  62 <-> [71: multiply, DECIMAL128(33,4), true]
+|  63 <-> if[([55: n_name, VARCHAR, true] = 'IRAN', [71: multiply, DECIMAL128(33,4), true], 0); args: BOOLEAN,DECIMAL128,DECIMAL128; result: DECIMAL128(33,4); args nullable: true; result nullable: true]
 |  common expressions:
-|  73 <-> cast([22: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
-|  74 <-> [23: l_discount, DECIMAL64(15,2), true]
-|  75 <-> 1 - [74: cast, DECIMAL64(18,2), true]
-|  76 <-> cast([75: subtract, DECIMAL64(18,2), true] as DECIMAL128(18,2))
-|  77 <-> [73: cast, DECIMAL128(15,2), true] * [76: cast, DECIMAL128(18,2), true]
+|  67 <-> cast([22: l_extendedprice, DECIMAL64(15,2), true] as DECIMAL128(15,2))
+|  68 <-> [23: l_discount, DECIMAL64(15,2), true]
+|  69 <-> 1 - [68: cast, DECIMAL64(18,2), true]
+|  70 <-> cast([69: subtract, DECIMAL64(18,2), true] as DECIMAL128(18,2))
+|  71 <-> [67: cast, DECIMAL128(15,2), true] * [70: cast, DECIMAL128(18,2), true]
 |  cardinality: 242843
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
@@ -328,7 +328,7 @@ OutPut Exchange Id: 18
 16:HdfsScanNode
 TABLE: part
 NON-PARTITION PREDICATES: 5: p_type = 'ECONOMY ANODIZED STEEL'
-MIN/MAX PREDICATES: 71: p_type <= 'ECONOMY ANODIZED STEEL', 72: p_type >= 'ECONOMY ANODIZED STEEL'
+MIN/MAX PREDICATES: 5: p_type <= 'ECONOMY ANODIZED STEEL', 5: p_type >= 'ECONOMY ANODIZED STEEL'
 partitions=1/1
 avgRowSize=33.0
 numNodes=0
@@ -372,7 +372,7 @@ OutPut Exchange Id: 14
 0:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 37: o_orderdate >= '1995-01-01', 37: o_orderdate <= '1996-12-31'
-MIN/MAX PREDICATES: 69: o_orderdate >= '1995-01-01', 70: o_orderdate <= '1996-12-31'
+MIN/MAX PREDICATES: 37: o_orderdate >= '1995-01-01', 37: o_orderdate <= '1996-12-31'
 partitions=1/1
 avgRowSize=20.0
 numNodes=0
@@ -485,7 +485,7 @@ OutPut Exchange Id: 05
 3:HdfsScanNode
 TABLE: region
 NON-PARTITION PREDICATES: 59: r_name = 'MIDDLE EAST'
-MIN/MAX PREDICATES: 67: r_name <= 'MIDDLE EAST', 68: r_name >= 'MIDDLE EAST'
+MIN/MAX PREDICATES: 59: r_name <= 'MIDDLE EAST', 59: r_name >= 'MIDDLE EAST'
 partitions=1/1
 avgRowSize=10.8
 numNodes=0

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q1.sql
@@ -23,9 +23,9 @@ order by
 [result]
 TOP-N (order by [[9: l_returnflag ASC NULLS FIRST, 10: l_linestatus ASC NULLS FIRST]])
     TOP-N (order by [[9: l_returnflag ASC NULLS FIRST, 10: l_linestatus ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{115: sum=sum(115: sum), 116: count=sum(116: count), 117: sum=sum(117: sum), 118: sum=sum(118: sum), 119: sum=sum(119: sum), 120: sum=sum(120: sum), 121: count=sum(121: count), 122: count=sum(122: count), 123: count=sum(123: count)}] group by [[81: l_returnflag, 82: l_linestatus]] having [null]
-            EXCHANGE SHUFFLE[81, 82]
-                AGGREGATE ([LOCAL] aggregate [{115: sum=sum(87: sum_discount), 116: count=sum(88: count_discount), 117: sum=sum(83: sum_qty), 118: sum=sum(85: sum_base_price), 119: sum=sum(89: sum_disc_price), 120: sum=sum(90: sum_charge), 121: count=sum(91: count_order), 122: count=sum(84: count_qty), 123: count=sum(86: count_base_price)}] group by [[81: l_returnflag, 82: l_linestatus]] having [null]
-                    SCAN (mv[lineitem_agg_mv1] columns[80: l_shipdate, 81: l_returnflag, 82: l_linestatus, 83: sum_qty, 84: count_qty, 85: sum_base_price, 86: count_base_price, 87: sum_discount, 88: count_discount, 89: sum_disc_price, 90: sum_charge, 91: count_order] predicate[80: l_shipdate <= 1998-12-01])
+        AGGREGATE ([GLOBAL] aggregate [{114: count=sum(114: count), 115: sum=sum(115: sum), 116: sum=sum(116: sum), 117: sum=sum(117: sum), 118: sum=sum(118: sum), 119: count=sum(119: count), 120: count=sum(120: count), 121: count=sum(121: count), 122: sum=sum(122: sum)}] group by [[29: l_returnflag, 30: l_linestatus]] having [null]
+            EXCHANGE SHUFFLE[29, 30]
+                AGGREGATE ([LOCAL] aggregate [{114: count=sum(36: count_discount), 115: sum=sum(31: sum_qty), 116: sum=sum(33: sum_base_price), 117: sum=sum(37: sum_disc_price), 118: sum=sum(38: sum_charge), 119: count=sum(39: count_order), 120: count=sum(32: count_qty), 121: count=sum(34: count_base_price), 122: sum=sum(35: sum_discount)}] group by [[29: l_returnflag, 30: l_linestatus]] having [null]
+                    SCAN (mv[lineitem_agg_mv1] columns[28: l_shipdate, 29: l_returnflag, 30: l_linestatus, 31: sum_qty, 32: count_qty, 33: sum_base_price, 34: count_base_price, 35: sum_discount, 36: count_discount, 37: sum_disc_price, 38: sum_charge, 39: count_order] predicate[28: l_shipdate <= 1998-12-01])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q20.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q20.sql
@@ -48,14 +48,12 @@ TOP-N (order by [[2: s_name ASC NULLS FIRST]])
                         EXCHANGE SHUFFLE[17]
                             SCAN (columns{17,18} predicate[17: p_partkey IS NOT NULL AND 18: p_name LIKE sienna%])
                     EXCHANGE SHUFFLE[28]
-                        AGGREGATE ([GLOBAL] aggregate [{149: sum=sum(149: sum)}] group by [[132: l_partkey, 130: l_suppkey]] having [null]
-                            EXCHANGE SHUFFLE[132, 130]
-                                AGGREGATE ([LOCAL] aggregate [{149: sum=sum(133: sum_qty)}] group by [[132: l_partkey, 130: l_suppkey]] having [null]
-                                    SCAN (mv[lineitem_agg_mv2] columns[130: l_suppkey, 131: l_shipdate, 132: l_partkey, 133: sum_qty] predicate[131: l_shipdate >= 1993-01-01 AND 131: l_shipdate < 1994-01-01])
+                        AGGREGATE ([GLOBAL] aggregate [{145: sum=sum(145: sum)}] group by [[65: l_partkey, 63: l_suppkey]] having [null]
+                            EXCHANGE SHUFFLE[65, 63]
+                                AGGREGATE ([LOCAL] aggregate [{145: sum=sum(66: sum_qty)}] group by [[65: l_partkey, 63: l_suppkey]] having [null]
+                                    SCAN (mv[lineitem_agg_mv2] columns[63: l_suppkey, 64: l_shipdate, 65: l_partkey, 66: sum_qty] predicate[64: l_shipdate >= 1993-01-01 AND 64: l_shipdate < 1994-01-01])
             EXCHANGE SHUFFLE[1]
                 INNER JOIN (join-predicate [4: s_nationkey = 8: n_nationkey] post-join-predicate [null])
                     SCAN (columns{1,2,3,4} predicate[4: s_nationkey IS NOT NULL])
                     EXCHANGE BROADCAST
-                        SCAN (columns{8,9,147,148} predicate[9: n_name = ARGENTINA])
-[end]
-
+                        SCAN (columns{8,9} predicate[9: n_name = ARGENTINA])

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q22.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q22.sql
@@ -50,9 +50,9 @@ TOP-N (order by [[29: substring ASC NULLS FIRST]])
                                 SCAN (columns{1,5,6} predicate[substring(5: c_phone, 1, 2) IN (21, 28, 24, 32, 35, 34, 37)])
                                 EXCHANGE BROADCAST
                                     ASSERT LE 1
-                                        AGGREGATE ([GLOBAL] aggregate [{97: count=sum(97: count), 96: sum=sum(96: sum)}] group by [[]] having [null]
+                                        AGGREGATE ([GLOBAL] aggregate [{95: sum=sum(95: sum), 96: count=sum(96: count)}] group by [[]] having [null]
                                             EXCHANGE GATHER
-                                                AGGREGATE ([LOCAL] aggregate [{97: count=sum(39: c_count), 96: sum=sum(40: c_sum)}] group by [[]] having [null]
+                                                AGGREGATE ([LOCAL] aggregate [{95: sum=sum(40: c_sum), 96: count=sum(39: c_count)}] group by [[]] having [null]
                                                     SCAN (mv[customer_agg_mv1] columns[37: c_acctbal, 38: substring_phone, 39: c_count, 40: c_sum] predicate[37: c_acctbal > 0.00 AND 38: substring_phone IN (21, 24, 28, 32, 34, 35, 37)])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q5.sql
@@ -29,6 +29,6 @@ TOP-N (order by [[49: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{49: sum=sum(49: sum)}] group by [[42: n_name]] having [null]
             EXCHANGE SHUFFLE[42]
                 AGGREGATE ([LOCAL] aggregate [{49: sum=sum(48: expr)}] group by [[42: n_name]] having [null]
-                    SCAN (mv[lineitem_mv] columns[75: c_nationkey, 90: o_orderdate, 101: s_nationkey, 103: l_saleprice, 109: n_name2, 112: r_name2] predicate[75: c_nationkey = 101: s_nationkey AND 90: o_orderdate >= 1995-01-01 AND 90: o_orderdate < 1996-01-01 AND 112: r_name2 = AFRICA])
+                    SCAN (mv[lineitem_mv] columns[112: c_nationkey, 127: o_orderdate, 138: s_nationkey, 140: l_saleprice, 146: n_name2, 149: r_name2] predicate[138: s_nationkey = 112: c_nationkey AND 127: o_orderdate >= 1995-01-01 AND 127: o_orderdate < 1996-01-01 AND 149: r_name2 = AFRICA])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/scheduler/external/hive/tpch/q1.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/external/hive/tpch/q1.sql
@@ -1,0 +1,107 @@
+[sql]
+select
+    l_returnflag,
+    l_linestatus,
+    sum(l_quantity) as sum_qty,
+    sum(l_extendedprice) as sum_base_price,
+    sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+    avg(l_quantity) as avg_qty,
+    avg(l_extendedprice) as avg_price,
+    avg(l_discount) as avg_disc,
+    count(*) as count_order
+from
+    lineitem
+where
+    l_shipdate <= date '1998-12-01'
+group by
+    l_returnflag,
+    l_linestatus
+order by
+    l_returnflag,
+    l_linestatus ;
+[scheduler]
+PLAN FRAGMENT 0(F02)
+  DOP: 16
+  INSTANCES
+    INSTANCE(0-F02#0)
+      BE: 10002
+
+PLAN FRAGMENT 1(F01)
+  DOP: 16
+  INSTANCES
+    INSTANCE(1-F01#0)
+      DESTINATIONS: 0-F02#0
+      BE: 10001
+
+PLAN FRAGMENT 2(F00)
+  DOP: 16
+  INSTANCES
+    INSTANCE(2-F00#0)
+      DESTINATIONS: 1-F01#0
+      BE: 10001
+
+[fragment]
+PLAN FRAGMENT 0
+ OUTPUT EXPRS:9: l_returnflag | 10: l_linestatus | 19: sum | 20: sum | 21: sum | 22: sum | 23: avg | 24: avg | 25: avg | 26: count
+  PARTITION: UNPARTITIONED
+
+  RESULT SINK
+
+  6:MERGING-EXCHANGE
+
+PLAN FRAGMENT 1
+ OUTPUT EXPRS:
+  PARTITION: HASH_PARTITIONED: 9: l_returnflag, 10: l_linestatus
+
+  STREAM DATA SINK
+    EXCHANGE ID: 06
+    UNPARTITIONED
+
+  5:SORT
+  |  order by: <slot 9> 9: l_returnflag ASC, <slot 10> 10: l_linestatus ASC
+  |  offset: 0
+  |  
+  4:AGGREGATE (merge finalize)
+  |  output: sum(19: sum), sum(20: sum), sum(21: sum), sum(22: sum), avg(23: avg), avg(24: avg), avg(25: avg), count(26: count)
+  |  group by: 9: l_returnflag, 10: l_linestatus
+  |  
+  3:EXCHANGE
+
+PLAN FRAGMENT 2
+ OUTPUT EXPRS:
+  PARTITION: RANDOM
+
+  STREAM DATA SINK
+    EXCHANGE ID: 03
+    HASH_PARTITIONED: 9: l_returnflag, 10: l_linestatus
+
+  2:AGGREGATE (update serialize)
+  |  STREAMING
+  |  output: sum(5: l_quantity), sum(6: l_extendedprice), sum(17: expr), sum(18: expr), avg(5: l_quantity), avg(6: l_extendedprice), avg(7: l_discount), count(*)
+  |  group by: 9: l_returnflag, 10: l_linestatus
+  |  
+  1:Project
+  |  <slot 5> : 5: l_quantity
+  |  <slot 6> : 6: l_extendedprice
+  |  <slot 7> : 7: l_discount
+  |  <slot 9> : 9: l_returnflag
+  |  <slot 10> : 10: l_linestatus
+  |  <slot 17> : 31: multiply
+  |  <slot 18> : 31: multiply * CAST(1 + CAST(8: l_tax AS DECIMAL64(16,2)) AS DECIMAL128(16,2))
+  |  common expressions:
+  |  <slot 27> : CAST(6: l_extendedprice AS DECIMAL128(15,2))
+  |  <slot 28> : CAST(7: l_discount AS DECIMAL64(18,2))
+  |  <slot 29> : 1 - 28: cast
+  |  <slot 30> : CAST(29: subtract AS DECIMAL128(18,2))
+  |  <slot 31> : 27: cast * 30: cast
+  |  
+  0:HdfsScanNode
+     TABLE: lineitem
+     NON-PARTITION PREDICATES: 11: l_shipdate <= '1998-12-01'
+     MIN/MAX PREDICATES: 11: l_shipdate <= '1998-12-01'
+     partitions=1/1
+     cardinality=600037902
+     avgRowSize=70.0
+[end]
+


### PR DESCRIPTION
Fixes #issue

Depend on PR: [[Enhancement]min-max conjuncts use original slotid by zombee0 · Pull Request #29513 · StarRocks/starrocks](https://github.com/StarRocks/starrocks/pull/29513)](https://github.com/StarRocks/starrocks/pull/29513)

Major Changes:
1.  Add `catalogName` and `dbName` to `Table`
2.  In `ColumnIdentifier`, use `catalogName.dbName.TableName` as unique key
3.  Refactor `AddDecodeNodeForDictStringRule.DecodeVisitor#visitPhysicalOlapScan`, code can be shared to add decode node in IcebergScanNode
4.  For IceberScanNode to collect global dict, it uses a inefficient way `select dict_merge(array<string>[n_name]) as x from hive_catalog.tpch_100g_zhangyan_parquet_lz4.nation;`.  So there is no need to write another meta scan node.


<img width="1132" alt="image" src="https://github.com/StarRocks/starrocks/assets/1081215/408eba7b-92e3-420d-af17-7154ee5d26b6">


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
