### PR TITLE
[BugFix] Fix segment size in metadata cache

### DIFF
--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -155,7 +155,7 @@ StatusOr<SegmentPtr> Tablet::load_segment(std::string_view segment_name, int seg
     ASSIGN_OR_RETURN(auto tablet_schema, get_schema());
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(location));
     ASSIGN_OR_RETURN(segment, Segment::open(fs, location, seg_id, std::move(tablet_schema), footer_size_hint, nullptr,
-                                            !fill_data_cache));
+                                            !fill_data_cache, _mgr));
     if (fill_metadata_cache) {
         _mgr->cache_segment(location, segment);
     }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -184,7 +184,7 @@ std::string TabletManager::tablet_latest_metadata_cache_key(int64_t tablet_id) {
     return fmt::format("TL{}", tablet_id);
 }
 
-void TabletManager::fill_metacache(std::string_view key, CacheValue* ptr, int size) {
+void TabletManager::fill_metacache(std::string_view key, CacheValue* ptr, size_t size) {
     Cache::Handle* handle = _metacache->insert(CacheKey(key), ptr, size, cache_value_deleter);
     if (handle == nullptr) {
         delete ptr;
@@ -221,8 +221,7 @@ TabletMetadataPtr TabletManager::lookup_tablet_latest_metadata(std::string_view 
 
 void TabletManager::cache_tablet_latest_metadata(TabletMetadataPtr metadata) {
     auto value_ptr = std::make_unique<CacheValue>(metadata);
-    fill_metacache(tablet_latest_metadata_cache_key(metadata->id()), value_ptr.release(),
-                   static_cast<int>(metadata->SpaceUsedLong()));
+    fill_metacache(tablet_latest_metadata_cache_key(metadata->id()), value_ptr.release(), metadata->SpaceUsedLong());
 }
 
 TabletSchemaPtr TabletManager::lookup_tablet_schema(std::string_view key) {
@@ -267,7 +266,18 @@ SegmentPtr TabletManager::lookup_segment(std::string_view key) {
 void TabletManager::cache_segment(std::string_view key, SegmentPtr segment) {
     auto mem_cost = segment->mem_usage();
     auto value = std::make_unique<CacheValue>(std::move(segment));
-    fill_metacache(key, value.release(), (int)mem_cost);
+    fill_metacache(key, value.release(), mem_cost);
+}
+
+void TabletManager::update_segment_cache_size(std::string_view key) {
+    auto segment = lookup_segment(key);
+    if (segment == nullptr) {
+        return;
+    }
+
+    // use write lock to protect parallel segment size update
+    std::unique_lock wrlock(_meta_lock);
+    cache_segment(key, std::move(segment));
 }
 
 DelVectorPtr TabletManager::lookup_delvec(std::string_view key) {
@@ -286,7 +296,7 @@ DelVectorPtr TabletManager::lookup_delvec(std::string_view key) {
 void TabletManager::cache_delvec(std::string_view key, DelVectorPtr delvec) {
     auto mem_cost = delvec->memory_usage();
     auto value = std::make_unique<CacheValue>(std::move(delvec));
-    fill_metacache(key, value.release(), (int)mem_cost);
+    fill_metacache(key, value.release(), mem_cost);
 }
 
 void TabletManager::erase_metacache(std::string_view key) {
@@ -394,7 +404,7 @@ Status TabletManager::put_tablet_metadata(TabletMetadataPtr metadata) {
     // put into metacache
     auto metadata_location = tablet_metadata_location(metadata->id(), metadata->version());
     auto value_ptr = std::make_unique<CacheValue>(metadata);
-    fill_metacache(metadata_location, value_ptr.release(), static_cast<int>(metadata->SpaceUsedLong()));
+    fill_metacache(metadata_location, value_ptr.release(), metadata->SpaceUsedLong());
     cache_tablet_latest_metadata(metadata);
     auto t1 = butil::gettimeofday_us();
     g_put_tablet_metadata_latency << (t1 - t0);
@@ -432,7 +442,7 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
     ASSIGN_OR_RETURN(auto ptr, load_tablet_metadata(path, fill_cache));
     if (fill_cache) {
         auto value_ptr = std::make_unique<CacheValue>(ptr);
-        fill_metacache(path, value_ptr.release(), static_cast<int>(ptr->SpaceUsedLong()));
+        fill_metacache(path, value_ptr.release(), ptr->SpaceUsedLong());
     }
     TRACE("end read tablet metadata");
     return ptr;
@@ -495,7 +505,7 @@ StatusOr<TxnLogPtr> TabletManager::get_txn_log(const std::string& path, bool fil
     ASSIGN_OR_RETURN(auto ptr, load_txn_log(path, fill_cache));
     if (fill_cache) {
         auto value_ptr = std::make_unique<CacheValue>(ptr);
-        fill_metacache(path, value_ptr.release(), static_cast<int>(ptr->SpaceUsedLong()));
+        fill_metacache(path, value_ptr.release(), ptr->SpaceUsedLong());
     }
     TRACE("end load txn log");
     return ptr;
@@ -526,7 +536,7 @@ Status TabletManager::put_txn_log(TxnLogPtr log) {
 
     // put txnlog into cache
     auto value_ptr = std::make_unique<CacheValue>(log);
-    fill_metacache(txn_log_path, value_ptr.release(), static_cast<int>(log->SpaceUsedLong()));
+    fill_metacache(txn_log_path, value_ptr.release(), log->SpaceUsedLong());
     auto t1 = butil::gettimeofday_us();
     g_put_txn_log_latency << (t1 - t0);
     return Status::OK();
@@ -652,7 +662,7 @@ StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema(int64_t tablet_id, in
 
     // Save the schema into the in-memory cache
     auto cache_value = std::make_unique<CacheValue>(schema);
-    auto cache_size = inserted ? (int)schema->mem_usage() : 0;
+    auto cache_size = inserted ? schema->mem_usage() : 0;
     fill_metacache(cache_key, cache_value.release(), cache_size);
     return schema;
 }
@@ -954,7 +964,7 @@ Status TabletManager::create_schema_file(int64_t tablet_id, const TabletSchemaPB
         }
         auto cache_key = global_schema_cache_key(schema_pb.id());
         auto cache_value = std::make_unique<CacheValue>(schema);
-        auto cache_size = inserted ? (int)schema->mem_usage() : 0;
+        auto cache_size = inserted ? schema->mem_usage() : 0;
         fill_metacache(cache_key, cache_value.release(), cache_size);
     }
     return Status::OK();

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -269,14 +269,14 @@ void TabletManager::cache_segment(std::string_view key, SegmentPtr segment) {
     fill_metacache(key, value.release(), mem_cost);
 }
 
+// current lru cache does not support updating value size, so use refill to update.
 void TabletManager::update_segment_cache_size(std::string_view key) {
+    // use write lock to protect parallel segment size update
+    std::unique_lock wrlock(_meta_lock);
     auto segment = lookup_segment(key);
     if (segment == nullptr) {
         return;
     }
-
-    // use write lock to protect parallel segment size update
-    std::unique_lock wrlock(_meta_lock);
     cache_segment(key, std::move(segment));
 }
 

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -161,6 +161,8 @@ public:
     // only for TEST purpose
     void TEST_set_global_schema_cache(int64_t index_id, TabletSchemaPtr schema);
 
+    void update_segment_cache_size(std::string_view key);
+
 private:
     using CacheValue = std::variant<TabletMetadataPtr, TxnLogPtr, TabletSchemaPtr, SegmentPtr, DelVectorPtr>;
 
@@ -178,7 +180,7 @@ private:
     StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location, bool fill_cache);
 
     /// Cache operations
-    void fill_metacache(std::string_view key, CacheValue* ptr, int size);
+    void fill_metacache(std::string_view key, CacheValue* ptr, size_t size);
     void erase_metacache(std::string_view key);
 
     TabletMetadataPtr lookup_tablet_metadata(std::string_view key);

--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -53,7 +53,7 @@ BitmapIndexReader::BitmapIndexReader() {
 }
 
 BitmapIndexReader::~BitmapIndexReader() {
-    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(), mem_usage());
 }
 
 StatusOr<bool> BitmapIndexReader::load(const IndexReadOptions& opts, const BitmapIndexPB& meta) {
@@ -61,7 +61,7 @@ StatusOr<bool> BitmapIndexReader::load(const IndexReadOptions& opts, const Bitma
         Status st = _do_load(opts, meta);
         if (st.ok()) {
             MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(),
-                                     _mem_usage() - sizeof(BitmapIndexReader));
+                                     mem_usage() - sizeof(BitmapIndexReader));
         } else {
             _reset();
         }

--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -80,10 +80,7 @@ public:
 
     bool loaded() const { return invoked(_load_once); }
 
-private:
-    friend class BitmapIndexIterator;
-
-    size_t _mem_usage() const {
+    size_t mem_usage() const {
         size_t size = sizeof(BitmapIndexReader);
         if (_dict_column_reader != nullptr) {
             size += _dict_column_reader->mem_usage();
@@ -93,6 +90,9 @@ private:
         }
         return size;
     }
+
+private:
+    friend class BitmapIndexIterator;
 
     void _reset();
 

--- a/be/src/storage/rowset/bloom_filter_index_reader.cpp
+++ b/be/src/storage/rowset/bloom_filter_index_reader.cpp
@@ -52,7 +52,7 @@ BloomFilterIndexReader::BloomFilterIndexReader() {
 }
 
 BloomFilterIndexReader::~BloomFilterIndexReader() {
-    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->bloom_filter_index_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->bloom_filter_index_mem_tracker(), mem_usage());
 }
 
 StatusOr<bool> BloomFilterIndexReader::load(const IndexReadOptions& opts, const BloomFilterIndexPB& meta) {
@@ -60,7 +60,7 @@ StatusOr<bool> BloomFilterIndexReader::load(const IndexReadOptions& opts, const 
         Status st = _do_load(opts, meta);
         if (st.ok()) {
             MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bloom_filter_index_mem_tracker(),
-                                     _mem_usage() - sizeof(BloomFilterIndexReader));
+                                     mem_usage() - sizeof(BloomFilterIndexReader));
         } else {
             _reset();
         }

--- a/be/src/storage/rowset/bloom_filter_index_reader.h
+++ b/be/src/storage/rowset/bloom_filter_index_reader.h
@@ -76,18 +76,18 @@ public:
 
     bool loaded() const { return invoked(_load_once); }
 
-private:
-    Status _do_load(const IndexReadOptions& opts, const BloomFilterIndexPB& meta);
-
-    void _reset();
-
-    size_t _mem_usage() const {
+    size_t mem_usage() const {
         size_t size = sizeof(BloomFilterIndexReader);
         if (_bloom_filter_reader != nullptr) {
             size += _bloom_filter_reader->mem_usage();
         }
         return size;
     }
+
+private:
+    Status _do_load(const IndexReadOptions& opts, const BloomFilterIndexPB& meta);
+
+    void _reset();
 
     OnceFlag _load_once;
     TypeInfoPtr _typeinfo;

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -91,9 +91,9 @@ public:
     // Note that |meta| is mutable, this method may change its internal state.
     //
     // To developers: keep this method lightweight, should not incur any I/O.
-    static StatusOr<std::unique_ptr<ColumnReader>> create(ColumnMetaPB* meta, const Segment* segment);
+    static StatusOr<std::unique_ptr<ColumnReader>> create(ColumnMetaPB* meta, Segment* segment);
 
-    ColumnReader(const private_type&, const Segment* segment);
+    ColumnReader(const private_type&, Segment* segment);
     ~ColumnReader();
 
     ColumnReader(const ColumnReader&) = delete;
@@ -154,6 +154,8 @@ public:
 
     uint32_t num_rows() const { return _segment->num_rows(); }
 
+    size_t mem_usage();
+
 private:
     const std::string& file_name() const { return _segment->file_name(); }
 
@@ -207,7 +209,7 @@ private:
     // Pointer to its father segment, as the column reader
     // is never released before the end of the parent's life cycle,
     // so here we just use a normal pointer
-    const Segment* _segment = nullptr;
+    Segment* _segment = nullptr;
 
     uint8_t _flags = 0;
 };

--- a/be/src/storage/rowset/ordinal_page_index.cpp
+++ b/be/src/storage/rowset/ordinal_page_index.cpp
@@ -80,7 +80,7 @@ OrdinalIndexReader::OrdinalIndexReader() {
 }
 
 OrdinalIndexReader::~OrdinalIndexReader() {
-    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->ordinal_index_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->ordinal_index_mem_tracker(), mem_usage());
 }
 
 StatusOr<bool> OrdinalIndexReader::load(const IndexReadOptions& opts, const OrdinalIndexPB& meta,
@@ -89,7 +89,7 @@ StatusOr<bool> OrdinalIndexReader::load(const IndexReadOptions& opts, const Ordi
         Status st = _do_load(opts, meta, num_values);
         if (st.ok()) {
             MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->ordinal_index_mem_tracker(),
-                                     _mem_usage() - sizeof(OrdinalIndexReader))
+                                     mem_usage() - sizeof(OrdinalIndexReader))
         } else {
             _reset();
         }

--- a/be/src/storage/rowset/ordinal_page_index.h
+++ b/be/src/storage/rowset/ordinal_page_index.h
@@ -111,12 +111,7 @@ public:
 
     bool loaded() const { return invoked(_load_once); }
 
-private:
-    friend OrdinalPageIndexIterator;
-
-    void _reset();
-
-    size_t _mem_usage() const {
+    size_t mem_usage() const {
         if (_num_pages == 0) {
             return sizeof(OrdinalIndexReader);
         } else {
@@ -124,6 +119,11 @@ private:
                    (_num_pages + 1) * sizeof(uint64_t);
         }
     }
+
+private:
+    friend OrdinalPageIndexIterator;
+
+    void _reset();
 
     Status _do_load(const IndexReadOptions& opts, const OrdinalIndexPB& meta, ordinal_t num_values);
 

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -47,6 +47,7 @@
 #include "segment_chunk_iterator_adapter.h"
 #include "segment_iterator.h"
 #include "segment_options.h"
+#include "storage/lake/tablet_manager.h"
 #include "storage/rowset/column_reader.h"
 #include "storage/rowset/default_value_column_iterator.h"
 #include "storage/rowset/page_io.h"
@@ -75,9 +76,9 @@ StatusOr<std::shared_ptr<Segment>> Segment::open(std::shared_ptr<FileSystem> fs,
                                                  uint32_t segment_id, std::shared_ptr<const TabletSchema> tablet_schema,
                                                  size_t* footer_length_hint,
                                                  const FooterPointerPB* partial_rowset_footer,
-                                                 bool skip_fill_local_cache) {
-    auto segment =
-            std::make_shared<Segment>(private_type(0), std::move(fs), path, segment_id, std::move(tablet_schema));
+                                                 bool skip_fill_local_cache, lake::TabletManager* tablet_manager) {
+    auto segment = std::make_shared<Segment>(private_type(0), std::move(fs), path, segment_id, std::move(tablet_schema),
+                                             tablet_manager);
 
     RETURN_IF_ERROR(segment->_open(footer_length_hint, partial_rowset_footer, skip_fill_local_cache));
     return std::move(segment);
@@ -174,11 +175,12 @@ Status Segment::parse_segment_footer(RandomAccessFile* read_file, SegmentFooterP
 }
 
 Segment::Segment(const private_type&, std::shared_ptr<FileSystem> fs, std::string path, uint32_t segment_id,
-                 TabletSchemaCSPtr tablet_schema)
+                 TabletSchemaCSPtr tablet_schema, lake::TabletManager* tablet_manager)
         : _fs(std::move(fs)),
           _fname(std::move(path)),
           _tablet_schema(std::move(tablet_schema)),
-          _segment_id(segment_id) {
+          _segment_id(segment_id),
+          _tablet_manager(tablet_manager) {
     MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->segment_metadata_mem_tracker(), _basic_info_mem_usage());
 }
 
@@ -278,6 +280,7 @@ Status Segment::load_index(bool skip_fill_local_cache) {
         if (st.ok()) {
             MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->short_key_index_mem_tracker(),
                                      _short_key_index_mem_usage());
+            update_cache_size();
         } else {
             _reset();
         }
@@ -411,6 +414,21 @@ Status Segment::get_short_key_index(std::vector<std::string>* sk_index_values) {
         sk_index_values->emplace_back(_sk_index_decoder->key(i).to_string());
     }
     return Status::OK();
+}
+
+size_t Segment::_column_index_mem_usage() {
+    size_t size = 0;
+    for (auto& r : _column_readers) {
+        auto& reader = r.second;
+        size += reader->mem_usage();
+    }
+    return size;
+}
+
+void Segment::update_cache_size() {
+    if (_tablet_manager != nullptr) {
+        _tablet_manager->update_segment_cache_size(file_name());
+    }
 }
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -90,14 +90,15 @@ public:
                                                    uint32_t segment_id, TabletSchemaCSPtr tablet_schema,
                                                    size_t* footer_length_hint = nullptr,
                                                    const FooterPointerPB* partial_rowset_footer = nullptr,
-                                                   bool skip_fill_local_cache = true);
+                                                   bool skip_fill_local_cache = true,
+                                                   lake::TabletManager* tablet_manager = nullptr);
 
     [[nodiscard]] static Status parse_segment_footer(RandomAccessFile* read_file, SegmentFooterPB* footer,
                                                      size_t* footer_length_hint,
                                                      const FooterPointerPB* partial_rowset_footer);
 
     Segment(const private_type&, std::shared_ptr<FileSystem> fs, std::string path, uint32_t segment_id,
-            TabletSchemaCSPtr tablet_schema);
+            TabletSchemaCSPtr tablet_schema, lake::TabletManager* tablet_manager);
 
     ~Segment();
 
@@ -164,7 +165,7 @@ public:
 
     const ShortKeyIndexDecoder* decoder() const { return _sk_index_decoder.get(); }
 
-    int64_t mem_usage() { return _basic_info_mem_usage() + _short_key_index_mem_usage(); }
+    size_t mem_usage() { return _basic_info_mem_usage() + _short_key_index_mem_usage() + _column_index_mem_usage(); }
 
     bool is_valid_column(uint32_t column_unique_id) const;
 
@@ -178,6 +179,11 @@ public:
 
     // read short_key_index, for data check, just used in unit test now
     [[nodiscard]] Status get_short_key_index(std::vector<std::string>* sk_index_values);
+
+    // for cloud native tablet metadata cache.
+    // after the segment is inserted into metadata cache, various indexes will be loaded later when used,
+    // so the segment size in the cache needs to be updated when indexes are loading.
+    void update_cache_size();
 
     DISALLOW_COPY_AND_MOVE(Segment);
 
@@ -213,15 +219,17 @@ private:
 
     void _reset();
 
-    int64_t _basic_info_mem_usage() { return static_cast<int64_t>(sizeof(Segment) + _fname.size()); }
+    size_t _basic_info_mem_usage() { return sizeof(Segment) + _fname.size(); }
 
-    int64_t _short_key_index_mem_usage() {
-        int64_t size = _sk_index_handle.mem_usage();
+    size_t _short_key_index_mem_usage() {
+        size_t size = _sk_index_handle.mem_usage();
         if (_sk_index_decoder != nullptr) {
             size += _sk_index_decoder->mem_usage();
         }
         return size;
     }
+
+    size_t _column_index_mem_usage();
 
     // open segment file and read the minimum amount of necessary information (footer)
     Status _open(size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer, bool skip_fill_local_cache);
@@ -258,6 +266,9 @@ private:
     std::unique_ptr<std::vector<LogicalType>> _column_storage_types;
     // When reading old type format data this will be set to true.
     bool _needs_chunk_adapter = false;
+
+    // for cloud native tablet
+    lake::TabletManager* _tablet_manager = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/zone_map_index.cpp
+++ b/be/src/storage/rowset/zone_map_index.cpp
@@ -287,7 +287,7 @@ ZoneMapIndexReader::ZoneMapIndexReader() {
 }
 
 ZoneMapIndexReader::~ZoneMapIndexReader() {
-    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->column_zonemap_index_mem_tracker(), _mem_usage());
+    MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->column_zonemap_index_mem_tracker(), mem_usage());
 }
 
 StatusOr<bool> ZoneMapIndexReader::load(const IndexReadOptions& opts, const ZoneMapIndexPB& meta) {
@@ -295,7 +295,7 @@ StatusOr<bool> ZoneMapIndexReader::load(const IndexReadOptions& opts, const Zone
         Status st = _do_load(opts, meta);
         if (st.ok()) {
             MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->column_zonemap_index_mem_tracker(),
-                                     _mem_usage() - sizeof(ZoneMapIndexReader))
+                                     mem_usage() - sizeof(ZoneMapIndexReader))
         } else {
             _reset();
         }
@@ -341,7 +341,7 @@ Status ZoneMapIndexReader::_do_load(const IndexReadOptions& opts, const ZoneMapI
     return Status::OK();
 }
 
-size_t ZoneMapIndexReader::_mem_usage() const {
+size_t ZoneMapIndexReader::mem_usage() const {
     size_t size = sizeof(ZoneMapIndexReader);
     for (const auto& zone_map : _page_zone_maps) {
         size += zone_map.SpaceUsedLong();

--- a/be/src/storage/rowset/zone_map_index.h
+++ b/be/src/storage/rowset/zone_map_index.h
@@ -97,12 +97,12 @@ public:
 
     bool loaded() const { return invoked(_load_once); }
 
+    size_t mem_usage() const;
+
 private:
     void _reset() { std::vector<ZoneMapPB>{}.swap(_page_zone_maps); }
 
     Status _do_load(const IndexReadOptions& opts, const ZoneMapIndexPB& meta);
-
-    size_t _mem_usage() const;
 
     OnceFlag _load_once;
     std::vector<ZoneMapPB> _page_zone_maps;

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -304,8 +304,8 @@ public:
 
     std::string debug_string() const;
 
-    int64_t mem_usage() const {
-        int64_t mem_usage = sizeof(TabletSchema);
+    size_t mem_usage() const {
+        size_t mem_usage = sizeof(TabletSchema);
         for (const auto& col : _cols) {
             mem_usage += col.mem_usage();
         }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -216,6 +216,7 @@ set(EXEC_FILES
         ./storage/lake/primary_key_compaction_task_test.cpp
         ./storage/lake/primary_key_publish_test.cpp
         ./storage/lake/meta_file_test.cpp
+        ./storage/lake/metadata_cache_test.cpp
         ./storage/rowset_update_state_test.cpp
         ./storage/rowset_column_update_state_test.cpp
         ./storage/rowset_column_partial_update_test.cpp

--- a/be/test/storage/lake/metadata_cache_test.cpp
+++ b/be/test/storage/lake/metadata_cache_test.cpp
@@ -1,0 +1,180 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/chunk.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "column/vectorized_fwd.h"
+#include "common/logging.h"
+#include "fs/fs_util.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/location_provider.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_writer.h"
+#include "storage/tablet_schema.h"
+#include "test_util.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+
+namespace starrocks::lake {
+
+using namespace starrocks;
+
+class LakeMetadataCacheTest : public TestBase {
+public:
+    LakeMetadataCacheTest() : TestBase(kTestDirectory) {
+        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+        }
+
+        _tablet_schema = TabletSchema::create(*schema);
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_lake_metadata_cache";
+
+    std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+};
+
+TEST_F(LakeMetadataCacheTest, test_segment_cache) {
+    auto* metacache = _tablet_mgr->metacache();
+
+    // write data and metadata
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+    std::vector<int> k1{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
+    std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    auto c2 = Int32Column::create();
+    auto c3 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c2->append_numbers(k1.data(), k1.size() * sizeof(int));
+    c3->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk1({c2, c3}, _schema);
+
+    const int segment_rows = chunk0.num_rows() + chunk1.num_rows();
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+
+    {
+        int64_t txn_id = next_id();
+        // write rowset 1 with 2 segments
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+
+        // write rowset data
+        // segment #1
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->write(chunk1));
+        ASSERT_OK(writer->finish());
+
+        // segment #2
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->write(chunk1));
+        ASSERT_OK(writer->finish());
+
+        auto files = writer->files();
+        ASSERT_EQ(2, files.size());
+
+        // add rowset metadata
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(true);
+        rowset->set_id(1);
+        auto* segs = rowset->mutable_segments();
+        for (auto& file : writer->files()) {
+            segs->Add(std::move(file));
+        }
+
+        writer->close();
+    }
+
+    _tablet_metadata->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    // no segment
+    auto sz0 = metacache->get_memory_usage();
+
+    ASSIGN_OR_ABORT(auto reader, tablet.new_reader(2, *_schema));
+    ASSERT_OK(reader->prepare());
+    TabletReaderParams params;
+    ASSERT_OK(reader->open(params));
+
+    // load segment without indexes
+    auto sz1 = metacache->get_memory_usage();
+
+    auto read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);
+    for (int j = 0; j < 2; ++j) {
+        read_chunk_ptr->reset();
+        ASSERT_OK(reader->get_next(read_chunk_ptr.get()));
+        ASSERT_EQ(segment_rows, read_chunk_ptr->num_rows());
+    }
+    read_chunk_ptr->reset();
+    ASSERT_TRUE(reader->get_next(read_chunk_ptr.get()).is_end_of_file());
+    reader->close();
+
+    // load segment with indexes, and remove index meta (index meta is larger than index)
+    auto sz2 = metacache->get_memory_usage();
+    std::cout << "metadata cache memory usage: " << sz0 << "-" << sz1 << "-" << sz2;
+    ASSERT_GT(sz1, sz0);
+    ASSERT_LT(sz2, sz1);
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -99,7 +99,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(Segment::private_type(0), fs, fname, 1, _dummy_segment_schema);
+        return std::make_shared<Segment>(Segment::private_type(0), fs, fname, 1, _dummy_segment_schema, nullptr);
     }
 
     template <LogicalType type, EncodingTypePB encoding, uint32_t version>

--- a/be/test/storage/rowset/map_column_rw_test.cpp
+++ b/be/test/storage/rowset/map_column_rw_test.cpp
@@ -48,7 +48,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(Segment::private_type(0), fs, fname, 1, _dummy_segment_schema);
+        return std::make_shared<Segment>(Segment::private_type(0), fs, fname, 1, _dummy_segment_schema, nullptr);
     }
 
     void test_int_map() {

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -50,7 +50,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(Segment::private_type(0), fs, fname, 1, _dummy_segment_schema);
+        return std::make_shared<Segment>(Segment::private_type(0), fs, fname, 1, _dummy_segment_schema, nullptr);
     }
 
     void test_int_struct() {


### PR DESCRIPTION
When loading a segment, only the footer and column meta are loaded,
and indexes are loaded lazily when they are used.
So segment memory usage is inaccurate when the segment is loading
and inserted into the metadata cache.
Therefore, the segment memory usage needs to be updated when
the indexes are loading.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
