### PR TITLE
[Enhancement] Only create necessay partitions when refreshing mv by partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -653,7 +653,7 @@ public class PartitionUtil {
             if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.DATE_TRUNC) ||
                     functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE)) {
                 return SyncPartitionUtils.getRangePartitionDiffOfExpr(basePartitionMap,
-                        mvPartitionMap, functionCallExpr, partitionColumn.getPrimitiveType());
+                        mvPartitionMap, functionCallExpr, partitionColumn.getPrimitiveType(), null);
             } else {
                 throw new SemanticException("Materialized view partition function " +
                         functionCallExpr.getFnName().getFunction() +

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -185,7 +185,7 @@ public class LoadMgr implements Writable {
                 .build());
     }
 
-    // add load job and also add to to callback factory
+    // add load job and also add to callback factory
     private void createLoadJob(LoadJob loadJob) {
         addLoadJob(loadJob);
         // add callback before txn created, because callback will be performed on replay without txn begin

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -56,6 +56,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -138,7 +139,9 @@ public class SyncPartitionUtils {
 
     public static RangePartitionDiff getRangePartitionDiffOfExpr(Map<String, Range<PartitionKey>> baseRangeMap,
                                                                  Map<String, Range<PartitionKey>> mvRangeMap,
-                                                                 FunctionCallExpr functionCallExpr, PrimitiveType partitionType) {
+                                                                 FunctionCallExpr functionCallExpr,
+                                                                 PrimitiveType partitionType,
+                                                                 Range<PartitionKey> rangeToInclude) {
 
         Map<String, Range<PartitionKey>> rollupRange = Maps.newHashMap();
         if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.DATE_TRUNC)) {
@@ -147,20 +150,21 @@ public class SyncPartitionUtils {
         } else if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE)) {
             rollupRange = mappingRangeList(baseRangeMap);
         }
-        return getRangePartitionDiff(baseRangeMap, mvRangeMap, rollupRange);
+        return getRangePartitionDiff(baseRangeMap, mvRangeMap, rollupRange, rangeToInclude);
     }
 
     public static RangePartitionDiff getRangePartitionDiffOfExpr(Map<String, Range<PartitionKey>> baseRangeMap,
                                                                  Map<String, Range<PartitionKey>> mvRangeMap,
                                                                  String granularity, PrimitiveType partitionType) {
         Map<String, Range<PartitionKey>> rollupRange = mappingRangeList(baseRangeMap, granularity, partitionType);
-        return getRangePartitionDiff(baseRangeMap, mvRangeMap, rollupRange);
+        return getRangePartitionDiff(baseRangeMap, mvRangeMap, rollupRange, null);
     }
 
     @NotNull
     private static RangePartitionDiff getRangePartitionDiff(Map<String, Range<PartitionKey>> baseRangeMap,
                                                             Map<String, Range<PartitionKey>> mvRangeMap,
-                                                            Map<String, Range<PartitionKey>> rollupRange) {
+                                                            Map<String, Range<PartitionKey>> rollupRange,
+                                                            Range<PartitionKey> rangeToInclude) {
         // TODO: Callers may use `List<PartitionRange>` directly.
         List<PartitionRange> rollupRanges = rollupRange.keySet().stream().map(name -> new PartitionRange(name,
                 rollupRange.get(name))).collect(Collectors.toList());
@@ -169,8 +173,8 @@ public class SyncPartitionUtils {
         List<PartitionRange> mvRanges = mvRangeMap.keySet().stream().map(name -> new PartitionRange(name,
                 mvRangeMap.get(name))).collect(Collectors.toList());
         Map<String, Set<String>> partitionRefMap = getIntersectedPartitions(rollupRanges, baseRanges);
-        Map<String, Range<PartitionKey>> adds = diffRange(rollupRanges, mvRanges);
-        Map<String, Range<PartitionKey>> deletes = diffRange(mvRanges, rollupRanges);
+        Map<String, Range<PartitionKey>> adds = diffRange(rollupRanges, mvRanges, rangeToInclude);
+        Map<String, Range<PartitionKey>> deletes = diffRange(mvRanges, rollupRanges, null);
 
         RangePartitionDiff diff = new RangePartitionDiff(adds, deletes);
         diff.setRollupToBasePartitionMap(partitionRefMap);
@@ -475,15 +479,32 @@ public class SyncPartitionUtils {
     }
 
     public static Map<String, Range<PartitionKey>> diffRange(List<PartitionRange> srcRanges,
-                                                             List<PartitionRange> dstRanges) {
+                                                             List<PartitionRange> dstRanges,
+                                                             Range<PartitionKey> rangeToInclude) {
         Map<String, Range<PartitionKey>> result = Maps.newHashMap();
-        Set<PartitionRange> dstRangeSet = dstRanges.stream().collect(Collectors.toSet());
+        Set<PartitionRange> dstRangeSet = new HashSet<>(dstRanges);
         for (PartitionRange range : srcRanges) {
-            if (!dstRangeSet.contains(range)) {
+            if (!dstRangeSet.contains(range) && (rangeToInclude == null || isRangeIncluded(range, rangeToInclude))) {
                 result.put(range.getPartitionName(), range.getPartitionKeyRange());
             }
         }
         return result;
+    }
+
+    /**
+     * Check whether `range` is included in `rangeToInclude`. Here we only want to
+     * create partitions which is between `start` and `end` when executing
+     * `refresh materialized view xxx partition start (xxx) end (xxx)`
+     *
+     * @param range range to check
+     * @param rangeToInclude range to check whether the to be checked range is in
+     * @return true if included, else false
+     */
+    private static boolean isRangeIncluded(PartitionRange range, Range<PartitionKey> rangeToInclude) {
+        Range<PartitionKey> rangeToCheck = range.getPartitionKeyRange();
+        int lowerCmp = rangeToInclude.lowerEndpoint().compareTo(rangeToCheck.upperEndpoint());
+        int upperCmp = rangeToInclude.upperEndpoint().compareTo(rangeToCheck.lowerEndpoint());
+        return !(lowerCmp >= 0 || upperCmp <= 0);
     }
 
     public static Map<String, List<List<String>>> diffList(Map<String, List<List<String>>> srcListMap,

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -311,7 +311,15 @@ public class PartitionBasedMvRefreshProcessorTest {
                         "PROPERTIES (\n" +
                         "\"replication_num\" = \"1\"\n" +
                         ") " +
-                        "as select a, b, c, d from jdbc0.partitioned_db0.tbl3;");
+                        "as select a, b, c, d from jdbc0.partitioned_db0.tbl3;")
+                .withMaterializedView("create materialized view jdbc_parttbl_mv6 " +
+                        "partition by ss " +
+                        "distributed by hash(a) buckets 10 " +
+                        "REFRESH DEFERRED MANUAL " +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\"\n" +
+                        ") " +
+                        "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;");
 
 
         new MockUp<StmtExecutor>() {
@@ -1268,7 +1276,7 @@ public class PartitionBasedMvRefreshProcessorTest {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("jdbc_parttbl_mv1"));
         HashMap<String, String> taskRunProperties = new HashMap<>();
-        taskRunProperties.put(PARTITION_START, "20230801");
+        taskRunProperties.put(PARTITION_START, "20230731");
         taskRunProperties.put(TaskRun.PARTITION_END, "20230805");
         taskRunProperties.put(TaskRun.FORCE, Boolean.toString(false));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
@@ -1310,7 +1318,7 @@ public class PartitionBasedMvRefreshProcessorTest {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("jdbc_parttbl_mv3"));
         HashMap<String, String> taskRunProperties = new HashMap<>();
-        taskRunProperties.put(PARTITION_START, "20230801");
+        taskRunProperties.put(PARTITION_START, "20230731");
         taskRunProperties.put(TaskRun.PARTITION_END, "20230805");
         taskRunProperties.put(TaskRun.FORCE, Boolean.toString(false));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
@@ -1334,7 +1342,7 @@ public class PartitionBasedMvRefreshProcessorTest {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("jdbc_parttbl_mv5"));
         HashMap<String, String> taskRunProperties = new HashMap<>();
-        taskRunProperties.put(PARTITION_START, "20230801");
+        taskRunProperties.put(PARTITION_START, "20230731");
         taskRunProperties.put(TaskRun.PARTITION_END, "20230805");
         taskRunProperties.put(TaskRun.FORCE, Boolean.toString(false));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
@@ -2517,5 +2525,36 @@ public class PartitionBasedMvRefreshProcessorTest {
         }
 
         starRocksAssert.dropMaterializedView("partition_prune_mv1");
+    }
+
+    @Test
+    public void testRefreshByParCreateOnlyNecessaryPar() throws Exception {
+        MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
+        MockedJDBCMetadata mockedJDBCMetadata =
+                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+        mockedJDBCMetadata.initPartitions();
+
+        // get base table partitions
+        List<String> baseParNames = mockedJDBCMetadata.listPartitionNames("partitioned_db0", "tbl1");
+        System.out.println(baseParNames);
+        Assert.assertEquals(3, baseParNames.size());
+
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("jdbc_parttbl_mv6"));
+        HashMap<String, String> taskRunProperties = new HashMap<>();
+        // check corner case: the first partition of base table is 0000 to 20230801
+        // p20230801 of mv should not be created
+        taskRunProperties.put(PARTITION_START, "20230801");
+        taskRunProperties.put(TaskRun.PARTITION_END, "20230802");
+        taskRunProperties.put(TaskRun.FORCE, Boolean.toString(false));
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(taskRunProperties).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+        Collection<Partition> partitions = materializedView.getPartitions();
+        System.out.println(partitions);
+        // check create only one partition
+        Assert.assertEquals(1, partitions.size());
+        Assert.assertNotNull(materializedView.getPartition("p20230802"));
     }
 }


### PR DESCRIPTION
This has been tested on 3.1 based branch in customer env, here is just a backport.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
