### PR TITLE
[Enhancement] Optimize task run and task run status to be better for show materialized views

### DIFF
--- a/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_materialized_views_scanner.cpp
@@ -49,6 +49,7 @@ SchemaScanner::ColumnDesc SchemaMaterializedViewsScanner::_s_tbls_columns[] = {
         {"LAST_REFRESH_ERROR_MESSAGE", TYPE_VARCHAR, sizeof(StringValue), false},
         {"TABLE_ROWS", TYPE_VARCHAR, sizeof(StringValue), false},
         {"MATERIALIZED_VIEW_DEFINITION", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"EXTRA_MESSAGE", TYPE_VARCHAR, sizeof(StringValue), false},
 };
 
 SchemaScanner::ColumnDesc SchemaMaterializedViewsScanner::_s_tbls_columns_v1[] = {
@@ -147,6 +148,7 @@ Status SchemaMaterializedViewsScanner::_fill_chunk_v2(ChunkPtr* chunk) {
             Slice(info.last_refresh_error_message),
             Slice(info.rows),
             Slice(info.text),
+            Slice(info.extra_message),
     };
 
     for (const auto& [slot_id, index] : slot_id_map) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -51,6 +51,7 @@ public class MaterializedViewsSystemTable {
                         .column("TABLE_ROWS", ScalarType.createVarchar(50))
                         .column("MATERIALIZED_VIEW_DEFINITION",
                                 ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("EXTRA_MESSAGE", ScalarType.createVarchar(1024))
                         .build(), TSchemaTableType.SCH_MATERIALIZED_VIEWS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1140,6 +1140,13 @@ public class Config extends ConfigBase {
     public static boolean enable_backup_materialized_view = true;
 
     /**
+     * Whether to display all task runs or only the newest task run in ShowMaterializedViews command to be
+     * compatible with old version.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_show_materialized_views_include_all_task_runs = true;
+
+    /**
      * The smaller schedule time is, the higher frequency TaskManager schedule which means
      * materialized view need to schedule to refresh.
      * <p>

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowMaterializedViewStatus.java
@@ -14,34 +14,248 @@
 
 package com.starrocks.qe;
 
+import com.google.api.client.util.Lists;
+import com.google.api.client.util.Sets;
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.TimeUtils;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.scheduler.Constants;
+import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.thrift.TMaterializedViewStatus;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+/**
+ * ShowMaterializedViewStatus represents one materialized view's refresh status for ShowMaterializedViews command usage.
+ */
 public class ShowMaterializedViewStatus {
+    public static final String MULTI_TASK_RUN_SEPARATOR = "|";
+
     private long id;
     private String dbName;
     private String name;
     private String refreshType;
     private boolean isActive;
-
     private String text;
     private long rows;
     private String partitionType;
     private long lastCheckTime;
-    private long createTime;
-    private long taskId;
-    private String taskName;
     private String inactiveReason;
+    private List<TaskRunStatus> lastJobTaskRunStatus;
 
-    private TaskRunStatus lastTaskRunStatus;
+    /**
+     * RefreshJobStatus represents a batch of batch TaskRunStatus because a fresh may trigger more than one task runs.
+     */
+    public class RefreshJobStatus {
+        private long taskId;
+        private String taskName;
+        private Constants.TaskRunState refreshState;
+        private long mvRefreshStartTime;
+        private long mvRefreshEndTime;
+        private long totalProcessDuration;
+        private boolean isForce;
+        private List<String> refreshedPartitionStarts;
+        private List<String> refreshedPartitionEnds;
+        private List<Map<String, Set<String>>> refreshedBasePartitionsToRefreshMaps;
+        private List<Set<String>> refreshedMvPartitionsToRefreshs;
+        private String errorCode;
+        private String errorMsg;
+        private boolean isRefreshFinished;
+        private ExtraMessage extraMessage;
+
+        public RefreshJobStatus() {
+        }
+
+        public long getMvRefreshStartTime() {
+            return mvRefreshStartTime;
+        }
+
+        public void setMvRefreshStartTime(long mvRefreshStartTime) {
+            this.mvRefreshStartTime = mvRefreshStartTime;
+        }
+
+        public long getMvRefreshEndTime() {
+            return mvRefreshEndTime;
+        }
+
+        public void setMvRefreshEndTime(long mvRefreshEndTime) {
+            this.mvRefreshEndTime = mvRefreshEndTime;
+        }
+
+        public long getTotalProcessDuration() {
+            return totalProcessDuration;
+        }
+
+        public void setTotalProcessDuration(long totalProcessDuration) {
+            this.totalProcessDuration = totalProcessDuration;
+        }
+
+        public boolean isForce() {
+            return isForce;
+        }
+
+        public void setForce(boolean force) {
+            isForce = force;
+        }
+
+        public List<String> getRefreshedPartitionStarts() {
+            return refreshedPartitionStarts == null ? Lists.newArrayList() : refreshedPartitionStarts;
+        }
+
+        public void setRefreshedPartitionStarts(List<String> refreshedPartitionStarts) {
+            this.refreshedPartitionStarts = refreshedPartitionStarts;
+        }
+
+        public List<String> getRefreshedPartitionEnds() {
+            return refreshedPartitionEnds == null ? Lists.newArrayList() : refreshedPartitionEnds;
+        }
+
+        public void setRefreshedPartitionEnds(List<String> refreshedPartitionEnds) {
+            this.refreshedPartitionEnds = refreshedPartitionEnds;
+        }
+
+        public List<Map<String, Set<String>>> getRefreshedBasePartitionsToRefreshMaps() {
+            return refreshedBasePartitionsToRefreshMaps == null ? Lists.newArrayList() : refreshedBasePartitionsToRefreshMaps;
+        }
+
+        public void setRefreshedBasePartitionsToRefreshMaps(List<Map<String, Set<String>>> refreshedBasePartitionsToRefreshMaps) {
+            this.refreshedBasePartitionsToRefreshMaps = refreshedBasePartitionsToRefreshMaps;
+        }
+
+        public List<Set<String>> getRefreshedMvPartitionsToRefreshs() {
+            return refreshedMvPartitionsToRefreshs == null ? Lists.newArrayList() : refreshedMvPartitionsToRefreshs;
+        }
+
+        public void setRefreshedMvPartitionsToRefreshs(List<Set<String>> refreshedMvPartitionsToRefreshs) {
+            this.refreshedMvPartitionsToRefreshs = refreshedMvPartitionsToRefreshs;
+        }
+
+        public String getErrorCode() {
+            return errorCode;
+        }
+
+        public void setErrorCode(String errorCode) {
+            this.errorCode = errorCode;
+        }
+
+        public String getErrorMsg() {
+            return errorMsg;
+        }
+
+        public void setErrorMsg(String errorMsg) {
+            this.errorMsg = errorMsg;
+        }
+
+        public Constants.TaskRunState getRefreshState() {
+            return refreshState;
+        }
+
+        public void setRefreshState(Constants.TaskRunState refreshState) {
+            this.refreshState = refreshState;
+        }
+
+        public boolean isRefreshFinished() {
+            return isRefreshFinished;
+        }
+
+        public void setRefreshFinished(boolean refreshFinished) {
+            isRefreshFinished = refreshFinished;
+        }
+
+        public long getTaskId() {
+            return taskId;
+        }
+
+        public void setTaskId(long taskId) {
+            this.taskId = taskId;
+        }
+
+        public String getTaskName() {
+            return taskName;
+        }
+
+        public void setTaskName(String taskName) {
+            this.taskName = taskName;
+        }
+
+        public ExtraMessage getExtraMessage() {
+            return extraMessage;
+        }
+
+        public void setExtraMessage(ExtraMessage extraMessage) {
+            this.extraMessage = extraMessage;
+        }
+    }
+
+    /**
+     * To avoid changing show materialized view's result schema, use this to keep extra message.
+     */
+    class ExtraMessage {
+        @SerializedName("queryIds")
+        private List<String> queryIds;
+        @SerializedName("isManual")
+        private boolean isManual = false;
+        @SerializedName("isSync")
+        private boolean isSync = false;
+        @SerializedName("isReplay")
+        private boolean isReplay = false;
+        @SerializedName("priority")
+        private int priority = Constants.TaskRunPriority.LOWEST.value();
+
+        public boolean isManual() {
+            return isManual;
+        }
+
+        public void setManual(boolean manual) {
+            isManual = manual;
+        }
+
+        public boolean isSync() {
+            return isSync;
+        }
+
+        public void setSync(boolean sync) {
+            isSync = sync;
+        }
+
+        public boolean isReplay() {
+            return isReplay;
+        }
+
+        public void setReplay(boolean replay) {
+            isReplay = replay;
+        }
+
+        public int getPriority() {
+            return priority;
+        }
+
+        public void setPriority(int priority) {
+            this.priority = priority;
+        }
+
+        public List<String> getQueryIds() {
+            return queryIds;
+        }
+
+        public void setQueryIds(List<String> queryIds) {
+            this.queryIds = queryIds;
+        }
+    }
 
     public ShowMaterializedViewStatus(long id, String dbName, String name) {
         this.id = id;
@@ -121,30 +335,6 @@ public class ShowMaterializedViewStatus {
         this.lastCheckTime = lastCheckTime;
     }
 
-    public long getCreateTime() {
-        return createTime;
-    }
-
-    public void setCreateTime(long createTime) {
-        this.createTime = createTime;
-    }
-
-    public long getTaskId() {
-        return taskId;
-    }
-
-    public void setTaskId(long taskId) {
-        this.taskId = taskId;
-    }
-
-    public String getTaskName() {
-        return taskName;
-    }
-
-    public void setTaskName(String taskName) {
-        this.taskName = taskName;
-    }
-
     public String getInactiveReason() {
         return inactiveReason;
     }
@@ -153,13 +343,100 @@ public class ShowMaterializedViewStatus {
         this.inactiveReason = inactiveReason;
     }
 
-    public TaskRunStatus getLastTaskRunStatus() {
-        return lastTaskRunStatus;
+    public void setLastJobTaskRunStatus(List<TaskRunStatus> lastJobTaskRunStatus) {
+        if (lastJobTaskRunStatus != null) {
+            // sort by process start time
+            lastJobTaskRunStatus.sort(Comparator.comparing(TaskRunStatus::getProcessStartTime));
+            this.lastJobTaskRunStatus = lastJobTaskRunStatus;
+        }
     }
 
-    public void setLastTaskRunStatus(TaskRunStatus lastTaskRunStatus) {
-        this.lastTaskRunStatus = lastTaskRunStatus;
+    private List<String> applyTaskRunStatusWith(Function<TaskRunStatus, String> func) {
+        return lastJobTaskRunStatus.stream()
+                .map(x -> func.apply(x))
+                .map(x -> Optional.ofNullable(x).orElse("NULL"))
+                .collect(Collectors.toList());
     }
+
+    public RefreshJobStatus getRefreshJobStatus() {
+        RefreshJobStatus status = new RefreshJobStatus();
+        if (lastJobTaskRunStatus == null || lastJobTaskRunStatus.isEmpty()) {
+            return status;
+        }
+
+        TaskRunStatus firstTaskRunStatus = lastJobTaskRunStatus.get(0);
+        TaskRunStatus lastTaskRunStatus = lastJobTaskRunStatus.get(lastJobTaskRunStatus.size() - 1);
+
+        status.setTaskId(firstTaskRunStatus.getTaskId());
+        status.setTaskName(firstTaskRunStatus.getTaskName());
+
+        // extra message
+        ExtraMessage extraMessage = new ExtraMessage();
+        List<String> queryIds = applyTaskRunStatusWith(x -> x.getQueryId());
+        // queryIds
+        extraMessage.setQueryIds(queryIds);
+        MVTaskRunExtraMessage firstTaskRunExtraMessage = firstTaskRunStatus.getMvTaskRunExtraMessage();
+        if (firstTaskRunExtraMessage != null && firstTaskRunExtraMessage.getExecuteOption() != null) {
+            ExecuteOption executeOption = firstTaskRunExtraMessage.getExecuteOption();
+            extraMessage.setManual(executeOption.isManual());
+            extraMessage.setSync(executeOption.getIsSync());
+            extraMessage.setReplay(executeOption.isReplay());
+            extraMessage.setPriority(executeOption.getPriority());
+            status.setExtraMessage(extraMessage);
+        }
+
+        // start time
+        long mvRefreshStartTime = firstTaskRunStatus.getProcessStartTime();
+        status.setMvRefreshStartTime(mvRefreshStartTime);
+
+        // last refresh state
+        status.setRefreshState(lastTaskRunStatus.getLastRefreshState());
+
+        // is force
+        MVTaskRunExtraMessage mvTaskRunExtraMessage = lastTaskRunStatus.getMvTaskRunExtraMessage();
+        status.setForce(mvTaskRunExtraMessage.isForceRefresh());
+
+        // getPartitionStart
+        List<String> refreshedPartitionStarts = applyTaskRunStatusWith(x ->
+                x.getMvTaskRunExtraMessage().getPartitionStart());
+        status.setRefreshedPartitionStarts(refreshedPartitionStarts);
+
+        // getPartitionEnd
+        List<String> refreshedPartitionEnds = applyTaskRunStatusWith(x ->
+                x.getMvTaskRunExtraMessage().getPartitionEnd());
+        status.setRefreshedPartitionEnds(refreshedPartitionEnds);
+
+        // getBasePartitionsToRefreshMapString
+        List<Map<String, Set<String>>> refreshedBasePartitionsToRefreshMaps = lastJobTaskRunStatus.stream()
+                .map(x -> x.getMvTaskRunExtraMessage().getBasePartitionsToRefreshMap())
+                .map(x -> Optional.ofNullable(x).orElse(Maps.newHashMap()))
+                .collect(Collectors.toList());
+        status.setRefreshedBasePartitionsToRefreshMaps(refreshedBasePartitionsToRefreshMaps);
+
+        // getMvPartitionsToRefreshString
+        List<Set<String>> refreshedMvPartitionsToRefreshs = lastJobTaskRunStatus.stream()
+                .map(x -> x.getMvTaskRunExtraMessage().getMvPartitionsToRefresh())
+                .map(x -> Optional.ofNullable(x).orElse(Sets.newHashSet()))
+                .collect(Collectors.toList());
+        status.setRefreshedMvPartitionsToRefreshs(refreshedMvPartitionsToRefreshs);
+
+        // only updated when refresh is finished
+        if (lastTaskRunStatus.isRefreshFinished()) {
+            status.setRefreshFinished(true);
+
+            long mvRefreshFinishTime = lastTaskRunStatus.getFinishTime();
+            status.setMvRefreshEndTime(mvRefreshFinishTime);
+
+            long totalProcessDuration = lastJobTaskRunStatus.stream()
+                    .map(x -> x.calculateRefreshProcessDuration())
+                    .collect(Collectors.summingLong(Long::longValue));
+            status.setTotalProcessDuration(totalProcessDuration);
+            status.setErrorCode(String.valueOf(lastTaskRunStatus.getErrorCode()));
+            status.setErrorMsg(Strings.nullToEmpty(lastTaskRunStatus.getErrorMessage()));
+        }
+        return status;
+    }
+
 
     /**
      * Return the thrift of show materialized views command from be's request.
@@ -174,30 +451,43 @@ public class ShowMaterializedViewStatus {
         status.setInactive_reason(this.inactiveReason);
         status.setPartition_type(this.partitionType);
 
-        status.setTask_id(String.valueOf(this.taskId));
-        status.setTask_name(this.taskName);
-        if (lastTaskRunStatus != null) {
-            status.setLast_refresh_start_time(TimeUtils.longToTimeString(lastTaskRunStatus.getCreateTime()));
-            status.setLast_refresh_finished_time(TimeUtils.longToTimeString(lastTaskRunStatus.getFinishTime()));
-            if (lastTaskRunStatus.getFinishTime() > lastTaskRunStatus.getCreateTime()) {
-                status.setLast_refresh_duration(DebugUtil.DECIMAL_FORMAT_SCALE_3.format(
-                        (lastTaskRunStatus.getFinishTime() - lastTaskRunStatus.getCreateTime()) / 1000D));
-            }
-            status.setLast_refresh_error_code(String.valueOf(lastTaskRunStatus.getErrorCode()));
-            status.setLast_refresh_error_message(Strings.nullToEmpty(lastTaskRunStatus.getErrorMessage()));
+        RefreshJobStatus refreshJobStatus = getRefreshJobStatus();
+        status.setTask_id(String.valueOf(refreshJobStatus.getTaskId()));
+        status.setTask_name(refreshJobStatus.getTaskName());
+        // start time
+        status.setLast_refresh_start_time(TimeUtils.longToTimeString(refreshJobStatus.getMvRefreshStartTime()));
+        // LAST_REFRESH_STATE
+        status.setLast_refresh_state(String.valueOf(refreshJobStatus.getRefreshState()));
+        // is force
+        status.setLast_refresh_force_refresh(refreshJobStatus.isForce() ? "true" : "false");
+        // partitionStart
+        status.setLast_refresh_start_partition(Joiner.on(MULTI_TASK_RUN_SEPARATOR)
+                .join(refreshJobStatus.getRefreshedPartitionStarts()));
+        // partitionEnd
+        status.setLast_refresh_end_partition(Joiner.on(MULTI_TASK_RUN_SEPARATOR)
+                .join(refreshJobStatus.getRefreshedPartitionEnds()));
+        // basePartitionsToRefreshMapString
+        status.setLast_refresh_base_refresh_partitions(Joiner.on(MULTI_TASK_RUN_SEPARATOR)
+                .join(refreshJobStatus.getRefreshedBasePartitionsToRefreshMaps()));
+        // mvPartitionsToRefreshString
+        status.setLast_refresh_mv_refresh_partitions(Joiner.on(MULTI_TASK_RUN_SEPARATOR)
+                .join(refreshJobStatus.getRefreshedMvPartitionsToRefreshs()));
 
-            status.setLast_refresh_state(String.valueOf(lastTaskRunStatus.getState()));
-            MVTaskRunExtraMessage extraMessage = lastTaskRunStatus.getMvTaskRunExtraMessage();
-            status.setLast_refresh_force_refresh(extraMessage.isForceRefresh() ? "true" : "false");
-            status.setLast_refresh_start_partition(Strings.nullToEmpty(extraMessage.getPartitionStart()));
-            status.setLast_refresh_end_partition(Strings.nullToEmpty(extraMessage.getPartitionEnd()));
-            status.setLast_refresh_base_refresh_partitions(
-                    Strings.nullToEmpty(extraMessage.getBasePartitionsToRefreshMapString()));
-            status.setLast_refresh_mv_refresh_partitions(Strings.nullToEmpty(extraMessage.getMvPartitionsToRefreshString()));
+        // only updated when refresh is finished
+        if (refreshJobStatus.isRefreshFinished()) {
+            status.setLast_refresh_finished_time(TimeUtils.longToTimeString(refreshJobStatus.getMvRefreshEndTime()));
+            status.setLast_refresh_duration(formatDuration(refreshJobStatus.getTotalProcessDuration()));
+            status.setLast_refresh_error_code(refreshJobStatus.getErrorCode());
+            status.setLast_refresh_error_message(refreshJobStatus.getErrorMsg());
         }
 
         status.setRows(String.valueOf(this.rows));
         status.setText(this.text);
+
+        // extra message
+        status.setExtra_message(refreshJobStatus.getExtraMessage() == null ? "" :
+                GsonUtils.GSON.toJson(refreshJobStatus.getExtraMessage()));
+
         return status;
     }
 
@@ -208,46 +498,60 @@ public class ShowMaterializedViewStatus {
     public List<String> toResultSet() {
         ArrayList<String> resultRow = new ArrayList<>();
 
+        // NOTE: All fields should be ordered by `MaterializedViewsSystemTable`'s definition.
         // Add fields to the result set
+        // mv id
         addField(resultRow, id);
+        // db name
         addField(resultRow, dbName);
+        // mv name
         addField(resultRow, name);
+        // mv refresh type
         addField(resultRow, refreshType);
+        // mv is active?
         addField(resultRow, isActive);
+        // mv inactive reason?
         addField(resultRow, inactiveReason);
+        // mv partition type
         addField(resultRow, partitionType);
 
-        if (lastTaskRunStatus != null) {
-            // Add fields related to task run status
-            addField(resultRow, lastTaskRunStatus.getTaskId());
-            addField(resultRow, Strings.nullToEmpty(lastTaskRunStatus.getTaskName()));
-            addField(resultRow, TimeUtils.longToTimeString(lastTaskRunStatus.getCreateTime()));
-            addField(resultRow, TimeUtils.longToTimeString(lastTaskRunStatus.getFinishTime()));
-            addField(resultRow, calculateRefreshDuration(lastTaskRunStatus));
-            addField(resultRow, lastTaskRunStatus.getState());
+        RefreshJobStatus refreshJobStatus = getRefreshJobStatus();
+        // task id
+        addField(resultRow, refreshJobStatus.getTaskId());
+        // task name
+        addField(resultRow, Strings.nullToEmpty(refreshJobStatus.getTaskName()));
+        // process start time
+        addField(resultRow, TimeUtils.longToTimeString(refreshJobStatus.getMvRefreshStartTime()));
+        // process finish time
+        addField(resultRow, TimeUtils.longToTimeString(refreshJobStatus.getMvRefreshEndTime()));
+        // process duration
+        addField(resultRow, formatDuration(refreshJobStatus.getTotalProcessDuration()));
+        // last refresh state
+        addField(resultRow, refreshJobStatus.getRefreshState());
+        // whether it's force refresh
+        addField(resultRow, refreshJobStatus.isForce);
+        // partitionStart
+        addField(resultRow, (Joiner.on(MULTI_TASK_RUN_SEPARATOR).join(refreshJobStatus.getRefreshedPartitionStarts())));
+        // partitionEnd
+        addField(resultRow, (Joiner.on(MULTI_TASK_RUN_SEPARATOR).join(refreshJobStatus.getRefreshedPartitionEnds())));
+        // basePartitionsToRefreshMapString
+        addField(resultRow, (Joiner.on(MULTI_TASK_RUN_SEPARATOR)
+                .join(refreshJobStatus.getRefreshedBasePartitionsToRefreshMaps())));
+        // mvPartitionsToRefreshString
+        addField(resultRow, (Joiner.on(MULTI_TASK_RUN_SEPARATOR)
+                .join(refreshJobStatus.getRefreshedMvPartitionsToRefreshs())));
+        // error code
+        addField(resultRow, refreshJobStatus.getErrorCode());
+        // error message
+        addField(resultRow, Strings.nullToEmpty(refreshJobStatus.getErrorMsg()));
 
-            MVTaskRunExtraMessage extraMessage = lastTaskRunStatus.getMvTaskRunExtraMessage();
-            if (extraMessage != null) {
-                // Add additional task run information fields
-                addField(resultRow, extraMessage.isForceRefresh() ? "true" : "false");
-                addField(resultRow, Strings.nullToEmpty(extraMessage.getPartitionStart()));
-                addField(resultRow, Strings.nullToEmpty(extraMessage.getPartitionEnd()));
-                addField(resultRow, Strings.nullToEmpty(extraMessage.getBasePartitionsToRefreshMapString()));
-                addField(resultRow, Strings.nullToEmpty(extraMessage.getMvPartitionsToRefreshString()));
-            } else {
-                // If there is no additional task run information, fill with empty fields
-                addEmptyFields(resultRow, 5);
-            }
-
-            addField(resultRow, lastTaskRunStatus.getErrorCode());
-            addField(resultRow, Strings.nullToEmpty(lastTaskRunStatus.getErrorMessage()));
-        } else {
-            // If there is no task run status, fill with empty fields
-            addEmptyFields(resultRow, 13);
-        }
-
+        // rows
         addField(resultRow, rows);
+        // text
         addField(resultRow, text);
+        // extra message
+        addField(resultRow, refreshJobStatus.getExtraMessage() == null ? "" :
+                GsonUtils.GSON.toJson(refreshJobStatus.getExtraMessage()));
 
         return resultRow;
     }
@@ -266,12 +570,8 @@ public class ShowMaterializedViewStatus {
         resultRow.addAll(Collections.nCopies(count, ""));
     }
 
-    // Calculate refresh duration
-    private String calculateRefreshDuration(TaskRunStatus taskRunStatus) {
-        if (taskRunStatus.getFinishTime() > taskRunStatus.getCreateTime()) {
-            return DebugUtil.DECIMAL_FORMAT_SCALE_3
-                    .format((taskRunStatus.getFinishTime() - taskRunStatus.getCreateTime()) / 1000D);
-        }
-        return "0.000";
+
+    private String formatDuration(long duration) {
+        return DebugUtil.DECIMAL_FORMAT_SCALE_3.format(duration / 1000D);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
@@ -15,16 +15,30 @@
 
 package com.starrocks.scheduler;
 
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.persist.gson.GsonUtils;
+
 import java.util.Map;
 
 public class ExecuteOption {
 
+    @SerializedName("priority")
     private int priority = Constants.TaskRunPriority.LOWEST.value();
-    private boolean mergeRedundant = false;
+
+    @SerializedName("taskRunProperties")
     private Map<String, String> taskRunProperties;
+
+    @SerializedName("isMergeRedundant")
+    private boolean isMergeRedundant = false;
     // indicates whether the current execution is manual
+
+    @SerializedName("isManual")
     private boolean isManual = false;
+    @SerializedName("isSync")
     private boolean isSync = false;
+
+    @SerializedName("isReplay")
+    private boolean isReplay = false;
 
     public ExecuteOption() {
     }
@@ -33,9 +47,9 @@ public class ExecuteOption {
         this.priority = priority;
     }
 
-    public ExecuteOption(int priority, boolean mergeRedundant, Map<String, String> taskRunProperties) {
+    public ExecuteOption(int priority, boolean isMergeRedundant, Map<String, String> taskRunProperties) {
         this.priority = priority;
-        this.mergeRedundant = mergeRedundant;
+        this.isMergeRedundant = isMergeRedundant;
         this.taskRunProperties = taskRunProperties;
     }
 
@@ -50,11 +64,11 @@ public class ExecuteOption {
     public boolean isMergeRedundant() {
         // If old task run is a sync-mode task, skip to merge it to avoid sync-mode task
         // hanging after removing it.
-        return !isSync && mergeRedundant;
+        return !isSync && isMergeRedundant;
     }
 
     public void setMergeRedundant(boolean mergeRedundant) {
-        this.mergeRedundant = mergeRedundant;
+        this.isMergeRedundant = mergeRedundant;
     }
 
     public Map<String, String> getTaskRunProperties() {
@@ -77,11 +91,16 @@ public class ExecuteOption {
         this.isSync = isSync;
     }
 
+    public boolean isReplay() {
+        return isReplay;
+    }
+
+    public void setReplay(boolean replay) {
+        isReplay = replay;
+    }
+
     @Override
     public String toString() {
-        return String.format("ExecuteOption{priority=%s, mergeRedundant=%s, isManual=%s, " +
-                        "isSync=%s, taskRunProperties={%s}}",
-                priority, mergeRedundant, isManual, isSync, taskRunProperties
-        );
+        return GsonUtils.GSON.toJson(this);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -592,6 +592,14 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
         newProperties.put(TaskRun.PARTITION_START, mvContext.getNextPartitionStart());
         newProperties.put(TaskRun.PARTITION_END, mvContext.getNextPartitionEnd());
+        if (mvContext.getStatus() != null) {
+            newProperties.put(TaskRun.START_TASK_RUN_ID, mvContext.getStatus().getStartTaskRunId());
+        }
+        updateTaskRunStatus(status -> {
+            MVTaskRunExtraMessage extraMessage = status.getMvTaskRunExtraMessage();
+            extraMessage.setNextPartitionStart(mvContext.getNextPartitionStart());
+            extraMessage.setNextPartitionEnd(mvContext.getNextPartitionEnd());
+        });
 
         // Partition refreshing task run should have the HIGHEST priority, and be scheduled before other tasks
         // Otherwise this round of partition refreshing would be staved and never got finished
@@ -887,6 +895,13 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         // should keep up with the base tables, or it will return outdated result.
         oldTransactionVisibleWaitTimeout = context.ctx.getSessionVariable().getTransactionVisibleWaitTimeout();
         context.ctx.getSessionVariable().setTransactionVisibleWaitTimeout(Long.MAX_VALUE / 1000);
+
+        // Initialize status's job id which is used to track a batch of task runs.
+        String jobId = properties.containsKey(TaskRun.START_TASK_RUN_ID) ?
+                properties.get(TaskRun.START_TASK_RUN_ID) : context.getTaskRunId();
+        if (context.status != null) {
+            context.status.setStartTaskRunId(jobId);
+        }
 
         mvContext = new MvTaskRunContext(context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -47,6 +47,7 @@ import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.optimizer.Utils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.parquet.Strings;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -60,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -634,43 +636,54 @@ public class TaskManager {
      * PendingTaskRunMap > RunningTaskRunMap > TaskRunHistory
      * TODO: Maybe only return needed MVs rather than all MVs.
      */
-    public Map<String, TaskRunStatus> showMVLastRefreshTaskRunStatus(String dbName) {
-        Map<String, TaskRunStatus> mvNameRunStatusMap = Maps.newHashMap();
-        if (dbName == null) {
-            for (Queue<TaskRun> pTaskRunQueue : taskRunManager.getPendingTaskRunMap().values()) {
-                pTaskRunQueue.stream()
-                        .filter(task -> task.getTask().getSource() == Constants.TaskSource.MV)
-                        .map(TaskRun::getStatus)
-                        .filter(Objects::nonNull)
-                        .forEach(task -> mvNameRunStatusMap.putIfAbsent(task.getTaskName(), task));
-            }
-            taskRunManager.getTaskRunHistory().getAllHistory()
-                    .forEach(task -> mvNameRunStatusMap.putIfAbsent(task.getTaskName(), task));
-            // use Map::put to make running task status overwrite the pending task
-            taskRunManager.getRunningTaskRunMap().values().stream()
+    public Map<String, List<TaskRunStatus>> listMVRefreshedTaskRunStatus(String dbName,
+                                                                         Set<String> taskNames) {
+        Map<String, List<TaskRunStatus>> mvNameRunStatusMap = Maps.newHashMap();
+        for (Queue<TaskRun> pTaskRunQueue : taskRunManager.getPendingTaskRunMap().values()) {
+            pTaskRunQueue.stream()
                     .filter(task -> task.getTask().getSource() == Constants.TaskSource.MV)
                     .map(TaskRun::getStatus)
                     .filter(Objects::nonNull)
-                    .forEach(task -> mvNameRunStatusMap.put(task.getTaskName(), task));
-        } else {
-            for (Queue<TaskRun> pTaskRunQueue : taskRunManager.getPendingTaskRunMap().values()) {
-                pTaskRunQueue.stream()
-                        .filter(task -> task.getTask().getSource() == Constants.TaskSource.MV)
-                        .map(TaskRun::getStatus)
-                        .filter(Objects::nonNull)
-                        .filter(u -> u.getDbName().equals(dbName))
-                        .forEach(task -> mvNameRunStatusMap.putIfAbsent(task.getTaskName(), task));
-            }
-            taskRunManager.getTaskRunHistory().getAllHistory().stream()
-                    .filter(u -> u.getDbName().equals(dbName))
-                    .forEach(task -> mvNameRunStatusMap.putIfAbsent(task.getTaskName(), task));
-            taskRunManager.getRunningTaskRunMap().values().stream()
-                    .filter(task -> task.getTask().getSource() == Constants.TaskSource.MV)
-                    .map(TaskRun::getStatus)
-                    .filter(u -> u != null && u.getDbName().equals(dbName))
-                    .forEach(task -> mvNameRunStatusMap.put(task.getTaskName(), task));
+                    .filter(u -> dbName == null || u.getDbName().equals(dbName))
+                    .filter(task -> taskNames == null || taskNames.contains(task.getTaskName()))
+                    .forEach(task -> mvNameRunStatusMap.computeIfAbsent(task.getTaskName(), x -> Lists.newArrayList()).add(task));
         }
+
+        // Add a batch of task runs with the same job id
+        taskRunManager.getTaskRunHistory().getAllHistory().stream()
+                .filter(u -> dbName == null || u.getDbName().equals(dbName))
+                .filter(task -> taskNames == null || taskNames.contains(task.getTaskName()))
+                .filter(task -> isSameTaskRunJob(task, mvNameRunStatusMap))
+                .forEach(task -> mvNameRunStatusMap
+                        .computeIfAbsent(task.getTaskName(), x -> Lists.newArrayList())
+                        .add(task));
+
+        taskRunManager.getRunningTaskRunMap().values().stream()
+                .filter(task -> task.getTask().getSource() == Constants.TaskSource.MV)
+                .map(TaskRun::getStatus)
+                .filter(u -> dbName == null || u != null && u.getDbName().equals(dbName))
+                .filter(task -> taskNames == null || taskNames.contains(task.getTaskName()))
+                .filter(task -> isSameTaskRunJob(task, mvNameRunStatusMap))
+                .forEach(task -> mvNameRunStatusMap.computeIfAbsent(task.getTaskName(), x -> Lists.newArrayList()).add(task));
         return mvNameRunStatusMap;
+    }
+
+    private boolean isSameTaskRunJob(TaskRunStatus taskRunStatus,
+                                     Map<String, List<TaskRunStatus>> mvNameRunStatusMap) {
+        // 1. if task status has already existed, existed task run status's job id is not null, find the same job id.
+        // 2. otherwise, add it to the result.
+        if (!mvNameRunStatusMap.containsKey(taskRunStatus.getTaskName())) {
+            return true;
+        }
+        List<TaskRunStatus> existedTaskRuns = mvNameRunStatusMap.get(taskRunStatus.getTaskName());
+        if (existedTaskRuns == null || existedTaskRuns.isEmpty()) {
+            return true;
+        }
+        if (!Config.enable_show_materialized_views_include_all_task_runs) {
+            return false;
+        }
+        String jobId = taskRunStatus.getStartTaskRunId();
+        return !Strings.isNullOrEmpty(jobId) && jobId.equals(existedTaskRuns.get(0).getStartTaskRunId());
     }
 
     public void replayCreateTaskRun(TaskRunStatus status) {
@@ -691,7 +704,14 @@ public class TaskManager {
                     LOG.warn("fail to obtain task name {} because task is null", taskName);
                     return;
                 }
-                TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                ExecuteOption executeOption = new ExecuteOption();
+                executeOption.setReplay(true);
+                TaskRun taskRun = TaskRunBuilder
+                        .newBuilder(task)
+                        .setExecuteOption(executeOption)
+                        .build();
+
+                // TODO: To avoid the same query id collision, use a new query id instead of an old query id
                 taskRun.initStatus(status.getQueryId(), status.getCreateTime());
                 taskRunManager.arrangeTaskRun(taskRun);
                 break;
@@ -905,6 +925,10 @@ public class TaskManager {
         } finally {
             taskUnlock();
         }
+    }
+
+    public Task getTaskWithoutLock(String taskName) {
+        return nameToTaskMap.get(taskName);
     }
 
     public long getTaskCount() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunContext.java
@@ -29,6 +29,7 @@ public class TaskRunContext {
     Constants.TaskType type;
     TaskRunStatus status;
     ExecuteOption executeOption;
+    String taskRunId;
 
     public TaskRunContext() {
     }
@@ -43,6 +44,7 @@ public class TaskRunContext {
         this.type = context.type;
         this.status = context.status;
         this.executeOption = context.executeOption;
+        this.taskRunId = context.taskRunId;
     }
 
     public ConnectContext getCtx() {
@@ -115,5 +117,13 @@ public class TaskRunContext {
 
     public void setExecuteOption(ExecuteOption executeOption) {
         this.executeOption = executeOption;
+    }
+
+    public String getTaskRunId() {
+        return taskRunId;
+    }
+
+    public void setTaskRunId(String uuid) {
+        this.taskRunId = uuid;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -46,6 +46,8 @@ public class TaskRunExecutor {
 
         CompletableFuture<Constants.TaskRunState> future = CompletableFuture.supplyAsync(() -> {
             status.setState(Constants.TaskRunState.RUNNING);
+            // set process start time
+            status.setProcessStartTime(System.currentTimeMillis());
             try {
                 boolean isSuccess = taskRun.executeTaskRun();
                 if (isSuccess) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Queue;
@@ -42,7 +43,8 @@ public class TaskRunManager {
 
     // taskId -> pending TaskRun Queue, for each Task only support 1 running taskRun currently,
     // so the map value is priority queue need to be sorted by priority from large to small
-    private final Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = Maps.newConcurrentMap();
+    private final Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap =
+            Collections.synchronizedMap(Maps.newLinkedHashMap());
 
     // taskId -> running TaskRun, for each Task only support 1 running taskRun currently,
     // so the map value is not queue
@@ -137,7 +139,7 @@ public class TaskRunManager {
                     // and queryId will be changed.
                     if (!oldTaskRun.equals(taskRun)) {
                         LOG.warn("failed to remove TaskRun definition is [{}]",
-                                taskRun.getStatus().getDefinition());
+                                taskRun);
                         continue;
                     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/persist/MVTaskRunExtraMessage.java
@@ -22,6 +22,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.scheduler.ExecuteOption;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.DataInput;
@@ -47,6 +48,14 @@ public class MVTaskRunExtraMessage implements Writable {
     // refreshed partitions of all the base tables which are optimized by optimizer and the real partitions in executing.
     @SerializedName("basePartitionsToRefreshMap")
     private Map<String, Set<String>> basePartitionsToRefreshMap = Maps.newHashMap();
+
+    @SerializedName("nextPartitionStart")
+    private String nextPartitionStart;
+    @SerializedName("nextPartitionEnd")
+    private String nextPartitionEnd;
+
+    @SerializedName("executeOption")
+    private ExecuteOption executeOption = new ExecuteOption();
 
     public MVTaskRunExtraMessage() {
     }
@@ -124,6 +133,29 @@ public class MVTaskRunExtraMessage implements Writable {
         return GsonUtils.GSON.fromJson(json, MVTaskRunExtraMessage.class);
     }
 
+    public ExecuteOption getExecuteOption() {
+        return executeOption;
+    }
+
+    public void setExecuteOption(ExecuteOption executeOption) {
+        this.executeOption = executeOption;
+    }
+
+    public String getNextPartitionStart() {
+        return nextPartitionStart;
+    }
+
+    public void setNextPartitionStart(String nextPartitionStart) {
+        this.nextPartitionStart = nextPartitionStart;
+    }
+
+    public String getNextPartitionEnd() {
+        return nextPartitionEnd;
+    }
+
+    public void setNextPartitionEnd(String nextPartitionEnd) {
+        this.nextPartitionEnd = nextPartitionEnd;
+    }
 
     @Override
     public void write(DataOutput out) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowMaterializedViewsStmt.java
@@ -63,6 +63,7 @@ public class ShowMaterializedViewsStmt extends ShowStmt {
                     .column("last_refresh_error_message", ScalarType.createVarchar(1024))
                     .column("rows", ScalarType.createVarchar(50))
                     .column("text", ScalarType.createVarchar(1024))
+                    .column("extra_message", ScalarType.createVarchar(1024))
                     .build();
 
     private static final Map<String, String> ALIAS_MAP = ImmutableMap.of(

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -113,7 +113,8 @@ public class ShowMaterializedViewTest {
                         "information_schema.materialized_views.last_refresh_error_code AS last_refresh_error_code, " +
                         "information_schema.materialized_views.last_refresh_error_message AS last_refresh_error_message, " +
                         "information_schema.materialized_views.TABLE_ROWS AS rows, " +
-                        "information_schema.materialized_views.MATERIALIZED_VIEW_DEFINITION AS text " +
+                        "information_schema.materialized_views.MATERIALIZED_VIEW_DEFINITION AS text, " +
+                        "information_schema.materialized_views.extra_message AS extra_message " +
                         "FROM information_schema.materialized_views " +
                         "WHERE (information_schema.materialized_views.TABLE_SCHEMA = 'abc') AND (information_schema.materialized_views.TABLE_NAME = 'mv1')",
                 AstToStringBuilder.toString(stmt.toSelectStmt()));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -981,11 +981,21 @@ public class ShowExecutorTest {
         Assert.assertEquals("true", resultSet.getString(4));
         Assert.assertEquals("", resultSet.getString(5));
         Assert.assertEquals("RANGE", resultSet.getString(6));
-        for (int i = 6; i < mvSchemaTable.size() - 2; i++) {
-            Assert.assertEquals("", resultSet.getString(7));
+        Assert.assertEquals("0", resultSet.getString(7));
+        Assert.assertEquals("", resultSet.getString(8));
+        Assert.assertEquals("\\N", resultSet.getString(9));
+        Assert.assertEquals("\\N", resultSet.getString(10));
+        Assert.assertEquals("0.000", resultSet.getString(11));
+        Assert.assertEquals("", resultSet.getString(12));
+        Assert.assertEquals("false", resultSet.getString(13));
+        System.out.println(resultSet.getResultRows());
+        for (int i = 14; i < mvSchemaTable.size() - 3; i++) {
+            System.out.println(i);
+            Assert.assertEquals("", resultSet.getString(i));
         }
-        Assert.assertEquals("10", resultSet.getString(mvSchemaTable.size() - 2));
-        Assert.assertEquals(expectedSqlText, resultSet.getString(mvSchemaTable.size() - 1));
+        Assert.assertEquals("10", resultSet.getString(mvSchemaTable.size() - 3));
+        Assert.assertEquals(expectedSqlText, resultSet.getString(mvSchemaTable.size() - 2));
+        Assert.assertEquals("", resultSet.getString(mvSchemaTable.size() - 1));
         Assert.assertFalse(resultSet.next());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -39,8 +39,10 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.ShowMaterializedViewStatus;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
+import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.LoadPlanner;
@@ -3596,12 +3598,13 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                     // without db name
                     Assert.assertFalse(tm.showTaskRunStatus(null).isEmpty());
                     Assert.assertFalse(tm.showTasks(null).isEmpty());
-                    Assert.assertFalse(tm.showMVLastRefreshTaskRunStatus(null).isEmpty());
+                    Assert.assertFalse(tm.listMVRefreshedTaskRunStatus(null, null).isEmpty());
+
 
                     // specific db
                     Assert.assertFalse(tm.showTaskRunStatus(TEST_DB_NAME).isEmpty());
                     Assert.assertFalse(tm.showTasks(TEST_DB_NAME).isEmpty());
-                    Assert.assertFalse(tm.showMVLastRefreshTaskRunStatus(TEST_DB_NAME).isEmpty());
+                    Assert.assertFalse(tm.listMVRefreshedTaskRunStatus(TEST_DB_NAME, null).isEmpty());
 
                     long taskId = tm.getTask(TaskBuilder.getMvTaskName(materializedView.getId())).getId();
                     Assert.assertNotNull(tm.getTaskRunManager().getRunnableTaskRun(taskId));
@@ -3809,6 +3812,376 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                                                 extraMessage.getBasePartitionsToRefreshMap().get("mock_tbl"));
                                         Assert.assertTrue(processor.getNextTaskRun() == null);
                                     }
+                                }
+                            });
+                }
+        );
+    }
+
+
+    @Test
+    public void testShowMaterializedViewsWithNonForce() {
+        MTable mTable = new MTable("mockTbl", "k2",
+                List.of(
+                        "k1 date",
+                        "k2 int",
+                        "v1 int"
+                ),
+                "k1",
+                List.of(
+                        "PARTITION p0 values [('2021-12-01'),('2022-01-01'))",
+                        "PARTITION p1 values [('2022-01-01'),('2022-02-01'))",
+                        "PARTITION p2 values [('2022-02-01'),('2022-03-01'))",
+                        "PARTITION p3 values [('2022-03-01'),('2022-04-01'))"
+                )
+        ).withValues(List.of(
+                "('2021-12-02',2,10)",
+                "('2022-01-02',2,10)",
+                "('2022-02-02',2,10)"
+        ));
+        starRocksAssert.withTable(mTable,
+                () -> {
+                    starRocksAssert.withMaterializedView("create materialized view mock_mv0 \n" +
+                                    "partition by k1 \n" +
+                                    "distributed by hash(k2) buckets 10\n" +
+                                    "refresh deferred manual\n" +
+                                    "properties(" +
+                                    "   'replication_num' = '1', " +
+                                    "   'partition_refresh_number'='1'" +
+                                    ")\n" +
+                                    "as select k1, k2 from mockTbl;",
+                            () -> {
+                                String mvName = "mock_mv0";
+                                Database testDb = GlobalStateMgr.getCurrentState().getDb(TEST_DB_NAME);
+                                MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                                TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+
+                                executeInsertSql(connectContext, mTable.getGenerateDataSQL());
+
+                                // refresh materialized view(non force)
+                                starRocksAssert.refreshMV(String.format("REFRESH MATERIALIZED VIEW %s", mvName));
+
+                                // without db name
+                                Assert.assertFalse(tm.listMVRefreshedTaskRunStatus(null, null).isEmpty());
+
+                                // specific db
+                                Assert.assertFalse(tm.listMVRefreshedTaskRunStatus(TEST_DB_NAME, null).isEmpty());
+
+                                String mvTaskName = TaskBuilder.getMvTaskName(materializedView.getId());
+                                Map<String, List<TaskRunStatus>> taskNameJobStatusMap =
+                                        tm.listMVRefreshedTaskRunStatus(TEST_DB_NAME, Set.of(mvTaskName));
+                                System.out.println(taskNameJobStatusMap);
+                                Assert.assertFalse(taskNameJobStatusMap.isEmpty());
+                                Assert.assertEquals(1, taskNameJobStatusMap.size());
+                                // refresh 4 times
+                                Assert.assertEquals(4, taskNameJobStatusMap.get(mvTaskName).size());
+
+                                ShowMaterializedViewStatus status =
+                                        new ShowMaterializedViewStatus(materializedView.getId(), TEST_DB_NAME,
+                                                materializedView.getName());
+                                status.setLastJobTaskRunStatus(taskNameJobStatusMap.get(mvTaskName));
+                                ShowMaterializedViewStatus.RefreshJobStatus refreshJobStatus = status.getRefreshJobStatus();
+                                System.out.println(refreshJobStatus);
+                                Assert.assertEquals(refreshJobStatus.isForce(), false);
+                                Assert.assertEquals(refreshJobStatus.isRefreshFinished(), true);
+                                Assert.assertEquals(refreshJobStatus.getRefreshState(), Constants.TaskRunState.SUCCESS);
+                                Assert.assertEquals(refreshJobStatus.getErrorCode(), "0");
+                                Assert.assertEquals(refreshJobStatus.getErrorMsg(), "");
+                                Assert.assertEquals("[NULL, 2022-01-01, 2022-02-01, 2022-03-01]",
+                                        refreshJobStatus.getRefreshedPartitionStarts().toString());
+                                Assert.assertEquals("[NULL, 2022-04-01, 2022-04-01, 2022-04-01]",
+                                        refreshJobStatus.getRefreshedPartitionEnds().toString());
+                                Assert.assertEquals("[{mockTbl=[p0]}, {mockTbl=[p1]}, {mockTbl=[p2]}, {mockTbl=[p3]}]",
+                                        refreshJobStatus.getRefreshedBasePartitionsToRefreshMaps().toString());
+                                Assert.assertEquals("[[p0], [p1], [p2], [p3]]",
+                                        refreshJobStatus.getRefreshedMvPartitionsToRefreshs().toString());
+                            });
+                }
+        );
+    }
+
+    @Test
+    public void testShowMaterializedViewsWithPartialRefresh() {
+        MTable mTable = new MTable("mockTbl", "k2",
+                List.of(
+                        "k1 date",
+                        "k2 int",
+                        "v1 int"
+                ),
+                "k1",
+                List.of(
+                        "PARTITION p0 values [('2021-12-01'),('2022-01-01'))",
+                        "PARTITION p1 values [('2022-01-01'),('2022-02-01'))",
+                        "PARTITION p2 values [('2022-02-01'),('2022-03-01'))",
+                        "PARTITION p3 values [('2022-03-01'),('2022-04-01'))"
+                )
+        ).withValues(List.of(
+                "('2021-12-02',2,10)",
+                "('2022-01-02',2,10)",
+                "('2022-02-02',2,10)"
+        ));
+        starRocksAssert.withTable(mTable,
+                () -> {
+                    starRocksAssert.withMaterializedView("create materialized view mock_mv0 \n" +
+                                    "partition by k1 \n" +
+                                    "distributed by hash(k2) buckets 10\n" +
+                                    "refresh deferred manual\n" +
+                                    "properties(" +
+                                    "   'replication_num' = '1', " +
+                                    "   'partition_refresh_number'='1'" +
+                                    ")\n" +
+                                    "as select k1, k2 from mockTbl;",
+                            () -> {
+                                String mvName = "mock_mv0";
+                                Database testDb = GlobalStateMgr.getCurrentState().getDb(TEST_DB_NAME);
+                                MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                                TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+
+                                executeInsertSql(connectContext, mTable.getGenerateDataSQL());
+
+                                // refresh materialized view(non force)
+                                starRocksAssert.refreshMV(String.format("REFRESH MATERIALIZED VIEW %s\n" +
+                                        "PARTITION START (\"%s\") END (\"%s\")", mvName, "2021-12-01", "2022-02-01"));
+
+                                // without db name
+                                Assert.assertFalse(tm.listMVRefreshedTaskRunStatus(null, null).isEmpty());
+
+                                // specific db
+                                Assert.assertFalse(tm.listMVRefreshedTaskRunStatus(TEST_DB_NAME, null).isEmpty());
+
+                                String mvTaskName = TaskBuilder.getMvTaskName(materializedView.getId());
+                                Map<String, List<TaskRunStatus>> taskNameJobStatusMap =
+                                        tm.listMVRefreshedTaskRunStatus(TEST_DB_NAME, Set.of(mvTaskName));
+                                System.out.println(taskNameJobStatusMap);
+                                Assert.assertFalse(taskNameJobStatusMap.isEmpty());
+                                Assert.assertEquals(1, taskNameJobStatusMap.size());
+                                // refresh 4 times
+                                Assert.assertEquals(2, taskNameJobStatusMap.get(mvTaskName).size());
+
+                                ShowMaterializedViewStatus status =
+                                        new ShowMaterializedViewStatus(materializedView.getId(), TEST_DB_NAME,
+                                                materializedView.getName());
+                                status.setLastJobTaskRunStatus(taskNameJobStatusMap.get(mvTaskName));
+                                ShowMaterializedViewStatus.RefreshJobStatus refreshJobStatus = status.getRefreshJobStatus();
+                                System.out.println(refreshJobStatus);
+                                Assert.assertEquals(refreshJobStatus.isForce(), false);
+                                Assert.assertEquals(refreshJobStatus.isRefreshFinished(), true);
+                                Assert.assertEquals(refreshJobStatus.getRefreshState(), Constants.TaskRunState.SUCCESS);
+                                Assert.assertEquals(refreshJobStatus.getErrorCode(), "0");
+                                Assert.assertEquals(refreshJobStatus.getErrorMsg(), "");
+                                Assert.assertEquals("[2021-12-01, 2022-01-01]",
+                                        refreshJobStatus.getRefreshedPartitionStarts().toString());
+                                Assert.assertEquals("[2022-02-01, 2022-02-01]",
+                                        refreshJobStatus.getRefreshedPartitionEnds().toString());
+                                Assert.assertEquals("[{mockTbl=[p0]}, {mockTbl=[p1]}]",
+                                        refreshJobStatus.getRefreshedBasePartitionsToRefreshMaps().toString());
+                                Assert.assertEquals("[[p0], [p1]]",
+                                        refreshJobStatus.getRefreshedMvPartitionsToRefreshs().toString());
+                            });
+                }
+        );
+    }
+
+    @Test
+    public void testShowMaterializedViewsWithForce() {
+        starRocksAssert.withTable(new MTable("mockTbl", "k2",
+                        List.of(
+                                "k1 date",
+                                "k2 int",
+                                "v1 int"
+                        ),
+                        "k1",
+                        List.of(
+                                "PARTITION p0 values [('2021-12-01'),('2022-01-01'))",
+                                "PARTITION p1 values [('2022-01-01'),('2022-02-01'))",
+                                "PARTITION p2 values [('2022-02-01'),('2022-03-01'))"
+                        )
+                ).withValues(List.of(
+                        "'2021-12-02',2,10",
+                        "'2022-01-02',2,10",
+                        "'2022-02-02',2,10"
+                )),
+                () -> {
+                    starRocksAssert.withMaterializedView("create materialized view mock_mv0 \n" +
+                                    "partition by k1 \n" +
+                                    "distributed by hash(k2) buckets 10\n" +
+                                    "refresh deferred manual\n" +
+                                    "properties(" +
+                                    "   'replication_num' = '1', " +
+                                    "   'partition_refresh_number'='1'" +
+                                    ")\n" +
+                                    "as select k1, k2 from mockTbl;",
+                            () -> {
+                                String mvName = "mock_mv0";
+                                Database testDb = GlobalStateMgr.getCurrentState().getDb(TEST_DB_NAME);
+                                MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+                                TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
+
+                                // refresh materialized view(force)
+                                refreshMVRange(mvName, "2021-12-01", "2022-03-01", true);
+
+                                // without db name
+                                Assert.assertFalse(tm.listMVRefreshedTaskRunStatus(null, null).isEmpty());
+
+                                // specific db
+                                Assert.assertFalse(tm.listMVRefreshedTaskRunStatus(TEST_DB_NAME, null).isEmpty());
+
+                                String mvTaskName = TaskBuilder.getMvTaskName(materializedView.getId());
+                                Map<String, List<TaskRunStatus>> taskNameJobStatusMap =
+                                        tm.listMVRefreshedTaskRunStatus(TEST_DB_NAME, Set.of(mvTaskName));
+                                System.out.println(taskNameJobStatusMap);
+                                Assert.assertFalse(taskNameJobStatusMap.isEmpty());
+                                Assert.assertEquals(1, taskNameJobStatusMap.size());
+
+                                ShowMaterializedViewStatus status =
+                                        new ShowMaterializedViewStatus(materializedView.getId(), TEST_DB_NAME,
+                                                materializedView.getName());
+                                status.setLastJobTaskRunStatus(taskNameJobStatusMap.get(mvTaskName));
+                                ShowMaterializedViewStatus.RefreshJobStatus refreshJobStatus = status.getRefreshJobStatus();
+                                System.out.println(refreshJobStatus);
+                                Assert.assertEquals(refreshJobStatus.isForce(), true);
+                                Assert.assertEquals(refreshJobStatus.isRefreshFinished(), true);
+                                Assert.assertEquals(refreshJobStatus.getRefreshState(), Constants.TaskRunState.SUCCESS);
+                                Assert.assertEquals(refreshJobStatus.getErrorCode(), "0");
+                                Assert.assertEquals(refreshJobStatus.getErrorMsg(), "");
+                            });
+                }
+        );
+    }
+
+    @Test
+    public void testMVRefreshStatus() {
+        starRocksAssert.withTables(List.of(
+                        new MTable("tt1", "k1",
+                                List.of(
+                                        "k1 date",
+                                        "k2 int",
+                                        "v1 int"
+                                ),
+
+                                "k1",
+                                List.of(
+                                        "PARTITION p0 values [('2021-12-01'),('2022-01-01'))",
+                                        "PARTITION p1 values [('2022-01-01'),('2022-02-01'))",
+                                        "PARTITION p2 values [('2022-02-01'),('2022-03-01'))",
+                                        "PARTITION p3 values [('2022-03-01'),('2022-04-01'))",
+                                        "PARTITION p4 values [('2022-04-01'),('2022-05-01'))"
+                                )
+                        ),
+                        new MTable("tt2", "k1",
+                                List.of(
+                                        "k1 date",
+                                        "k2 int",
+                                        "v1 int"
+                                ),
+
+                                "k1",
+                                List.of(
+                                        "PARTITION p0 values [('2021-12-01'),('2022-01-01'))",
+                                        "PARTITION p1 values [('2022-01-01'),('2022-02-01'))",
+                                        "PARTITION p2 values [('2022-02-01'),('2022-03-01'))",
+                                        "PARTITION p3 values [('2022-03-01'),('2022-04-01'))",
+                                        "PARTITION p4 values [('2022-04-01'),('2022-05-01'))"
+                                )
+                        )
+                ),
+                () -> {
+                    starRocksAssert.withMaterializedView("create materialized view mv_with_join0\n" +
+                                    "partition by k1\n" +
+                                    "distributed by hash(k2) buckets 10\n" +
+                                    "PROPERTIES('partition_refresh_number' = '1')" +
+                                    "refresh deferred manual\n" +
+                                    "as select a.k1, b.k2 from tt1 a join tt2 b on a.k1=b.k1;",
+                            () -> {
+                                Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+
+                                MaterializedView materializedView =
+                                        ((MaterializedView) testDb.getTable("mv_with_join0"));
+                                Assert.assertEquals(2, materializedView.getPartitionExprMaps().size());
+                                Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+                                Map<String, String> testProperties = task.getProperties();
+                                testProperties.put(TaskRun.IS_TEST, "true");
+
+                                TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+                                taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+                                taskRun.executeTaskRun();
+
+                                executeInsertSql(connectContext,
+                                        "insert into tt1 partition(p1) values('2022-01-02', 3, 10);");
+                                executeInsertSql(connectContext,
+                                        "insert into tt1 partition(p2) values('2022-02-03', 3, 10);");
+
+                                String jobID = "";
+                                {
+                                    TaskRunStatus taskRunStatus =
+                                            taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+                                    taskRun.executeTaskRun();
+                                    taskRunStatus.setState(Constants.TaskRunState.SUCCESS);
+                                    MvTaskRunContext mvContext =
+                                            ((PartitionBasedMvRefreshProcessor) taskRun.getProcessor()).getMvContext();
+                                    Assert.assertTrue(mvContext.hasNextBatchPartition());
+                                    PartitionBasedMvRefreshProcessor processor =
+                                            (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+                                    Assert.assertEquals(Sets.newHashSet("p1"),
+                                            processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+
+                                    Assert.assertEquals(taskRunStatus.getStartTaskRunId(), taskRun.getUUID());
+
+                                    jobID = taskRunStatus.getStartTaskRunId();
+                                    {
+                                        MVTaskRunExtraMessage extraMessage = taskRunStatus.getMvTaskRunExtraMessage();
+                                        System.out.println(extraMessage);
+                                        Assert.assertTrue(extraMessage != null);
+                                        Assert.assertTrue(extraMessage.getPartitionStart() == null);
+                                        Assert.assertTrue(extraMessage.getPartitionEnd() == null);
+                                        Assert.assertEquals(extraMessage.getNextPartitionStart(), "2022-02-01");
+                                        Assert.assertEquals(extraMessage.getNextPartitionEnd(), "2022-03-01");
+
+
+                                        Assert.assertTrue(extraMessage.getExecuteOption() != null);
+                                        Assert.assertFalse(extraMessage.getExecuteOption().isMergeRedundant());
+                                        Assert.assertFalse(extraMessage.getExecuteOption().isReplay());
+                                    }
+
+                                    Assert.assertFalse(taskRunStatus.isRefreshFinished());
+                                    Assert.assertEquals(String.valueOf(taskRunStatus.getLastRefreshState()), "RUNNING");
+
+                                    taskRun = processor.getNextTaskRun();
+                                    Assert.assertTrue(taskRun != null);
+                                }
+
+                                {
+                                    TaskRunStatus taskRunStatus =
+                                            taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+                                    taskRun.executeTaskRun();
+                                    taskRunStatus.setState(Constants.TaskRunState.SUCCESS);
+
+                                    MvTaskRunContext mvContext =
+                                            ((PartitionBasedMvRefreshProcessor) taskRun.getProcessor()).getMvContext();
+                                    Assert.assertTrue(!mvContext.hasNextBatchPartition());
+                                    PartitionBasedMvRefreshProcessor processor =
+                                            (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+                                    Assert.assertEquals(Sets.newHashSet("p2"),
+                                            processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+
+                                    Assert.assertEquals(jobID, taskRunStatus.getStartTaskRunId());
+                                    {
+                                        MVTaskRunExtraMessage extraMessage = taskRunStatus.getMvTaskRunExtraMessage();
+                                        System.out.println(extraMessage);
+                                        Assert.assertTrue(extraMessage != null);
+                                        Assert.assertEquals(extraMessage.getPartitionStart(), "2022-02-01");
+                                        Assert.assertEquals(extraMessage.getPartitionEnd(), "2022-03-01");
+                                        Assert.assertTrue(extraMessage.getNextPartitionStart() == null);
+                                        Assert.assertTrue(extraMessage.getNextPartitionEnd() == null);
+                                        Assert.assertTrue(extraMessage.getExecuteOption() != null);
+                                        Assert.assertTrue(extraMessage.getExecuteOption().isMergeRedundant());
+                                        Assert.assertFalse(extraMessage.getExecuteOption().isReplay());
+                                    }
+
+                                    Assert.assertTrue(taskRunStatus.isRefreshFinished());
+                                    Assert.assertEquals(String.valueOf(taskRunStatus.getLastRefreshState()), "SUCCESS");
+                                    taskRun = processor.getNextTaskRun();
+                                    Assert.assertTrue(taskRun == null);
                                 }
                             });
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -56,6 +56,7 @@ public class TaskManagerTest {
     private static StarRocksAssert starRocksAssert;
     private static final ExecuteOption DEFAULT_MERGE_OPTION = makeExecuteOption(true, false);
     private static final ExecuteOption DEFAULT_NO_MERGE_OPTION = makeExecuteOption(false, false);
+
     @Before
     public void setUp() {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
@@ -84,31 +85,31 @@ public class TaskManagerTest {
 
         starRocksAssert.withDatabase("test").useDatabase("test")
                 .withTable("CREATE TABLE test.tbl1\n" +
-                "(\n" +
-                "    k1 date,\n" +
-                "    k2 int,\n" +
-                "    v1 int sum\n" +
-                ")\n" +
-                "PARTITION BY RANGE(k1)\n" +
-                "(\n" +
-                "    PARTITION p1 values less than('2020-02-01'),\n" +
-                "    PARTITION p2 values less than('2020-03-01')\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                "PROPERTIES('replication_num' = '1');")
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values less than('2020-02-01'),\n" +
+                        "    PARTITION p2 values less than('2020-03-01')\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
                 .withTable("CREATE TABLE test.tbl2\n" +
-                "(\n" +
-                "    k1 date,\n" +
-                "    k2 int,\n" +
-                "    v1 int sum\n" +
-                ")\n" +
-                "PARTITION BY RANGE(k1)\n" +
-                "(\n" +
-                "    PARTITION p1 values less than('2020-02-01'),\n" +
-                "    PARTITION p2 values less than('2020-03-01')\n" +
-                ")\n" +
-                "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                "PROPERTIES('replication_num' = '1');");
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p1 values less than('2020-02-01'),\n" +
+                        "    PARTITION p2 values less than('2020-03-01')\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');");
     }
 
     @Test
@@ -213,6 +214,7 @@ public class TaskManagerTest {
 
         TaskRunManager taskRunManager = new TaskRunManager();
         Task task = new Task("test");
+        task.setDefinition("select 1");
 
         long taskId = 1;
 
@@ -223,7 +225,6 @@ public class TaskManagerTest {
         long now = System.currentTimeMillis();
         taskRun1.setTaskId(taskId);
         taskRun1.initStatus("1", now);
-        taskRun1.getStatus().setDefinition("select 1");
         taskRun1.getStatus().setPriority(0);
 
         TaskRun taskRun2 = TaskRunBuilder
@@ -232,7 +233,6 @@ public class TaskManagerTest {
                 .build();
         taskRun2.setTaskId(taskId);
         taskRun2.initStatus("2", now);
-        taskRun2.getStatus().setDefinition("select 1");
         taskRun2.getStatus().setPriority(10);
 
         taskRunManager.arrangeTaskRun(taskRun1);
@@ -251,6 +251,7 @@ public class TaskManagerTest {
 
         TaskRunManager taskRunManager = new TaskRunManager();
         Task task = new Task("test");
+        task.setDefinition("select 1");
 
         long taskId = 1;
 
@@ -261,7 +262,6 @@ public class TaskManagerTest {
         long now = System.currentTimeMillis();
         taskRun1.setTaskId(taskId);
         taskRun1.initStatus("1", now);
-        taskRun1.getStatus().setDefinition("select 1");
         taskRun1.getStatus().setPriority(0);
 
         TaskRun taskRun2 = TaskRunBuilder
@@ -270,7 +270,6 @@ public class TaskManagerTest {
                 .build();
         taskRun2.setTaskId(taskId);
         taskRun2.initStatus("2", now);
-        taskRun2.getStatus().setDefinition("select 1");
         taskRun2.getStatus().setPriority(10);
 
         taskRunManager.arrangeTaskRun(taskRun2);
@@ -289,6 +288,7 @@ public class TaskManagerTest {
 
         TaskRunManager taskRunManager = new TaskRunManager();
         Task task = new Task("test");
+        task.setDefinition("select 1");
 
         long taskId = 1;
 
@@ -299,7 +299,6 @@ public class TaskManagerTest {
         long now = System.currentTimeMillis();
         taskRun1.setTaskId(taskId);
         taskRun1.initStatus("1", now + 10);
-        taskRun1.getStatus().setDefinition("select 1");
         taskRun1.getStatus().setPriority(0);
 
         TaskRun taskRun2 = TaskRunBuilder
@@ -308,7 +307,6 @@ public class TaskManagerTest {
                 .build();
         taskRun2.setTaskId(taskId);
         taskRun2.initStatus("2", now);
-        taskRun2.getStatus().setDefinition("select 1");
         taskRun2.getStatus().setPriority(0);
 
         taskRunManager.arrangeTaskRun(taskRun1);
@@ -327,6 +325,7 @@ public class TaskManagerTest {
 
         TaskRunManager taskRunManager = new TaskRunManager();
         Task task = new Task("test");
+        task.setDefinition("select 1");
 
         long taskId = 1;
 
@@ -337,7 +336,6 @@ public class TaskManagerTest {
         long now = System.currentTimeMillis();
         taskRun1.setTaskId(taskId);
         taskRun1.initStatus("1", now + 10);
-        taskRun1.getStatus().setDefinition("select 1");
         taskRun1.getStatus().setPriority(0);
 
         TaskRun taskRun2 = TaskRunBuilder
@@ -346,7 +344,6 @@ public class TaskManagerTest {
                 .build();
         taskRun2.setTaskId(taskId);
         taskRun2.initStatus("2", now);
-        taskRun2.getStatus().setDefinition("select 1");
         taskRun2.getStatus().setPriority(0);
 
         taskRunManager.arrangeTaskRun(taskRun2);
@@ -365,6 +362,7 @@ public class TaskManagerTest {
 
         TaskRunManager taskRunManager = new TaskRunManager();
         Task task = new Task("test");
+        task.setDefinition("select 1");
 
         long taskId = 1;
 
@@ -375,7 +373,6 @@ public class TaskManagerTest {
         long now = System.currentTimeMillis();
         taskRun1.setTaskId(taskId);
         taskRun1.initStatus("1", now);
-        taskRun1.getStatus().setDefinition("select 1");
         taskRun1.getStatus().setPriority(0);
 
         TaskRun taskRun2 = TaskRunBuilder
@@ -384,7 +381,6 @@ public class TaskManagerTest {
                 .build();
         taskRun2.setTaskId(taskId);
         taskRun2.initStatus("2", now);
-        taskRun2.getStatus().setDefinition("select 1");
         taskRun2.getStatus().setPriority(10);
 
         TaskRun taskRun3 = TaskRunBuilder
@@ -393,7 +389,6 @@ public class TaskManagerTest {
                 .build();
         taskRun3.setTaskId(taskId);
         taskRun3.initStatus("3", now + 10);
-        taskRun3.getStatus().setDefinition("select 1");
         taskRun3.getStatus().setPriority(10);
 
         taskRunManager.arrangeTaskRun(taskRun2);
@@ -408,6 +403,7 @@ public class TaskManagerTest {
     public void testReplayUpdateTaskRunOutOfOrder() {
         TaskManager taskManager = new TaskManager();
         Task task = new Task("test");
+        task.setDefinition("select 1");
         taskManager.replayCreateTask(task);
         long taskId = 1;
 
@@ -415,12 +411,10 @@ public class TaskManagerTest {
         long now = System.currentTimeMillis();
         taskRun1.setTaskId(taskId);
         taskRun1.initStatus("1", now);
-        taskRun1.getStatus().setDefinition("select 1");
 
         TaskRun taskRun2 = TaskRunBuilder.newBuilder(task).build();
         taskRun2.setTaskId(taskId);
         taskRun2.initStatus("2", now);
-        taskRun2.getStatus().setDefinition("select 1");
         taskManager.replayCreateTaskRun(taskRun2.getStatus());
         taskManager.replayCreateTaskRun(taskRun1.getStatus());
 
@@ -484,7 +478,7 @@ public class TaskManagerTest {
         ExecuteOption executeOption = new ExecuteOption();
         executeOption.setMergeRedundant(isMergeRedundant);
         executeOption.setSync(isSync);
-        return  executeOption;
+        return executeOption;
     }
 
     private TaskRun makeTaskRun(long taskId, Task task, ExecuteOption executeOption) {
@@ -558,5 +552,61 @@ public class TaskManagerTest {
         Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.REJECTED);
         pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
         Assert.assertEquals(Config.task_runs_queue_length, pendingTaskRunMap.get(taskId).size());
+    }
+
+
+    @Test
+    public void testTaskEquality() {
+        Task task1 = new Task("test");
+        task1.setDefinition("select 1");
+        task1.setId(1);
+
+        TaskRun taskRun1 = TaskRunBuilder
+                .newBuilder(task1)
+                .setExecuteOption(DEFAULT_MERGE_OPTION)
+                .build();
+        {
+            long now = System.currentTimeMillis();
+            taskRun1.setTaskId(task1.getId());
+            taskRun1.initStatus("1", now + 10);
+            taskRun1.getStatus().setPriority(0);
+        }
+
+        TaskRun taskRun2 = TaskRunBuilder
+                .newBuilder(task1)
+                .setExecuteOption(DEFAULT_MERGE_OPTION)
+                .build();
+        {
+            long now = System.currentTimeMillis();
+            taskRun2.setTaskId(task1.getId());
+            taskRun2.initStatus("1", now + 10);
+            taskRun2.getStatus().setPriority(0);
+            Assert.assertTrue(taskRun1.equals(taskRun2));
+        }
+
+        {
+            long now = System.currentTimeMillis();
+            taskRun2.setTaskId(task1.getId());
+            taskRun2.initStatus("2", now + 10);
+            taskRun2.getStatus().setPriority(10);
+            Assert.assertTrue(taskRun1.equals(taskRun2));
+        }
+        {
+            long now = System.currentTimeMillis();
+            taskRun2.setTaskId(task1.getId());
+            taskRun2.initStatus("2", now + 10);
+            taskRun2.getStatus().setPriority(10);
+            taskRun2.setExecuteOption(DEFAULT_NO_MERGE_OPTION);
+            Assert.assertTrue(taskRun1.equals(taskRun2));
+        }
+
+        {
+            long now = System.currentTimeMillis();
+            taskRun2.setTaskId(2);
+            taskRun2.initStatus("2", now + 10);
+            taskRun2.getStatus().setPriority(10);
+            taskRun2.setExecuteOption(DEFAULT_NO_MERGE_OPTION);
+            Assert.assertFalse(taskRun1.equals(taskRun2));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/schema/MSchema.java
+++ b/fe/fe-core/src/test/java/com/starrocks/schema/MSchema.java
@@ -304,7 +304,8 @@ public class MSchema {
 
     public static MTable getTable(String tableName) {
         if (!TABLE_MAP.containsKey(tableName)) {
-            throw new RuntimeException(String.format("%s is not in metadata marketing, please add it in the marketing"));
+            throw new RuntimeException(String.format("%s is not in metadata marketing, please add it in the marketing",
+                    tableName));
         }
         return TABLE_MAP.get(tableName);
     }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -402,6 +402,8 @@ struct TMaterializedViewStatus {
     23: optional string task_id
     24: optional string task_name
     25: optional string inactive_reason
+
+    26: optional string extra_message
 }
 
 struct TListPipesParams {

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -960,15 +960,15 @@ class StarrocksSQLApiLib(object):
             count += 1
         tools.assert_equal("FINISHED", status, "wait alter table finish error")
 
-    def wait_async_materialized_view_finish(self, mv_name, min_success_num = 1, check_count=60):
+    def wait_async_materialized_view_finish(self, mv_name, check_count=60):
         """
         wait async materialized view job finish and return status
         """
         status = ""
         show_sql = "SHOW MATERIALIZED VIEWS WHERE name='" + mv_name + "'"
         count = 0
-        success_num = 0
-        while count < check_count and success_num < min_success_num:
+        num = 0
+        while count < check_count:
             res = self.execute_sql(show_sql, True)
             status = res["result"][-1][12]
             if status != "SUCCESS":
@@ -976,7 +976,7 @@ class StarrocksSQLApiLib(object):
             else:
                 # sleep another 5s to avoid FE's async action.
                 time.sleep(1)
-                success_num += 1
+                break
             count += 1
         tools.assert_equal("SUCCESS", status, "wait aysnc materialized view finish error")
 

--- a/test/sql/test_materialized_view/R/test_create_mv_with_params
+++ b/test/sql/test_materialized_view/R/test_create_mv_with_params
@@ -55,13 +55,13 @@ FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
 -- result:
 -- !result
 refresh materialized view test_iceberg_mv0_${uuid0};
-function: wait_async_materialized_view_finish("test_iceberg_mv0_${uuid0}", 2)
+function: wait_async_materialized_view_finish("test_iceberg_mv0_${uuid0}")
 -- result:
 None
 -- !result
-select count(*) > 1 from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv0_${uuid0}%";
+select count(*) from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv0_${uuid0}%";
 -- result:
-1
+4
 -- !result
 SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
 -- result:
@@ -83,13 +83,13 @@ FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
 -- result:
 -- !result
 refresh materialized view test_iceberg_mv1_${uuid0};
-function: wait_async_materialized_view_finish("test_iceberg_mv1_${uuid0}", 2)
+function: wait_async_materialized_view_finish("test_iceberg_mv1_${uuid0}")
 -- result:
 None
 -- !result
-select count(*) > 1 from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv1_${uuid0}%";
+select count(*) from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv1_${uuid0}%";
 -- result:
-1
+4
 -- !result
 SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
 -- result:
@@ -116,9 +116,9 @@ function: wait_async_materialized_view_finish("test_iceberg_mv2_${uuid0}")
 -- result:
 None
 -- !result
-select count(*) == 1 from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv2_${uuid0}%";
+select count(*) from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv2_${uuid0}%";
 -- result:
-E: (1064, "Getting syntax error at line 1, column 16. Detail message: Unexpected input '=', the most similar input is {<EOF>, ';'}.")
+1
 -- !result
 SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
 -- result:
@@ -131,5 +131,60 @@ drop materialized view test_iceberg_mv2_${uuid0};
 -- result:
 -- !result
 drop database test_create_mv_with_params;
+-- result:
+-- !result
+-- name: test_create_olap_mv_with_params
+create database db_mv_with_params_${uuid0};
+-- result:
+-- !result
+use db_mv_with_params_${uuid0};
+-- result:
+-- !result
+create table test_tbl_with_params (
+ k1 INT,
+  k2 string,
+  v1 INT,
+  v2 INT
+) ENGINE=OLAP
+PARTITION BY RANGE(`k1`)
+(
+  PARTITION `p1` VALUES LESS THAN ('3'),
+  PARTITION `p2` VALUES LESS THAN ('6'),
+  PARTITION `p3` VALUES LESS THAN ('9')
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into test_tbl_with_params values (1,'a',1,1), (4,'aa',1,1), (8,'aa',1,1);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_tbl_with_params_mv 
+PARTITION BY k1
+REFRESH DEFERRED MANUAL 
+properties (
+    "partition_refresh_number" = "1"
+)
+AS SELECT * from test_tbl_with_params;
+-- result:
+-- !result
+refresh materialized view test_tbl_with_params_mv;
+function: wait_async_materialized_view_finish("test_tbl_with_params_mv")
+-- result:
+None
+-- !result
+select count(*) from information_schema.task_runs where `database`="db_mv_with_params_${uuid0}" and `DEFINITION` like "%test_tbl_with_params%";
+-- result:
+3
+-- !result
+select * from test_tbl_with_params_mv order by 1;
+-- result:
+1	a	1	1
+4	aa	1	1
+8	aa	1	1
+-- !result
+drop database db_mv_with_params_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/R/test_create_mv_with_params
+++ b/test/sql/test_materialized_view/R/test_create_mv_with_params
@@ -130,6 +130,12 @@ SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_$
 drop materialized view test_iceberg_mv2_${uuid0};
 -- result:
 -- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result
 drop database test_create_mv_with_params;
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite
+++ b/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite
@@ -179,9 +179,15 @@ true
   
 REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
 -- result:
-0910c516-a54e-11ee-a82f-5e4f71f202d3
+c45fa9dd-ab93-11ee-9b00-5e4f71f202d3
 -- !result
 select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
 -- result:
 2023-12-01	4000
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
 -- !result

--- a/test/sql/test_materialized_view/T/test_create_mv_with_params
+++ b/test/sql/test_materialized_view/T/test_create_mv_with_params
@@ -41,9 +41,9 @@ AS SELECT dt,sum(col_int)
 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
 
 refresh materialized view test_iceberg_mv0_${uuid0};
-function: wait_async_materialized_view_finish("test_iceberg_mv0_${uuid0}", 2)
+function: wait_async_materialized_view_finish("test_iceberg_mv0_${uuid0}")
 -- result should be > 1, because it refresh partitions one by one
-select count(*) > 1 from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv0_${uuid0}%";
+select count(*) from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv0_${uuid0}%";
 SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
 drop materialized view test_iceberg_mv0_${uuid0};
 
@@ -57,9 +57,9 @@ AS SELECT dt,sum(col_int)
 FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
 
 refresh materialized view test_iceberg_mv1_${uuid0};
-function: wait_async_materialized_view_finish("test_iceberg_mv1_${uuid0}", 2)
+function: wait_async_materialized_view_finish("test_iceberg_mv1_${uuid0}")
 -- result should be > 1, because it refresh partitions one by one
-select count(*) > 1 from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv1_${uuid0}%";
+select count(*) from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv1_${uuid0}%";
 SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
 drop materialized view test_iceberg_mv1_${uuid0};
 
@@ -76,8 +76,43 @@ FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
 refresh materialized view test_iceberg_mv2_${uuid0} with sync mode;
 function: wait_async_materialized_view_finish("test_iceberg_mv2_${uuid0}")
 -- result should be 1, because it refresh partitions by sync
-select count(*) = 1 from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv2_${uuid0}%";
+select count(*) from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv2_${uuid0}%";
 SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
 drop materialized view test_iceberg_mv2_${uuid0};
 
 drop database test_create_mv_with_params;
+
+-- name: test_create_olap_mv_with_params
+create database db_mv_with_params_${uuid0};
+use db_mv_with_params_${uuid0};
+
+create table test_tbl_with_params (
+ k1 INT,
+  k2 string,
+  v1 INT,
+  v2 INT
+) ENGINE=OLAP
+PARTITION BY RANGE(`k1`)
+(
+  PARTITION `p1` VALUES LESS THAN ('3'),
+  PARTITION `p2` VALUES LESS THAN ('6'),
+  PARTITION `p3` VALUES LESS THAN ('9')
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into test_tbl_with_params values (1,'a',1,1), (4,'aa',1,1), (8,'aa',1,1);
+CREATE MATERIALIZED VIEW test_tbl_with_params_mv 
+PARTITION BY k1
+REFRESH DEFERRED MANUAL 
+properties (
+    "partition_refresh_number" = "1"
+)
+AS SELECT * from test_tbl_with_params;
+refresh materialized view test_tbl_with_params_mv;
+function: wait_async_materialized_view_finish("test_tbl_with_params_mv")
+select count(*) from information_schema.task_runs where `database`="db_mv_with_params_${uuid0}" and `DEFINITION` like "%test_tbl_with_params%";
+select * from test_tbl_with_params_mv order by 1;
+drop database db_mv_with_params_${uuid0};

--- a/test/sql/test_materialized_view/T/test_create_mv_with_params
+++ b/test/sql/test_materialized_view/T/test_create_mv_with_params
@@ -80,6 +80,8 @@ select count(*) from information_schema.task_runs where `database`='test_create_
 SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
 drop materialized view test_iceberg_mv2_${uuid0};
 
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
 drop database test_create_mv_with_params;
 
 -- name: test_create_olap_mv_with_params

--- a/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite
+++ b/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite
@@ -90,3 +90,7 @@ select is_active, inactive_reason from information_schema.materialized_views
   
 REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
 select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
+
+
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;


### PR DESCRIPTION
Why I'm doing:

After PR(https://github.com/StarRocks/starrocks/pull/36560), mv refresh will be partition by partition by default. 

But we can not distinguish whether the multi partitions have been already refreshed or not, because there is no mark to distinguish which refresh the task run belongs to.

So it's difficult for users to monitor/observe the refresh tasks.

What I'm doing:
- Add `startTaskRunId` for each task run status, the same refresh action will generate multi task runs with the same `jobId`.
- Refactor `ShowMaterializedViewStatus` to be better represents for last refresh.
- Remove definition  for task run status because it may cost much memory, we can use task's definition by default.

Changes for `ShowMaterializedViews` command:
Before  : last refresh means the last pending/running/finished partition refresh.
Current: last refresh means all pending/running/finished partitions that is triggerred by the same refresh, in other words task runs with the same `jobId`. 

Final Result:
### New Version
```
mysql> show materialized views\G;
*************************** 1. row ***************************
                                  id: 12038
                       database_name: test
                                name: mv1
                        refresh_type: ASYNC
                           is_active: true
                     inactive_reason:
                      partition_type: RANGE
                             task_id: 12040
                           task_name: mv-12038
             last_refresh_start_time: 2024-01-05 13:49:24
          last_refresh_finished_time: 2024-01-05 13:49:29
               last_refresh_duration: 2.146
                  last_refresh_state: SUCCESS
          last_refresh_force_refresh: false
        last_refresh_start_partition: NULL|2023-01-01|2023-02-01|2023-03-01|2023-04-01|2023-05-01
          last_refresh_end_partition: NULL|2023-06-01|2023-06-01|2023-06-01|2023-06-01|2023-06-01
last_refresh_base_refresh_partitions: {t1=[p1]}|{t1=[p2]}|{t1=[p3]}|{t1=[p4]}|{t1=[p5]}|{t1=[p6]}
  last_refresh_mv_refresh_partitions: [p1]|[p2]|[p3]|[p4]|[p5]|[p6]
             last_refresh_error_code: 0
          last_refresh_error_message:
                                rows: 0
                                text: CREATE MATERIALIZED VIEW `mv1` (`k1`, `sum_v1`)
PARTITION BY (`k1`)
DISTRIBUTED BY HASH(`k1`) BUCKETS 10
REFRESH ASYNC
PROPERTIES (
"replicated_storage" = "true",
"replication_num" = "1",
"storage_medium" = "HDD"
)
AS SELECT `t1`.`k1`, sum(`t1`.`v1`) AS `sum_v1`
FROM `test`.`t1`
GROUP BY `t1`.`k1`;
                       extra_message: {"queryIds":["2da57d52-ab8e-11ee-9b00-5e4f71f202d3","2e3fe89c-ab8e-11ee-9b00-5e4f71f202d3","2ed4878c-ab8e-11ee-9b00-5e4f71f202d3","2f67039c-ab8e-11ee-9b00-5e4f71f202d3","2ffdc56d-ab8e-11ee-9b00-5e4f71f202d3","3093c3ed-ab8e-11ee-9b00-5e4f71f202d3"],"isManual":false,"isSync":false,"isReplay":false,"priority":0}
1 row in set (0.00 sec)
```
### Old version

```
mysql> admin set frontend config("enable_show_materialized_views_include_all_task_runs" = "false");
Query OK, 0 rows affected (0.00 sec)


mysql> show materialized views\G;
*************************** 1. row ***************************
                                  id: 12038
                       database_name: test
                                name: mv1
                        refresh_type: ASYNC
                           is_active: true
                     inactive_reason:
                      partition_type: RANGE
                             task_id: 12040
                           task_name: mv-12038
             last_refresh_start_time: 2024-01-05 13:49:29
          last_refresh_finished_time: 2024-01-05 13:49:29
               last_refresh_duration: 0.325
                  last_refresh_state: SUCCESS
          last_refresh_force_refresh: false
        last_refresh_start_partition: 2023-05-01
          last_refresh_end_partition: 2023-06-01
last_refresh_base_refresh_partitions: {t1=[p6]}
  last_refresh_mv_refresh_partitions: [p6]
             last_refresh_error_code: 0
          last_refresh_error_message:
                                rows: 0
                                text: CREATE MATERIALIZED VIEW `mv1` (`k1`, `sum_v1`)
PARTITION BY (`k1`)
DISTRIBUTED BY HASH(`k1`) BUCKETS 10
REFRESH ASYNC
PROPERTIES (
"replicated_storage" = "true",
"replication_num" = "1",
"storage_medium" = "HDD"
)
AS SELECT `t1`.`k1`, sum(`t1`.`v1`) AS `sum_v1`
FROM `test`.`t1`
GROUP BY `t1`.`k1`;
                       extra_message: {"queryIds":["3093c3ed-ab8e-11ee-9b00-5e4f71f202d3"],"isManual":false,"isSync":false,"isReplay":false,"priority":100}
1 row in set (0.00 sec)
```
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
