### PR TITLE
[Feature] persistent index support compression

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1040,6 +1040,8 @@ CONF_mInt64(pindex_major_compaction_schedule_interval_seconds, "15");
 CONF_mInt64(pindex_shard_data_gc_interval_seconds, "18000"); // 5 hour
 // enable use bloom filter for pindex or not
 CONF_mBool(enable_pindex_filter, "true");
+// enable persistent index compression
+CONF_mBool(enable_pindex_compression, "true");
 // use bloom filter in pindex can reduce disk io, but in the following scenarios, we should skip the bloom filter
 // 1. The records to be found are in the index, bloom filter is no usage
 // 2. The records to be found is very small but bloom filter is very large, read bloom filter may cost a lot of disk io

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -155,6 +155,12 @@ struct ImmutableIndexShard {
 
     Status write(WritableFile& wb) const;
 
+    Status compress_and_write(const CompressionTypePB& compression_type, WritableFile& wb,
+                              size_t* uncompressed_size) const;
+
+    Status decompress_pages(const CompressionTypePB& compression_type, uint32_t npage, size_t uncompressed_size,
+                            size_t compressed_size);
+
     static StatusOr<std::unique_ptr<ImmutableIndexShard>> try_create(size_t key_size, size_t npage, size_t nbucket,
                                                                      const std::vector<KVRef>& kv_refs);
 
@@ -171,6 +177,46 @@ Status ImmutableIndexShard::write(WritableFile& wb) const {
     } else {
         return Status::OK();
     }
+}
+
+Status ImmutableIndexShard::compress_and_write(const CompressionTypePB& compression_type, WritableFile& wb,
+                                               size_t* uncompressed_size) const {
+    if (compression_type == CompressionTypePB::NO_COMPRESSION) {
+        return write(wb);
+    }
+    if (pages.size() > 0) {
+        const BlockCompressionCodec* codec = nullptr;
+        RETURN_IF_ERROR(get_block_compression_codec(compression_type, &codec));
+        Slice input((uint8_t*)pages.data(), kPageSize * pages.size());
+        *uncompressed_size = input.get_size();
+        faststring compressed_body;
+        compressed_body.resize(codec->max_compressed_len(*uncompressed_size));
+        Slice compressed_slice(compressed_body);
+        RETURN_IF_ERROR(codec->compress(input, &compressed_slice));
+        return wb.append(compressed_slice);
+    } else {
+        return Status::OK();
+    }
+}
+
+Status ImmutableIndexShard::decompress_pages(const CompressionTypePB& compression_type, uint32_t npage,
+                                             size_t uncompressed_size, size_t compressed_size) {
+    if (uncompressed_size == 0) {
+        // No compression
+        return Status::OK();
+    }
+    if (kPageSize * npage != uncompressed_size) {
+        return Status::Corruption(
+                fmt::format("invalid uncompressed shared size, {} / {}", kPageSize * npage, uncompressed_size));
+    }
+    const BlockCompressionCodec* codec = nullptr;
+    RETURN_IF_ERROR(get_block_compression_codec(compression_type, &codec));
+    Slice compressed_body((uint8_t*)pages.data(), compressed_size);
+    std::vector<IndexPage> uncompressed_pages(npage);
+    Slice decompressed_body((uint8_t*)uncompressed_pages.data(), uncompressed_size);
+    RETURN_IF_ERROR(codec->decompress(compressed_body, &decompressed_body));
+    pages.swap(uncompressed_pages);
+    return Status::OK();
 }
 
 inline size_t num_pack_for_bucket(size_t kv_size, size_t num_kv) {
@@ -496,6 +542,11 @@ Status ImmutableIndexWriter::init(const string& idx_file_path, const EditVersion
 
     _bf_file_path = _idx_file_path + BloomFilterSuffix;
     ASSIGN_OR_RETURN(_bf_wb, _fs->new_writable_file(wblock_opts, _bf_file_path));
+    if (config::enable_pindex_compression) {
+        _meta.set_compression_type(CompressionTypePB::LZ4_FRAME);
+    } else {
+        _meta.set_compression_type(CompressionTypePB::NO_COMPRESSION);
+    }
     return Status::OK();
 }
 
@@ -545,7 +596,9 @@ Status ImmutableIndexWriter::write_shard(size_t key_size, size_t npage_hint, siz
     }
     auto& shard = rs_create.value();
     size_t pos_before = _idx_wb->size();
-    RETURN_IF_ERROR(shard->write(*_idx_wb));
+    size_t uncompressed_size = 0;
+    RETURN_IF_ERROR(shard->compress_and_write(static_cast<CompressionTypePB>(_meta.compression_type()), *_idx_wb,
+                                              &uncompressed_size));
     size_t pos_after = _idx_wb->size();
     auto shard_meta = _meta.add_shards();
     shard_meta->set_size(kvs.size());
@@ -553,6 +606,7 @@ Status ImmutableIndexWriter::write_shard(size_t key_size, size_t npage_hint, siz
     shard_meta->set_key_size(key_size);
     shard_meta->set_value_size(kIndexValueSize);
     shard_meta->set_nbucket(nbucket);
+    shard_meta->set_uncompressed_size(uncompressed_size);
     auto ptr_meta = shard_meta->mutable_data();
     ptr_meta->set_offset(pos_before);
     ptr_meta->set_size(pos_after - pos_before);
@@ -631,12 +685,14 @@ Status ImmutableIndexWriter::finish() {
         RETURN_IF_ERROR(write_bf());
     }
     LOG(INFO) << strings::Substitute(
-            "finish writing immutable index $0 #shard:$1 #kv:$2 #moved:$3($4) kv_bytes:$5 usage:$6 bf_bytes:$7",
+            "finish writing immutable index $0 #shard:$1 #kv:$2 #moved:$3($4) kv_bytes:$5 usage:$6 bf_bytes:$7 "
+            "compression_type:$8",
             _idx_file_path_tmp, _nshard, _total, _total_moved, _total_moved * 1000 / std::max(_total, 1UL) / 1000.0,
-            _total_kv_bytes, _total_kv_size * 1000 / std::max(_total_kv_bytes, 1UL) / 1000.0, _total_bf_bytes);
+            _total_kv_bytes, _total_kv_size * 1000 / std::max(_total_kv_bytes, 1UL) / 1000.0, _total_bf_bytes,
+            _meta.compression_type());
     _version.to_pb(_meta.mutable_version());
     _meta.set_size(_total);
-    _meta.set_format_version(PERSISTENT_INDEX_VERSION_3);
+    _meta.set_format_version(PERSISTENT_INDEX_VERSION_4);
     for (const auto& [key_size, shard_info] : _shard_info_by_length) {
         const auto [shard_offset, shard_num] = shard_info;
         auto info = _meta.add_shard_info();
@@ -1804,7 +1860,7 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         // create a new empty _l0 file, set _offset to 0
         data->set_offset(0);
         data->set_size(0);
-        meta->set_format_version(PERSISTENT_INDEX_VERSION_3);
+        meta->set_format_version(PERSISTENT_INDEX_VERSION_4);
         _offset = 0;
         _page_size = 0;
         break;
@@ -1839,7 +1895,7 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         data->set_size(snapshot_size);
         snapshot->clear_dumped_shard_idxes();
         snapshot->mutable_dumped_shard_idxes()->Add(dumped_shard_idxes.begin(), dumped_shard_idxes.end());
-        meta->set_format_version(PERSISTENT_INDEX_VERSION_3);
+        meta->set_format_version(PERSISTENT_INDEX_VERSION_4);
         _offset = snapshot_size;
         _page_size = 0;
         break;
@@ -1850,7 +1906,7 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         PagePointerPB* data = wal_pb->mutable_data();
         data->set_offset(_offset);
         data->set_size(_page_size);
-        meta->set_format_version(PERSISTENT_INDEX_VERSION_3);
+        meta->set_format_version(PERSISTENT_INDEX_VERSION_4);
         _offset += _page_size;
         _page_size = 0;
         break;
@@ -1864,9 +1920,10 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
 
 Status ShardByLengthMutableIndex::load(const MutableIndexMetaPB& meta) {
     auto format_version = meta.format_version();
-    if (format_version != PERSISTENT_INDEX_VERSION_2 && format_version != PERSISTENT_INDEX_VERSION_3) {
+    if (format_version != PERSISTENT_INDEX_VERSION_2 && format_version != PERSISTENT_INDEX_VERSION_3 &&
+        format_version != PERSISTENT_INDEX_VERSION_4) {
         std::string msg = strings::Substitute("different l0 format, should rebuid index. actual:$0, expect:$1",
-                                              format_version, PERSISTENT_INDEX_VERSION_3);
+                                              format_version, PERSISTENT_INDEX_VERSION_4);
         LOG(WARNING) << msg;
         return Status::InternalError(msg);
     }
@@ -2069,6 +2126,8 @@ Status ImmutableIndex::_get_kvs_for_shard(std::vector<std::vector<KVRef>>& kvs_b
     }
     *shard = std::make_unique<ImmutableIndexShard>(shard_info.npage);
     RETURN_IF_ERROR(_file->read_at_fully(shard_info.offset, (*shard)->pages.data(), shard_info.bytes));
+    RETURN_IF_ERROR((*shard)->decompress_pages(_compression_type, shard_info.npage, shard_info.uncompressed_size,
+                                               shard_info.bytes));
     if (shard_info.key_size != 0) {
         return _get_fixlen_kvs_for_shard(kvs_by_shard, shard_idx, shard_bits, shard);
     } else {
@@ -2352,13 +2411,19 @@ Status ImmutableIndex::_get_in_shard(size_t shard_idx, size_t n, const Slice* ke
         return st;
     }
 
-    if (st.ok() && keys_info_by_page.size() == 1) {
+    if (st.ok() && keys_info_by_page.size() == 1 && shard_info.uncompressed_size == 0) {
         return _get_in_shard_by_page(shard_idx, n, keys, values, found_keys_info, keys_info_by_page);
     }
 
     std::unique_ptr<ImmutableIndexShard> shard = std::make_unique<ImmutableIndexShard>(shard_info.npage);
-    CHECK(shard->pages.size() * kPageSize == shard_info.bytes) << "illegal shard size";
+    if (shard_info.uncompressed_size == 0) {
+        CHECK(shard->pages.size() * kPageSize == shard_info.bytes) << "illegal shard size";
+    } else {
+        CHECK(shard->pages.size() * kPageSize == shard_info.uncompressed_size) << "illegal shard size";
+    }
     RETURN_IF_ERROR(_file->read_at_fully(shard_info.offset, shard->pages.data(), shard_info.bytes));
+    RETURN_IF_ERROR(shard->decompress_pages(_compression_type, shard_info.npage, shard_info.uncompressed_size,
+                                            shard_info.bytes));
     if (stat != nullptr) {
         stat->read_io_bytes += shard_info.bytes;
     }
@@ -2434,8 +2499,14 @@ Status ImmutableIndex::_check_not_exist_in_shard(size_t shard_idx, size_t n, con
         return Status::OK();
     }
     std::unique_ptr<ImmutableIndexShard> shard = std::make_unique<ImmutableIndexShard>(shard_info.npage);
-    CHECK(shard->pages.size() * kPageSize == shard_info.bytes) << "illegal shard size";
+    if (shard_info.uncompressed_size == 0) {
+        CHECK(shard->pages.size() * kPageSize == shard_info.bytes) << "illegal shard size";
+    } else {
+        CHECK(shard->pages.size() * kPageSize == shard_info.uncompressed_size) << "illegal shard size";
+    }
     RETURN_IF_ERROR(_file->read_at_fully(shard_info.offset, shard->pages.data(), shard_info.bytes));
+    RETURN_IF_ERROR(shard->decompress_pages(_compression_type, shard_info.npage, shard_info.uncompressed_size,
+                                            shard_info.bytes));
     if (shard_info.key_size != 0) {
         return _check_not_exist_in_fixlen_shard(shard_idx, n, keys, keys_info, &shard);
     } else {
@@ -2641,10 +2712,11 @@ StatusOr<std::unique_ptr<ImmutableIndex>> ImmutableIndex::load(std::unique_ptr<R
     }
 
     auto format_version = meta.format_version();
-    if (format_version != PERSISTENT_INDEX_VERSION_2 && format_version != PERSISTENT_INDEX_VERSION_3) {
+    if (format_version != PERSISTENT_INDEX_VERSION_2 && format_version != PERSISTENT_INDEX_VERSION_3 &&
+        format_version != PERSISTENT_INDEX_VERSION_4) {
         std::string msg =
                 strings::Substitute("different immutable index format, should rebuid index. actual:$0, expect:$1",
-                                    format_version, PERSISTENT_INDEX_VERSION_3);
+                                    format_version, PERSISTENT_INDEX_VERSION_4);
         LOG(WARNING) << msg;
         return Status::InternalError(msg);
     }
@@ -2652,6 +2724,11 @@ StatusOr<std::unique_ptr<ImmutableIndex>> ImmutableIndex::load(std::unique_ptr<R
     std::unique_ptr<ImmutableIndex> idx = std::make_unique<ImmutableIndex>();
     idx->_version = EditVersion(meta.version());
     idx->_size = meta.size();
+    if (meta.compression_type() > 0) {
+        idx->_compression_type = static_cast<CompressionTypePB>(meta.compression_type());
+    } else {
+        idx->_compression_type = CompressionTypePB::NO_COMPRESSION;
+    }
     size_t nshard = meta.shards_size();
     idx->_shards.resize(nshard);
     for (size_t i = 0; i < nshard; i++) {
@@ -2664,6 +2741,11 @@ StatusOr<std::unique_ptr<ImmutableIndex>> ImmutableIndex::load(std::unique_ptr<R
         dest.key_size = src.key_size();
         dest.value_size = src.value_size();
         dest.nbucket = src.nbucket();
+        dest.uncompressed_size = src.uncompressed_size();
+        if (idx->_compression_type == CompressionTypePB::NO_COMPRESSION) {
+            CHECK(dest.uncompressed_size == 0) << "compression type: " << idx->_compression_type
+                                               << " uncompressed_size: " << dest.uncompressed_size;
+        }
         // This is for compatibility, we don't add data_size in shard_info in the rc version
         // And data_size is added to reslove some bug(https://github.com/StarRocks/starrocks/issues/11868)
         // However, if we upgrade from rc version, the data_size will be used as default value(0) which will cause
@@ -3194,7 +3276,7 @@ Status PersistentIndex::load_from_tablet(Tablet* tablet) {
     index_meta.clear_l1_version();
     index_meta.clear_l2_versions();
     index_meta.set_key_size(_key_size);
-    index_meta.set_format_version(PERSISTENT_INDEX_VERSION_3);
+    index_meta.set_format_version(PERSISTENT_INDEX_VERSION_4);
     lastest_applied_version.to_pb(index_meta.mutable_version());
     MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
     l0_meta->clear_wals();
@@ -3367,7 +3449,7 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta, IOStat* stat) 
         // update PersistentIndexMetaPB
         index_meta->set_size(_size);
         index_meta->set_usage(_usage);
-        index_meta->set_format_version(PERSISTENT_INDEX_VERSION_3);
+        index_meta->set_format_version(PERSISTENT_INDEX_VERSION_4);
         _version.to_pb(index_meta->mutable_version());
         _version.to_pb(index_meta->mutable_l1_version());
         MutableIndexMetaPB* l0_meta = index_meta->mutable_l0_meta();
@@ -3377,14 +3459,14 @@ Status PersistentIndex::commit(PersistentIndexMetaPB* index_meta, IOStat* stat) 
     } else if (_dump_snapshot) {
         index_meta->set_size(_size);
         index_meta->set_usage(_usage);
-        index_meta->set_format_version(PERSISTENT_INDEX_VERSION_3);
+        index_meta->set_format_version(PERSISTENT_INDEX_VERSION_4);
         _version.to_pb(index_meta->mutable_version());
         MutableIndexMetaPB* l0_meta = index_meta->mutable_l0_meta();
         RETURN_IF_ERROR(_l0->commit(l0_meta, _version, kSnapshot));
     } else {
         index_meta->set_size(_size);
         index_meta->set_usage(_usage);
-        index_meta->set_format_version(PERSISTENT_INDEX_VERSION_3);
+        index_meta->set_format_version(PERSISTENT_INDEX_VERSION_4);
         _version.to_pb(index_meta->mutable_version());
         MutableIndexMetaPB* l0_meta = index_meta->mutable_l0_meta();
         RETURN_IF_ERROR(_l0->commit(l0_meta, _version, kAppendWAL));
@@ -4442,7 +4524,7 @@ Status PersistentIndex::_minor_compaction(PersistentIndexMetaPB* index_meta) {
     // 3. modify meta
     index_meta->set_size(_size);
     index_meta->set_usage(_usage);
-    index_meta->set_format_version(PERSISTENT_INDEX_VERSION_3);
+    index_meta->set_format_version(PERSISTENT_INDEX_VERSION_4);
     _version.to_pb(index_meta->mutable_version());
     _version.to_pb(index_meta->mutable_l1_version());
     MutableIndexMetaPB* l0_meta = index_meta->mutable_l0_meta();

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -43,7 +43,8 @@ enum PersistentIndexFileVersion {
     PERSISTENT_INDEX_VERSION_UNKNOWN = 0,
     PERSISTENT_INDEX_VERSION_1,
     PERSISTENT_INDEX_VERSION_2,
-    PERSISTENT_INDEX_VERSION_3
+    PERSISTENT_INDEX_VERSION_3,
+    PERSISTENT_INDEX_VERSION_4
 };
 
 static constexpr uint64_t NullIndexValue = -1;
@@ -535,12 +536,14 @@ private:
         uint32_t value_size;
         uint32_t nbucket;
         uint64_t data_size;
+        uint64_t uncompressed_size;
     };
 
     std::vector<ShardInfo> _shards;
     std::map<size_t, std::pair<size_t, size_t>> _shard_info_by_length;
     mutable std::vector<std::unique_ptr<BloomFilter>> _bf_vec;
     std::vector<size_t> _bf_off;
+    CompressionTypePB _compression_type;
 };
 
 class ImmutableIndexWriter {

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -35,7 +35,18 @@
 #include "util/faststring.h"
 
 namespace starrocks {
-PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
+
+struct PersistentIndexTestParam {
+    bool enable_pindex_compression;
+};
+
+class PersistentIndexTest : public testing::TestWithParam<PersistentIndexTestParam> {
+public:
+    virtual ~PersistentIndexTest() {}
+    void SetUp() override { config::enable_pindex_compression = GetParam().enable_pindex_compression; }
+};
+
+TEST_P(PersistentIndexTest, test_fixlen_mutable_index) {
     using Key = uint64_t;
     const int N = 1000;
     vector<Key> keys;
@@ -133,7 +144,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
     ASSERT_EQ(upsert_not_found.size(), expect_not_found);
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
+TEST_P(PersistentIndexTest, test_small_varlen_mutable_index) {
     using Key = std::string;
     const int N = 1000;
     vector<Key> keys(N);
@@ -243,7 +254,7 @@ static std::string gen_random_string_of_random_length(size_t floor, size_t ceil)
     return str;
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index) {
+TEST_P(PersistentIndexTest, test_large_varlen_mutable_index) {
     using Key = std::string;
     const int N = 1000;
     vector<Key> keys(N);
@@ -351,7 +362,7 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index) {
     ASSERT_EQ(upsert_not_found.size(), expect_not_found);
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
+TEST_P(PersistentIndexTest, test_fixlen_mutable_index_wal) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_fixlen_mutable_index_wal";
     const std::string kIndexFile = "./PersistentIndexTest_test_fixlen_mutable_index_wal/index.l0.0.0";
@@ -508,7 +519,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_l0_max_file_size) {
+TEST_P(PersistentIndexTest, test_l0_max_file_size) {
     int64_t l0_max_file_size = config::l0_max_file_size;
     config::l0_max_file_size = 200000;
     config::l0_max_mem_usage = 10240;
@@ -589,7 +600,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_max_file_size) {
     config::l0_max_file_size = l0_max_file_size;
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_l0_max_memory_usage) {
+TEST_P(PersistentIndexTest, test_l0_max_memory_usage) {
     write_pindex_bf = false;
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_l0_max_memory_usage";
@@ -651,7 +662,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_max_memory_usage) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_l0_min_memory_usage) {
+TEST_P(PersistentIndexTest, test_l0_min_memory_usage) {
     write_pindex_bf = false;
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_l0_min_memory_usage";
@@ -722,7 +733,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_min_memory_usage) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot) {
+TEST_P(PersistentIndexTest, test_small_varlen_mutable_index_snapshot) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_small_varlen_mutable_index_snapshot";
     const std::string kIndexFile = "./PersistentIndexTest_test_small_varlen_mutable_index_snapshot/index.l0.0.0";
@@ -790,7 +801,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal) {
+TEST_P(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_small_varlen_mutable_index_snapshot_wal";
     const std::string kIndexFile = "./PersistentIndexTest_test_small_varlen_mutable_index_snapshot_wal/index.l0.0.0";
@@ -887,7 +898,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal)
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
+TEST_P(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_small_varlen_mutable_index_wal";
     const std::string kIndexFile = "./PersistentIndexTest_test_small_varlen_mutable_index_wal/index.l0.0.0";
@@ -1014,7 +1025,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
+TEST_P(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_large_varlen_mutable_index_wal";
     const std::string kIndexFile = "./PersistentIndexTest_test_large_varlen_mutable_index_wal/index.l0.0.0";
@@ -1140,7 +1151,7 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_flush_fixlen_to_immutable) {
+TEST_P(PersistentIndexTest, test_flush_fixlen_to_immutable) {
     using Key = uint64_t;
     const int N = 200000;
     vector<Key> keys(N);
@@ -1207,7 +1218,7 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_fixlen_to_immutable) {
     ASSERT_TRUE(fs::remove_all("./index.l1.1.1").ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_flush_varlen_to_immutable) {
+TEST_P(PersistentIndexTest, test_flush_varlen_to_immutable) {
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_flush_varlen_to_immutable";
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString("posix://"));
     bool created;
@@ -1453,7 +1464,7 @@ void build_persistent_index_from_tablet(size_t N) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_build_from_tablet) {
+TEST_P(PersistentIndexTest, test_build_from_tablet) {
     auto manager = StorageEngine::instance()->update_manager();
     config::l0_max_mem_usage = 104857600;
     manager->mem_tracker()->set_limit(-1);
@@ -1470,7 +1481,7 @@ PARALLEL_TEST(PersistentIndexTest, test_build_from_tablet) {
     config::l0_max_mem_usage = 104857600;
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_fixlen_replace) {
+TEST_P(PersistentIndexTest, test_fixlen_replace) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_fixlen_replace";
     const std::string kIndexFile = "./PersistentIndexTest_test_fixlen_replace/index.l0.0.0";
@@ -1544,7 +1555,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_replace) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_varlen_replace) {
+TEST_P(PersistentIndexTest, test_varlen_replace) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_varlen_replace";
     const std::string kIndexFile = "./PersistentIndexTest_test_varlen_replace/index.l0.0.0";
@@ -1618,7 +1629,7 @@ PARALLEL_TEST(PersistentIndexTest, test_varlen_replace) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_get_move_buckets) {
+TEST_P(PersistentIndexTest, test_get_move_buckets) {
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_get_move_buckets";
     PersistentIndex index(kPersistentIndexDir);
     std::vector<uint8_t> bucket_packs_in_page;
@@ -1644,7 +1655,7 @@ PARALLEL_TEST(PersistentIndexTest, test_get_move_buckets) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_flush_l1_advance) {
+TEST_P(PersistentIndexTest, test_flush_l1_advance) {
     config::l0_max_mem_usage = 10240;
     config::max_tmp_l1_num = 10;
     FileSystem* fs = FileSystem::Default();
@@ -1760,7 +1771,7 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_l1_advance) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_bloom_filter_for_pindex) {
+TEST_P(PersistentIndexTest, test_bloom_filter_for_pindex) {
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_bloom_filter_for_pindex";
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString("posix://"));
     bool created;
@@ -1904,7 +1915,7 @@ PARALLEL_TEST(PersistentIndexTest, test_bloom_filter_for_pindex) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_multi_l2_tmp_l1) {
+TEST_P(PersistentIndexTest, test_multi_l2_tmp_l1) {
     config::l0_max_mem_usage = 1024;
     config::max_tmp_l1_num = 10;
     FileSystem* fs = FileSystem::Default();
@@ -2037,7 +2048,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_tmp_l1) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1) {
+TEST_P(PersistentIndexTest, test_multi_l2_not_tmp_l1) {
     config::l0_max_mem_usage = 1 * 1024 * 1024; // 1MB
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_multi_l2_not_tmp_l1";
@@ -2138,7 +2149,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1_fixlen) {
+TEST_P(PersistentIndexTest, test_multi_l2_not_tmp_l1_fixlen) {
     config::l0_max_mem_usage = 1 * 1024 * 1024; // 1MB
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_multi_l2_not_tmp_l1_fixlen";
@@ -2234,7 +2245,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1_fixlen) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_multi_l2_delete) {
+TEST_P(PersistentIndexTest, test_multi_l2_delete) {
     config::l0_max_mem_usage = 1024;
     config::max_tmp_l1_num = 10;
     FileSystem* fs = FileSystem::Default();
@@ -2339,7 +2350,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_delete) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_l2_versions) {
+TEST_P(PersistentIndexTest, test_l2_versions) {
     EditVersionWithMerge m1(INT64_MAX, INT64_MAX, true);
     EditVersionWithMerge m2(INT64_MAX, INT64_MAX, false);
     EditVersionWithMerge m3(10, 0, true);
@@ -2365,7 +2376,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l2_versions) {
     ASSERT_TRUE(m10 < m9);
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_index_keep_delete) {
+TEST_P(PersistentIndexTest, test_index_keep_delete) {
     config::l0_max_mem_usage = 1024;
     config::enable_pindex_minor_compaction = false;
     FileSystem* fs = FileSystem::Default();
@@ -2440,5 +2451,8 @@ PARALLEL_TEST(PersistentIndexTest, test_index_keep_delete) {
     }
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
+
+INSTANTIATE_TEST_SUITE_P(PersistentIndexTest, PersistentIndexTest,
+                         ::testing::Values(PersistentIndexTestParam{true}, PersistentIndexTestParam{false}));
 
 } // namespace starrocks

--- a/gensrc/proto/persistent_index.proto
+++ b/gensrc/proto/persistent_index.proto
@@ -45,6 +45,7 @@ message ImmutableIndexShardMetaPB {
     uint64 value_size = 5;
     uint64 nbucket = 6;
     uint64 data_size = 7;
+    uint64 uncompressed_size = 8; // if uncompressed_size is 0, which means no compression
 }
 
 message ShardInfoPB {
@@ -60,6 +61,8 @@ message ImmutableIndexMetaPB {
     repeated ImmutableIndexShardMetaPB shards = 4;
     repeated ShardInfoPB shard_info = 5;
     repeated uint64 shard_bf_off = 6;
+    // because CompressionTypePB defined in proto2, so we use int32 here to be compatible
+    int32 compression_type = 7;
 }
 
 message PersistentIndexMetaPB {


### PR DESCRIPTION
Support compression in persistent index, using `LZ4_FRAME` by default now.

#### Case1: 
| | Index space usage (within a single tablet) (MB) | Average apply latency (ms) |
| --- | --- | --- |
| Enable compression (lz4) |  648 | 36133 |
| Disable compression |  821 | 37599 |
| Enable(lz4) vs Disable | -22% | -4% |

#### Case2:
| | Index space usage (within a single tablet) (MB) | Average apply latency (ms) |
| --- | --- | --- |
| Enable compression | 115 | 2947 |
| disable compression | 147 | 2349 |
| Enable vs. Disable | -22% | +25% |

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
