### PR TITLE
[Enhancement] Support gc local persistent index in shared data

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -589,6 +589,8 @@ CONF_mInt64(max_runnings_transactions_per_txn_map, "100");
 // The tablet map shard size, the value must be power of two.
 // this is an enhancement for better performance to manage tablet.
 CONF_Int32(tablet_map_shard_size, "32");
+// The value must be power of two.
+CONF_Int32(pk_index_map_shard_size, "32");
 
 CONF_String(plugin_path, "${STARROCKS_HOME}/plugin");
 
@@ -1015,6 +1017,8 @@ CONF_mInt64(max_allow_pindex_l2_num, "5");
 CONF_mInt64(pindex_major_compaction_num_threads, "0");
 // control the persistent index schedule compaction interval
 CONF_mInt64(pindex_major_compaction_schedule_interval_seconds, "15");
+// control the local persistent index in shared_data gc interval
+CONF_mInt64(pindex_shard_data_gc_interval_seconds, "5 * 3600");
 // enable use bloom filter for pindex or not
 CONF_mBool(enable_pindex_filter, "true");
 // use bloom filter in pindex can reduce disk io, but in the following scenarios, we should skip the bloom filter

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -590,7 +590,7 @@ CONF_mInt64(max_runnings_transactions_per_txn_map, "100");
 // this is an enhancement for better performance to manage tablet.
 CONF_Int32(tablet_map_shard_size, "32");
 // The value must be power of two.
-CONF_Int32(pk_index_map_shard_size, "32");
+CONF_Int32(pk_index_map_shard_size, "4096");
 
 CONF_String(plugin_path, "${STARROCKS_HOME}/plugin");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1018,7 +1018,7 @@ CONF_mInt64(pindex_major_compaction_num_threads, "0");
 // control the persistent index schedule compaction interval
 CONF_mInt64(pindex_major_compaction_schedule_interval_seconds, "15");
 // control the local persistent index in shared_data gc interval
-CONF_mInt64(pindex_shard_data_gc_interval_seconds, "5 * 3600");
+CONF_mInt64(pindex_shard_data_gc_interval_seconds, "18000"); // 5 hour
 // enable use bloom filter for pindex or not
 CONF_mBool(enable_pindex_filter, "true");
 // use bloom filter in pindex can reduce disk io, but in the following scenarios, we should skip the bloom filter

--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -142,7 +142,7 @@ public:
 
     Status update_capacity();
 
-    std::string get_persistent_index_path() { return _path + "/" + PERSISTENT_INDEX_PREFIX; }
+    std::string get_persistent_index_path() { return _path + PERSISTENT_INDEX_PREFIX; }
     Status init_persistent_index_dir();
 
     // for test

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -94,7 +94,7 @@ Status LakePrimaryIndex::_do_lake_load(Tablet* tablet, const TabletMetadata& met
                                         ->get_persistent_index_store(tablet->id())
                                         ->create_dir_if_path_not_exists(path));
                 _persistent_index = std::make_unique<LakeLocalPersistentIndex>(path);
-                return ((LakeLocalPersistentIndex*)_persistent_index.get())
+                return dynamic_cast<LakeLocalPersistentIndex*>(_persistent_index.get())
                         ->load_from_lake_tablet(tablet, metadata, base_version, builder);
             }
             default:

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -526,6 +526,20 @@ StatusOr<int64_t> TabletManager::get_tablet_data_size(int64_t tablet_id, int64_t
     return size;
 }
 
