### PR TITLE
[Enhancement] Compare txn commit time with grace time when executing vacuum.

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -172,10 +172,12 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
             auto new_version = request->new_version();
             auto txns = request->txn_ids().data();
             auto txns_size = request->txn_ids().size();
+            auto commit_time = request->commit_time();
             auto tablet_manager = _env->lake_tablet_manager();
             g_publish_tablet_version_queuing_latency << (run_ts - start_ts);
 
-            auto res = tablet_manager->publish_version(tablet_id, base_version, new_version, txns, txns_size);
+            auto res =
+                    tablet_manager->publish_version(tablet_id, base_version, new_version, txns, txns_size, commit_time);
             if (res.ok()) {
                 auto metadata = std::move(res).value();
                 auto score = compaction_score(metadata);

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -124,7 +124,8 @@ static bvar::PassiveStatus<size_t> g_metacache_usage("lake", "metacache_usage", 
 #endif
 
 static StatusOr<TabletMetadataPtr> publish(TabletManager* tablet_mgr, Tablet* tablet, int64_t base_version,
-                                           int64_t new_version, const int64_t* txns, int txns_size);
+                                           int64_t new_version, const int64_t* txns, int txns_size,
+                                           int64_t commit_time);
 
 TabletManager::TabletManager(LocationProvider* location_provider, UpdateManager* update_mgr, int64_t cache_capacity)
         : _location_provider(location_provider),
@@ -675,13 +676,13 @@ StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema_by_index_id(int64_t t
 }
 
 StatusOr<TabletMetadataPtr> TabletManager::publish_version(int64_t tablet_id, int64_t base_version, int64_t new_version,
-                                                           const int64_t* txns, int txns_size) {
+                                                           const int64_t* txns, int txns_size, int64_t commit_time) {
     ASSIGN_OR_RETURN(auto tablet, get_tablet(tablet_id));
-    return publish(this, &tablet, base_version, new_version, txns, txns_size);
+    return publish(this, &tablet, base_version, new_version, txns, txns_size, commit_time);
 }
 
 StatusOr<TabletMetadataPtr> publish(TabletManager* tablet_mgr, Tablet* tablet, int64_t base_version,
-                                    int64_t new_version, const int64_t* txns, int txns_size) {
+                                    int64_t new_version, const int64_t* txns, int txns_size, int64_t commit_time) {
     if (txns_size != 1) {
         return Status::NotSupported("does not support publish multiple txns yet");
     }
@@ -718,6 +719,8 @@ StatusOr<TabletMetadataPtr> publish(TabletManager* tablet_mgr, Tablet* tablet, i
     if (base_metadata->compaction_inputs_size() > 0 || base_metadata->orphan_files_size() > 0) {
         new_metadata->set_prev_garbage_version(base_metadata->version());
     }
+
+    new_metadata->set_commit_time(commit_time);
 
     auto init_st = log_applier->init();
     if (!init_st.ok()) {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -68,7 +68,7 @@ public:
 
     // Returns the the newly created tablet metadata
     StatusOr<TabletMetadataPtr> publish_version(int64_t tablet_id, int64_t base_version, int64_t new_version,
-                                                const int64_t* txns, int txns_size);
+                                                const int64_t* txns, int txns_size, int64_t commit_time);
 
     void abort_txn(int64_t tablet_id, const int64_t* txns, int txns_size);
 
@@ -150,6 +150,7 @@ public:
 
     void update_metacache_limit(size_t limit);
 
+    // The return value will never be null.
     Cache* metacache() { return _metacache.get(); }
 
     int64_t in_writing_data_size(int64_t tablet_id);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -199,24 +199,26 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         request.set_new_version(3);
         request.add_tablet_ids(_tablet_id);
         request.add_txn_ids(1001);
+        request.set_commit_time(987654321);
         _lake_service.publish_version(nullptr, &request, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
     }
-
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_id));
-    ASSIGN_OR_ABORT(auto metadata, tablet.get_metadata(3));
-    ASSERT_EQ(3, metadata->version());
-    ASSERT_EQ(_tablet_id, metadata->id());
-    ASSERT_EQ(3, metadata->next_rowset_id());
-    ASSERT_EQ(1, metadata->rowsets_size());
-    ASSERT_EQ(1, metadata->rowsets(0).id());
-    ASSERT_EQ(2, metadata->rowsets(0).segments_size());
-    ASSERT_TRUE(metadata->rowsets(0).overlapped());
-    ASSERT_EQ(101, metadata->rowsets(0).num_rows());
-    ASSERT_EQ(4096, metadata->rowsets(0).data_size());
-    ASSERT_EQ("1.dat", metadata->rowsets(0).segments(0));
-    ASSERT_EQ("2.dat", metadata->rowsets(0).segments(1));
-
+    {
+        ASSIGN_OR_ABORT(auto metadata, tablet.get_metadata(3));
+        ASSERT_EQ(3, metadata->version());
+        ASSERT_EQ(_tablet_id, metadata->id());
+        ASSERT_EQ(3, metadata->next_rowset_id());
+        ASSERT_EQ(1, metadata->rowsets_size());
+        ASSERT_EQ(1, metadata->rowsets(0).id());
+        ASSERT_EQ(2, metadata->rowsets(0).segments_size());
+        ASSERT_TRUE(metadata->rowsets(0).overlapped());
+        ASSERT_EQ(101, metadata->rowsets(0).num_rows());
+        ASSERT_EQ(4096, metadata->rowsets(0).data_size());
+        ASSERT_EQ("1.dat", metadata->rowsets(0).segments(0));
+        ASSERT_EQ("2.dat", metadata->rowsets(0).segments(1));
+        EXPECT_EQ(987654321, metadata->commit_time());
+    }
     ExecEnv::GetInstance()->vacuum_thread_pool()->wait();
     // TxnLog`s should have been deleted
     ASSERT_TRUE(tablet.get_txn_log(1000).status().is_not_found());
@@ -275,6 +277,29 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         _lake_service.publish_version(nullptr, &request, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
         ASSERT_TRUE(response.compaction_scores().contains(_tablet_id));
+    }
+
+    // Empty TxnLog
+    {
+        lake::TxnLog txnlog;
+        txnlog.set_tablet_id(_tablet_id);
+        txnlog.set_txn_id(2000);
+        ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
+    }
+    // Publish txn 2000
+    {
+        lake::PublishVersionRequest request;
+        lake::PublishVersionResponse response;
+        request.set_base_version(3);
+        request.set_new_version(4);
+        request.add_tablet_ids(_tablet_id);
+        request.add_txn_ids(2000);
+        request.set_commit_time(0);
+        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+        ASSERT_EQ(0, response.failed_tablets_size());
+
+        ASSIGN_OR_ABORT(auto metadata, tablet.get_metadata(4));
+        EXPECT_EQ(0, metadata->commit_time());
     }
 }
 

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -82,7 +82,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
     update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
 
