### PR TITLE
[Refactor] lake::{Async}DeltaWriter creation using Builder pattern

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -441,19 +441,19 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
             // already created for the tablet, usually in incremental open case
             continue;
         }
-        std::unique_ptr<AsyncDeltaWriter> writer;
-        if (params.miss_auto_increment_column()) {
-            writer = AsyncDeltaWriter::create(_tablet_manager, tablet.tablet_id(), _txn_id, tablet.partition_id(),
-                                              slots, params.merge_condition(), true, params.table_id(),
-                                              params.min_immutable_tablet_size(), _mem_tracker);
-        } else if (!params.merge_condition().empty()) {
-            writer = AsyncDeltaWriter::create(_tablet_manager, tablet.tablet_id(), _txn_id, tablet.partition_id(),
-                                              slots, params.merge_condition(), params.min_immutable_tablet_size(),
-                                              _mem_tracker);
-        } else {
-            writer = AsyncDeltaWriter::create(_tablet_manager, tablet.tablet_id(), _txn_id, tablet.partition_id(),
-                                              slots, params.min_immutable_tablet_size(), _mem_tracker);
-        }
+        std::unique_ptr<AsyncDeltaWriter> writer =
+                lake::AsyncDeltaWriterBuilder()
+                        .set_tablet_manager(_tablet_manager)
+                        .set_tablet_id(tablet.tablet_id())
+                        .set_txn_id(_txn_id)
+                        .set_partition_id(tablet.partition_id())
+                        .set_slot_descriptors(slots)
+                        .set_merge_condition(params.merge_condition())
+                        .set_miss_auto_increment_column(params.miss_auto_increment_column())
+                        .set_table_id(params.table_id())
+                        .set_immutable_tablet_size(params.min_immutable_tablet_size())
+                        .set_mem_tracker(_mem_tracker)
+                        .build();
         _delta_writers.emplace(tablet.tablet_id(), std::move(writer));
         tablet_ids.emplace_back(tablet.tablet_id());
     }

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -40,38 +40,23 @@ public:
     constexpr static uint64_t kInvalidQueueId = (uint64_t)-1;
 
     AsyncDeltaWriterImpl(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
-                         const std::vector<SlotDescriptor*>* slots, int64_t immutable_tablet_size,
-                         MemTracker* mem_tracker)
-            : _writer(DeltaWriter::create(tablet_manager, tablet_id, txn_id, partition_id, slots, immutable_tablet_size,
-                                          mem_tracker)),
-              _queue_id{kInvalidQueueId},
-              _mtx(),
-              _status(),
-              _opened(false),
-              _closed(false) {}
-
-    AsyncDeltaWriterImpl(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
-                         const std::vector<SlotDescriptor*>* slots, const std::string& merge_condition,
-                         int64_t immutable_tablet_size, MemTracker* mem_tracker)
-            : _writer(DeltaWriter::create(tablet_manager, tablet_id, txn_id, partition_id, slots, merge_condition,
-                                          immutable_tablet_size, mem_tracker)),
-              _queue_id{kInvalidQueueId},
-              _mtx(),
-              _status(),
-              _opened(false),
-              _closed(false) {}
-
-    AsyncDeltaWriterImpl(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
                          const std::vector<SlotDescriptor*>* slots, const std::string& merge_condition,
                          bool miss_auto_increment_column, int64_t table_id, int64_t immutable_tablet_size,
                          MemTracker* mem_tracker)
-            : _writer(DeltaWriter::create(tablet_manager, tablet_id, txn_id, partition_id, slots, merge_condition,
-                                          miss_auto_increment_column, table_id, immutable_tablet_size, mem_tracker)),
-              _queue_id{kInvalidQueueId},
-              _mtx(),
-              _status(),
-              _opened(false),
-              _closed(false) {}
+            : _queue_id{kInvalidQueueId}, _mtx(), _status(), _opened(false), _closed(false) {
+        _writer = DeltaWriterBuilder()
+                          .set_tablet_manager(tablet_manager)
+                          .set_tablet_id(tablet_id)
+                          .set_txn_id(txn_id)
+                          .set_partition_id(partition_id)
+                          .set_slot_descriptors(slots)
+                          .set_merge_condition(merge_condition)
+                          .set_miss_auto_increment_column(miss_auto_increment_column)
+                          .set_table_id(table_id)
+                          .set_immutable_tablet_size(immutable_tablet_size)
+                          .set_mem_tracker(mem_tracker)
+                          .build();
+    }
 
     ~AsyncDeltaWriterImpl();
 
@@ -110,7 +95,7 @@ private:
     Status do_open();
     bool closed();
 
-    DeltaWriter::Ptr _writer;
+    std::unique_ptr<DeltaWriter> _writer;
     bthread::ExecutionQueueId<Task> _queue_id;
     StackTraceMutex<bthread::Mutex> _mtx;
     // _status、_opened and _closed are protected by _mtx
@@ -290,34 +275,11 @@ Status AsyncDeltaWriter::check_immutable() {
     return _impl->check_immutable();
 }
 
