### PR TITLE
[BugFix] fix deleting data file by mistake when do partial update in cloud native primary table

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -56,9 +56,15 @@ void MetaFileBuilder::append_delvec(const DelVectorPtr& delvec, uint32_t segment
     }
 }
 
-void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::vector<std::string>& orphan_files) {
+void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write,
+                                    const std::map<int, std::string>& replace_segments,
+                                    const std::vector<std::string>& orphan_files) {
     auto rowset = _tablet_meta->add_rowsets();
     rowset->CopyFrom(op_write.rowset());
+    for (const auto& replace_seg : replace_segments) {
+        // when handle partial update, replace old segments with new rewrite segments
+        rowset->set_segments(replace_seg.first, replace_seg.second);
+    }
     rowset->set_id(_tablet_meta->next_rowset_id());
     // if rowset don't contain segment files, still inc next_rowset_id
     _tablet_meta->set_next_rowset_id(_tablet_meta->next_rowset_id() + std::max(1, rowset->segments_size()));

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -38,7 +38,8 @@ public:
     // append delvec to builder's buffer
     void append_delvec(const DelVectorPtr& delvec, uint32_t segment_id);
     // handle txn log
-    void apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::vector<std::string>& orphan_files);
+    void apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, std::string>& replace_segments,
+                       const std::vector<std::string>& orphan_files);
     void apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction);
     // finalize will generate and sync final meta state to storage.
     // |txn_id| the maximum applied transaction ID, used to construct the delvec file name, and

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -449,18 +449,18 @@ Status RowsetUpdateState::_prepare_partial_update_states(const TxnLogPB_OpWrite&
 }
 
 Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata,
-                                          Tablet* tablet, std::vector<std::string>* orphan_files) {
-    // const_cast for paritial update to rewrite segment file in op_write
-    RowsetMetadata* rowset_meta = const_cast<TxnLogPB_OpWrite*>(&op_write)->mutable_rowset();
+                                          Tablet* tablet, std::map<int, std::string>* replace_segments,
+                                          std::vector<std::string>* orphan_files) {
+    const RowsetMetadata& rowset_meta = op_write.rowset();
     auto root_path = tablet->metadata_root_location();
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_path));
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(metadata.schema());
     // get rowset schema
-    if (!op_write.has_txn_meta() || op_write.rewrite_segments_size() == 0 || rowset_meta->num_rows() == 0 ||
+    if (!op_write.has_txn_meta() || op_write.rewrite_segments_size() == 0 || rowset_meta.num_rows() == 0 ||
         op_write.txn_meta().has_merge_condition()) {
         return Status::OK();
     }
-    CHECK(op_write.rewrite_segments_size() == rowset_meta->segments_size());
+    CHECK(op_write.rewrite_segments_size() == rowset_meta.segments_size());
     // currently assume it's a partial update
     const auto& txn_meta = op_write.txn_meta();
     // columns supplied in rowset
@@ -478,10 +478,11 @@ Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, cons
         }
     }
 