-    auto new_tablet_meta = _tablet_mgr->publish_version(tablet_id, 1, 2, &txn_id, 1);
+    auto new_tablet_meta = _tablet_mgr->publish_version(tablet_id, 1, 2, &txn_id, 1, time(NULL));
     ASSERT_OK(new_tablet_meta.status());
     ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
 
@@ -98,7 +98,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
     update_tablet_meta_req2.tabletMetaInfos.push_back(tablet_meta_info2);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req2));
 
-    auto new_tablet_meta2 = _tablet_mgr->publish_version(tablet_id, 2, 3, &txn_id2, 1);
+    auto new_tablet_meta2 = _tablet_mgr->publish_version(tablet_id, 2, 3, &txn_id2, 1, time(NULL));
     ASSERT_OK(new_tablet_meta2.status());
     ASSERT_EQ(false, new_tablet_meta2.value()->enable_persistent_index());
 }
@@ -118,7 +118,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index_not_change) {
     update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
 
-    auto new_tablet_meta = _tablet_mgr->publish_version(tablet_id, 1, 2, &txn_id, 1);
+    auto new_tablet_meta = _tablet_mgr->publish_version(tablet_id, 1, 2, &txn_id, 1, time(NULL));
     ASSERT_OK(new_tablet_meta.status());
     ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
 
@@ -135,7 +135,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index_not_change) {
     update_tablet_meta_req2.tabletMetaInfos.push_back(tablet_meta_info2);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req2));
 
-    auto new_tablet_meta2 = _tablet_mgr->publish_version(tablet_id, 2, 3, &txn_id2, 1);
+    auto new_tablet_meta2 = _tablet_mgr->publish_version(tablet_id, 2, 3, &txn_id2, 1, time(NULL));
     ASSERT_OK(new_tablet_meta2.status());
     ASSERT_EQ(true, new_tablet_meta2.value()->enable_persistent_index());
 }

