### PR TITLE
[BugFix] fix duplicate array_agg/group_concat in CallOperator

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -338,9 +338,9 @@ public class AggregateFunction extends Function {
             return false;
         }
         AggregateFunction agg = (AggregateFunction) obj;
-        if (!intermediateType.equals(agg.intermediateType) || ignoresDistinct != agg.ignoresDistinct ||
+        if (!Objects.equals(intermediateType, agg.intermediateType) || ignoresDistinct != agg.ignoresDistinct ||
                 isAnalyticFn != agg.isAggregateFn || returnsNonNullOnEmpty != agg.returnsNonNullOnEmpty ||
-                !symbolName.equals(agg.symbolName) || isDistinct != agg.isDistinct ||
+                !Objects.equals(symbolName, agg.symbolName) || isDistinct != agg.isDistinct ||
                 !Objects.equals(nullsFirst, agg.getNullsFirst()) || !Objects.equals(isAscOrder, agg.getIsAscOrder())) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -338,13 +338,12 @@ public class AggregateFunction extends Function {
             return false;
         }
         AggregateFunction agg = (AggregateFunction) obj;
-        if (!Objects.equals(intermediateType, agg.intermediateType) || ignoresDistinct != agg.ignoresDistinct ||
-                isAnalyticFn != agg.isAggregateFn || returnsNonNullOnEmpty != agg.returnsNonNullOnEmpty ||
-                !Objects.equals(symbolName, agg.symbolName) || isDistinct != agg.isDistinct ||
-                !Objects.equals(nullsFirst, agg.getNullsFirst()) || !Objects.equals(isAscOrder, agg.getIsAscOrder())) {
-            return false;
-        }
-        return super.equals(obj);
+
+        return Objects.equals(intermediateType, agg.intermediateType) && ignoresDistinct == agg.ignoresDistinct &&
+                isAnalyticFn == agg.isAnalyticFn && isAggregateFn == agg.isAggregateFn &&
+                returnsNonNullOnEmpty == agg.returnsNonNullOnEmpty && Objects.equals(symbolName, agg.symbolName)
+                && isDistinct == agg.isDistinct && Objects.equals(nullsFirst, agg.getNullsFirst()) &&
+                Objects.equals(isAscOrder, agg.getIsAscOrder()) && super.equals(obj);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -51,6 +51,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.starrocks.common.io.IOUtils.readOptionStringOrNull;
 import static com.starrocks.common.io.IOUtils.writeOptionString;
@@ -151,6 +152,7 @@ public class AggregateFunction extends Function {
         return createBuiltin(name, argTypes, retType, intermediateType, false, ignoresDistinct, isAnalyticFn,
                 returnsNonNullOnEmpty);
     }
+
 
     public static AggregateFunction createBuiltin(String name,
                                                   List<Type> argTypes, Type retType, Type intermediateType,
@@ -328,6 +330,21 @@ public class AggregateFunction extends Function {
             sb.append(" INTERMEDIATE " + getIntermediateType() + "\n");
         }
         return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof AggregateFunction)) {
+            return false;
+        }
+        AggregateFunction agg = (AggregateFunction) obj;
+        if (!intermediateType.equals(agg.intermediateType) || ignoresDistinct != agg.ignoresDistinct ||
+                isAnalyticFn != agg.isAggregateFn || returnsNonNullOnEmpty != agg.returnsNonNullOnEmpty ||
+                !symbolName.equals(agg.symbolName) || isDistinct != agg.isDistinct ||
+                !Objects.equals(nullsFirst, agg.getNullsFirst()) || !Objects.equals(isAscOrder, agg.getIsAscOrder())) {
+            return false;
+        }
+        return super.equals(obj);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
@@ -84,6 +84,10 @@ public class CallOperator extends ScalarOperator {
         return fn;
     }
 
+    public void setFunction(Function fn) {
+        this.fn = fn;
+    }
+
     public List<ScalarOperator> getArguments() {
         return arguments;
     }
@@ -174,13 +178,11 @@ public class CallOperator extends ScalarOperator {
             return false;
         }
         CallOperator other = (CallOperator) obj;
-        if (fn != null && other.fn != null && !fn.equals(other.fn)) { // as fn may missed
-            return false;
-        }
         return isDistinct == other.isDistinct &&
                 Objects.equals(fnName, other.fnName) &&
                 Objects.equals(type, other.type) &&
