### PR TITLE
[BugFix] check whether partitioned mv for jdbc is supported

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Splitter;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.annotations.SerializedName;
@@ -25,6 +26,9 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TJDBCTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.EnumUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.parquet.Strings;
@@ -32,6 +36,8 @@ import org.apache.parquet.Strings;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -99,6 +105,14 @@ public class JDBCTable extends Table {
 
     public List<Column> getPartitionColumns() {
         return partitionColumns;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        if (properties == null) {
+            this.properties = new HashMap<>();
+        }
+        return properties;
     }
 
     @Override
@@ -221,5 +235,32 @@ public class JDBCTable extends Table {
     @Override
     public boolean isSupported() {
         return true;
+    }
+
+    public ProtocolType getProtocolType() {
+        String uri = properties.get(JDBCResource.URI);
+        if (StringUtils.isEmpty(uri)) {
+            return ProtocolType.UNKNOWN;
+        }
+        URI u = URI.create(uri);
+        String protocol = u.getSchemeSpecificPart();
+        List<String> slices = Splitter.on(":").splitToList(protocol);
+        if (CollectionUtils.isEmpty(slices) || slices.size() <= 1) {
+            throw new IllegalArgumentException("illegal jdbc uri: " + uri);
+        }
+        protocol = slices.get(0);
+
+        ProtocolType res = EnumUtils.getEnumIgnoreCase(ProtocolType.class, protocol);
+        if (res == null) {
+            return ProtocolType.UNKNOWN;
+        }
+        return res;
+    }
+
+    public enum ProtocolType {
+        UNKNOWN,
+        MYSQL,
+        POSTGRES,
+        ORACLE;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -110,6 +110,9 @@ import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceM
 public class MaterializedViewAnalyzer {
     private static final Logger LOG = LogManager.getLogger(MaterializedViewAnalyzer.class);
 
+    private static final Set<JDBCTable.ProtocolType> SUPPORTED_JDBC_PARTITION_TYPE =
+            ImmutableSet.of(JDBCTable.ProtocolType.MYSQL);
+
     private static final Set<Table.TableType> SUPPORTED_TABLE_TYPE =
             ImmutableSet.of(Table.TableType.OLAP,
                     Table.TableType.HIVE,
@@ -780,6 +783,10 @@ public class MaterializedViewAnalyzer {
 
         private void checkPartitionColumnWithBaseJDBCTable(SlotRef slotRef, JDBCTable table) {
             checkPartitionColumnWithBaseTable(slotRef, table.getPartitionColumns(), table.isUnPartitioned());
+            if (!SUPPORTED_JDBC_PARTITION_TYPE.contains(table.getProtocolType())) {
+                throw new SemanticException(String.format("Materialized view PARTITION BY for JDBC %s is not " +
+                        "supported, you could remove the PARTITION BY clause", table.getProtocolType()));
+            }
         }
 
         // if mv is partitioned, mv will be refreshed by partition.

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MockedJDBCMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MockedJDBCMetadata.java
@@ -33,6 +33,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class MockedJDBCMetadata implements ConnectorMetadata {
     private final AtomicLong idGen = new AtomicLong(0L);
     public static final String MOCKED_JDBC_CATALOG_NAME = "jdbc0";
+    public static final String MOCKED_JDBC_PG_CATALOG_NAME = "jdbc_postgres";
     public static final String MOCKED_PARTITIONED_DB_NAME = "partitioned_db0";
     public static final String MOCKED_PARTITIONED_TABLE_NAME0 = "tbl0";
     public static final String MOCKED_PARTITIONED_TABLE_NAME1 = "tbl1";

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Sets;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.JDBCResource;
+import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedView;
@@ -28,6 +30,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
@@ -1264,6 +1267,34 @@ public class PartitionBasedMvRefreshProcessorTest {
         String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
         Assert.assertTrue(plan.contains("PARTITION PREDICATES: 5: par_date >= '2020-01-01', 5: par_date < '2020-01-03'"));
         Assert.assertTrue(plan.contains("partitions=3/7"));
+    }
+
+    @Test
+    public void testJDBCProtocolType() {
+        JDBCTable table = new JDBCTable();
+        table.getProperties().put(JDBCResource.URI, "jdbc:postgres:aaa");
+        Assert.assertEquals(JDBCTable.ProtocolType.POSTGRES, table.getProtocolType());
+        table.getProperties().put(JDBCResource.URI, "jdbc:mysql:aaa");
+        Assert.assertEquals(JDBCTable.ProtocolType.MYSQL, table.getProtocolType());
+        table.getProperties().put(JDBCResource.URI, "jdbc:h2:aaa");
+        Assert.assertEquals(JDBCTable.ProtocolType.UNKNOWN, table.getProtocolType());
+    }
+
+    @Test
+    public void testPartitionJDBCSupported() throws Exception {
+        // not supported
+        Assert.assertThrows(AnalysisException.class, () ->
+                starRocksAssert.withMaterializedView("create materialized view mv_jdbc_postgres " +
+                        "partition by d " +
+                        "refresh manual " +
+                        "AS SELECT `a`, `b`, `c`, `d`  FROM `jdbc_postgres`.`partitioned_db0`.`tbl0`;")
+        );
+
+        // supported
+        starRocksAssert.withMaterializedView("create materialized view mv_jdbc_mysql " +
+                "partition by d " +
+                "refresh manual " +
+                "AS SELECT `a`, `b`, `c`, `d`  FROM `jdbc0`.`partitioned_db0`.`tbl0`;");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.common.DdlException;
@@ -199,5 +200,19 @@ public class ConnectorPlanTestBase extends PlanTestBase {
 
         MockedJDBCMetadata mockedJDBCMetadata = new MockedJDBCMetadata(properties);
         metadataMgr.registerMockedMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME, mockedJDBCMetadata);
+
+        Map<String, String> pgProperties = ImmutableMap.<String, String>builder()
+                .put(JDBCResource.TYPE, "jdbc")
+                .put(JDBCResource.DRIVER_CLASS, "com.postgres.Driver")
+                .put(JDBCResource.URI, "jdbc:postgres://127.0.0.1:3306")
+                .put(JDBCResource.USER, "root")
+                .put(JDBCResource.PASSWORD, "123456")
+                .put(JDBCResource.CHECK_SUM, "xxxx")
+                .put(JDBCResource.DRIVER_URL, "xxxx")
+                .build();
+        GlobalStateMgr.getCurrentState().getCatalogMgr().
+                createCatalog("jdbc", MockedJDBCMetadata.MOCKED_JDBC_PG_CATALOG_NAME, "", pgProperties);
+        metadataMgr.registerMockedMetadata(MockedJDBCMetadata.MOCKED_JDBC_PG_CATALOG_NAME,
+                new MockedJDBCMetadata(pgProperties));
     }
 }


### PR DESCRIPTION
Fixes #issue

Only partitioned mv for MySQL JDBC table is supported right now, others should report exception.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
