### PR TITLE
[Enhancement] add switch: brpc_connection_type

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -567,6 +567,9 @@ CONF_mInt32(tablet_meta_checkpoint_min_interval_secs, "600");
 CONF_Int64(brpc_max_body_size, "2147483648");
 // Max unwritten bytes in each socket, if the limit is reached, Socket.Write fails with EOVERCROWDED.
 CONF_Int64(brpc_socket_max_unwritten_bytes, "1073741824");
+// BRPC connection type, possible values are: single/pooled/short
+// TODO: turn the default value to pooled after benchmark
+CONF_String(brpc_connection_type, "single")
 
 // Max number of txns for every txn_partition_map in txn manager.
 // this is a self-protection to avoid too many txns saving in manager.

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -37,6 +37,7 @@
 #include <memory>
 #include <mutex>
 
+#include "common/config.h"
 #include "common/statusor.h"
 #include "gen_cpp/Types_types.h" // TNetworkAddress
 #include "gen_cpp/doris_internal_service.pb.h"
@@ -73,6 +74,7 @@ public:
         // new one stub and insert into map
         brpc::ChannelOptions options;
         options.connect_timeout_ms = 3000;
+        options.connection_type = config::brpc_connection_type;
         // Explicitly set the max_retry
         // TODO(meegoo): The retry strategy can be customized in the future
         options.max_retry = 3;
@@ -103,6 +105,7 @@ public:
         brpc::ChannelOptions options;
         options.connect_timeout_ms = 3000;
         options.protocol = "http";
+        options.connection_type = config::brpc_connection_type;
         // Explicitly set the max_retry
         // TODO(meegoo): The retry strategy can be customized in the future
         options.max_retry = 3;


### PR DESCRIPTION
Fixes #issue

Add BE switch `brpc_connection_type`, default value is "single", same as before.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
