### PR TITLE
[Enhancement] Resolve hostname in frontend

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DnsCache.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DnsCache.java
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.starrocks.thrift.TNetworkAddress;
+import org.apache.commons.validator.routines.InetAddressValidator;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+// This class is used to translate hostname to IP.
+// Because JVM has DNS cache already, this class doesn't maintain its own cache.
+public class DnsCache {
+    public static TNetworkAddress lookup(TNetworkAddress address) throws UnknownHostException {
+        if (InetAddressValidator.getInstance().isValidInet4Address(address.hostname)) {
+            return address;
+        }
+        return new TNetworkAddress(InetAddress.getByName(address.hostname).getHostAddress(), address.port);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -210,10 +210,6 @@ public class ComputeNode implements IComputable, Writable {
         return new TNetworkAddress(host, brpcPort);
     }
 
-    public TNetworkAddress getBeRpcAddress() {
-        return new TNetworkAddress(host, beRpcPort);
-    }
-
     public TNetworkAddress getHttpAddress() {
         return new TNetworkAddress(host, httpPort);
     }


### PR DESCRIPTION
Because compute node has no DNS cache in contaiener, it may cause resolving flooding for DNS server. To avoid this scenario, we resolve hostnames in frontend. After applying this patch, Compute node doesn't need to resolve hostname anymore.

Fixes #32045 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [] 3.1
  - [] 3.0
  - [] 2.5