--- a/be/test/storage/lake/auto_increment_partial_update_test.cpp
+++ b/be/test/storage/lake/auto_increment_partial_update_test.cpp
@@ -206,7 +206,7 @@ TEST_F(LakeAutoIncrementPartialUpdateTest, test_write) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c1 - 1 == c0) && (c1 - 1 == c2); }));
@@ -239,7 +239,7 @@ TEST_F(LakeAutoIncrementPartialUpdateTest, test_write) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c1 - 1 == c0) && (c1 - 1 == c2); }));
@@ -276,7 +276,7 @@ TEST_F(LakeAutoIncrementPartialUpdateTest, test_resolve_conflict) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c1 - 1 == c0) && (c1 - 1 == c2); }));
@@ -313,7 +313,7 @@ TEST_F(LakeAutoIncrementPartialUpdateTest, test_resolve_conflict) {
     }
     // publish in order
     for (auto txn_id : txn_ids) {
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c1 - 1 == c0) && (c1 - 1 == c2); }));

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -175,7 +175,7 @@ TEST_P(LakeDuplicateKeyCompactionTest, test1) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -189,7 +189,8 @@ TEST_P(LakeDuplicateKeyCompactionTest, test1) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
+    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
+                      .status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
 
@@ -215,7 +216,8 @@ TEST_F(LakeDuplicateKeyCompactionTest, test_empty_tablet) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
+    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
+                      .status());
     version++;
     ASSERT_EQ(0, read(version));
 }
@@ -342,7 +344,7 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 6, read(version));
@@ -365,7 +367,8 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
         CompactionTask::Progress progress;
         ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
         EXPECT_EQ(100, progress.value());
-        ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
+                          .status());
         version++;
         ASSERT_EQ(kChunkSize * 6, read(version));
     }
@@ -520,7 +523,7 @@ TEST_P(LakeUniqueKeyCompactionTest, test1) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, read(version));
@@ -534,7 +537,8 @@ TEST_P(LakeUniqueKeyCompactionTest, test1) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
+    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
+                      .status());
     version++;
     ASSERT_EQ(kChunkSize, read(version));
 