+#ifdef USE_STAROS
+bool TabletManager::is_tablet_in_worker(int64_t tablet_id) {
+    if (g_worker != nullptr) {
+        auto shard_info_or = g_worker->get_shard_info(tablet_id);
+        if (absl::IsNotFound(shard_info_or.status())) {
+            return false;
+        }
+    }
+    // think the tablet is assigned to this worker by default,
+    // for we may take action if tablet is not in the worker
+    return true;
+}
+#endif // USE_STAROS
+
 StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema(int64_t tablet_id, int64_t* version_hint) {
     // 1. direct lookup in cache, if there is schema info for the tablet
     auto cache_key = tablet_schema_cache_key(tablet_id);

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -92,6 +92,10 @@ public:
 
     StatusOr<TxnLogPtr> get_txn_vlog(const std::string& path, bool fill_cache = true);
 
+#ifdef USE_STAROS
+    bool is_tablet_in_worker(int64_t tablet_id);
+#endif // USE_STAROS
+
     void prune_metacache();
 
     // TODO: remove this method

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -104,9 +104,18 @@ private:
             !op_write.rowset().has_delete_predicate()) {
             return Status::OK();
         }
+
+        // get lock to avoid gc
+        _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
+        DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });
+
         // We call `prepare_primary_index` only when first time we apply `write_log` or `compaction_log`, instead of
         // in `TxnLogApplier.init`, because we have to build primary index after apply `schema_change_log` finish.
         if (_index_entry == nullptr) {
+            // get lock to avoid gc
+            _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
+            DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });
+
             ASSIGN_OR_RETURN(_index_entry, _tablet.update_mgr()->prepare_primary_index(*_metadata, &_tablet, &_builder,
                                                                                        _base_version, _new_version));
         }
@@ -119,6 +128,11 @@ private:
             DCHECK(!op_compaction.has_output_rowset() || op_compaction.output_rowset().num_rows() == 0);
             return Status::OK();
         }
