### PR TITLE
[Enhancement] support partition rollup for string column in mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
@@ -236,7 +236,6 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
         int otherKeyLen = other.keys.size();
         int minLen = Math.min(thisKeyLen, otherKeyLen);
         for (int i = 0; i < minLen; ++i) {
-            assert types.get(i) == other.types.get(i);
             int ret = compareLiteralExpr(this.getKeys().get(i), other.getKeys().get(i));
             if (0 != ret) {
                 return ret;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
@@ -60,6 +60,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Objects;
 
 public class PartitionKey implements Comparable<PartitionKey>, Writable {
     private static final Logger LOG = LogManager.getLogger(PartitionKey.class);
@@ -162,6 +163,13 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
         return partitionKey;
     }
 
+    public static PartitionKey ofString(String str) {
+        PartitionKey partitionKey = new PartitionKey();
+        partitionKey.keys.add(new StringLiteral(str));
+        partitionKey.types.add(PrimitiveType.VARCHAR);
+        return partitionKey;
+    }
+
     public void pushColumn(LiteralExpr keyValue, PrimitiveType keyType) {
         keys.add(keyValue);
         types.add(keyType);
@@ -224,6 +232,7 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
     // compare with other PartitionKey. used for partition prune
     @Override
     public int compareTo(PartitionKey other) {
+        assert Objects.equals(types, other.types);
         int thisKeyLen = this.keys.size();
         int otherKeyLen = other.keys.size();
         int minLen = Math.min(thisKeyLen, otherKeyLen);
@@ -525,49 +534,20 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (!(obj instanceof PartitionKey)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
-        PartitionKey partitionKey = (PartitionKey) obj;
-
-        // Check keys
-        if (keys != partitionKey.keys) {
-            if (keys.size() != partitionKey.keys.size()) {
-                return false;
-            }
-            for (int i = 0; i < keys.size(); i++) {
-                if (!keys.get(i).equals(partitionKey.keys.get(i))) {
-                    return false;
-                }
-            }
-        }
-
-        // Check types
-        if (types != partitionKey.types) {
-            if (types.size() != partitionKey.types.size()) {
-                return false;
-            }
-            for (int i = 0; i < types.size(); i++) {
-                if (!types.get(i).equals(partitionKey.types.get(i))) {
-                    return false;
-                }
-            }
-        }
-
-        return true;
+        PartitionKey that = (PartitionKey) o;
+        assert Objects.equals(types, that.types);
+        return Objects.equals(keys, that.keys) && Objects.equals(types, that.types);
     }
 
     @Override
     public int hashCode() {
-        int code = 0;
-        for (LiteralExpr expr : keys) {
-            code += code * 31 + expr.hashCode();
-        }
-        return code;
+        return Objects.hash(keys, types);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
@@ -232,11 +232,11 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
     // compare with other PartitionKey. used for partition prune
     @Override
     public int compareTo(PartitionKey other) {
-        assert Objects.equals(types, other.types);
         int thisKeyLen = this.keys.size();
         int otherKeyLen = other.keys.size();
         int minLen = Math.min(thisKeyLen, otherKeyLen);
         for (int i = 0; i < minLen; ++i) {
+            assert types.get(i) == other.types.get(i);
             int ret = compareLiteralExpr(this.getKeys().get(i), other.getKeys().get(i));
             if (0 != ret) {
                 return ret;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -653,7 +653,7 @@ public class PartitionUtil {
             if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.DATE_TRUNC) ||
                     functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE)) {
                 return SyncPartitionUtils.getRangePartitionDiffOfExpr(basePartitionMap,
-                        mvPartitionMap, functionCallExpr, partitionColumn.getPrimitiveType(), null);
+                        mvPartitionMap, functionCallExpr, null);
             } else {
                 throw new SemanticException("Materialized view partition function " +
                         functionCallExpr.getFnName().getFunction() +

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -152,7 +152,7 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
                 return Lists.newArrayList();
             }
         } catch (SQLException | NullPointerException e) {
-            throw new StarRocksConnectorException(e.getMessage());
+            throw new StarRocksConnectorException(e.getMessage(), e);
         }
     }
 
@@ -176,7 +176,7 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
                 return Lists.newArrayList();
             }
         } catch (SQLException | NullPointerException e) {
-            throw new StarRocksConnectorException(e.getMessage());
+            throw new StarRocksConnectorException(e.getMessage(), e);
         }
     }
 
@@ -202,7 +202,7 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
                 return Lists.newArrayList();
             }
         } catch (SQLException | NullPointerException e) {
-            throw new StarRocksConnectorException(e.getMessage());
+            throw new StarRocksConnectorException(e.getMessage(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -146,7 +146,7 @@ public class DDLStmtExecutor {
             } else if (re.getCause() instanceof IOException) {
                 throw (IOException) re.getCause();
             } else if (re.getCause() != null) {
-                throw new DdlException(re.getCause().getMessage());
+                throw new DdlException(re.getCause().getMessage(), re);
             } else {
                 throw re;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1949,7 +1949,7 @@ public class StmtExecutor {
                     errMsg = coord.getExecStatus().getErrorCodeString();
                 }
                 LOG.warn("insert failed: {}", errMsg);
-                ErrorReport.reportDdlException(errMsg, ErrorCode.ERR_FAILED_WHEN_INSERT);
+                ErrorReport.reportDdlException("%s", ErrorCode.ERR_FAILED_WHEN_INSERT, errMsg);
             }
 
             LOG.debug("delta files is {}", coord.getDeltaUrls());
@@ -2142,7 +2142,7 @@ public class StmtExecutor {
             } catch (Exception abortTxnException) {
                 LOG.warn("errors when cancel insert load job {}", jobId);
             }
-            throw new UserException(t.getMessage());
+            throw new UserException(t.getMessage(), t);
         } finally {
             QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
             if (insertError) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -46,7 +46,6 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PartitionType;
-import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.SinglePartitionInfo;
@@ -665,7 +664,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         Expr partitionExpr = materializedView.getFirstPartitionRefTableExpr();
         Table refBaseTable = mvContext.getRefBaseTable();
         Column refBaseTablePartitionColumn = mvContext.getRefBaseTablePartitionColumn();
-        PrimitiveType mvPartitionColumnType = PrimitiveType.DATE;
 
         RangePartitionDiff rangePartitionDiff = new RangePartitionDiff();
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -46,6 +46,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.catalog.SinglePartitionInfo;
@@ -664,6 +665,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         Expr partitionExpr = materializedView.getFirstPartitionRefTableExpr();
         Table refBaseTable = mvContext.getRefBaseTable();
         Column refBaseTablePartitionColumn = mvContext.getRefBaseTablePartitionColumn();
+        PrimitiveType mvPartitionColumnType = PrimitiveType.DATE;
 
         RangePartitionDiff rangePartitionDiff = new RangePartitionDiff();
 
@@ -699,8 +701,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                         rangeToInclude = SyncPartitionUtils.createRange(start, end, partitionColumn);
                     }
                     rangePartitionDiff = SyncPartitionUtils.getRangePartitionDiffOfExpr(refBaseTablePartitionMap,
-                            mvRangePartitionMap, functionCallExpr, refBaseTablePartitionColumn.getPrimitiveType(),
-                            rangeToInclude);
+                            mvRangePartitionMap, functionCallExpr, rangeToInclude);
                 } else {
                     throw new SemanticException("Materialized view partition function " +
                             functionCallExpr.getFnName().getFunction() +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -504,18 +504,12 @@ public class MaterializedViewAnalyzer {
         private boolean isValidPartitionExpr(Expr partitionExpr) {
             if (partitionExpr instanceof FunctionCallExpr) {
                 FunctionCallExpr partitionColumnExpr = (FunctionCallExpr) partitionExpr;
-                // support time_slice(dt, 'minute')
-                if (partitionColumnExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.TIME_SLICE)) {
-                    if (!(partitionColumnExpr.getChild(0) instanceof SlotRef)) {
-                        return false;
-                    }
-                    return true;
+                String fnName = partitionColumnExpr.getFnName().getFunction();
+                if (fnName.equalsIgnoreCase(FunctionSet.TIME_SLICE) || fnName.equalsIgnoreCase(FunctionSet.STR2DATE)) {
+                    return partitionColumnExpr.getChild(0) instanceof SlotRef;
                 }
             }
-            if (!(partitionExpr instanceof SlotRef)) {
-                return false;
-            }
-            return true;
+            return partitionExpr instanceof SlotRef;
         }
 
         private void checkPartitionColumnExprs(CreateMaterializedViewStatement statement,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionExprAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionExprAnalyzer.java
@@ -27,6 +27,38 @@ import java.util.ArrayList;
 
 public class PartitionExprAnalyzer {
 
+    /**
+     * Recursive analyze the date_trunc function
+     */
+    public static void analyzeDateTruncFunction(FunctionCallExpr funcCall, SlotRef partitionSlotRef) {
+        String functionName = funcCall.getFnName().getFunction();
+        if (functionName.equalsIgnoreCase(FunctionSet.DATE_TRUNC)) {
+            Expr arg1 = funcCall.getParams().exprs().get(1);
+            if (arg1 instanceof SlotRef) {
+                Type targetColType = partitionSlotRef.getType();
+                Type[] dateTruncType = {Type.VARCHAR, targetColType};
+                Function builtinFunction = Expr.getBuiltinFunction(funcCall.getFnName().getFunction(),
+                        dateTruncType, Function.CompareMode.IS_IDENTICAL);
+
+                funcCall.setFn(builtinFunction);
+                funcCall.setType(targetColType);
+            } else if (arg1 instanceof FunctionCallExpr) {
+                analyzePartitionExpr((FunctionCallExpr) arg1, partitionSlotRef);
+
+                Type targetColType = arg1.getType();
+                Type[] dateTruncType = {Type.VARCHAR, targetColType};
+                Function builtinFunction = Expr.getBuiltinFunction(funcCall.getFnName().getFunction(),
+                        dateTruncType, Function.CompareMode.IS_IDENTICAL);
+
+                funcCall.setFn(builtinFunction);
+                funcCall.setType(targetColType);
+            }
+        }
+    }
+
+    /**
+     * TODO(murphy) refactor the analyze procedure with standard Analyzer instead of manual analyzing
+     */
     public static void analyzePartitionExpr(Expr expr, SlotRef partitionSlotRef) {
         if (expr instanceof FunctionCallExpr) {
             FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
@@ -34,9 +66,8 @@ public class PartitionExprAnalyzer {
             Type targetColType = partitionSlotRef.getType();
             String functionName = functionCallExpr.getFnName().getFunction();
             if (functionName.equalsIgnoreCase(FunctionSet.DATE_TRUNC)) {
-                Type[] dateTruncType = {Type.VARCHAR, targetColType};
-                builtinFunction = Expr.getBuiltinFunction(functionCallExpr.getFnName().getFunction(),
-                        dateTruncType, Function.CompareMode.IS_IDENTICAL);
+                analyzeDateTruncFunction(functionCallExpr, partitionSlotRef);
+                return;
             } else if (functionName.equalsIgnoreCase(FunctionSet.TIME_SLICE)) {
                 Type[] timeSliceType = {targetColType, Type.INT, Type.VARCHAR, Type.VARCHAR};
                 builtinFunction = Expr.getBuiltinFunction(functionCallExpr.getFnName().getFunction(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionExprAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionExprAnalyzer.java
@@ -67,7 +67,8 @@ public class PartitionExprAnalyzer {
             String functionName = functionCallExpr.getFnName().getFunction();
             if (functionName.equalsIgnoreCase(FunctionSet.DATE_TRUNC)) {
                 analyzeDateTruncFunction(functionCallExpr, partitionSlotRef);
-                return;
+                builtinFunction = functionCallExpr.getFn();
+                targetColType = functionCallExpr.getType();
             } else if (functionName.equalsIgnoreCase(FunctionSet.TIME_SLICE)) {
                 Type[] timeSliceType = {Type.DATETIME, Type.INT, Type.VARCHAR, Type.VARCHAR};
                 builtinFunction = Expr.getBuiltinFunction(functionCallExpr.getFnName().getFunction(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionExprAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionExprAnalyzer.java
@@ -69,7 +69,7 @@ public class PartitionExprAnalyzer {
                 analyzeDateTruncFunction(functionCallExpr, partitionSlotRef);
                 return;
             } else if (functionName.equalsIgnoreCase(FunctionSet.TIME_SLICE)) {
-                Type[] timeSliceType = {targetColType, Type.INT, Type.VARCHAR, Type.VARCHAR};
+                Type[] timeSliceType = {Type.DATETIME, Type.INT, Type.VARCHAR, Type.VARCHAR};
                 builtinFunction = Expr.getBuiltinFunction(functionCallExpr.getFnName().getFunction(),
                         timeSliceType, Function.CompareMode.IS_IDENTICAL);
             } else if (functionName.equalsIgnoreCase(FunctionSet.SUBSTR) ||

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -239,7 +239,7 @@ public class SyncPartitionUtils {
 
     private static Range<PartitionKey> convertToDatePartitionRange(Range<PartitionKey> range) {
         LiteralExpr lower = range.lowerEndpoint().getKeys().get(0);
-        LiteralExpr upper = range.lowerEndpoint().getKeys().get(0);
+        LiteralExpr upper = range.upperEndpoint().getKeys().get(0);
         if (lower instanceof DateLiteral) {
             return range;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -102,7 +102,6 @@ public class SyncPartitionUtils {
         return new ListPartitionDiff(adds, deletes);
     }
 
-
     public static boolean hasRangePartitionChanged(Map<String, Range<PartitionKey>> baseRangeMap,
                                                    Map<String, Range<PartitionKey>> mvRangeMap) {
         Map<String, Range<PartitionKey>> adds = diffRange(baseRangeMap, mvRangeMap);
@@ -114,7 +113,7 @@ public class SyncPartitionUtils {
     }
 
     public static boolean hasListPartitionChanged(Map<String, List<List<String>>> baseRangeMap,
-                                                 Map<String, List<List<String>>> mvRangeMap) {
+                                                  Map<String, List<List<String>>> mvRangeMap) {
         Map<String, List<List<String>>> adds = diffList(baseRangeMap, mvRangeMap);
         if (adds != null && !adds.isEmpty()) {
             return true;
@@ -172,14 +171,14 @@ public class SyncPartitionUtils {
     private static Map<String, Range<PartitionKey>> mappingRangeListForDate(
             Map<String, Range<PartitionKey>> baseRangeMap) {
         Map<String, Range<PartitionKey>> result = Maps.newHashMap();
-            for (Map.Entry<String, Range<PartitionKey>> rangeEntry : baseRangeMap.entrySet()) {
-                Range<PartitionKey> dateRange = convertToDatePartitionRange(rangeEntry.getValue());
-                DateLiteral lowerDate = (DateLiteral) dateRange.lowerEndpoint().getKeys().get(0);
-                DateLiteral upperDate = (DateLiteral) dateRange.upperEndpoint().getKeys().get(0);
-                String mvPartitionName = getMVPartitionName(lowerDate.toLocalDateTime(), upperDate.toLocalDateTime());
+        for (Map.Entry<String, Range<PartitionKey>> rangeEntry : baseRangeMap.entrySet()) {
+            Range<PartitionKey> dateRange = convertToDatePartitionRange(rangeEntry.getValue());
+            DateLiteral lowerDate = (DateLiteral) dateRange.lowerEndpoint().getKeys().get(0);
+            DateLiteral upperDate = (DateLiteral) dateRange.upperEndpoint().getKeys().get(0);
+            String mvPartitionName = getMVPartitionName(lowerDate.toLocalDateTime(), upperDate.toLocalDateTime());
 
-                result.put(mvPartitionName, dateRange);
-            }
+            result.put(mvPartitionName, dateRange);
+        }
 
         return result;
     }
@@ -294,11 +293,11 @@ public class SyncPartitionUtils {
     /**
      * @param srcRanges : src partition ranges
      * @param dstRanges : dst partition ranges
-     * @return          : return all src partition name to intersected dst partition names which the src partition
+     * @return : return all src partition name to intersected dst partition names which the src partition
      * is intersected with dst ranges.
      */
     public static Map<String, Set<String>> getIntersectedPartitions(List<PartitionRange> srcRanges,
-                                                                     List<PartitionRange> dstRanges) {
+                                                                    List<PartitionRange> dstRanges) {
         if (!srcRanges.isEmpty() && !dstRanges.isEmpty()) {
             List<PrimitiveType> srcTypes = srcRanges.get(0).getPartitionKeyRange().lowerEndpoint().getTypes();
             List<PrimitiveType> dstTypes = dstRanges.get(0).getPartitionKeyRange().lowerEndpoint().getTypes();
@@ -513,7 +512,7 @@ public class SyncPartitionUtils {
      * create partitions which is between `start` and `end` when executing
      * `refresh materialized view xxx partition start (xxx) end (xxx)`
      *
-     * @param range range to check
+     * @param range          range to check
      * @param rangeToInclude range to check whether the to be checked range is in
      * @return true if included, else false
      */
@@ -565,10 +564,11 @@ public class SyncPartitionUtils {
 
         int lastPartitionNum;
         if (partitionTTLNumber > 0 && isAutoRefresh && autoRefreshPartitionsLimit > 0) {
-            lastPartitionNum = Math.min(partitionTTLNumber, autoRefreshPartitionsLimit);;
+            lastPartitionNum = Math.min(partitionTTLNumber, autoRefreshPartitionsLimit);
+            ;
         } else if (isAutoRefresh && autoRefreshPartitionsLimit > 0) {
             lastPartitionNum = autoRefreshPartitionsLimit;
-        } else if (partitionTTLNumber > 0)  {
+        } else if (partitionTTLNumber > 0) {
             lastPartitionNum = partitionTTLNumber;
         } else {
             lastPartitionNum = TableProperty.INVALID;
@@ -578,9 +578,9 @@ public class SyncPartitionUtils {
     }
 
     public static Set<String> getPartitionNamesByListWithPartitionLimit(MaterializedView materializedView,
-                                                                         String start, String end,
-                                                                         int partitionTTLNumber,
-                                                                         boolean isAutoRefresh) {
+                                                                        String start, String end,
+                                                                        int partitionTTLNumber,
+                                                                        boolean isAutoRefresh) {
         int autoRefreshPartitionsLimit = materializedView.getTableProperty().getAutoRefreshPartitionsLimit();
         boolean hasPartitionRange = StringUtils.isNoneEmpty(start) || StringUtils.isNoneEmpty(end);
 
@@ -598,10 +598,11 @@ public class SyncPartitionUtils {
 
         int lastPartitionNum;
         if (partitionTTLNumber > 0 && isAutoRefresh && autoRefreshPartitionsLimit > 0) {
-            lastPartitionNum = Math.min(partitionTTLNumber, autoRefreshPartitionsLimit);;
+            lastPartitionNum = Math.min(partitionTTLNumber, autoRefreshPartitionsLimit);
+            ;
         } else if (isAutoRefresh && autoRefreshPartitionsLimit > 0) {
             lastPartitionNum = autoRefreshPartitionsLimit;
-        } else if (partitionTTLNumber > 0)  {
+        } else if (partitionTTLNumber > 0) {
             lastPartitionNum = partitionTTLNumber;
         } else {
             lastPartitionNum = TableProperty.INVALID;
@@ -707,7 +708,6 @@ public class SyncPartitionUtils {
                     baseTable.getName(), baseTable.getTableIdentifier()));
         }
     }
-
 
     public static void dropBaseVersionMeta(MaterializedView mv, String mvPartitionName,
                                            Range<PartitionKey> partitionRange) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -517,6 +517,9 @@ public class SyncPartitionUtils {
      * @return true if included, else false
      */
     private static boolean isRangeIncluded(PartitionRange range, Range<PartitionKey> rangeToInclude) {
+        if (rangeToInclude == null) {
+            return true;
+        }
         Range<PartitionKey> rangeToCheck = range.getPartitionKeyRange();
         int lowerCmp = rangeToInclude.lowerEndpoint().compareTo(rangeToCheck.upperEndpoint());
         int upperCmp = rangeToInclude.upperEndpoint().compareTo(rangeToCheck.lowerEndpoint());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -568,7 +568,6 @@ public class SyncPartitionUtils {
         int lastPartitionNum;
         if (partitionTTLNumber > 0 && isAutoRefresh && autoRefreshPartitionsLimit > 0) {
             lastPartitionNum = Math.min(partitionTTLNumber, autoRefreshPartitionsLimit);
-            ;
         } else if (isAutoRefresh && autoRefreshPartitionsLimit > 0) {
             lastPartitionNum = autoRefreshPartitionsLimit;
         } else if (partitionTTLNumber > 0) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -876,16 +876,17 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testPartitionWithFunctionUseStr2Date() {
-        String sql = "create materialized view mv1 " +
-                "partition by str2date(d,'%Y%m%d') " +
-                "distributed by hash(a) buckets 10 " +
-                "REFRESH DEFERRED MANUAL " +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ") " +
-                "as select a, b, c, d from jdbc0.partitioned_db0.tbl1;";
-        try {
+    public void testPartitionWithFunctionUseStr2Date() throws Exception {
+        // basic
+        {
+            String sql = "create materialized view mv1 " +
+                    "partition by str2date(d,'%Y%m%d') " +
+                    "distributed by hash(a) buckets 10 " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ") " +
+                    "as select a, b, c, d from jdbc0.partitioned_db0.tbl1;";
             CreateMaterializedViewStatement createMaterializedViewStatement =
                     (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             ExpressionPartitionDesc partitionExpDesc = createMaterializedViewStatement.getPartitionExpDesc();
@@ -893,8 +894,32 @@ public class CreateMaterializedViewTest {
             Assert.assertTrue(partitionExpDesc.getExpr() instanceof FunctionCallExpr);
             Assert.assertEquals(partitionExpDesc.getExpr().getChild(0), partitionExpDesc.getSlotRef());
             Assert.assertEquals("d", partitionExpDesc.getSlotRef().getColumnName());
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
+        }
+
+        // slot
+        {
+            String sql = "create materialized view mv1 " +
+                    "partition by p " +
+                    "distributed by hash(a) buckets 10 " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ") " +
+                    "as select str2date(d,'%Y%m%d') as p,  a, b, c, d from jdbc0.partitioned_db0.tbl1;";
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        }
+
+        // rollup
+        {
+            String sql = "create materialized view mv1 " +
+                    "partition by date_trunc('month', p) " +
+                    "distributed by hash(a) buckets 10 " +
+                    "REFRESH DEFERRED MANUAL " +
+                    "PROPERTIES (\n" +
+                    "\"replication_num\" = \"1\"\n" +
+                    ") " +
+                    "as select str2date(d,'%Y%m%d') as p,  a, b, c, d from jdbc0.partitioned_db0.tbl1;";
+            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -898,7 +898,7 @@ public class CreateMaterializedViewTest {
 
         // slot
         {
-            String sql = "create materialized view mv1 " +
+            String sql = "create materialized view mv_str2date " +
                     "partition by p " +
                     "distributed by hash(a) buckets 10 " +
                     "REFRESH DEFERRED MANUAL " +
@@ -906,12 +906,12 @@ public class CreateMaterializedViewTest {
                     "\"replication_num\" = \"1\"\n" +
                     ") " +
                     "as select str2date(d,'%Y%m%d') as p,  a, b, c, d from jdbc0.partitioned_db0.tbl1;";
-            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            starRocksAssert.withMaterializedView(sql);
         }
 
         // rollup
         {
-            String sql = "create materialized view mv1 " +
+            String sql = "create materialized view mv_date_trunc_str2date " +
                     "partition by date_trunc('month', p) " +
                     "distributed by hash(a) buckets 10 " +
                     "REFRESH DEFERRED MANUAL " +
@@ -919,7 +919,7 @@ public class CreateMaterializedViewTest {
                     "\"replication_num\" = \"1\"\n" +
                     ") " +
                     "as select str2date(d,'%Y%m%d') as p,  a, b, c, d from jdbc0.partitioned_db0.tbl1;";
-            UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            starRocksAssert.withMaterializedView(sql);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -1334,7 +1334,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     }
 
     @Test
-    public void test_$str2date_date_trunc() throws Exception {
+    public void test_str2date_date_trunc() throws Exception {
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
         MockedJDBCMetadata mockedJDBCMetadata =
                 (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -1345,14 +1345,8 @@ public class PartitionBasedMvRefreshProcessorTest {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
 
-        HashMap<String, String> taskRunProperties = new HashMap<>();
-        taskRunProperties.put(PARTITION_START, "20230801");
-        taskRunProperties.put(TaskRun.PARTITION_END, "20230805");
-        taskRunProperties.put(TaskRun.FORCE, Boolean.toString(false));
-        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-        TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(taskRunProperties).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
+
 
         List<String> partitions =
                 materializedView.getPartitions().stream().map(Partition::getName).sorted().collect(Collectors.toList());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.sql.common;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
@@ -31,6 +33,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.DateUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.PartitionValue;
@@ -41,6 +44,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -645,6 +649,34 @@ public class SyncPartitionUtilsTest {
         SyncPartitionUtils.dropBaseVersionMeta(mv, "p1", null);
 
         Assert.assertNull(tableMap.get("p1"));
+    }
+
+    private PartitionRange buildPartitionRange(String name, String start, String end) throws AnalysisException {
+        return new PartitionRange(name,
+                Range.closedOpen(
+                        PartitionKey.ofDateTime(DateUtils.parseStrictDateTime(start)),
+                        PartitionKey.ofDateTime(DateUtils.parseStrictDateTime(end))));
+    }
+
+    @Test
+    public void test_getIntersectedPartitions() throws AnalysisException {
+        List<PartitionRange> srcs = Arrays.asList(
+                buildPartitionRange("p20230801", "00000101", "20230801"),
+                buildPartitionRange("p20230802", "20230801", "20230802"),
+                buildPartitionRange("p20230803", "20230802", "20230803")
+        );
+        List<PartitionRange> dsts = Arrays.asList(
+                buildPartitionRange("p000101_202308", "0001-01-01", "2023-08-01"),
+                buildPartitionRange("p202308_202309", "2023-08-01", "2023-09-01")
+        );
+        Map<String, Set<String>> res = SyncPartitionUtils.getIntersectedPartitions(srcs, dsts);
+        Assert.assertEquals(
+                ImmutableMap.of(
+                        "p20230801", ImmutableSet.of("p000101_202308"),
+                        "p20230802", ImmutableSet.of("p202308_202309"),
+                        "p20230803", ImmutableSet.of("p202308_202309")
+                ),
+                res);
     }
 
 }


### PR DESCRIPTION
Fixes #issue

support such mv:
```sql
create materialized view mv 
partition by date_trunc('month', dt)
as 
select str2date(str, '%Y-%m-%d') as dt from tbl;
```

but not support this kind of partition: 
- `partition by date_trunc('month', str2date(str, '%Y%m%d'))`


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
