### PR TITLE
[BugFix] Fix iceberg hive catalog + s3 protocol will occur S3Client authentication failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -23,6 +23,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.util.Util;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergAwsClientFactory;
 import com.starrocks.connector.iceberg.IcebergCatalog;
 import com.starrocks.connector.iceberg.IcebergCatalogType;
 import com.starrocks.connector.iceberg.cost.IcebergMetricsReporter;
@@ -36,6 +37,7 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hive.HiveCatalog;
@@ -80,6 +82,7 @@ public class IcebergHiveCatalog implements IcebergCatalog {
 
         copiedProperties.put(CatalogProperties.URI, metastoreURI);
         copiedProperties.put(CatalogProperties.FILE_IO_IMPL, IcebergCachingFileIO.class.getName());
+        copiedProperties.put(AwsProperties.CLIENT_FACTORY, IcebergAwsClientFactory.class.getName());
         copiedProperties.put(CatalogProperties.METRICS_REPORTER_IMPL, IcebergMetricsReporter.class.getName());
 
         delegate = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(), name, copiedProperties, conf);


### PR DESCRIPTION
User will face below error msg in iceberg catalog, when using hive catalog + s3 protocol

```bash
2023-10-05 00:00:06,263 WARN (pool-21-thread-1084|755883) [Tasks$Builder.runTaskWithRetry():456] Retrying task after failure: Unable to load region from any of the providers in the chain software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain@54fcbf4e: [software.amazon.awssdk.regions.providers.SystemSettingsRegionProvider@20d1f480: Unable to load region from system settings. Region must be specified either via environment variable (AWS_REGION) or  system property (aws.region)., software.amazon.awssdk.regions.providers.AwsProfileRegionProvider@65d37efe: No region provided in profile: default, software.amazon.awssdk.regions.providers.InstanceProfileRegionProvider@3e3bbab: Unable to contact EC2 metadata service.]
software.amazon.awssdk.core.exception.SdkClientException: Unable to load region from any of the providers in the chain software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain@54fcbf4e: [software.amazon.awssdk.regions.providers.SystemSettingsRegionProvider@20d1f480: Unable to load region from system settings. Region must be specified either via environment variable (AWS_REGION) or  system property (aws.region)., software.amazon.awssdk.regions.providers.AwsProfileRegionProvider@65d37efe: No region provided in profile: default, software.amazon.awssdk.regions.providers.InstanceProfileRegionProvider@3e3bbab: Unable to contact EC2 metadata service.]
	at software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:102) ~[bundle-2.17.257.jar:?]
	at software.amazon.awssdk.regions.providers.AwsRegionProviderChain.getRegion(AwsRegionProviderChain.java:70) ~[bundle-2.17.257.jar:?]
	at software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder.regionFromDefaultProvider(AwsDefaultClientBuilder.java:276) ~[bundle-2.17.257.jar:?]
	at software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder.resolveRegion(AwsDefaultClientBuilder.java:258) ~[bundle-2.17.257.jar:?]
	at software.amazon.awssdk.awscore.client.builder.AwsDefaultClientBuilder.finalizeChildConfiguration(AwsDefaultClientBuilder.java:179) ~[bundle-2.17.257.jar:?]
	at software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder.syncClientConfiguration(SdkDefaultClientBuilder.java:177) ~[bundle-2.17.257.jar:?]
	at software.amazon.awssdk.services.s3.DefaultS3ClientBuilder.buildClient(DefaultS3ClientBuilder.java:27) ~[bundle-2.17.257.jar:?]
	at software.amazon.awssdk.services.s3.DefaultS3ClientBuilder.buildClient(DefaultS3ClientBuilder.java:22) ~[bundle-2.17.257.jar:?]
	at software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder.build(SdkDefaultClientBuilder.java:145) ~[bundle-2.17.257.jar:?]
	at org.apache.iceberg.aws.AwsClientFactories$DefaultAwsClientFactory.s3(AwsClientFactories.java:107) ~[iceberg-aws-1.2.1.jar:?]
	at org.apache.iceberg.aws.s3.S3FileIO.client(S3FileIO.java:326) ~[iceberg-aws-1.2.1.jar:?]
	at org.apache.iceberg.aws.s3.S3FileIO.newInputFile(S3FileIO.java:124) ~[iceberg-aws-1.2.1.jar:?]
	at org.apache.iceberg.io.ResolvingFileIO.newInputFile(ResolvingFileIO.java:61) ~[iceberg-core-1.2.1.jar:?]
	at com.starrocks.connector.iceberg.io.IcebergCachingFileIO.newInputFile(IcebergCachingFileIO.java:133) ~[starrocks-fe.jar:?]
	at org.apache.iceberg.TableMetadataParser.read(TableMetadataParser.java:266) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.BaseMetastoreTableOperations.lambda$refreshFromMetadataLocation$0(BaseMetastoreTableOperations.java:189) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.BaseMetastoreTableOperations.lambda$refreshFromMetadataLocation$1(BaseMetastoreTableOperations.java:208) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.util.Tasks$Builder.runTaskWithRetry(Tasks.java:413) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.util.Tasks$Builder.runSingleThreaded(Tasks.java:219) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:203) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:196) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.BaseMetastoreTableOperations.refreshFromMetadataLocation(BaseMetastoreTableOperations.java:208) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.BaseMetastoreTableOperations.refreshFromMetadataLocation(BaseMetastoreTableOperations.java:185) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.BaseMetastoreTableOperations.refreshFromMetadataLocation(BaseMetastoreTableOperations.java:180) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.hive.HiveTableOperations.doRefresh(HiveTableOperations.java:176) ~[iceberg-hive-metastore-1.2.1.jar:?]
	at org.apache.iceberg.BaseMetastoreTableOperations.refresh(BaseMetastoreTableOperations.java:97) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.BaseMetastoreTableOperations.current(BaseMetastoreTableOperations.java:80) ~[iceberg-core-1.2.1.jar:?]
	at org.apache.iceberg.BaseMetastoreCatalog.loadTable(BaseMetastoreCatalog.java:47) ~[iceberg-core-1.2.1.jar:?]
	at com.starrocks.connector.iceberg.hive.IcebergHiveCatalog.getTable(IcebergHiveCatalog.java:95) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.iceberg.IcebergMetadata.getTable(IcebergMetadata.java:184) ~[starrocks-fe.jar:?]
	at com.starrocks.server.MetadataMgr.lambda$getTable$3(MetadataMgr.java:226) ~[starrocks-fe.jar:?]
	at java.util.Optional.map(Optional.java:215) ~[?:1.8.0_371]
	at com.starrocks.server.MetadataMgr.getTable(MetadataMgr.java:226) ~[starrocks-fe.jar:?]
	at com.starrocks.catalog.BaseTableInfo.getTable(BaseTableInfo.java:135) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.collectBaseTables(PartitionBasedMvRefreshProcessor.java:1191) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.syncPartitions(PartitionBasedMvRefreshProcessor.java:586) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.doMvRefresh(PartitionBasedMvRefreshProcessor.java:180) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.processTaskRun(PartitionBasedMvRefreshProcessor.java:163) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:189) ~[starrocks-fe.jar:?]
	at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:47) ~[starrocks-fe.jar:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604) ~[?:1.8.0_371]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_371]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_371]
	at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_371]
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