-    std::vector<bool> need_rename(rowset_meta->segments_size(), true);
-    for (int i = 0; i < rowset_meta->segments_size(); i++) {
-        auto src_path = rowset_meta->segments(i);
+    std::vector<bool> need_rename(rowset_meta.segments_size(), true);
+    for (int i = 0; i < rowset_meta.segments_size(); i++) {
+        const auto& src_path = rowset_meta.segments(i);
         const auto& dest_path = op_write.rewrite_segments(i);
+        DCHECK(src_path != dest_path);
 
         int64_t t_rewrite_start = MonotonicMillis();
         if (op_write.txn_meta().has_auto_increment_partial_update_column_id() &&
@@ -503,16 +504,16 @@ Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, cons
         int64_t t_rewrite_end = MonotonicMillis();
         LOG(INFO) << strings::Substitute(
                 "lake apply partial segment tablet:$0 rowset:$1 seg:$2 #column:$3 #rewrite:$4ms [$5 -> $6]",
-                tablet->id(), rowset_meta->id(), i, read_column_ids.size(), t_rewrite_end - t_rewrite_start, src_path,
+                tablet->id(), rowset_meta.id(), i, read_column_ids.size(), t_rewrite_end - t_rewrite_start, src_path,
                 dest_path);
     }
 
     // rename segment file
-    for (int i = 0; i < rowset_meta->segments_size(); i++) {
+    for (int i = 0; i < rowset_meta.segments_size(); i++) {
         if (need_rename[i]) {
             // after rename, add old segment to orphan files, for gc later.
-            orphan_files->push_back(rowset_meta->segments(i));
-            rowset_meta->set_segments(i, op_write.rewrite_segments(i));
+            orphan_files->push_back(rowset_meta.segments(i));
+            (*replace_segments)[i] = op_write.rewrite_segments(i);
         }
     }
     TRACE("end rewrite segment");

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -62,7 +62,7 @@ public:
                 const MetaFileBuilder* builder, bool need_check_conflict);
 
     Status rewrite_segment(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet,
-                           std::vector<std::string>* orphan_files);
+                           std::map<int, std::string>* replace_segments, std::vector<std::string>* orphan_files);
 
     const std::vector<ColumnUniquePtr>& upserts() const { return _upserts; }
     const std::vector<ColumnUniquePtr>& deletes() const { return _deletes; }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -383,6 +383,11 @@ Status TabletManager::delete_tablet(int64_t tablet_id) {
 
 Status TabletManager::put_tablet_metadata(TabletMetadataPtr metadata) {
     // write metadata file
+    Status st = Status::OK();
+    TEST_SYNC_POINT_CALLBACK("put_tablet_metadata.1", &st);
+    if (!st.ok()) {
+        return st;
+    }
     auto t0 = butil::gettimeofday_us();
     auto filepath = _location_provider->tablet_metadata_location(metadata->id(), metadata->version());
     auto options = WritableFileOptions{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -34,6 +34,7 @@
 #include "storage/tablet_schema.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
+#include "testutil/sync_point.h"
 
 namespace starrocks::lake {
 
@@ -599,6 +600,71 @@ TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
     if (GetParam().enable_persistent_index) {
         check_local_persistent_index_meta(tablet_id, version);
     }
+}
+
+TEST_P(LakePartialUpdateTest, test_partial_update_publish_retry) {
+    if (GetParam().enable_persistent_index) return;
+    auto chunk0 = generate_data(kChunkSize, 0, false, 3);
+    auto chunk1 = generate_data(kChunkSize, 0, true, 3);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // normal write
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_index_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
+
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    SyncPoint::GetInstance()->SetCallBack("put_tablet_metadata.1",
+                                          [](void* arg) { ((Status*)arg)->update(Status::InternalError("inject")); });
+    // partial update
+    auto txn_id = next_id();
+    {
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_index_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_ERROR(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+    }
+    SyncPoint::GetInstance()->ClearCallBack("put_tablet_metadata:1");
+    SyncPoint::GetInstance()->DisableProcessing();
+    // retry publish again
+    ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+    _tablet_mgr->prune_metacache();
+    ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePartialUpdateTest, LakePartialUpdateTest,


### PR DESCRIPTION
In current implementation, TxnLog in meta cache will be modified when do partial update and it could cause deleting data file by mistake. E.g.
1. We have `TxnLog` in meta cache:
```
OpWrite {
        RowsetMetadataPB {
               segments : ["aaa.dat"]
        }
    
        rewrite_segments : ["bbb.dat"]
    }
```
If publishing version failed when putting TabletMeta to object storage, so that `TxnLog` in meta cache will be:
```
OpWrite {
        RowsetMetadataPB {
               segments : ["bbb.dat"]
        }
    
        rewrite_segments : ["bbb.dat"]
    }
```
2. Then SR publish version again, `bbb.dat` will be moved to trash files, and will be deleted later.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
