### PR TITLE
[BugFix] Disable row mode partial update when sort key columns are incomplete

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -331,13 +331,17 @@ Status DeltaWriter::_check_partial_update_with_sort_key(const Chunk& chunk) {
             auto* ops = reinterpret_cast<const uint8_t*>(op_column->raw_data());
             for (size_t i = 0; i < chunk.num_rows(); i++) {
                 if (ops[i] == TOpType::UPSERT) {
-                    LOG(WARNING) << "table with sort key do not support partial update";
-                    return Status::NotSupported("table with sort key do not support partial update");
+                    std::string msg = strings::Substitute("tablet:$0 with sort key do not support partial update",
+                                                          _tablet->tablet_id());
+                    LOG(WARNING) << msg;
+                    return Status::NotSupported(msg);
                 }
             }
         } else {
-            LOG(WARNING) << "table with sort key do not support partial update";
-            return Status::NotSupported("table with sort key do not support partial update");
+            std::string msg =
+                    strings::Substitute("tablet:$0 with sort key do not support partial update", _tablet->tablet_id());
+            LOG(WARNING) << msg;
+            return Status::NotSupported(msg);
         }
     }
     return Status::OK();


### PR DESCRIPTION
We don't support row mode partial update if sort key columns are incomplete so far except for the pure delete task. So we will check the `__op` column is `UPSERT` or not when we find we are doing a partial update with incomplete sort key columns.  But when we lost `__op` column, the check will fail, this pr fixes the bug.  And now the check logic is following:
1. If we do a column mode partial update task, sort key columns are not necessary.
2. If we do a row mode partial update task which all sort key columns are provided, we could support upsert and delete.
3. If we do a row mode partial update which sort key columns are incomplete, and `__op` column exists, we will check the operation when we write data. If we find `UPSERT`, the task will fail.
4. If we do a row mode partial update which sort key columns are incomplete, and `__op` column not exists, we will reject the task because when the 'op' column is missing, it defaults to an upsert task.

BTW, This bug has no real impact right now.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
