### PR TITLE
[Enhancement] autovacuum without list tablet metadata

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1060,4 +1060,6 @@ CONF_mBool(enable_drop_tablet_if_unfinished_txn, "true");
 // 0 means no limit
 CONF_Int32(lake_service_max_concurrency, "0");
 
+CONF_mInt64(lake_vacuum_max_batch_delete_size, "10000");
+
 } // namespace starrocks::config

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -17,8 +17,6 @@
 #include <butil/time.h>
 #include <bvar/bvar.h>
 
-#include <algorithm>
-#include <ctime>
 #include <string_view>
 #include <unordered_map>
 
@@ -35,14 +33,19 @@
 #include "storage/lake/update_manager.h"
 #include "storage/olap_common.h"
 #include "testutil/sync_point.h"
+#include "util/defer_op.h"
 #include "util/raw_container.h"
 
 namespace starrocks::lake {
 
-static bvar::LatencyRecorder g_del_file_latency("lake_vacuum_del_file");
+static bvar::LatencyRecorder g_del_file_latency("lake_vacuum_del_file"); // unit: us
 static bvar::Adder<uint64_t> g_del_fails("lake_vacuum_del_file_fails");
+static bvar::LatencyRecorder g_metadata_travel_latency("lake_vacuum_metadata_travel");    // unit: ms
+static bvar::LatencyRecorder g_vacuum_single_tablet_latency("lake_vacuum_single_tablet"); // unit: ms
+static bvar::LatencyRecorder g_txnlog_travel_latency("lake_vacuum_txnlog_travel");
 
 static Status delete_file(FileSystem* fs, const std::string& path) {
+#ifndef STARROCKS_VACUUM_DISABLE_FILE_DELETION
     auto wait_duration = config::experimental_lake_wait_per_delete_ms;
     if (wait_duration > 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(wait_duration));
@@ -58,9 +61,13 @@ static Status delete_file(FileSystem* fs, const std::string& path) {
         LOG(WARNING) << "Fail to delete " << path << ": " << st;
     }
     return st;
+#else
+    return Status::OK();
+#endif
 }
 
 static Status delete_files(FileSystem* fs, const std::vector<std::string>& paths) {
+#ifndef STARROCKS_VACUUM_DISABLE_FILE_DELETION
     if (paths.empty()) {
         return Status::OK();
     }
@@ -81,7 +88,113 @@ static Status delete_files(FileSystem* fs, const std::vector<std::string>& paths
     } else {
         LOG(WARNING) << "Fail to delete: " << st;
     }
+    TEST_SYNC_POINT_CALLBACK("vacuum.delete_files", &st);
     return st;
+#else
+    return Status::OK();
+#endif
+}
+
+static void collect_garbage_files(const TabletMetadataPB& metadata, const std::string& base_dir,
+                                  std::vector<std::string>* garbage_files, int64_t* garbage_data_size) {
+    for (const auto& rowset : metadata.compaction_inputs()) {
+        for (const auto& segment : rowset.segments()) {
+            garbage_files->emplace_back(join_path(base_dir, segment));
+        }
+        *garbage_data_size += rowset.data_size();
+    }
+    for (const auto& file : metadata.orphan_files()) {
+        garbage_files->emplace_back(join_path(base_dir, file.name()));
+        *garbage_data_size += file.size();
+    }
+}
+
+static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_view root_dir, int64_t tablet_id,
+                                      int64_t grace_timestamp, bool* skip_check_grace_timestamp,
+                                      int64_t* retain_version, std::vector<std::string>* datafiles_to_vacuum,
+                                      std::vector<std::string>* metafiles_to_vacuum, int64_t* total_datafile_size) {
+    auto t0 = butil::gettimeofday_ms();
+    auto meta_dir = join_path(root_dir, kMetadataDirectoryName);
+    auto data_dir = join_path(root_dir, kSegmentDirectoryName);
+    auto version = *retain_version;
+    int64_t num_opened_metadata = 0;
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_dir));
+    // Starting at |*retain_version|, read the tablet metadata forward along
+    // the |prev_garbage_version| pointer until the tablet metadata does not exist.
+    while (version > 0) {
+        auto path = join_path(meta_dir, tablet_metadata_filename(tablet_id, version));
+        auto res = tablet_mgr->get_tablet_metadata(path, false);
+        TEST_SYNC_POINT_CALLBACK("collect_files_to_vacuum:get_tablet_metadata", &res);
+        if (res.status().is_not_found()) {
+            break;
+        } else if (!res.ok()) {
+            return res.status();
+        } else {
+            num_opened_metadata++;
+            auto metadata = std::move(res).value();
+            if (*skip_check_grace_timestamp) {
+                // Reached here means all versions less than |*retain_version| were create before
+                // |grace_timestamp| and can be vacuumed.
+                //
+                // Note: As a compromise design, here we use the creation time of the first tablet in
+                // the request and compare it with grace_timestamp to determine whether the tablet
+                // metadata can be deleted or not, because the creation time of the metadata of
+                // different tablets may be different, so it is possible to delete a tablet metadata
+                // created after the grace_timestamp. A more rigorous approach might be to take the
+                // maximum creation time of different tablet metadata and compare it to grace_timestamp.
+                // However, this can be costly when there are a lot of tablets in a partition.
+                DCHECK_LE(version, *retain_version);
+                collect_garbage_files(*metadata, data_dir, datafiles_to_vacuum, total_datafile_size);
+            } else {
+                // Reached here means that the tablet metadata that has been traversed was created after
+                // |grace_timestamp| and cannot be deleted.
+                // Now check if the current |version| was created before |grace_timestamp|.
+                ASSIGN_OR_RETURN(auto mtime, fs->get_file_modified_time(path));
+                TEST_SYNC_POINT_CALLBACK("collect_files_to_vacuum:get_file_modified_time", &mtime);
+                if (mtime < grace_timestamp) {
+                    // |version| is the first version encountered that was created before |grace_timestamp|.
+                    //
+                    // Why not delete this version:
+                    // Assuming |grace_timestamp| is the earliest possible initiation time of queries still
+                    // in process, then the earliest version to be accessed is the last version created
+                    // before |grace_timestamp|, so the last version created before |grace_timestamp| should
+                    // be kept in case the query fails. And the |version| here is probably the last version
+                    // created before grace_timestamp.
+                    *retain_version = version;
+                    *skip_check_grace_timestamp = true;
+
+                    // We need to retain metadata files with version |*retain_version|, but garbage
+                    // files recorded in it can be deleted.
+                    collect_garbage_files(*metadata, data_dir, datafiles_to_vacuum, total_datafile_size);
+
+                    // from now on, all versions smaller than |*retain_version| are versions that can
+                    // be cleaned up, and it is no longer necessary to check the modification time of the
+                    // tablet metadata.
+                } else {
+                    // Although |version| is smaller than |*retain_version|, since |version| was created after
+                    // the |grace_timestamp|, |version| cannot be deleted either;
+                    // set |version| as the new retain version.
+                    DCHECK_LE(version, *retain_version);
+                    *retain_version = version;
+                }
+            }
+
+            CHECK_LT(metadata->prev_garbage_version(), version);
+            version = metadata->prev_garbage_version();
+        }
+    }
+    auto t1 = butil::gettimeofday_ms();
+    g_metadata_travel_latency << (t1 - t0);
+
+    if (!*skip_check_grace_timestamp) {
+        // All tablet metadata files encountered were created after the grace timestamp, there were no files to delete
+        return Status::OK();
+    }
+    DCHECK_LE(version, *retain_version);
+    for (auto v = version + 1; v < *retain_version; v++) {
+        metafiles_to_vacuum->emplace_back(join_path(meta_dir, tablet_metadata_filename(tablet_id, v)));
+    }
+    return Status::OK();
 }
 
 static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view root_dir,
