### PR TITLE
[Feature] Support where exprs in synchronized materialized view

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -106,7 +106,7 @@ Status OlapTableSchemaParam::init(const POlapTableSchemaParam& pschema) {
     return Status::OK();
 }
 
-Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema) {
+Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema, RuntimeState* state) {
     _db_id = tschema.db_id;
     _table_id = tschema.table_id;
     _version = tschema.version;
@@ -140,6 +140,9 @@ Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema) {
             }
             col_param->short_key_column_count = t_index.column_param.short_key_column_count;
             index->column_param = col_param;
+        }
+        if (t_index.__isset.where_clause) {
+            RETURN_IF_ERROR(Expr::create_expr_tree(&_obj_pool, t_index.where_clause, &index->where_clause, state));
         }
         _indexes.emplace_back(index);
     }

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -46,6 +46,7 @@ struct OlapTableIndexSchema {
     std::vector<SlotDescriptor*> slots;
     int32_t schema_hash;
     OlapTableColumnParam* column_param;
+    ExprContext* where_clause = nullptr;
 
     void to_protobuf(POlapTableIndexSchema* pindex) const;
 };
@@ -55,7 +56,7 @@ public:
     OlapTableSchemaParam() = default;
     ~OlapTableSchemaParam() noexcept = default;
 
-    Status init(const TOlapTableSchemaParam& tschema);
+    Status init(const TOlapTableSchemaParam& tschema, RuntimeState* state = nullptr);
     Status init(const POlapTableSchemaParam& pschema);
 
     int64_t db_id() const { return _db_id; }

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -146,7 +146,7 @@ Status OlapTableSink::init(const TDataSink& t_sink, RuntimeState* state) {
     _ts_profile->server_wait_flush_timer = ADD_TIMER(_profile, "RpcServerWaitFlushTime");
 
     _schema = std::make_shared<OlapTableSchemaParam>();
-    RETURN_IF_ERROR(_schema->init(table_sink.schema));
+    RETURN_IF_ERROR(_schema->init(table_sink.schema, state));
     _vectorized_partition = _pool->add(new OlapTablePartitionParam(_schema, table_sink.partition));
     RETURN_IF_ERROR(_vectorized_partition->init(state));
     _location = _pool->add(new OlapTableLocationParam(table_sink.location));
@@ -184,6 +184,8 @@ Status OlapTableSink::prepare(RuntimeState* state) {
     SCOPED_TIMER(_profile->total_time_counter());
 
     RETURN_IF_ERROR(DataSink::prepare(state));
+
+    _state = state;
 
     _sender_id = state->per_fragment_instance_idx();
     _num_senders = state->num_per_fragment_instances();
@@ -325,7 +327,7 @@ Status OlapTableSink::_init_node_channels(RuntimeState* state, IndexIdToTabletBE
         }
         index_id_to_tablet_be_map.emplace(index->index_id, std::move(tablet_to_be));
 
-        auto channel = std::make_unique<IndexChannel>(this, index->index_id);
+        auto channel = std::make_unique<IndexChannel>(this, index->index_id, index->where_clause);
         RETURN_IF_ERROR(channel->init(state, tablets, false));
         _channels.emplace_back(std::move(channel));
     }

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -244,6 +244,7 @@ private:
     // bucket size for automatic bucket
     int64_t _automatic_bucket_size = 0;
     std::set<int64_t> _immutable_partition_ids;
+    RuntimeState* _state = nullptr;
 };
 
 } // namespace starrocks::stream_load

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -101,7 +101,7 @@ using IndexIdToTabletBEMap = std::unordered_map<int64_t, std::unordered_map<int6
 
 class NodeChannel {
 public:
-    NodeChannel(OlapTableSink* parent, int64_t node_id, bool is_incremental);
+    NodeChannel(OlapTableSink* parent, int64_t node_id, bool is_incremental, ExprContext* where_clause = nullptr);
     ~NodeChannel() noexcept;
 
     // called before open, used to add tablet loacted in this backend
@@ -173,6 +173,8 @@ private:
     Status _open_wait(RefCountClosure<PTabletWriterOpenResult>* open_closure);
     Status _send_request(bool eos, bool wait_all_sender_close = false);
     void _cancel(int64_t index_id, const Status& err_st);
+    Status _filter_indexes_with_where_expr(Chunk* input, const std::vector<uint32_t>& indexes,
+                                           std::vector<uint32_t>& filtered_indexes);
 
     std::unique_ptr<MemTracker> _mem_tracker = nullptr;
 
@@ -240,11 +242,14 @@ private:
     bool _is_incremental;
 
     std::set<int64_t> _immutable_partition_ids;
+
+    ExprContext* _where_clause = nullptr;
 };
 
 class IndexChannel {
 public:
-    IndexChannel(OlapTableSink* parent, int64_t index_id) : _parent(parent), _index_id(index_id) {}
+    IndexChannel(OlapTableSink* parent, int64_t index_id, ExprContext* where_clause)
+            : _parent(parent), _index_id(index_id), _where_clause(where_clause) {}
     ~IndexChannel();
 
     Status init(RuntimeState* state, const std::vector<PTabletWithPartition>& tablets, bool is_incremental);
@@ -297,6 +302,7 @@ private:
     TWriteQuorumType::type _write_quorum_type = TWriteQuorumType::MAJORITY;
 
     bool _has_incremental_node_channel = false;
+    ExprContext* _where_clause = nullptr;
 };
 
 } // namespace stream_load

--- a/be/src/storage/lake/schema_change.h
+++ b/be/src/storage/lake/schema_change.h
@@ -42,6 +42,7 @@ private:
         int64_t version;
         int64_t txn_id;
         MaterializedViewParamMap materialized_params_map;
+        std::unique_ptr<TExpr> where_expr;
         bool sc_sorting = false;
         bool sc_directly = false;
         std::unique_ptr<ChunkChanger> chunk_changer = nullptr;

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -52,6 +52,7 @@
 #include "serde/column_array_serde.h"
 #include "storage/aggregate_iterator.h"
 #include "storage/chunk_helper.h"
+#include "storage/empty_iterator.h"
 #include "storage/merge_iterator.h"
 #include "storage/metadata_util.h"
 #include "storage/olap_define.h"