+
+        // get lock to avoid gc
+        _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
+        DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });
+
         // We call `prepare_primary_index` only when first time we apply `write_log` or `compaction_log`, instead of
         // in `TxnLogApplier.init`, because we have to build primary index after apply `schema_change_log` finish.
         if (_index_entry == nullptr) {

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -112,10 +112,6 @@ private:
         // We call `prepare_primary_index` only when first time we apply `write_log` or `compaction_log`, instead of
         // in `TxnLogApplier.init`, because we have to build primary index after apply `schema_change_log` finish.
         if (_index_entry == nullptr) {
-            // get lock to avoid gc
-            _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
-            DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });
-
             ASSIGN_OR_RETURN(_index_entry, _tablet.update_mgr()->prepare_primary_index(*_metadata, &_tablet, &_builder,
                                                                                        _base_version, _new_version));
         }

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -34,7 +34,8 @@ namespace starrocks::lake {
 UpdateManager::UpdateManager(LocationProvider* location_provider, MemTracker* mem_tracker)
         : _index_cache(std::numeric_limits<size_t>::max()),
           _update_state_cache(std::numeric_limits<size_t>::max()),
-          _location_provider(location_provider) {
+          _location_provider(location_provider),
+          _pk_index_shards(config::pk_index_map_shard_size) {
     _update_mem_tracker = mem_tracker;
     _update_state_mem_tracker = std::make_unique<MemTracker>(-1, "lake_rowset_update_state", mem_tracker);
     _index_cache_mem_tracker = std::make_unique<MemTracker>(-1, "lake_index_cache", mem_tracker);
@@ -563,6 +564,10 @@ void UpdateManager::remove_primary_index_cache(uint32_t tablet_id) {
         succ = true;
     }
     LOG(WARNING) << "Lake update manager remove primary index cache, tablet_id: " << tablet_id << " , succ: " << succ;
+}
+
+bool UpdateManager::try_remove_primary_index_cache(uint32_t tablet_id) {
+    return _index_cache.try_remove_by_key(tablet_id);
 }
 
 Status UpdateManager::check_meta_version(const Tablet& tablet, int64_t base_version) {

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -43,8 +43,10 @@
 #include <unordered_set>
 
 #include "common/status.h"
+#include "fs/fs_util.h"
 #include "storage/compaction.h"
 #include "storage/compaction_manager.h"
+#include "storage/lake/tablet_manager.h"
 #include "storage/lake/update_manager.h"
 #include "storage/olap_common.h"
 #include "storage/olap_define.h"
@@ -53,6 +55,7 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
 #include "storage/update_manager.h"
+#include "tablet_meta_manager.h"
 #include "util/gc_helper.h"
 #include "util/thread.h"
 #include "util/time.h"
@@ -95,6 +98,12 @@ Status StorageEngine::start_bg_threads() {
 
     _pk_index_major_compaction_thread = std::thread([this] { _pk_index_major_compaction_thread_callback(nullptr); });
     Thread::set_thread_name(_pk_index_major_compaction_thread, "pk_index_compaction_scheduler");
+
+#ifdef USE_STAROS
+    _local_pk_index_shard_data_gc_thread =
+            std::thread([this] { _local_pk_index_shard_data_gc_thread_callback(nullptr); });
+    Thread::set_thread_name(_local_pk_index_shard_data_gc_thread, " pk_index_shard_data_gc");
+#endif
 
     // start thread for check finish publish version
     _finish_publish_version_thread = std::thread([this] { _finish_publish_version_thread_callback(nullptr); });
@@ -390,6 +399,88 @@ void* StorageEngine::_pk_index_major_compaction_thread_callback(void* arg) {
         SLEEP_IN_BG_WORKER(config::pindex_major_compaction_schedule_interval_seconds);
         // schedule persistent index compaction
         _update_manager->get_pindex_compaction_mgr()->schedule();
+    }
+
+    return nullptr;
+}
+
+void* StorageEngine::_local_pk_index_shard_data_gc_thread_callback(void* arg) {
+    if (is_as_cn()) {
+        return nullptr;
+    }
+#ifdef GOOGLE_PROFILER
+    ProfilerRegisterThread();
+#endif
+    auto lake_update_manager = ExecEnv::GetInstance()->lake_update_manager();
+    auto lake_tablet_manager = ExecEnv::GetInstance()->lake_tablet_manager();
+
+    while (!_bg_worker_stopped.load(std::memory_order_consume)) {
+        SLEEP_IN_BG_WORKER(config::pindex_shard_data_gc_interval_seconds);
+
+        for (DataDir* data_dir : get_stores()) {
+            auto pk_path = data_dir->get_persistent_index_path();
+            LOG(INFO) << "start to gc local persistent index dir:" << pk_path;
+            int64_t t_start = MonotonicMillis();
+
+            std::set<std::string> tablet_ids;
+            Status ret = fs::list_dirs_files(pk_path, &tablet_ids, nullptr);
+            if (!ret.ok()) {
+                LOG(WARNING) << "fail to walk dir. path=[" + pk_path << "] error[" << ret.to_string() << "]";
+                continue;
+            }
+
+            std::vector<int64_t> not_in_worker_tablet_ids;
+            std::vector<int64_t> dir_changed_tablet_ids;
+            std::vector<int64_t> removed_dir_tablet_ids;
+
+            for (const auto& tablet_id : tablet_ids) {
+                auto tablet_pk_path = pk_path + "/" + tablet_id;
+                int64_t id = std::stoll(tablet_id);
+                // judge whether tablet should be in the data_dir or not,
+                // for data_dir may change if config:storage_path changed.
+                // just remove if not.
+                if (get_persistent_index_store(id) != data_dir) {
+                    dir_changed_tablet_ids.push_back(id);
+                    if (_clear_persistent_index(data_dir, id, tablet_pk_path).ok()) {
+                        removed_dir_tablet_ids.push_back(id);
+                    }
+                } else if (!lake_tablet_manager->is_tablet_in_worker(id)) {
+                    // the shard may be scheduled to other nodes
+                    if (lake_update_manager->try_lock_pk_index_shard(id)) {
+                        not_in_worker_tablet_ids.emplace_back(id);
+                        // judge whether tablet is scheduled again,
+                        // and pk_index_shard write_lock has been hold, so no process will build the persistent index.
+                        if (!lake_tablet_manager->is_tablet_in_worker(id)) {
+                            // try to remove pk index cache to avoid continuing to use the index in the cache after deletion.
+                            if (lake_update_manager->try_remove_primary_index_cache(id)) {
+                                if (_clear_persistent_index(data_dir, id, tablet_pk_path).ok()) {
+                                    removed_dir_tablet_ids.push_back(id);
+                                }
+                            }
+                        }
+                        lake_update_manager->unlock_pk_index_shard(id);
+                    }
+                }
+            }
+
+            auto debug_vector_info = [](std::vector<int64_t> vector) -> std::string {
+                std::string result;
+                for (int i = 0; i < vector.size(); i++) {
+                    if (i != 0) {
+                        result.append(",");
+                    }
+                    result += vector[i];
+                }
+                return result;
+            };
+
+            int64_t t_end = MonotonicMillis();
+            LOG(INFO) << "finish gc local persistent index dir: " << pk_path
+                      << ", found tablet not in the worker, tablet_ids: " << debug_vector_info(not_in_worker_tablet_ids)
+                      << ", data_dir changed tablet_ids: " << debug_vector_info(dir_changed_tablet_ids)
+                      << ", and removed dir successfully, tablet_ids: " << debug_vector_info(removed_dir_tablet_ids)
+                      << ", cost:" << t_end - t_start << "ms";
+        }
     }
 
     return nullptr;

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -404,6 +404,7 @@ void* StorageEngine::_pk_index_major_compaction_thread_callback(void* arg) {
     return nullptr;
 }
 
+#ifdef USE_STAROS
 void* StorageEngine::_local_pk_index_shard_data_gc_thread_callback(void* arg) {
     if (is_as_cn()) {
         return nullptr;
@@ -469,7 +470,7 @@ void* StorageEngine::_local_pk_index_shard_data_gc_thread_callback(void* arg) {
                     if (i != 0) {
                         result.append(",");
                     }
-                    result += vector[i];
+                    result += std::to_string(vector[i]);
                 }
                 return result;
             };
@@ -485,6 +486,7 @@ void* StorageEngine::_local_pk_index_shard_data_gc_thread_callback(void* arg) {
 
     return nullptr;
 }
+#endif
 
 void* StorageEngine::_update_compaction_thread_callback(void* arg, DataDir* data_dir) {
 #ifdef GOOGLE_PROFILER

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -615,7 +615,9 @@ void StorageEngine::stop() {
 
     JOIN_THREAD(_pk_index_major_compaction_thread)
 
+#ifndef USE_STAROS
     JOIN_THREAD(_local_pk_index_shard_data_gc_thread)
+#endif
 
     JOIN_THREAD(_fd_cache_clean_thread)
     JOIN_THREAD(_adjust_cache_thread)

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -615,6 +615,8 @@ void StorageEngine::stop() {
 
     JOIN_THREAD(_pk_index_major_compaction_thread)
 
+    JOIN_THREAD(_local_pk_index_shard_data_gc_thread)
+
     JOIN_THREAD(_fd_cache_clean_thread)
     JOIN_THREAD(_adjust_cache_thread)
 
@@ -1491,6 +1493,28 @@ Status StorageEngine::get_delta_column_group(KVStore* meta, int64_t tablet_id, R
         }
     }
     return Status::OK();
+}
+
+Status StorageEngine::_clear_persistent_index(DataDir* data_dir, int64_t tablet_id, std::string dir) {
+    // remove meta in RocksDB
+    WriteBatch wb;
+    auto status = TabletMetaManager::clear_persistent_index(data_dir, &wb, tablet_id);
+    if (status.ok()) {
+        status = data_dir->get_meta()->write_batch(&wb);
+        if (!status.ok()) {
+            LOG(WARNING) << "fail to remove persistent index meta, tablet_id=[" + tablet_id << "] error["
+                         << status.to_string() << "]";
+        } else {
+            // remove tablet persistent_index dir
+            status = fs::remove_all(dir);
+            if (!status.ok()) {
+                LOG(WARNING) << "fail to remove local persistent index dir=[" + dir << "] error[" << status.to_string()
+                             << "]";
+            }
+        }
+    }
+
+    return status;
 }
 
 void StorageEngine::clear_cached_delta_column_group(const std::vector<DeltaColumnGroupKey>& dcg_keys) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1497,15 +1497,15 @@ Status StorageEngine::get_delta_column_group(KVStore* meta, int64_t tablet_id, R
     return Status::OK();
 }
 
-Status StorageEngine::_clear_persistent_index(DataDir* data_dir, int64_t tablet_id, std::string dir) {
+Status StorageEngine::_clear_persistent_index(DataDir* data_dir, int64_t tablet_id, const std::string& dir) {
     // remove meta in RocksDB
     WriteBatch wb;
     auto status = TabletMetaManager::clear_persistent_index(data_dir, &wb, tablet_id);
     if (status.ok()) {
         status = data_dir->get_meta()->write_batch(&wb);
         if (!status.ok()) {
-            LOG(WARNING) << "fail to remove persistent index meta, tablet_id=[" + tablet_id << "] error["
-                         << status.to_string() << "]";
+            LOG(WARNING) << "fail to remove persistent index meta, tablet_id=[" + std::to_string(tablet_id)
+                         << "] error[" << status.to_string() << "]";
         } else {
             // remove tablet persistent_index dir
             status = fs::remove_all(dir);

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -312,6 +312,9 @@ private:
 
     void _clean_unused_rowset_metas();
 
+    // remove pk index meta first, and if success then remove dir.
+    Status _clear_persistent_index(DataDir* data_dir, int64_t tablet_id, std::string dir);
+
     Status _do_sweep(const std::string& scan_root, const time_t& local_tm_now, const int32_t expire);
 
     Status _get_remote_next_increment_id_interval(const TAllocateAutoIncrementIdParam& request,
@@ -338,6 +341,9 @@ private:
     void* _manual_compaction_thread_callback(void* arg);
     // pk index major compaction function
     void* _pk_index_major_compaction_thread_callback(void* arg);
+
+    // local pk index of SHARD_DATA gc function
+    void* _local_pk_index_shard_data_gc_thread_callback(void* arg);
 
     bool _check_and_run_manual_compaction_task();
 
@@ -407,6 +413,9 @@ private:
     std::vector<std::thread> _manual_compaction_threads;
     // thread to run pk index major compaction
     std::thread _pk_index_major_compaction_thread;
+    // thread to gc local pk index in sharded_data
+    std::thread _local_pk_index_shard_data_gc_thread;
+
     // threads to clean all file descriptor not actively in use
     std::thread _fd_cache_clean_thread;
     std::thread _adjust_cache_thread;

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -313,7 +313,7 @@ private:
     void _clean_unused_rowset_metas();
 
     // remove pk index meta first, and if success then remove dir.
-    Status _clear_persistent_index(DataDir* data_dir, int64_t tablet_id, std::string dir);
+    Status _clear_persistent_index(DataDir* data_dir, int64_t tablet_id, const std::string& dir);
 
     Status _do_sweep(const std::string& scan_root, const time_t& local_tm_now, const int32_t expire);
 

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -342,8 +342,10 @@ private:
     // pk index major compaction function
     void* _pk_index_major_compaction_thread_callback(void* arg);
 
+#ifdef USE_STAROS
     // local pk index of SHARD_DATA gc function
     void* _local_pk_index_shard_data_gc_thread_callback(void* arg);
+#endif
 
     bool _check_and_run_manual_compaction_task();
 


### PR DESCRIPTION
Fixes #issue

In the scenario of separation of storage and computing, if the shard is scheduled to other nodes or `storage_path` has been changed, then the l0/l1 file and meta  of persistent index  should be deleted. This PR adds a background thread to do this.
## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