@@ -94,102 +207,41 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
     DCHECK(vacuumed_files != nullptr);
     DCHECK(vacuumed_file_size != nullptr);
 
+    bool skip_check_grace_time = false;
+    int64_t max_batch_delete_size = config::lake_vacuum_max_batch_delete_size;
+    int64_t actual_retain_version = min_retain_version;
+    std::vector<std::string> datafiles_to_vacuum;
+    std::vector<std::string> metafiles_to_vacuum;
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_dir));
-
-    std::unordered_map<int64_t, std::vector<std::pair<int64_t, int64_t>>> expired_tablets;
-    //                 ^^^^^^^ tablet id
-    //                                                ^^^^^^^^^^^^^^^^ version number and file size
-
-    auto meta_dir = join_path(root_dir, kMetadataDirectoryName);
-    auto data_dir = join_path(root_dir, kSegmentDirectoryName);
-    RETURN_IF_ERROR(fs->iterate_dir2(meta_dir, [&](DirEntry entry) {
-        TEST_SYNC_POINT_CALLBACK("vacuum_tablet_metadata:iterate_metadata", &entry);
-        if (!is_tablet_metadata(entry.name)) {
-            return true;
+    for (auto tablet_id : tablet_ids) {
+        RETURN_IF_ERROR(collect_files_to_vacuum(tablet_mgr, root_dir, tablet_id, grace_timestamp,
+                                                &skip_check_grace_time, &actual_retain_version, &datafiles_to_vacuum,
+                                                &metafiles_to_vacuum, vacuumed_file_size));
+        if (datafiles_to_vacuum.size() >= max_batch_delete_size ||
+            metafiles_to_vacuum.size() >= max_batch_delete_size) {
+            (*vacuumed_files) += (datafiles_to_vacuum.size() + metafiles_to_vacuum.size());
+            RETURN_IF_ERROR(delete_files(fs.get(), datafiles_to_vacuum));
+            RETURN_IF_ERROR(delete_files(fs.get(), metafiles_to_vacuum));
+            datafiles_to_vacuum.clear();
+            metafiles_to_vacuum.clear();
         }
-        // NOTE: If mtime is unknown, the grace timestamp will be ignored.
-        if (entry.mtime.value_or(0) >= grace_timestamp) {
-            return true;
-        }
-        auto [tablet_id, version] = parse_tablet_metadata_filename(entry.name);
-        if (!std::binary_search(tablet_ids.begin(), tablet_ids.end(), tablet_id)) {
-            return true;
-        }
-        if (version <= min_retain_version) {
-            // We need to retain metadata files with version |min_retain_version|, but garbage files
-            // recorded in the |min_retain_version| can be deleted. So metadata file with |min_retain_version| will
-            // also be read.
-            expired_tablets[tablet_id].emplace_back(version, entry.size.value_or(0));
-        } else {
-            // nothing to do
-        }
-        return true;
-    }));
-
-    for (auto& [tablet_id, versions] : expired_tablets) {
-        DCHECK(!versions.empty());
-        std::sort(versions.begin(), versions.end());
-
-        // Find metadata files that has garbage data files and delete all those files
-        std::vector<std::string> paths;
-        for (int64_t garbage_version = versions.back().first; garbage_version >= versions[0].first; /**/) {
-            auto path = join_path(meta_dir, tablet_metadata_filename(tablet_id, garbage_version));
-            auto res = tablet_mgr->get_tablet_metadata(path, false);
-            if (res.status().is_not_found()) {
-                break;
-            } else if (!res.ok()) {
-                LOG(ERROR) << "Fail to read " << path << ": " << res.status();
-                return res.status();
-            } else {
-                auto metadata = std::move(res).value();
-                for (const auto& rowset : metadata->compaction_inputs()) {
-                    for (const auto& segment : rowset.segments()) {
-                        paths.emplace_back(join_path(data_dir, segment));
-                    }
-                    *vacuumed_files += rowset.segments_size();
-                    *vacuumed_file_size += rowset.data_size();
-                }
-                for (const auto& file : metadata->orphan_files()) {
-                    paths.emplace_back(join_path(data_dir, file.name()));
-                    *vacuumed_files += 1;
-                    *vacuumed_file_size += file.size();
-                }
-                if (metadata->has_prev_garbage_version()) {
-                    garbage_version = metadata->prev_garbage_version();
-                } else {
-                    break;
-                }
-            }
-        }
-        RETURN_IF_ERROR(delete_files(fs.get(), paths));
-
-        // Do not delete the last version created before grace_timestamp.
-        // Assuming grace_timestamp is the earliest possible initiation time of queries still in process, then the
-        // earliest version to be accessed is the last version created before grace_timestamp. So retain this version.
-        versions.pop_back();
-
-        paths.clear();
-        paths.reserve(versions.size());
-        for (auto version : versions) {
-            auto path = join_path(meta_dir, tablet_metadata_filename(tablet_id, version.first));
-            paths.emplace_back(path);
-            *vacuumed_files += 1;
-            *vacuumed_file_size += version.second;
-        }
-        RETURN_IF_ERROR(delete_files(fs.get(), paths));
     }
-
+    CHECK_LE(actual_retain_version, min_retain_version);
+    (*vacuumed_files) += (datafiles_to_vacuum.size() + metafiles_to_vacuum.size());
+    RETURN_IF_ERROR(delete_files(fs.get(), datafiles_to_vacuum));
+    RETURN_IF_ERROR(delete_files(fs.get(), metafiles_to_vacuum));
     return Status::OK();
 }
 
 static Status vacuum_txn_log(std::string_view root_location, const std::vector<int64_t>& tablet_ids,
                              int64_t min_active_txn_id, int64_t* vacuumed_files, int64_t* vacuumed_file_size) {
+    auto t0 = butil::gettimeofday_s();
     DCHECK(std::is_sorted(tablet_ids.begin(), tablet_ids.end()));
     DCHECK(vacuumed_files != nullptr);
     DCHECK(vacuumed_file_size != nullptr);
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_location));
     auto log_dir = join_path(root_location, kTxnLogDirectoryName);
