### PR TITLE
[Enhancement] Make JEMALLOC_CONF mutable in be.conf

### DIFF
--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -71,7 +71,11 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true"
+if [ "$JEMALLOC_CONF" = "" ]; then
+    export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true"
+else
+    echo "JEMALLOC_CONF from conf is '$JEMALLOC_CONF'"
+fi
 # enable coredump when BE build with ASAN
 export ASAN_OPTIONS=abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1
 export LSAN_OPTIONS=suppressions=${STARROCKS_HOME}/conf/asan_suppressions.conf

--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -71,7 +71,8 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [ "$JEMALLOC_CONF" = "" ]; then
+# Set JEMALLOC_CONF environment variable if not already set
+if [[ -z "$JEMALLOC_CONF" ]]; then
     export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true"
 else
     echo "JEMALLOC_CONF from conf is '$JEMALLOC_CONF'"


### PR DESCRIPTION
If `JEMALLOC_CONF` is set in be.conf or from environment variable, then use this value to override the default one.
```
# be.conf
JEMALLOC_CONF=xxxx
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
