### PR TITLE
[BugFix] Fix use-after-free in GlobalRuntimeFilter

### DIFF
--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -468,10 +468,13 @@ void RuntimeFilterProbeCollector::compute_hash_values(Chunk* chunk, Column* colu
     if (rf_desc->partition_by_expr_contexts()->empty()) {
         filter->compute_hash({column}, &eval_context.running_context);
     } else {
+        // Used to hold generated columns
+        std::vector<ColumnPtr> column_holders;
         std::vector<Column*> partition_by_columns;
         for (auto& partition_ctx : *(rf_desc->partition_by_expr_contexts())) {
             ColumnPtr partition_column = EVALUATE_NULL_IF_ERROR(partition_ctx, partition_ctx->root(), chunk);
             partition_by_columns.push_back(partition_column.get());
+            column_holders.emplace_back(std::move(partition_column));
         }
         filter->compute_hash(partition_by_columns, &eval_context.running_context);
     }

--- a/test/sql/test_grf/R/test_grf
+++ b/test/sql/test_grf/R/test_grf
@@ -1,0 +1,36 @@
+-- name: testGlobalRuntimeFilter
+CREATE TABLE left_tbl
+    (c1 int,
+    c2  int)
+    DISTRIBUTED BY HASH(c1) BUCKETS 3
+    PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into left_tbl values
+(1, 1),
+(2, 2),
+(3, 3);
+-- result:
+-- !result
+CREATE TABLE right_tbl
+    (c1 int,
+    c2  int)
+    DISTRIBUTED BY HASH(c1) BUCKETS 3
+    PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into right_tbl values
+(1, 1),
+(2, 2),
+(3, 3);
+-- result:
+-- !result
+set global_runtime_filter_probe_min_size = 0;
+-- result:
+-- !result
+select * from left_tbl join [shuffle]  right_tbl on left_tbl.c1 = right_tbl.c1 where right_tbl.c2 < 4;
+-- result:
+1	1	1	1
+2	2	2	2
+3	3	3	3
+-- !result


### PR DESCRIPTION
In some cases, columns will be used after free, this PR fix it.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
