### PR TITLE
[UT] Fix unstable test BinlogReaderTest.test_read_full_columns

### DIFF
--- a/be/test/storage/binlog_reader_test.cpp
+++ b/be/test/storage/binlog_reader_test.cpp
@@ -163,8 +163,11 @@ void BinlogReaderTest::ingestion_rowsets(std::vector<std::vector<RowsetInfo>>& r
         for (auto& rowset_info : rowset_infos) {
             RowsetSharedPtr rowset;
             create_rowset(&start_key, rowset_info, &rowset);
-            rowset_info.create_time_in_us = rowset->creation_time() * 1000000;
             ASSERT_OK(_tablet->add_inc_rowset(rowset, rowset_info.version));
+            // the creation time of the rowset will be set to the visible time in add_inc_rowset(), and
+            // the binlog timestamp actually use the creation time after rowset is visible, so should
+            // get the creation time after add_inc_rowset() to verify the correctness of binlog timestamp
+            rowset_info.create_time_in_us = rowset->creation_time() * 1000000;
         }
         binlog_manager->close_active_writer();
     }
@@ -297,7 +300,7 @@ public:
 };
 
 // verify that for the output including both meta and data columns
-TEST_F(BinlogReaderTest, DISABLED_test_read_full_columns) {
+TEST_F(BinlogReaderTest, test_read_full_columns) {
     Schema schema;
     FieldPtr op = make_field(4, BINLOG_OP, TYPE_TINYINT);
     FieldPtr version = make_field(5, BINLOG_VERSION, TYPE_BIGINT);
@@ -325,7 +328,7 @@ public:
 };
 
 // verify that for the output only including data columns
-TEST_F(BinlogReaderTest, DISABLED_test_read_data_columns) {
+TEST_F(BinlogReaderTest, test_read_data_columns) {
     DataColumnsVerifier verifier;
     test_reader(_schema, verifier);
 }
@@ -340,7 +343,7 @@ public:
 };
 
 // verify that for the output including random columns
-TEST_F(BinlogReaderTest, DISABLED_test_read_random_columns) {
+TEST_F(BinlogReaderTest, test_read_random_columns) {
     Schema schema;
     FieldPtr op = make_field(4, BINLOG_OP, TYPE_TINYINT);
     schema.append(op);


### PR DESCRIPTION
BinlogReaderTest.test_read_full_columns is unstable, and is disabled temporarily  in #25571. Now fix it, and enable the test.
The failure is
```
binlog_reader_test.cpp:295: Failure
Expected equality of these values:
  row_info.timestamp
    Which is: 1696845778000000
  actual_tuple[6].get_int64()
    Which is: 1696845779000000
```
It is just the problem of test implementation. The reason is that the creation time of the rowset will be set to the visible time in `add_inc_rowset()`, and the binlog timestamp actually use the creation time after rowset is visible, so should get the creation time after add_inc_rowset() to verify the correctness of binlog timestamp

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