@@ -668,7 +672,7 @@ TEST_P(LakeUniqueKeyCompactionWithDeleteTest, test_base_compaction_with_delete) 
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, read(version));
@@ -706,7 +710,8 @@ TEST_P(LakeUniqueKeyCompactionWithDeleteTest, test_base_compaction_with_delete) 
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
+    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
+                      .status());
     version++;
     ASSERT_EQ(kChunkSize - 4, read(version));
 

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -192,7 +192,7 @@ TEST_P(ConditionUpdateTest, test_condition_update) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -226,7 +226,7 @@ TEST_P(ConditionUpdateTest, test_condition_update) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
         ASSERT_EQ(kChunkSize, check(version, [&](int c0, int c1, int c2) {
                       return (c0 * result[i].first == c1) && (c0 * result[i].second == c2);
@@ -264,7 +264,7 @@ TEST_P(ConditionUpdateTest, test_condition_update_multi_segment) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -292,7 +292,7 @@ TEST_P(ConditionUpdateTest, test_condition_update_multi_segment) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     config::write_buffer_size = old_size;
@@ -334,7 +334,7 @@ TEST_P(ConditionUpdateTest, test_condition_update_in_memtable) {
     ASSERT_OK(delta_writer->finish());
     delta_writer->close();
     // Publish version
-    ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+    ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
     version++;
     ASSERT_EQ(kChunkSize, check(version, [&](int c0, int c1, int c2) {
                   return (c0 * result.first == c1) && (c0 * result.second == c2);

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -223,7 +223,7 @@ TEST_P(LakePartialUpdateTest, test_write) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -248,7 +248,7 @@ TEST_P(LakePartialUpdateTest, test_write) {
         delta_writer->close();
         add_trash_files(tablet_id, txn_id);
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -285,7 +285,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -313,7 +313,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment) {
         delta_writer->close();
         add_trash_files(tablet_id, txn_id);
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     config::write_buffer_size = old_size;
@@ -354,7 +354,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -382,7 +382,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val) {
         delta_writer->close();
         add_trash_files(tablet_id, txn_id);
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     config::write_buffer_size = old_size;
@@ -422,7 +422,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -452,7 +452,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict) {
     // publish in order
     for (auto txn_id : txn_ids) {
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -490,7 +490,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict_multi_segment) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -523,7 +523,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict_multi_segment) {
     // publish in order
     for (auto txn_id : txn_ids) {
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     config::write_buffer_size = old_size;
@@ -563,7 +563,7 @@ TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -591,7 +591,7 @@ TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
         delta_writer->close();
         add_trash_files(tablet_id, txn_id);
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -629,7 +629,7 @@ TEST_P(LakePartialUpdateTest, test_partial_update_publish_retry) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -655,12 +655,12 @@ TEST_P(LakePartialUpdateTest, test_partial_update_publish_retry) {
 
         SyncPoint::GetInstance()->SetCallBack("ProtobufFile::save:serialize", [](void* arg) { *(bool*)arg = false; });
         SyncPoint::GetInstance()->EnableProcessing();
-        ASSERT_ERROR(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_ERROR(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         SyncPoint::GetInstance()->ClearCallBack("ProtobufFile::save:serialize");
         SyncPoint::GetInstance()->DisableProcessing();
     }
     // retry publish again
-    ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+    ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
     _tablet_mgr->prune_metacache();
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
 }

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -224,7 +224,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, read(version));
@@ -248,7 +248,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+    ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
     version++;
     ASSERT_EQ(kChunkSize, read(version));
     if (GetParam().enable_persistent_index) {
@@ -290,7 +290,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test2) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -303,7 +303,8 @@ TEST_P(LakePrimaryKeyCompactionTest, test2) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
+    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
+                      .status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
     if (GetParam().enable_persistent_index) {
@@ -354,7 +355,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 2, read(version));
@@ -367,7 +368,8 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
+    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
+                      .status());
     version++;
     if (GetParam().enable_persistent_index) {
         check_local_persistent_index_meta(tablet_id, version);
@@ -408,7 +410,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -457,7 +459,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy2) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     {
@@ -475,7 +477,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy2) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 6, read(version));
@@ -532,7 +534,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy3) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     {
@@ -550,7 +552,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy3) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     config::write_buffer_size = old_size;
@@ -603,7 +605,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_score_by_policy) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -658,7 +660,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -684,7 +686,8 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {
         EXPECT_EQ(_update_mgr->compaction_state_mem_tracker()->consumption(), 0);
     }
     // publish version
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1).status());
+    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
+                      .status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
 

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -248,7 +248,8 @@ TEST_P(SchemaChangeAddColumnTest, test_add_column) {
         ASSERT_OK(delta_writer->write(chunk0, indexes, sizeof(indexes) / sizeof(indexes[0])));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1, time(NULL))
+                          .status());
         version++;
         txn_id++;
     }
@@ -301,12 +302,14 @@ TEST_P(SchemaChangeAddColumnTest, test_add_column) {
     // publish schema change
     int concurrency = GetParam().concurrency;
     if (concurrency == 1) {
-        ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1).status());
+        ASSERT_OK(
+                _tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL)).status());
     } else {
         std::vector<std::thread> threads;
         for (int i = 0; i < concurrency; i++) {
-            threads.emplace_back(
-                    [&]() { (void)_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1); });
+            threads.emplace_back([&]() {
+                (void)_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL));
+            });
         }
         for (auto& t : threads) {
             t.join();
@@ -503,7 +506,8 @@ TEST_P(SchemaChangeModifyColumnTypeTest, test_alter_column_type) {
         ASSERT_OK(delta_writer->write(chunk0, indexes, sizeof(indexes) / sizeof(indexes[0])));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1, time(NULL))
+                          .status());
         version++;
         txn_id++;
     }
@@ -554,12 +558,14 @@ TEST_P(SchemaChangeModifyColumnTypeTest, test_alter_column_type) {
 
     int concurrency = GetParam().concurrency;
     if (concurrency == 1) {
-        ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1).status());
+        ASSERT_OK(
+                _tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL)).status());
     } else {
         std::vector<std::thread> threads;
         for (int i = 0; i < concurrency; i++) {
-            threads.emplace_back(
-                    [&]() { (void)_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1); });
+            threads.emplace_back([&]() {
+                (void)_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL));
+            });
         }
         for (auto& t : threads) {
             t.join();
@@ -782,7 +788,8 @@ TEST_P(SchemaChangeModifyColumnOrderTest, test_alter_key_order) {
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1, time(NULL))
+                          .status());
         version++;
         txn_id++;
     }
@@ -821,7 +828,7 @@ TEST_P(SchemaChangeModifyColumnOrderTest, test_alter_key_order) {
         txn_id++;
     }
 
-    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1).status());
+    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL)).status());
     version++;
     txn_id++;
 
@@ -1043,7 +1050,8 @@ TEST_P(SchemaChangeSortKeyReorderTest1, test_alter_sortkey_reorder_1) {
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1, time(NULL))
+                          .status());
         version++;
         txn_id++;
     }
