### PR TITLE
[Enhancement]Remove useless op for cn start for 3.1

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -41,7 +41,7 @@ namespace starrocks::config {
 CONF_Int32(cluster_id, "-1");
 // The port on which ImpalaInternalService is exported.
 CONF_Int32(be_port, "9060");
-CONF_Int32(thrift_port, "9060");
+CONF_Int32(thrift_port, "0");
 
 // The port for brpc.
 CONF_Int32(brpc_port, "8060");

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -35,11 +35,16 @@ void start_be() {
 
     // Begin to start services
     // 1. Start thrift server with 'be_port'.
-    auto thrift_server = BackendService::create<BackendService>(exec_env, starrocks::config::be_port);
+    int thrift_port = config::be_port;
+    if (as_cn && config::thrift_port != 0) {
+        thrift_port = config::thrift_port;
+        LOG(WARNING) << "'thrift_port' is deprecated, please update be.conf to use 'be_port' instead!";
+    }
+    auto thrift_server = BackendService::create<BackendService>(exec_env, thrift_port);
+    
     if (auto status = thrift_server->start(); !status.ok()) {
-        LOG(ERROR) << "Fail to start BackendService thrift server on port " << starrocks::config::be_port << ": "
-                   << status;
-        starrocks::shutdown_logging();
+        LOG(ERROR) << "Fail to start BackendService thrift server on port " << thrift_port << ": " << status;
+        shutdown_logging();
         exit(1);
     }
 

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -41,7 +41,7 @@ void start_be() {
         LOG(WARNING) << "'thrift_port' is deprecated, please update be.conf to use 'be_port' instead!";
     }
     auto thrift_server = BackendService::create<BackendService>(exec_env, thrift_port);
-    
+
     if (auto status = thrift_server->start(); !status.ok()) {
         LOG(ERROR) << "Fail to start BackendService thrift server on port " << thrift_port << ": " << status;
         shutdown_logging();

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -35,9 +35,9 @@ void start_be() {
 
     // Begin to start services
     // 1. Start thrift server with 'be_port'.
-    int thrift_port = config::be_port;
-    if (as_cn && config::thrift_port != 0) {
-        thrift_port = config::thrift_port;
+    int thrift_port = starrocks::config::be_port;
+    if (as_cn && starrocks::config::thrift_port != 0) {
+        thrift_port = starrocks::config::thrift_port;
         LOG(WARNING) << "'thrift_port' is deprecated, please update be.conf to use 'be_port' instead!";
     }
     auto thrift_server = BackendService::create<BackendService>(exec_env, thrift_port);

--- a/conf/cn.conf
+++ b/conf/cn.conf
@@ -19,7 +19,7 @@
 sys_log_level = INFO
 
 # ports for admin, web, heartbeat service 
-thrift_port = 9060
+be_port = 9060
 be_http_port = 8040
 heartbeat_service_port = 9050
 brpc_port = 8060


### PR DESCRIPTION

Fixes #issue
maually backport for pr： https://github.com/StarRocks/starrocks/pull/32084

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
