### PR TITLE
[BugFix] Fix resource group in audit log for broker load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadMgr.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ResourceGroupClassifier;
 import com.starrocks.common.Config;
 import com.starrocks.common.DataQualityException;
 import com.starrocks.common.DdlException;
@@ -94,6 +95,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
+import static com.starrocks.qe.CoordinatorPreprocessor.prepareResourceGroup;
+
 /**
  * The broker and spark load jobs are included in this class.
  * <p>
@@ -136,6 +139,9 @@ public class LoadMgr implements Writable {
                         "There are more than " + Config.desired_max_waiting_jobs + " load jobs in waiting queue, "
                                 + "please retry later.");
             }
+
+            prepareResourceGroup(context, ResourceGroupClassifier.QueryType.INSERT);
+
             loadJob = BulkLoadJob.fromLoadStmt(stmt, context);
             createLoadJob(loadJob);
         } finally {


### PR DESCRIPTION
The field `ResourceGroup` in the `fe.audit.log` is lost for broker load.

`prepareResourceGroup`, called in `Coordinator`, sets the selected resource group to `ConnectContext`. However, the `ConnectContext` used by `Coordinator` for broker load is not from the real connect, but generated by the asynchronous load task.
Therefore, we should call `prepareResourceGroup` before submitting the load task to asynchronous executor.
 
---
Besides, the classifier using `db` is ineffective for broker load and export .
Classifiers of resource group uses `ConnectContext::getCurrentSqlDbIds`, but asynchronous task doesn't set this. Will fix this in the future.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
