### PR TITLE
[Feature] Add l2_distance function

### DIFF
--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -895,4 +895,97 @@ template StatusOr<ColumnPtr> MathFunctions::cosine_similarity<TYPE_FLOAT, true>(
 template StatusOr<ColumnPtr> MathFunctions::cosine_similarity<TYPE_FLOAT, false>(FunctionContext* context,
                                                                                  const Columns& columns);
 
+template <LogicalType TYPE>
+StatusOr<ColumnPtr> MathFunctions::l2_distance(FunctionContext* context, const Columns& columns) {
+    DCHECK_EQ(columns.size(), 2);
+
+    const Column* base = columns[0].get();
+    const Column* target = columns[1].get();
+    size_t target_size = target->size();
+    if (base->size() != target_size) {
+        return Status::InvalidArgument(fmt::format(
+                "l2_distance requires equal length arrays. base array size is {} and target array size is {}.",
+                base->size(), target->size()));
+    }
+    if (base->has_null() || target->has_null()) {
+        return Status::InvalidArgument(fmt::format("l2_distance does not support null values. {} array has null value.",
+                                                   base->has_null() ? "base" : "target"));
+    }
+    if (base->is_nullable()) {
+        base = down_cast<const NullableColumn*>(base)->data_column().get();
+    }
+    if (target->is_nullable()) {
+        target = down_cast<const NullableColumn*>(target)->data_column().get();
+    }
+
+    // check dimension equality.
+    const Column* base_flat = down_cast<const ArrayColumn*>(base)->elements_column().get();
+    const uint32_t* base_offset = down_cast<const ArrayColumn*>(base)->offsets().get_data().data();
+    size_t base_flat_size = base_flat->size();
+
+    const Column* target_flat = down_cast<const ArrayColumn*>(target)->elements_column().get();
+    size_t target_flat_size = target_flat->size();
+    const uint32_t* target_offset = down_cast<const ArrayColumn*>(target)->offsets().get_data().data();
+
+    if (base_flat_size != target_flat_size) {
+        return Status::InvalidArgument("l2_distance requires equal length arrays");
+    }
+
+    if (base_flat->has_null() || target_flat->has_null()) {
+        return Status::InvalidArgument("l2_distance does not support null values");
+    }
+    if (base_flat->is_nullable()) {
+        base_flat = down_cast<const NullableColumn*>(base_flat)->data_column().get();
+    }
+    if (target_flat->is_nullable()) {
+        target_flat = down_cast<const NullableColumn*>(target_flat)->data_column().get();
+    }
+
+    using CppType = RunTimeCppType<TYPE>;
+    using ColumnType = RunTimeColumnType<TYPE>;
+
+    const CppType* base_data_head = down_cast<const ColumnType*>(base_flat)->get_data().data();
+    const CppType* target_data_head = down_cast<const ColumnType*>(target_flat)->get_data().data();
+
+    // prepare result with nullable value.
+    ColumnPtr result = ColumnHelper::create_column(TypeDescriptor{TYPE}, false, false, target_size);
+    ColumnType* data_result = down_cast<ColumnType*>(result.get());
+    CppType* result_data = data_result->get_data().data();
+
+    for (size_t i = 0; i < target_size; i++) {
+        size_t t_dim_size = target_offset[i + 1] - target_offset[i];
+        size_t b_dim_size = base_offset[i + 1] - base_offset[i];
+        if (t_dim_size != b_dim_size) {
+            return Status::InvalidArgument(
+                    fmt::format("l2_distance requires equal length arrays in each row. base array dimension size "
+                                "is {}, target array dimension size is {}.",
+                                b_dim_size, t_dim_size));
+        }
+        if (t_dim_size == 0) {
+            return Status::InvalidArgument("l2_distance requires non-empty arrays in each row");
+        }
+    }
+
+    const CppType* target_data = target_data_head;
+    const CppType* base_data = base_data_head;
+
+    for (size_t i = 0; i < target_size; i++) {
+        CppType sum = 0;
+        size_t dim_size = target_offset[i + 1] - target_offset[i];
+        for (size_t j = 0; j < dim_size; j++) {
+            CppType distance;
+            distance = (base_data[j] - target_data[j]) * (base_data[j] - target_data[j]);
+            sum += distance;
+        }
+        result_data[i] = sum;
+        target_data += dim_size;
+        base_data += dim_size;
+    }
+
+    return result;
+}
+
+// explicitly instaniate template function.
+template StatusOr<ColumnPtr> MathFunctions::l2_distance<TYPE_FLOAT>(FunctionContext* context, const Columns& columns);
+
 } // namespace starrocks