@@ -1082,7 +1090,7 @@ TEST_P(SchemaChangeSortKeyReorderTest1, test_alter_sortkey_reorder_1) {
         txn_id++;
     }
 
-    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1).status());
+    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL)).status());
     version++;
     txn_id++;
 
@@ -1281,7 +1289,8 @@ TEST_P(SchemaChangeSortKeyReorderTest2, test_alter_sortkey_reorder2) {
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1, time(NULL))
+                          .status());
         version++;
         txn_id++;
     }
@@ -1320,7 +1329,7 @@ TEST_P(SchemaChangeSortKeyReorderTest2, test_alter_sortkey_reorder2) {
         txn_id++;
     }
 
-    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1).status());
+    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL)).status());
     version++;
     txn_id++;
 
@@ -1517,7 +1526,8 @@ TEST_P(SchemaChangeSortKeyReorderTest3, test_alter_sortkey_reorder3) {
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1).status());
+        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1, time(NULL))
+                          .status());
         version++;
         txn_id++;
     }
@@ -1556,7 +1566,7 @@ TEST_P(SchemaChangeSortKeyReorderTest3, test_alter_sortkey_reorder3) {
         txn_id++;
     }
 
-    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1).status());
+    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL)).status());
     version++;
     txn_id++;
 

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -976,4 +976,128 @@ TEST_F(LakeVacuumTest, test_dont_delete_txn_log) {
     }
 }
 
+// NOLINTNEXTLINE
+TEST_F(LakeVacuumTest, test_commit_time) {
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 5000,
+        "version": 1,
+        "commit_time": 1696998530,
+        "prev_garbage_version": 0
+        }
+        )DEL")));
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 5000,
+        "version": 2,
+        "commit_time": 1696998535,
+        "prev_garbage_version": 0
+        }
+        )DEL")));
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 5000,
+        "version": 3,
+        "commit_time": 1696998540,
+        "prev_garbage_version": 2
+        }
+        )DEL")));
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 5000,
+        "version": 4,
+        "commit_time": 1696998545,
+        "prev_garbage_version": 3
+        }
+        )DEL")));
+
+    int invoked = 0;
+    SyncPoint::GetInstance()->SetCallBack("collect_files_to_vacuum:get_file_modified_time",
+                                          [&](void* arg) { invoked++; });
+
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.add_tablet_ids(5000);
+        request.set_min_retain_version(4);
+        request.set_grace_timestamp(1696998542); // <----- greater than the commit time of version 3
+        request.set_min_active_txn_id(10);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        ASSERT_EQ(0, response.status().status_code());
+        EXPECT_EQ(2, response.vacuumed_files());
+        EXPECT_EQ(0, response.vacuumed_file_size());
+
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(5000, 1)));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(5000, 2)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(5000, 3)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(5000, 4)));
+        EXPECT_EQ(0, invoked);
+    }
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.add_tablet_ids(5000);
+        request.set_min_retain_version(4);
+        request.set_grace_timestamp(1696998545); // <----- equals to the commit time of version 4
+        request.set_min_active_txn_id(10);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        ASSERT_EQ(0, response.status().status_code());
+        EXPECT_EQ(0, response.vacuumed_files());
+        EXPECT_EQ(0, response.vacuumed_file_size());
+
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(5000, 1)));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(5000, 2)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(5000, 3)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(5000, 4)));
+        EXPECT_EQ(0, invoked);
+    }
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.add_tablet_ids(5000);
+        request.set_min_retain_version(4);
+        request.set_grace_timestamp(1696998550); // <----- greater than the commit time of version 4
+        request.set_min_active_txn_id(10);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        ASSERT_EQ(0, response.status().status_code());
+        EXPECT_EQ(1, response.vacuumed_files());
+        EXPECT_EQ(0, response.vacuumed_file_size());
+
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(5000, 1)));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(5000, 2)));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(5000, 3)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(5000, 4)));
+        EXPECT_EQ(0, invoked);
+    }
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.add_tablet_ids(5000);
+        request.set_min_retain_version(4);
+        request.set_grace_timestamp(1696998550); // <----- greater than the commit time of version 4
+        request.set_min_active_txn_id(10);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        ASSERT_EQ(0, response.status().status_code());
+        EXPECT_EQ(0, response.vacuumed_files());
+        EXPECT_EQ(0, response.vacuumed_file_size());
+
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(5000, 1)));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(5000, 2)));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(5000, 3)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(5000, 4)));
+        EXPECT_EQ(0, invoked);
+    }
+    SyncPoint::GetInstance()->ClearCallBack("collect_files_to_vacuum:get_file_modified_time");
+    SyncPoint::GetInstance()->DisableProcessing();
+}
+
 } // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.alter;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -171,7 +170,8 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
         partitionIndexMap.put(partitionId, shadowIdxId, shadowIdx);
     }
 
