### PR TITLE
[BugFix] Fix union isnullable error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2578,9 +2578,16 @@ public class PlanFragmentBuilder {
             // reset column is nullable, for handle union select xx join select xxx...
             setOperationNode.setHasNullableGenerateChild();
             List<Expr> setOutputList = Lists.newArrayList();
-            for (ColumnRefOperator columnRefOperator : setOperation.getOutputColumnRefOp()) {
+            for (int index = 0; index < setOperation.getOutputColumnRefOp().size(); index++) {
+                ColumnRefOperator columnRefOperator = setOperation.getOutputColumnRefOp().get(index);
                 SlotDescriptor slotDesc = context.getDescTbl().getSlotDesc(new SlotId(columnRefOperator.getId()));
-                slotDesc.setIsNullable(slotDesc.getIsNullable() | setOperationNode.isHasNullableGenerateChild());
+                boolean isNullable = slotDesc.getIsNullable() | setOperationNode.isHasNullableGenerateChild();
+                for (List<ColumnRefOperator> childOutputColumn : setOperation.getChildOutputColumns()) {
+                    ColumnRefOperator childRef = childOutputColumn.get(index);
+                    Expr childExpr = ScalarOperatorToExpr.buildExecExpression(childRef, formatterContext);
+                    isNullable |= childExpr.isNullable();
+                }
+                slotDesc.setIsNullable(isNullable);
                 setOutputList.add(new SlotRef(String.valueOf(columnRefOperator.getId()), slotDesc));
             }
             setOperationTuple.computeMemLayout();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EmptyValueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EmptyValueTest.java
@@ -178,4 +178,20 @@ public class EmptyValueTest extends PlanTestBase {
                 "  |  \n" +
                 "  1:EMPTYSET");
     }
+
+    @Test
+    public void testUnionSlot() throws Exception {
+        String sql = "select L_ORDERKEY " +
+                "from t0 left outer join lineitem_partition on L_ORDERKEY = t0.v2 and L_SHIPDATE = '2000-01-01' " +
+                "union all " +
+                "select L_ORDERKEY " +
+                "from t0 left outer join lineitem_partition on L_ORDERKEY = t0.v2 and L_SHIPDATE = '2000-01-01' ";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  0:UNION\n" +
+                "  |  output exprs:\n" +
+                "  |      [41, INT, true]\n" +
+                "  |  child exprs:\n" +
+                "  |      [4: L_ORDERKEY, INT, true]\n" +
+                "  |      [24: L_ORDERKEY, INT, true]");
+    }
 }


### PR DESCRIPTION
Fixes #issue

For SQL:
```
SELECT t1.c_1_0
FROM t1
RIGHT JOIN t0 ON t1.c_1_0 = t0.c_0_1
UNION ALL
SELECT t1.c_1_0
FROM t1
RIGHT JOIN t0 ON t1.c_1_0 = t0.c_0_1    
```

`t1` must empty table, the optimizer will trans SQL to  
```
SELECT NULL
FROM t0 
UNION ALL
SELECT NULL
FROM t0 
```

the `union` set output expr's isnullable error

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
