### PR TITLE
[Enhancement] Support delay some time before drop tablet on tablet report

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1347,6 +1347,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long tablet_sched_consecutive_full_clone_delay_sec = 180; // 3min
 
+    @ConfField(mutable = true, comment = "How much time we should wait before dropping the tablet from BE on tablet report")
+    public static long tablet_report_drop_tablet_delay_sec = 120;
+
     /**
      * After checked tablet_checker_partition_batch_num partitions, db lock will be released,
      * so that other threads can get the lock.

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -144,6 +144,12 @@ public class ReportHandler extends Daemon {
      * Record the mapping of <tablet id, backend id> to the to be dropped time of tablet.
      * We will delay the drop of tablet based on configuration `tablet_report_drop_tablet_delay_sec`
      * if we don't find the meta of the tablet in FE.
+     * <p>
+     * There's no concurrency here since it will only be used by a single thread of ReportHandler, so
+     * we don't need lock protection.
+     * <p>
+     * And because the tablet drop only relies on some runtime state, if the map is lost after restart,
+     * the drop can retry. So we don't need to persist this map either.
      */
     private static final Table<Long, Long, Long> TABLET_TO_DROP_TIME = HashBasedTable.create();
 

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -899,7 +899,12 @@ public class ReportHandler extends Daemon {
             TABLET_TO_DROP_TIME.put(tabletId, backendId,
                     currentTimeMs + Config.tablet_report_drop_tablet_delay_sec * 1000);
         } else {
-            return currentTimeMs > time;
+            boolean ready = currentTimeMs > time;
+            if (ready) {
+                // clean the map
+                TABLET_TO_DROP_TIME.remove(tabletId, backendId);
+                return true;
+            }
         }
 
         return false;

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -395,4 +395,22 @@ public class ReportHandlerTest {
         ReportHandler.handleMigration(tabletMetaMigrationMap, backendId);
         Assert.assertEquals(30, AgentTaskQueue.getTaskNum(backendId, TTaskType.STORAGE_MEDIUM_MIGRATE, false));
     }
+
+    @Test
+    public void testTabletDropDelay() throws InterruptedException {
+        long tabletId = 100001;
+        long backendId = 100002;
+        Config.tablet_report_drop_tablet_delay_sec = 3;
+
+        boolean ready = ReportHandler.checkReadyToBeDropped(tabletId, backendId);
+        Assert.assertFalse(ready);
+
+        Thread.sleep(1000);
+        ready = ReportHandler.checkReadyToBeDropped(tabletId, backendId);
+        Assert.assertFalse(ready);
+
+        Thread.sleep(2000);
+        ready = ReportHandler.checkReadyToBeDropped(tabletId, backendId);
+        Assert.assertTrue(ready);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -409,7 +409,15 @@ public class ReportHandlerTest {
         ready = ReportHandler.checkReadyToBeDropped(tabletId, backendId);
         Assert.assertFalse(ready);
 
-        Thread.sleep(2000);
+        Thread.sleep(3000);
+        ready = ReportHandler.checkReadyToBeDropped(tabletId, backendId);
+        Assert.assertTrue(ready);
+
+        // check map is cleaned
+        ready = ReportHandler.checkReadyToBeDropped(tabletId, backendId);
+        Assert.assertFalse(ready);
+
+        Thread.sleep(4000);
         ready = ReportHandler.checkReadyToBeDropped(tabletId, backendId);
         Assert.assertTrue(ready);
     }


### PR DESCRIPTION
Delay the tablet drop based on configuration `tablet_report_drop_tablet_delay_sec`,
by default it's 120 seconds(2min). This is to avoid some concurrency issues which may
cause the query fail. Errors may look like below,
```
no delete vector found tablet:21091 segment:0 version:2
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