-    void addIndexSchema(long shadowIdxId, long originIdxId, @NotNull String shadowIndexName, short shadowIdxShortKeyCount,
+    void addIndexSchema(long shadowIdxId, long originIdxId, @NotNull String shadowIndexName,
+                        short shadowIdxShortKeyCount,
                         @NotNull List<Column> shadowIdxSchema) {
         indexIdMap.put(shadowIdxId, originIdxId);
         indexIdToName.put(shadowIdxId, shadowIndexName);
@@ -188,7 +188,8 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
             Map<Long, MaterializedIndex> shadowIndexMap = partitionIndexMap.row(partitionId);
             for (MaterializedIndex shadowIndex : shadowIndexMap.values()) {
                 shadowIndex.setVisibleTxnId(watershedTxnId);
-                Preconditions.checkState(shadowIndex.getState() == MaterializedIndex.IndexState.SHADOW, shadowIndex.getState());
+                Preconditions.checkState(shadowIndex.getState() == MaterializedIndex.IndexState.SHADOW,
+                        shadowIndex.getState());
                 partition.createRollupIndex(shadowIndex);
             }
         }
@@ -271,7 +272,8 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
             LakeTable table = getTableOrThrow(db, tableId);
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE);
             MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(table.getBaseIndexId());
-            numTablets = partitionIndexMap.values().stream().map(MaterializedIndex::getTablets).mapToLong(List::size).sum();
+            numTablets =
+                    partitionIndexMap.values().stream().map(MaterializedIndex::getTablets).mapToLong(List::size).sum();
             countDownLatch = new MarkedCountDownLatch<>((int) numTablets);
 
             for (long partitionId : partitionIndexMap.rowKeySet()) {
@@ -347,12 +349,16 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                         }
                         countDownLatch.addMark(backendId, shadowTabletId);
                         // No need to set base tablet id for CreateReplicaTask
-                        CreateReplicaTask createReplicaTask = new CreateReplicaTask(backendId, dbId, tableId, partitionId,
-                                shadowIdxId, shadowTabletId, shadowShortKeyColumnCount, 0, Partition.PARTITION_INIT_VERSION,
-                                originKeysType, TStorageType.COLUMN, storageMedium, copiedShadowSchema, bfColumns, bfFpp,
-                                countDownLatch, indexes, table.isInMemory(), table.enablePersistentIndex(),
-                                table.primaryIndexCacheExpireSec(), TTabletType.TABLET_TYPE_LAKE, table.getCompressionType(), 
-                                copiedSortKeyIdxes, null);
+                        CreateReplicaTask createReplicaTask =
+                                new CreateReplicaTask(backendId, dbId, tableId, partitionId,
+                                        shadowIdxId, shadowTabletId, shadowShortKeyColumnCount, 0,
+                                        Partition.PARTITION_INIT_VERSION,
+                                        originKeysType, TStorageType.COLUMN, storageMedium, copiedShadowSchema,
+                                        bfColumns, bfFpp,
+                                        countDownLatch, indexes, table.isInMemory(), table.enablePersistentIndex(),
+                                        table.primaryIndexCacheExpireSec(), TTabletType.TABLET_TYPE_LAKE,
+                                        table.getCompressionType(),
+                                        copiedSortKeyIdxes, null);
                         batchTask.addTask(createReplicaTask);
                     }
                 }
@@ -379,7 +385,8 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
 
         writeEditLog(this);
 
-        LOG.info("transfer schema change job {} state to {}, watershed txn_id: {}", jobId, this.jobState, watershedTxnId);
+        LOG.info("transfer schema change job {} state to {}, watershed txn_id: {}", jobId, this.jobState,
+                watershedTxnId);
     }
 
     @Override
@@ -417,9 +424,12 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                             throw new AlterCancelException("No alive backend");
                         }
                         long shadowTabletId = shadowTablet.getId();
