### PR TITLE
[Enhancement] use bthread::Mutex in PipelineSenderQueue

### DIFF
--- a/be/src/runtime/sender_queue.h
+++ b/be/src/runtime/sender_queue.h
@@ -22,6 +22,7 @@
 #include "serde/protobuf_serde.h"
 #include "util/moodycamel/concurrentqueue.h"
 #include "util/spinlock.h"
+#include "bthread/mutex.h"
 
 namespace google::protobuf {
 class Closure;
@@ -220,7 +221,7 @@ private:
     std::atomic<bool> _is_cancelled{false};
     std::atomic<int> _num_remaining_senders;
 
-    typedef SpinLock Mutex;
+    typedef bthread::Mutex Mutex;
     Mutex _lock;
 
     // if _is_pipeline_level_shuffle=true, we will create a queue for each driver sequence to avoid competition

--- a/be/src/runtime/sender_queue.h
+++ b/be/src/runtime/sender_queue.h
@@ -17,12 +17,12 @@
 #include <condition_variable>
 #include <utility>
 
+#include "bthread/mutex.h"
 #include "column/vectorized_fwd.h"
 #include "runtime/data_stream_recvr.h"
 #include "serde/protobuf_serde.h"
 #include "util/moodycamel/concurrentqueue.h"
 #include "util/spinlock.h"
-#include "bthread/mutex.h"
 
 namespace google::protobuf {
 class Closure;


### PR DESCRIPTION
`PipelineSenderQueue::_lock` may be used in bthread, the function call stack like the following, waiting for the lock may cause bthread thread to be stuck, we change it to bthread::Mutex so that bthread can schedule by itself.

```shell
#0  0x000000000495aaaa in starrocks::SpinLock::slow_acquire() ()
#1  0x000000000487e06c in starrocks::DataStreamRecvr::PipelineSenderQueue::try_to_build_chunk_meta(starrocks::PTransmitChunkParams const&) ()
#2  0x0000000004889e38 in starrocks::Status starrocks::DataStreamRecvr::PipelineSenderQueue::add_chunks<false>(starrocks::PTransmitChunkParams const&, google::protobuf::Closure**) ()
#3  0x0000000004880152 in starrocks::DataStreamRecvr::PipelineSenderQueue::add_chunks(starrocks::PTransmitChunkParams const&, google::protobuf::Closure**) ()
#4  0x00000000047fbac3 in starrocks::DataStreamRecvr::add_chunks(starrocks::PTransmitChunkParams const&, google::protobuf::Closure**) ()
#5  0x000000000479ca66 in starrocks::DataStreamMgr::transmit_chunk(starrocks::PTransmitChunkParams const&, google::protobuf::Closure**) ()
#6  0x00000000052130d8 in starrocks::PInternalServiceImplBase<doris::PBackendService>::transmit_chunk(google::protobuf::RpcController*, starrocks::PTransmitChunkParams const*, starrocks::PTransmitChunkResult*, google::protobuf::Closure*) ()
#7  0x0000000005b8a2ad in brpc::policy::ProcessRpcRequest(brpc::InputMessageBase*) ()
#8  0x0000000005c6aa57 in brpc::ProcessInputMessage(void*) ()
#9  0x0000000005ab4bef in bthread::TaskGroup::task_runner(long) ()
#10 0x0000000005bf9151 in bthread_make_fcontext ()
#11 0x0000000000000000 in ?? ()
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
