### PR TITLE
[Enhancement] adaptive execute node by costs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -101,6 +101,8 @@ import java.util.stream.Stream;
  * fix that
  */
 public class PlanFragment extends TreeNode<PlanFragment> {
+    public static final int HOST_FACTOR_MAX = 1;
+
     // id for this plan fragment
     protected final PlanFragmentId fragmentId;
 
@@ -140,6 +142,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     protected int parallelExecNum = 1;
     protected int pipelineDop = 1;
     protected boolean dopEstimated = false;
+    private double hostFactor = HOST_FACTOR_MAX;
 
     // Whether to assign scan ranges to each driver sequence of pipeline,
     // for the normal backend assignment (not colocate, bucket, and replicated join).
@@ -195,6 +198,14 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         for (PlanNode child : node.getChildren()) {
             setFragmentInPlanTree(child);
         }
+    }
+
+    public double getHostFactor() {
+        return hostFactor;
+    }
+
+    public void setHostFactor(double hostFactor) {
+        this.hostFactor = hostFactor;
     }
 
     public boolean canUsePipeline() {
@@ -501,6 +512,9 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         }
         str.append(outputBuilder.toString());
         str.append("\n");
+        if (hostFactor != HOST_FACTOR_MAX) {
+            str.append("  Host Factor: ").append(String.format("%.2f" ,hostFactor)).append("\n");
+        }
         str.append("  Input Partition: ").append(dataPartition.getExplainString(TExplainLevel.NORMAL));
         if (sink != null) {
             str.append(sink.getVerboseExplain("  ")).append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -521,6 +521,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String AUDIT_EXECUTE_STMT = "audit_execute_stmt";
 
+    public static final String ENABLE_ADAPTIVE_EXECUTE_NODE_NUM = "enable_adaptive_execute_node_num";
+
+    public static final String ADAPTIVE_EXECUTE_NODE_NUM_MIN_FACTOR = "adaptive_execute_node_num_min_factor";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1357,6 +1361,28 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = LARGE_DECIMAL_UNDERLYING_TYPE)
     private String largeDecimalUnderlyingType = SessionVariableConstants.PANIC;
