### PR TITLE
[Enhancement] Prevent memory overruns during Parquet data parsing

### DIFF
--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -48,7 +48,7 @@ ParquetReaderWrap::ParquetReaderWrap(std::shared_ptr<arrow::io::RandomAccessFile
     _parquet = std::move(parquet_file);
     _properties = parquet::ReaderProperties();
     _properties.enable_buffered_stream();
-    _properties.set_buffer_size(8 * 1024 * 1024);
+    _properties.set_buffer_size(1 * 1024 * 1024);
     _filename = (reinterpret_cast<ParquetChunkFile*>(_parquet.get()))->filename();
 }
 


### PR DESCRIPTION
Reduce buffer size for Parquet data parsing using the Arrow library in SR. Arrow's Parquet parsing process previously allocated a significant amount of virtual memory, triggering memory overflow detection and causing import job failures. This PR addresses the issue by decreasing the buffer size during Parquet parsing, effectively preventing this problem. Benchmark indicates that reducing the buffer size from 8MB to 1MB does not negatively impact import performance.

type:broker_load    table:clickbench    key_type:duplicate    data_type:parquet    parquet_buffer: 8MB    bucket:15    concurrency:8    time_cost(s):68

type:broker_load    table:clickbench    key_type:duplicate    data_type:parquet    parquet_buffer: 1MB    bucket:15    concurrency:8    time_cost(s):63

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
