### PR TITLE
[BugFix] Set default AWS region when user not specific region explictily

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/AWSGlueClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/AWSGlueClientFactory.java
@@ -90,7 +90,7 @@ public final class AWSGlueClientFactory implements GlueClientFactory {
             return glueClientBuilder.build();
         } catch (Exception e) {
             String message = "Unable to build AWSGlueClient: " + e;
-            LOGGER.error(message);
+            LOGGER.error(message, e);
             throw new MetaException(message);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.iceberg;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.credential.aws.AWSCloudConfigurationProvider;
 import org.apache.iceberg.aws.AwsClientFactory;
 import org.apache.iceberg.aws.AwsProperties;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
@@ -94,7 +95,7 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
         s3SessionToken = properties.getOrDefault(AWS_S3_SESSION_TOKEN, "");
         s3IamRoleArn = properties.getOrDefault(AWS_S3_IAM_ROLE_ARN, "");
         s3ExternalId = properties.getOrDefault(AWS_S3_EXTERNAL_ID, "");
-        s3Region = properties.getOrDefault(AWS_S3_REGION, "");
+        s3Region = properties.getOrDefault(AWS_S3_REGION, AWSCloudConfigurationProvider.DEFAULT_AWS_REGION);
         s3Endpoint = properties.getOrDefault(AWS_S3_ENDPOINT, "");
 
         glueUseAWSSDKDefaultBehavior = Boolean.parseBoolean(
@@ -105,7 +106,7 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
         glueSessionToken = properties.getOrDefault(AWS_GLUE_SESSION_TOKEN, "");
         glueIamRoleArn = properties.getOrDefault(AWS_GLUE_IAM_ROLE_ARN, "");
         glueExternalId = properties.getOrDefault(AWS_GLUE_EXTERNAL_ID, "");
-        glueRegion = properties.getOrDefault(AWS_GLUE_REGION, "");
+        glueRegion = properties.getOrDefault(AWS_GLUE_REGION, AWSCloudConfigurationProvider.DEFAULT_AWS_REGION);
         glueEndpoint = properties.getOrDefault(AWS_GLUE_ENDPOINT, "");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfigurationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfigurationProvider.java
@@ -43,6 +43,13 @@ import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_USE_AW
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE;
 public class AWSCloudConfigurationProvider implements CloudConfigurationProvider {
 
+    /**
+     * In S3 SDK this region is implicitly the default one.
+     * So setting it by default to `us-east-1` simulates S3 better
+     * Refer this issue: <a href="https://issues.apache.org/jira/browse/HADOOP-17771">S3AFS creation fails "Unable to find a region via the region provider chain."</a>
+     */
+    public static final String DEFAULT_AWS_REGION = "us-east-1";
+
     public AWSCloudCredential buildGlueCloudCredential(HiveConf hiveConf) {
         Preconditions.checkNotNull(hiveConf);
         AWSCloudCredential awsCloudCredential = new AWSCloudCredential(
@@ -53,7 +60,7 @@ public class AWSCloudConfigurationProvider implements CloudConfigurationProvider
                 hiveConf.get(AWS_GLUE_SESSION_TOKEN, ""),
                 hiveConf.get(AWS_GLUE_IAM_ROLE_ARN, ""),
                 hiveConf.get(AWS_GLUE_EXTERNAL_ID, ""),
-                hiveConf.get(AWS_GLUE_REGION, ""),
+                hiveConf.get(AWS_GLUE_REGION, DEFAULT_AWS_REGION),
                 hiveConf.get(AWS_GLUE_ENDPOINT, "")
         );
         if (!awsCloudCredential.validate()) {
@@ -73,7 +80,7 @@ public class AWSCloudConfigurationProvider implements CloudConfigurationProvider
                 properties.getOrDefault(AWS_S3_SESSION_TOKEN, ""),
                 properties.getOrDefault(AWS_S3_IAM_ROLE_ARN, ""),
                 properties.getOrDefault(AWS_S3_EXTERNAL_ID, ""),
-                properties.getOrDefault(AWS_S3_REGION, ""),
+                properties.getOrDefault(AWS_S3_REGION, DEFAULT_AWS_REGION),
                 properties.getOrDefault(AWS_S3_ENDPOINT, "")
         );
         if (!awsCloudCredential.validate()) {

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudCredential.java
@@ -133,9 +133,12 @@ public class AWSCloudCredential implements CloudCredential {
             if (!externalId.isEmpty()) {
                 builder.withExternalId(externalId);
             }
-            AWSSecurityTokenService token =
-                    AWSSecurityTokenServiceClientBuilder.standard().withCredentials(awsCredentialsProvider)
-                            .build();
+            AWSSecurityTokenServiceClientBuilder stsBuilder = AWSSecurityTokenServiceClientBuilder.standard()
+                    .withCredentials(awsCredentialsProvider);
+            if (!region.isEmpty()) {
+                stsBuilder.setRegion(region);
+            }
+            AWSSecurityTokenService token = stsBuilder.build();
             builder.withStsClient(token);
             awsCredentialsProvider = builder.build();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudCredential.java
@@ -172,9 +172,10 @@ public class AWSCloudCredential implements CloudCredential {
                 "com.starrocks.credential.provider.AssumedRoleCredentialProvider");
         configuration.set("fs.s3a.assumed.role.arn", iamRoleArn);
         configuration.set(AssumedRoleCredentialProvider.CUSTOM_CONSTANT_HADOOP_EXTERNAL_ID, externalId);
-        if (!region.isEmpty()) {
-            configuration.set("fs.s3a.assumed.role.sts.endpoint.region", region);
-        }
+        // TODO(SmithCruise) Not support assume role in none-ec2 machine
+        // if (!region.isEmpty()) {
+        // configuration.set("fs.s3a.assumed.role.sts.endpoint.region", region);
+        // }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AWSCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AWSCloudConfigurationTest.java
@@ -71,4 +71,17 @@ public class AWSCloudConfigurationTest {
         awsCloudCredential = CloudConfigurationFactory.buildGlueCloudCredential(hiveConf);
         Assert.assertNull(awsCloudCredential);
     }
+
+    @Test
+    public void testForAWSRegion() {
+        Map<String, String>  properties = new HashMap<>();
+        properties.put("aws.s3.access_key", "ak");
+        properties.put("aws.s3.secret_key", "sk");
+        properties.put("aws.s3.endpoint", "endpoint");
+        CloudConfiguration cloudConfiguration = CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+        Assert.assertNotNull(cloudConfiguration);
+        Configuration configuration = new Configuration();
+        cloudConfiguration.applyToConfiguration(configuration);
+        Assert.assertEquals("us-east-1", configuration.get("fs.s3a.endpoint.region"));
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -228,6 +228,6 @@ public class CloudConfigurationFactoryTest {
         AWSCloudCredential cred = CloudConfigurationFactory.buildGlueCloudCredential(conf);
         Assert.assertEquals(cred.toCredString(),
                 "AWSCloudCredential{useAWSSDKDefaultBehavior=true, useInstanceProfile=false, accessKey='', secretKey='', " +
-                        "sessionToken='', iamRoleArn='', externalId='', region='', endpoint=''}");
+                        "sessionToken='', iamRoleArn='', externalId='', region='us-east-1', endpoint=''}");
     }
 }


### PR DESCRIPTION
Fix `"Unable to find a region via the region provider chain."` problem.
Refer to the same problem in https://issues.apache.org/jira/browse/HADOOP-17771

In iceberg s3, if a user is not using aws services, and he only configures `aws.s3.endpoint` to access files in Minio using `s3://` protocol, sr will throw the below exception:
```bash
software.amazon.awssdk.core.exception.SdkClientException: Unable to load region from any of the providers in the chain software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain@13f10a6b: 
[software.amazon.awssdk.regions.providers.SystemSettingsRegionProvider@240eb9d5: Unable to load region from system settings. Region must be specified either via environment variable (AWS_REGION) or  system property (aws.region).
, software.amazon.awssdk.regions.providers.AwsProfileRegionProvider@7856ae5a: No region provided in profile: default, software.amazon.awssdk.regions.providers.InstanceProfileRegionProvider@d656d66: Unable to contact EC2 metadata service.] 
```

So we need to set a default region here.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