-    return ignore_not_found(fs->iterate_dir2(log_dir, [&](DirEntry entry) {
+    auto ret = ignore_not_found(fs->iterate_dir2(log_dir, [&](DirEntry entry) {
         if (!is_txn_log(entry.name)) {
             return true;
         }
@@ -210,6 +262,9 @@ static Status vacuum_txn_log(std::string_view root_location, const std::vector<i
         }
         return true;
     }));
+    auto t1 = butil::gettimeofday_s();
+    g_txnlog_travel_latency << (t1 - t0);
+    return ret;
 }
 
 Status vacuum_impl(TabletManager* tablet_mgr, const VacuumRequest& request, VacuumResponse* response) {
@@ -259,6 +314,7 @@ void vacuum_full(TabletManager* tablet_mgr, const VacuumFullRequest& request, Va
     st.to_protobuf(response->mutable_status());
 }
 
+// TODO: remote list objects requests
 Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_dir,
                            const std::vector<int64_t>& tablet_ids) {
     DCHECK(tablet_mgr != nullptr);
@@ -295,7 +351,7 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
         return true;
     })));
 
-    std::vector<std::string> paths;
+    std::vector<std::string> files_to_vacuum;
     for (const auto& log_name : txn_logs) {
         auto res = tablet_mgr->get_txn_log(join_path(log_dir, log_name), false);
         if (res.status().is_not_found()) {
@@ -307,30 +363,30 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
             if (log->has_op_write()) {
                 const auto& op = log->op_write();
                 for (const auto& segment : op.rowset().segments()) {
-                    paths.emplace_back(join_path(data_dir, segment));
+                    files_to_vacuum.emplace_back(join_path(data_dir, segment));
                 }
                 for (const auto& f : op.dels()) {
-                    paths.emplace_back((join_path(data_dir, f)));
+                    files_to_vacuum.emplace_back((join_path(data_dir, f)));
                 }
             }
             if (log->has_op_compaction()) {
                 const auto& op = log->op_compaction();
                 for (const auto& segment : op.output_rowset().segments()) {
-                    paths.emplace_back((join_path(data_dir, segment)));
+                    files_to_vacuum.emplace_back((join_path(data_dir, segment)));
                 }
             }
             if (log->has_op_schema_change()) {
                 const auto& op = log->op_schema_change();
                 for (const auto& rowset : op.rowsets()) {
                     for (const auto& segment : rowset.segments()) {
-                        paths.emplace_back((join_path(data_dir, segment)));
+                        files_to_vacuum.emplace_back((join_path(data_dir, segment)));
                     }
                 }
             }
-            paths.emplace_back((join_path(log_dir, log_name)));
+            files_to_vacuum.emplace_back((join_path(log_dir, log_name)));
         }
     }