+
+    @VarAttr(name = ENABLE_ADAPTIVE_EXECUTE_NODE_NUM)
+    private boolean enableAdaptiveExecuteNodeNum = false;
+
+    @VarAttr(name = ADAPTIVE_EXECUTE_NODE_NUM_MIN_FACTOR)
+    private double adaptiveExecuteNodeMinFactor = 0.5;
+
+    public double getAdaptiveExecuteNodeMinFactor() {
+        return adaptiveExecuteNodeMinFactor;
+    }
+
+    public void setAdaptiveExecuteNodeMinFactor(double adaptiveExecuteNodeMinFactor) {
+        this.adaptiveExecuteNodeMinFactor = adaptiveExecuteNodeMinFactor;
+    }
+
+    public boolean enableAdaptiveExecuteNodeNum() {
+        return enableAdaptiveExecuteNodeNum;
+    }
+
+    public void setEnableAdaptiveExecuteNodeNum(boolean enableAdaptiveExecuteNodeNum) {
+        this.enableAdaptiveExecuteNodeNum = enableAdaptiveExecuteNodeNum;
+    }
 
     public boolean isEnablePruneIcebergManifest() {
         return enablePruneIcebergManifest;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -383,7 +383,57 @@ public class PlanFragmentBuilder {
         }
 
         public PlanFragment translate(OptExpression optExpression, ExecPlan context) {
-            return visit(optExpression, context);
+            PlanFragment fragment = visit(optExpression, context);
+            if (context.getConnectContext().getSessionVariable().enableAdaptiveExecuteNodeNum()) {
+                computeHostFactor(context, fragment);
+            }
+            return fragment;
+        }
+
+        /*
+         * Reduce the compute node when input data decreases, example:
+         *                      Agg(1 rows)                      5 be
+         *                         |                              ^
+         *                    Join(50 rows)                      10 be
+         *                   /             \                      ^
+         *      Join(200 rows)            Scan(100 rows)         10 be
+         *     /              \                                   ^
+         *  Scan(200 rows)    Scan(100 rows)                     10 be
+         */
+        private double computeHostFactor(ExecPlan context, PlanFragment fragment) {
+            double childNodeCost = 0;
+            for (PlanFragment child : fragment.getChildren()) {
+                childNodeCost += computeHostFactor(context, child);
+            }
+
+            OptExpression output = getOptExpression(context, fragment.getPlanRoot());
+
+            // scan fragment
+            if (fragment.getLeftMostNode() instanceof ScanNode) {
+                fragment.setHostFactor(PlanFragment.HOST_FACTOR_MAX);
+                return output.getCost();
+            }
+
+            List<OptExpression> inputs = fragment.getChildren().stream().map(PlanFragment::getPlanRoot)
+                    .map(p -> getOptExpression(context, p)).collect(Collectors.toList());
+
+            double childPlanCost = inputs.stream().map(OptExpression::getCost).reduce(Double::sum).orElse(0D);
+            double selfCost = output.getCost() - childPlanCost;
+
+            double factor = selfCost / childNodeCost;
+            factor = Math.min(PlanFragment.HOST_FACTOR_MAX, factor);
+            factor = Math.max(factor,
+                    context.getConnectContext().getSessionVariable().getAdaptiveExecuteNodeMinFactor());
+            fragment.setHostFactor(factor);
+
+            return selfCost;
+        }
+
+        private OptExpression getOptExpression(ExecPlan context, PlanNode node) {
+            if (context.getOptExpression(node.getId().asInt()) == null && node instanceof ProjectNode) {
+                node = node.getChild(0);
+            }
+            return context.getOptExpression(node.getId().asInt());
         }
 
         @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AdaptiveNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AdaptiveNodeTest.java
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AdaptiveNodeTest extends DistributedEnvPlanTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        DistributedEnvPlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+        FeConstants.showLocalShuffleColumnsInExplain = false;
+        connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(true);
+        connectContext.getSessionVariable().setEnableMultiColumnsOnGlobbalRuntimeFilter(true);
+        connectContext.getSessionVariable().setEnableAdaptiveExecuteNodeNum(true);
+        connectContext.getSessionVariable().setAdaptiveExecuteNodeMinFactor(0);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        connectContext.getSessionVariable().setEnableAdaptiveExecuteNodeNum(false);
+        FeConstants.showLocalShuffleColumnsInExplain = true;
+    }
+
+    @Test
+    public void testShuffle() throws Exception {
+        String sql = "select c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) as revenue, " +
+                "            c_acctbal, n_name, c_address, c_phone, c_comment\n" +
+                "from lineitem join[shuffle] orders on l_orderkey = o_orderkey" +
+                "              join[shuffle] customer on c_custkey = o_custkey" +
+                "              join[shuffle] nation on c_nationkey = n_nationkey\n" +
+                "where o_orderdate >= date '1994-05-01'\n" +
+                "  and o_orderdate < date '1994-08-01'\n" +
+                "  and l_returnflag = 'R'\n" +
+                "group by\n" +
+                "    c_custkey,\n" +
+                "    c_name,\n" +
+                "    c_acctbal,\n" +
+                "    c_phone,\n" +
+                "    n_name,\n" +
+                "    c_address,\n" +
+                "    c_comment\n" +
+                "order by\n" +
+                "    revenue desc limit 20;";
+
+        String plan = getCostExplain(sql);
+        assertContains(plan, "Host Factor: 0.99");
+    }
+
+    @Test
+    public void testShuffle2() throws Exception {
+        String sql = "select * " +
+                "from lineitem join[shuffle] (select distinct o_orderkey, n_nationkey " +
+                "                             from orders join nation on n_nationkey = o_custkey" +
+                "                             ) x on l_orderkey = o_orderkey " +
+                "where l_returnflag = 'R' and L_SUPPKEY = 2";
+
+        String plan = getCostExplain(sql);
+        assertContains(plan, "Host Factor: 0.00");
+    }
+}


### PR DESCRIPTION
Fixes #issue

session:
```
| adaptive_execute_node_num_min_factor | 0.5   |
| enable_adaptive_execute_node_num     | true  |
```

the factor logical: `min(min_factor, selfNodeCosts/childNodeCosts)`
the execute node logical: `self execute node = child execute node * factor`
example: If the cost of a fragment is half of the previous node, then the machines it uses is also half of the previous fragment. On a cluster without enough resources, the logical will lead to poor performance.
I think better factor is `0.7~0.9`

and can find `host factor` in `explain costs`

example 1:
![image](https://github.com/StarRocks/starrocks/assets/5609319/da619975-7085-4638-91e0-b16187f37994)
![image](https://github.com/StarRocks/starrocks/assets/5609319/9fd2f167-0d66-4ce6-8fc8-6c9abb6220df)

example 2:
before:
![image](https://github.com/StarRocks/starrocks/assets/5609319/380e555d-7efe-45cd-a27c-d3cd0e53f581)

after:
![image](https://github.com/StarRocks/starrocks/assets/5609319/21427d94-6cce-4a62-8974-b208bab70f9a)

![image](https://github.com/StarRocks/starrocks/assets/5609319/cb2004f2-f4b1-4a5a-b048-a8670a70419d)


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