@@ -883,7 +884,9 @@ Status HorizontalRowsetWriter::_final_merge() {
 
         ChunkIteratorPtr itr;
         // create temporary segment files at first, then merge them and create final segment files if schema change with sorting
-        if (_context.schema_change_sorting) {
+        if (seg_iterators.empty()) {
+            itr = new_empty_iterator(schema, config::vector_chunk_size);
+        } else if (_context.schema_change_sorting) {
             if (_context.tablet_schema->keys_type() == KeysType::DUP_KEYS ||
                 _context.tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
                 itr = new_heap_merge_iterator(seg_iterators);

--- a/be/src/storage/schema_change.h
+++ b/be/src/storage/schema_change.h
@@ -47,9 +47,6 @@
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/schema_change_utils.h"
-#include "storage/tablet.h"
-#include "storage/tablet_reader.h"
-#include "storage/tablet_reader_params.h"
 
 namespace starrocks {
 class Field;
@@ -146,19 +143,6 @@ public:
     void set_alter_msg_header(std::string msg) { _alter_msg_header = msg; }
 
 private:
-    struct SchemaChangeParams {
-        TabletSharedPtr base_tablet;
-        TabletSharedPtr new_tablet;
-        std::vector<std::unique_ptr<TabletReader>> rowset_readers;
-        Version version;
-        TabletSchemaCSPtr base_tablet_schema = nullptr;
-        MaterializedViewParamMap materialized_params_map;
-        std::vector<RowsetSharedPtr> rowsets_to_change;
-        bool sc_sorting = false;
-        bool sc_directly = false;
-        std::unique_ptr<ChunkChanger> chunk_changer = nullptr;
-    };
-
     Status _get_versions_to_be_changed(const TabletSharedPtr& base_tablet,
                                        std::vector<Version>* versions_to_be_changed);
 

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -15,9 +15,11 @@
 #include "storage/schema_change_utils.h"
 
 #include "column/column_helper.h"
+#include "column/column_viewer.h"
 #include "column/datum_convert.h"
 #include "runtime/mem_pool.h"
 #include "runtime/runtime_state.h"
+#include "simd/simd.h"
 #include "storage/chunk_helper.h"
 #include "types/bitmap_value.h"
 #include "types/hll.h"
@@ -25,8 +27,16 @@
 
 namespace starrocks {
 
-ChunkChanger::ChunkChanger(const TabletSchemaCSPtr& tablet_schema) {
-    _schema_mapping.resize(tablet_schema->num_columns());
+ChunkChanger::ChunkChanger(const TabletSchemaCSPtr& new_schema) {
+    _schema_mapping.resize(new_schema->num_columns());
+}
+
+ChunkChanger::ChunkChanger(const TabletSchemaCSPtr& base_schema, const TabletSchemaCSPtr& new_schema,
+                           std::vector<std::string>& base_table_column_names, TAlterJobType::type alter_job_type)
+        : _base_schema(std::move(base_schema)),
+          _base_table_column_names(base_table_column_names),
+          _alter_job_type(alter_job_type) {
+    _schema_mapping.resize(new_schema->num_columns());
 }
 
 ChunkChanger::~ChunkChanger() {
@@ -202,163 +212,17 @@ ConvertTypeResolver::ConvertTypeResolver() {
 
 ConvertTypeResolver::~ConvertTypeResolver() = default;
 
-bool ChunkChanger::change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const TabletMetaSharedPtr& base_tablet_meta,
-                                const TabletMetaSharedPtr& new_tablet_meta, MemPool* mem_pool) {
-    if (new_chunk->num_columns() != _schema_mapping.size()) {
-        LOG(WARNING) << "new chunk does not match with schema mapping rules. "
-                     << "base_tablet_id=" << base_tablet_meta->tablet_id()
-                     << ", new_tablet_id=" << new_tablet_meta->tablet_id()
-                     << ", chunk_schema_size=" << new_chunk->num_columns()
-                     << ", mapping_schema_size=" << _schema_mapping.size();
-        return false;
+Buffer<uint8_t> ChunkChanger::_execute_where_expr(ChunkPtr& chunk) {
+    DCHECK(_where_expr != nullptr);
+    ColumnPtr filter_col = _where_expr->evaluate(chunk.get()).value();
+
+    size_t size = filter_col->size();
+    Buffer<uint8_t> filter(size, 0);
+    ColumnViewer<TYPE_BOOLEAN> col(filter_col);
+    for (size_t i = 0; i < size; ++i) {
+        filter[i] = !col.is_null(i) && col.value(i);
     }
-    if (_has_mv_expr_context) {
-        if (base_chunk->num_columns() != _slot_id_to_index_map.size()) {
-            LOG(WARNING) << "base chunk does not match with _slot_id_to_index_map mapping rules. "
-                         << "base_tablet_id=" << base_tablet_meta->tablet_id()
-                         << ", new_tablet_id=" << new_tablet_meta->tablet_id()
-                         << ", base_chunk_size=" << base_chunk->num_columns()
-                         << ", slot_id_to_index_map's size=" << _slot_id_to_index_map.size();
-            return false;
-        }
-        // init for expression evaluation only
-        for (auto& iter : _slot_id_to_index_map) {
-            base_chunk->set_slot_id_to_index(iter.first, iter.second);
-        }
-    }
-
-    for (size_t i = 0; i < new_chunk->num_columns(); ++i) {
-        int ref_column = _schema_mapping[i].ref_column;
-        if (ref_column >= 0) {
-            if (_schema_mapping[i].mv_expr_ctx != nullptr) {
-                auto new_col_status = (_schema_mapping[i].mv_expr_ctx)->evaluate(base_chunk.get());
-                if (!new_col_status.ok()) {
-                    return false;
-                }
-                auto new_col = new_col_status.value();
-                auto new_schema = new_chunk->schema();
-                if (!new_schema->field(i)->is_nullable() && new_col->is_nullable()) {
-                    LOG(WARNING) << "schema of column(" << new_schema->field(i)->name()
-                                 << ") is not null but data contains null";
-                    return false;
-                }
-                // NOTE: Unpack const column first to avoid generating NullColumn<ConstColumn> result.
-                new_col = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
-                if (new_schema->field(i)->is_nullable()) {
-                    new_col = ColumnHelper::cast_to_nullable_column(new_col);
-                }
-                new_chunk->columns()[i] = std::move(new_col);
-            } else {
-                LogicalType ref_type = base_tablet_meta->tablet_schema_ptr()->column(ref_column).type();
-                LogicalType new_type = new_tablet_meta->tablet_schema_ptr()->column(i).type();
-
-                int reftype_precision = base_tablet_meta->tablet_schema_ptr()->column(ref_column).precision();
-                int reftype_scale = base_tablet_meta->tablet_schema_ptr()->column(ref_column).scale();
-                int newtype_precision = new_tablet_meta->tablet_schema_ptr()->column(i).precision();
-                int newtype_scale = new_tablet_meta->tablet_schema_ptr()->column(i).scale();
-
-                ColumnPtr& base_col = base_chunk->get_column_by_index(ref_column);
-                ColumnPtr& new_col = new_chunk->get_column_by_index(i);
-
-                if (new_type == ref_type &&
-                    (!is_decimalv3_field_type(new_type) ||
-                     (reftype_precision == newtype_precision && reftype_scale == newtype_scale))) {
-                    if (new_type == TYPE_CHAR) {
-                        for (size_t row_index = 0; row_index < base_chunk->num_rows(); ++row_index) {
-                            Datum base_datum = base_col->get(row_index);
-                            Datum new_datum;
-                            if (base_datum.is_null()) {
-                                new_datum.set_null();
-                                new_col->append_datum(new_datum);
-                                continue;
-                            }
-                            Slice base_slice = base_datum.get_slice();
-                            Slice slice;
-                            slice.size = new_tablet_meta->tablet_schema_ptr()->column(i).length();
-                            slice.data = reinterpret_cast<char*>(mem_pool->allocate(slice.size));
-                            if (slice.data == nullptr) {
-                                LOG(WARNING) << "failed to allocate memory in mem_pool";
-                                return false;
-                            }
-                            memset(slice.data, 0, slice.size);
-                            size_t copy_size = slice.size < base_slice.size ? slice.size : base_slice.size;
-                            memcpy(slice.data, base_slice.data, copy_size);
-                            new_datum.set(slice);
-                            new_col->append_datum(new_datum);
-                        }
-                    } else if (new_col->is_nullable() != base_col->is_nullable()) {
-                        new_col->append(*base_col.get());
-                    } else {
-                        new_col = base_col;
-                    }
-                } else if (ConvertTypeResolver::instance()->convert_type_exist(ref_type, new_type)) {
-                    auto converter = get_type_converter(ref_type, new_type);
-                    if (converter == nullptr) {
-                        LOG(WARNING) << "failed to get type converter, from_type=" << ref_type << ", to_type"
-                                     << new_type << ", base_tablet_id=" << base_tablet_meta->tablet_id()
-                                     << ", new_tablet_id=" << new_tablet_meta->tablet_id();
-                        return false;
-                    }
-
-                    Field ref_field = ChunkHelper::convert_field(
-                            ref_column, base_tablet_meta->tablet_schema_ptr()->column(ref_column));
-                    Field new_field = ChunkHelper::convert_field(i, new_tablet_meta->tablet_schema_ptr()->column(i));
-
-                    Status st = converter->convert_column(ref_field.type().get(), *base_col, new_field.type().get(),
-                                                          new_col.get(), mem_pool);
-                    if (!st.ok()) {
-                        LOG(WARNING) << "failed to convert " << logical_type_to_string(ref_type) << " to "
-                                     << logical_type_to_string(new_type)
-                                     << ", base_tablet_id=" << base_tablet_meta->tablet_id()
-                                     << ", new_tablet_id=" << new_tablet_meta->tablet_id();
-                        return false;
-                    }
-                } else {
-                    // copy and alter the field
-                    switch (ref_type) {
-                    case TYPE_TINYINT:
-                        CONVERT_FROM_TYPE(int8_t);
-                    case TYPE_UNSIGNED_TINYINT:
-                        CONVERT_FROM_TYPE(uint8_t);
-                    case TYPE_SMALLINT:
-                        CONVERT_FROM_TYPE(int16_t);
-                    case TYPE_UNSIGNED_SMALLINT:
-                        CONVERT_FROM_TYPE(uint16_t);
-                    case TYPE_INT:
-                        CONVERT_FROM_TYPE(int32_t);
-                    case TYPE_UNSIGNED_INT:
-                        CONVERT_FROM_TYPE(uint32_t);
-                    case TYPE_BIGINT:
-                        CONVERT_FROM_TYPE(int64_t);
-                    case TYPE_UNSIGNED_BIGINT:
-                        CONVERT_FROM_TYPE(uint64_t);
-                    default:
-                        LOG(WARNING) << "the column type which was altered from was unsupported."
-                                     << " from_type=" << ref_type << ", to_type=" << new_type
-                                     << ", base_tablet_id=" << base_tablet_meta->tablet_id()
-                                     << ", new_tablet_id=" << new_tablet_meta->tablet_id();
-                        ;
-                        return false;
-                    }
-                    if (new_type < ref_type) {
-                        LOG(INFO) << "type degraded while altering column. "
-                                  << "column=" << new_tablet_meta->tablet_schema_ptr()->column(i).name()
-                                  << ", origin_type=" << logical_type_to_string(ref_type)
-                                  << ", alter_type=" << logical_type_to_string(new_type)
-                                  << ", base_tablet_id=" << base_tablet_meta->tablet_id()
-                                  << ", new_tablet_id=" << new_tablet_meta->tablet_id();
-                        ;
-                    }
-                }
-            }
-        } else {
-            ColumnPtr& new_col = new_chunk->get_column_by_index(i);
-            for (size_t row_index = 0; row_index < base_chunk->num_rows(); ++row_index) {
-                new_col->append_datum(_schema_mapping[i].default_value_datum);
-            }
-        }
-    }
-    return true;
+    return filter;
 }
 
 bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const Schema& base_schema,
@@ -369,110 +233,120 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
                      << ", mapping_schema_size=" << _schema_mapping.size();
         return false;
     }
-    if (_has_mv_expr_context) {
-        if (base_chunk->num_columns() != _slot_id_to_index_map.size()) {
-            LOG(WARNING) << "base chunk does not match with _slot_id_to_index_map mapping rules. "
-                         << "base_chunk_size=" << base_chunk->num_columns()
-                         << ", slot_id_to_index_map's size=" << _slot_id_to_index_map.size();
-            return false;
+    if (_alter_job_type == TAlterJobType::ROLLUP) {
+        for (auto slot : _query_slots) {
+            size_t column_index = base_chunk->schema()->get_field_index_by_name(slot->col_name());
+            VLOG(2) << "col name:" << slot->col_name() << ", slot_id:" << slot->id()
+                    << ", column_index:" << column_index;
+            if (column_index != -1) {
+                base_chunk->set_slot_id_to_index(slot->id(), column_index);
+            }
         }
-        // init for expression evaluation only
-        for (auto& iter : _slot_id_to_index_map) {
-            base_chunk->set_slot_id_to_index(iter.first, iter.second);
+        if (_where_expr) {
+            auto filter = _execute_where_expr(base_chunk);
+            base_chunk->filter(filter);
         }
     }
 
     for (size_t i = 0; i < new_chunk->num_columns(); ++i) {
         int ref_column = _schema_mapping[i].ref_column;
+
+        // For rollup, if new column has expr, just evalute the mv expr, otherwise do the normal schema change.
+        if (_alter_job_type == TAlterJobType::ROLLUP && _schema_mapping[i].mv_expr_ctx != nullptr) {
+            VLOG(2) << "This rollup column has mv expr, i=" << i << ", ref_column=" << ref_column;
+
+            // init for expression evaluation only
+            auto new_col_status = (_schema_mapping[i].mv_expr_ctx)->evaluate(base_chunk.get());
+            if (!new_col_status.ok()) {
+                return false;
+            }
+            auto new_col = new_col_status.value();
+            if (!new_schema.field(i)->is_nullable() && new_col->is_nullable()) {
+                LOG(WARNING) << "schema of column(" << new_schema.field(i)->name()
+                             << ") is not null but data contains null";
+                return false;
+            }
+
+            // NOTE: Unpack const column first to avoid generating NullColumn<ConstColumn> result.
+            new_col = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
+            if (new_schema.field(i)->is_nullable()) {
+                new_col = ColumnHelper::cast_to_nullable_column(new_col);
+            }
+            new_chunk->columns()[i] = std::move(new_col);
+            continue;
+        }
+
         if (ref_column >= 0) {
-            if (_schema_mapping[i].mv_expr_ctx != nullptr) {
-                auto new_col_status = (_schema_mapping[i].mv_expr_ctx)->evaluate(base_chunk.get());
-                if (!new_col_status.ok()) {
-                    return false;
-                }
-                auto new_col = new_col_status.value();
-                if (!new_schema.field(i)->is_nullable() && new_col->is_nullable()) {
-                    LOG(WARNING) << "schema of column(" << new_schema.field(i)->name()
-                                 << ") is not null but data contains null";
-                    return false;
-                }
-                // NOTE: Unpack const column first to avoid generating NullColumn<ConstColumn> result.
-                new_col = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
-                if (new_schema.field(i)->is_nullable()) {
-                    new_col = ColumnHelper::cast_to_nullable_column(new_col);
-                }
-                new_chunk->columns()[i] = std::move(new_col);
-            } else {
-                DCHECK(_slot_id_to_index_map.find(ref_column) != _slot_id_to_index_map.end());
-                int base_index = _slot_id_to_index_map[ref_column];
-                const TypeInfoPtr& ref_type_info = base_schema.field(base_index)->type();
-                const TypeInfoPtr& new_type_info = new_schema.field(i)->type();
+            DCHECK(_column_ref_mapping.find(ref_column) != _column_ref_mapping.end());
+            int base_index = _column_ref_mapping.at(ref_column);
+            const TypeInfoPtr& ref_type_info = base_schema.field(base_index)->type();
+            const TypeInfoPtr& new_type_info = new_schema.field(i)->type();
 
-                int reftype_precision = ref_type_info->precision();
-                int reftype_scale = ref_type_info->scale();
-                int newtype_precision = new_type_info->precision();
-                int newtype_scale = new_type_info->scale();
-                auto ref_type = ref_type_info->type();
-                auto new_type = new_type_info->type();
+            int reftype_precision = ref_type_info->precision();
+            int reftype_scale = ref_type_info->scale();
+            int newtype_precision = new_type_info->precision();
+            int newtype_scale = new_type_info->scale();
+            auto ref_type = ref_type_info->type();
+            auto new_type = new_type_info->type();
+            VLOG(2) << "i=" << i << ", ref_column=" << ref_column << ", base_index=" << base_index
+                    << ", ref_type=" << ref_type << ", new_type=" << new_type;
 
-                ColumnPtr& base_col = base_chunk->get_column_by_index(base_index);
-                ColumnPtr& new_col = new_chunk->get_column_by_index(i);
-                if (new_type == ref_type &&
-                    (!is_decimalv3_field_type(new_type) ||
-                     (reftype_precision == newtype_precision && reftype_scale == newtype_scale))) {
-                    if (new_col->is_nullable() != base_col->is_nullable()) {
-                        new_col->append(*base_col.get());
-                    } else {
-                        new_col = base_col;
-                    }
-                } else if (ConvertTypeResolver::instance()->convert_type_exist(ref_type, new_type)) {
-                    auto converter = get_type_converter(ref_type, new_type);
-                    if (converter == nullptr) {
-                        LOG(WARNING) << "failed to get type converter, from_type=" << ref_type << ", to_type"
-                                     << new_type;
-                        return false;
-                    }
-                    Status st = converter->convert_column(ref_type_info.get(), *base_col, new_type_info.get(),
-                                                          new_col.get(), mem_pool);
-                    if (!st.ok()) {
-                        LOG(WARNING) << "failed to convert " << logical_type_to_string(ref_type) << " to "
-                                     << logical_type_to_string(new_type);
-                        return false;
-                    }
+            ColumnPtr& base_col = base_chunk->get_column_by_index(base_index);
+            ColumnPtr& new_col = new_chunk->get_column_by_index(i);
+            if (new_type == ref_type && (!is_decimalv3_field_type(new_type) ||
+                                         (reftype_precision == newtype_precision && reftype_scale == newtype_scale))) {
+                if (new_col->is_nullable() != base_col->is_nullable()) {
+                    new_col->append(*base_col.get());
                 } else {
-                    // copy and alter the field
-                    switch (ref_type) {
-                    case TYPE_TINYINT:
-                        CONVERT_FROM_TYPE(int8_t);
-                    case TYPE_UNSIGNED_TINYINT:
-                        CONVERT_FROM_TYPE(uint8_t);
-                    case TYPE_SMALLINT:
-                        CONVERT_FROM_TYPE(int16_t);
-                    case TYPE_UNSIGNED_SMALLINT:
-                        CONVERT_FROM_TYPE(uint16_t);
-                    case TYPE_INT:
-                        CONVERT_FROM_TYPE(int32_t);
-                    case TYPE_UNSIGNED_INT:
-                        CONVERT_FROM_TYPE(uint32_t);
-                    case TYPE_BIGINT:
-                        CONVERT_FROM_TYPE(int64_t);
-                    case TYPE_UNSIGNED_BIGINT:
-                        CONVERT_FROM_TYPE(uint64_t);
-                    default:
-                        LOG(WARNING) << "the column type which was altered from was unsupported."
-                                     << " from_type=" << logical_type_to_string(ref_type)
-                                     << ", to_type=" << logical_type_to_string(new_type);
-                        return false;
-                    }
-                    if (new_type < ref_type) {
-                        LOG(INFO) << "type degraded while altering column. "
-                                  << "column=" << new_schema.field(i)->name()
-                                  << ", origin_type=" << logical_type_to_string(ref_type)
-                                  << ", alter_type=" << logical_type_to_string(new_type);
-                    }
+                    new_col = base_col;
+                }
+            } else if (ConvertTypeResolver::instance()->convert_type_exist(ref_type, new_type)) {
+                auto converter = get_type_converter(ref_type, new_type);
+                if (converter == nullptr) {
+                    LOG(WARNING) << "failed to get type converter, from_type=" << ref_type << ", to_type" << new_type;
+                    return false;
+                }
+                Status st = converter->convert_column(ref_type_info.get(), *base_col, new_type_info.get(),
+                                                      new_col.get(), mem_pool);
+                if (!st.ok()) {
+                    LOG(WARNING) << "failed to convert " << logical_type_to_string(ref_type) << " to "
+                                 << logical_type_to_string(new_type);
+                    return false;
+                }
+            } else {
+                // copy and alter the field
+                switch (ref_type) {
+                case TYPE_TINYINT:
+                    CONVERT_FROM_TYPE(int8_t);
+                case TYPE_UNSIGNED_TINYINT:
+                    CONVERT_FROM_TYPE(uint8_t);
+                case TYPE_SMALLINT:
+                    CONVERT_FROM_TYPE(int16_t);
+                case TYPE_UNSIGNED_SMALLINT:
+                    CONVERT_FROM_TYPE(uint16_t);
+                case TYPE_INT:
+                    CONVERT_FROM_TYPE(int32_t);
+                case TYPE_UNSIGNED_INT:
+                    CONVERT_FROM_TYPE(uint32_t);
+                case TYPE_BIGINT:
+                    CONVERT_FROM_TYPE(int64_t);
+                case TYPE_UNSIGNED_BIGINT:
+                    CONVERT_FROM_TYPE(uint64_t);
+                default:
+                    LOG(WARNING) << "the column type which was altered from was unsupported."
+                                 << " from_type=" << logical_type_to_string(ref_type)
+                                 << ", to_type=" << logical_type_to_string(new_type);
+                    return false;
+                }
+                if (new_type < ref_type) {
+                    LOG(INFO) << "type degraded while altering column. "
+                              << "column=" << new_schema.field(i)->name()
+                              << ", origin_type=" << logical_type_to_string(ref_type)
+                              << ", alter_type=" << logical_type_to_string(new_type);
                 }
             }
         } else {
+            VLOG(2) << "no ref column: i=" << i << ", ref_column=" << ref_column;
             ColumnPtr& new_col = new_chunk->get_column_by_index(i);
             for (size_t row_index = 0; row_index < base_chunk->num_rows(); ++row_index) {
                 new_col->append_datum(_schema_mapping[i].default_value_datum);
@@ -519,24 +393,55 @@ Status ChunkChanger::fill_generated_columns(ChunkPtr& new_chunk) {
 }
 
 Status ChunkChanger::prepare() {
-    // base tablet schema: k1 k2 k3 v1 v2
-    // new tablet schema: k3 k1 v2
-    // base reader schema: k1 k3 v2
-    // selected_column_index: 0 2 4
-    // ref_column: 2 0 4
-    int32_t index = 0;
-    for (int i = 0; i < _schema_mapping.size(); ++i) {
-        ColumnMapping* column_mapping = get_mutable_column_mapping(i);
-        if (column_mapping == nullptr) {
-            return Status::InternalError("referenced column was missing: " + std::to_string(i));
+    if (_alter_job_type == TAlterJobType::ROLLUP) {
+        int real_idx = 0;
+        DCHECK(!_base_table_column_names.empty());
+        for (auto& ref_column_name : _base_table_column_names) {
+            DCHECK(_base_schema);
+            size_t index = _base_schema->field_index(ref_column_name);
+            if (index == -1) {
+                return Status::InternalError("referenced column was missing in base table: " + ref_column_name);
+            }
+            _selected_column_indexes.emplace_back(index);
+            // construct column ref mapping from real base table columns which may be subset of all base table columns.
+            _column_ref_mapping.insert({index, real_idx++});
         }
-        int32_t ref_column = column_mapping->ref_column;
-        if (ref_column < 0) {
-            continue;
+
+        for (int i = 0; i < _schema_mapping.size(); ++i) {
+            ColumnMapping* column_mapping = get_mutable_column_mapping(i);
+            if (column_mapping == nullptr) {
+                return Status::InternalError("referenced column was missing: " + std::to_string(i));
+            }
+            int32_t ref_column = column_mapping->ref_column;
+            if (ref_column < 0) {
+                continue;
+            }
+            auto ref_column_name = _base_schema->column(ref_column).name();
+            if (_column_ref_mapping.find(ref_column) == _column_ref_mapping.end()) {
+                return Status::InternalError("referenced column was missing in base table: " +
+                                             std::string(ref_column_name));
+            }
         }
-        if (_slot_id_to_index_map.find(ref_column) == _slot_id_to_index_map.end()) {
-            _slot_id_to_index_map.emplace(ref_column, index++);
+    } else {
+        // base tablet schema: k1 k2 k3 v1 v2
+        // new tablet schema: k3 k1 v2
+        // base reader schema: k1 k3 v2
+        // selected_column_index: 0 2 4
+        // ref_column: 2 0 4
+        int index = 0;
+        for (int i = 0; i < _schema_mapping.size(); ++i) {
+            ColumnMapping* column_mapping = get_mutable_column_mapping(i);
+            if (column_mapping == nullptr) {
+                return Status::InternalError("referenced column was missing: " + std::to_string(i));
+            }
+            int32_t ref_column = column_mapping->ref_column;
+            if (ref_column < 0) {
+                continue;
+            }
             _selected_column_indexes.emplace_back(ref_column);
+            // NOTE: construct column ref mapping (column_ref to real base table index) because base table's
+            // column orders
+            _column_ref_mapping.emplace(ref_column, index++);
         }
     }
     return Status::OK();
@@ -594,37 +499,40 @@ Status ChunkChanger::append_generated_columns(ChunkPtr& read_chunk, ChunkPtr& ne
 #undef COLUMN_APPEND_DATUM
 
 void SchemaChangeUtils::init_materialized_params(const TAlterTabletReqV2& request,
-                                                 MaterializedViewParamMap* materialized_view_param_map) {
+                                                 MaterializedViewParamMap* materialized_view_param_map,
+                                                 std::unique_ptr<TExpr>& where_expr) {
     DCHECK(materialized_view_param_map != nullptr);
-    if (!request.__isset.materialized_view_params) {
-        return;
+    if (request.__isset.materialized_view_params) {
+        for (const auto& item : request.materialized_view_params) {
+            AlterMaterializedViewParam mv_param;
+            mv_param.column_name = item.column_name;
+            // origin_column_name is always be set now,
+            // but origin_column_name may be not set in some materialized view function. eg:count(1)
+            if (item.__isset.origin_column_name) {
+                mv_param.origin_column_name = item.origin_column_name;
+            }
+
+            if (item.__isset.mv_expr) {
+                mv_param.mv_expr = std::make_unique<starrocks::TExpr>(item.mv_expr);
+            }
+            materialized_view_param_map->insert(std::make_pair(item.column_name, std::move(mv_param)));
+        }
     }
 
-    for (const auto& item : request.materialized_view_params) {
-        AlterMaterializedViewParam mv_param;
-        mv_param.column_name = item.column_name;
-        /*
-         * origin_column_name is always be set now,
-         * but origin_column_name may be not set in some materialized view function. eg:count(1)
-        */
-        if (item.__isset.origin_column_name) {
-            mv_param.origin_column_name = item.origin_column_name;
-        }
-
-        if (item.__isset.mv_expr) {
-            mv_param.mv_expr = std::make_unique<starrocks::TExpr>(item.mv_expr);
-        }
-        materialized_view_param_map->insert(std::make_pair(item.column_name, std::move(mv_param)));
+    if (request.__isset.where_expr) {
+        where_expr = std::make_unique<starrocks::TExpr>(request.where_expr);
     }
 }
 
 Status SchemaChangeUtils::parse_request(const TabletSchemaCSPtr& base_schema, const TabletSchemaCSPtr& new_schema,
                                         ChunkChanger* chunk_changer,
                                         const MaterializedViewParamMap& materialized_view_param_map,
-                                        bool has_delete_predicates, bool* sc_sorting, bool* sc_directly,
+                                        const std::unique_ptr<TExpr>& where_expr, bool has_delete_predicates,
+                                        bool* sc_sorting, bool* sc_directly,
                                         std::unordered_set<int>* generated_column_idxs) {
     RETURN_IF_ERROR(parse_request_normal(base_schema, new_schema, chunk_changer, materialized_view_param_map,
-                                         has_delete_predicates, sc_sorting, sc_directly, generated_column_idxs));
+                                         where_expr, has_delete_predicates, sc_sorting, sc_directly,
+                                         generated_column_idxs));
     if (base_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         return parse_request_for_pk(base_schema, new_schema, sc_sorting, sc_directly);
     }
@@ -634,9 +542,9 @@ Status SchemaChangeUtils::parse_request(const TabletSchemaCSPtr& base_schema, co
 Status SchemaChangeUtils::parse_request_normal(const TabletSchemaCSPtr& base_schema,
                                                const TabletSchemaCSPtr& new_schema, ChunkChanger* chunk_changer,
                                                const MaterializedViewParamMap& materialized_view_param_map,
-                                               bool has_delete_predicates, bool* sc_sorting, bool* sc_directly,
+                                               const std::unique_ptr<TExpr>& where_expr, bool has_delete_predicates,
+                                               bool* sc_sorting, bool* sc_directly,
                                                std::unordered_set<int>* generated_column_idxs) {
-    std::map<ColumnId, ColumnId> base_to_new;
     bool is_modify_generated_column = false;
     for (int i = 0; i < new_schema->num_columns(); ++i) {
         const TabletColumn& new_column = new_schema->column(i);
@@ -646,7 +554,6 @@ Status SchemaChangeUtils::parse_request_normal(const TabletSchemaCSPtr& base_sch
         if (materialized_view_param_map.find(column_name) != materialized_view_param_map.end()) {
             auto& mvParam = materialized_view_param_map.find(column_name)->second;
             if (mvParam.mv_expr != nullptr) {
-                chunk_changer->set_has_mv_expr_context(true);
                 RuntimeState* runtime_state = chunk_changer->get_runtime_state();
                 if (runtime_state == nullptr) {
                     return Status::InternalError("change materialized view but query_options/query_globals is not set");
@@ -660,7 +567,6 @@ Status SchemaChangeUtils::parse_request_normal(const TabletSchemaCSPtr& base_sch
             int32_t column_index = base_schema->field_index(mvParam.origin_column_name);
             if (column_index >= 0) {
                 column_mapping->ref_column = column_index;
-                base_to_new[column_index] = i;
                 continue;
             } else {
                 LOG(WARNING) << "referenced column was missing. "
@@ -677,7 +583,6 @@ Status SchemaChangeUtils::parse_request_normal(const TabletSchemaCSPtr& base_sch
         if (column_index >= 0 && ((generated_column_idxs == nullptr) ||
                                   generated_column_idxs->find(column_index) == generated_column_idxs->end())) {
             column_mapping->ref_column = column_index;
-            base_to_new[column_index] = i;
             continue;
         }
 
@@ -703,6 +608,10 @@ Status SchemaChangeUtils::parse_request_normal(const TabletSchemaCSPtr& base_sch
                     << "column=" << column_name << ", default_value=" << new_column.default_value();
             continue;
         }
+    }
+
+    if (where_expr) {
+        RETURN_IF_ERROR(chunk_changer->prepare_where_expr(*where_expr));
     }
 
     // initialized chunk charger state.
@@ -785,6 +694,9 @@ Status SchemaChangeUtils::parse_request_normal(const TabletSchemaCSPtr& base_sch
 
     if (has_delete_predicates) {
         // there exists delete condition in header, can't do linked schema change
+        *sc_directly = true;
+    }
+    if (where_expr) {
         *sc_directly = true;
     }
 

--- a/be/src/storage/schema_change_utils.h
+++ b/be/src/storage/schema_change_utils.h
@@ -18,10 +18,15 @@
 #include "exprs/expr.h"
 #include "storage/column_mapping.h"
 #include "storage/convert_helper.h"
+#include "storage/tablet.h"
 #include "storage/tablet_meta.h"
+#include "storage/tablet_reader.h"
+#include "storage/tablet_reader_params.h"
 #include "storage/tablet_schema.h"
 
 namespace starrocks {
+
+class ChunkChanger;
 
 struct AlterMaterializedViewParam {
     std::string column_name;
@@ -30,26 +35,51 @@ struct AlterMaterializedViewParam {
 };
 using MaterializedViewParamMap = std::unordered_map<std::string, AlterMaterializedViewParam>;
 
+struct SchemaChangeParams {
+    TabletSharedPtr base_tablet;
+    TabletSharedPtr new_tablet;
+    std::vector<std::unique_ptr<TabletReader>> rowset_readers;
+    Version version;
+    TabletSchemaCSPtr base_tablet_schema = nullptr;
+    std::vector<RowsetSharedPtr> rowsets_to_change;
+    bool sc_sorting = false;
+    bool sc_directly = false;
+    std::unique_ptr<ChunkChanger> chunk_changer = nullptr;
+
+    TAlterJobType::type alter_job_type;
+
+    // materialzied view parameters
+    DescriptorTbl* desc_tbl = nullptr;
+    std::unique_ptr<TExpr> where_expr;
+    std::vector<std::string> base_table_column_names;
+    MaterializedViewParamMap materialized_params_map;
+};
+
 class ChunkChanger {
 public:
-    ChunkChanger(const TabletSchemaCSPtr& tablet_schema);
+    ChunkChanger(const TabletSchemaCSPtr& base_schema, const TabletSchemaCSPtr& new_schema,
+                 std::vector<std::string>& base_table_column_names, TAlterJobType::type alter_job_type);
+    ChunkChanger(const TabletSchemaCSPtr& new_schema);
     ~ChunkChanger();
 
     ColumnMapping* get_mutable_column_mapping(size_t column_index);
 
-    const SchemaMapping& get_schema_mapping() const { return _schema_mapping; }
+    Status prepare_where_expr(const TExpr& where_expr) {
+        VLOG(2) << "parse contain where expr";
+        RETURN_IF_ERROR(Expr::create_expr_tree(&_obj_pool, where_expr, &_where_expr, _state));
+        RETURN_IF_ERROR(_where_expr->prepare(_state));
+        RETURN_IF_ERROR(_where_expr->open(_state));
+        return Status::OK();
+    }
+    ExprContext* get_where_expr() { return _where_expr; }
 
-    const std::unordered_map<int32_t, int32_t>& get_slot_id_to_index_map() const { return _slot_id_to_index_map; }
-    std::unordered_map<int32_t, int32_t>* get_mutable_slot_id_to_index_map() { return &_slot_id_to_index_map; }
+    const SchemaMapping& get_schema_mapping() const { return _schema_mapping; }
 
     ObjectPool* get_object_pool() { return &_obj_pool; }
 
     RuntimeState* get_runtime_state() { return _state; }
 
     std::unordered_map<int, ExprContext*>* get_gc_exprs() { return &_gc_exprs; }
-
-    bool change_chunk(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const TabletMetaSharedPtr& base_tablet_meta,
-                      const TabletMetaSharedPtr& new_tablet_meta, MemPool* mem_pool);
 
     bool change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, const Schema& base_schema, const Schema& new_schema,
                          MemPool* mem_pool);
@@ -64,11 +94,23 @@ public:
     const std::vector<ColumnId>& get_selected_column_indexes() const { return _selected_column_indexes; }
     std::vector<ColumnId>* get_mutable_selected_column_indexes() { return &_selected_column_indexes; }
 
-    void set_has_mv_expr_context(bool has_mv_expr_context) { this->_has_mv_expr_context = has_mv_expr_context; }
-
     Status prepare();
 
+    void set_query_slots(DescriptorTbl* desc_tbl) {
+        std::vector<TupleDescriptor*> tuples;
+        desc_tbl->get_tuple_descs(&tuples);
+        DCHECK_EQ(0, tuples.size());
+        _query_slots = tuples[0]->slots();
+    }
+
 private:
+    Buffer<uint8_t> _execute_where_expr(ChunkPtr& chunk);
+
+private:
+    TabletSchemaCSPtr _base_schema;
+    std::vector<std::string> _base_table_column_names;
+    TAlterJobType::type _alter_job_type = TAlterJobType::SCHEMA_CHANGE;
+
     // @brief column-mapping specification of new schema
     SchemaMapping _schema_mapping;
 
@@ -79,9 +121,17 @@ private:
     // columnId -> expr
     std::unordered_map<int, ExprContext*> _gc_exprs;
 
-    bool _has_mv_expr_context{false};
-    // base table's slot_id to index mapping
-    std::unordered_map<int32_t, int32_t> _slot_id_to_index_map;
+    // slot descriptors for each one of |_scanner_columns|.
+    std::vector<SlotDescriptor*> _query_slots;
+    ExprContext* _where_expr = nullptr;
+    // column_ref based on base schema -> real column idx based on pruned columns
+    // eg: base table schema        : a, b, c, d, e
+    //     select column indexes    : 1, 0, 2
+    // then this column ref mapping:
+    //                              0 -> 1 (a is in 1th slot of fetched chunk)
+    //                              1 -> 0 (b is in 0th slot of fetched chunk)
+    //                              2 -> 2 (c is in 2th slot of fetched chunk)
+    std::unordered_map<int, int> _column_ref_mapping;
 
     DISALLOW_COPY(ChunkChanger);
 };
@@ -89,12 +139,14 @@ private:
 class SchemaChangeUtils {
 public:
     static void init_materialized_params(const TAlterTabletReqV2& request,
-                                         MaterializedViewParamMap* materialized_view_param_map);
+                                         MaterializedViewParamMap* materialized_view_param_map,
+                                         std::unique_ptr<TExpr>& where_expr);
 
     static Status parse_request(const TabletSchemaCSPtr& base_schema, const TabletSchemaCSPtr& new_schema,
                                 ChunkChanger* chunk_changer,
-                                const MaterializedViewParamMap& materialized_view_param_map, bool has_delete_predicates,
-                                bool* sc_sorting, bool* sc_directly, std::unordered_set<int>* materialized_column_idxs);
+                                const MaterializedViewParamMap& materialized_view_param_map,
+                                const std::unique_ptr<TExpr>& where_expr, bool has_delete_predicates, bool* sc_sorting,
+                                bool* sc_directly, std::unordered_set<int>* materialized_column_idxs);
 
 private:
     // default_value for new column is needed
@@ -104,7 +156,8 @@ private:
     static Status parse_request_normal(const TabletSchemaCSPtr& base_schema, const TabletSchemaCSPtr& new_schema,
                                        ChunkChanger* chunk_changer,
                                        const MaterializedViewParamMap& materialized_view_param_map,
-                                       bool has_delete_predicates, bool* sc_sorting, bool* sc_directly,
+                                       const std::unique_ptr<TExpr>& where_expr, bool has_delete_predicates,
+                                       bool* sc_sorting, bool* sc_directly,
                                        std::unordered_set<int>* materialized_column_idxs);
 
     static Status parse_request_for_pk(const TabletSchemaCSPtr& base_schema, const TabletSchemaCSPtr& new_schema,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -38,6 +38,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -212,8 +213,8 @@ public class MaterializedViewHandler extends AlterHandler {
 
         // Step2: create mv job
         RollupJobV2 rollupJobV2 = createMaterializedViewJob(mvIndexName, baseIndexName, mvColumns,
-                addMVClause.getProperties(), olapTable, db, baseIndexId, addMVClause.getMVKeysType(),
-                addMVClause.getOrigStmt(), addMVClause.getQueryStatement());
+                addMVClause.getWhereClause(), addMVClause.getProperties(), olapTable, db, baseIndexId,
+                addMVClause.getMVKeysType(), addMVClause.getOrigStmt(), addMVClause.getQueryStatement());
 
         addAlterJobV2(rollupJobV2);
 
@@ -271,7 +272,7 @@ public class MaterializedViewHandler extends AlterHandler {
 
                 // step 3 create rollup job
                 RollupJobV2 alterJobV2 = createMaterializedViewJob(rollupIndexName, baseIndexName, rollupSchema,
-                        addRollupClause.getProperties(),
+                        null, addRollupClause.getProperties(),
                         olapTable, db, baseIndexId, olapTable.getKeysType(), null, null);
 
                 rollupNameJobMap.put(addRollupClause.getRollupName(), alterJobV2);
@@ -319,8 +320,8 @@ public class MaterializedViewHandler extends AlterHandler {
      * @throws DdlException
      * @throws AnalysisException
      */
-    private RollupJobV2 createMaterializedViewJob(String mvName, String baseIndexName,
-                                                  List<Column> mvColumns, Map<String, String> properties,
+    private RollupJobV2 createMaterializedViewJob(String mvName, String baseIndexName, List<Column> mvColumns,
+                                                  Expr whereClause, Map<String, String> properties,
                                                   OlapTable olapTable, Database db, long baseIndexId,
                                                   KeysType mvKeysType, OriginStatement origStmt,
                                                   QueryStatement queryStatement)
@@ -351,14 +352,14 @@ public class MaterializedViewHandler extends AlterHandler {
 
         // Check table is in colocate group if the mv wants to use colocate mv optimization.
         boolean isColocateMv = PropertyAnalyzer.analyzeBooleanProp(properties,
-                PropertyAnalyzer.PROPERTIES_COLOCATE_MV, false);
+                PropertyAnalyzer.PROPERTIES_COLOCATE_MV, false) && whereClause == null;
         if (isColocateMv && Strings.isNullOrEmpty(olapTable.getColocateGroup())) {
             throw new AnalysisException(String.format("Please ensure table %s is in colocate group if you want to use " +
                     "mv colocate optimization.", olapTable.getName()));
         }
         RollupJobV2 mvJob = new RollupJobV2(jobId, dbId, tableId, olapTable.getName(), timeoutMs,
                 baseIndexId, mvIndexId, baseIndexName, mvName,
-                mvColumns, baseSchemaHash, mvSchemaHash,
+                mvColumns, whereClause, baseSchemaHash, mvSchemaHash,
                 mvKeysType, mvShortKeyColumnCount, origStmt, viewDefineSql, isColocateMv);
 
         /*

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -38,10 +38,12 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.ExprSubstitutionMap;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
@@ -57,11 +59,14 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Replica.ReplicaState;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
@@ -78,6 +83,7 @@ import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SelectAnalyzer;
+import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
@@ -153,14 +159,16 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
     @SerializedName(value = "isColocateMVIndex")
     protected boolean isColocateMVIndex = false;
 
+    private Expr whereClause;
+
     // save all create rollup tasks
     private AgentBatchTask rollupBatchTask = new AgentBatchTask();
 
     public RollupJobV2(long jobId, long dbId, long tableId, String tableName, long timeoutMs,
                        long baseIndexId, long rollupIndexId, String baseIndexName, String rollupIndexName,
-                       List<Column> rollupSchema, int baseSchemaHash, int rollupSchemaHash, KeysType rollupKeysType,
-                       short rollupShortKeyColumnCount, OriginStatement origStmt, String viewDefineSql,
-                       boolean isColocateMVIndex) {
+                       List<Column> rollupSchema, Expr whereClause, int baseSchemaHash, int rollupSchemaHash,
+                       KeysType rollupKeysType, short rollupShortKeyColumnCount, OriginStatement origStmt,
+                       String viewDefineSql, boolean isColocateMVIndex) {
         super(jobId, JobType.ROLLUP, dbId, tableId, tableName, timeoutMs);
 
         this.baseIndexId = baseIndexId;
@@ -177,10 +185,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         this.origStmt = origStmt;
         this.viewDefineSql = viewDefineSql;
         this.isColocateMVIndex = isColocateMVIndex;
-    }
-
-    private RollupJobV2() {
-        super(JobType.ROLLUP);
+        this.whereClause = whereClause;
     }
 
     public void addTabletIdMap(long partitionId, long rollupTabletId, long baseTabletId) {
@@ -352,7 +357,56 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         indexMeta.setDbId(dbId);
         indexMeta.setViewDefineSql(viewDefineSql);
         indexMeta.setColocateMVIndex(isColocateMVIndex);
+        indexMeta.setWhereClause(whereClause);
         tbl.rebuildFullSchema();
+    }
+
+    private Expr analyzeExpr(Type type, String name, Expr defineExpr, Map<String, SlotDescriptor> slotDescByName,
+                             List<Expr> outputExprs, OlapTable tbl, TableName tableName) throws AlterCancelException {
+        List<SlotRef> slots = new ArrayList<>();
+        defineExpr.collect(SlotRef.class, slots);
+        for (SlotRef slot : slots) {
+            SlotDescriptor slotDesc = slotDescByName.get(slot.getColumnName());
+            if (slotDesc == null) {
+                slotDesc = slotDescByName.get(name);
+            }
+            if (slotDesc == null) {
+                throw new AlterCancelException("slotDesc is null, slot = " + slot.getColumnName()
+                        + ", column = " + name);
+            }
+            slot.setDesc(slotDesc);
+        }
+
+        ExprSubstitutionMap smap = new ExprSubstitutionMap();
+        for (SlotRef slot : slots) {
+            SlotDescriptor slotDesc = slotDescByName.get(slot.getColumnName());
+            Preconditions.checkNotNull(slotDesc);
+            smap.getLhs().add(slot);
+            SlotRef slotRef = new SlotRef(slotDesc);
+            slotRef.setColumnName(slot.getColumnName());
+            smap.getRhs().add(slotRef);
+        }
+        Expr newExpr = defineExpr.clone(smap);
+        // sourceScope must be set null tableName for its Field in RelationFields
+        // because we hope slotRef can not be resolved in sourceScope but can be
+        // resolved in outputScope to force to replace the node using outputExprs.
+        Scope sourceScope = new Scope(RelationId.anonymous(),
+                new RelationFields(tbl.getBaseSchema().stream().map(col ->
+                                new Field(col.getName(), col.getType(), null, null))
+                        .collect(Collectors.toList())));
+        Scope outputScope = new Scope(RelationId.anonymous(),
+                new RelationFields(tbl.getBaseSchema().stream().map(col ->
+                                new Field(col.getName(), col.getType(), tableName, null))
+                        .collect(Collectors.toList())));
+        SelectAnalyzer.RewriteAliasVisitor visitor =
+                new SelectAnalyzer.RewriteAliasVisitor(sourceScope, outputScope,
+                        outputExprs, new ConnectContext());
+        newExpr = newExpr.accept(visitor, null);
+        newExpr = Expr.analyzeAndCastFold(newExpr);
+        if (!newExpr.getType().equals(type)) {
+            newExpr = new CastExpr(type, newExpr);
+        }
+        return newExpr;
     }
 
     /**
@@ -406,15 +460,19 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                     Map<String, SlotDescriptor> slotDescByName = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
                     List<Column> rollupColumns = new ArrayList<Column>();
                     Set<String> columnNames = new HashSet<String>();
+                    Set<String> baseTableColumnNames = Sets.newHashSet();
                     for (Column column : tbl.getBaseSchema()) {
                         rollupColumns.add(column);
                         columnNames.add(column.getName());
+                        baseTableColumnNames.add(column.getName());
                     }
+                    Set<String> usedBaseTableColNames = Sets.newLinkedHashSet();
                     for (Column column : rollupSchema) {
-                        if (columnNames.contains(column.getName())) {
-                            continue;
+                        if (!columnNames.contains(column.getName())) {
+                            rollupColumns.add(column);
+                        } else {
+                            usedBaseTableColNames.add(column.getName());
                         }
-                        rollupColumns.add(column);
                     }
 
                     /*
@@ -423,7 +481,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                      * if it is init by SlotDescriptor. The slot information will be used by be to identify
                      * the column location in a chunk.
                      */
-                    for (Column column : rollupColumns) {
+                    for (Column column : tbl.getBaseSchema()) {
                         SlotDescriptor destSlotDesc = descTable.addSlotDescriptor(tupleDesc);
                         destSlotDesc.setIsMaterialized(true);
                         destSlotDesc.setColumn(column);
@@ -451,49 +509,41 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
                             continue;
                         }
 
-                        List<SlotRef> slots = new ArrayList<>();
-                        column.getDefineExpr().collect(SlotRef.class, slots);
-                        for (SlotRef slot : slots) {
-                            SlotDescriptor slotDesc = slotDescByName.get(slot.getColumnName());
-                            if (slotDesc == null) {
-                                slotDesc = slotDescByName.get(column.getName());
-                            }
-                            if (slotDesc == null) {
-                                throw new AlterCancelException("slotDesc is null, slot=" + slot.getColumnName()
-                                        + ", column=" + column.getName());
-                            }
-                            slot.setDesc(slotDesc);
-                        }
+                        Expr definedExpr = analyzeExpr(column.getType(), column.getName(), column.getDefineExpr(),
+                                slotDescByName, outputExprs, tbl, tableName);
 
-                        // sourceScope must be set null tableName for its Field in RelationFields
-                        // because we hope slotRef can not be resolved in sourceScope but can be
-                        // resolved in outputScope to force to replace the node using outputExprs.
-                        Scope sourceScope = new Scope(RelationId.anonymous(),
-                                new RelationFields(tbl.getBaseSchema().stream().map(col ->
-                                                new Field(col.getName(), col.getType(), null, null))
-                                        .collect(Collectors.toList())));
-                        Scope outputScope = new Scope(RelationId.anonymous(),
-                                new RelationFields(tbl.getBaseSchema().stream().map(col ->
-                                                new Field(col.getName(), col.getType(), tableName, null))
-                                        .collect(Collectors.toList())));
-                        SelectAnalyzer.RewriteAliasVisitor visitor =
-                                new SelectAnalyzer.RewriteAliasVisitor(sourceScope, outputScope,
-                                        outputExprs, new ConnectContext());
-                        Expr definedExpr = column.getDefineExpr().clone();
-                        definedExpr = definedExpr.accept(visitor, null);
-                        definedExpr = Expr.analyzeAndCastFold(definedExpr);
-                        if (!definedExpr.getType().equals(column.getType())) {
-                            definedExpr = new CastExpr(column.getType(), definedExpr);
-                        }
                         defineExprs.put(column.getName(), definedExpr);
+
+                        List<SlotRef> slots = Lists.newArrayList();
+                        definedExpr.collect(SlotRef.class, slots);
+                        slots.stream().map(slot -> slot.getColumnName()).forEach(usedBaseTableColNames::add);
+                    }
+
+                    Expr whereExpr = null;
+                    if (whereClause != null) {
+                        Type type = ScalarType.createType(PrimitiveType.BOOLEAN);
+                        whereExpr = analyzeExpr(type, CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME, whereClause,
+                                slotDescByName, outputExprs, tbl, tableName);
+                        List<SlotRef> slots = Lists.newArrayList();
+                        whereExpr.collect(SlotRef.class, slots);
+                        slots.stream().map(slot -> slot.getColumnName()).forEach(usedBaseTableColNames::add);
                     }
 
                     List<Replica> rollupReplicas = ((LocalTablet) rollupTablet).getImmutableReplicas();
+                    for (String refColName : usedBaseTableColNames) {
+                        if (!baseTableColumnNames.contains(refColName)) {
+                            throw new AlterCancelException("Materialized view's ref column " + refColName + " is not " +
+                                    "found in the base table.");
+                        }
+                    }
+                    AlterReplicaTask.RollupJobV2Params rollupJobV2Params =
+                            new AlterReplicaTask.RollupJobV2Params(defineExprs, whereExpr, descTable,
+                                    Lists.newLinkedList(usedBaseTableColNames));
                     for (Replica rollupReplica : rollupReplicas) {
                         AlterReplicaTask rollupTask = AlterReplicaTask.rollupLocalTablet(
                                 rollupReplica.getBackendId(), dbId, tableId, partitionId, rollupIndexId, rollupTabletId,
                                 baseTabletId, rollupReplica.getId(), rollupSchemaHash, baseSchemaHash, visibleVersion, jobId,
-                                defineExprs);
+                                rollupJobV2Params);
                         rollupBatchTask.addTask(rollupTask);
                     }
                 }
@@ -918,6 +968,10 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
 
     @Override
     public void gsonPostProcess() throws IOException {
+        if (this.rollupBatchTask == null) {
+            this.rollupBatchTask = new AgentBatchTask();
+        }
+
         // analyze define stmt
         if (origStmt == null) {
             return;
@@ -928,6 +982,9 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
         }
 
         Map<String, Expr> columnNameToDefineExpr = MetaUtils.parseColumnNameToDefineExpr(origStmt);
+        if (columnNameToDefineExpr.containsKey(CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME)) {
+            whereClause = columnNameToDefineExpr.get(CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME);
+        }
         setColumnsDefineExpr(columnNameToDefineExpr);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/InPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/InPredicate.java
@@ -66,11 +66,13 @@ public class InPredicate extends Predicate {
         children.add(compareExpr);
         children.addAll(inList);
         this.isNotIn = isNotIn;
+        this.opcode = isNotIn ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN;
     }
 
     protected InPredicate(InPredicate other) {
         super(other);
         isNotIn = other.isNotIn();
+        this.opcode = isNotIn ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN;
     }
 
     public int getInElementNum() {
@@ -95,6 +97,7 @@ public class InPredicate extends Predicate {
         children.add(compareExpr);
         children.add(subquery);
         this.isNotIn = isNotIn;
+        this.opcode = isNotIn ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -44,6 +44,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.OriginStatement;
+import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.thrift.TStorageType;
 
@@ -83,6 +84,7 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     @SerializedName(value = "isColocateMVIndex")
     private boolean isColocateMVIndex = false;
 
+    private Expr whereClause;
 
     public MaterializedIndexMeta(long indexId, List<Column> schema, int schemaVersion, int schemaHash,
                                  short shortKeyColumnCount, TStorageType storageType, KeysType keysType,
@@ -209,6 +211,14 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         isColocateMVIndex = colocateMVIndex;
     }
 
+    public void setWhereClause(Expr whereClause) {
+        this.whereClause = whereClause;
+    }
+
+    public Expr getWhereClause() {
+        return whereClause;
+    }
+
     // The column names of the materialized view are all lowercase, but the column names may be uppercase
     @VisibleForTesting
     public void setColumnsDefineExpr(Map<String, Expr> columnNameToDefineExpr) {
@@ -262,7 +272,7 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         if (indexMeta.keysType != this.keysType) {
             return false;
         }
-        return true;
+        return indexMeta.whereClause == this.whereClause;
     }
 
     @Override
@@ -282,6 +292,9 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
             return;
         }
         Map<String, Expr> columnNameToDefineExpr = MetaUtils.parseColumnNameToDefineExpr(defineStmt);
+        if (columnNameToDefineExpr.containsKey(CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME)) {
+            whereClause = columnNameToDefineExpr.get(CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME);
+        }
         setColumnsDefineExpr(columnNameToDefineExpr);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -272,7 +272,15 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         if (indexMeta.keysType != this.keysType) {
             return false;
         }
-        return indexMeta.whereClause == this.whereClause;
+        if (indexMeta.whereClause != null && this.whereClause == null) {
+            return false;
+        } else if (indexMeta.whereClause == null && this.whereClause != null) {
+            return false;
+        } else if (indexMeta.whereClause != null && this.whereClause != null &&
+                !indexMeta.whereClause.equals(this.whereClause)) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -324,7 +324,6 @@ public class OlapTableSink extends DataSink {
                     descMap.put(slot.getColumn().getName(), slot);
                 }
 
-
                 Expr whereClause = indexMeta.getWhereClause().clone();
                 List<SlotRef> slots = Lists.newArrayList();
                 whereClause.collect(SlotRef.class, slots);
@@ -368,7 +367,9 @@ public class OlapTableSink extends DataSink {
                 whereClause = Expr.analyzeAndCastFold(whereClause);
 
                 indexSchema.setWhere_clause(whereClause.treeToThrift());
-                LOG.info("OlapTableSink Where clause: {}", whereClause.explain());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("OlapTableSink Where clause: {}", whereClause.explain());
+                }
             }
         }
         return schemaParam;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -42,9 +42,11 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
 import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.ExprSubstitutionMap;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.TableName;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -77,7 +79,10 @@ import com.starrocks.common.Status;
 import com.starrocks.common.UserException;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.load.Load;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.*;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TDataSink;
@@ -105,9 +110,13 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+
 import java.util.stream.Collectors;
 
 public class OlapTableSink extends DataSink {
@@ -307,6 +316,60 @@ public class OlapTableSink extends DataSink {
                     indexMeta.getSchemaHash());
             indexSchema.setColumn_param(columnParam);
             schemaParam.addToIndexes(indexSchema);
+            if (indexMeta.getWhereClause() != null) {
+                String dbName = MetaUtils.getDatabase(dbId).getFullName();
+
+                Map<String, SlotDescriptor> descMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+                for (SlotDescriptor slot : tupleDescriptor.getSlots()) {
+                    descMap.put(slot.getColumn().getName(), slot);
+                }
+
+
+                Expr whereClause = indexMeta.getWhereClause().clone();
+                List<SlotRef> slots = Lists.newArrayList();
+                whereClause.collect(SlotRef.class, slots);
+
+                ExprSubstitutionMap smap = new ExprSubstitutionMap();
+                for (SlotRef slot : slots) {
+                    SlotDescriptor slotDesc = descMap.get(slot.getColumnName());
+                    Preconditions.checkNotNull(slotDesc);
+                    smap.getLhs().add(slot);
+                    SlotRef slotRef = new SlotRef(slotDesc);
+                    slotRef.setColumnName(slot.getColumnName());
+                    smap.getRhs().add(slotRef);
+                }
+                whereClause = whereClause.clone(smap);
+
+                // sourceScope must be set null tableName for its Field in RelationFields
+                // because we hope slotRef can not be resolved in sourceScope but can be
+                // resolved in outputScope to force to replace the node using outputExprs.
+                List<Expr> outputExprs = Lists.newArrayList();
+                for (Column col : table.getBaseSchema()) {
+                    SlotDescriptor slotDesc = descMap.get(col.getName());
+                    Preconditions.checkState(slotDesc != null);
+                    SlotRef slotRef = new SlotRef(slotDesc);
+                    slotRef.setColumnName(col.getName());
+                    outputExprs.add(slotRef);
+                }
+                ConnectContext connectContext = new ConnectContext();
+                Scope sourceScope = new Scope(RelationId.anonymous(),
+                        new RelationFields(table.getBaseSchema().stream().map(col ->
+                                        new Field(col.getName(), col.getType(), null, null))
+                                .collect(Collectors.toList())));
+                Scope outputScope = new Scope(RelationId.anonymous(),
+                        new RelationFields(table.getBaseSchema().stream().map(col ->
+                                        new Field(col.getName(), col.getType(), new TableName(dbName, table.getName()), null))
+                                .collect(Collectors.toList())));
+                SelectAnalyzer.RewriteAliasVisitor visitor =
+                        new SelectAnalyzer.RewriteAliasVisitor(sourceScope, outputScope,
+                                outputExprs, connectContext);
+
+                whereClause = whereClause.accept(visitor, null);
+                whereClause = Expr.analyzeAndCastFold(whereClause);
+
+                indexSchema.setWhere_clause(whereClause.treeToThrift());
+                LOG.info("OlapTableSink Where clause: {}", whereClause.explain());
+            }
         }
         return schemaParam;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStmt.java
@@ -131,6 +131,8 @@ public class CreateMaterializedViewStmt extends DdlStmt {
      * This order of mvColumnItemList is meaningful.
      */
     private List<MVColumnItem> mvColumnItemList = Lists.newArrayList();
+
+    private Expr whereClause;
     private String baseIndexName;
     private String dbName;
     private KeysType mvKeysType = KeysType.DUP_KEYS;
@@ -138,6 +140,8 @@ public class CreateMaterializedViewStmt extends DdlStmt {
     // If the process is replaying log, isReplay is true, otherwise is false,
     // avoid throwing error during replay process, only in Rollup or MaterializedIndexMeta is true.
     private boolean isReplay = false;
+
+    public static String WHERE_PREDICATE_COLUMN_NAME = "__WHERE_PREDICATION";
 
     public CreateMaterializedViewStmt(TableName mvTableName, QueryStatement queryStatement, Map<String, String> properties) {
         super(NodePosition.ZERO);
@@ -198,6 +202,10 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         this.mvKeysType = mvKeysType;
     }
 
+    public Expr getWhereClause() {
+        return whereClause;
+    }
+
     // NOTE: This method is used to replay persistent MaterializedViewMeta,
     // so need keep the same with `genColumnAndSetIntoStmt` and keep compatible with old version policy.
     public Map<String, Expr> parseDefineExprWithoutAnalyze(String originalSql) throws AnalysisException {
@@ -205,7 +213,11 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         SelectList selectList = null;
         QueryRelation queryRelation = queryStatement.getQueryRelation();
         if (queryRelation instanceof SelectRelation) {
-            selectList = ((SelectRelation) queryRelation).getSelectList();
+            SelectRelation selectRelation = (SelectRelation) queryRelation;
+            selectList = selectRelation.getSelectList();
+            if (selectRelation.hasWhereClause()) {
+                result.put(WHERE_PREDICATE_COLUMN_NAME, selectRelation.getWhereClause());
+            }
         }
         if (selectList == null) {
             LOG.warn("parse defineExpr may not correctly for sql [{}] ", originalSql);
@@ -317,8 +329,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             setMvKeysType(KeysType.AGG_KEYS);
         }
         if (selectRelation.hasWhereClause()) {
-            throw new UnsupportedMVException("The where clause is not supported in add materialized view clause, expr:"
-                    + selectRelation.getWhereClause().toSql());
+            whereClause = selectRelation.getWhereClause();
         }
         if (selectRelation.hasHavingClause()) {
             throw new UnsupportedMVException("The having clause is not supported in add materialized view clause, expr:"
@@ -329,8 +340,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             throw new UnsupportedMVException("The limit clause is not supported in add materialized view clause, expr:"
                     + " limit " + selectRelation.getLimit());
         }
-        final String countPrefix = new StringBuilder().append(MATERIALIZED_VIEW_NAME_PREFIX)
-                .append(FunctionSet.COUNT).append("_").toString();
+        final String countPrefix = MATERIALIZED_VIEW_NAME_PREFIX + FunctionSet.COUNT + "_";
         for (MVColumnItem mvColumnItem : getMVColumnItemList()) {
             if (!isReplay && mvColumnItem.isKey() && !mvColumnItem.getType().canBeMVKey()) {
                 throw new UnsupportedMVException(
@@ -371,12 +381,6 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                 if (slots.size() == 0) {
                     throw new UnsupportedMVException(String.format("The materialized view currently does not support " +
                             "const expr in select " + "statement: {}", selectListItemExpr.toMySql()));
-                }
-                // TODO: support multi slot-refs later.
-                if (slots.size() > 1) {
-                    throw new UnsupportedMVException(
-                            String.format("The materialized view currently does not support multi-slot-refs expr: {}",
-                                    selectListItemExpr.toSql()));
                 }
             }
             MVColumnItem mvColumnItem;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MVColumnItem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MVColumnItem.java
@@ -39,7 +39,6 @@ import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Type;
-import com.starrocks.common.DdlException;
 
 import java.util.Set;
 
@@ -120,7 +119,7 @@ public class MVColumnItem {
         return baseColumnNames;
     }
 
-    public Column toMVColumn(OlapTable olapTable) throws DdlException {
+    public Column toMVColumn(OlapTable olapTable) {
         Column baseColumn = olapTable.getBaseColumn(name);
         Column result;
         boolean useLightSchemaChange = olapTable.getUseLightSchemaChange();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MVUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MVUtils.java
@@ -93,6 +93,9 @@ public class MVUtils {
     // - only support specific function  for aggregate column.
     // 2. MV with Complex expressions will be used to rewrite query by AggregatedMaterializedViewRewriter.
     public static boolean containComplexExpresses(MaterializedIndexMeta mvMeta) {
+        if (mvMeta.getWhereClause() != null) {
+            return true;
+        }
         for (Column mvColumn : mvMeta.getSchema()) {
             Expr definedExpr = mvColumn.getDefineExpr();
             if (definedExpr == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -37,6 +37,7 @@ package com.starrocks.task;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.alter.AlterJobV2;
+import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.Column;
@@ -51,6 +52,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.persist.ReplicaPersistInfo;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TAlterJobType;
 import com.starrocks.thrift.TAlterMaterializedViewParam;
 import com.starrocks.thrift.TAlterTabletMaterializedColumnReq;
 import com.starrocks.thrift.TAlterTabletReqV2;
@@ -88,9 +90,41 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
     private final AlterJobV2.JobType jobType;
     private final TTabletType tabletType;
     private final long txnId;
-    private final Map<String, Expr> defineExprs;
     private final TAlterTabletMaterializedColumnReq generatedColumnReq;
     private List<Column> baseSchemaColumns;
+    private RollupJobV2Params rollupJobV2Params;
+
+    public static class RollupJobV2Params {
+        private final Map<String, Expr> defineExprs;
+        private final Expr whereExpr;
+        private final DescriptorTable descTabl;
+        private final List<String> baseTableColNames;
+        public RollupJobV2Params(Map<String, Expr> defineExprs,
+                                 Expr whereExpr,
+                                 DescriptorTable descTabl,
+                                 List<String> baseTableColNames) {
+            this.defineExprs = defineExprs;
+            this.whereExpr = whereExpr;
+            this.descTabl = descTabl;
+            this.baseTableColNames = baseTableColNames;
+        }
+
+        public Map<String, Expr> getDefineExprs() {
+            return defineExprs;
+        }
+
+        public Expr getWhereExpr() {
+            return whereExpr;
+        }
+
+        public DescriptorTable getDescTabl() {
+            return descTabl;
+        }
+
+        public List<String> getBaseTableColNames() {
+            return baseTableColNames;
+        }
+    }
 
     public static AlterReplicaTask alterLocalTablet(long backendId, long dbId, long tableId, long partitionId, long rollupIndexId,
                                                     long rollupTabletId, long baseTabletId, long newReplicaId, int newSchemaHash,
@@ -99,29 +133,31 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
                                                     List<Column> baseSchemaColumns) {
         return new AlterReplicaTask(backendId, dbId, tableId, partitionId, rollupIndexId, rollupTabletId,
                 baseTabletId, newReplicaId, newSchemaHash, baseSchemaHash, version, jobId, AlterJobV2.JobType.SCHEMA_CHANGE,
-                null, TTabletType.TABLET_TYPE_DISK, 0, generatedColumnReq, baseSchemaColumns);
+                TTabletType.TABLET_TYPE_DISK, 0, generatedColumnReq, baseSchemaColumns, null);
     }
 
     public static AlterReplicaTask alterLakeTablet(long backendId, long dbId, long tableId, long partitionId, long rollupIndexId,
             long rollupTabletId, long baseTabletId, long version, long jobId, long txnId) {
         return new AlterReplicaTask(backendId, dbId, tableId, partitionId, rollupIndexId, rollupTabletId,
                 baseTabletId, -1, -1, -1, version, jobId, AlterJobV2.JobType.SCHEMA_CHANGE,
-                null, TTabletType.TABLET_TYPE_LAKE, txnId, null, Collections.emptyList());
+                TTabletType.TABLET_TYPE_LAKE, txnId, null, Collections.emptyList(), null);
     }
 
     public static AlterReplicaTask rollupLocalTablet(long backendId, long dbId, long tableId, long partitionId,
             long rollupIndexId, long rollupTabletId, long baseTabletId,
             long newReplicaId, int newSchemaHash, int baseSchemaHash, long version,
-            long jobId, Map<String, Expr> defineExprs) {
+            long jobId, RollupJobV2Params rollupJobV2Params) {
         return new AlterReplicaTask(backendId, dbId, tableId, partitionId, rollupIndexId, rollupTabletId,
                 baseTabletId, newReplicaId, newSchemaHash, baseSchemaHash, version, jobId, AlterJobV2.JobType.ROLLUP,
-                defineExprs, TTabletType.TABLET_TYPE_DISK, 0, null, Collections.emptyList());
+                TTabletType.TABLET_TYPE_DISK, 0, null,
+                Collections.emptyList(), rollupJobV2Params);
     }
 
     private AlterReplicaTask(long backendId, long dbId, long tableId, long partitionId, long rollupIndexId, long rollupTabletId,
                              long baseTabletId, long newReplicaId, int newSchemaHash, int baseSchemaHash, long version,
-                             long jobId, AlterJobV2.JobType jobType, Map<String, Expr> defineExprs, TTabletType tabletType,
-                             long txnId, TAlterTabletMaterializedColumnReq generatedColumnReq, List<Column> baseSchemaColumns) {
+                             long jobId, AlterJobV2.JobType jobType,
+                             TTabletType tabletType, long txnId, TAlterTabletMaterializedColumnReq generatedColumnReq, 
+                             List<Column> baseSchemaColumns, RollupJobV2Params rollupJobV2Params) {
         super(null, backendId, TTaskType.ALTER, dbId, tableId, partitionId, rollupIndexId, rollupTabletId);
 
         this.baseTabletId = baseTabletId;
@@ -134,13 +170,13 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
         this.jobId = jobId;
 
         this.jobType = jobType;
-        this.defineExprs = defineExprs;
-
         this.tabletType = tabletType;
         this.txnId = txnId;
 
         this.generatedColumnReq = generatedColumnReq;
         this.baseSchemaColumns = baseSchemaColumns;
+
+        this.rollupJobV2Params = rollupJobV2Params;
     }
 
     public long getBaseTabletId() {
@@ -174,30 +210,53 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
     public TAlterTabletReqV2 toThrift() {
         TAlterTabletReqV2 req = new TAlterTabletReqV2(baseTabletId, signature, baseSchemaHash, newSchemaHash);
         req.setAlter_version(version);
-        if (defineExprs != null) {
-            for (Map.Entry<String, Expr> entry : defineExprs.entrySet()) {
-                List<SlotRef> slots = Lists.newArrayList();
-                entry.getValue().collect(SlotRef.class, slots);
-                TAlterMaterializedViewParam mvParam = new TAlterMaterializedViewParam(entry.getKey());
-                mvParam.setOrigin_column_name(slots.get(0).getColumnName());
-                mvParam.setMv_expr(entry.getValue().treeToThrift());
-                req.addToMaterialized_view_params(mvParam);
+        switch (jobType) {
+            case ROLLUP:
+                req.setAlter_job_type(TAlterJobType.ROLLUP);
+                break;
+            case SCHEMA_CHANGE:
+                req.setAlter_job_type(TAlterJobType.SCHEMA_CHANGE);
+                break;
+            case DECOMMISSION_BACKEND:
+                req.setAlter_job_type(TAlterJobType.DECOMMISSION_BACKEND);
+                break;
+            default:
+                break;
+        }
+        if (rollupJobV2Params != null) {
+            Map<String, Expr> defineExprs = rollupJobV2Params.getDefineExprs();
+            Expr whereExpr = rollupJobV2Params.getWhereExpr();
+            DescriptorTable descTable = rollupJobV2Params.getDescTabl();
+            List<String> baseTableColNames = rollupJobV2Params.getBaseTableColNames();
+            if (defineExprs != null) {
+                for (Map.Entry<String, Expr> entry : defineExprs.entrySet()) {
+                    List<SlotRef> slots = Lists.newArrayList();
+                    entry.getValue().collect(SlotRef.class, slots);
+                    TAlterMaterializedViewParam mvParam = new TAlterMaterializedViewParam(entry.getKey());
+                    mvParam.setOrigin_column_name(slots.get(0).getColumnName());
+                    mvParam.setMv_expr(entry.getValue().treeToThrift());
+                    req.addToMaterialized_view_params(mvParam);
+                }
+
+                // we need this thing, otherwise some expr evalution will fail in BE
+                TQueryGlobals queryGlobals = new TQueryGlobals();
+                SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+                queryGlobals.setNow_string(dateFormat.format(new Date()));
+                queryGlobals.setTimestamp_ms(System.currentTimeMillis());
+                queryGlobals.setTime_zone(TimeUtils.DEFAULT_TIME_ZONE);
+                TQueryOptions queryOptions = new TQueryOptions();
+                req.setQuery_globals(queryGlobals);
+                req.setQuery_options(queryOptions);
             }
+            if (whereExpr != null) {
+                req.setWhere_expr(whereExpr.treeToThrift());
+            }
+            if (descTable != null) {
+                req.setDesc_tbl(descTable.toThrift());
+            }
+            req.setBase_table_column_names(baseTableColNames);
         }
         req.setMaterialized_column_req(generatedColumnReq);
-
-        // TODO: merge `generatedColumnReq`'s query options into this later.
-        if (defineExprs != null && defineExprs.size() > 0) {
-            // we need this thing, otherwise some expr evalution will fail in BE
-            TQueryGlobals queryGlobals = new TQueryGlobals();
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-            queryGlobals.setNow_string(dateFormat.format(new Date()));
-            queryGlobals.setTimestamp_ms(System.currentTimeMillis());
-            queryGlobals.setTime_zone(TimeUtils.DEFAULT_TIME_ZONE);
-            TQueryOptions queryOptions = new TQueryOptions();
-            req.setQuery_globals(queryGlobals);
-            req.setQuery_options(queryOptions);
-        }
 
         req.setTablet_type(tabletType);
         req.setTxn_id(txnId);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
@@ -257,7 +257,8 @@ public class RollupJobV2Test extends DDLTestBase {
         Column column = new Column(mvColumnName, Type.BITMAP, false, AggregateType.BITMAP_UNION, false,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("1")), "");
         columns.add(column);
-        RollupJobV2 rollupJobV2 = new RollupJobV2(1, 1, 1, "test", 1, 1, 1, "test", "rollup", columns, 1, 1,
+        RollupJobV2 rollupJobV2 = new RollupJobV2(1, 1, 1, "test", 1, 1,
+                1, "test", "rollup", columns, null, 1, 1,
                 KeysType.AGG_KEYS, keysCount,
                 new OriginStatement("create materialized view rollup as select bitmap_union(to_bitmap(c1)) from test",
                         0), "", false);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -33,8 +33,6 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.Pair;
-import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
@@ -307,20 +305,6 @@ public class CreateMaterializedViewTest {
 
     private void dropMv(String mvName) throws Exception {
         String sql = "drop materialized view " + mvName;
-        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statementBase);
-        stmtExecutor.execute();
-    }
-
-    private void dropTableForce(String tableName) throws Exception {
-        String sql = "drop table " + tableName + " force";
-        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statementBase);
-        stmtExecutor.execute();
-    }
-
-    private void dropTable(String tableName) throws Exception {
-        String sql = "drop table " + tableName;
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, statementBase);
         stmtExecutor.execute();
@@ -3077,164 +3061,6 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testSelectFromSyncMV() throws Exception {
-        // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
-        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
-                parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
-
-        waitingRollupJobV2Finish();
-        sql = "select * from sync_mv1 [_SYNC_MV_];";
-        Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
-        String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
-        Assert.assertTrue(explainString.contains("partitions=2/2\n" +
-                "     rollup: sync_mv1\n" +
-                "     tabletRatio=6/6"));
-        starRocksAssert.dropMaterializedView("sync_mv1");
-    }
-
-    // create sync mv that mv's name already existed in the db
-    @Test
-    public void testCreateSyncMV1() throws Exception {
-        try {
-            String sql = "create materialized view aggregate_table_with_null as select k1, sum(v1) from tbl1 group by k1;";
-            CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
-                    parseStmtWithNewParser(sql, connectContext);
-            // aggregate_table_with_null already existed in the db
-            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
-            Assert.fail();
-        } catch (Throwable e) {
-            Assert.assertTrue(e.getMessage().contains("Table [aggregate_table_with_null] already exists in the db test"));
-        }
-    }
-
-    // create sync mv that mv's name already existed in the same table
-    @Test
-    public void testCreateSyncMV2() throws Exception {
-        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
-                parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
-
-        waitingRollupJobV2Finish();
-        OlapTable tbl1 = (OlapTable) (getTable("test", "tbl1"));
-        Assert.assertTrue(tbl1 != null);
-        Assert.assertTrue(tbl1.hasMaterializedIndex("sync_mv1"));
-
-        try {
-            // sync_mv1 already existed in the tbl1
-            sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
-            createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
-                    parseStmtWithNewParser(sql, connectContext);
-            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
-            Assert.fail();
-        } catch (Throwable e) {
-            Assert.assertTrue(e.getMessage().contains("Materialized view[sync_mv1] already exists in " +
-                    "the table tbl1"));
-        }
-        starRocksAssert.dropMaterializedView("sync_mv1");
-    }
-
-    // create sync mv that mv's name already existed in other table
-    @Test
-    public void testCreateSyncMV3() throws Exception {
-        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
-                parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
-
-        waitingRollupJobV2Finish();
-        OlapTable tbl1 = (OlapTable) (getTable("test", "tbl1"));
-        Assert.assertTrue(tbl1 != null);
-        Assert.assertTrue(tbl1.hasMaterializedIndex("sync_mv1"));
-        try {
-            // sync_mv1 already existed in tbl1
-            sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl3 group by k1;";
-            createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
-                    parseStmtWithNewParser(sql, connectContext);
-            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
-            Assert.fail();
-        } catch (Throwable e) {
-            Assert.assertTrue(e.getMessage().contains("Materialized view[sync_mv1] already exists " +
-                    "in table tbl1"));
-        }
-        starRocksAssert.dropMaterializedView("sync_mv1");
-    }
-
-    @Test
-    public void testCreateSyncMV_WithUpperColumn() throws Exception {
-        // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
-        String sql = "create materialized view UPPER_MV1 as select K1, sum(V1) from TBL1 group by K1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
-                parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
-
-        waitingRollupJobV2Finish();
-        {
-            sql = "select * from UPPER_MV1 [_SYNC_MV_];";
-            Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
-            String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
-            // output columns should be same with the base table.
-            Assert.assertTrue(explainString.contains("PLAN FRAGMENT 0\n" +
-                    " OUTPUT EXPRS:1: K1 | 2: mv_sum_V1\n" +
-                    "  PARTITION: UNPARTITIONED"));
-        }
-        {
-            sql = "select K1, sum(V1) from TBL1 group by K1";
-            Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
-            String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
-            Assert.assertTrue(explainString.contains("1:AGGREGATE (update serialize)\n" +
-                    "  |  STREAMING\n" +
-                    "  |  output: sum(4: mv_sum_V1)\n" +
-                    "  |  group by: 1: K1\n" +
-                    "  |  \n" +
-                    "  0:OlapScanNode\n" +
-                    "     TABLE: TBL1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=2/2\n" +
-                    "     rollup: UPPER_MV1"));
-        }
-        starRocksAssert.dropMaterializedView("UPPER_MV1");
-    }
-
-    @Test
-    public void testCreateSyncMV_WithLowerColumn() throws Exception {
-        // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
-        String sql = "create materialized view lower_mv1 as select k1, sum(v1) from tbl1 group by K1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
-                parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
-
-        waitingRollupJobV2Finish();
-        {
-            sql = "select * from lower_mv1 [_SYNC_MV_];";
-            Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
-            String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
-            // output columns should be same with the base table.
-            Assert.assertTrue(explainString.contains("PLAN FRAGMENT 0\n" +
-                    " OUTPUT EXPRS:1: k1 | 2: mv_sum_v1\n" +
-                    "  PARTITION: UNPARTITIONED"));
-        }
-        {
-            sql = "select K1, sum(v1) from tbl1 group by K1";
-            Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
-            String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
-            Assert.assertTrue(explainString.contains("1:AGGREGATE (update serialize)\n" +
-                    "  |  STREAMING\n" +
-                    "  |  output: sum(4: mv_sum_v1)\n" +
-                    "  |  group by: 1: k1\n" +
-                    "  |  \n" +
-                    "  0:OlapScanNode\n" +
-                    "     TABLE: tbl1\n" +
-                    "     PREAGGREGATION: ON\n" +
-                    "     partitions=2/2\n" +
-                    "     rollup: lower_mv1"));
-        }
-        starRocksAssert.dropMaterializedView("lower_mv1");
-    }
-
-    @Test
     public void testCreateAsyncDateTruncAndTimeSLice() throws Exception {
         LocalDateTime startTime = LocalDateTime.now().plusSeconds(3);
 
@@ -3730,37 +3556,6 @@ public class CreateMaterializedViewTest {
         starRocksAssert.dropView("view_1");
         starRocksAssert.dropView("view_2");
         starRocksAssert.dropView("view_3");
-    }
-
-    @Test
-    public void testCreateSynchronousMVOnLakeTable() throws Exception {
-        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from mocked_cloud_table group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
-                parseStmtWithNewParser(sql, connectContext);
-        Table table = getTable("test", "mocked_cloud_table");
-        // Change table type to cloud native table
-        Deencapsulation.setField(table, "type", Table.TableType.CLOUD_NATIVE);
-        DdlException e = Assert.assertThrows(DdlException.class, () -> {
-            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
-        });
-        Assert.assertTrue(e.getMessage().contains("Creating synchronous materialized view(rollup) is not supported in " +
-                "shared data clusters.\nPlease use asynchronous materialized view instead.\n" +
-                "Refer to https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements" +
-                "/data-definition/CREATE%20MATERIALIZED%20VIEW#asynchronous-materialized-view for details."));
-    }
-
-    @Test
-    public void testCreateSynchronousMVOnAnotherMV() throws Exception {
-        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from mocked_cloud_table group by k1;";
-        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
-                parseStmtWithNewParser(sql, connectContext);
-        Table table = getTable("test", "mocked_cloud_table");
-        // Change table type to materialized view
-        Deencapsulation.setField(table, "type", Table.TableType.MATERIALIZED_VIEW);
-        DdlException e = Assert.assertThrows(DdlException.class, () -> {
-            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
-        });
-        Assert.assertTrue(e.getMessage().contains("Do not support create synchronous materialized view(rollup) on"));
     }
 
     MaterializedView getMaterializedViewChecked(String sql) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateSyncMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateSyncMaterializedViewTest.java
@@ -1,0 +1,502 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.Pair;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import static com.starrocks.sql.optimizer.MVTestUtils.waitingRollupJobV2Finish;
+
+public class CreateSyncMaterializedViewTest {
+    private static final Logger LOG = LogManager.getLogger(CreateSyncMaterializedViewTest.class);
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Rule
+    public TestName name = new TestName();
+
+    @ClassRule
+    public static TemporaryFolder temp = new TemporaryFolder();
+
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+    private static Database testDb;
+    private static GlobalStateMgr currentState;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        ConnectorPlanTestBase.doInit(temp.newFolder().toURI().toString());
+        Config.alter_scheduler_interval_millisecond = 100;
+        Config.dynamic_partition_enable = true;
+        Config.dynamic_partition_check_interval_seconds = 1;
+        Config.enable_experimental_mv = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE test.tbl1\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2020-01-01'),('2020-02-01')),\n" +
+                        "    PARTITION p2 values [('2020-02-01'),('2020-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE test.TBL1 \n" +
+                        "(\n" +
+                        "    K1 date,\n" +
+                        "    K2 int,\n" +
+                        "    V1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(K1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2020-01-01'),('2020-02-01')),\n" +
+                        "    PARTITION p2 values [('2020-02-01'),('2020-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(K2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE `aggregate_table_with_null` (\n" +
+                        "`k1` date,\n" +
+                        "`v2` datetime MAX,\n" +
+                        "`v3` char(20) MIN,\n" +
+                        "`v4` bigint SUM,\n" +
+                        "`v8` bigint SUM,\n" +
+                        "`v5` HLL HLL_UNION,\n" +
+                        "`v6` BITMAP BITMAP_UNION,\n" +
+                        "`v7` PERCENTILE PERCENTILE_UNION\n" +
+                        ") ENGINE=OLAP\n" +
+                        "AGGREGATE KEY(`k1`)\n" +
+                        "COMMENT \"OLAP\"\n" +
+                        "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\"\n" +
+                        ");")
+                .withView("CREATE VIEW v1 AS SELECT * FROM aggregate_table_with_null;")
+                .withTable("CREATE TABLE test.tbl2\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k2)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values less than('10'),\n" +
+                        "    PARTITION p2 values less than('20')\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE test.tbl3\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE `duplicate_tbl` (\n" +
+                        "    `k1` date NULL COMMENT \"\",   \n" +
+                        "    `k2` datetime NULL COMMENT \"\",   \n" +
+                        "    `k3` char(20) NULL COMMENT \"\",   \n" +
+                        "    `k4` varchar(20) NULL COMMENT \"\",   \n" +
+                        "    `k5` boolean NULL COMMENT \"\",   \n" +
+                        "    `k6` tinyint(4) NULL COMMENT \"\",   \n" +
+                        "    `k7` smallint(6) NULL COMMENT \"\",   \n" +
+                        "    `k8` int(11) NULL COMMENT \"\",   \n" +
+                        "    `k9` bigint(20) NULL COMMENT \"\",   \n" +
+                        "    `k10` largeint(40) NULL COMMENT \"\",   \n" +
+                        "    `k11` float NULL COMMENT \"\",   \n" +
+                        "    `k12` double NULL COMMENT \"\",   \n" +
+                        "    `k13` decimal128(27, 9) NULL COMMENT \"\",   \n" +
+                        "    INDEX idx1 (`k6`) USING BITMAP \n" +
+                        ") \n" +
+                        "ENGINE=OLAP DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) \n" +
+                        "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 \n" +
+                        "PROPERTIES ( \n" +
+                        "    \"replication_num\" = \"1\" \n" +
+                        ")")
+                .withDatabase("test2").useDatabase("test2")
+                .withTable("CREATE TABLE test2.tbl3\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values less than('2021-02-01'),\n" +
+                        "    PARTITION p2 values less than('2021-03-01')\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE test.mocked_cloud_table\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values [('2020-01-01'),('2020-02-01')),\n" +
+                        "    PARTITION p2 values [('2020-02-01'),('2020-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .useDatabase("test");
+        starRocksAssert.withView("create view test.view_to_tbl1 as select * from test.tbl1;");
+        currentState = GlobalStateMgr.getCurrentState();
+        testDb = currentState.getDb("test");
+    }
+
+    private Table getTable(String dbName, String mvName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Table table = db.getTable(mvName);
+        Assert.assertNotNull(table);
+        return table;
+    }
+
+    private MaterializedView getMv(String dbName, String mvName) {
+        Table table = getTable(dbName, mvName);
+        Assert.assertTrue(table instanceof MaterializedView);
+        MaterializedView mv = (MaterializedView) table;
+        return mv;
+    }
+
+    @Test
+    public void testSelectFromSyncMV() throws Exception {
+        // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
+        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
+        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+
+        waitingRollupJobV2Finish();
+        sql = "select * from sync_mv1 [_SYNC_MV_];";
+        Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+        String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
+        Assert.assertTrue(explainString.contains("partitions=2/2\n" +
+                "     rollup: sync_mv1\n" +
+                "     tabletRatio=6/6"));
+        starRocksAssert.dropMaterializedView("sync_mv1");
+    }
+
+    // create sync mv that mv's name already existed in the db
+    @Test
+    public void testCreateSyncMV1() throws Exception {
+        String sql = "create materialized view aggregate_table_with_null as select k1, sum(v1) from tbl1 group by k1;";
+        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        try {
+            // aggregate_table_with_null already existed in the db
+            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Table [aggregate_table_with_null] already exists in the db test"));
+        }
+    }
+
+    // create sync mv that mv's name already existed in the same table
+    @Test
+    public void testCreateSyncMV2() throws Exception {
+        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
+        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+
+        waitingRollupJobV2Finish();
+        OlapTable tbl1 = (OlapTable) (getTable("test", "tbl1"));
+        Assert.assertTrue(tbl1 != null);
+        Assert.assertTrue(tbl1.hasMaterializedIndex("sync_mv1"));
+
+        // sync_mv1 already existed in the tbl1
+        sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
+        createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        try {
+            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+            Assert.fail();
+        } catch (Throwable e) {
+            Assert.assertTrue(e.getMessage().contains("Materialized view[sync_mv1] already exists in " +
+                    "the table tbl1"));
+        }
+        starRocksAssert.dropMaterializedView("sync_mv1");
+    }
+
+    // create sync mv that mv's name already existed in other table
+    @Test
+    public void testCreateSyncMV3() throws Exception {
+        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl1 group by k1;";
+        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+
+        waitingRollupJobV2Finish();
+        OlapTable tbl1 = (OlapTable) (getTable("test", "tbl1"));
+        Assert.assertTrue(tbl1 != null);
+        Assert.assertTrue(tbl1.hasMaterializedIndex("sync_mv1"));
+        // sync_mv1 already existed in tbl1
+        sql = "create materialized view sync_mv1 as select k1, sum(v1) from tbl3 group by k1;";
+        createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        try {
+            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+            Assert.fail();
+        } catch (Throwable e) {
+            Assert.assertTrue(e.getMessage().contains("Materialized view[sync_mv1] already exists " +
+                    "in table tbl1"));
+        }
+        starRocksAssert.dropMaterializedView("sync_mv1");
+    }
+
+    @Test
+    public void testCreateSyncMV_WithUpperColumn() throws Exception {
+        // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
+        String sql = "create materialized view UPPER_MV1 as select K1, sum(V1) from TBL1 group by K1;";
+        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+
+        waitingRollupJobV2Finish();
+        {
+            sql = "select * from UPPER_MV1 [_SYNC_MV_];";
+            Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+            String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
+            // output columns should be same with the base table.
+            Assert.assertTrue(explainString.contains("PLAN FRAGMENT 0\n" +
+                    " OUTPUT EXPRS:1: K1 | 2: mv_sum_V1\n" +
+                    "  PARTITION: UNPARTITIONED"));
+        }
+        {
+            sql = "select K1, sum(V1) from TBL1 group by K1";
+            Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+            String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
+            Assert.assertTrue(explainString.contains("1:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  output: sum(4: mv_sum_V1)\n" +
+                    "  |  group by: 1: K1\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: TBL1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=2/2\n" +
+                    "     rollup: UPPER_MV1"));
+        }
+        starRocksAssert.dropMaterializedView("UPPER_MV1");
+    }
+
+    @Test
+    public void testCreateSyncMV_WithLowerColumn() throws Exception {
+        // `tbl1`'s distribution keys is k2, sync_mv1 no `k2` in its outputs.
+        String sql = "create materialized view lower_mv1 as select k1, sum(v1) from tbl1 group by K1;";
+        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+
+        waitingRollupJobV2Finish();
+        {
+            sql = "select * from lower_mv1 [_SYNC_MV_];";
+            Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+            String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
+            // output columns should be same with the base table.
+            Assert.assertTrue(explainString.contains("PLAN FRAGMENT 0\n" +
+                    " OUTPUT EXPRS:1: k1 | 2: mv_sum_v1\n" +
+                    "  PARTITION: UNPARTITIONED"));
+        }
+        {
+            sql = "select K1, sum(v1) from tbl1 group by K1";
+            Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+            String explainString = pair.second.getExplainString(StatementBase.ExplainLevel.NORMAL);
+            Assert.assertTrue(explainString.contains("1:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  output: sum(4: mv_sum_v1)\n" +
+                    "  |  group by: 1: k1\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode\n" +
+                    "     TABLE: tbl1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=2/2\n" +
+                    "     rollup: lower_mv1"));
+        }
+        starRocksAssert.dropMaterializedView("lower_mv1");
+    }
+
+    @Test
+    public void testCreateSynchronousMVOnLakeTable() throws Exception {
+        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from mocked_cloud_table group by k1;";
+        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        Table table = getTable("test", "mocked_cloud_table");
+        // Change table type to cloud native table
+        Deencapsulation.setField(table, "type", Table.TableType.CLOUD_NATIVE);
+        DdlException e = Assert.assertThrows(DdlException.class, () -> {
+            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+        });
+        Assert.assertTrue(e.getMessage().contains("Creating synchronous materialized view(rollup) is not supported in " +
+                "shared data clusters.\nPlease use asynchronous materialized view instead.\n" +
+                "Refer to https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements" +
+                "/data-definition/CREATE%20MATERIALIZED%20VIEW#asynchronous-materialized-view for details."));
+    }
+
+    @Test
+    public void testCreateSynchronousMVOnAnotherMV() throws Exception {
+        String sql = "create materialized view sync_mv1 as select k1, sum(v1) from mocked_cloud_table group by k1;";
+        CreateMaterializedViewStmt createTableStmt = (CreateMaterializedViewStmt) UtFrameUtils.
+                parseStmtWithNewParser(sql, connectContext);
+        Table table = getTable("test", "mocked_cloud_table");
+        // Change table type to materialized view
+        Deencapsulation.setField(table, "type", Table.TableType.MATERIALIZED_VIEW);
+        DdlException e = Assert.assertThrows(DdlException.class, () -> {
+            GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
+        });
+        Assert.assertTrue(e.getMessage().contains("Do not support create synchronous materialized view(rollup) on"));
+    }
+
+    @Test
+    public void testCreateSyncMaterializedViewWithWhereMultiSlots1() throws Exception {
+        String mv1 = "CREATE MATERIALIZED VIEW test_mv_with_multi_slots1 \n" +
+                "as\n" +
+                "select k1, sum(k6+k7) as sum1, max(k7*k10) as max1 from duplicate_tbl group by k1;";
+        starRocksAssert.withMaterializedView(mv1);
+
+        {
+            String query = "select k1, sum(k6+k7) as sum1, max(k7*k10) as max1 from duplicate_tbl group by k1;";
+            starRocksAssert.query(query).explainContains("test_mv_with_multi_slots1");
+        }
+        {
+            String query = "select k1, sum(k6+k7) as sum1 from duplicate_tbl group by k1;";
+            starRocksAssert.query(query).explainContains("test_mv_with_multi_slots1");
+        }
+        {
+            String query = "select k1, sum(k6+k7+1) as sum1 from duplicate_tbl group by k1;";
+            starRocksAssert.query(query).explainWithout("test_mv_with_multi_slots1");
+        }
+        starRocksAssert.dropMaterializedView("test_mv_with_multi_slots1");
+    }
+
+    @Test
+    public void testCreateSyncMaterializedViewWithWhereMultiSlots2() throws Exception {
+        String mv1 = "CREATE MATERIALIZED VIEW test_mv_with_multi_slots1 \n" +
+                "as\n" +
+                "select k1, (case when k6 + k7> 0 then 1 when k6 + k7 < 0 then -1 else 0 end) as case1 from duplicate_tbl;";
+        starRocksAssert.withMaterializedView(mv1);
+
+        {
+            String query = "select k1, (case when k6 + k7> 0 then 1 when k6 + k7 < 0 then -1 else 0 end) as case1 " +
+                    "from duplicate_tbl;";
+            starRocksAssert.query(query).explainContains("test_mv_with_multi_slots1");
+        }
+        {
+            String query = "select (case when k6 + k7> 0 then 1 when k6 + k7 < 0 then -1 else 0 end) as case1 " +
+                    "from duplicate_tbl;";
+            starRocksAssert.query(query).explainContains("test_mv_with_multi_slots1");
+        }
+        {
+            String query = "select (case when k6 + k7> 0 then 1 when k6 + k7 < 0 then -1 else 0 end) as case1 " +
+                    "from duplicate_tbl where k1>'2023-01-01';";
+            starRocksAssert.query(query).explainContains("test_mv_with_multi_slots1");
+        }
+        {
+            String query = "select (case when k6 + k7 + 1> 0 then 1 when k6 + k7 + 1 < 0 then -1 else 0 end) as case1 " +
+                    "from duplicate_tbl where k1>'2023-01-01';";
+            starRocksAssert.query(query).explainWithout("test_mv_with_multi_slots1");
+        }
+        starRocksAssert.dropMaterializedView("test_mv_with_multi_slots1");
+    }
+
+    @Test
+    public void testCreateSyncMaterializedViewWithWhereExpr1() throws Exception {
+        String mv1 = "CREATE MATERIALIZED VIEW test_mv_with_where1\n" +
+                "as\n" +
+                "select k1, sum(k6) as sum1, sum(k6+k7) as sum2 from duplicate_tbl where k1 > '2023-01-01' group by k1;";
+        starRocksAssert.withMaterializedView(mv1);
+        {
+            String query = "select k1, sum(k6) as sum1, sum(k6+k7) as sum2 from duplicate_tbl " +
+                    "where k1 > '2023-01-01' group by k1;";
+            starRocksAssert.query(query).explainContains("test_mv_with_where1");
+        }
+        {
+            String query = "select k1, sum(k6) as sum1, sum(k6+k7) as sum2 from duplicate_tbl " +
+                    "where k1 > '2023-02-01' group by k1;";
+            starRocksAssert.query(query).explainContains("test_mv_with_where1");
+        }
+        {
+            String query = "select k1, sum(k6) as sum1, sum(k6+k7*10) as sum2 from duplicate_tbl " +
+                    "where k1 > '2023-02-01' group by k1;";
+            starRocksAssert.query(query).explainWithout("test_mv_with_where1");
+        }
+        starRocksAssert.dropMaterializedView("test_mv_with_where1");
+    }
+
+    @Test
+    public void testCreateSyncMaterializedViewWithWhereExpr2() throws Exception {
+        String mv1 = "CREATE MATERIALIZED VIEW test_mv_with_where1\n" +
+                "as\n" +
+                "select k1, (case when k6 + k7> 0 then 1 when k6 + k7 < 0 then -1 else 0 end) as case1 " +
+                "from duplicate_tbl where k1>'2023-01-01';";
+        starRocksAssert.withMaterializedView(mv1);
+
+        {
+            String query = "select k1, (case when k6 + k7> 0 then 1 when k6 + k7 < 0 then -1 else 0 end) as case1 " +
+                    "from duplicate_tbl where k1>'2023-01-01';";
+            starRocksAssert.query(query).explainContains("test_mv_with_where1");
+        }
+        {
+            String query = "select (case when k6 + k7> 0 then 1 when k6 + k7 < 0 then -1 else 0 end) as case1 " +
+                    "from duplicate_tbl where k1>'2023-01-01';";
+            starRocksAssert.query(query).explainContains("test_mv_with_where1");
+        }
+        {
+            String query = "select (case when k6 + k7> 0 then 1 when k6 + k7 < 0 then -1 else 0 end) as case1 " +
+                    "from duplicate_tbl where k1>'2023-02-01';";
+            starRocksAssert.query(query).explainContains("test_mv_with_where1");
+        }
+        {
+            String query = "select (case when k6 + k7 + 1> 0 then 1 when k6 + k7 + 1 < 0 then -1 else 0 end) as case1 " +
+                    "from duplicate_tbl where k1>'2023-01-01';";
+            starRocksAssert.query(query).explainWithout("test_mv_with_where1");
+        }
+        starRocksAssert.dropMaterializedView("test_mv_with_where1");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/task/AlterReplicaTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AlterReplicaTaskTest.java
@@ -22,7 +22,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.HashMap;
 
 public class AlterReplicaTaskTest {
 
@@ -83,7 +82,7 @@ public class AlterReplicaTaskTest {
     @Test
     public void testRollupLocalTablet() {
         AlterReplicaTask task = AlterReplicaTask.rollupLocalTablet(1, 2, 3, 4, 5, 6,
-                7, 8, 9, 10, 11, 12, new HashMap<>());
+                7, 8, 9, 10, 11, 12, null);
 
         Assert.assertEquals(1, task.getBackendId());
         Assert.assertEquals(2, task.getDbId());

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -134,6 +134,13 @@ struct TAlterTabletMaterializedColumnReq {
     3: optional map<i32, Exprs.TExpr> mc_exprs
 }
 
+enum TAlterJobType {
+    ROLLUP = 0,
+    SCHEMA_CHANGE = 1,
+    DECOMMISSION_BACKEND = 2
+}
+
+
 // This v2 request will replace the old TAlterTabletReq.
 // TAlterTabletReq should be deprecated after new alter job process merged.
 struct TAlterTabletReqV2 {
@@ -151,6 +158,11 @@ struct TAlterTabletReqV2 {
     12: optional InternalService.TQueryGlobals query_globals
     13: optional InternalService.TQueryOptions query_options
     14: optional list<Descriptors.TColumn> columns
+    // synchronized materialized view parameters
+    15: optional TAlterJobType alter_job_type = TAlterJobType.SCHEMA_CHANGE
+    16: optional Descriptors.TDescriptorTable desc_tbl
+    17: optional Exprs.TExpr where_expr
+    18: optional list<string> base_table_column_names 
 }
 
 struct TAlterMaterializedViewParam {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -268,6 +268,7 @@ struct TOlapTableIndexSchema {
     2: required list<string> columns
     3: required i32 schema_hash
     4: optional TOlapTableColumnParam column_param
+    5: optional Exprs.TExpr where_clause
 }
 
 struct TOlapTableSchemaParam {

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -949,7 +949,7 @@ class StarrocksSQLApiLib(object):
         time.sleep(1)
         sql = "explain %s" % (query)
         res = self.execute_sql(sql, True)
-        print(res)
+        #print(res)
         tools.assert_true(str(res["result"]).find(mv_name) > 0, "assert mv %s is not found" % (mv_name))
 
     def check_no_hit_materialized_view(self, query, mv_name):

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_rewrite
@@ -1,4 +1,4 @@
--- name: test_sync_materialized_view_rewrite
+-- name: test_sync_materialized_view_rewrite 
 CREATE TABLE `duplicate_tbl` (
     `k1` date NULL COMMENT "",   
     `k2` datetime NULL COMMENT "",   
@@ -63,6 +63,59 @@ function: wait_materialized_view_finish()
 -- result:
 None
 -- !result
+CREATE MATERIALIZED VIEW mv_5
+AS SELECT k1, MIN(k6+k7) as min1, SUM(k9) as sum1, MAX(k10 + 2 * k11) as max1, SUM(2 * k13) as sum2 FROM duplicate_tbl GROUP BY k1;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, sum(k6) as k6, max(k7) as k7 from duplicate_tbl group by 1 order by 1", "mv_1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, sum(k6 + 1) as k6, max(k7 * 10) as k7 from duplicate_tbl group by 1 order by 1", "mv_2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, count(k6 + 1) as c_k6, min(k7 * 10) as m_k7 from duplicate_tbl group by 1 order by 1", "mv_3")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1 order by 1", "mv_4")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, MIN(k6+k7) as min1, SUM(k9) as sum1, MAX(k10 + 2 * k11) as max1, SUM(2 * k13) FROM duplicate_tbl GROUP BY k1", "mv_5")
+-- result:
+None
+-- !result
+select k1, sum(k6) as k6, max(k7) as k7 from duplicate_tbl group by 1 order by 1;
+-- result:
+2023-06-15	3	1
+2023-06-16	1	1
+-- !result
+select k1, sum(k6 + 1) as k6, max(k7 * 10) as k7 from duplicate_tbl group by 1 order by 1;
+-- result:
+2023-06-15	6	10
+2023-06-16	2	10
+-- !result
+select k1, count(k6 + 1) as c_k6, min(k7 * 10) as m_k7 from duplicate_tbl group by 1 order by 1;
+-- result:
+2023-06-15	3	10
+2023-06-16	1	10
+-- !result
+SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1 order by 1;
+-- result:
+2023-06-15	1	1	1	3	1	1.0	1.0	3.000000000
+2023-06-16	1	1	1	1	1	1.0	1.0	1.000000000
+-- !result
+SELECT k1, MIN(k6+k7) as min1, SUM(k9) as sum1, MAX(k10 + 2 * k11) as max1, SUM(2 * k13) FROM duplicate_tbl GROUP BY k1 order by 1;
+-- result:
+2023-06-15	2	3	3.0	6.000000000
+2023-06-16	2	1	3.0	2.000000000
+-- !result
 insert into duplicate_tbl values 
     ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
     ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
@@ -70,6 +123,26 @@ insert into duplicate_tbl values
     ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0)
 ;
 -- result:
+-- !result
+function: check_hit_materialized_view("select k1, sum(k6) as k6, max(k7) as k7 from duplicate_tbl group by 1 order by 1", "mv_1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, sum(k6 + 1) as k6, max(k7 * 10) as k7 from duplicate_tbl group by 1 order by 1", "mv_2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, count(k6 + 1) as c_k6, min(k7 * 10) as m_k7 from duplicate_tbl group by 1 order by 1", "mv_3")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1 order by 1", "mv_4")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, MIN(k6+k7) as min1, SUM(k9) as sum1, MAX(k10 + 2 * k11) as max1, SUM(2 * k13) FROM duplicate_tbl GROUP BY k1", "mv_5")
+-- result:
+None
 -- !result
 select k1, sum(k6) as k6, max(k7) as k7 from duplicate_tbl group by 1 order by 1;
 -- result:
@@ -91,6 +164,11 @@ SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM
 2023-06-15	1	1	1	6	1	1.0	1.0	6.000000000
 2023-06-16	1	1	1	2	1	1.0	1.0	2.000000000
 -- !result
+SELECT k1, MIN(k6+k7) as min1, SUM(k9) as sum1, MAX(k10 + 2 * k11) as max1, SUM(2 * k13) FROM duplicate_tbl GROUP BY k1 order by 1;
+-- result:
+2023-06-15	2	6	3.0	12.000000000
+2023-06-16	2	2	3.0	4.000000000
+-- !result
 drop materialized view mv_1;
 -- result:
 -- !result
@@ -103,7 +181,9 @@ drop materialized view mv_3;
 drop materialized view mv_4;
 -- result:
 -- !result
--- name: test_case_when
+drop materialized view mv_5;
+-- result:
+-- !result
 drop table if exists case_when_tbl1;
 -- result:
 -- !result
@@ -114,7 +194,7 @@ DUPLICATE KEY(k1)
 DISTRIBUTED BY HASH(k1);
 -- result:
 -- !result
-insert into case_when_tbl1 values (1,'xian');
+insert into case_when_tbl1 values (1,'xian'), (2, 'beijing'), (3, 'hangzhou');
 -- result:
 -- !result
 create materialized view case_when_mv1 AS SELECT k1, (CASE k2 WHEN 'beijing' THEN 'bigcity' ELSE 'smallcity' END) as city FROM case_when_tbl1;
@@ -124,9 +204,66 @@ function: wait_materialized_view_finish()
 -- result:
 None
 -- !result
+create materialized view case_when_mv2 AS SELECT k1, (CASE k2 WHEN 'beijing' THEN concat(k1, 'bigcity') ELSE concat(k1, 'smallcity') END) as case2 FROM case_when_tbl1;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, (CASE k2 WHEN 'beijing' THEN 'bigcity' ELSE 'smallcity' END) as city FROM case_when_tbl1", "case_when_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1, (CASE k2 WHEN 'beijing' THEN concat(k1, 'bigcity') ELSE concat(k1, 'smallcity') END) as city FROM case_when_tbl1", "case_when_mv2")
+-- result:
+None
+-- !result
+SELECT k1, (CASE k2 WHEN 'beijing' THEN 'bigcity' ELSE 'smallcity' END) as city FROM case_when_tbl1;
+-- result:
+3	smallcity
+1	smallcity
+2	bigcity
+-- !result
+SELECT k1, (CASE k2 WHEN 'beijing' THEN concat(k1, 'bigcity') ELSE concat(k1, 'smallcity') END) as city FROM case_when_tbl1;
+-- result:
+1	1smallcity
+2	2bigcity
+3	3smallcity
+-- !result
+insert into duplicate_tbl values 
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0)
+;
+-- result:
+-- !result
+function: check_hit_materialized_view("SELECT k1, (CASE k2 WHEN 'beijing' THEN 'bigcity' ELSE 'smallcity' END) as city FROM case_when_tbl1", "case_when_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view(" SELECT k1, (CASE k2 WHEN 'beijing' THEN concat(k1, 'bigcity') ELSE concat(k1, 'smallcity') END) as city FROM case_when_tbl1", "case_when_mv2")
+-- result:
+None
+-- !result
 SELECT k1, (CASE k2 WHEN 'beijing' THEN 'bigcity' ELSE 'smallcity' END) as city FROM case_when_tbl1;
 -- result:
 1	smallcity
+2	bigcity
+3	smallcity
+-- !result
+SELECT k1, (CASE k2 WHEN 'beijing' THEN concat(k1, 'bigcity') ELSE concat(k1, 'smallcity') END) as city FROM case_when_tbl1;
+-- result:
+3	3smallcity
+1	1smallcity
+2	2bigcity
+-- !result
+drop materialized view case_when_mv1;
+-- result:
+-- !result
+drop materialized view case_when_mv2;
+-- result:
 -- !result
 drop table if exists case_when_tbl1;
 -- result:

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_with_where
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_with_where
@@ -1,0 +1,330 @@
+-- name: test_sync_materialized_view_rewrite
+CREATE TABLE `duplicate_tbl` (
+    `k1` date NULL COMMENT "",   
+    `k2` datetime NULL COMMENT "",   
+    `k3` char(20) NULL COMMENT "",   
+    `k4` varchar(20) NULL COMMENT "",   
+    `k5` boolean NULL COMMENT "",   
+    `k6` tinyint(4) NULL COMMENT "",   
+    `k7` smallint(6) NULL COMMENT "",   
+    `k8` int(11) NULL COMMENT "",   
+    `k9` bigint(20) NULL COMMENT "",   
+    `k10` largeint(40) NULL COMMENT "",   
+    `k11` float NULL COMMENT "",   
+    `k12` double NULL COMMENT "",   
+    `k13` decimal128(27, 9) NULL COMMENT "",   
+    INDEX idx1 (`k6`) USING BITMAP 
+) 
+ENGINE=OLAP DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 
+PROPERTIES ( 
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into duplicate_tbl values 
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 2, 2, 2, 2, 2, 2.0, 2.0, 2.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 3, 3, 3, 3, 3, 3.0, 3.0, 3.0),
+    ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 4, 4, 4, 4, 4, 4.0, 4.0, 4.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 5, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 6, 7, 2, 2, 2, 2.0, 2.0, 2.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 7, 8, 3, 3, 3, 3.0, 3.0, 3.0),
+    ('2023-06-15', '2023-06-15 00:00:00', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+    ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 8, 10, 4, 4, 4, 4.0, 4.0, 4.0)
+;
+-- result:
+-- !result
+create materialized view mv_1 as select k1, sum(k6) as sum_k6, max(k7) as max from duplicate_tbl where k7 > 2  group by 1;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 2  group by 1", "mv_1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 2 and k1 > 1 group by 1", "mv_1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select k1, sum(k6), max(k7 + 1) as max from duplicate_tbl where k7 > 2  group by 1", "mv_1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 3  group by 1", "mv_1")
+-- result:
+None
+-- !result
+select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 2  group by 1 order by 1;
+-- result:
+2023-06-15	16	8
+2023-06-16	12	10
+-- !result
+select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 2 and k1 > '2023-06-15' group by 1 order by 1;
+-- result:
+2023-06-16	12	10
+-- !result
+create materialized view mv_2 as select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 2 ;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 2;", "mv_2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 3;", "mv_2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 3 and k1 > 1;", "mv_2")
+-- result:
+None
+-- !result
+select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 2 order by k1;
+-- result:
+2023-06-15	2023-06-15 00:00:00	a	a	0	3	3
+2023-06-15	2023-06-15 00:00:00	a	a	0	6	7
+2023-06-15	2023-06-15 00:00:00	a	a	0	7	8
+2023-06-16	2023-06-15 00:00:00	a	a	0	4	4
+2023-06-16	2023-06-15 00:00:00	a	a	0	8	10
+-- !result
+insert into duplicate_tbl values 
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 9, 9, 3, 3, 3, 3.0, 3.0, 3.0),
+    ('2023-06-15', '2023-06-15 00:00:00', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+    ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 10, 10, 4, 4, 4, 4.0, 4.0, 4.0)
+;
+-- result:
+-- !result
+select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 2  group by 1 order by 1;
+-- result:
+2023-06-15	25	9
+2023-06-16	22	10
+-- !result
+select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 2 and k1 > '2023-06-15' group by 1 order by 1;
+-- result:
+2023-06-16	22	10
+-- !result
+select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 2 order by k1;
+-- result:
+2023-06-15	2023-06-15 00:00:00	a	a	0	3	3
+2023-06-15	2023-06-15 00:00:00	a	a	0	6	7
+2023-06-15	2023-06-15 00:00:00	a	a	0	7	8
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-16	2023-06-15 00:00:00	a	a	0	4	4
+2023-06-16	2023-06-15 00:00:00	a	a	0	8	10
+2023-06-16	2023-06-15 00:00:00	a	a	0	10	10
+-- !result
+drop materialized view mv_1;
+-- result:
+-- !result
+drop materialized view mv_2;
+-- result:
+-- !result
+create materialized view mv_1 as select k1, k8, sum(k6) as sum_k6 , max(k7) as max_k7 from duplicate_tbl where k7 > 2 and k8 < 4 group by 1,2;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 2 and k8 < 4 group by 1;", "mv_1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 3 and k8 < 4 group by 1;", "mv_1")
+-- result:
+None
+-- !result
+select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 2 and k8 < 4 group by 1 order by 1;
+-- result:
+2023-06-15	25	9
+-- !result
+select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 3 and k8 < 4 group by 1 order by 1;
+-- result:
+2023-06-15	22	9
+-- !result
+create materialized view mv_2 as select  k1, k2, k3, k4, k5, k6, k7,k8  from duplicate_tbl where k7 > 2 and k8 < 4;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select  k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 2 and k8 < 4", "mv_2")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select  k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 3 and k8 < 2", "mv_2")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select  k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 0 and k8 < 10", "mv_2")
+-- result:
+None
+-- !result
+select  k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 2 and k8 < 4 order by k1;
+-- result:
+2023-06-15	2023-06-15 00:00:00	a	a	0	3	3
+2023-06-15	2023-06-15 00:00:00	a	a	0	6	7
+2023-06-15	2023-06-15 00:00:00	a	a	0	7	8
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+-- !result
+select  k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 3 and k8 < 10 order by k1;
+-- result:
+2023-06-15	2023-06-15 00:00:00	a	a	0	6	7
+2023-06-15	2023-06-15 00:00:00	a	a	0	7	8
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-16	2023-06-15 00:00:00	a	a	0	4	4
+2023-06-16	2023-06-15 00:00:00	a	a	0	8	10
+2023-06-16	2023-06-15 00:00:00	a	a	0	10	10
+-- !result
+insert into duplicate_tbl values 
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 9, 9, 3, 3, 3, 3.0, 3.0, 3.0),
+    ('2023-06-15', '2023-06-15 00:00:00', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+    ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 10, 10, 4, 4, 4, 4.0, 4.0, 4.0)
+;
+-- result:
+-- !result
+select k1, sum(k6), max(k7) as max_k7 from duplicate_tbl where k7 > 2 and k8 < 4 group by 1 order by 1;
+-- result:
+2023-06-15	34	9
+-- !result
+select k1, sum(k6), max(k7) as max_k7 from duplicate_tbl where k7 > 3 and k8 < 4 group by 1 order by 1;
+-- result:
+2023-06-15	31	9
+-- !result
+select k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 2 and k8 < 4 order by k1;
+-- result:
+2023-06-15	2023-06-15 00:00:00	a	a	0	3	3
+2023-06-15	2023-06-15 00:00:00	a	a	0	6	7
+2023-06-15	2023-06-15 00:00:00	a	a	0	7	8
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+-- !result
+select k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 3 and k8 < 10 order by k1;
+-- result:
+2023-06-15	2023-06-15 00:00:00	a	a	0	6	7
+2023-06-15	2023-06-15 00:00:00	a	a	0	7	8
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-16	2023-06-15 00:00:00	a	a	0	4	4
+2023-06-16	2023-06-15 00:00:00	a	a	0	8	10
+2023-06-16	2023-06-15 00:00:00	a	a	0	10	10
+2023-06-16	2023-06-15 00:00:00	a	a	0	10	10
+-- !result
+drop materialized view mv_1;
+-- result:
+-- !result
+drop materialized view mv_2;
+-- result:
+-- !result
+create materialized view mv_1 as select k1, k8, sum(k6) as sum_k6, max(k7) as max_k7 from duplicate_tbl where k7 + 1 > 2 and k8 * 2 < 4 group by 1, 2;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, k8, sum(k6) as sum_k6, max(k7) as max_k7 from duplicate_tbl where k7 + 1 > 2 and k8 * 2 < 4 group by 1, 2", "mv_1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 3 and k8 < 4 group by 1;", "mv_1")
+-- result:
+None
+-- !result
+select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 2 and k8 < 4 group by 1 order by 1;
+-- result:
+2023-06-15	34	9
+-- !result
+select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 3 and k8 < 4 group by 1 order by 1;
+-- result:
+2023-06-15	31	9
+-- !result
+create materialized view mv_2 as select k1, k2, k3, k4, k5, k6, k7,k8 from duplicate_tbl where k7 + 1 > 2 and k8 * 2 > 4;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select k1, k2, k3, k4, k5, k6, k7,k8 from duplicate_tbl where k7 + 1 > 2 and k8 * 2 > 4", "mv_2")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 3 and k8 < 10", "mv_2")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 0 and k8 < 10", "mv_2")
+-- result:
+None
+-- !result
+select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 2 and k8 < 4 order by k1;
+-- result:
+2023-06-15	2023-06-15 00:00:00	a	a	0	3	3
+2023-06-15	2023-06-15 00:00:00	a	a	0	6	7
+2023-06-15	2023-06-15 00:00:00	a	a	0	7	8
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+-- !result
+select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 3 and k8 < 10 order by k1;
+-- result:
+2023-06-15	2023-06-15 00:00:00	a	a	0	6	7
+2023-06-15	2023-06-15 00:00:00	a	a	0	7	8
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-16	2023-06-15 00:00:00	a	a	0	4	4
+2023-06-16	2023-06-15 00:00:00	a	a	0	8	10
+2023-06-16	2023-06-15 00:00:00	a	a	0	10	10
+2023-06-16	2023-06-15 00:00:00	a	a	0	10	10
+-- !result
+insert into duplicate_tbl values 
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 9, 9, 3, 3, 3, 3.0, 3.0, 3.0),
+    ('2023-06-15', '2023-06-15 00:00:00', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+    ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 10, 10, 4, 4, 4, 4.0, 4.0, 4.0)
+;
+-- result:
+-- !result
+select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 2 and k8 < 4 group by 1 order by 1;
+-- result:
+2023-06-15	43	9
+-- !result
+select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 3 and k8 < 4 group by 1 order by 1;
+-- result:
+2023-06-15	40	9
+-- !result
+select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 2 and k8 < 4 order by k1;
+-- result:
+2023-06-15	2023-06-15 00:00:00	a	a	0	3	3
+2023-06-15	2023-06-15 00:00:00	a	a	0	6	7
+2023-06-15	2023-06-15 00:00:00	a	a	0	7	8
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+-- !result
+select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 3 and k8 < 10 order by k1;
+-- result:
+2023-06-15	2023-06-15 00:00:00	a	a	0	6	7
+2023-06-15	2023-06-15 00:00:00	a	a	0	7	8
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-15	2023-06-15 00:00:00	a	a	0	9	9
+2023-06-16	2023-06-15 00:00:00	a	a	0	4	4
+2023-06-16	2023-06-15 00:00:00	a	a	0	8	10
+2023-06-16	2023-06-15 00:00:00	a	a	0	10	10
+2023-06-16	2023-06-15 00:00:00	a	a	0	10	10
+2023-06-16	2023-06-15 00:00:00	a	a	0	10	10
+-- !result
+drop materialized view mv_1;
+-- result:
+-- !result
+drop materialized view mv_2;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite
@@ -48,6 +48,21 @@ CREATE MATERIALIZED VIEW mv_4
 AS SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1;
 function: wait_materialized_view_finish()
 
+CREATE MATERIALIZED VIEW mv_5
+AS SELECT k1, MIN(k6+k7) as min1, SUM(k9) as sum1, MAX(k10 + 2 * k11) as max1, SUM(2 * k13) as sum2 FROM duplicate_tbl GROUP BY k1;
+function: wait_materialized_view_finish()
+
+function: check_hit_materialized_view("select k1, sum(k6) as k6, max(k7) as k7 from duplicate_tbl group by 1 order by 1", "mv_1")
+function: check_hit_materialized_view("select k1, sum(k6 + 1) as k6, max(k7 * 10) as k7 from duplicate_tbl group by 1 order by 1", "mv_2")
+function: check_hit_materialized_view("select k1, count(k6 + 1) as c_k6, min(k7 * 10) as m_k7 from duplicate_tbl group by 1 order by 1", "mv_3")
+function: check_hit_materialized_view("SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1 order by 1", "mv_4")
+function: check_hit_materialized_view("SELECT k1, MIN(k6+k7) as min1, SUM(k9) as sum1, MAX(k10 + 2 * k11) as max1, SUM(2 * k13) FROM duplicate_tbl GROUP BY k1", "mv_5")
+select k1, sum(k6) as k6, max(k7) as k7 from duplicate_tbl group by 1 order by 1;
+select k1, sum(k6 + 1) as k6, max(k7 * 10) as k7 from duplicate_tbl group by 1 order by 1;
+select k1, count(k6 + 1) as c_k6, min(k7 * 10) as m_k7 from duplicate_tbl group by 1 order by 1;
+SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1 order by 1;
+SELECT k1, MIN(k6+k7) as min1, SUM(k9) as sum1, MAX(k10 + 2 * k11) as max1, SUM(2 * k13) FROM duplicate_tbl GROUP BY k1 order by 1;
+
 insert into duplicate_tbl values 
     ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
     ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
@@ -55,27 +70,54 @@ insert into duplicate_tbl values
     ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0)
 ;
 
+function: check_hit_materialized_view("select k1, sum(k6) as k6, max(k7) as k7 from duplicate_tbl group by 1 order by 1", "mv_1")
+function: check_hit_materialized_view("select k1, sum(k6 + 1) as k6, max(k7 * 10) as k7 from duplicate_tbl group by 1 order by 1", "mv_2")
+function: check_hit_materialized_view("select k1, count(k6 + 1) as c_k6, min(k7 * 10) as m_k7 from duplicate_tbl group by 1 order by 1", "mv_3")
+function: check_hit_materialized_view("SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1 order by 1", "mv_4")
+function: check_hit_materialized_view("SELECT k1, MIN(k6+k7) as min1, SUM(k9) as sum1, MAX(k10 + 2 * k11) as max1, SUM(2 * k13) FROM duplicate_tbl GROUP BY k1", "mv_5")
 select k1, sum(k6) as k6, max(k7) as k7 from duplicate_tbl group by 1 order by 1;
 select k1, sum(k6 + 1) as k6, max(k7 * 10) as k7 from duplicate_tbl group by 1 order by 1;
 select k1, count(k6 + 1) as c_k6, min(k7 * 10) as m_k7 from duplicate_tbl group by 1 order by 1;
 SELECT k1, MIN(k6), MIN(k7), MIN(k8), SUM(k9), MAX(k10), MIN(k11), MIN(k12), SUM(k13) FROM duplicate_tbl GROUP BY k1 order by 1;
+SELECT k1, MIN(k6+k7) as min1, SUM(k9) as sum1, MAX(k10 + 2 * k11) as max1, SUM(2 * k13) FROM duplicate_tbl GROUP BY k1 order by 1;
 
 drop materialized view mv_1;
 drop materialized view mv_2;
 drop materialized view mv_3;
 drop materialized view mv_4;
+drop materialized view mv_5;
 
--- name: test_case_when
 drop table if exists case_when_tbl1;
 CREATE TABLE case_when_tbl1 (
     k1 INT,
     k2 char(20))
 DUPLICATE KEY(k1)
 DISTRIBUTED BY HASH(k1);
-insert into case_when_tbl1 values (1,'xian');
+insert into case_when_tbl1 values (1,'xian'), (2, 'beijing'), (3, 'hangzhou');
 
 create materialized view case_when_mv1 AS SELECT k1, (CASE k2 WHEN 'beijing' THEN 'bigcity' ELSE 'smallcity' END) as city FROM case_when_tbl1;
 function: wait_materialized_view_finish()
 
+create materialized view case_when_mv2 AS SELECT k1, (CASE k2 WHEN 'beijing' THEN concat(k1, 'bigcity') ELSE concat(k1, 'smallcity') END) as case2 FROM case_when_tbl1;
+function: wait_materialized_view_finish()
+
+function: check_hit_materialized_view("SELECT k1, (CASE k2 WHEN 'beijing' THEN 'bigcity' ELSE 'smallcity' END) as city FROM case_when_tbl1", "case_when_mv1")
+function: check_hit_materialized_view("SELECT k1, (CASE k2 WHEN 'beijing' THEN concat(k1, 'bigcity') ELSE concat(k1, 'smallcity') END) as city FROM case_when_tbl1", "case_when_mv2")
 SELECT k1, (CASE k2 WHEN 'beijing' THEN 'bigcity' ELSE 'smallcity' END) as city FROM case_when_tbl1;
+SELECT k1, (CASE k2 WHEN 'beijing' THEN concat(k1, 'bigcity') ELSE concat(k1, 'smallcity') END) as city FROM case_when_tbl1;
+
+insert into duplicate_tbl values 
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0)
+;
+
+function: check_hit_materialized_view("SELECT k1, (CASE k2 WHEN 'beijing' THEN 'bigcity' ELSE 'smallcity' END) as city FROM case_when_tbl1", "case_when_mv1")
+function: check_hit_materialized_view(" SELECT k1, (CASE k2 WHEN 'beijing' THEN concat(k1, 'bigcity') ELSE concat(k1, 'smallcity') END) as city FROM case_when_tbl1", "case_when_mv2")
+SELECT k1, (CASE k2 WHEN 'beijing' THEN 'bigcity' ELSE 'smallcity' END) as city FROM case_when_tbl1;
+SELECT k1, (CASE k2 WHEN 'beijing' THEN concat(k1, 'bigcity') ELSE concat(k1, 'smallcity') END) as city FROM case_when_tbl1;
+
+drop materialized view case_when_mv1;
+drop materialized view case_when_mv2;
 drop table if exists case_when_tbl1;

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_with_where
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_with_where
@@ -1,0 +1,128 @@
+-- name: test_sync_materialized_view_rewrite @sequential
+CREATE TABLE `duplicate_tbl` (
+    `k1` date NULL COMMENT "",   
+    `k2` datetime NULL COMMENT "",   
+    `k3` char(20) NULL COMMENT "",   
+    `k4` varchar(20) NULL COMMENT "",   
+    `k5` boolean NULL COMMENT "",   
+    `k6` tinyint(4) NULL COMMENT "",   
+    `k7` smallint(6) NULL COMMENT "",   
+    `k8` int(11) NULL COMMENT "",   
+    `k9` bigint(20) NULL COMMENT "",   
+    `k10` largeint(40) NULL COMMENT "",   
+    `k11` float NULL COMMENT "",   
+    `k12` double NULL COMMENT "",   
+    `k13` decimal128(27, 9) NULL COMMENT "",   
+    INDEX idx1 (`k6`) USING BITMAP 
+) 
+ENGINE=OLAP DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) 
+DISTRIBUTED BY HASH(`k1`, `k2`, `k3`) BUCKETS 3 
+PROPERTIES ( 
+    "replication_num" = "1"
+);
+
+insert into duplicate_tbl values 
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 2, 2, 2, 2, 2, 2.0, 2.0, 2.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 3, 3, 3, 3, 3, 3.0, 3.0, 3.0),
+    ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 4, 4, 4, 4, 4, 4.0, 4.0, 4.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 5, 1, 1, 1, 1, 1.0, 1.0, 1.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 6, 7, 2, 2, 2, 2.0, 2.0, 2.0),
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 7, 8, 3, 3, 3, 3.0, 3.0, 3.0),
+    ('2023-06-15', '2023-06-15 00:00:00', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+    ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 8, 10, 4, 4, 4, 4.0, 4.0, 4.0)
+;
+
+-- test agg with filter
+create materialized view mv_1 as select k1, sum(k6) as sum_k6, max(k7) as max from duplicate_tbl where k7 > 2  group by 1;
+function: wait_materialized_view_finish()
+function: check_hit_materialized_view("select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 2  group by 1", "mv_1")
+function: check_hit_materialized_view("select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 2 and k1 > 1 group by 1", "mv_1")
+function: check_no_hit_materialized_view("select k1, sum(k6), max(k7 + 1) as max from duplicate_tbl where k7 > 2  group by 1", "mv_1")
+function: check_no_hit_materialized_view("select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 3  group by 1", "mv_1")
+select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 2  group by 1 order by 1;
+select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 2 and k1 > '2023-06-15' group by 1 order by 1;
+
+-- test project with filter
+create materialized view mv_2 as select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 2 ;
+function: wait_materialized_view_finish()
+function: check_hit_materialized_view("select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 2;", "mv_2")
+function: check_hit_materialized_view("select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 3;", "mv_2")
+function: check_hit_materialized_view("select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 3 and k1 > 1;", "mv_2")
+select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 2 order by k1;
+
+insert into duplicate_tbl values 
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 9, 9, 3, 3, 3, 3.0, 3.0, 3.0),
+    ('2023-06-15', '2023-06-15 00:00:00', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+    ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 10, 10, 4, 4, 4, 4.0, 4.0, 4.0)
+;
+
+select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 2  group by 1 order by 1;
+select k1, sum(k6), max(k7) as max from duplicate_tbl where k7 > 2 and k1 > '2023-06-15' group by 1 order by 1;
+select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 2 order by k1;
+
+drop materialized view mv_1;
+drop materialized view mv_2;
+
+-- test agg with multi filter
+create materialized view mv_1 as select k1, k8, sum(k6) as sum_k6 , max(k7) as max_k7 from duplicate_tbl where k7 > 2 and k8 < 4 group by 1,2;
+function: wait_materialized_view_finish()
+function: check_hit_materialized_view("select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 2 and k8 < 4 group by 1;", "mv_1")
+function: check_no_hit_materialized_view("select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 3 and k8 < 4 group by 1;", "mv_1")
+select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 2 and k8 < 4 group by 1 order by 1;
+select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 3 and k8 < 4 group by 1 order by 1;
+
+-- test project with filter (with multi predicates)
+create materialized view mv_2 as select  k1, k2, k3, k4, k5, k6, k7,k8  from duplicate_tbl where k7 > 2 and k8 < 4;
+function: wait_materialized_view_finish()
+function: check_hit_materialized_view("select  k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 2 and k8 < 4", "mv_2")
+function: check_hit_materialized_view("select  k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 3 and k8 < 2", "mv_2")
+function: check_no_hit_materialized_view("select  k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 0 and k8 < 10", "mv_2")
+select  k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 2 and k8 < 4 order by k1;
+select  k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 3 and k8 < 10 order by k1;
+
+insert into duplicate_tbl values 
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 9, 9, 3, 3, 3, 3.0, 3.0, 3.0),
+    ('2023-06-15', '2023-06-15 00:00:00', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+    ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 10, 10, 4, 4, 4, 4.0, 4.0, 4.0)
+;
+
+select k1, sum(k6), max(k7) as max_k7 from duplicate_tbl where k7 > 2 and k8 < 4 group by 1 order by 1;
+select k1, sum(k6), max(k7) as max_k7 from duplicate_tbl where k7 > 3 and k8 < 4 group by 1 order by 1;
+select k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 2 and k8 < 4 order by k1;
+select k1, k2, k3, k4, k5, k6, k7  from duplicate_tbl where k7 > 3 and k8 < 10 order by k1;
+
+drop materialized view mv_1;
+drop materialized view mv_2;
+
+
+-- test where with complex expressions
+create materialized view mv_1 as select k1, k8, sum(k6) as sum_k6, max(k7) as max_k7 from duplicate_tbl where k7 + 1 > 2 and k8 * 2 < 4 group by 1, 2;
+function: wait_materialized_view_finish()
+function: check_hit_materialized_view("select k1, k8, sum(k6) as sum_k6, max(k7) as max_k7 from duplicate_tbl where k7 + 1 > 2 and k8 * 2 < 4 group by 1, 2", "mv_1")
+function: check_no_hit_materialized_view("select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 3 and k8 < 4 group by 1;", "mv_1")
+select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 2 and k8 < 4 group by 1 order by 1;
+select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 3 and k8 < 4 group by 1 order by 1;
+
+-- test project with filter (with multi predicates)
+create materialized view mv_2 as select k1, k2, k3, k4, k5, k6, k7,k8 from duplicate_tbl where k7 + 1 > 2 and k8 * 2 > 4;
+function: wait_materialized_view_finish()
+function: check_hit_materialized_view("select k1, k2, k3, k4, k5, k6, k7,k8 from duplicate_tbl where k7 + 1 > 2 and k8 * 2 > 4", "mv_2")
+function: check_no_hit_materialized_view("select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 3 and k8 < 10", "mv_2")
+function: check_no_hit_materialized_view("select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 0 and k8 < 10", "mv_2")
+select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 2 and k8 < 4 order by k1;
+select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 3 and k8 < 10 order by k1;
+
+insert into duplicate_tbl values 
+    ('2023-06-15', '2023-06-15 00:00:00', 'a', 'a', false, 9, 9, 3, 3, 3, 3.0, 3.0, 3.0),
+    ('2023-06-15', '2023-06-15 00:00:00', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+    ('2023-06-16', '2023-06-15 00:00:00', 'a', 'a', false, 10, 10, 4, 4, 4, 4.0, 4.0, 4.0)
+;
+
+select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 2 and k8 < 4 group by 1 order by 1;
+select k1, sum(k6), max(k7) from duplicate_tbl where k7 > 3 and k8 < 4 group by 1 order by 1;
+select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 2 and k8 < 4 order by k1;
+select k1, k2, k3, k4, k5, k6, k7 from duplicate_tbl where k7 > 3 and k8 < 10 order by k1;
+
+drop materialized view mv_1;
+drop materialized view mv_2;


### PR DESCRIPTION
This PR is based on the PR: https://github.com/StarRocks/starrocks/pull/29415, which adds the schema change functions.

### Changes
To support creating synchronized materialized view with where exprs, main changes:
- Add more infos in `TAlterTabletReqV2 ` 
- Support where-exprs evaluation in schema change and olap table sink.
```
    // synchronized materialized view parameters
    // flag to mark the alter table type: rollup/schema change/DECOMMISSION_BACKEND
    15: optional TAlterJobType alter_job_type = TAlterJobType.SCHEMA_CHANGE
    // used for where expression evaluations
    16: optional Descriptors.TDescriptorTable desc_tbl
    // where expr to eval
    17: optional Exprs.TExpr where_expr
    // selected columns in the base table to avoid queries all columns for the base table.
    18: optional list<string> base_table_column_names 
```

### Examples
```
create materialized view mv_1 as select k1, sum(k6) as sum_k6, max(k7) as max from duplicate_tbl where k7 > 2  group by 1;
```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