-                        long originTabletId = partitionIndexTabletMap.row(partitionId).get(shadowIdxId).get(shadowTabletId);
-                        AlterReplicaTask alterTask = AlterReplicaTask.alterLakeTablet(backendId, dbId, tableId, partitionId,
-                                shadowIdxId, shadowTabletId, originTabletId, visibleVersion, jobId, watershedTxnId);
+                        long originTabletId =
+                                partitionIndexTabletMap.row(partitionId).get(shadowIdxId).get(shadowTabletId);
+                        AlterReplicaTask alterTask =
+                                AlterReplicaTask.alterLakeTablet(backendId, dbId, tableId, partitionId,
+                                        shadowIdxId, shadowTabletId, originTabletId, visibleVersion, jobId,
+                                        watershedTxnId);
                         getOrCreateSchemaChangeBatchTask().addTask(alterTask);
                     }
                 }
@@ -456,7 +466,8 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
             List<AgentTask> tasks = getOrCreateSchemaChangeBatchTask().getUnfinishedTasks(2000);
             AgentTask task = tasks.stream().filter(t -> t.getFailedTimes() >= 3).findAny().orElse(null);
             if (task != null) {
-                throw new AlterCancelException("schema change task failed after try three times: " + task.getErrorMsg());
+                throw new AlterCancelException(
+                        "schema change task failed after try three times: " + task.getErrorMsg());
             } else {
                 return;
             }
@@ -474,6 +485,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                 LOG.debug("commit version of partition {} is {}. jobId={}", partitionId, commitVersion, jobId);
             }
             this.jobState = JobState.FINISHED_REWRITING;
+            this.finishedTimeMs = System.currentTimeMillis();
 
             writeEditLog(this);
 
@@ -545,7 +557,6 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
             StarMgrMetaSyncer.dropTabletAndDeleteShard(shards, GlobalStateMgr.getCurrentStarOSAgent());
         }
 
-
         if (span != null) {
             span.end();
         }
@@ -577,7 +588,8 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                 long commitVersion = commitVersionMap.get(partitionId);
                 Map<Long, MaterializedIndex> shadowIndexMap = partitionIndexMap.row(partitionId);
                 for (MaterializedIndex shadowIndex : shadowIndexMap.values()) {
-                    Utils.publishVersion(shadowIndex.getTablets(), watershedTxnId, 1, commitVersion);
+                    Utils.publishVersion(shadowIndex.getTablets(), watershedTxnId, 1, commitVersion,
+                            finishedTimeMs / 1000);
                 }
             }
             return true;
@@ -789,7 +801,8 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
             Preconditions.checkState(commitVersionMap.containsKey(partition.getId()));
             long commitVersion = commitVersionMap.get(partition.getId());
 
-            LOG.debug("update partition visible version. partition=" + partition.getId() + " commitVersion=" + commitVersion);
+            LOG.debug("update partition visible version. partition=" + partition.getId() + " commitVersion=" +
+                    commitVersion);
             // Update Partition's visible version
             Preconditions.checkState(commitVersion == partition.getVisibleVersion() + 1,
                     commitVersion + " vs " + partition.getVisibleVersion());
@@ -816,7 +829,8 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                 Preconditions.checkNotNull(droppedIdx, originIdxId + " vs. " + shadowIdxId);
 
                 // Add Tablet to TabletInvertedIndex.
-                TabletMeta shadowTabletMeta = new TabletMeta(dbId, tableId, partition.getId(), shadowIdxId, 0, medium, true);
+                TabletMeta shadowTabletMeta =
+                        new TabletMeta(dbId, tableId, partition.getId(), shadowIdxId, 0, medium, true);
                 for (Tablet tablet : shadowIdx.getTablets()) {
                     invertedIndex.addTablet(tablet.getId(), shadowTabletMeta);
                 }
@@ -901,7 +915,8 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
     }
 
     AgentBatchTask getOrCreateSchemaChangeBatchTask() {
-        if (schemaChangeBatchTask == null) { // This would happen after FE restarted and this object was deserialized from Json.
+        if (schemaChangeBatchTask ==
+                null) { // This would happen after FE restarted and this object was deserialized from Json.
             schemaChangeBatchTask = new AgentBatchTask();
         }
         return schemaChangeBatchTask;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.lake;
 
 import com.google.common.collect.Lists;
@@ -98,13 +97,14 @@ public class Utils {
         return groupMap;
     }
 
-    public static void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion)
+    public static void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion,
+                                      long commitTimeInSecond)
             throws NoAliveBackendException, RpcException {
-        publishVersion(tablets, txnId, baseVersion, newVersion, null);
+        publishVersion(tablets, txnId, baseVersion, newVersion, commitTimeInSecond, null);
     }
 
