### PR TITLE
[Enhancement] Refine profile to support visualization refactor(5)

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -460,9 +460,12 @@ void PipelineDriver::report_exec_state_if_necessary() {
 }
 
 void PipelineDriver::runtime_report_action() {
-    COUNTER_SET(_total_timer, static_cast<int64_t>(_total_timer_sw->elapsed_time()));
-    COUNTER_SET(_schedule_timer, _total_timer->value() - _active_timer->value() - _pending_timer->value());
-    _update_overhead_timer();
+    if (is_finished()) {
+        return;
+    }
+
+    _update_driver_level_timer();
+
     for (auto& op : _operators) {
         COUNTER_SET(op->_total_timer, op->_pull_timer->value() + op->_push_timer->value() +
                                               op->_finishing_timer->value() + op->_finished_timer->value() +
@@ -484,14 +487,22 @@ void PipelineDriver::mark_precondition_ready(RuntimeState* runtime_state) {
     }
 }
 
-void PipelineDriver::start_schedule(int64_t start_count, int64_t start_time) {
-    // start timers
+void PipelineDriver::start_timers() {
     _total_timer_sw->start();
     _pending_timer_sw->start();
     _precondition_block_timer_sw->start();
     _input_empty_timer_sw->start();
     _output_full_timer_sw->start();
     _pending_finish_timer_sw->start();
+}
+
+void PipelineDriver::stop_timers() {
+    _total_timer_sw->stop();
+    _pending_timer_sw->stop();
+    _precondition_block_timer_sw->stop();
+    _input_empty_timer_sw->stop();
+    _output_full_timer_sw->stop();
+    _pending_finish_timer_sw->stop();
 }
 
 void PipelineDriver::submit_operators() {
@@ -576,6 +587,7 @@ void PipelineDriver::_try_to_release_buffer(RuntimeState* state, OperatorPtr& op
 
 void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state, int64_t schedule_count,
                               int64_t execution_time) {
+    stop_timers();
     int64_t time_spent = 0;
     // The driver may be destructed after finalizing, so use a temporal driver to record
     // the information about the driver queue and workgroup.
@@ -598,9 +610,7 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state, in
 
     set_driver_state(state);
 
-    COUNTER_SET(_total_timer, static_cast<int64_t>(_total_timer_sw->elapsed_time()));
-    COUNTER_SET(_schedule_timer, _total_timer->value() - _active_timer->value() - _pending_timer->value());
-    _update_overhead_timer();
+    _update_driver_level_timer();
 
     // Acquire the pointer to avoid be released when removing query
     auto query_trace = _query_ctx->shared_query_trace();
@@ -609,7 +619,14 @@ void PipelineDriver::finalize(RuntimeState* runtime_state, DriverState state, in
     QUERY_TRACE_END("finalize", driver_name);
 }
 
-void PipelineDriver::_update_overhead_timer() {
+void PipelineDriver::_update_driver_level_timer() {
+    // Total Time
+    COUNTER_SET(_total_timer, static_cast<int64_t>(_total_timer_sw->elapsed_time()));
+
+    // Schedule Time
+    COUNTER_SET(_schedule_timer, _total_timer->value() - _active_timer->value() - _pending_timer->value());
+
+    // Overhead Time
     int64_t overhead_time = _active_timer->value();
     RuntimeProfile* profile = _runtime_profile.get();
     std::vector<RuntimeProfile*> operator_profiles;

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -298,7 +298,8 @@ public:
     // drivers in PRECONDITION_BLOCK state must be marked READY after its dependent runtime-filters or hash tables
     // are finished.
     void mark_precondition_ready(RuntimeState* runtime_state);
-    void start_schedule(int64_t start_count, int64_t start_time);
+    void start_timers();
+    void stop_timers();
     int64_t get_active_time() const { return _active_timer->value(); }
     void submit_operators();
     // Notify all the unfinished operators to be finished.
@@ -478,7 +479,7 @@ protected:
     void _update_driver_acct(size_t total_chunks_moved, size_t total_rows_moved, size_t time_spent);
     void _update_statistics(RuntimeState* state, size_t total_chunks_moved, size_t total_rows_moved, size_t time_spent);
     void _update_scan_statistics(RuntimeState* state);
-    void _update_overhead_timer();
+    void _update_driver_level_timer();
 
     RuntimeState* _runtime_state = nullptr;
     Operators _operators;

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -252,7 +252,7 @@ StatusOr<DriverRawPtr> GlobalDriverExecutor::_get_next_driver(std::queue<DriverR
 }
 
 void GlobalDriverExecutor::submit(DriverRawPtr driver) {
-    driver->start_schedule(_schedule_count, _driver_execution_ns);
+    driver->start_timers();
 
     if (driver->is_precondition_block()) {
         driver->set_driver_state(DriverState::PRECONDITION_BLOCK);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -434,7 +434,7 @@ public class QueryRuntimeProfile {
                     }
 
                     if (commonMetrics.containsInfoString("IsFinalSink")) {
-                        Counter outputFullTime = pipelineProfile.getCounter("OutputFullTime");
+                        Counter outputFullTime = pipelineProfile.getMaxCounter("OutputFullTime");
                         if (outputFullTime != null) {
                             long resultDeliverTime = outputFullTime.getValue();
                             Counter resultDeliverTimer =


### PR DESCRIPTION
This pr is an continuation work of #29063, #30381, #30975 and #31380, and the main objectives of this pr are:

1. Fix incorrect `ScheduleTime`
2. Fix incorrect `ResultDeliverTime `

## Incorrect ScheduleTime

This issue is introduced by runtime profiling #27021.

When executing a long-running query with session variable `enable_profile=true`, the runtime profiling mechanism is automitically enabled. And there may have some pipelines that are soon finished at the first beginning, which will be  also updated incorrectly as those still-running pipelines reporting their states. And the `TotalDriverTime` will be updated to a large value, and results in the large `ScheduleTime`

So the solution is simple, add a check at the start of `PipelineDriver::runtime_report_action`

```cpp
void PipelineDriver::runtime_report_action() {
    if (is_finished()) {
        return;
    }
    ...
}
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
