### PR TITLE
[BugFix] Fix the issue of scan range allocation when reading paimon table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -141,6 +141,7 @@ public class PaimonScanNode extends ScanNode {
         hdfsScanRange.setPaimon_predicate_info(predicateInfo);
         long totalFileLength = getTotalFileLength(split);
         hdfsScanRange.setFile_length(totalFileLength);
+        hdfsScanRange.setLength(totalFileLength);
 
         TScanRange scanRange = new TScanRange();
         scanRange.setHdfs_scan_range(hdfsScanRange);
@@ -153,8 +154,7 @@ public class PaimonScanNode extends ScanNode {
     }
 
     long getTotalFileLength(DataSplit split) {
-        long totalFileLength = split.dataFiles().stream().map(DataFileMeta::fileSize).reduce(0L, Long::sum);
-        return totalFileLength;
+        return split.dataFiles().stream().map(DataFileMeta::fileSize).reduce(0L, Long::sum);
     }
 
     private long nextPartitionId() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -173,7 +173,7 @@ public class HDFSBackendSelector implements BackendSelector {
             }
         }
         if (node == null) {
-            Random rand = new Random();
+            Random rand = new Random(System.currentTimeMillis());
             int i = rand.nextInt(backends.size());
             node = backends.get(i);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -53,6 +53,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 
 /**
@@ -172,7 +173,9 @@ public class HDFSBackendSelector implements BackendSelector {
             }
         }
         if (node == null) {
-            node = backends.get(0);
+            Random rand = new Random();
+            int i = rand.nextInt(backends.size());
+            node = backends.get(i);
         }
         return node;
     }


### PR DESCRIPTION
Fixed the issue that all scan ranges are assigned to the first backend when reading the paimon table due to missing `length` info in paimon scan range

- set `length` value in paimon scan range
- provide a random backend instead of the 1st backend when `HDFSBackendSelector` can not find a suitable backend.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
