### PR TITLE
[Enhancement] Make replica log replay robust

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -390,12 +390,32 @@ public class ConsistencyChecker extends FrontendDaemon {
 
     public void replayFinishConsistencyCheck(ConsistencyCheckInfo info, GlobalStateMgr globalStateMgr) {
         Database db = globalStateMgr.getDb(info.getDbId());
+        if (db == null) {
+            LOG.warn("replay finish consistency check failed, db is null, info: {}", info);
+            return;
+        }
         db.writeLock();
         try {
             OlapTable table = (OlapTable) db.getTable(info.getTableId());
+            if (table == null) {
+                LOG.warn("replay finish consistency check failed, table is null, info: {}", info);
+                return;
+            }
             Partition partition = table.getPartition(info.getPartitionId());
+            if (partition == null) {
+                LOG.warn("replay finish consistency check failed, partition is null, info: {}", info);
+                return;
+            }
             MaterializedIndex index = partition.getIndex(info.getIndexId());
+            if (index == null) {
+                LOG.warn("replay finish consistency check failed, index is null, info: {}", info);
+                return;
+            }
             LocalTablet tablet = (LocalTablet) index.getTablet(info.getTabletId());
+            if (tablet == null) {
+                LOG.warn("replay finish consistency check failed, tablet is null, info: {}", info);
+                return;
+            }
 
             long lastCheckTime = info.getLastCheckTime();
             db.setLastCheckTime(lastCheckTime);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ConsistencyCheckInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ConsistencyCheckInfo.java
@@ -36,6 +36,7 @@ package com.starrocks.persist;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -144,5 +145,10 @@ public class ConsistencyCheckInfo implements Writable {
         ConsistencyCheckInfo info = new ConsistencyCheckInfo();
         info.readFields(in);
         return info;
+    }
+
+    @Override
+    public String toString() {
+        return GsonUtils.GSON.toJson(this);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2592,10 +2592,30 @@ public class LocalMetastore implements ConnectorMetadata {
     private void unprotectAddReplica(ReplicaPersistInfo info) {
         LOG.debug("replay add a replica {}", info);
         Database db = getDbIncludeRecycleBin(info.getDbId());
+        if (db == null) {
+            LOG.warn("replay add replica failed, db is null, info: {}", info);
+            return;
+        }
         OlapTable olapTable = (OlapTable) getTableIncludeRecycleBin(db, info.getTableId());
+        if (olapTable == null) {
+            LOG.warn("replay add replica failed, table is null, info: {}", info);
+            return;
+        }
         Partition partition = getPartitionIncludeRecycleBin(olapTable, info.getPartitionId());
+        if (partition == null) {
+            LOG.warn("replay add replica failed, partition is null, info: {}", info);
+            return;
+        }
         MaterializedIndex materializedIndex = partition.getIndex(info.getIndexId());
+        if (materializedIndex == null) {
+            LOG.warn("replay add replica failed, materializedIndex is null, info: {}", info);
+            return;
+        }
         LocalTablet tablet = (LocalTablet) materializedIndex.getTablet(info.getTabletId());
+        if (tablet == null) {
+            LOG.warn("replay add replica failed, tablet is null, info: {}", info);
+            return;
+        }
 
         // for compatibility
         int schemaHash = info.getSchemaHash();
@@ -2615,12 +2635,35 @@ public class LocalMetastore implements ConnectorMetadata {
     private void unprotectUpdateReplica(ReplicaPersistInfo info) {
         LOG.debug("replay update a replica {}", info);
         Database db = getDbIncludeRecycleBin(info.getDbId());
+        if (db == null) {
+            LOG.warn("replay update replica failed, db is null, info: {}", info);
+            return;
+        }
         OlapTable olapTable = (OlapTable) getTableIncludeRecycleBin(db, info.getTableId());
+        if (olapTable == null) {
+            LOG.warn("replay update replica failed, table is null, info: {}", info);
+            return;
+        }
         Partition partition = getPartitionIncludeRecycleBin(olapTable, info.getPartitionId());
+        if (partition == null) {
+            LOG.warn("replay update replica failed, partition is null, info: {}", info);
+            return;
+        }
         MaterializedIndex materializedIndex = partition.getIndex(info.getIndexId());
+        if (materializedIndex == null) {
+            LOG.warn("replay update replica failed, materializedIndex is null, info: {}", info);
+            return;
+        }
         LocalTablet tablet = (LocalTablet) materializedIndex.getTablet(info.getTabletId());
+        if (tablet == null) {
+            LOG.warn("replay update replica failed, tablet is null, info: {}", info);
+            return;
+        }
         Replica replica = tablet.getReplicaByBackendId(info.getBackendId());
-        Preconditions.checkNotNull(replica, info);
+        if (replica == null) {
+            LOG.warn("replay update replica failed, replica is null, info: {}", info);
+            return;
+        }
         replica.updateRowCount(info.getVersion(), info.getMinReadableVersion(), info.getDataSize(), info.getRowCount());
         replica.setBad(false);
     }
@@ -2647,10 +2690,30 @@ public class LocalMetastore implements ConnectorMetadata {
 
     public void unprotectDeleteReplica(ReplicaPersistInfo info) {
         Database db = getDbIncludeRecycleBin(info.getDbId());
+        if (db == null) {
+            LOG.warn("replay delete replica failed, db is null, info: {}", info);
+            return;
+        }
         OlapTable olapTable = (OlapTable) getTableIncludeRecycleBin(db, info.getTableId());
+        if (olapTable == null) {
+            LOG.warn("replay delete replica failed, table is null, info: {}", info);
+            return;
+        }
         Partition partition = getPartitionIncludeRecycleBin(olapTable, info.getPartitionId());
+        if (partition == null) {
+            LOG.warn("replay delete replica failed, partition is null, info: {}", info);
+            return;
+        }
         MaterializedIndex materializedIndex = partition.getIndex(info.getIndexId());
+        if (materializedIndex == null) {
+            LOG.warn("replay delete replica failed, materializedIndex is null, info: {}", info);
+            return;
+        }
         LocalTablet tablet = (LocalTablet) materializedIndex.getTablet(info.getTabletId());
+        if (tablet == null) {
+            LOG.warn("replay delete replica failed, tablet is null, info: {}", info);
+            return;
+        }
         tablet.deleteReplicaByBackendId(info.getBackendId());
     }
 


### PR DESCRIPTION
It's not easy to control the concurrency of delete/update for replica operation in some corner case. This enhancement can protect FE from crash when replay replica operation failed.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
