### PR TITLE
[BugFix] Support recover with empty tablet when all backends are lost

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -22,9 +22,11 @@ import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
@@ -305,5 +307,23 @@ public class TabletSchedulerTest {
                 result.get(new ColocateTableIndex.GroupId(200L, 300L)));
         Assert.assertEquals(Optional.of(2L).get(),
                 result.get(new ColocateTableIndex.GroupId(200L, 301L)));
+    }
+
+    @Test
+    public void testForceRecoverWithEmptyTablet() {
+        Config.recover_with_empty_tablet = true;
+        List<Replica> replicas = new ArrayList<>();
+        replicas.add(new Replica(2, 3001, -1, Replica.ReplicaState.NORMAL));
+        replicas.add(new Replica(3, 3002, -2, Replica.ReplicaState.NORMAL));
+        replicas.add(new Replica(4, 3003, -3, Replica.ReplicaState.NORMAL));
+
+        LocalTablet localTablet = new LocalTablet(5001, replicas);
+        Pair<LocalTablet.TabletStatus, TabletSchedCtx.Priority> result = localTablet.getHealthStatusWithPriority(
+                systemInfoService, 1, 3, Arrays.asList(1001L, 1002L, 1003L));
+        System.out.println(result);
+
+        Assert.assertEquals(LocalTablet.TabletStatus.FORCE_REDUNDANT, result.first);
+
+        Config.recover_with_empty_tablet = false;
     }
 }


### PR DESCRIPTION
branch-3.1 already merged this pr, backport to main.
Fix the problem when all the backends for a specified tablet are lost
forever, and we need to create an empty tablet to recover. So after that
we can read the table normally, see what data remains.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [x] 3.0
  - [x] 2.5