-    RETURN_IF_ERROR(delete_files(fs.get(), paths));
+    RETURN_IF_ERROR(delete_files(fs.get(), files_to_vacuum));
 
     RETURN_IF_ERROR(ignore_not_found(fs->iterate_dir(meta_dir, [&](std::string_view name) {
         if (!is_tablet_metadata(name)) {
@@ -351,7 +407,7 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
         TabletMetadataPtr latest_metadata = nullptr;
 
         // Find metadata files that has garbage data files and delete all those files
-        paths.clear();
+        files_to_vacuum.clear();
         for (int64_t garbage_version = versions.back(); garbage_version >= versions[0]; /**/) {
             auto path = join_path(meta_dir, tablet_metadata_filename(tablet_id, garbage_version));
             auto res = tablet_mgr->get_tablet_metadata(path, false);
@@ -365,14 +421,8 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                 if (latest_metadata == nullptr) {
                     latest_metadata = metadata;
                 }
-                for (const auto& rowset : metadata->compaction_inputs()) {
-                    for (const auto& segment : rowset.segments()) {
-                        paths.emplace_back(join_path(data_dir, segment));
-                    }
-                }
-                for (const auto& file : metadata->orphan_files()) {
-                    paths.emplace_back(join_path(data_dir, file.name()));
-                }
+                int64_t dummy_file_size = 0;
+                collect_garbage_files(*metadata, data_dir, &files_to_vacuum, &dummy_file_size);
                 if (metadata->has_prev_garbage_version()) {
                     garbage_version = metadata->prev_garbage_version();
                 } else {
@@ -380,28 +430,28 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
                 }
             }
         }
-        RETURN_IF_ERROR(delete_files(fs.get(), paths));
+        RETURN_IF_ERROR(delete_files(fs.get(), files_to_vacuum));
 
         // Delete all data files referenced in the latest version
-        paths.clear();
+        files_to_vacuum.clear();
         if (latest_metadata != nullptr) {
             for (const auto& rowset : latest_metadata->rowsets()) {
                 for (const auto& segment : rowset.segments()) {
-                    paths.emplace_back(join_path(data_dir, segment));
+                    files_to_vacuum.emplace_back(join_path(data_dir, segment));
                 }
             }
             if (latest_metadata->has_delvec_meta()) {
                 for (const auto& [v, f] : latest_metadata->delvec_meta().version_to_file()) {
-                    paths.emplace_back(join_path(data_dir, f.name()));
+                    files_to_vacuum.emplace_back(join_path(data_dir, f.name()));
                 }
             }
         }
 
         for (auto version : versions) {
             auto path = join_path(meta_dir, tablet_metadata_filename(tablet_id, version));
-            paths.emplace_back(std::move(path));
+            files_to_vacuum.emplace_back(std::move(path));
         }
-        RETURN_IF_ERROR(delete_files(fs.get(), paths));
+        RETURN_IF_ERROR(delete_files(fs.get(), files_to_vacuum));
     }
 
     return Status::OK();

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -44,7 +44,6 @@ static bvar::LatencyRecorder g_metadata_travel_latency("lake_vacuum_metadata_tra
 static bvar::LatencyRecorder g_txnlog_travel_latency("lake_vacuum_txnlog_travel");
 
 static Status delete_file(FileSystem* fs, const std::string& path) {
-#ifndef STARROCKS_VACUUM_DISABLE_FILE_DELETION
     auto wait_duration = config::experimental_lake_wait_per_delete_ms;
     if (wait_duration > 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(wait_duration));
@@ -60,13 +59,9 @@ static Status delete_file(FileSystem* fs, const std::string& path) {
         LOG(WARNING) << "Fail to delete " << path << ": " << st;
     }
     return st;
-#else
-    return Status::OK();
-#endif
 }
 
 static Status delete_files(FileSystem* fs, const std::vector<std::string>& paths) {
-#ifndef STARROCKS_VACUUM_DISABLE_FILE_DELETION
     if (paths.empty()) {
         return Status::OK();
     }
@@ -89,9 +84,6 @@ static Status delete_files(FileSystem* fs, const std::vector<std::string>& paths
     }
     TEST_SYNC_POINT_CALLBACK("vacuum.delete_files", &st);
     return st;
-#else
-    return Status::OK();
-#endif
 }
 
 static void collect_garbage_files(const TabletMetadataPB& metadata, const std::string& base_dir,


### PR DESCRIPTION
Executing autovacuum tasks no longer performs a list of tablet metadata. list tablet metadata is a costly operation, and when there is a large amount of tablet metadata (more than a few million), it takes a very long time for the results to be returned, affecting the speed of the vacuum.

Note that the autovacuum task still lists txn logs, which normally doesn't have too many files and shouldn't take too long, so it hasn't been optimized away for now.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
