### PR TITLE
[Enhancement] Resolve backend FQDN to ip when generating plan fragment

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2550,4 +2550,8 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static boolean replan_on_insert = false;
+
+    @ConfField(mutable = true, comment = "Whether or not resolve the fqdn of compute node/backend" +
+            "to ip when scheduling query")
+    public static boolean query_coordinator_enable_fqdn_resolve = false;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/FQDNResolveException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/FQDNResolveException.java
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import static java.lang.String.format;
+
+public class FQDNResolveException extends RuntimeException {
+    public FQDNResolveException(String message) {
+        super(message);
+    }
+
+    public FQDNResolveException(String formatString, Object... args) {
+        super(format(formatString, args));
+    }
+
+    public FQDNResolveException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public String getErrorMessage() {
+        return super.getMessage();
+    }
+
+    @Override
+    public String getMessage() {
+        return getErrorMessage();
+    }
+
+    public static void check(boolean test, String message, Object... args) {
+        if (!test) {
+            throw new FQDNResolveException(message, args);
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/NetworkUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/NetworkUtils.java
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/common/util/KafkaUtil.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.common.util;
+
+import com.google.common.net.InetAddresses;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Config;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Objects;
+
+public class NetworkUtils {
+    public static class NetworkAddress {
+        @SerializedName("h")
+        public String hostname;
+        @SerializedName("p")
+        public int port;
+
+        public NetworkAddress() {
+
+        }
+
+        public NetworkAddress(String hostname, int port) {
+            this.hostname = hostname;
+            this.port = port;
+        }
+
+        public String getHostname() {
+            return hostname;
+        }
+
+        public void setHostname(String hostname) {
+            this.hostname = hostname;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof NetworkAddress
+                    && this.hostname.equals(((NetworkAddress) obj).hostname)
+                    && this.port == ((NetworkAddress) obj).port;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(hostname, port);
+        }
+
+        @Override
+        public String toString() {
+            return hostname + ":" + port;
+        }
+    }
+
+    private static boolean isFQDN(String host) {
+        return !InetAddresses.isInetAddress(host);
+    }
+
+    /**
+     * Try to resolve the fqdn to ip if necessary
+     * @param host fqdn
+     * @return ip
+     * @throws RuntimeException
+     */
+    public static String resolveFQDNIfNecessary(String host) throws RuntimeException {
+        if (Config.query_coordinator_enable_fqdn_resolve && isFQDN(host)) {
+            try {
+                InetAddress address = InetAddress.getByName(host);
+                return address.getHostAddress();
+            } catch (UnknownHostException e) {
+                throw new FQDNResolveException("resolve fqdn " + host + "failed, " + e.getMessage(), e);
+            }
+        }
+        return host;
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -112,11 +112,12 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+
+import static com.starrocks.common.util.NetworkUtils.NetworkAddress;
 
 // NOTE: we must be carefully if we send next request
 //       as soon as receiving one instance's report from one BE,
@@ -1159,55 +1160,6 @@ public class ExportJob implements Writable, GsonPostProcessable {
                             -> Pair.create(new TNetworkAddress(snapshotPath.first.hostname, snapshotPath.first.port),
                             snapshotPath.second))
                     .collect(Collectors.toList());
-        }
-    }
-
-    public static class NetworkAddress {
-        @SerializedName("h")
-        String hostname;
-        @SerializedName("p")
-        int port;
-
-        public NetworkAddress() {
-
-        }
-
-        public NetworkAddress(String hostname, int port) {
-            this.hostname = hostname;
-            this.port = port;
-        }
-
-        public String getHostname() {
-            return hostname;
-        }
-
-        public void setHostname(String hostname) {
-            this.hostname = hostname;
-        }
-
-        public int getPort() {
-            return port;
-        }
-
-        public void setPort(int port) {
-            this.port = port;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return obj instanceof NetworkAddress
-                    && this.hostname.equals(((NetworkAddress) obj).hostname)
-                    && this.port == ((NetworkAddress) obj).port;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(hostname, port);
-        }
-
-        @Override
-        public String toString() {
-            return hostname + ":" + port;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -22,6 +22,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
+import com.starrocks.common.util.NetworkUtils;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.CoordinatorMonitor;
 import com.starrocks.qe.GlobalVariable;
@@ -202,20 +203,16 @@ public class ComputeNode implements IComputable, Writable {
         return brpcPort;
     }
 
-    public TNetworkAddress getAddress() {
-        return new TNetworkAddress(host, bePort);
+    public TNetworkAddress getAddress() throws RuntimeException {
+        return new TNetworkAddress(NetworkUtils.resolveFQDNIfNecessary(host), bePort);
     }
 
     public TNetworkAddress getBrpcAddress() {
-        return new TNetworkAddress(host, brpcPort);
-    }
-
-    public TNetworkAddress getBeRpcAddress() {
-        return new TNetworkAddress(host, beRpcPort);
+        return new TNetworkAddress(NetworkUtils.resolveFQDNIfNecessary(host), brpcPort);
     }
 
     public TNetworkAddress getHttpAddress() {
-        return new TNetworkAddress(host, httpPort);
+        return new TNetworkAddress(NetworkUtils.resolveFQDNIfNecessary(host), httpPort);
     }
 
     public String getHeartbeatErrMsg() {

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportJobTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static com.starrocks.common.util.NetworkUtils.NetworkAddress;
+
 public class ExportJobTest {
 
     @Test
@@ -30,8 +32,8 @@ public class ExportJobTest {
 
         List<Pair<TNetworkAddress, String>> tList = Lists.newArrayList(
                 Pair.create(new TNetworkAddress("host1", 1000), "path1"));
-        List<Pair<ExportJob.NetworkAddress, String>> sList = Lists.newArrayList(
-                Pair.create(new ExportJob.NetworkAddress("host1", 1000), "path1")
+        List<Pair<NetworkAddress, String>> sList = Lists.newArrayList(
+                Pair.create(new NetworkAddress("host1", 1000), "path1")
         );
 
         Assert.assertEquals(sList, updateInfo.serialize(tList));


### PR DESCRIPTION
To release the pressure on DNS server when multi backends querying it.
Besides, move the NetworkAddress from `ExportJob.java` to `NetworkUtils.java`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