--- a/be/src/exprs/math_functions.h
+++ b/be/src/exprs/math_functions.h
@@ -167,6 +167,9 @@ public:
     template <LogicalType TYPE, bool isNorm>
     DEFINE_VECTORIZED_FN(cosine_similarity);
 
+    template <LogicalType TYPE>
+    DEFINE_VECTORIZED_FN(l2_distance);
+
     /**
     * @param columns: [DoubleColumn]
     * @return BigIntColumn

--- a/docs/en/sql-reference/sql-functions/math-functions/l2_distance.md
+++ b/docs/en/sql-reference/sql-functions/math-functions/l2_distance.md
@@ -1,0 +1,58 @@
+# l2_distance
+
+## Description
+
+Measures the distance between two vectors by calculating the Euclidean distance between them. The Euclidean distance, or L2 distance, is the sum of the squared differences between corresponding elements of the two vectors.
+
+The distance is always non-negative and is zero if and only if the two vectors are identical.
+
+l2_distance is commonly used for assessing similarity in various fields, including image processing, machine learning, and data analysis.
+
+This function does not require the input vectors to be normalized.
+
+The l2_distance used here refers to the distance without taking the square root, which is consistent with the behavior in faiss.
+
+## Syntax
+
+```Haskell
+l2_distance(a, b)
+```
+
+## Parameters
+
+`a` and `b` are the vectors to compare. They must have the same dimension. The supported data type is `Array<float>`. The two arrays must have the same number of elements. Otherwise, an error is returned.
+
+## Return value
+
+Returns a FLOAT value that is always non-negative. If any input parameter is null or invalid, an error is reported.
+
+## Examples
+
+1. Create a table to store vectors and insert data into this table.
+
+    ```SQL
+    CREATE TABLE test 
+    (id int, data array<float>)
+    DISTRIBUTED BY HASH(id);
+
+    INSERT INTO test VALUES
+    (1, array<float>[0.1, 0.2, 0.3]), 
+    (2, array<float>[0.2, 0.1, 0.3]), 
+    (3, array<float>[0.3, 0.2, 0.1]);
+    ```
+
+2. Calculate the similarity of each row in the `data` column compared to the array `[0.1, 0.2, 0.3]` and list the result in descending order.
+
+    ```Plain
+    SELECT id, data, l2_distance([0.1, 0.2, 0.3], data) as dist
+    FROM test 
+    ORDER BY dist DESC;
+
+    +------+---------------+-------------+
+    | id   | data          | dist        |
+    +------+---------------+-------------+
+    |    3 | [0.1,0.2,0.3] | 0.08000001  |
+    |    2 | [0.2,0.1,0.3] | 0.020000001 |
+    |    1 | [0.3,0.2,0.1] | 0           |
+    +------+---------------+-------------+
+    ```

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -60,6 +60,8 @@ vectorized_functions = [
      "MathFunctions::cosine_similarity<TYPE_FLOAT, false>"],
     [10103, "cosine_similarity_norm", True, False, "FLOAT", ["ARRAY_FLOAT", "ARRAY_FLOAT"],
      "MathFunctions::cosine_similarity<TYPE_FLOAT, true>"],
+    [10104, "l2_distance", True, False "FLOAT", ["ARRAY_FLOAT", "ARRAY_FLOAT"],
+     "MathFunctions::l2_distance<TYPE_FLOAT>"],
 
     [10110, "ceil", True, False, "BIGINT", ["DOUBLE"], "MathFunctions::ceil"],
     [10111, "ceiling", True, False, "BIGINT", ["DOUBLE"], "MathFunctions::ceil"],

--- a/test/sql/test_function/R/test_math
+++ b/test/sql/test_function/R/test_math
@@ -1,4 +1,4 @@
--- name: test_math_cosine_similarity
+-- name: test_math: cosine_similarity, l2_distance
 create table t1 (id int, data array<float>) engine = olap distributed by hash(id) properties ("replication_num" = "1");
 -- result:
 []
@@ -21,23 +21,33 @@ select cosine_similarity_norm(array<float>[0.1, 0.2, 0.3], array<float>[0.1, 0.2
 -- result:
 0.14000002
 -- !result
-create table test_cosine (id int, data array<float>) ENGINE=olap DUPLICATE KEY (id) DISTRIBUTED BY HASH(id) properties ("replication_num" = "1");
+select l2_distance(array<float>[0.1, 0.2, 0.3], data) as dist, id from t1 order by dist desc;
+-- result:
+0.08000001	3
+0.020000001	2
+0	1
+-- !result
+select l2_distance(array<float>[0.1, 0.2, 0.3], array<float>[0.1, 0.2, 0.3]) as dist;
+-- result:
+0
+-- !result
+create table test_vector (id int, data array<float>) ENGINE=olap DUPLICATE KEY (id) DISTRIBUTED BY HASH(id) properties ("replication_num" = "1");
 -- result:
 []
 -- !result
-insert into test_cosine values (1, array<float>[0.1, 0.2, 0.3]), (2, array<float>[0.2, 0.1, 0.3]);
+insert into test_vector values (1, array<float>[0.1, 0.2, 0.3]), (2, array<float>[0.2, 0.1, 0.3]);
 -- result:
 []
 -- !result
-insert into test_cosine values (3, array<float>[0.15, 0.25, 0.32]), (4, array<float>[0.12, 0.11, 0.32]);
+insert into test_vector values (3, array<float>[0.15, 0.25, 0.32]), (4, array<float>[0.12, 0.11, 0.32]);
 -- result:
 []
 -- !result
-insert into test_cosine values (5, array<float>[0.25, 0.12, 0.13]), (6, array<float>[0.22, 0.01, 0.39]);
+insert into test_vector values (5, array<float>[0.25, 0.12, 0.13]), (6, array<float>[0.22, 0.01, 0.39]);
 -- result:
 []
 -- !result
-select id, data, cosine_similarity(array<float>[0.1, 0.2, 0.3], data) as sim from test_cosine order by sim desc;
+select id, data, cosine_similarity(array<float>[0.1, 0.2, 0.3], data) as sim from test_vector order by sim desc;
 -- result:
 1	[0.1,0.2,0.3]	0.9999999
 3	[0.15,0.25,0.32]	0.99397856
@@ -46,7 +56,7 @@ select id, data, cosine_similarity(array<float>[0.1, 0.2, 0.3], data) as sim fro
 6	[0.22,0.01,0.39]	0.841375
 5	[0.25,0.12,0.13]	0.76792216
 -- !result
-select a.id, b.id, a.data, b.data, cosine_similarity(a.data, b.data) as sim from test_cosine as a cross join test_cosine as b;
+select a.id, b.id, a.data, b.data, cosine_similarity(a.data, b.data) as sim from test_vector as a cross join test_vector as b;
 -- result:
 6	4	[0.22,0.01,0.39]	[0.12,0.11,0.32]	0.94712645
 6	1	[0.22,0.01,0.39]	[0.1,0.2,0.3]	0.841375
@@ -85,7 +95,7 @@ select a.id, b.id, a.data, b.data, cosine_similarity(a.data, b.data) as sim from
 4	5	[0.12,0.11,0.32]	[0.25,0.12,0.13]	0.77120167
 4	6	[0.12,0.11,0.32]	[0.22,0.01,0.39]	0.94712645
 -- !result
-select a.id, b.id, a.data, b.data, cosine_similarity(a.data, b.data) as sim from test_cosine as a cross join test_cosine as b order by sim desc;
+select a.id, b.id, a.data, b.data, cosine_similarity(a.data, b.data) as sim from test_vector as a cross join test_vector as b order by sim desc;
 -- result:
 3	3	[0.15,0.25,0.32]	[0.15,0.25,0.32]	1.0
 5	5	[0.25,0.12,0.13]	[0.25,0.12,0.13]	0.99999994
@@ -123,4 +133,91 @@ select a.id, b.id, a.data, b.data, cosine_similarity(a.data, b.data) as sim from
 4	5	[0.12,0.11,0.32]	[0.25,0.12,0.13]	0.77120167
 1	5	[0.1,0.2,0.3]	[0.25,0.12,0.13]	0.76792216
 5	1	[0.25,0.12,0.13]	[0.1,0.2,0.3]	0.76792216
+-- !result
+select id, data, l2_distance(array<float>[0.1, 0.2, 0.3], data) as sim from test_vector order by sim desc;
+-- result:
+6 [0.22,0.01,0.39]	0.058599994
+5 [0.25,0.12,0.13]	0.057800006
+2 [0.2,0.1,0.3]	0.020000001
+4 [0.12,0.11,0.32]	0.0089
+3 [0.15,0.25,0.32]	0.005399999
+1	[0.1,0.2,0.3]	0
+-- !result
+select a.id, b.id, a.data, b.data, l2_distance(a.data, b.data) as sim from test_vector as a cross join test_vector as b;
+-- result:
+2	3	[0.2,0.1,0.3]   [0.15,0.25,0.32]	0.0254
+2	1	[0.2,0.1,0.3]   [0.1,0.2,0.3]   0.020000001
+2	2	[0.2,0.1,0.3]   [0.2,0.1,0.3]   0
+2	4	[0.2,0.1,0.3]   [0.12,0.11,0.32]	0.0069
+2	5	[0.2,0.1,0.3]   [0.25,0.12,0.13]	0.031800006
+2	6	[0.2,0.1,0.3]   [0.22,0.01,0.39]	0.016599996
+6	3	[0.22,0.01,0.39]	[0.15,0.25,0.32]	0.0674
+6	1	[0.22,0.01,0.39]	[0.1,0.2,0.3]   0.058599994
+6	2	[0.22,0.01,0.39]	[0.2,0.1,0.3]   0.016599996
+6	4	[0.22,0.01,0.39]	[0.12,0.11,0.32]	0.0249
+6	5	[0.22,0.01,0.39]	[0.25,0.12,0.13]	0.08059999
+6	6	[0.22,0.01,0.39]	[0.22,0.01,0.39]	0
+3	3	[0.15,0.25,0.32]	[0.15,0.25,0.32]	0
+3	1	[0.15,0.25,0.32]	[0.1,0.2,0.3]   0.005399999
+3	2	[0.15,0.25,0.32]	[0.2,0.1,0.3]   0.0254
+3	4	[0.15,0.25,0.32]	[0.12,0.11,0.32]	0.0205
+3	5	[0.15,0.25,0.32]	[0.25,0.12,0.13]	0.06299999
+3	6	[0.15,0.25,0.32]	[0.22,0.01,0.39]	0.0674
+1	3	[0.1,0.2,0.3]   [0.15,0.25,0.32]	0.005399999
+1	1	[0.1,0.2,0.3]   [0.1,0.2,0.3]   0
+1	2	[0.1,0.2,0.3]   [0.2,0.1,0.3]   0.020000001
+1	4	[0.1,0.2,0.3]   [0.12,0.11,0.32]	0.0089
+1	5	[0.1,0.2,0.3]   [0.25,0.12,0.13]	0.057800006
+1	6	[0.1,0.2,0.3]   [0.22,0.01,0.39]	0.058599994
+5	3	[0.25,0.12,0.13]	[0.15,0.25,0.32]	0.06299999
+5	1	[0.25,0.12,0.13]	[0.1,0.2,0.3]   0.057800006
+5	2	[0.25,0.12,0.13]	[0.2,0.1,0.3]   0.031800006
+5	4	[0.25,0.12,0.13]	[0.12,0.11,0.32]	0.053099997
+5	5	[0.25,0.12,0.13]	[0.25,0.12,0.13]	0
+5	6	[0.25,0.12,0.13]	[0.22,0.01,0.39]	0.08059999
+4	3	[0.12,0.11,0.32]	[0.15,0.25,0.32]	0.0205
+4	1	[0.12,0.11,0.32]	[0.1,0.2,0.3]   0.0089
+4	2	[0.12,0.11,0.32]	[0.2,0.1,0.3]   0.0069
+4	4	[0.12,0.11,0.32]	[0.12,0.11,0.32]	0
+4	5	[0.12,0.11,0.32]	[0.25,0.12,0.13]	0.053099997
+4	6	[0.12,0.11,0.32]	[0.22,0.01,0.39]	0.0249
+-- !result
+select a.id, b.id, a.data, b.data, l2_distance(a.data, b.data) as sim from test_vector as a cross join test_vector as b order by sim desc;
+-- result:
+5	6	[0.25,0.12,0.13]	[0.22,0.01,0.39]	0.08059999
+6	5	[0.22,0.01,0.39]	[0.25,0.12,0.13]	0.08059999
+3	6	[0.15,0.25,0.32]	[0.22,0.01,0.39]	0.0674
+6	3	[0.22,0.01,0.39]	[0.15,0.25,0.32]	0.0674
+5	3	[0.25,0.12,0.13]	[0.15,0.25,0.32]	0.06299999
+3	5	[0.15,0.25,0.32]	[0.25,0.12,0.13]	0.06299999
+1	6	[0.1,0.2,0.3]   [0.22,0.01,0.39]	0.058599994
+6	1	[0.22,0.01,0.39]	[0.1,0.2,0.3]   0.058599994
+1	5	[0.1,0.2,0.3]   [0.25,0.12,0.13]	0.057800006
+5	1	[0.25,0.12,0.13]	[0.1,0.2,0.3]   0.057800006
+4	5	[0.12,0.11,0.32]	[0.25,0.12,0.13]	0.053099997
+5	4	[0.25,0.12,0.13]	[0.12,0.11,0.32]	0.053099997
+5	2	[0.25,0.12,0.13]	[0.2,0.1,0.3]   0.031800006
+2	5	[0.2,0.1,0.3]   [0.25,0.12,0.13]	0.031800006
+3	2	[0.15,0.25,0.32]	[0.2,0.1,0.3]   0.0254
+2	3	[0.2,0.1,0.3]   [0.15,0.25,0.32]	0.0254
+4	6	[0.12,0.11,0.32]	[0.22,0.01,0.39]	0.0249
+6	4	[0.22,0.01,0.39]	[0.12,0.11,0.32]	0.0249
+3	4	[0.15,0.25,0.32]	[0.12,0.11,0.32]	0.0205
+4	3	[0.12,0.11,0.32]	[0.15,0.25,0.32]	0.0205
+1	2	[0.1,0.2,0.3]   [0.2,0.1,0.3]   0.020000001
+2	1	[0.2,0.1,0.3]   [0.1,0.2,0.3]   0.020000001
+2	6	[0.2,0.1,0.3]   [0.22,0.01,0.39]	0.016599996
+6	2	[0.22,0.01,0.39]	[0.2,0.1,0.3]   0.016599996
+4	1	[0.12,0.11,0.32]	[0.1,0.2,0.3]   0.0089
+1	4	[0.1,0.2,0.3]   [0.12,0.11,0.32]	0.0089
+4	2	[0.12,0.11,0.32]	[0.2,0.1,0.3]   0.0069
+2	4	[0.2,0.1,0.3]   [0.12,0.11,0.32]	0.0069
+3	1	[0.15,0.25,0.32]	[0.1,0.2,0.3]   0.005399999
+1	3	[0.1,0.2,0.3]   [0.15,0.25,0.32]	0.005399999
+4	4	[0.12,0.11,0.32]	[0.12,0.11,0.32]	0
+3	3	[0.15,0.25,0.32]	[0.15,0.25,0.32]	0
+5	5	[0.25,0.12,0.13]	[0.25,0.12,0.13]	0
+1	1	[0.1,0.2,0.3]   [0.1,0.2,0.3]   0
+2	2	[0.2,0.1,0.3]   [0.2,0.1,0.3]   0
+6	6	[0.22,0.01,0.39]	[0.22,0.01,0.39]	0
 -- !result

--- a/test/sql/test_function/T/test_math
+++ b/test/sql/test_function/T/test_math
@@ -10,14 +10,22 @@ select cosine_similarity(array<float>[0.1, 0.2, 0.3], array<float>[0.1, 0.2, 0.3
 
 select cosine_similarity_norm(array<float>[0.1, 0.2, 0.3], array<float>[0.1, 0.2, 0.3]) as dist;
 
+select l2_distance(array<float>[0.1, 0.2, 0.3], data) as dist, id from t1 order by dist desc;
+
+select l2_distance(array<float>[0.1, 0.2, 0.3], array<float>[0.1, 0.2, 0.3]) as dist;
+
 --------------- cross join -----------------
 
-create table test_cosine (id int, data array<float>) ENGINE=olap DUPLICATE KEY (id) DISTRIBUTED BY HASH(id) properties ("replication_num" = "1");
+create table test_vector (id int, data array<float>) ENGINE=olap DUPLICATE KEY (id) DISTRIBUTED BY HASH(id) properties ("replication_num" = "1");
 
-insert into test_cosine values (1, array<float>[0.1, 0.2, 0.3]), (2, array<float>[0.2, 0.1, 0.3]);
-insert into test_cosine values (3, array<float>[0.15, 0.25, 0.32]), (4, array<float>[0.12, 0.11, 0.32]);
-insert into test_cosine values (5, array<float>[0.25, 0.12, 0.13]), (6, array<float>[0.22, 0.01, 0.39]);
+insert into test_vector values (1, array<float>[0.1, 0.2, 0.3]), (2, array<float>[0.2, 0.1, 0.3]);
+insert into test_vector values (3, array<float>[0.15, 0.25, 0.32]), (4, array<float>[0.12, 0.11, 0.32]);
+insert into test_vector values (5, array<float>[0.25, 0.12, 0.13]), (6, array<float>[0.22, 0.01, 0.39]);
 
-select id, data, cosine_similarity(array<float>[0.1, 0.2, 0.3], data) as sim from test_cosine order by sim desc;
-select a.id, b.id, a.data, b.data, cosine_similarity(a.data, b.data) as sim from test_cosine as a cross join test_cosine as b;
-select a.id, b.id, a.data, b.data, cosine_similarity(a.data, b.data) as sim from test_cosine as a cross join test_cosine as b order by sim desc;
+select id, data, cosine_similarity(array<float>[0.1, 0.2, 0.3], data) as sim from test_vector order by sim desc;
+select a.id, b.id, a.data, b.data, cosine_similarity(a.data, b.data) as sim from test_vector as a cross join test_vector as b;
+select a.id, b.id, a.data, b.data, cosine_similarity(a.data, b.data) as sim from test_vector as a cross join test_vector as b order by sim desc;
+
+select id, data, l2_distance(array<float>[0.1, 0.2, 0.3], data) as sim from test_vector order by sim desc;
+select a.id, b.id, a.data, b.data, l2_distance(a.data, b.data) as sim from test_vector as a cross join test_vector as b;
+select a.id, b.id, a.data, b.data, l2_distance(a.data, b.data) as sim from test_vector as a cross join test_vector as b order by sim desc;


### PR DESCRIPTION
## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Problem Summary(Required) ：

### Syntax
```plaintext
select l2_distance([1.1,2.2,3.3], feature1) from test.vector_index_test
```
### Motivation
In the vector similarity retrieval scenario, two algorithms are commonly used: 

- cosine similarity algorithm 

- euclidean distance algorithm. 

Starrocks already has the cosine_similarity function, but in our vector retrieval scenario, there is a need for the l2_distance algorithm, so we add the l2_distance function.

### Note
The l2_distance used here refers to the distance without taking the square root, which is consistent with the behavior in faiss.

### Showcase
<img width="1231" alt="image" src="https://github.com/StarRocks/starrocks/assets/86234715/ebd071d5-c404-4fe2-8fba-4c019e80848a">


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5