### PR TITLE
[Enhancement] Create dummy storage descriptor for iceberg/deltalake table from glue

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -971,7 +971,7 @@ under the License.
                         <id>generate-sources</id>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <property name="ant.python" value="${python}"/>
                                 <mkdir dir="${basedir}/target/generated-sources/proto"/>
                                 <exec executable="${java.home}/bin/java">
@@ -1018,7 +1018,7 @@ under the License.
                                     <arg value="--java"/>
                                     <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build"/>
                                 </exec>
-                            </tasks>
+                            </target>
                         </configuration>
                         <goals>
                             <goal>run</goal>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -971,7 +971,7 @@ under the License.
                         <id>generate-sources</id>
                         <phase>generate-sources</phase>
                         <configuration>
-                            <target>
+                            <tasks>
                                 <property name="ant.python" value="${python}"/>
                                 <mkdir dir="${basedir}/target/generated-sources/proto"/>
                                 <exec executable="${java.home}/bin/java">
@@ -1018,7 +1018,7 @@ under the License.
                                     <arg value="--java"/>
                                     <arg value="${starrocks.home}/fe/fe-core/target/generated-sources/build"/>
                                 </exec>
-                            </target>
+                            </tasks>
                         </configuration>
                         <goals>
                             <goal>run</goal>

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/converters/CatalogToHiveConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/converters/CatalogToHiveConverter.java
@@ -19,7 +19,6 @@ import com.amazonaws.services.glue.model.ErrorDetail;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.starrocks.connector.hive.glue.util.HiveTableValidator;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -153,12 +152,7 @@ public class CatalogToHiveConverter {
         Date lastAccessedTime = catalogTable.getLastAccessTime();
         hiveTable.setLastAccessTime(lastAccessedTime == null ? 0 : (int) (lastAccessedTime.getTime() / 1000));
         hiveTable.setRetention(catalogTable.getRetention());
-        // for iceberg table, don't need to set StorageDescriptor
-        // just use metadata location in parameters that checked in HiveTableValidator
-        // TODO(zombee0), check hudi deltalake
-        if (!HiveTableValidator.isIcebergTable(catalogTable)) {
-            hiveTable.setSd(convertStorageDescriptor(catalogTable.getStorageDescriptor()));
-        }
+        hiveTable.setSd(convertStorageDescriptor(catalogTable.getStorageDescriptor()));
         hiveTable.setPartitionKeys(convertFieldSchemaList(catalogTable.getPartitionKeys()));
         // Hive may throw a NPE during dropTable if the parameter map is null.
         Map<String, String> parameterMap = catalogTable.getParameters();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/converters/CatalogToHiveConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/converters/CatalogToHiveConverter.java
@@ -16,9 +16,11 @@
 package com.starrocks.connector.hive.glue.converters;
 
 import com.amazonaws.services.glue.model.ErrorDetail;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -46,9 +48,13 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static com.starrocks.connector.hive.HiveClassNames.MAPRED_PARQUET_INPUT_FORMAT_CLASS;
+import static com.starrocks.connector.unified.UnifiedMetadata.isDeltaLakeTable;
+import static com.starrocks.connector.unified.UnifiedMetadata.isIcebergTable;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
 public class CatalogToHiveConverter {
@@ -152,7 +158,22 @@ public class CatalogToHiveConverter {
         Date lastAccessedTime = catalogTable.getLastAccessTime();
         hiveTable.setLastAccessTime(lastAccessedTime == null ? 0 : (int) (lastAccessedTime.getTime() / 1000));
         hiveTable.setRetention(catalogTable.getRetention());
-        hiveTable.setSd(convertStorageDescriptor(catalogTable.getStorageDescriptor()));
+
+        Optional<StorageDescriptor> optionalStorageDescriptor = Optional.ofNullable(catalogTable.getStorageDescriptor())
+                .map(CatalogToHiveConverter::convertStorageDescriptor);
+        // Provide dummy storage descriptor for compatibility if not explicitly configured
+        if (!optionalStorageDescriptor.isPresent() && (isIcebergTable(catalogTable.getParameters()) ||
+                isDeltaLakeTable(catalogTable.getParameters()))) {
+            StorageDescriptor sd = new StorageDescriptor();
+            sd.setCols(ImmutableList.of());
+            sd.setInputFormat(MAPRED_PARQUET_INPUT_FORMAT_CLASS);
+            optionalStorageDescriptor = Optional.of(sd);
+        }
+
+        if (!optionalStorageDescriptor.isPresent()) {
+            throw new StarRocksConnectorException("Table StorageDescriptor is null for table " + catalogTable.getName());
+        }
+        hiveTable.setSd(optionalStorageDescriptor.get());
         hiveTable.setPartitionKeys(convertFieldSchemaList(catalogTable.getPartitionKeys()));
         // Hive may throw a NPE during dropTable if the parameter map is null.
         Map<String, String> parameterMap = catalogTable.getParameters();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -24,6 +24,7 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HiveMetadata;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.sql.ast.CreateTableStmt;
@@ -50,13 +51,19 @@ public class UnifiedMetadata implements ConnectorMetadata {
     public static final String ICEBERG_TABLE_TYPE_VALUE = "iceberg";
     public static final String SPARK_TABLE_PROVIDER_KEY = "spark.sql.sources.provider";
     public static final String DELTA_LAKE_PROVIDER = "delta";
+    public static final String PAIMON_STORAGE_HANDLER_KEY = "storage_handler";
+    public static final String PAIMON_STORAGE_HANDLER_VALUE = "org.apache.paimon.hive.PaimonStorageHandler";
 
-    static boolean isIcebergTable(Map<String, String> properties) {
+    public static boolean isIcebergTable(Map<String, String> properties) {
         return ICEBERG_TABLE_TYPE_VALUE.equalsIgnoreCase(properties.get(ICEBERG_TABLE_TYPE_NAME));
     }
 
-    static boolean isDeltaLakeTable(Map<String, String> properties) {
+    public static boolean isDeltaLakeTable(Map<String, String> properties) {
         return DELTA_LAKE_PROVIDER.equalsIgnoreCase(properties.get(SPARK_TABLE_PROVIDER_KEY));
+    }
+
+    public static boolean isPaimonTable(Map<String, String> properties) {
+        return PAIMON_STORAGE_HANDLER_VALUE.equalsIgnoreCase(properties.get(PAIMON_STORAGE_HANDLER_KEY));
     }
 
     private final Map<Table.TableType, ConnectorMetadata> metadataMap;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -24,7 +24,6 @@ import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
-import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HiveMetadata;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.sql.ast.CreateTableStmt;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/GlueToHiveConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/GlueToHiveConverterTest.java
@@ -1,0 +1,179 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive;
+
+import com.amazonaws.services.glue.model.Column;
+import com.amazonaws.services.glue.model.SerDeInfo;
+import com.amazonaws.services.glue.model.StorageDescriptor;
+import com.amazonaws.services.glue.model.Table;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.hive.glue.converters.CatalogToHiveConverter;
+import org.apache.hadoop.hive.metastore.TableType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.amazonaws.util.CollectionUtils.isNullOrEmpty;
+import static com.starrocks.connector.unified.UnifiedMetadata.ICEBERG_TABLE_TYPE_NAME;
+import static com.starrocks.connector.unified.UnifiedMetadata.ICEBERG_TABLE_TYPE_VALUE;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class GlueToHiveConverterTest {
+
+    @Test
+    public void testConvertTable() {
+        com.amazonaws.services.glue.model.Table glueTable = new Table()
+                .withDatabaseName("test-db")
+                .withName("test-tbl")
+                .withOwner("owner")
+                .withParameters(ImmutableMap.of())
+                .withPartitionKeys(ImmutableList.of())
+                .withStorageDescriptor(getGlueTestStorageDescriptor())
+                .withTableType(TableType.EXTERNAL_TABLE.name())
+                .withViewOriginalText("originalText")
+                .withViewExpandedText("expandedText")
+                .withRetention(100);
+
+        org.apache.hadoop.hive.metastore.api.Table hmsTable = CatalogToHiveConverter.convertTable(glueTable, "test-db");
+        assertEquals(hmsTable.getTableName(), glueTable.getName());
+        assertEquals(hmsTable.getDbName(), glueTable.getDatabaseName());
+        assertEquals(hmsTable.getTableType(), glueTable.getTableType());
+        assertEquals(hmsTable.getOwner(), glueTable.getOwner());
+        assertEquals(hmsTable.getParameters(), glueTable.getParameters());
+        assertColumnList(hmsTable.getSd().getCols(), glueTable.getStorageDescriptor().getColumns());
+        assertColumnList(hmsTable.getPartitionKeys(), glueTable.getPartitionKeys());
+        assertStorage(hmsTable.getSd(), glueTable.getStorageDescriptor());
+        assertEquals(hmsTable.getViewOriginalText(), glueTable.getViewOriginalText());
+        assertEquals(hmsTable.getViewExpandedText(), glueTable.getViewExpandedText());
+        assertEquals(hmsTable.getRetention(), glueTable.getRetention());
+    }
+
+    @Test
+    public void testConvertIcebergTableWithoutSd() {
+        com.amazonaws.services.glue.model.Table glueTable = new Table()
+                .withDatabaseName("test-db")
+                .withName("test-tbl")
+                .withOwner("owner")
+                .withParameters(ImmutableMap.of(ICEBERG_TABLE_TYPE_NAME, ICEBERG_TABLE_TYPE_VALUE))
+                .withPartitionKeys(ImmutableList.of())
+                .withStorageDescriptor(null)
+                .withTableType(TableType.EXTERNAL_TABLE.name())
+                .withViewOriginalText("originalText")
+                .withViewExpandedText("expandedText")
+                .withRetention(100);
+
+        org.apache.hadoop.hive.metastore.api.Table hmsTable = CatalogToHiveConverter.convertTable(glueTable, "test-db");
+        assertEquals(hmsTable.getTableName(), glueTable.getName());
+        assertEquals(hmsTable.getDbName(), glueTable.getDatabaseName());
+        assertEquals(hmsTable.getTableType(), glueTable.getTableType());
+        assertEquals(hmsTable.getOwner(), glueTable.getOwner());
+        assertEquals(hmsTable.getParameters(), glueTable.getParameters());
+        assertColumnList(hmsTable.getPartitionKeys(), glueTable.getPartitionKeys());
+        assertNotNull(hmsTable.getSd()); // dummy Sd
+        assertEquals(hmsTable.getViewOriginalText(), glueTable.getViewOriginalText());
+        assertEquals(hmsTable.getViewExpandedText(), glueTable.getViewExpandedText());
+        assertEquals(hmsTable.getRetention(), glueTable.getRetention());
+    }
+
+    @Test
+    public void testConvertTableWithoutSd() {
+        com.amazonaws.services.glue.model.Table glueTable = new Table()
+                .withDatabaseName("test-db")
+                .withName("test-tbl")
+                .withOwner("owner")
+                .withParameters(ImmutableMap.of())
+                .withPartitionKeys(ImmutableList.of())
+                .withStorageDescriptor(null)
+                .withTableType(TableType.EXTERNAL_TABLE.name())
+                .withViewOriginalText("originalText")
+                .withViewExpandedText("expandedText")
+                .withRetention(100);
+
+        assertThrows(StarRocksConnectorException.class, () -> CatalogToHiveConverter.convertTable(glueTable, "test-db"));
+    }
+
+    private static void assertColumnList(List<org.apache.hadoop.hive.metastore.api.FieldSchema> actual,
+                                         List<com.amazonaws.services.glue.model.Column> expected) {
+        if (expected == null) {
+            assertNull(actual);
+        }
+        assertEquals(actual.size(), expected.size());
+
+        for (int i = 0; i < expected.size(); i++) {
+            assertColumn(actual.get(i), expected.get(i));
+        }
+    }
+
+    private static void assertColumn(org.apache.hadoop.hive.metastore.api.FieldSchema actual,
+                                     com.amazonaws.services.glue.model.Column expected) {
+        assertEquals(actual.getName(), expected.getName());
+        assertEquals(actual.getType(), expected.getType());
+        assertEquals(actual.getComment(), expected.getComment());
+    }
+
+    private static void assertStorage(org.apache.hadoop.hive.metastore.api.StorageDescriptor actual,
+                                      com.amazonaws.services.glue.model.StorageDescriptor expected) {
+        assertEquals(actual.getLocation(), expected.getLocation());
+        assertEquals(actual.getSerdeInfo().getSerializationLib(), expected.getSerdeInfo().getSerializationLibrary());
+        assertEquals(actual.getInputFormat(), expected.getInputFormat());
+        assertEquals(actual.getOutputFormat(), expected.getOutputFormat());
+        if (!isNullOrEmpty(expected.getBucketColumns())) {
+            assertEquals(actual.getBucketCols(), expected.getBucketColumns());
+            assertEquals(actual.getBucketColsSize(), expected.getNumberOfBuckets().intValue());
+        }
+    }
+
+    public static Column getGlueTestColumn() {
+        return getGlueTestColumn("string");
+    }
+
+    public static Column getGlueTestColumn(String type) {
+        return new Column()
+                .withName("test-col" + generateRandom())
+                .withType(type)
+                .withComment("column comment");
+    }
+
+    private static String generateRandom() {
+        return format("%04x", ThreadLocalRandom.current().nextInt());
+    }
+
+    public static StorageDescriptor getGlueTestStorageDescriptor() {
+        return getGlueTestStorageDescriptor(ImmutableList.of(getGlueTestColumn()), "SerdeLib");
+    }
+
+    public static StorageDescriptor getGlueTestStorageDescriptor(List<Column> columns, String serde) {
+        return new StorageDescriptor()
+                .withBucketColumns(ImmutableList.of("test-bucket-col"))
+                .withColumns(columns)
+                .withParameters(ImmutableMap.of())
+                .withSerdeInfo(new SerDeInfo()
+                        .withSerializationLibrary(serde)
+                        .withParameters(ImmutableMap.of()))
+                .withInputFormat("InputFormat")
+                .withOutputFormat("OutputFormat")
+                .withLocation("/test-tbl")
+                .withNumberOfBuckets(1)
+                .withCompressed(false)
+                .withStoredAsSubDirectories(false);
+    }
+}


### PR DESCRIPTION
Otherwise `getTable` throws exception

```java
public Table getTable(String dbName, String tableName) {
    org.apache.hadoop.hive.metastore.api.Table table = client.getTable(dbName, tableName);
    StorageDescriptor sd = table.getSd();
    if (sd == null) {
        throw new StarRocksConnectorException("Table is missing storage descriptor");
    }

    ...
}
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