-    public static void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion, Map<Long,
-            Double> compactionScores)
+    public static void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion,
+                                      long commitTimeInSecond, Map<Long, Double> compactionScores)
             throws NoAliveBackendException, RpcException {
         Map<Long, List<Long>> beToTablets = new HashMap<>();
         for (Tablet tablet : tablets) {
@@ -131,6 +131,7 @@ public class Utils {
             request.newVersion = newVersion;
             request.tabletIds = entry.getValue();
             request.txnIds = txnIds;
+            request.commitTime = commitTimeInSecond;
 
             LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
             Future<PublishVersionResponse> future = lakeService.publishVersion(request);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -343,7 +343,8 @@ public class PublishVersionDaemon extends FrontendDaemon {
         } else {
             List<CompletableFuture<Boolean>> futureList = new ArrayList<>();
             for (PartitionCommitInfo partitionCommitInfo : tableCommitInfo.getIdToPartitionCommitInfo().values()) {
-                CompletableFuture<Boolean> future = publishLakePartitionAsync(db, tableCommitInfo, partitionCommitInfo, txnState);
+                CompletableFuture<Boolean> future =
+                        publishLakePartitionAsync(db, tableCommitInfo, partitionCommitInfo, txnState);
                 futureList.add(future);
             }
             return CompletableFuture.allOf(futureList.toArray(new CompletableFuture[0]))
@@ -351,7 +352,8 @@ public class PublishVersionDaemon extends FrontendDaemon {
         }
     }
 
-    private CompletableFuture<Boolean> publishLakePartitionAsync(@NotNull Database db, @NotNull TableCommitInfo tableCommitInfo,
+    private CompletableFuture<Boolean> publishLakePartitionAsync(@NotNull Database db,
+                                                                 @NotNull TableCommitInfo tableCommitInfo,
                                                                  @NotNull PartitionCommitInfo partitionCommitInfo,
                                                                  @NotNull TransactionState txnState) {
         long versionTime = partitionCommitInfo.getVersionTime();
@@ -379,6 +381,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
         long tableId = tableCommitInfo.getTableId();
         long txnVersion = partitionCommitInfo.getVersion();
         long txnId = txnState.getTransactionId();
+        long commitTime = txnState.getCommitTime();
         String txnLabel = txnState.getLabel();
         List<Tablet> normalTablets = null;
         List<Tablet> shadowTablets = null;
@@ -424,7 +427,8 @@ public class PublishVersionDaemon extends FrontendDaemon {
             }
             if (CollectionUtils.isNotEmpty(normalTablets)) {
                 Map<Long, Double> compactionScores = new HashMap<>();
-                Utils.publishVersion(normalTablets, txnId, txnVersion - 1, txnVersion, compactionScores);
+                Utils.publishVersion(normalTablets, txnId, txnVersion - 1, txnVersion, commitTime / 1000,
+                        compactionScores);
 
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());
                 partitionCommitInfo.setCompactionScore(quantiles);

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -29,6 +29,10 @@ message PublishVersionRequest {
     // it explicitly for more clarity and better forward compatibility.
     optional int64 base_version = 3;
     optional int64 new_version = 4;
+    // Commit time of the transaction to be published.
+    // If the size of txn_ids is greater than 1, commit_time should be the commit time of the last transaction.
+    // Meansured as the number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC)
+    optional int64 commit_time = 5;
 }
 
 message PublishVersionResponse {
@@ -193,6 +197,7 @@ message VacuumRequest {
     // the timestamp after which created tablet metadata files will not be vacuumed.
     // In addition to retaining all versions after grace_timestamp, retain the last version before
     // grace_timestamp.
+    // Meansured as the number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC)
     optional int64 grace_timestamp = 3;
     // Delete txn log files with txn IDs less than min_active_txn_id
     optional int64 min_active_txn_id = 4;

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -84,6 +84,9 @@ message TabletMetadataPB {
     repeated FileMetaPB orphan_files = 10;
     optional bool enable_persistent_index = 11;
     optional PersistentIndexTypePB persistent_index_type = 12;
+    // The commit time on the FE for the transaction that created this tablet metadata.
+    // Meansured as the number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).
+    optional int64 commit_time = 13;
 }
 
 message MetadataUpdateInfoPB {


### PR DESCRIPTION
Instead of using the file creation time to compare
with the grace timestamp, the transaction commit
time is used to compare with the grace timestamp.

The main goal is to improve vacuum performance
by removing head object requests, as well as avoiding
early or delayed file deletion due to clock drift between
the object store and the FE.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