-std::unique_ptr<AsyncDeltaWriter> AsyncDeltaWriter::create(TabletManager* tablet_manager, int64_t tablet_id,
-                                                           int64_t txn_id, int64_t partition_id,
-                                                           const std::vector<SlotDescriptor*>* slots,
-                                                           int64_t immutable_tablet_size, MemTracker* mem_tracker) {
-    auto impl = new AsyncDeltaWriterImpl(tablet_manager, tablet_id, txn_id, partition_id, slots, immutable_tablet_size,
-                                         mem_tracker);
-    return std::make_unique<AsyncDeltaWriter>(impl);
-}
-
-std::unique_ptr<AsyncDeltaWriter> AsyncDeltaWriter::create(TabletManager* tablet_manager, int64_t tablet_id,
-                                                           int64_t txn_id, int64_t partition_id,
-                                                           const std::vector<SlotDescriptor*>* slots,
-                                                           const std::string& merge_condition,
-                                                           int64_t immutable_tablet_size, MemTracker* mem_tracker) {
-    auto impl = new AsyncDeltaWriterImpl(tablet_manager, tablet_id, txn_id, partition_id, slots, merge_condition,
-                                         immutable_tablet_size, mem_tracker);
-    return std::make_unique<AsyncDeltaWriter>(impl);
-}
-
-std::unique_ptr<AsyncDeltaWriter> AsyncDeltaWriter::create(TabletManager* tablet_manager, int64_t tablet_id,
-                                                           int64_t txn_id, int64_t partition_id,
-                                                           const std::vector<SlotDescriptor*>* slots,
-                                                           const std::string& merge_condition,
-                                                           bool miss_auto_increment_column, int64_t table_id,
-                                                           int64_t immutable_tablet_size, MemTracker* mem_tracker) {
-    auto impl = new AsyncDeltaWriterImpl(tablet_manager, tablet_id, txn_id, partition_id, slots, merge_condition,
-                                         miss_auto_increment_column, table_id, immutable_tablet_size, mem_tracker);
-    return std::make_unique<AsyncDeltaWriter>(impl);
-}
+AsyncDeltaWriter::AsyncDeltaWriter(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id,
+                                   int64_t partition_id, const std::vector<SlotDescriptor*>* slots,
+                                   const std::string& merge_condition, bool miss_auto_increment_column,
+                                   int64_t table_id, int64_t immutable_tablet_size, MemTracker* mem_tracker)
+        : _impl(new AsyncDeltaWriterImpl(tablet_manager, tablet_id, txn_id, partition_id, slots, merge_condition,
+                                         miss_auto_increment_column, table_id, immutable_tablet_size, mem_tracker)) {}
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -42,8 +42,7 @@ public:
     AsyncDeltaWriterImpl(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
                          const std::vector<SlotDescriptor*>* slots, const std::string& merge_condition,
                          bool miss_auto_increment_column, int64_t table_id, int64_t immutable_tablet_size,
-                         MemTracker* mem_tracker)
-            : _queue_id{kInvalidQueueId}, _mtx(), _status(), _opened(false), _closed(false) {
+                         MemTracker* mem_tracker) {
         _writer = DeltaWriterBuilder()
                           .set_tablet_manager(tablet_manager)
                           .set_tablet_id(tablet_id)
@@ -95,13 +94,13 @@ private:
     Status do_open();
     bool closed();
 
-    std::unique_ptr<DeltaWriter> _writer;
-    bthread::ExecutionQueueId<Task> _queue_id;
-    StackTraceMutex<bthread::Mutex> _mtx;
+    std::unique_ptr<DeltaWriter> _writer{};
+    bthread::ExecutionQueueId<Task> _queue_id{kInvalidQueueId};
+    StackTraceMutex<bthread::Mutex> _mtx{};
     // _status、_opened and _closed are protected by _mtx
-    Status _status;
-    bool _opened;
-    bool _closed;
+    Status _status{};
+    bool _opened{false};
+    bool _closed{false};
 };
 
 AsyncDeltaWriterImpl::~AsyncDeltaWriterImpl() {

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -39,27 +39,11 @@ class TabletManager;
 // AsyncDeltaWriter is a wrapper on DeltaWriter to support non-blocking async write.
 // All submitted tasks will be executed in the FIFO order.
 class AsyncDeltaWriter {
-    using Chunk = starrocks::Chunk;
+    friend class AsyncDeltaWriterBuilder;
 
 public:
     using Ptr = std::unique_ptr<AsyncDeltaWriter>;
     using Callback = std::function<void(Status st)>;
-
-    // |tablet_manager|、|slots| and |mem_tracker| must outlive the AsyncDeltaWriter
-    static Ptr create(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
-                      const std::vector<SlotDescriptor*>* slots, int64_t immutable_tablet_size,
-                      MemTracker* mem_tracker);
-
-    // |tablet_manager|、|slots| and |mem_tracker| must outlive the AsyncDeltaWriter
-    static Ptr create(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
-                      const std::vector<SlotDescriptor*>* slots, const std::string& merge_condition,
-                      int64_t immutable_tablet_size, MemTracker* mem_tracker);
-
-    // |tablet_manager|、|slots| and |mem_tracker| must outlive the AsyncDeltaWriter
-    static Ptr create(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
-                      const std::vector<SlotDescriptor*>* slots, const std::string& merge_condition,
-                      bool miss_auto_increment_column, int64_t table_id, int64_t immutable_tablet_size,
-                      MemTracker* mem_tracker);
 
     explicit AsyncDeltaWriter(AsyncDeltaWriterImpl* impl) : _impl(impl) {}
 
@@ -112,7 +96,90 @@ public:
     [[nodiscard]] Status check_immutable();
 
 private:
+    // |tablet_manager|、|slots| and |mem_tracker| must outlive the AsyncDeltaWriter
+    AsyncDeltaWriter(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
+                     const std::vector<SlotDescriptor*>* slots, const std::string& merge_condition,
+                     bool miss_auto_increment_column, int64_t table_id, int64_t immutable_tablet_size,
+                     MemTracker* mem_tracker);
+
     AsyncDeltaWriterImpl* _impl;
+};
+
+class AsyncDeltaWriterBuilder {
+public:
+    AsyncDeltaWriterBuilder() = default;
+
+    ~AsyncDeltaWriterBuilder() = default;
+
+    DISALLOW_COPY_AND_MOVE(AsyncDeltaWriterBuilder);
+
+    AsyncDeltaWriterBuilder& set_tablet_manager(TabletManager* tablet_mgr) {
+        _tablet_mgr = tablet_mgr;
+        return *this;
+    }
+
+    AsyncDeltaWriterBuilder& set_tablet_id(int64_t tablet_id) {
+        _tablet_id = tablet_id;
+        return *this;
+    }
+
+    AsyncDeltaWriterBuilder& set_txn_id(int64_t txn_id) {
+        _txn_id = txn_id;
+        return *this;
+    }
+
+    AsyncDeltaWriterBuilder& set_table_id(int64_t table_id) {
+        _table_id = table_id;
+        return *this;
+    }
+
+    AsyncDeltaWriterBuilder& set_partition_id(int64_t partition_id) {
+        _partition_id = partition_id;
+        return *this;
+    }
+
+    AsyncDeltaWriterBuilder& set_slot_descriptors(const std::vector<SlotDescriptor*>* slots) {
+        _slots = slots;
+        return *this;
+    }
+
+    AsyncDeltaWriterBuilder& set_immutable_tablet_size(int64_t immutable_tablet_size) {
+        _immutable_tablet_size = immutable_tablet_size;
+        return *this;
+    }
+
+    AsyncDeltaWriterBuilder& set_mem_tracker(MemTracker* mem_tracker) {
+        _mem_tracker = mem_tracker;
+        return *this;
+    }
+
+    AsyncDeltaWriterBuilder& set_miss_auto_increment_column(bool miss_auto_increment_column) {
+        _miss_auto_increment_column = miss_auto_increment_column;
+        return *this;
+    }
+
+    AsyncDeltaWriterBuilder& set_merge_condition(std::string merge_condition) {
+        _merge_condition = std::move(merge_condition);
+        return *this;
+    }
+
+    std::unique_ptr<AsyncDeltaWriter> build() {
+        return std::unique_ptr<AsyncDeltaWriter>(
+                new AsyncDeltaWriter(_tablet_mgr, _tablet_id, _txn_id, _partition_id, _slots, _merge_condition,
+                                     _miss_auto_increment_column, _table_id, _immutable_tablet_size, _mem_tracker));
+    }
+
+private:
+    TabletManager* _tablet_mgr = nullptr;
+    int64_t _txn_id = 0;
+    int64_t _table_id;
+    int64_t _partition_id = 0;
+    int64_t _tablet_id = 0;
+    const std::vector<SlotDescriptor*>* _slots = nullptr;
+    int64_t _immutable_tablet_size = 0;
+    MemTracker* _mem_tracker = nullptr;
+    std::string _merge_condition;
+    bool _miss_auto_increment_column = false;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -170,16 +170,16 @@ public:
     }
 
 private:
-    TabletManager* _tablet_mgr = nullptr;
-    int64_t _txn_id = 0;
-    int64_t _table_id;
-    int64_t _partition_id = 0;
-    int64_t _tablet_id = 0;
-    const std::vector<SlotDescriptor*>* _slots = nullptr;
-    int64_t _immutable_tablet_size = 0;
-    MemTracker* _mem_tracker = nullptr;
-    std::string _merge_condition;
-    bool _miss_auto_increment_column = false;
+    TabletManager* _tablet_mgr{nullptr};
+    int64_t _txn_id{0};
+    int64_t _table_id{0};
+    int64_t _partition_id{0};
+    int64_t _tablet_id{0};
+    const std::vector<SlotDescriptor*>* _slots{nullptr};
+    int64_t _immutable_tablet_size{0};
+    MemTracker* _mem_tracker{nullptr};
+    std::string _merge_condition{};
+    bool _miss_auto_increment_column{false};
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -82,7 +82,6 @@ public:
               _mem_tracker(mem_tracker),
               _slots(slots),
               _max_buffer_size(max_buffer_size > 0 ? max_buffer_size : config::write_buffer_size),
-              _schema_initialized(false),
               _immutable_tablet_size(immutable_tablet_size),
               _merge_condition(std::move(merge_condition)),
               _miss_auto_increment_column(miss_auto_increment_column),
@@ -154,7 +153,7 @@ private:
     std::unique_ptr<FlushToken> _flush_token;
     std::shared_ptr<const TabletSchema> _tablet_schema;
     Schema _vectorized_schema;
-    bool _schema_initialized;
+    bool _schema_initialized{false};
 
     // for automatic bucket
     int64_t _immutable_tablet_size = 0;

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -35,39 +35,13 @@ class TabletManager;
 class TabletWriter;
 
 class DeltaWriter {
-    using Chunk = starrocks::Chunk;
+    friend class DeltaWriterBuilder;
 
 public:
-    using Ptr = std::unique_ptr<DeltaWriter>;
-
     enum FinishMode {
         kWriteTxnLog,
         kDontWriteTxnLog,
     };
-
-    // for load
-    // Does NOT take the ownership of |tablet_manager|、|slots| and |mem_tracker|
-    static Ptr create(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
-                      const std::vector<SlotDescriptor*>* slots, int64_t immutable_tablet_size,
-                      MemTracker* mem_tracker);
-
-    // for condition update
-    // Does NOT take the ownership of |tablet_manager|、|slots| and |mem_tracker|
-    static Ptr create(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
-                      const std::vector<SlotDescriptor*>* slots, const std::string& merge_condition,
-                      int64_t immutable_tablet_size, MemTracker* mem_tracker);
-
-    // for auto increment
-    // Does NOT take the ownership of |tablet_manager|、|slots| and |mem_tracker|
-    static Ptr create(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
-                      const std::vector<SlotDescriptor*>* slots, const std::string& merge_condition,
-                      bool miss_auto_increment_column, int64_t table_id, int64_t immutable_tablet_size,
-                      MemTracker* mem_tracker);
-
-    // for schema change
-    // Does NOT take the ownership of |tablet_manager| and |mem_tracker|
-    static Ptr create(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t max_buffer_size,
-                      int64_t immutable_tablet_size, MemTracker* mem_tracker);
 
     // Return the thread pool used for performing write IO.
     static ThreadPool* io_threads();
@@ -128,7 +102,94 @@ public:
     void TEST_set_miss_auto_increment_column();
 
 private:
+    DeltaWriter(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
+                const std::vector<SlotDescriptor*>* slots, const std::string& merge_condition,
+                bool miss_auto_increment_column, int64_t table_id, int64_t immutable_tablet_size,
+                MemTracker* mem_tracker, int64_t max_buffer_size);
+
     DeltaWriterImpl* _impl;
+};
+
+class DeltaWriterBuilder {
+public:
+    DeltaWriterBuilder() = default;
+    ~DeltaWriterBuilder() = default;
+
+    DISALLOW_COPY_AND_MOVE(DeltaWriterBuilder);
+
+    DeltaWriterBuilder& set_tablet_manager(TabletManager* tablet_mgr) {
+        _tablet_mgr = tablet_mgr;
+        return *this;
+    }
+
+    DeltaWriterBuilder& set_txn_id(int64_t txn_id) {
+        _txn_id = txn_id;
+        return *this;
+    }
+
+    DeltaWriterBuilder& set_table_id(int64_t table_id) {
+        _table_id = table_id;
+        return *this;
+    }
+
+    DeltaWriterBuilder& set_partition_id(int64_t partition_id) {
+        _partition_id = partition_id;
+        return *this;
+    }
+
+    DeltaWriterBuilder& set_tablet_id(int64_t tablet_id) {
+        _tablet_id = tablet_id;
+        return *this;
+    }
+
+    DeltaWriterBuilder& set_slot_descriptors(const std::vector<SlotDescriptor*>* slots) {
+        _slots = slots;
+        return *this;
+    }
+
+    DeltaWriterBuilder& set_merge_condition(std::string merge_condition) {
+        _merge_condition = std::move(merge_condition);
+        return *this;
+    }
+
+    DeltaWriterBuilder& set_immutable_tablet_size(int64_t immutable_tablet_size) {
+        _immutable_tablet_size = immutable_tablet_size;
+        return *this;
+    }
+
+    DeltaWriterBuilder& set_mem_tracker(MemTracker* mem_tracker) {
+        _mem_tracker = mem_tracker;
+        return *this;
+    }
+
+    DeltaWriterBuilder& set_miss_auto_increment_column(bool miss_auto_increment_column) {
+        _miss_auto_increment_column = miss_auto_increment_column;
+        return *this;
+    }
+
+    DeltaWriterBuilder& set_max_buffer_size(int64_t max_buffer_size) {
+        _max_buffer_size = max_buffer_size;
+        return *this;
+    }
+
+    std::unique_ptr<DeltaWriter> build() {
+        return std::unique_ptr<DeltaWriter>(new DeltaWriter(_tablet_mgr, _tablet_id, _txn_id, _partition_id, _slots,
+                                                            _merge_condition, _miss_auto_increment_column, _table_id,
+                                                            _immutable_tablet_size, _mem_tracker, _max_buffer_size));
+    }
+
+private:
+    TabletManager* _tablet_mgr = nullptr;
+    int64_t _txn_id = 0;
+    int64_t _table_id = 0;
+    int64_t _partition_id = 0;
+    int64_t _tablet_id = 0;
+    const std::vector<SlotDescriptor*>* _slots = nullptr;
+    std::string _merge_condition;
+    int64_t _immutable_tablet_size = 0;
+    MemTracker* _mem_tracker = nullptr;
+    int64_t _max_buffer_size = 0;
+    bool _miss_auto_increment_column = false;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -179,17 +179,17 @@ public:
     }
 
 private:
-    TabletManager* _tablet_mgr = nullptr;
-    int64_t _txn_id = 0;
-    int64_t _table_id = 0;
-    int64_t _partition_id = 0;
-    int64_t _tablet_id = 0;
-    const std::vector<SlotDescriptor*>* _slots = nullptr;
-    std::string _merge_condition;
-    int64_t _immutable_tablet_size = 0;
-    MemTracker* _mem_tracker = nullptr;
-    int64_t _max_buffer_size = 0;
-    bool _miss_auto_increment_column = false;
+    TabletManager* _tablet_mgr{nullptr};
+    int64_t _txn_id{0};
+    int64_t _table_id{0};
+    int64_t _partition_id{0};
+    int64_t _tablet_id{0};
+    const std::vector<SlotDescriptor*>* _slots{nullptr};
+    std::string _merge_condition{};
+    int64_t _immutable_tablet_size{0};
+    MemTracker* _mem_tracker{nullptr};
+    int64_t _max_buffer_size{0};
+    bool _miss_auto_increment_column{false};
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -224,8 +224,13 @@ Status SortedSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_
     RETURN_IF_ERROR(reader->open(_read_params));
 
     // create writer
-    auto writer = DeltaWriter::create(_tablet_manager, _new_tablet->id(), _txn_id, _max_buffer_size, 0,
-                                      CurrentThread::mem_tracker());
+    auto writer = DeltaWriterBuilder()
+                          .set_tablet_manager(_tablet_manager)
+                          .set_tablet_id(_new_tablet->id())
+                          .set_txn_id(_txn_id)
+                          .set_max_buffer_size(_max_buffer_size)
+                          .set_mem_tracker(CurrentThread::mem_tracker())
+                          .build();
     RETURN_IF_ERROR(writer->open());
     DeferOp defer([&]() { writer->close(); });
 

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -120,8 +120,13 @@ TEST_F(LakeAsyncDeltaWriterTest, test_open) {
     {
         auto txn_id = next_id();
         auto tablet_id = -1;
-        auto delta_writer = AsyncDeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                     _mem_tracker.get());
+        auto delta_writer = AsyncDeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         delta_writer->close();
     }
@@ -129,8 +134,13 @@ TEST_F(LakeAsyncDeltaWriterTest, test_open) {
     {
         auto txn_id = next_id();
         auto tablet_id = _tablet_metadata->id();
-        auto delta_writer = AsyncDeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                     _mem_tracker.get());
+        auto delta_writer = AsyncDeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->open());
@@ -140,8 +150,13 @@ TEST_F(LakeAsyncDeltaWriterTest, test_open) {
     {
         auto txn_id = next_id();
         auto tablet_id = _tablet_metadata->id();
-        auto delta_writer = AsyncDeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                     _mem_tracker.get());
+        auto delta_writer = AsyncDeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         auto t1 = std::thread([&]() {
             for (int i = 0; i < 10000; i++) {
                 ASSERT_OK(delta_writer->open());
@@ -170,8 +185,13 @@ TEST_F(LakeAsyncDeltaWriterTest, test_write) {
     // Create and open DeltaWriter
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = AsyncDeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                 _mem_tracker.get());
+    auto delta_writer = AsyncDeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
     // Call open() again
     ASSERT_OK(delta_writer->open());
@@ -248,8 +268,13 @@ TEST_F(LakeAsyncDeltaWriterTest, test_write_concurrently) {
     // Create and open DeltaWriter
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = AsyncDeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                 _mem_tracker.get());
+    auto delta_writer = AsyncDeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
 
     ASSERT_OK(delta_writer->open());
 
@@ -344,8 +369,13 @@ TEST_F(LakeAsyncDeltaWriterTest, test_write_after_close) {
     // Create and open DeltaWriter
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = AsyncDeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                 _mem_tracker.get());
+    auto delta_writer = AsyncDeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
 
     // close()
@@ -374,8 +404,13 @@ TEST_F(LakeAsyncDeltaWriterTest, test_finish_after_close) {
     // Create and open DeltaWriter
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = AsyncDeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                 _mem_tracker.get());
+    auto delta_writer = AsyncDeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
 
     // close()
@@ -394,8 +429,13 @@ TEST_F(LakeAsyncDeltaWriterTest, test_close) {
     {
         auto txn_id = next_id();
         auto tablet_id = _tablet_metadata->id();
-        auto delta_writer = AsyncDeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                     _mem_tracker.get());
+        auto delta_writer = AsyncDeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
 
         delta_writer->close();
@@ -405,8 +445,13 @@ TEST_F(LakeAsyncDeltaWriterTest, test_close) {
     {
         auto txn_id = next_id();
         auto tablet_id = _tablet_metadata->id();
-        auto delta_writer = AsyncDeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                     _mem_tracker.get());
+        auto delta_writer = AsyncDeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         auto t1 = std::thread([&]() {
             for (int i = 0; i < 10000; i++) {
@@ -426,8 +471,13 @@ TEST_F(LakeAsyncDeltaWriterTest, test_close) {
 TEST_F(LakeAsyncDeltaWriterTest, test_open_after_close) {
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = AsyncDeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                 _mem_tracker.get());
+    auto delta_writer = AsyncDeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
     delta_writer->close();
     auto st = delta_writer->open();
@@ -451,8 +501,13 @@ TEST_F(LakeAsyncDeltaWriterTest, test_concurrent_write_and_close) {
     // Create and open DeltaWriter
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = AsyncDeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                 _mem_tracker.get());
+    auto delta_writer = AsyncDeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
 
     auto tid = std::this_thread::get_id();

--- a/be/test/storage/lake/auto_increment_partial_update_test.cpp
+++ b/be/test/storage/lake/auto_increment_partial_update_test.cpp
@@ -185,8 +185,13 @@ TEST_F(AutoIncrementPartialUpdateTest, test_write) {
     // normal write
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -202,8 +207,13 @@ TEST_F(AutoIncrementPartialUpdateTest, test_write) {
     // partial update with normal column and auto increment column
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         delta_writer->TEST_set_partial_update(_partial_tablet_schema, _referenced_column_ids);
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -236,8 +246,13 @@ TEST_F(AutoIncrementPartialUpdateTest, test_resolve_conflict) {
     // normal write
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -255,8 +270,13 @@ TEST_F(AutoIncrementPartialUpdateTest, test_resolve_conflict) {
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
         txn_ids.push_back(txn_id);
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         delta_writer->TEST_set_partial_update(_partial_tablet_schema, _referenced_column_ids);
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -162,8 +162,13 @@ TEST_P(LakeDuplicateKeyCompactionTest, test1) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -320,8 +325,13 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         for (int j = 0; j < i + 1; ++j) {
             ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
@@ -495,8 +505,13 @@ TEST_P(LakeUniqueKeyCompactionTest, test1) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -637,8 +652,13 @@ TEST_P(LakeUniqueKeyCompactionWithDeleteTest, test_base_compaction_with_delete) 
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -179,8 +179,13 @@ TEST_P(ConditionUpdateTest, test_condition_update) {
     // normal write
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -206,8 +211,14 @@ TEST_P(ConditionUpdateTest, test_condition_update) {
     result[3] = std::make_pair(5, 6);
     for (int i = 0; i < 4; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, "c1", 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .set_merge_condition("c1")
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunks[i], indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -238,8 +249,13 @@ TEST_P(ConditionUpdateTest, test_condition_update_multi_segment) {
     // normal write
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -259,8 +275,14 @@ TEST_P(ConditionUpdateTest, test_condition_update_multi_segment) {
     config::write_buffer_size = 1;
     for (int i = 0; i < 2; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, "c1", 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .set_merge_condition("c1")
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(i == 0 ? chunk1 : chunk2, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -292,8 +314,14 @@ TEST_P(ConditionUpdateTest, test_condition_update_in_memtable) {
     auto version = 1;
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, "c1", 0,
-                                            _mem_tracker.get());
+    auto delta_writer = DeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .set_merge_condition("c1")
+                                .build();
     ASSERT_OK(delta_writer->open());
     // finish condition merge in one memtable
     ASSERT_OK(delta_writer->write(chunks[0], indexes.data(), indexes.size()));

--- a/be/test/storage/lake/delta_writer_test.cpp
+++ b/be/test/storage/lake/delta_writer_test.cpp
@@ -120,8 +120,13 @@ TEST_F(LakeDeltaWriterTest, test_open) {
     {
         auto txn_id = next_id();
         auto tablet_id = -1;
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         delta_writer->close();
     }
@@ -139,8 +144,13 @@ TEST_F(LakeDeltaWriterTest, test_write) {
     // Create and open DeltaWriter
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer =
-            DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0, _mem_tracker.get());
+    auto delta_writer = DeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
 
     // Write and flush
@@ -212,8 +222,13 @@ TEST_F(LakeDeltaWriterTest, test_close) {
     // Create and open DeltaWriter
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer =
-            DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0, _mem_tracker.get());
+    auto delta_writer = DeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
 
     // write()
@@ -245,8 +260,13 @@ TEST_F(LakeDeltaWriterTest, test_finish_without_write_txn_log) {
     // Create and open DeltaWriter
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer =
-            DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0, _mem_tracker.get());
+    auto delta_writer = DeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
 
     // write()
@@ -271,8 +291,13 @@ TEST_F(LakeDeltaWriterTest, test_finish_without_write_txn_log) {
 TEST_F(LakeDeltaWriterTest, test_empty_write) {
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer =
-            DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0, _mem_tracker.get());
+    auto delta_writer = DeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
     ASSERT_OK(delta_writer->finish());
     delta_writer->close();
@@ -294,8 +319,13 @@ TEST_F(LakeDeltaWriterTest, test_empty_write) {
 
 TEST_F(LakeDeltaWriterTest, test_negative_txn_id) {
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer =
-            DeltaWriter::create(_tablet_mgr.get(), tablet_id, -1, _partition_id, nullptr, 0, _mem_tracker.get());
+    auto delta_writer = DeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(-1)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
     ASSERT_ERROR(delta_writer->finish());
     delta_writer->close();
@@ -313,8 +343,13 @@ TEST_F(LakeDeltaWriterTest, test_memory_limit_unreached) {
     // Create and open DeltaWriter
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer =
-            DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0, _mem_tracker.get());
+    auto delta_writer = DeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
 
     // Write three times
@@ -357,8 +392,13 @@ TEST_F(LakeDeltaWriterTest, test_reached_memory_limit) {
     // Create and open DeltaWriter
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer =
-            DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0, _mem_tracker.get());
+    auto delta_writer = DeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
 
     // Write tree times
@@ -402,8 +442,13 @@ TEST_F(LakeDeltaWriterTest, test_reached_parent_memory_limit) {
     // Create and open DeltaWriter
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer =
-            DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0, _mem_tracker.get());
+    auto delta_writer = DeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
 
     // Write tree times
@@ -448,8 +493,13 @@ TEST_F(LakeDeltaWriterTest, test_memtable_full) {
     // Create and open DeltaWriter
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
-    auto delta_writer =
-            DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0, _mem_tracker.get());
+    auto delta_writer = DeltaWriterBuilder()
+                                .set_tablet_manager(_tablet_mgr.get())
+                                .set_tablet_id(tablet_id)
+                                .set_txn_id(txn_id)
+                                .set_partition_id(_partition_id)
+                                .set_mem_tracker(_mem_tracker.get())
+                                .build();
     ASSERT_OK(delta_writer->open());
 
     // Write three times

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -201,8 +201,13 @@ TEST_P(PartialUpdateTest, test_write) {
     // normal write
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -218,8 +223,13 @@ TEST_P(PartialUpdateTest, test_write) {
     // partial update
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         delta_writer->TEST_set_partial_update(_partial_tablet_schema, _referenced_column_ids);
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -251,8 +261,13 @@ TEST_P(PartialUpdateTest, test_write_multi_segment) {
     // normal write
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -270,8 +285,13 @@ TEST_P(PartialUpdateTest, test_write_multi_segment) {
     config::write_buffer_size = 1;
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         delta_writer->TEST_set_partial_update(_partial_tablet_schema, _referenced_column_ids);
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -308,8 +328,13 @@ TEST_P(PartialUpdateTest, test_write_multi_segment_by_diff_val) {
     // normal write
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -327,8 +352,13 @@ TEST_P(PartialUpdateTest, test_write_multi_segment_by_diff_val) {
     config::write_buffer_size = 1;
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         delta_writer->TEST_set_partial_update(_partial_tablet_schema, _referenced_column_ids);
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -364,8 +394,13 @@ TEST_P(PartialUpdateTest, test_resolve_conflict) {
     // normal write
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -383,8 +418,13 @@ TEST_P(PartialUpdateTest, test_resolve_conflict) {
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
         txn_ids.push_back(txn_id);
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         delta_writer->TEST_set_partial_update(_partial_tablet_schema, _referenced_column_ids);
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -420,8 +460,13 @@ TEST_P(PartialUpdateTest, test_resolve_conflict_multi_segment) {
     // normal write
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -441,8 +486,13 @@ TEST_P(PartialUpdateTest, test_resolve_conflict_multi_segment) {
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
         txn_ids.push_back(txn_id);
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         delta_writer->TEST_set_partial_update(_partial_tablet_schema, _referenced_column_ids);
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
@@ -481,8 +531,13 @@ TEST_P(PartialUpdateTest, test_write_with_index_reload) {
     // normal write
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -501,8 +556,13 @@ TEST_P(PartialUpdateTest, test_write_with_index_reload) {
     // partial update
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         delta_writer->TEST_set_partial_update(_partial_tablet_schema, _referenced_column_ids);
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -211,8 +211,13 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -271,8 +276,13 @@ TEST_P(LakePrimaryKeyCompactionTest, test2) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunks[i], indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -325,8 +335,13 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         if (i == 1) {
             ASSERT_OK(delta_writer->write(chunks[i], indexes_empty.data(), indexes_empty.size()));
@@ -377,8 +392,13 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunks[i], indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -422,8 +442,13 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy2) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunks[i], indexes_list[i].data(), indexes_list[i].size()));
         ASSERT_OK(delta_writer->finish());
@@ -434,8 +459,13 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy2) {
     }
     {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunks[0], indexes_list[0].data(), indexes_list[0].size()));
         ASSERT_OK(delta_writer->finish());
@@ -481,8 +511,13 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy3) {
     size_t chunk_index = 0;
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         for (int seg_cnt = 0; seg_cnt <= i; seg_cnt++) {
             ASSERT_OK(delta_writer->write(chunks[chunk_index], indexes_list[chunk_index].data(),
@@ -497,8 +532,13 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy3) {
     }
     {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunks[0], indexes_list[0].data(), indexes_list[0].size()));
         ASSERT_OK(delta_writer->finish());
@@ -544,8 +584,13 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_score_by_policy) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunks[i], indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -594,8 +639,13 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunks[chunk_write_without_order[i]], indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -226,8 +226,13 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_multitime_check_result) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         int64_t txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -260,8 +265,13 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
     // write success
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(*chunks[i], indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -274,8 +284,13 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
     // write failed
     for (int i = 3; i < 5; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(*chunks[i], indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -300,8 +315,13 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
     // write success
     for (int i = 3; i < 5; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(*chunks[i], indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -326,8 +346,13 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_times) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         int64_t txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -359,8 +384,13 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_concurrent) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -390,8 +420,13 @@ TEST_P(LakePrimaryKeyPublishTest, test_resolve_conflict) {
     auto tablet_id = _tablet_metadata->id();
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -408,8 +443,13 @@ TEST_P(LakePrimaryKeyPublishTest, test_resolve_conflict) {
     // concurrent write
     for (int i = 0; i < 3; i++) {
         auto txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
         // will preload update state here.
@@ -450,8 +490,13 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_read_success_multiple_tablet) {
             auto chunk_ptr = (j == 0) ? chunk0 : chunk1;
             auto indexes = (j == 0) ? indexes_1.data() : indexes_2.data();
             auto indexes_size = (j == 0) ? indexes_1.size() : indexes_2.size();
-            auto w = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                         _mem_tracker.get());
+            auto w = DeltaWriterBuilder()
+                             .set_tablet_manager(_tablet_mgr.get())
+                             .set_tablet_id(tablet_id)
+                             .set_txn_id(txn_id)
+                             .set_partition_id(_partition_id)
+                             .set_mem_tracker(_mem_tracker.get())
+                             .build();
             ASSERT_OK(w->open());
             ASSERT_OK(w->write(*chunk_ptr, indexes, indexes_size));
             ASSERT_OK(w->finish());
@@ -481,8 +526,13 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_largedata) {
     for (int i = 0; i < N; i++) {
         auto [chunk0, indexes] = gen_data_and_index(kChunkSize, i, true);
         int64_t txn_id = next_id();
-        auto delta_writer = DeltaWriter::create(_tablet_mgr.get(), tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_mgr.get())
+                                    .set_tablet_id(tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(*chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -234,8 +234,13 @@ TEST_P(SchemaChangeAddColumnTest, test_add_column) {
         VChunk chunk0({c0, c1}, _base_schema);
         uint32_t indexes[1] = {0};
 
-        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), base_tablet_id, txn_id, _partition_id, nullptr,
-                                                0, _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_manager.get())
+                                    .set_tablet_id(base_tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes, sizeof(indexes) / sizeof(indexes[0])));
         ASSERT_OK(delta_writer->finish());
@@ -273,8 +278,13 @@ TEST_P(SchemaChangeAddColumnTest, test_add_column) {
         VChunk chunk1({c0, c1, c2}, _new_schema);
         uint32_t indexes[1] = {0};
 
-        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), new_tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_manager.get())
+                                    .set_tablet_id(new_tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes, sizeof(indexes) / sizeof(indexes[0])));
         ASSERT_OK(delta_writer->finish());
@@ -477,8 +487,13 @@ TEST_P(SchemaChangeModifyColumnTypeTest, test_alter_column_type) {
         VChunk chunk0({c0, c1}, _base_schema);
         uint32_t indexes[1] = {0};
 
-        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), base_tablet_id, txn_id, _partition_id, nullptr,
-                                                0, _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_manager.get())
+                                    .set_tablet_id(base_tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes, sizeof(indexes) / sizeof(indexes[0])));
         ASSERT_OK(delta_writer->finish());
@@ -515,8 +530,13 @@ TEST_P(SchemaChangeModifyColumnTypeTest, test_alter_column_type) {
         VChunk chunk1({c0, c1}, _new_schema);
         uint32_t indexes[1] = {0};
 
-        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), new_tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_manager.get())
+                                    .set_tablet_id(new_tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes, sizeof(indexes) / sizeof(indexes[0])));
         ASSERT_OK(delta_writer->finish());
@@ -744,8 +764,13 @@ TEST_P(SchemaChangeModifyColumnOrderTest, test_alter_key_order) {
     int64_t txn_id = 1000;
     auto base_tablet_id = _base_tablet_metadata->id();
     for (int i = 0; i < GetParam().writes_before; i++) {
-        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), base_tablet_id, txn_id, _partition_id, nullptr,
-                                                0, _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_manager.get())
+                                    .set_tablet_id(base_tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
@@ -772,8 +797,13 @@ TEST_P(SchemaChangeModifyColumnOrderTest, test_alter_key_order) {
     for (int i = 0; i < GetParam().writes_after; i++) {
         VChunk chunk1({ck1, ck0, cv0}, _new_schema);
 
-        auto delta_writer = DeltaWriter::create(_tablet_manager.get(), new_tablet_id, txn_id, _partition_id, nullptr, 0,
-                                                _mem_tracker.get());
+        auto delta_writer = DeltaWriterBuilder()
+                                    .set_tablet_manager(_tablet_manager.get())
+                                    .set_tablet_id(new_tablet_id)
+                                    .set_txn_id(txn_id)
+                                    .set_partition_id(_partition_id)
+                                    .set_mem_tracker(_mem_tracker.get())
+                                    .build();
         ASSERT_OK(delta_writer->open());
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());


### PR DESCRIPTION
Introduced lake::{Async}DeltaWriterBuilder class to unify the creation of {Async}DeltaWriter instances, instead of multiple overloaded constructors. This avoids confusion on which constructor to use.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