-                Objects.equals(arguments, other.arguments);
+                Objects.equals(arguments, other.arguments) &&
+                Objects.equals(fn, other.fn);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
@@ -178,7 +178,7 @@ public class CallOperator extends ScalarOperator {
                 Objects.equals(fnName, other.fnName) &&
                 Objects.equals(type, other.type) &&
                 Objects.equals(arguments, other.arguments) &&
-                fn.equals(other.fn);
+                Objects.equals(fn, other.fn);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
@@ -174,11 +174,13 @@ public class CallOperator extends ScalarOperator {
             return false;
         }
         CallOperator other = (CallOperator) obj;
+        if (fn != null && other.fn != null && !fn.equals(other.fn)) { // as fn may missed
+            return false;
+        }
         return isDistinct == other.isDistinct &&
                 Objects.equals(fnName, other.fnName) &&
                 Objects.equals(type, other.type) &&
-                Objects.equals(arguments, other.arguments) &&
-                Objects.equals(fn, other.fn);
+                Objects.equals(arguments, other.arguments);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CallOperator.java
@@ -174,11 +174,11 @@ public class CallOperator extends ScalarOperator {
             return false;
         }
         CallOperator other = (CallOperator) obj;
-
         return isDistinct == other.isDistinct &&
                 Objects.equals(fnName, other.fnName) &&
                 Objects.equals(type, other.type) &&
-                Objects.equals(arguments, other.arguments);
+                Objects.equals(arguments, other.arguments) &&
+                fn.equals(other.fn);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
@@ -1579,7 +1579,10 @@ public class OptimizerTaskTest {
 
         ColumnRefOperator column7 = columnRefFactory.getColumnRef(7);
         assertTrue(projection.getCommonSubOperatorMap().containsKey(column7));
-        assertEquals(projection.getCommonSubOperatorMap().get(column7), add1);
+        assertTrue(projection.getCommonSubOperatorMap().get(column7) instanceof CallOperator);
+        CallOperator res = (CallOperator) projection.getCommonSubOperatorMap().get(column7);
+        add1.setFunction(res.getFunction());
+        assertEquals(res, add1);
 
         assertEquals(physicalTree.getOp().getOpType(), OperatorType.PHYSICAL_OLAP_SCAN);
         PhysicalOlapScanOperator physicalOlapScan = (PhysicalOlapScanOperator) physicalTree.getOp();

--- a/test/sql/test_agg_function/R/test_array_agg
+++ b/test/sql/test_agg_function/R/test_array_agg
@@ -1066,14 +1066,14 @@ select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 de
 ["张三此地无银三百两","张三掩耳盗铃"]	["张三此地无银三百两","张三掩耳盗铃"]
 ["李四大闹天空"]	["李四大闹天空"]
 -- !result
-select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 asc nulls last) from ss group by id order by id;
 -- result:
 [null,"Ti"]	["Ti",null]
 ["Tom","Tom"]	["Tom","Tom"]
-["王武程咬金","Tom","Tom"]	["王武程咬金","Tom","Tom"]
-["欧阳诸葛方程","Ti","May"]	["欧阳诸葛方程","Ti","May"]
+["王武程咬金","Tom","Tom"]	["Tom","Tom","王武程咬金"]
+["欧阳诸葛方程","Ti","May"]	["May","Ti","欧阳诸葛方程"]
 [null]	[null]
-["张三此地无银三百两","张三掩耳盗铃"]	["张三此地无银三百两","张三掩耳盗铃"]
+["张三此地无银三百两","张三掩耳盗铃"]	["张三掩耳盗铃","张三此地无银三百两"]
 ["李四大闹天空"]	["李四大闹天空"]
 -- !result
 select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss group by id order by id;

--- a/test/sql/test_agg_function/R/test_array_agg
+++ b/test/sql/test_agg_function/R/test_array_agg
@@ -62,23 +62,23 @@ insert into ss values (3,"欧阳诸葛方程","数学大不列颠",NULL,[],null)
 -- !result
 select max(id), array_agg(distinct name), count(distinct id), array_agg(name) from ss where id < 2  order by 1;
 -- result:
-E: (1064, 'Unknown error')
+1	["Tom"]	1	["Tom","Tom"]
 -- !result
 select max(id), array_agg(distinct name) from ss where id < 2  order by 1;
 -- result:
-E: (1064, 'Unknown error')
+1	["Tom"]
 -- !result
 select max(id), array_agg(distinct name), array_agg(distinct (score > 0)) from ss where id < 2 order by 1;
 -- result:
-E: (1064, 'Unknown error')
+1	["Tom"]	[1]
 -- !result
 select max(id),array_agg(distinct name), count(distinct id), array_agg(name) from ss where id < 2  order by 1;
 -- result:
-E: (1064, 'Unknown error')
+1	["Tom"]	1	["Tom","Tom"]
 -- !result
 select max(id),array_agg(distinct name) from ss where id < 2  order by 1;
 -- result:
-E: (1064, 'Unknown error')
+1	["Tom"]
 -- !result
 select max(id),array_agg(name), array_agg(name,score order by 1,2) from ss where id < 2  order by 1;
 -- result:
@@ -86,11 +86,11 @@ E: (1064, "Getting syntax error at line 1, column 53. Detail message: Unexpected
 -- !result
 select max(id),array_agg(name), array_agg(distinct name) from ss where id < 2 order by 1;
 -- result:
-E: (1064, 'Unknown error')
+1	["Tom","Tom"]	["Tom"]
 -- !result
 select max(id),array_agg(distinct name), array_agg(distinct (score > 0)) from ss where id < 2 order by 1;
 -- result:
-E: (1064, 'Unknown error')
+1	["Tom"]	[1]
 -- !result
 select id, array_agg(distinct name), count(distinct score), array_agg(name) from ss where id < 2 group by id order by 1;
 -- result:
@@ -153,7 +153,14 @@ None	["Tom","Tom"]	["Tom","Tom"]
 -- !result
 select array_agg(distinct name order by 1, score), count(distinct id), array_agg(name order by 1) from ss group by rollup(id) order by 1;
 -- result:
-E: (1064, 'Unknown error')
+[null]	1	[null]
+[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	6	[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]
+[null,"Ti"]	0	[null,"Ti"]
+["May","Ti","欧阳诸葛方程"]	1	["May","Ti","欧阳诸葛方程"]
+["Tom"]	1	["Tom","Tom"]
+["Tom","王武程咬金"]	1	["Tom","Tom","王武程咬金"]
+["张三掩耳盗铃","张三此地无银三百两"]	1	["张三掩耳盗铃","张三此地无银三百两"]
+["李四大闹天空"]	1	["李四大闹天空"]
 -- !result
 select array_agg(distinct subject order by 1, name) from ss group by rollup(id) order by id;
 -- result:
@@ -624,9 +631,9 @@ select array_agg(name order by score,4,1), count(distinct id), max(score)  from 
 -- result:
 E: (1064, 'Getting syntax error from line 1, column 7 to line 1, column 40. Detail message: ORDER BY position 4 is not in array_agg output list.')
 -- !result
-select array_agg( name order by score,4.00),array_agg(distinct name order by score,4.00) from ss order by 1;
+select array_agg( name order by 1,score,4.00),array_agg(distinct name order by 1,score,4.00) from ss order by 1;
 -- result:
-["欧阳诸葛方程","Tom","李四大闹天空","Tom",null,null,"May","王武程咬金","张三掩耳盗铃","Tom","Tom","张三此地无银三百两","Ti","Ti"]	["欧阳诸葛方程","Tom","李四大闹天空",null,"May","王武程咬金","张三掩耳盗铃","张三此地无银三百两","Ti"]
+[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]
 -- !result
 select array_agg( null order by score,4.00) from ss order by 1;
 -- result:
@@ -999,9 +1006,9 @@ select array_agg(name order by score,4,1), count(distinct id), max(score)  from 
 -- result:
 E: (1064, 'Getting syntax error from line 1, column 7 to line 1, column 40. Detail message: ORDER BY position 4 is not in array_agg output list.')
 -- !result
-select array_agg( name order by score,4.00),array_agg(distinct name order by score,4.00) from ss order by 1;
+select array_agg( name order by 1,score,4.00),array_agg(distinct name order by 1,score,4.00) from ss order by 1;
 -- result:
-[null,null,"Tom","Tom","欧阳诸葛方程","May","李四大闹天空","王武程咬金","张三掩耳盗铃","Tom","Tom","张三此地无银三百两","Ti","Ti"]	[null,"Tom","欧阳诸葛方程","May","李四大闹天空","王武程咬金","张三掩耳盗铃","张三此地无银三百两","Ti"]
+[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]
 -- !result
 select array_agg( null order by score,4.00) from ss order by 1;
 -- result:
@@ -1461,9 +1468,9 @@ select array_agg(name order by score,4,1), count(distinct id), max(score)  from 
 -- result:
 E: (1064, 'Getting syntax error from line 1, column 7 to line 1, column 40. Detail message: ORDER BY position 4 is not in array_agg output list.')
 -- !result
-select array_agg( name order by score,4.00),array_agg(distinct name order by score,4.00) from ss order by 1;
+select array_agg( name order by 1,score,4.00),array_agg(distinct name order by 1,score,4.00) from ss order by 1;
 -- result:
-["May","李四大闹天空",null,null,"欧阳诸葛方程","Tom","Tom","王武程咬金","张三掩耳盗铃","Tom","Tom","Ti","张三此地无银三百两","Ti"]	["May","李四大闹天空",null,"欧阳诸葛方程","Tom","王武程咬金","张三掩耳盗铃","Ti","张三此地无银三百两"]
+[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]
 -- !result
 select array_agg( null order by score,4.00) from ss order by 1;
 -- result:
@@ -1574,7 +1581,7 @@ select array_agg(distinct subject order by 1), count(distinct score), array_agg(
 -- !result
 select count(distinct score), array_agg(name order by 1) from ss order by 1;
 -- result:
-E: (1064, 'Unknown error')
+6	[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]
 -- !result
 select array_agg(distinct name order by 1, score), count(distinct id), array_agg(name order by 1) from ss group by id order by 1;
 -- result:

--- a/test/sql/test_agg_function/R/test_array_agg
+++ b/test/sql/test_agg_function/R/test_array_agg
@@ -62,23 +62,23 @@ insert into ss values (3,"欧阳诸葛方程","数学大不列颠",NULL,[],null)
 -- !result
 select max(id), array_agg(distinct name), count(distinct id), array_agg(name) from ss where id < 2  order by 1;
 -- result:
-1	["Tom"]	1	["Tom","Tom"]
+E: (1064, 'Unknown error')
 -- !result
 select max(id), array_agg(distinct name) from ss where id < 2  order by 1;
 -- result:
-1	["Tom"]
+E: (1064, 'Unknown error')
 -- !result
 select max(id), array_agg(distinct name), array_agg(distinct (score > 0)) from ss where id < 2 order by 1;
 -- result:
-1	["Tom"]	[1]
+E: (1064, 'Unknown error')
 -- !result
 select max(id),array_agg(distinct name), count(distinct id), array_agg(name) from ss where id < 2  order by 1;
 -- result:
-1	["Tom"]	1	["Tom","Tom"]
+E: (1064, 'Unknown error')
 -- !result
 select max(id),array_agg(distinct name) from ss where id < 2  order by 1;
 -- result:
-1	["Tom"]
+E: (1064, 'Unknown error')
 -- !result
 select max(id),array_agg(name), array_agg(name,score order by 1,2) from ss where id < 2  order by 1;
 -- result:
@@ -86,11 +86,11 @@ E: (1064, "Getting syntax error at line 1, column 53. Detail message: Unexpected
 -- !result
 select max(id),array_agg(name), array_agg(distinct name) from ss where id < 2 order by 1;
 -- result:
-1	["Tom","Tom"]	["Tom"]
+E: (1064, 'Unknown error')
 -- !result
 select max(id),array_agg(distinct name), array_agg(distinct (score > 0)) from ss where id < 2 order by 1;
 -- result:
-1	["Tom"]	[1]
+E: (1064, 'Unknown error')
 -- !result
 select id, array_agg(distinct name), count(distinct score), array_agg(name) from ss where id < 2 group by id order by 1;
 -- result:
@@ -153,14 +153,7 @@ None	["Tom","Tom"]	["Tom","Tom"]
 -- !result
 select array_agg(distinct name order by 1, score), count(distinct id), array_agg(name order by 1) from ss group by rollup(id) order by 1;
 -- result:
-[null]	1	[null]
-[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	6	[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]
-[null,"Ti"]	0	[null,"Ti"]
-["May","Ti","欧阳诸葛方程"]	1	["May","Ti","欧阳诸葛方程"]
-["Tom"]	1	["Tom","Tom"]
-["Tom","王武程咬金"]	1	["Tom","Tom","王武程咬金"]
-["张三掩耳盗铃","张三此地无银三百两"]	1	["张三掩耳盗铃","张三此地无银三百两"]
-["李四大闹天空"]	1	["李四大闹天空"]
+E: (1064, 'Unknown error')
 -- !result
 select array_agg(distinct subject order by 1, name) from ss group by rollup(id) order by id;
 -- result:
@@ -204,6 +197,90 @@ select array_agg(distinct name order by 1, score), count(distinct id), array_agg
 ["Tom","王武程咬金"]	1	["Tom","Tom","王武程咬金"]
 ["张三掩耳盗铃","张三此地无银三百两"]	1	["张三掩耳盗铃","张三此地无银三百两"]
 ["李四大闹天空"]	1	["李四大闹天空"]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by 1;
+-- result:
+[null]	[null]
+[null,"Ti"]	["Ti",null]
+["May","Ti","欧阳诸葛方程"]	["欧阳诸葛方程","Ti","May"]
+["Tom"]	["Tom","Tom"]
+["Tom","王武程咬金"]	["王武程咬金","Tom","Tom"]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss group by id order by 1;
+-- result:
+[null]	[null]
+[null,"Ti"]	["Ti",null]
+["May","Ti","欧阳诸葛方程"]	["欧阳诸葛方程","Ti","May"]
+["Tom"]	["Tom"]
+["Tom","王武程咬金"]	["王武程咬金","Tom"]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["Tom","Tom","王武程咬金"]	["王武程咬金","Tom","Tom"]
+["May","Ti","欧阳诸葛方程"]	["欧阳诸葛方程","Ti","May"]
+[null]	[null]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["王武程咬金","Tom","Tom"]	["王武程咬金","Tom","Tom"]
+["欧阳诸葛方程","Ti","May"]	["欧阳诸葛方程","Ti","May"]
+[null]	[null]
+["张三此地无银三百两","张三掩耳盗铃"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["王武程咬金","Tom","Tom"]	["王武程咬金","Tom","Tom"]
+["欧阳诸葛方程","Ti","May"]	["欧阳诸葛方程","Ti","May"]
+[null]	[null]
+["张三此地无银三百两","张三掩耳盗铃"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["Tom","Tom","王武程咬金"]	["Tom","Tom","王武程咬金"]
+["May","Ti","欧阳诸葛方程"]	["May","Ti","欧阳诸葛方程"]
+[null]	[null]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三掩耳盗铃","张三此地无银三百两"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+-- result:
+[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss order by 1;
+-- result:
+[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Ti","May",null]
+-- !result
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+-- result:
+[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+-- result:
+[null,null,"王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+-- result:
+[null,null,"王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss order by 1;
+-- result:
+[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金",null,null]
 -- !result
 select array_agg(distinct subject order by 1, name) from ss group by id order by id;
 -- result:
@@ -549,7 +626,7 @@ E: (1064, 'Getting syntax error from line 1, column 7 to line 1, column 40. Deta
 -- !result
 select array_agg( name order by score,4.00),array_agg(distinct name order by score,4.00) from ss order by 1;
 -- result:
-["李四大闹天空",null,null,"欧阳诸葛方程","May","Tom","Tom","王武程咬金","张三掩耳盗铃","Tom","Tom","张三此地无银三百两","Ti","Ti"]	["李四大闹天空",null,"欧阳诸葛方程","May","Tom","王武程咬金","张三掩耳盗铃","张三此地无银三百两","Ti"]
+["欧阳诸葛方程","Tom","李四大闹天空","Tom",null,null,"May","王武程咬金","张三掩耳盗铃","Tom","Tom","张三此地无银三百两","Ti","Ti"]	["欧阳诸葛方程","Tom","李四大闹天空",null,"May","王武程咬金","张三掩耳盗铃","张三此地无银三百两","Ti"]
 -- !result
 select array_agg( null order by score,4.00) from ss order by 1;
 -- result:
@@ -924,7 +1001,7 @@ E: (1064, 'Getting syntax error from line 1, column 7 to line 1, column 40. Deta
 -- !result
 select array_agg( name order by score,4.00),array_agg(distinct name order by score,4.00) from ss order by 1;
 -- result:
-["李四大闹天空","May","Tom","Tom",null,null,"欧阳诸葛方程","王武程咬金","张三掩耳盗铃","Tom","Tom","Ti","张三此地无银三百两","Ti"]	["李四大闹天空","May","Tom","欧阳诸葛方程",null,"王武程咬金","张三掩耳盗铃","Ti","张三此地无银三百两"]
+[null,null,"Tom","Tom","欧阳诸葛方程","May","李四大闹天空","王武程咬金","张三掩耳盗铃","Tom","Tom","张三此地无银三百两","Ti","Ti"]	[null,"Tom","欧阳诸葛方程","May","李四大闹天空","王武程咬金","张三掩耳盗铃","张三此地无银三百两","Ti"]
 -- !result
 select array_agg( null order by score,4.00) from ss order by 1;
 -- result:
@@ -941,6 +1018,90 @@ select array_agg( score order by 1,name) from ss order by 1;
 select array_agg(distinct 1 order by 1) from ss order by 1;
 -- result:
 [1]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by 1;
+-- result:
+[null]	[null]
+[null,"Ti"]	["Ti",null]
+["May","Ti","欧阳诸葛方程"]	["欧阳诸葛方程","Ti","May"]
+["Tom"]	["Tom","Tom"]
+["Tom","王武程咬金"]	["王武程咬金","Tom","Tom"]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss group by id order by 1;
+-- result:
+[null]	[null]
+[null,"Ti"]	["Ti",null]
+["May","Ti","欧阳诸葛方程"]	["欧阳诸葛方程","Ti","May"]
+["Tom"]	["Tom"]
+["Tom","王武程咬金"]	["王武程咬金","Tom"]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["Tom","Tom","王武程咬金"]	["王武程咬金","Tom","Tom"]
+["May","Ti","欧阳诸葛方程"]	["欧阳诸葛方程","Ti","May"]
+[null]	[null]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["王武程咬金","Tom","Tom"]	["王武程咬金","Tom","Tom"]
+["欧阳诸葛方程","Ti","May"]	["欧阳诸葛方程","Ti","May"]
+[null]	[null]
+["张三此地无银三百两","张三掩耳盗铃"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["王武程咬金","Tom","Tom"]	["王武程咬金","Tom","Tom"]
+["欧阳诸葛方程","Ti","May"]	["欧阳诸葛方程","Ti","May"]
+[null]	[null]
+["张三此地无银三百两","张三掩耳盗铃"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["Tom","Tom","王武程咬金"]	["Tom","Tom","王武程咬金"]
+["May","Ti","欧阳诸葛方程"]	["May","Ti","欧阳诸葛方程"]
+[null]	[null]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三掩耳盗铃","张三此地无银三百两"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+-- result:
+[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss order by 1;
+-- result:
+[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Ti","May",null]
+-- !result
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+-- result:
+[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+-- result:
+[null,null,"王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+-- result:
+[null,null,"王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss order by 1;
+-- result:
+[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金",null,null]
 -- !result
 set new_planner_agg_stage = 0;
 -- result:
@@ -1302,7 +1463,7 @@ E: (1064, 'Getting syntax error from line 1, column 7 to line 1, column 40. Deta
 -- !result
 select array_agg( name order by score,4.00),array_agg(distinct name order by score,4.00) from ss order by 1;
 -- result:
-[null,"Tom","Tom",null,"李四大闹天空","欧阳诸葛方程","May","王武程咬金","张三掩耳盗铃","Tom","Tom","Ti","张三此地无银三百两","Ti"]	[null,"Tom","李四大闹天空","欧阳诸葛方程","May","王武程咬金","张三掩耳盗铃","Ti","张三此地无银三百两"]
+["May","李四大闹天空",null,null,"欧阳诸葛方程","Tom","Tom","王武程咬金","张三掩耳盗铃","Tom","Tom","Ti","张三此地无银三百两","Ti"]	["May","李四大闹天空",null,"欧阳诸葛方程","Tom","王武程咬金","张三掩耳盗铃","Ti","张三此地无银三百两"]
 -- !result
 select array_agg( null order by score,4.00) from ss order by 1;
 -- result:
@@ -1320,6 +1481,90 @@ select array_agg(distinct 1 order by 1) from ss order by 1;
 -- result:
 [1]
 -- !result
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by 1;
+-- result:
+[null]	[null]
+[null,"Ti"]	["Ti",null]
+["May","Ti","欧阳诸葛方程"]	["欧阳诸葛方程","Ti","May"]
+["Tom"]	["Tom","Tom"]
+["Tom","王武程咬金"]	["王武程咬金","Tom","Tom"]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss group by id order by 1;
+-- result:
+[null]	[null]
+[null,"Ti"]	["Ti",null]
+["May","Ti","欧阳诸葛方程"]	["欧阳诸葛方程","Ti","May"]
+["Tom"]	["Tom"]
+["Tom","王武程咬金"]	["王武程咬金","Tom"]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["Tom","Tom","王武程咬金"]	["王武程咬金","Tom","Tom"]
+["May","Ti","欧阳诸葛方程"]	["欧阳诸葛方程","Ti","May"]
+[null]	[null]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["王武程咬金","Tom","Tom"]	["王武程咬金","Tom","Tom"]
+["欧阳诸葛方程","Ti","May"]	["欧阳诸葛方程","Ti","May"]
+[null]	[null]
+["张三此地无银三百两","张三掩耳盗铃"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["王武程咬金","Tom","Tom"]	["王武程咬金","Tom","Tom"]
+["欧阳诸葛方程","Ti","May"]	["欧阳诸葛方程","Ti","May"]
+[null]	[null]
+["张三此地无银三百两","张三掩耳盗铃"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["Tom","Tom","王武程咬金"]	["Tom","Tom","王武程咬金"]
+["May","Ti","欧阳诸葛方程"]	["May","Ti","欧阳诸葛方程"]
+[null]	[null]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三掩耳盗铃","张三此地无银三百两"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+-- result:
+[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss order by 1;
+-- result:
+[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Ti","May",null]
+-- !result
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+-- result:
+[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+-- result:
+[null,null,"王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+-- result:
+[null,null,"王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss order by 1;
+-- result:
+[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金",null,null]
+-- !result
 set enable_query_cache = true;
 -- result:
 -- !result
@@ -1329,7 +1574,7 @@ select array_agg(distinct subject order by 1), count(distinct score), array_agg(
 -- !result
 select count(distinct score), array_agg(name order by 1) from ss order by 1;
 -- result:
-6	[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]
+E: (1064, 'Unknown error')
 -- !result
 select array_agg(distinct name order by 1, score), count(distinct id), array_agg(name order by 1) from ss group by id order by 1;
 -- result:
@@ -1428,6 +1673,90 @@ select array_agg(distinct name order by 1) from ss order by 1;
 select cardinality(array_agg(distinct arr order by score, 1)) from ss order by 1;
 -- result:
 9
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by 1;
+-- result:
+[null]	[null]
+[null,"Ti"]	["Ti",null]
+["May","Ti","欧阳诸葛方程"]	["欧阳诸葛方程","Ti","May"]
+["Tom"]	["Tom","Tom"]
+["Tom","王武程咬金"]	["王武程咬金","Tom","Tom"]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss group by id order by 1;
+-- result:
+[null]	[null]
+[null,"Ti"]	["Ti",null]
+["May","Ti","欧阳诸葛方程"]	["欧阳诸葛方程","Ti","May"]
+["Tom"]	["Tom"]
+["Tom","王武程咬金"]	["王武程咬金","Tom"]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["Tom","Tom","王武程咬金"]	["王武程咬金","Tom","Tom"]
+["May","Ti","欧阳诸葛方程"]	["欧阳诸葛方程","Ti","May"]
+[null]	[null]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["王武程咬金","Tom","Tom"]	["王武程咬金","Tom","Tom"]
+["欧阳诸葛方程","Ti","May"]	["欧阳诸葛方程","Ti","May"]
+[null]	[null]
+["张三此地无银三百两","张三掩耳盗铃"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["王武程咬金","Tom","Tom"]	["王武程咬金","Tom","Tom"]
+["欧阳诸葛方程","Ti","May"]	["欧阳诸葛方程","Ti","May"]
+[null]	[null]
+["张三此地无银三百两","张三掩耳盗铃"]	["张三此地无银三百两","张三掩耳盗铃"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss group by id order by id;
+-- result:
+[null,"Ti"]	["Ti",null]
+["Tom","Tom"]	["Tom","Tom"]
+["Tom","Tom","王武程咬金"]	["Tom","Tom","王武程咬金"]
+["May","Ti","欧阳诸葛方程"]	["May","Ti","欧阳诸葛方程"]
+[null]	[null]
+["张三掩耳盗铃","张三此地无银三百两"]	["张三掩耳盗铃","张三此地无银三百两"]
+["李四大闹天空"]	["李四大闹天空"]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+-- result:
+[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss order by 1;
+-- result:
+[null,"May","Ti","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Ti","May",null]
+-- !result
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+-- result:
+[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+-- result:
+[null,null,"王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+-- result:
+[null,null,"王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May"]	["王武程咬金","欧阳诸葛方程","李四大闹天空","张三此地无银三百两","张三掩耳盗铃","Tom","Tom","Tom","Tom","Ti","Ti","May",null,null]
+-- !result
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss order by 1;
+-- result:
+[null,null,"May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金"]	["May","Ti","Ti","Tom","Tom","Tom","Tom","张三掩耳盗铃","张三此地无银三百两","李四大闹天空","欧阳诸葛方程","王武程咬金",null,null]
 -- !result
 select array_agg();
 -- result:

--- a/test/sql/test_agg_function/T/test_array_agg
+++ b/test/sql/test_agg_function/T/test_array_agg
@@ -126,7 +126,7 @@ select group_concat(name,subject order by 1,2), array_agg(distinct id order by 1
 select array_agg( name order by 1,score), count(distinct id), max(score)  from ss order by 1;
 select array_agg( subject order by score,1), count(distinct id), max(score)  from ss order by 1;
 select array_agg(name order by score,4,1), count(distinct id), max(score)  from ss order by 1;
-select array_agg( name order by score,4.00),array_agg(distinct name order by score,4.00) from ss order by 1;
+select array_agg( name order by 1,score,4.00),array_agg(distinct name order by 1,score,4.00) from ss order by 1;
 select array_agg( null order by score,4.00) from ss order by 1;
 select array_agg( score order by 1) from ss order by 1;
 select array_agg( score order by 1,name) from ss order by 1;
@@ -184,7 +184,7 @@ select group_concat(name,subject order by 1,2), array_agg(distinct id order by 1
 select array_agg( name order by 1,score), count(distinct id), max(score)  from ss order by 1;
 select array_agg( subject order by score,1), count(distinct id), max(score)  from ss order by 1;
 select array_agg(name order by score,4,1), count(distinct id), max(score)  from ss order by 1;
-select array_agg( name order by score,4.00),array_agg(distinct name order by score,4.00) from ss order by 1;
+select array_agg( name order by 1,score,4.00),array_agg(distinct name order by 1,score,4.00) from ss order by 1;
 select array_agg( null order by score,4.00) from ss order by 1;
 select array_agg( score order by 1) from ss order by 1;
 select array_agg( score order by 1,name) from ss order by 1;
@@ -256,7 +256,7 @@ select group_concat(name,subject order by 1,2), array_agg(distinct id order by 1
 select array_agg( name order by 1,score), count(distinct id), max(score)  from ss order by 1;
 select array_agg( subject order by score,1), count(distinct id), max(score)  from ss order by 1;
 select array_agg(name order by score,4,1), count(distinct id), max(score)  from ss order by 1;
-select array_agg( name order by score,4.00),array_agg(distinct name order by score,4.00) from ss order by 1;
+select array_agg( name order by 1,score,4.00),array_agg(distinct name order by 1,score,4.00) from ss order by 1;
 select array_agg( null order by score,4.00) from ss order by 1;
 select array_agg( score order by 1) from ss order by 1;
 select array_agg( score order by 1,name) from ss order by 1;

--- a/test/sql/test_agg_function/T/test_array_agg
+++ b/test/sql/test_agg_function/T/test_array_agg
@@ -193,7 +193,7 @@ select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) 
 select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss group by id order by 1;
 select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by id;
 select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
-select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 asc nulls last) from ss group by id order by id;
 select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss group by id order by id;
 
 select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;

--- a/test/sql/test_agg_function/T/test_array_agg
+++ b/test/sql/test_agg_function/T/test_array_agg
@@ -62,6 +62,20 @@ select array_agg(distinct name order by 1), array_agg(distinct subject order by 
 
 
 select array_agg(distinct name order by 1, score), count(distinct id), array_agg(name order by 1) from ss group by id order by 1;
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by 1;
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss group by id order by 1;
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by id;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss group by id order by id;
+
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss order by 1;
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss order by 1;
+
 select array_agg(distinct subject order by 1, name) from ss group by id order by id;
 select array_agg(distinct name order by 1), cardinality(array_agg(distinct arr order by score)) from ss group by id order by 1;
 select array_agg(name order by 1), array_agg(distinct name order by 1, score) from ss group by id order by 1;
@@ -175,6 +189,19 @@ select array_agg( null order by score,4.00) from ss order by 1;
 select array_agg( score order by 1) from ss order by 1;
 select array_agg( score order by 1,name) from ss order by 1;
 select array_agg(distinct 1 order by 1) from ss order by 1;
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by 1;
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss group by id order by 1;
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by id;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss group by id order by id;
+
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss order by 1;
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss order by 1;
 set new_planner_agg_stage = 0;
 
 set enable_exchange_pass_through = false;
@@ -234,6 +261,19 @@ select array_agg( null order by score,4.00) from ss order by 1;
 select array_agg( score order by 1) from ss order by 1;
 select array_agg( score order by 1,name) from ss order by 1;
 select array_agg(distinct 1 order by 1) from ss order by 1;
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by 1;
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss group by id order by 1;
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by id;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss group by id order by id;
+
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss order by 1;
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss order by 1;
 
 set enable_query_cache = true;
 select array_agg(distinct subject order by 1), count(distinct score), array_agg(name order by 1) from ss order by 1;
@@ -252,6 +292,19 @@ select array_agg(name order by 1), array_agg(distinct name order by 1, score) fr
 select array_agg(distinct name order by 1,score), array_agg(distinct score order by 1) from ss order by 1;
 select array_agg(distinct name order by 1) from ss order by 1;
 select cardinality(array_agg(distinct arr order by score, 1)) from ss order by 1;
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by 1;
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss group by id order by 1;
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss group by id order by id;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss group by id order by id;
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss group by id order by id;
+
+select array_agg(distinct name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+select array_agg(distinct name order by 1 asc), array_agg(distinct name order by 1 desc) from ss order by 1;
+select array_agg(name order by 1 asc), array_agg(name order by 1 desc) from ss order by 1;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+select array_agg(name order by 1 desc nulls first), array_agg(name order by 1 desc nulls last) from ss order by 1;
+select array_agg(name order by 1 nulls first), array_agg(name order by 1 nulls last) from ss order by 1;
 
 select array_agg();
 select array_agg() from ss;


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/31757
equal `array_agg/group_concat `with consideration of nullsFist and isAsc when compare `CallOperator`

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
