### PR TITLE
[Enhancement] support statistics for iceberg table and optimize statistics calculation 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -38,6 +38,7 @@ import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;
@@ -49,6 +50,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.starrocks.connector.iceberg.IcebergConnector.ICEBERG_CATALOG_TYPE;
@@ -77,6 +79,8 @@ public class IcebergTable extends Table {
 
     private org.apache.iceberg.Table nativeTable; // actual iceberg table
     private List<Column> partitionColumns;
+
+    private Optional<Snapshot> snapshot = Optional.empty();
 
     public IcebergTable() {
         super(TableType.ICEBERG);
@@ -108,6 +112,15 @@ public class IcebergTable extends Table {
 
     public String getRemoteTableName() {
         return remoteTableName;
+    }
+
+    public Optional<Snapshot> getSnapshot() {
+        if (snapshot.isPresent()) {
+            return snapshot;
+        } else {
+            snapshot = Optional.ofNullable(getNativeTable().currentSnapshot());
+            return snapshot;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -249,7 +249,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
             ImmutableList.Builder<FileScanTask> builder = ImmutableList.builder();
             org.apache.iceberg.Table nativeTable = table.getNativeTable();
-            TableScan scan = nativeTable.newScan().useSnapshot(snapshotId);
+            TableScan scan = nativeTable.newScan().useSnapshot(snapshotId).includeColumnStats();
             if (icebergPredicate.op() != Expression.Operation.TRUE) {
                 scan = scan.filter(icebergPredicate);
             }
@@ -286,7 +286,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                                          Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys,
                                          ScalarOperator predicate) {
-        return statisticProvider.getTableStatistics((IcebergTable) table, predicate, columns);
+        return statisticProvider.getTableStatistics((IcebergTable) table, predicate, columns, session);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
@@ -127,6 +127,18 @@ public class IcebergFileStats {
         return getBoundStatistic(fieldId, minValues);
     }
 
+    public boolean canUseStats(Integer fieldId, Map<Integer, Object> values) {
+        if (idToTypeMapping == null || values == null) {
+            return false;
+        }
+
+        if (idToTypeMapping.get(fieldId) == null || values.get(fieldId) == null) {
+            return false;
+        }
+
+        return true;
+    }
+
     private Optional<Double> getBoundStatistic(Integer fieldId, Map<Integer, Object> boundValues) {
         if (idToTypeMapping == null || boundValues == null) {
             return Optional.empty();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergFileStats.java
@@ -23,11 +23,13 @@ import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -119,6 +121,27 @@ public class IcebergFileStats {
 
     public Map<Integer, Object> getMinValues() {
         return minValues;
+    }
+
+    public Optional<Double> getMinValue(Integer fieldId) {
+        return getBoundStatistic(fieldId, minValues);
+    }
+
+    private Optional<Double> getBoundStatistic(Integer fieldId, Map<Integer, Object> boundValues) {
+        if (idToTypeMapping == null || boundValues == null) {
+            return Optional.empty();
+        }
+        if (idToTypeMapping.get(fieldId) == null || boundValues.get(fieldId) == null) {
+            return Optional.empty();
+        }
+        Type.PrimitiveType type = idToTypeMapping.get(fieldId);
+        Object value = boundValues.get(fieldId);
+        return convertObjectToOptionalDouble(type, value);
+    }
+
+
+    public Optional<Double> getMaxValue(Integer fieldId) {
+        return getBoundStatistic(fieldId, maxValues);
     }
 
     public Map<Integer, Object> getMaxValues() {
@@ -220,5 +243,34 @@ public class IcebergFileStats {
             }
         });
         return map.build();
+    }
+
+    public static Optional<Double> convertObjectToOptionalDouble(Type.PrimitiveType type, Object value) {
+        double valueConvert = 0;
+        if (type instanceof Types.BooleanType) {
+            valueConvert = (boolean) value ? 1 : 0;
+        } else if (type instanceof Types.IntegerType) {
+            valueConvert = (int) value;
+        } else if (type instanceof Types.LongType) {
+            valueConvert = (long) value;
+        } else if (type instanceof Types.FloatType) {
+            valueConvert = (float) value;
+        } else if (type instanceof Types.DoubleType) {
+            valueConvert = (double) value;
+        } else if (type instanceof Types.TimestampType) {
+            // we deal iceberg TimestampType as seconds in columnstatistics
+            // in iceberg it's microsecond
+            valueConvert = ((long) value) / 1000000;
+        } else if (type instanceof Types.DateType) {
+            // we deal iceberg DateType as seconds in columnstatistics
+            // in iceberg it's num of day from 1970-01-01
+            valueConvert = ((long) ((int) value)) * 86400;
+        } else if (type instanceof Types.DecimalType) {
+            valueConvert = ((BigDecimal) value).doubleValue();
+        } else {
+            return Optional.empty();
+        }
+
+        return Optional.of(valueConvert);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -217,18 +217,22 @@ public class IcebergStatisticProvider {
             builder.setDistinctValuesCount(Math.min(ndv, icebergStats.getRecordCount()));
         }
 
-        if (column.getType().isStringType()) {
-            String minString = icebergStats.getMinValues().get(fieldId).toString();
-            builder.setMinString(minString);
-        } else if (icebergStats.getMinValue(fieldId).isPresent()) {
-            builder.setMinValue(icebergStats.getMinValue(fieldId).get());
+        if (icebergStats.getMinValue(fieldId).isPresent()) {
+            if (column.getType().isStringType()) {
+                String minString = icebergStats.getMinValues().get(fieldId).toString();
+                builder.setMinString(minString);
+            } else {
+                builder.setMinValue(icebergStats.getMinValue(fieldId).get());
+            }
         }
 
-        if (column.getType().isStringType()) {
-            String maxString = icebergStats.getMaxValues().get(fieldId).toString();
-            builder.setMaxString(maxString);
-        } else if (icebergStats.getMaxValue(fieldId).isPresent()) {
-            builder.setMaxValue(icebergStats.getMaxValue(fieldId).get());
+        if (icebergStats.getMaxValue(fieldId).isPresent()) {
+            if (column.getType().isStringType()) {
+                String maxString = icebergStats.getMaxValues().get(fieldId).toString();
+                builder.setMaxString(maxString);
+            } else {
+                builder.setMaxValue(icebergStats.getMaxValue(fieldId).get());
+            }
         }
 
         Long nullCount = icebergStats.getNullCounts() == null ? null : icebergStats.getNullCounts().get(fieldId);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -235,22 +235,18 @@ public class IcebergStatisticProvider {
         Long nullCount = icebergStats.getNullCounts() == null ? null : icebergStats.getNullCounts().get(fieldId);
         if (nullCount != null) {
             builder.setNullsFraction(nullCount * 1.0 / Math.max(icebergStats.getRecordCount(), 1));
+        } else {
+            builder.setNullsFraction(0);
         }
 
-        if (!column.getType().isStringType()) {
-            builder.setAverageRowSize(column.getType().getTypeSize());
-        } else {
-            Long columnSize = icebergStats.getColumnSizes() == null ? null : icebergStats.getColumnSizes().get(fieldId);
-            if (columnSize != null) {
-                builder.setAverageRowSize(Math.max(columnSize * 1.0 / Math.max(icebergStats.getRecordCount(), 1), 1));
-            }
-        }
+        builder.setAverageRowSize(1);
 
         Long ndv = columnNdvs.get(fieldId);
         if (ndv != null) {
-            builder.setDistinctValuesCount(Math.min(ndv, icebergStats.getRecordCount()));
+            builder.setDistinctValuesCount(Math.max(Math.min(ndv, icebergStats.getRecordCount()), 1));
             builder.setType(ColumnStatistic.StatisticType.ESTIMATE);
         } else {
+            builder.setDistinctValuesCount(1);
             builder.setType(ColumnStatistic.StatisticType.UNKNOWN);
         }
         return builder.build();
@@ -397,4 +393,5 @@ public class IcebergStatisticProvider {
             }
         };
     }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -15,21 +15,28 @@
 
 package com.starrocks.connector.iceberg.cost;
 
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
+import org.apache.iceberg.BlobMetadata;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.puffin.StandardBlobTypes;
 import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,6 +44,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -44,11 +52,12 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.starrocks.connector.ColumnTypeConverter.fromIcebergType;
-import static org.apache.iceberg.SnapshotSummary.TOTAL_EQ_DELETES_PROP;
-import static org.apache.iceberg.SnapshotSummary.TOTAL_POS_DELETES_PROP;
-import static org.apache.iceberg.SnapshotSummary.TOTAL_RECORDS_PROP;
-
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 
 public class IcebergStatisticProvider {
     private static final Logger LOG = LogManager.getLogger(IcebergStatisticProvider.class);
@@ -57,41 +66,74 @@ public class IcebergStatisticProvider {
     }
 
     public Statistics getTableStatistics(IcebergTable icebergTable, ScalarOperator predicate,
-                                         Map<ColumnRefOperator, Column> colRefToColumnMetaMap) {
+                                         Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+                                         OptimizerContext session) {
         LOG.debug("Begin to make iceberg table statistics!");
         Table nativeTable = icebergTable.getNativeTable();
-        IcebergFileStats icebergFileStats = generateIcebergFileStats(icebergTable, predicate);
-
         Statistics.Builder statisticsBuilder = Statistics.builder();
-        double recordCount = Math.max(icebergFileStats == null ? 0 : icebergFileStats.getRecordCount(), 1);
-        statisticsBuilder.addColumnStatistics(buildColumnStatistics(nativeTable, colRefToColumnMetaMap));
-        statisticsBuilder.setOutputRowCount(recordCount);
+        Optional<Snapshot> snapshot = icebergTable.getSnapshot();
+        if (snapshot.isPresent()) {
+            IcebergFileStats icebergFileStats = generateIcebergFileStats(icebergTable, predicate);
+            Set<Integer> primitiveColumnsFiledIds = nativeTable.schema().columns().stream()
+                    .filter(column -> column.type().isPrimitiveType())
+                    .map(Types.NestedField::fieldId).collect(Collectors.toSet());
+            Map<Integer, Long> columnNdvs = new HashMap<>();
+            if (session != null && session.getSessionVariable().isEnableIcebergNdv()) {
+                columnNdvs = readNdvs(icebergTable, primitiveColumnsFiledIds);
+            }
+
+            statisticsBuilder.setOutputRowCount(icebergFileStats.getRecordCount());
+            if (!columnNdvs.isEmpty()) {
+                statisticsBuilder.addColumnStatistics(buildColumnStatistics(
+                        nativeTable, colRefToColumnMetaMap, icebergFileStats, columnNdvs));
+            } else {
+                statisticsBuilder.addColumnStatistics(buildUnknownColumnStatistics(colRefToColumnMetaMap.keySet()));
+            }
+        } else {
+            statisticsBuilder.setOutputRowCount(1);
+            statisticsBuilder.addColumnStatistics(buildUnknownColumnStatistics(colRefToColumnMetaMap.keySet()));
+        }
         LOG.debug("Finish to make iceberg table statistics!");
         return statisticsBuilder.build();
     }
 
-    private IcebergFileStats generateIcebergFileStats(IcebergTable icebergTable, ScalarOperator icebergPredicate) {
-        Optional<Snapshot> snapshot = Optional.ofNullable(icebergTable.getNativeTable().currentSnapshot());
-        if (!snapshot.isPresent()) {
-            return null;
+    private Map<ColumnRefOperator, ColumnStatistic> buildUnknownColumnStatistics(Set<ColumnRefOperator> columnRefOperatorSet) {
+        Map<ColumnRefOperator, ColumnStatistic> columnStatistics = new HashMap<>();
+        for (ColumnRefOperator columnRefOperator : columnRefOperatorSet) {
+            columnStatistics.put(columnRefOperator, ColumnStatistic.unknown());
         }
+        return columnStatistics;
+    }
 
-        long snapshotId = snapshot.get().snapshotId();
-        IcebergFileStats icebergFileStats = null;
+    private IcebergFileStats generateIcebergFileStats(IcebergTable icebergTable, ScalarOperator icebergPredicate) {
         String catalogName = icebergTable.getCatalogName();
+        Optional<Snapshot> snapshot = icebergTable.getSnapshot();
+        long snapshotId = snapshot.get().snapshotId();
 
+        Table nativeTable = icebergTable.getNativeTable();
+        List<Types.NestedField> columns = nativeTable.schema().columns();
+        Map<Integer, Type.PrimitiveType> idToTypeMapping = columns.stream()
+                .filter(column -> column.type().isPrimitiveType())
+                .collect(Collectors.toMap(Types.NestedField::fieldId, column -> column.type().asPrimitiveType()));
+
+        List<PartitionField> partitionFields = nativeTable.spec().fields();
+
+        Set<Integer> identityPartitionIds = nativeTable.spec().fields().stream()
+                .filter(x -> x.transform().isIdentity())
+                .map(PartitionField::sourceId)
+                .collect(Collectors.toSet());
+
+        List<Types.NestedField> nonPartitionPrimitiveColumns = columns.stream()
+                .filter(column -> !identityPartitionIds.contains(column.fieldId()) &&
+                        column.type().isPrimitiveType())
+                .collect(toImmutableList());
+
+        IcebergFileStats icebergFileStats = null;
         List<RemoteFileInfo> splits = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
                 catalogName, icebergTable, null, snapshotId, icebergPredicate, null);
 
         if (splits.isEmpty()) {
             return new IcebergFileStats(1);
-        }
-
-        if (icebergPredicate == null) {
-            long totalRecords = Long.parseLong(snapshot.get().summary().getOrDefault(TOTAL_RECORDS_PROP, "1"));
-            long totalPosDeletes = Long.parseLong(snapshot.get().summary().getOrDefault(TOTAL_POS_DELETES_PROP, "0"));
-            long totalEqDeletes = Long.parseLong(snapshot.get().summary().getOrDefault(TOTAL_EQ_DELETES_PROP, "0"));
-            return new IcebergFileStats(totalRecords - totalPosDeletes - totalEqDeletes);
         }
 
         RemoteFileDesc remoteFileDesc = splits.get(0).getFiles().get(0);
@@ -111,9 +153,26 @@ public class IcebergStatisticProvider {
                 }
                 files.add(dataFile.path().toString());
                 if (icebergFileStats == null) {
-                    icebergFileStats = new IcebergFileStats(dataFile.recordCount());
+                    icebergFileStats = new IcebergFileStats(
+                            idToTypeMapping,
+                            nonPartitionPrimitiveColumns,
+                            dataFile.partition(),
+                            dataFile.recordCount(),
+                            dataFile.fileSizeInBytes(),
+                            IcebergFileStats.toMap(idToTypeMapping, dataFile.lowerBounds()),
+                            IcebergFileStats.toMap(idToTypeMapping, dataFile.upperBounds()),
+                            dataFile.nullValueCounts(),
+                            dataFile.columnSizes());
                 } else {
+                    icebergFileStats.incrementFileCount();
                     icebergFileStats.incrementRecordCount(dataFile.recordCount());
+                    icebergFileStats.incrementSize(dataFile.fileSizeInBytes());
+                    updateSummaryMin(icebergFileStats, partitionFields, IcebergFileStats.toMap(idToTypeMapping,
+                            dataFile.lowerBounds()), dataFile.nullValueCounts(), dataFile.recordCount());
+                    updateSummaryMax(icebergFileStats, partitionFields, IcebergFileStats.toMap(idToTypeMapping,
+                            dataFile.upperBounds()), dataFile.nullValueCounts(), dataFile.recordCount());
+                    icebergFileStats.updateNullCount(dataFile.nullValueCounts());
+                    updateColumnSizes(icebergFileStats, dataFile.columnSizes());
                 }
             }
         }
@@ -127,7 +186,8 @@ public class IcebergStatisticProvider {
     }
 
     private Map<ColumnRefOperator, ColumnStatistic> buildColumnStatistics(
-            Table nativeTable, Map<ColumnRefOperator, Column> colRefToColumnMetaMap) {
+            Table nativeTable, Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+            IcebergFileStats icebergFileStats, Map<Integer, Long> columnNdvs) {
         Map<ColumnRefOperator, ColumnStatistic> columnStatistics = new HashMap<>();
         List<Types.NestedField> columns = nativeTable.schema().columns();
         Map<Integer, String> idToColumnNames = columns.stream().
@@ -143,9 +203,48 @@ public class IcebergStatisticProvider {
                 continue;
             }
 
-            columnStatistics.put(columnList.get(0), ColumnStatistic.unknown());
+            columnStatistics.put(columnList.get(0), generateColumnStatistic(
+                    idColumn.getKey(), colRefToColumnMetaMap.get(columnList.get(0)), icebergFileStats, columnNdvs));
         }
         return columnStatistics;
+    }
+
+    private ColumnStatistic generateColumnStatistic(Integer fieldId, Column column, IcebergFileStats icebergStats,
+                                                    Map<Integer, Long> columnNdvs) {
+        ColumnStatistic.Builder builder = ColumnStatistic.builder();
+        Long ndv = columnNdvs.get(fieldId);
+        if (ndv != null) {
+            builder.setDistinctValuesCount(Math.min(ndv, icebergStats.getRecordCount()));
+        }
+
+        if (column.getType().isStringType()) {
+            String minString = icebergStats.getMinValues().get(fieldId).toString();
+            builder.setMinString(minString);
+        } else if (icebergStats.getMinValue(fieldId).isPresent()) {
+            builder.setMinValue(icebergStats.getMinValue(fieldId).get());
+        }
+
+        if (column.getType().isStringType()) {
+            String maxString = icebergStats.getMaxValues().get(fieldId).toString();
+            builder.setMaxString(maxString);
+        } else if (icebergStats.getMaxValue(fieldId).isPresent()) {
+            builder.setMaxValue(icebergStats.getMaxValue(fieldId).get());
+        }
+
+        Long nullCount = icebergStats.getNullCounts() == null ? null : icebergStats.getNullCounts().get(fieldId);
+        if (nullCount != null) {
+            builder.setNullsFraction(nullCount * 1.0 / Math.max(icebergStats.getRecordCount(), 1));
+        }
+
+        if (!column.getType().isStringType()) {
+            builder.setAverageRowSize(column.getType().getTypeSize());
+        } else {
+            Long columnSize = icebergStats.getColumnSizes() == null ? null : icebergStats.getColumnSizes().get(fieldId);
+            if (columnSize != null) {
+                builder.setAverageRowSize(Math.max(columnSize * 1.0 / Math.max(icebergStats.getRecordCount(), 1), 1));
+            }
+        }
+        return builder.build();
     }
 
     public void updateColumnSizes(IcebergFileStats icebergFileStats, Map<Integer, Long> addedColumnSizes) {
@@ -191,6 +290,10 @@ public class IcebergStatisticProvider {
             Map<Integer, Object> current,
             Map<Integer, Object> newStats,
             Predicate<Integer> predicate) {
+        if (!icebergFileStats.hasValidColumnMetrics()) {
+            return;
+        }
+
         for (PartitionField field : partitionFields) {
             int id = field.sourceId();
             if (icebergFileStats.getCorruptedStats().contains(id)) {
@@ -199,6 +302,8 @@ public class IcebergStatisticProvider {
 
             Object newValue = newStats.get(id);
             if (newValue == null) {
+                current.remove(id);
+                icebergFileStats.getCorruptedStats().add(id);
                 continue;
             }
 
@@ -210,5 +315,66 @@ public class IcebergStatisticProvider {
                 }
             }
         }
+    }
+
+    public static Map<Integer, Long> readNdvs(IcebergTable icebergTable, Set<Integer> columnIds) {
+        ImmutableMap.Builder<Integer, Long> colIdToNdv = ImmutableMap.builder();
+        Set<Integer> remainingColumnIds = new HashSet<>(columnIds);
+
+        Iterator<StatisticsFile> statisticsFiles = getStatisticsFiles(
+                icebergTable.getNativeTable(), icebergTable.getSnapshot().get().snapshotId());
+        while (!remainingColumnIds.isEmpty() && statisticsFiles.hasNext()) {
+            StatisticsFile statisticsFile = statisticsFiles.next();
+
+            Map<Integer, BlobMetadata> thetaBlobsByFieldId = statisticsFile.blobMetadata().stream()
+                    .filter(blobMetadata -> blobMetadata.type().equals(StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1))
+                    .filter(blobMetadata -> blobMetadata.fields().size() == 1)
+                    .filter(blobMetadata -> remainingColumnIds.contains(getOnlyElement(blobMetadata.fields())))
+                    // Fail loud upon duplicates (there must be none)
+                    .collect(toImmutableMap(blobMetadata -> getOnlyElement(blobMetadata.fields()), identity()));
+
+            for (Map.Entry<Integer, BlobMetadata> entry : thetaBlobsByFieldId.entrySet()) {
+                int fieldId = entry.getKey();
+                BlobMetadata blobMetadata = entry.getValue();
+                String ndv = blobMetadata.properties().get("ndv");
+                if (ndv == null) {
+                    LOG.debug("Blob %s is missing ndv property", blobMetadata.type());
+                    remainingColumnIds.remove(fieldId);
+                } else {
+                    remainingColumnIds.remove(fieldId);
+                    colIdToNdv.put(fieldId, Long.parseLong(ndv));
+                }
+            }
+        }
+
+        return colIdToNdv.build();
+    }
+
+    public static Iterator<StatisticsFile> getStatisticsFiles(Table icebergTable, long snapshotId) {
+        return new AbstractIterator<StatisticsFile>() {
+            private final Map<Long, StatisticsFile> statsFileBySnapshot = icebergTable.statisticsFiles().stream()
+                    .collect(toMap(
+                            StatisticsFile::snapshotId,
+                            identity(),
+                            (a, b) -> {
+                                throw new IllegalStateException(String.format(
+                                        "Unexpected duplicate statistics files %s, %s", a, b));
+                            },
+                            HashMap::new));
+
+            @Override
+            protected StatisticsFile computeNext() {
+                if (statsFileBySnapshot.isEmpty()) {
+                    // Already found all statistics files
+                    return endOfData();
+                }
+
+                StatisticsFile statisticsFile = statsFileBySnapshot.remove(snapshotId);
+                if (statisticsFile != null) {
+                    return statisticsFile;
+                }
+                return endOfData();
+            }
+        };
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -302,6 +302,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String CBO_USE_DB_LOCK = "cbo_use_lock_db";
 
+    public static final String CBO_DERIVE_RANGE_JOIN_PREDICATE = "cbo_derive_range_join_predicate";
+
     // --------  New planner session variables end --------
 
     // Type of compression of transmitted data
@@ -506,6 +508,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_EXPR_PRUNE_PARTITION = "enable_expr_prune_partition";
 
+    public static final String ENABLE_ICEBERG_NDV = "enable_iceberg_ndv";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -699,6 +703,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // The current time zone
     @VariableMgr.VarAttr(name = TIME_ZONE)
     private String timeZone = TimeUtils.getSystemTimeZone().getID();
+
+    @VariableMgr.VarAttr(name = ENABLE_ICEBERG_NDV)
+    private boolean enableIcebergNdv = true;
 
     @VariableMgr.VarAttr(name = INNODB_READ_ONLY)
     private boolean innodbReadOnly = true;
@@ -1089,6 +1096,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableParallelMerge = enableParallelMerge;
     }
 
+    public boolean isEnableIcebergNdv() {
+        return enableIcebergNdv;
+    }
+
+    public void setEnableIcebergNdv(boolean enableIcebergNdv) {
+        this.enableIcebergNdv = enableIcebergNdv;
+    }
+
     @VariableMgr.VarAttr(name = ENABLE_SCAN_BLOCK_CACHE)
     private boolean useScanBlockCache = false;
 
@@ -1279,6 +1294,18 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = LARGE_DECIMAL_UNDERLYING_TYPE)
     private String largeDecimalUnderlyingType = SessionVariableConstants.PANIC;
+
+
+    @VarAttr(name = CBO_DERIVE_RANGE_JOIN_PREDICATE)
+    private boolean cboDeriveRangeJoinPredicate = false;
+
+    public boolean enableCboDeriveRangeJoinPredicate() {
+        return cboDeriveRangeJoinPredicate;
+    }
+
+    public void setCboDeriveRangeJoinPredicate(boolean cboDeriveRangeJoinPredicate) {
+        this.cboDeriveRangeJoinPredicate = cboDeriveRangeJoinPredicate;
+    }
 
     public int getExprChildrenLimit() {
         return exprChildrenLimit;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -34,6 +34,7 @@ import com.starrocks.sql.optimizer.rule.RuleSetType;
 import com.starrocks.sql.optimizer.rule.join.ReorderJoinRule;
 import com.starrocks.sql.optimizer.rule.mv.MaterializedViewRule;
 import com.starrocks.sql.optimizer.rule.transformation.ApplyExceptionRule;
+import com.starrocks.sql.optimizer.rule.transformation.DeriveRangeJoinPredicateRule;
 import com.starrocks.sql.optimizer.rule.transformation.GroupByCountDistinctRewriteRule;
 import com.starrocks.sql.optimizer.rule.transformation.JoinLeftAsscomRule;
 import com.starrocks.sql.optimizer.rule.transformation.LimitPruneTabletsRule;
@@ -421,6 +422,7 @@ public class Optimizer {
         // if this rule has applied before MV.
         ruleRewriteOnlyOnce(tree, rootTaskContext, new GroupByCountDistinctRewriteRule());
 
+        ruleRewriteOnlyOnce(tree, rootTaskContext, new DeriveRangeJoinPredicateRule());
         return tree.getInputs().get(0);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -396,9 +396,7 @@ public class Utils {
                 }
                 return true;
             } else if (operator instanceof LogicalIcebergScanOperator) {
-                // TODO(stephen): support `analyze table` to collect iceberg table ndv
-                // iceberg metadata doesn't have ndv, we default to unknown for all iceberg table column statistics.
-                return true;
+                return ((LogicalIcebergScanOperator) operator).hasUnknownColumn();
             } else {
                 // For other scan operators, we do not know the column statistics.
                 return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 public class LogicalIcebergScanOperator extends LogicalScanOperator {
     private ScanOperatorPredicates predicates = new ScanOperatorPredicates();
-
+    private boolean hasUnknownColumn = true;
     public LogicalIcebergScanOperator(Table table,
                                       Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
                                       Map<Column, ColumnRefOperator> columnMetaToColRefMap,
@@ -58,6 +58,13 @@ public class LogicalIcebergScanOperator extends LogicalScanOperator {
         this.predicates = predicates;
     }
 
+    public boolean hasUnknownColumn() {
+        return hasUnknownColumn;
+    }
+
+    public void setHasUnknownColumn(boolean hasUnknownColumn) {
+        this.hasUnknownColumn = hasUnknownColumn;
+    }
     @Override
     public <R, C> R accept(OperatorVisitor<R, C> visitor, C context) {
         return visitor.visitLogicalIcebergScan(this, context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
@@ -162,6 +162,8 @@ public enum RuleType {
 
     TF_GROUP_BY_COUNT_DISTINCT_DATA_SKEW_ELIMINATE_RULE,
 
+    TF_DERIVE_RANGE_JOIN_PREDICATE,
+
     // The following are implementation rules:
     IMP_OLAP_LSCAN_TO_PSCAN,
     IMP_HIVE_LSCAN_TO_PSCAN,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DeriveRangeJoinPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DeriveRangeJoinPredicateRule.java
@@ -1,0 +1,211 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.BinaryType;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.ExpressionContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class DeriveRangeJoinPredicateRule extends TransformationRule {
+    public DeriveRangeJoinPredicateRule() {
+        super(RuleType.TF_DERIVE_RANGE_JOIN_PREDICATE,
+                Pattern.create(OperatorType.LOGICAL_JOIN, OperatorType.PATTERN_SCAN, OperatorType.PATTERN_SCAN));
+    }
+
+    @Override
+    public boolean check(OptExpression input, OptimizerContext context) {
+        if (context.getSessionVariable().enableCboDeriveRangeJoinPredicate()) {
+            return input.inputAt(0).getOp().getOpType() == OperatorType.LOGICAL_ICEBERG_SCAN &&
+                    input.inputAt(1).getOp().getOpType() == OperatorType.LOGICAL_ICEBERG_SCAN;
+        }
+
+        return false;
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalJoinOperator join = input.getOp().cast();
+        List<ScalarOperator> onPredicate = Utils.extractConjuncts(join.getOnPredicate());
+
+        Map<ColumnRefSet, List<BinaryPredicateOperator>> columnToRange = Maps.newHashMap();
+
+        ColumnRefSet leftChildColumns = input.inputAt(0).getOutputColumns();
+        ColumnRefSet rightChildColumns = input.inputAt(1).getOutputColumns();
+
+        for (ScalarOperator p : onPredicate) {
+            if (!(p instanceof BinaryPredicateOperator)) {
+                continue;
+            }
+            BinaryPredicateOperator binaryPredicate = (BinaryPredicateOperator) p;
+            if (!binaryPredicate.getBinaryType().isRange()) {
+                continue;
+            }
+
+            ColumnRefSet left = binaryPredicate.getChild(0).getUsedColumns();
+            ColumnRefSet right = binaryPredicate.getChild(1).getUsedColumns();
+
+            if (left.isEmpty() || right.isEmpty()) {
+                continue;
+            }
+
+            // normalized to left OP right
+            if (leftChildColumns.containsAll(left) && rightChildColumns.containsAll(right)) {
+                columnToRange.computeIfAbsent(left, k -> Lists.newArrayList()).add(binaryPredicate);
+                columnToRange.computeIfAbsent(right, k -> Lists.newArrayList()).add(binaryPredicate);
+            } else if (rightChildColumns.containsAll(left) && leftChildColumns.containsAll(right)) {
+                columnToRange.computeIfAbsent(left, k -> Lists.newArrayList()).add(binaryPredicate.commutative());
+                columnToRange.computeIfAbsent(right, k -> Lists.newArrayList()).add(binaryPredicate.commutative());
+            }
+        }
+
+        // filter range predicate: [lower < refs < upper] and refs must one column
+        columnToRange.entrySet().removeIf(entry -> {
+            List<BinaryPredicateOperator> predicates = entry.getValue();
+            ColumnRefSet key = entry.getKey();
+            if (predicates.stream().map(BinaryPredicateOperator::getBinaryType)
+                    .map(t -> BinaryType.GE.equals(t) || BinaryType.GT.equals(t)).distinct().count() < 2) {
+                return true;
+            }
+
+            // must one column
+            return key.cardinality() != 1;
+        });
+
+        if (columnToRange.isEmpty()) {
+            return Lists.newArrayList(input);
+        }
+
+        // generate range predicate
+        LogicalScanOperator leftScan = input.inputAt(0).getOp().cast();
+        LogicalScanOperator rightScan = input.inputAt(1).getOp().cast();
+        Statistics leftStatics = getStatistics(input.inputAt(0), context);
+        Statistics rightStatics = getStatistics(input.inputAt(1), context);
+
+        List<ScalarOperator> leftPredicates = Lists.newArrayList();
+        List<ScalarOperator> rightPredicates = Lists.newArrayList();
+        for (ColumnRefSet refs : columnToRange.keySet()) {
+            Optional<ColumnRefOperator> optional =
+                    refs.getStream().map(context.getColumnRefFactory()::getColumnRef).findFirst();
+            if (!optional.isPresent()) {
+                continue;
+            }
+
+            ColumnRefOperator anchor = optional.get();
+            ColumnStatistic columnStatistic =
+                    leftScan.getColRefToColumnMetaMap().containsKey(anchor) ? leftStatics.getColumnStatistic(anchor) :
+                            rightStatics.getColumnStatistic(anchor);
+
+            if (StringUtils.isEmpty(columnStatistic.getMinString()) ||
+                    StringUtils.isEmpty(columnStatistic.getMaxString())) {
+                continue;
+            }
+
+            ScalarOperator lower = new CastOperator(anchor.getType(),
+                    new ConstantOperator(columnStatistic.getMinString(), Type.STRING));
+            ScalarOperator upper = new CastOperator(anchor.getType(),
+                    new ConstantOperator(columnStatistic.getMaxString(), Type.STRING));
+
+            List<BinaryPredicateOperator> predicates = columnToRange.get(refs);
+            // must be range predicate
+            for (BinaryPredicateOperator binary : predicates) {
+                boolean isLeft = binary.getChild(0).getUsedColumns().containsAll(refs);
+                BinaryType type = binary.getBinaryType();
+                if (BinaryType.GE.equals(type) || BinaryType.GT.equals(type)) {
+                    // A > l > B
+                    if (isLeft) {
+                        // l > B -> l-lower > B
+                        rightPredicates.add(new BinaryPredicateOperator(BinaryType.LE, binary.getChild(1), upper));
+                    } else {
+                        // A > l -> A > l-upper
+                        leftPredicates.add(new BinaryPredicateOperator(BinaryType.GE, binary.getChild(0), lower));
+                    }
+                } else if (BinaryType.LE.equals(type) || BinaryType.LT.equals(type)) {
+                    // A < l < B
+                    if (isLeft) {
+                        // l < B -> l-lower < B
+                        rightPredicates.add(new BinaryPredicateOperator(BinaryType.GE, binary.getChild(1), lower));
+                    } else {
+                        // A < l -> A < l-upper
+                        leftPredicates.add(new BinaryPredicateOperator(BinaryType.LE, binary.getChild(0), upper));
+                    }
+                }
+            }
+        }
+
+        if (leftPredicates.isEmpty() && rightPredicates.isEmpty()) {
+            return Lists.newArrayList(input);
+        }
+
+        leftPredicates.add(leftScan.getPredicate());
+        rightPredicates.add(rightScan.getPredicate());
+
+        if (join.getJoinType().isInnerJoin()) {
+            Operator ls = OperatorBuilderFactory.build(leftScan).withOperator(leftScan)
+                    .setPredicate(Utils.compoundAnd(leftPredicates)).build();
+            Operator rs = OperatorBuilderFactory.build(rightScan).withOperator(rightScan)
+                    .setPredicate(Utils.compoundAnd(rightPredicates)).build();
+            return Lists.newArrayList(OptExpression.create(join, OptExpression.create(ls), OptExpression.create(rs)));
+        } else if (join.getJoinType().isLeftOuterJoin()) {
+            Operator rs = OperatorBuilderFactory.build(rightScan).withOperator(rightScan)
+                    .setPredicate(Utils.compoundAnd(rightPredicates)).build();
+            return Lists.newArrayList(
+                    OptExpression.create(join, OptExpression.create(leftScan), OptExpression.create(rs)));
+        } else if (join.getJoinType().isRightOuterJoin()) {
+            Operator ls = OperatorBuilderFactory.build(leftScan).withOperator(leftScan)
+                    .setPredicate(Utils.compoundAnd(leftPredicates)).build();
+            return Lists.newArrayList(
+                    OptExpression.create(join, OptExpression.create(ls), OptExpression.create(rightScan)));
+        }
+
+        return null;
+    }
+
+    private static Statistics getStatistics(OptExpression input, OptimizerContext context) {
+        if (input.getStatistics() != null) {
+            return input.getStatistics();
+        }
+        ExpressionContext ec = new ExpressionContext(input);
+        StatisticsCalculator sc = new StatisticsCalculator(ec, context.getColumnRefFactory(),
+                context.getTaskContext().getOptimizerContext());
+        sc.estimatorStats();
+        return ec.getStatistics();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DeriveRangeJoinPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DeriveRangeJoinPredicateRule.java
@@ -142,7 +142,9 @@ public class DeriveRangeJoinPredicateRule extends TransformationRule {
             }
             if (StringUtils.isEmpty(columnStatistic.getMinString()) ||
                     StringUtils.isEmpty(columnStatistic.getMaxString())) {
-                LOG.debug("column minString value: {}, maxString value: {}");
+                LOG.debug("column minString value: {}, maxString value: {}",
+                        columnStatistic.getMinString(),
+                        columnStatistic.getMaxValue());
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.base.Preconditions;
@@ -42,6 +41,11 @@ public class ColumnStatistic {
     private final Histogram histogram;
     private final StatisticType type;
 
+    // for iceberg test
+    // @todo refactor this!
+    private String minString = null;
+    private String maxString = null;
+
     // TODO deal with string max, min
     public ColumnStatistic(
             double minValue,
@@ -66,6 +70,22 @@ public class ColumnStatistic {
                            double averageRowSize,
                            double distinctValuesCount) {
         this(minValue, maxValue, nullsFraction, averageRowSize, distinctValuesCount, null, StatisticType.ESTIMATE);
+    }
+
+    public String getMinString() {
+        return minString;
+    }
+
+    public void setMinString(String minString) {
+        this.minString = minString;
+    }
+
+    public String getMaxString() {
+        return maxString;
+    }
+
+    public void setMaxString(String maxString) {
+        this.maxString = maxString;
     }
 
     public double getMinValue() {
@@ -179,6 +199,8 @@ public class ColumnStatistic {
         private double distinctValuesCount = NaN;
         private Histogram histogram;
         private StatisticType type = StatisticType.ESTIMATE;
+        private String minString = null;
+        private String maxString = null;
 
         private Builder() {
         }
@@ -235,8 +257,22 @@ public class ColumnStatistic {
             return this;
         }
 
+        public Builder setMinString(String minString) {
+            this.minString = minString;
+            return this;
+        }
+
+        public Builder setMaxString(String maxString) {
+            this.maxString = maxString;
+            return this;
+        }
+
         public ColumnStatistic build() {
-            return new ColumnStatistic(minValue, maxValue, nullsFraction, averageRowSize, distinctValuesCount, histogram, type);
+            ColumnStatistic columnStatistic = new ColumnStatistic(
+                    minValue, maxValue, nullsFraction, averageRowSize, distinctValuesCount, histogram, type);
+            columnStatistic.setMaxString(maxString);
+            columnStatistic.setMinString(minString);
+            return columnStatistic;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
@@ -21,7 +21,7 @@ import static java.lang.Double.NaN;
 import static java.lang.Double.POSITIVE_INFINITY;
 
 public class ColumnStatistic {
-    private enum StatisticType {
+    public enum StatisticType {
         UNKNOWN,
         ESTIMATE
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
@@ -150,8 +150,8 @@ public class ColumnStatistic {
     }
 
     public static Builder buildFrom(ColumnStatistic other) {
-        return new Builder(other.minValue, other.maxValue, other.nullsFraction, other.averageRowSize,
-                other.distinctValuesCount, other.histogram, other.type);
+        return new Builder(other.minString, other.maxString, other.minValue, other.maxValue,
+                other.nullsFraction, other.averageRowSize, other.distinctValuesCount, other.histogram, other.type);
     }
 
     public static Builder buildFrom(String columnStatistic) {
@@ -208,6 +208,16 @@ public class ColumnStatistic {
         private Builder(double minValue, double maxValue, double nullsFraction, double averageRowSize,
                         double distinctValuesCount, Histogram histogram,
                         StatisticType type) {
+            this(null, null, minValue, maxValue, nullsFraction,
+                    averageRowSize, distinctValuesCount, histogram, type);
+        }
+
+        private Builder(String maxString, String minString, double minValue, double maxValue,
+                        double nullsFraction, double averageRowSize,
+                        double distinctValuesCount, Histogram histogram,
+                        StatisticType type) {
+            this.maxString = maxString;
+            this.minString = minString;
             this.minValue = minValue;
             this.maxValue = maxValue;
             this.nullsFraction = nullsFraction;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ExpressionStatisticCalculator.java
@@ -106,8 +106,13 @@ public class ExpressionStatisticCalculator {
             // 2. use sum of then clause and else clause's distinct values as column distinctValues
             double distinctValues = childrenColumnStatistics.stream().mapToDouble(
                     ColumnStatistic::getDistinctValuesCount).sum();
-            return new ColumnStatistic(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, 0,
-                    caseWhenOperator.getType().getTypeSize(), distinctValues);
+            return ColumnStatistic.builder()
+                    .setMinValue(Double.NEGATIVE_INFINITY)
+                    .setMaxValue(Double.POSITIVE_INFINITY)
+                    .setNullsFraction(0)
+                    .setAverageRowSize(caseWhenOperator.getType().getTypeSize())
+                    .setDistinctValuesCount(distinctValues)
+                    .build();
         }
 
         @Override
@@ -149,8 +154,13 @@ public class ExpressionStatisticCalculator {
             double maxValue = Utils.getLongFromDateTime(max.getDatetime());
             double minValue = Utils.getLongFromDateTime(min.getDatetime());
 
-            return new ColumnStatistic(minValue, maxValue, childStatistic.getNullsFraction(),
-                    childStatistic.getAverageRowSize(), childStatistic.getDistinctValuesCount());
+            return ColumnStatistic.builder()
+                    .setMinValue(minValue)
+                    .setMaxValue(maxValue)
+                    .setNullsFraction(childStatistic.getNullsFraction())
+                    .setAverageRowSize(childStatistic.getAverageRowSize())
+                    .setDistinctValuesCount(childStatistic.getDistinctValuesCount())
+                    .build();
         }
 
         @Override
@@ -224,7 +234,13 @@ public class ExpressionStatisticCalculator {
                 default:
                     return ColumnStatistic.unknown();
             }
-            return new ColumnStatistic(minValue, maxValue, 0, callOperator.getType().getTypeSize(), distinctValue);
+            return ColumnStatistic.builder()
+                    .setMinValue(minValue)
+                    .setMaxValue(maxValue)
+                    .setNullsFraction(0)
+                    .setAverageRowSize(callOperator.getType().getTypeSize())
+                    .setDistinctValuesCount(distinctValue)
+                    .build();
         }
 
         private ColumnStatistic unaryExpressionCalculate(CallOperator callOperator, ColumnStatistic columnStatistic) {
@@ -459,8 +475,14 @@ public class ExpressionStatisticCalculator {
             } else {
                 averageRowSize = columnStatistic.getAverageRowSize();
             }
-            return new ColumnStatistic(minValue, maxValue, columnStatistic.getNullsFraction(), averageRowSize,
-                    distinctValue);
+
+            return ColumnStatistic.builder()
+                    .setMinValue(minValue)
+                    .setMaxValue(maxValue)
+                    .setNullsFraction(columnStatistic.getNullsFraction())
+                    .setAverageRowSize(averageRowSize)
+                    .setDistinctValuesCount(distinctValue)
+                    .build();
         }
 
         private ColumnStatistic binaryExpressionCalculate(CallOperator callOperator, ColumnStatistic left,
@@ -558,8 +580,13 @@ public class ExpressionStatisticCalculator {
                 default:
                     return ColumnStatistic.unknown();
             }
-
-            return new ColumnStatistic(minValue, maxValue, nullsFraction, averageRowSize, distinctValues);
+            return ColumnStatistic.builder()
+                    .setMinValue(minValue)
+                    .setMaxValue(maxValue)
+                    .setNullsFraction(nullsFraction)
+                    .setAverageRowSize(averageRowSize)
+                    .setDistinctValuesCount(distinctValues)
+                    .build();
         }
 
         private ColumnStatistic multiaryExpressionCalculate(CallOperator callOperator,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -108,7 +108,32 @@ public class PredicateStatisticsCalculator {
             // 1. compute the inPredicate children column statistics
             ColumnStatistic inColumnStatistic = getExpressionStatistic(firstChild);
             List<ColumnStatistic> otherChildrenColumnStatisticList =
-                    otherChildrenList.stream().map(this::getExpressionStatistic).collect(Collectors.toList());
+                    otherChildrenList.stream().distinct().map(this::getExpressionStatistic).collect(Collectors.toList());
+
+            // using ndv to estimate string col inPredicate
+            if (!predicate.isNotIn() && firstChild.getType().getPrimitiveType().isCharFamily()
+                    && !inColumnStatistic.isUnknown()) {
+                selectivity = Math.min(otherChildrenList.size() / inColumnStatistic.getDistinctValuesCount(), 1);
+
+                double rowCount = Math.max(1, statistics.getOutputRowCount() * selectivity);
+
+                // only columnRefOperator could add column statistic to statistics
+                Optional<ColumnRefOperator> childOpt =
+                        firstChild.isColumnRef() ? Optional.of((ColumnRefOperator) firstChild) : Optional.empty();
+                ColumnStatistic newInColumnStatistic =
+                        ColumnStatistic.builder()
+                                .setDistinctValuesCount(Math.min(inColumnStatistic.getDistinctValuesCount(),
+                                        otherChildrenList.size()))
+                                .setAverageRowSize(inColumnStatistic.getAverageRowSize())
+                                .setNullsFraction(0)
+                                .build();
+
+                Statistics inStatistics = childOpt.map(operator ->
+                                Statistics.buildFrom(statistics).setOutputRowCount(rowCount).
+                                        addColumnStatistic(operator, newInColumnStatistic).build()).
+                        orElseGet(() -> Statistics.buildFrom(statistics).setOutputRowCount(rowCount).build());
+                return StatisticsEstimateUtils.adjustStatisticsByRowCount(inStatistics, rowCount);
+            }
 
             double columnMaxVal = inColumnStatistic.getMaxValue();
             double columnMinVal = inColumnStatistic.getMinValue();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -112,6 +112,7 @@ public class PredicateStatisticsCalculator {
 
             // using ndv to estimate string col inPredicate
             if (!predicate.isNotIn() && firstChild.getType().getPrimitiveType().isCharFamily()
+                    && firstChild.isColumnRef()
                     && !inColumnStatistic.isUnknown()) {
                 selectivity = Math.min(otherChildrenList.size() / inColumnStatistic.getDistinctValuesCount(), 1);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -1400,7 +1400,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                     BinaryPredicateOperator bop = scalarOperator.cast();
                     if (bop.getBinaryType().isEqualOrRange()
                             && bop.getChild(1).isConstantRef()
-                            && shouldRemove(bop.getChild(0), partitionColNames)) {
+                            && isPartitionCol(bop.getChild(0), partitionColNames)) {
                         // do nothing
                     } else {
                         newPredicates.add(scalarOperator);
@@ -1409,7 +1409,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
                     InPredicateOperator inOp = scalarOperator.cast();
                     if (!inOp.isNotIn()
                             && inOp.getChildren().stream().skip(1).allMatch(ScalarOperator::isConstant)
-                            && shouldRemove(inOp.getChild(0), partitionColNames)) {
+                            && isPartitionCol(inOp.getChild(0), partitionColNames)) {
                         // do nothing
                     } else {
                         newPredicates.add(scalarOperator);
@@ -1421,7 +1421,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
         return predicate;
     }
 
-    private boolean shouldRemove(ScalarOperator scalarOperator, Collection<String> partitionColumns) {
+    private boolean isPartitionCol(ScalarOperator scalarOperator, Collection<String> partitionColumns) {
         if (scalarOperator.isColumnRef()) {
             String colName = ((ColumnRefOperator) scalarOperator).getName();
             return partitionColumns.contains(StringUtils.lowerCase(colName));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProviderTest.java
@@ -63,7 +63,7 @@ public class IcebergStatisticProviderTest extends TableTestBase {
         colRefToColumnMetaMap.put(columnRefOperator1, new Column("id", Type.INT));
         colRefToColumnMetaMap.put(columnRefOperator2, new Column("data", Type.STRING));
 
-        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, null, colRefToColumnMetaMap);
+        Statistics statistics = statisticProvider.getTableStatistics(icebergTable, null, colRefToColumnMetaMap, null);
         Assert.assertEquals(2.0, statistics.getOutputRowCount(), 0.001);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1542,10 +1542,19 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         sql = "select * from t0 left outer join t1 on t0.v1 = t1.v4 and t1.v5 > t0.v2 and t0.v2 > t1.v6" +
                 " and t0.v2 > t1.v4";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "     TABLE: t1\n" +
-                "     PREAGGREasfGATION: ON\n" +
+        assertContains(plan, "TABLE: t1\n" +
+                "     PREAGGREGATION: ON\n" +
                 "     PREDICATES: 5: v5 >= CAST('test_min_v2' AS BIGINT), 6: v6 <= CAST('test_max_v2' AS BIGINT), " +
                 "4: v4 <= CAST('test_max_v2' AS BIGINT)");
 
+        sql = "select * from t0 left outer join t2 on t0.v1 = t2.v7 left outer join t1 on t0.v1 = t1.v4 and " +
+                "t1.v5 > t0.v2 and t0.v2 > t1.v6" +
+                " and t0.v2 > t1.v4";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "TABLE: t1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 8: v5 >= CAST('test_min_v2' AS BIGINT), 9: v6 <= CAST('test_max_v2' AS BIGINT), " +
+                "7: v4 <= CAST('test_max_v2' AS BIGINT)\n" +
+                "     partitions=1/1");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -15,20 +15,29 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.planner.AggregationNode;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.rule.transformation.DeriveRangeJoinPredicateRule;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
     @BeforeClass
@@ -1283,7 +1292,8 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         assertContains(costPlan, "* min-->[-Infinity, Infinity, 0.0, 25.0, 7500000.0] ESTIMATE\n" +
                 "  |  * max-->[-Infinity, Infinity, 0.0, 25.0, 7500000.0] ESTIMATE");
 
-        sql = "select C_CUSTKEY, Min(C_NAME) as min, Max(C_NAME) as max from customer group by C_CUSTKEY having max < '1234'";
+        sql =
+                "select C_CUSTKEY, Min(C_NAME) as min, Max(C_NAME) as max from customer group by C_CUSTKEY having max < '1234'";
         costPlan = getCostExplain(sql);
         assertContains(costPlan, " * min-->[-Infinity, Infinity, 0.0, 25.0, 7500000.0] ESTIMATE\n" +
                 "  |  * max-->[-Infinity, Infinity, 0.0, 25.0, 7500000.0] ESTIMATE");
@@ -1490,5 +1500,52 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 65: cast = 38: v9\n" +
                 "  |  equal join conjunct: 58: S_ADDRESS = 66: coalesce");
+    }
+
+    @Test
+    public void testRnagePredicateJoin() throws Exception {
+        new MockUp<DeriveRangeJoinPredicateRule>() {
+            @Mock
+            public boolean check(OptExpression input, OptimizerContext context) {
+                return true;
+            }
+        };
+
+        new MockUp<MockTpchStatisticStorage>() {
+            @Mock
+            ColumnStatistic getColumnStatistic(Table table, String column) {
+                ColumnStatistic c;
+                c = new ColumnStatistic(1, 2, 3, 4, 5);
+                c.setMaxString("test_max_" + column);
+                c.setMinString("test_min_" + column);
+                return c;
+            }
+
+            @Mock
+            List<ColumnStatistic> getColumnStatistics(Table table, List<String> columns) {
+                return columns.stream().map(column -> getColumnStatistic(table, column)).collect(Collectors.toList());
+            }
+        };
+
+        String sql = "select * from t0 left outer join t1 on t0.v1 = t1.v4 and t1.v5 < t0.v2 and t0.v2 < t1.v6";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "     TABLE: t1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 5: v5 <= CAST('test_max_v2' AS BIGINT), 6: v6 >= CAST('test_min_v2' AS BIGINT)");
+
+        sql = "select * from t0 left outer join t1 on t0.v1 = t1.v4 and t1.v5 > t0.v2 and t0.v2 > t1.v6";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "     TABLE: t1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     PREDICATES: 5: v5 >= CAST('test_min_v2' AS BIGINT), 6: v6 <= CAST('test_max_v2' AS BIGINT)");
+
+        sql = "select * from t0 left outer join t1 on t0.v1 = t1.v4 and t1.v5 > t0.v2 and t0.v2 > t1.v6" +
+                " and t0.v2 > t1.v4";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "     TABLE: t1\n" +
+                "     PREAGGREasfGATION: ON\n" +
+                "     PREDICATES: 5: v5 >= CAST('test_min_v2' AS BIGINT), 6: v6 <= CAST('test_max_v2' AS BIGINT), " +
+                "4: v4 <= CAST('test_max_v2' AS BIGINT)");
+
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -220,15 +220,15 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "join (select * from t1 join t3 on t1.v4 = t3.v10 join t0 on t1.v4 = t0.v2 join t2 on t1.v5 = t2.v8) as a  " +
                 "on t1.v5 = a.v8 ";
         String planFragment = getCostExplain(sql);
-        Assert.assertTrue(planFragment, planFragment.contains("  23:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                "  |  equal join conjunct: [1: v4, BIGINT, true] = [4: v10, BIGINT, true]\n" +
-                "  |  output columns: 7\n" +
-                "  |  cardinality: 900000000\n"));
-
-        Assert.assertTrue(planFragment, planFragment.contains("  18:HASH JOIN\n" +
+        Assert.assertTrue(planFragment, planFragment.contains("22:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  equal join conjunct: [13: v10, BIGINT, true] = [10: v4, BIGINT, true]\n"));
+                "  |  equal join conjunct: [13: v10, BIGINT, true] = [10: v4, BIGINT, true]\n" +
+                "  |  output columns: 7\n" +
+                "  |  cardinality: 56250000"));
+
+        Assert.assertTrue(planFragment, planFragment.contains("15:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
+                "  |  equal join conjunct: [4: v10, BIGINT, true] = [1: v4, BIGINT, true]"));
     }
 
     @Test
@@ -300,58 +300,42 @@ public class MultiJoinReorderTest extends PlanTestBase {
         String planFragment = getFragmentPlan(sql);
 
         // Top join tree
-        assertContains(planFragment, "  28:HASH JOIN\n" +
+        assertContains(planFragment, "3:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 14: v10 = 11: v4\n" +
                 "  |  \n" +
-                "  |----27:EXCHANGE\n" +
+                "  |----2:EXCHANGE\n" +
                 "  |    \n" +
                 "  0:OlapScanNode\n" +
-                "     TABLE: t3\n");
+                "     TABLE: t3");
 
-        // Left sub join tree (b)
-        Assert.assertTrue(planFragment, planFragment.contains("  26:HASH JOIN\n" +
-                "  |  join op: INNER JOIN (BROADCAST)\n" +
+        Assert.assertTrue(planFragment, planFragment.contains("27:Project\n" +
+                "  |  <slot 10> : 10: count\n" +
+                "  |  \n" +
+                "  26:NESTLOOP JOIN\n" +
+                "  |  join op: CROSS JOIN\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 10: count = 12: v5\n" +
                 "  |  \n" +
                 "  |----25:EXCHANGE\n" +
                 "  |    \n" +
-                "  23:Project\n" +
-                "  |  <slot 10> : 10: count\n" +
-                "  |  \n" +
-                "  22:NESTLOOP JOIN\n" +
-                "  |  join op: CROSS JOIN\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  \n" +
-                "  |----21:EXCHANGE\n" +
-                "  |    \n" +
-                "  2:Project\n" +
+                "  6:Project\n" +
                 "  |  <slot 26> : 1\n" +
                 "  |  \n" +
-                "  1:OlapScanNode\n" +
-                "     TABLE: t2\n" +
-                "     PREAGGREGATION: ON\n" +
-                "     partitions=1/1\n" +
-                "     rollup: t2\n" +
-                "     tabletRatio=3/3\n"));
+                "  5:OlapScanNode\n" +
+                "     TABLE: t2"));
 
         // Right sub join tree (a)
-        assertContains(planFragment, "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 21\n" +
-                "    UNPARTITIONED\n" +
-                "\n" +
-                "  20:Project\n" +
+        assertContains(planFragment, "24:Project\n" +
                 "  |  <slot 10> : 10: count\n" +
                 "  |  \n" +
-                "  19:NESTLOOP JOIN\n" +
+                "  23:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
-                "  |----18:EXCHANGE\n" +
+                "  |----22:EXCHANGE\n" +
                 "  |    \n" +
-                "  15:AGGREGATE (merge finalize)");
+                "  19:AGGREGATE (merge finalize)");
     }
 
     @Test
@@ -378,6 +362,8 @@ public class MultiJoinReorderTest extends PlanTestBase {
     @Order(5)
     void testCrossJoinReorderDP() throws Exception {
         connectContext.getSessionVariable().enableDPJoinReorder();
+        connectContext.getSessionVariable().disableGreedyJoinReorder();
+
         String sql = "select * from t1, t2, t3, t0;";
         String planFragment = getCostExplain(sql);
         Assert.assertTrue(planFragment, planFragment.contains("  5:NESTLOOP JOIN\n" +
@@ -395,25 +381,32 @@ public class MultiJoinReorderTest extends PlanTestBase {
     @Order(5)
     void testInnerJoinReorderDP() throws Exception {
         connectContext.getSessionVariable().enableDPJoinReorder();
+        connectContext.getSessionVariable().disableGreedyJoinReorder();
         String sql = "select * from t1 " +
                 "join t3 on t1.v4 = t3.v10 " +
                 "join t0 on t1.v4 = t0.v2 " +
                 "join t2 on t1.v5 = t2.v8 ";
         String planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("  3:OlapScanNode\n" +
+        System.out.println(planFragment);
+        Assert.assertTrue(planFragment.contains("2:OlapScanNode\n" +
                 "     TABLE: t0"));
-        Assert.assertTrue(planFragment.contains("  |----4:EXCHANGE\n" +
-                "  |    \n" +
-                "  2:OlapScanNode\n" +
-                "     TABLE: t1"));
-        Assert.assertTrue(planFragment.contains("  |----6:EXCHANGE\n" +
+        Assert.assertTrue(planFragment.contains("4:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v4 = 8: v2\n" +
+                "  |  \n" +
+                "  |----3:EXCHANGE\n" +
                 "  |    \n" +
                 "  1:OlapScanNode\n" +
+                "     TABLE: t1"));
+        Assert.assertTrue(planFragment.contains("7:OlapScanNode\n" +
                 "     TABLE: t2"));
-        Assert.assertTrue(planFragment.contains("  |----8:EXCHANGE\n" +
+        Assert.assertTrue(planFragment.contains("|----8:EXCHANGE\n" +
                 "  |    \n" +
-                "  0:OlapScanNode\n" +
-                "     TABLE: t3"));
+                "  6:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 4: v10 = 1: v4"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -49,6 +49,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.POSITIVE_INFINITY;
+
 public class PlanFragmentWithCostTest extends PlanTestBase {
     private static final int NUM_TABLE2_ROWS = 10000;
     private static final int NUM_TABLE0_ROWS = 10000;
@@ -68,6 +71,9 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
 
         OlapTable colocateT0 = (OlapTable) globalStateMgr.getDb("test").getTable("colocate_t0");
         setTableStatistics(colocateT0, NUM_TABLE0_ROWS);
+
+        OlapTable lineitem = (OlapTable) globalStateMgr.getDb("test").getTable("lineitem");
+        setTableStatistics(lineitem, NUM_TABLE0_ROWS * NUM_TABLE0_ROWS);
 
         StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.withTable("CREATE TABLE test_mv\n" +
@@ -2274,5 +2280,53 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
         Assert.assertTrue("planMemCosts should be > 1, but: " + event.planMemCosts, event.planMemCosts > 1);
         Assert.assertTrue("planCpuCosts should be > 1, but: " + event.planCpuCosts, event.planCpuCosts > 1);
 
+    }
+
+    @Test
+    public void testStringInPredicateEstimate(
+            @Mocked MockTpchStatisticStorage mockedStatisticStorage) throws Exception {
+        new Expectations() {
+            {
+                mockedStatisticStorage.getColumnStatistics((Table) any,
+                        Lists.newArrayList("t1a", (String) any, (String) any, (String) any));
+                result = Lists.newArrayList(new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY,
+                        0.0, 10, 3),
+                        new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY,
+                                0.0, 10, 3, null,
+                                ColumnStatistic.StatisticType.UNKNOWN),
+                        new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY,
+                                0.0, 10, 3, null,
+                                ColumnStatistic.StatisticType.UNKNOWN),
+                        new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY,
+                                0.0, 10, 3, null,
+                                ColumnStatistic.StatisticType.UNKNOWN));
+            }
+        };
+
+        String sql = "SELECT t1a from test_all_type where t1a in ('a', 'b', 'c');";
+        String plan = getCostExplain(sql);
+        assertContains(plan, "cardinality: 10000");
+
+        sql = "SELECT t1a from test_all_type where t1a not in ('a', 'b', 'c');";
+        plan = getCostExplain(sql);
+        assertContains(plan, "cardinality: 1");
+
+        sql = "SELECT t1a from test_all_type where t1a  in ('a', 'b', 'c', 'd', 'e');";
+        plan = getCostExplain(sql);
+        assertContains(plan, "cardinality: 10000");
+
+        sql = "SELECT t1a from test_all_type where t1a != 'a' and  t1a != 'a';";
+        plan = getCostExplain(sql);
+        assertContains(plan, "cardinality: 6667");
+
+        sql = "SELECT t1.L_PARTKEY from lineitem t1 join nation t2 on t1.L_PARTKEY = t2.N_NATIONKEY " +
+                "and t1.L_SUPPKEY = t2.N_NATIONKEY;";
+        plan = getCostExplain(sql);
+        assertContains(plan, "cardinality: 6250000");
+
+        sql = "SELECT t1.L_PARTKEY from lineitem t1 left join nation t2 on t1.L_PARTKEY = t2.N_NATIONKEY " +
+                "and t1.L_SUPPKEY = t2.N_NATIONKEY;";
+        plan = getCostExplain(sql);
+        assertContains(plan, "cardinality: 100000000");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -2309,7 +2309,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
 
         sql = "SELECT t1a from test_all_type where t1a not in ('a', 'b', 'c');";
         plan = getCostExplain(sql);
-        assertContains(plan, "cardinality: 1");
+        assertContains(plan, "cardinality: 5000");
 
         sql = "SELECT t1a from test_all_type where t1a  in ('a', 'b', 'c', 'd', 'e');";
         plan = getCostExplain(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -326,7 +326,8 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/multi_count_distinct"), null, TExplainLevel.NORMAL);
         String plan = replayPair.second;
-        Assert.assertTrue(plan, plan.contains("34:AGGREGATE (update finalize)\n" +
+        Assert.assertTrue(plan, plan.contains("33:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
                 "  |  output: multi_distinct_count(6: order_id), multi_distinct_count(11: delivery_phone)," +
                 " multi_distinct_count(128: case), max(103: count)\n" +
                 "  |  group by: 40: city, 116: division_en, 104: department, 106: category, 126: concat, " +
@@ -634,7 +635,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/hive_tpch02_catalog"), null,
                         TExplainLevel.NORMAL);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("5:HASH JOIN\n" +
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("19:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 17: ps_partkey = 1: p_partkey"));

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q18.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q18.sql
@@ -34,14 +34,15 @@ order by
 [result]
 TOP-N (order by [[12: o_totalprice DESC NULLS LAST, 13: o_orderdate ASC NULLS FIRST]])
     TOP-N (order by [[12: o_totalprice DESC NULLS LAST, 13: o_orderdate ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{52: sum=sum(22: l_quantity)}] group by [[2: c_name, 1: c_custkey, 9: o_orderkey, 13: o_orderdate, 12: o_totalprice]] having [null]
-            LEFT SEMI JOIN (join-predicate [9: o_orderkey = 34: l_orderkey] post-join-predicate [null])
-                EXCHANGE SHUFFLE[9]
-                    SCAN (mv[lineitem_mv] columns[62: c_name, 68: l_orderkey, 70: l_quantity, 77: o_custkey, 78: o_orderdate, 82: o_totalprice] predicate[null])
-                EXCHANGE SHUFFLE[34]
-                    AGGREGATE ([GLOBAL] aggregate [{155: sum=sum(155: sum)}] group by [[108: l_orderkey]] having [155: sum > 315.00]
-                        EXCHANGE SHUFFLE[108]
-                            AGGREGATE ([LOCAL] aggregate [{155: sum=sum(112: sum_qty)}] group by [[108: l_orderkey]] having [null]
-                                SCAN (mv[lineitem_agg_mv1] columns[108: l_orderkey, 112: sum_qty] predicate[null])
+        AGGREGATE ([GLOBAL] aggregate [{52: sum=sum(52: sum)}] group by [[2: c_name, 1: c_custkey, 9: o_orderkey, 13: o_orderdate, 12: o_totalprice]] having [null]
+            EXCHANGE SHUFFLE[2, 1, 9, 13, 12]
+                AGGREGATE ([LOCAL] aggregate [{52: sum=sum(22: l_quantity)}] group by [[2: c_name, 1: c_custkey, 9: o_orderkey, 13: o_orderdate, 12: o_totalprice]] having [null]
+                    LEFT SEMI JOIN (join-predicate [9: o_orderkey = 34: l_orderkey] post-join-predicate [null])
+                        SCAN (mv[lineitem_mv] columns[99: c_name, 105: l_orderkey, 107: l_quantity, 114: o_custkey, 115: o_orderdate, 119: o_totalprice] predicate[null])
+                        EXCHANGE BROADCAST
+                            AGGREGATE ([GLOBAL] aggregate [{155: sum=sum(155: sum)}] group by [[56: l_orderkey]] having [155: sum > 315.00]
+                                EXCHANGE SHUFFLE[56]
+                                    AGGREGATE ([LOCAL] aggregate [{155: sum=sum(60: sum_qty)}] group by [[56: l_orderkey]] having [null]
+                                        SCAN (mv[lineitem_agg_mv1] columns[56: l_orderkey, 60: sum_qty] predicate[null])
 [end]
 


### PR DESCRIPTION
Fixes #issue

## Main work:
- support push down predicate generated from range join on condition to its children.
- support collect ndv info from iceberg ndv metadata.
- optimize join statistics calculation process

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
