### PR TITLE
[Enhancement] Support time-based cache adaptor to skip reading cache when disk overload is high.

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -83,8 +83,8 @@ Status BlockCache::init(const CacheOptions& options) {
     return _kv_cache->init(options);
 }
 
-Status BlockCache::write_cache(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer, size_t ttl_seconds,
-                               bool overwrite) {
+Status BlockCache::write_cache(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer,
+                               WriteCacheOptions* options) {
     if (offset % _block_size != 0) {
         LOG(WARNING) << "write block key: " << cache_key << " with invalid args, offset: " << offset;
         return Status::InvalidArgument(strings::Substitute("offset must be aligned by block size $0", _block_size));
@@ -92,36 +92,40 @@ Status BlockCache::write_cache(const CacheKey& cache_key, off_t offset, const IO
     if (buffer.empty()) {
         return Status::OK();
     }
+
     size_t index = offset / _block_size;
     std::string block_key = fmt::format("{}/{}", cache_key, index);
-    return _kv_cache->write_cache(block_key, buffer, ttl_seconds, overwrite);
+    return _kv_cache->write_cache(block_key, buffer, options);
 }
 
 static void empty_deleter(void*) {}
 
 Status BlockCache::write_cache(const CacheKey& cache_key, off_t offset, size_t size, const char* data,
-                               size_t ttl_seconds, bool overwrite) {
+                               WriteCacheOptions* options) {
     if (!data) {
         return Status::InvalidArgument("invalid data buffer");
     }
 
     IOBuffer buffer;
     buffer.append_user_data((void*)data, size, empty_deleter);
-    return write_cache(cache_key, offset, buffer, ttl_seconds, overwrite);
+    return write_cache(cache_key, offset, buffer, options);
 }
 
-Status BlockCache::read_cache(const CacheKey& cache_key, off_t offset, size_t size, IOBuffer* buffer) {
+Status BlockCache::read_cache(const CacheKey& cache_key, off_t offset, size_t size, IOBuffer* buffer,
+                              ReadCacheOptions* options) {
     if (size == 0) {
         return Status::OK();
     }
+
     size_t index = offset / _block_size;
     std::string block_key = fmt::format("{}/{}", cache_key, index);
-    return _kv_cache->read_cache(block_key, offset - index * _block_size, size, buffer);
+    return _kv_cache->read_cache(block_key, offset - index * _block_size, size, buffer, options);
 }
 
-StatusOr<size_t> BlockCache::read_cache(const CacheKey& cache_key, off_t offset, size_t size, char* data) {
+StatusOr<size_t> BlockCache::read_cache(const CacheKey& cache_key, off_t offset, size_t size, char* data,
+                                        ReadCacheOptions* options) {
     IOBuffer buffer;
-    RETURN_IF_ERROR(read_cache(cache_key, offset, size, &buffer));
+    RETURN_IF_ERROR(read_cache(cache_key, offset, size, &buffer, options));
     buffer.copy_to(data);
     return buffer.size();
 }
@@ -140,6 +144,14 @@ Status BlockCache::remove_cache(const CacheKey& cache_key, off_t offset, size_t 
     size_t index = offset / _block_size;
     std::string block_key = fmt::format("{}/{}", cache_key, index);
     return _kv_cache->remove_cache(block_key);
+}
+
+void BlockCache::record_read_remote(size_t size, int64_t lateny_us) {
+    _kv_cache->record_read_remote(size, lateny_us);
+}
+
+void BlockCache::record_read_cache(size_t size, int64_t lateny_us) {
+    _kv_cache->record_read_cache(size, lateny_us);
 }
 
 Status BlockCache::shutdown() {

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -30,20 +30,26 @@ public:
     Status init(const CacheOptions& options);
 
     // Write data to cache, the offset must be aligned by block size
-    Status write_cache(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer, size_t ttl_seconds = 0,
-                       bool overwrite = true);
+    Status write_cache(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer,
+                       WriteCacheOptions* options = nullptr);
 
-    Status write_cache(const CacheKey& cache_key, off_t offset, size_t size, const char* data, size_t ttl_seconds = 0,
-                       bool overwrite = true);
+    Status write_cache(const CacheKey& cache_key, off_t offset, size_t size, const char* data,
+                       WriteCacheOptions* options = nullptr);
 
     // Read data from cache, it returns the data size if successful; otherwise the error status
     // will be returned. The offset and size must be aligned by block size.
-    Status read_cache(const CacheKey& cache_key, off_t offset, size_t size, IOBuffer* buffer);
+    Status read_cache(const CacheKey& cache_key, off_t offset, size_t size, IOBuffer* buffer,
+                      ReadCacheOptions* options = nullptr);
 
-    StatusOr<size_t> read_cache(const CacheKey& cache_key, off_t offset, size_t size, char* data);
+    StatusOr<size_t> read_cache(const CacheKey& cache_key, off_t offset, size_t size, char* data,
+                                ReadCacheOptions* options = nullptr);
 
     // Remove data from cache. The offset and size must be aligned by block size
     Status remove_cache(const CacheKey& cache_key, off_t offset, size_t size);
+
+    void record_read_remote(size_t size, int64_t lateny_us);
+
+    void record_read_cache(size_t size, int64_t lateny_us);
 
     // Shutdown the cache instance to save some state meta
     Status shutdown();

--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -37,6 +37,27 @@ struct CacheOptions {
     std::string engine;
     size_t max_concurrent_inserts;
     size_t max_flying_memory_mb;
+    bool enable_cache_adaptor;
+    size_t skip_read_factor;
+};
+
+struct WriteCacheOptions {
+    // If ttl_seconds=0 (default), no ttl restriction will be set. If an old one exists, remove it.
+    uint64_t ttl_seconds = 0;
+    // If overwrite=true, the cache value will be replaced if it already exists.
+    bool overwrite = true;
+
+    struct Stats {
+        int64_t write_mem_bytes = 0;
+        int64_t write_disk_bytes = 0;
+    } stats;
+};
+
+struct ReadCacheOptions {
+    struct Stats {
+        int64_t read_mem_bytes = 0;
+        int64_t read_disk_bytes = 0;
+    } stats;
 };
 
 int64_t parse_mem_size(const std::string& mem_size_str, int64_t mem_limit = -1);

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -55,10 +55,9 @@ Status CacheLibWrapper::init(const CacheOptions& options) {
     return Status::OK();
 }
 
-Status CacheLibWrapper::write_cache(const std::string& key, const IOBuffer& buffer, size_t ttl_seconds,
-                                    bool overwrite) {
+Status CacheLibWrapper::write_cache(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) {
     //  Simulate the behavior of skipping if exists
-    if (!overwrite && _cache->find(key)) {
+    if (options && !options->overwrite && _cache->find(key)) {
         return Status::AlreadyExist("the cache item already exists");
     }
     // TODO: check size for chain item
@@ -71,7 +70,8 @@ Status CacheLibWrapper::write_cache(const std::string& key, const IOBuffer& buff
     return Status::OK();
 }
 
-Status CacheLibWrapper::read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer) {
+Status CacheLibWrapper::read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
+                                   ReadCacheOptions* options) {
     // TODO:
     // 1. check chain item
     // 2. replace with async methods
@@ -96,6 +96,10 @@ std::unordered_map<std::string, double> CacheLibWrapper::cache_stats() {
     const auto navy_stats = _cache->getNvmCacheStatsMap().toMap();
     return navy_stats;
 }
+
+void CacheLibWrapper::record_read_remote(size_t size, int64_t lateny_us) {}
+
+void CacheLibWrapper::record_read_cache(size_t size, int64_t lateny_us) {}
 
 Status CacheLibWrapper::shutdown() {
     if (_cache) {

--- a/be/src/block_cache/cachelib_wrapper.h
+++ b/be/src/block_cache/cachelib_wrapper.h
@@ -44,13 +44,18 @@ public:
 
     Status init(const CacheOptions& options) override;
 
-    Status write_cache(const std::string& key, const IOBuffer& buffer, size_t ttl_seconds, bool overwrite) override;
+    Status write_cache(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) override;
 
-    Status read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer) override;
+    Status read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
+                      ReadCacheOptions* options) override;
 
     Status remove_cache(const std::string& key) override;
 
     std::unordered_map<std::string, double> cache_stats() override;
+
+    void record_read_remote(size_t size, int64_t lateny_us) override;
+
+    void record_read_cache(size_t size, int64_t lateny_us) override;
 
     Status shutdown() override;
 

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -28,16 +28,21 @@ public:
     virtual Status init(const CacheOptions& options) = 0;
 
     // Write data to cache
-    virtual Status write_cache(const std::string& key, const IOBuffer& buffer, size_t ttl_seconds, bool overwrite) = 0;
+    virtual Status write_cache(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) = 0;
 
     // Read data from cache, it returns the data size if successful; otherwise the error status
     // will be returned.
-    virtual Status read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer) = 0;
+    virtual Status read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
+                              ReadCacheOptions* options) = 0;
 
     // Remove data from cache. The offset must be aligned by block size
     virtual Status remove_cache(const std::string& key) = 0;
 
     virtual std::unordered_map<std::string, double> cache_stats() = 0;
+
+    virtual void record_read_remote(size_t size, int64_t lateny_us) = 0;
+
+    virtual void record_read_cache(size_t size, int64_t lateny_us) = 0;
 
     virtual Status shutdown() = 0;
 };

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -965,6 +965,12 @@ CONF_Int64(datacache_max_concurrent_inserts, "1500000");
 // Total memory limit for in-flight cache jobs.
 // Once this is reached, cache populcation will be rejected until the flying memory usage gets under the limit.
 CONF_Int64(datacache_max_flying_memory_mb, "256");
+// Whether to use datacache adaptor, which will skip reading cache when disk overload is high.
+CONF_Bool(datacache_adaptor_enable, "true");
+// A factor to control the io traffic between cache and network. The larger this parameter,
+// the more requests will be sent to the network.
+// Usually there is no need to modify it.
+CONF_Int64(datacache_skip_read_factor, "1");
 // DataCache engines, alternatives: cachelib, starcache.
 // Set the default value empty to indicate whether it is manully configured by users.
 // If not, we need to adjust the default engine based on build switches like "WITH_CACHELIB" and "WITH_STARCACHE".

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -252,6 +252,11 @@ public:
         return code() == TStatusCode::CORRUPTION;
     }
 
+    bool is_resource_busy() const {
+        mark_checked();
+        return code() == TStatusCode::RESOURCE_BUSY;
+    }
+
     /// @return @c true if the status indicates Uninitialized.
     bool is_uninitialized() const {
         mark_checked();

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -309,6 +309,14 @@ void HiveDataSource::_init_counter(RuntimeState* state) {
         _profile.datacache_read_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadCounter", TUnit::UNIT, prefix);
         _profile.datacache_read_bytes = ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBytes", TUnit::BYTES, prefix);
+        _profile.datacache_read_mem_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadMemBytes", TUnit::BYTES, "DataCacheReadBytes");
+        _profile.datacache_read_disk_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadDiskBytes", TUnit::BYTES, "DataCacheReadBytes");
+        _profile.datacache_skip_read_counter =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheSkipReadCounter", TUnit::UNIT, prefix);
+        _profile.datacache_skip_read_bytes =
+                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheSkipReadBytes", TUnit::BYTES, prefix);
         _profile.datacache_read_timer = ADD_CHILD_TIMER(_runtime_profile, "DataCacheReadTimer", prefix);
         _profile.datacache_write_counter =
                 ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteCounter", TUnit::UNIT, prefix);

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -303,7 +303,11 @@ void HdfsScanner::update_counter() {
         const io::CacheInputStream::Stats& stats = _cache_input_stream->stats();
         COUNTER_UPDATE(profile->datacache_read_counter, stats.read_cache_count);
         COUNTER_UPDATE(profile->datacache_read_bytes, stats.read_cache_bytes);
+        COUNTER_UPDATE(profile->datacache_read_mem_bytes, stats.read_mem_cache_bytes);
+        COUNTER_UPDATE(profile->datacache_read_disk_bytes, stats.read_disk_cache_bytes);
         COUNTER_UPDATE(profile->datacache_read_timer, stats.read_cache_ns);
+        COUNTER_UPDATE(profile->datacache_skip_read_counter, stats.skip_read_cache_count);
+        COUNTER_UPDATE(profile->datacache_skip_read_bytes, stats.skip_read_cache_bytes);
         COUNTER_UPDATE(profile->datacache_write_counter, stats.write_cache_count);
         COUNTER_UPDATE(profile->datacache_write_bytes, stats.write_cache_bytes);
         COUNTER_UPDATE(profile->datacache_write_timer, stats.write_cache_ns);

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -95,7 +95,11 @@ struct HdfsScanProfile {
 
     RuntimeProfile::Counter* datacache_read_counter = nullptr;
     RuntimeProfile::Counter* datacache_read_bytes = nullptr;
+    RuntimeProfile::Counter* datacache_read_mem_bytes = nullptr;
+    RuntimeProfile::Counter* datacache_read_disk_bytes = nullptr;
     RuntimeProfile::Counter* datacache_read_timer = nullptr;
+    RuntimeProfile::Counter* datacache_skip_read_counter = nullptr;
+    RuntimeProfile::Counter* datacache_skip_read_bytes = nullptr;
     RuntimeProfile::Counter* datacache_write_counter = nullptr;
     RuntimeProfile::Counter* datacache_write_bytes = nullptr;
     RuntimeProfile::Counter* datacache_write_timer = nullptr;

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -18,7 +18,6 @@
 
 #include <utility>
 
-#include "block_cache/block_cache.h"
 #include "gutil/strings/fastmem.h"
 #include "util/hash_util.hpp"
 #include "util/runtime_profile.h"
@@ -40,7 +39,9 @@ CacheInputStream::CacheInputStream(const std::shared_ptr<SharedBufferedInputStre
           _size(size) {
     // _cache_key = _filename;
     // use hash(filename) as cache key.
-    _block_size = BlockCache::instance()->block_size();
+    _cache = BlockCache::instance();
+    _block_size = _cache->block_size();
+
     _cache_key.resize(12);
     char* data = _cache_key.data();
     uint64_t hash_value = HashUtil::hash64(filename.data(), filename.size(), 0);
@@ -58,6 +59,14 @@ CacheInputStream::CacheInputStream(const std::shared_ptr<SharedBufferedInputStre
         memcpy(data + 8, &file_size, sizeof(file_size));
     }
     _buffer.reserve(_block_size);
+}
+
+CacheInputStream::~CacheInputStream() {
+    int64_t io_bytes = _sb_stream->shared_io_bytes();
+    if (io_bytes > 0) {
+        int64_t latency_us_per_block = (_sb_stream->shared_io_timer() / 1000 * _block_size / io_bytes);
+        _cache->record_read_remote(io_bytes, latency_us_per_block);
+    }
 }
 
 Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bool can_zero_copy) {
@@ -92,23 +101,30 @@ Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bo
     }
 
     // read cache
-    BlockCache* cache = BlockCache::instance();
     Status res;
+    int64_t read_cache_ns = 0;
+    BlockBuffer block;
+    ReadCacheOptions options;
     {
-        SCOPED_RAW_TIMER(&_stats.read_cache_ns);
-        BlockBuffer block;
-        res = cache->read_cache(_cache_key, block_offset, load_size, &block.buffer);
-        if (res.ok()) {
-            block.buffer.copy_to(out, size, shift);
-            block.offset = block_offset;
-            _block_map[block_id] = block;
-            _stats.read_cache_count += 1;
-            _stats.read_cache_bytes += load_size;
-            return Status::OK();
-        }
+        SCOPED_RAW_TIMER(&read_cache_ns);
+        res = _cache->read_cache(_cache_key, block_offset, load_size, &block.buffer, &options);
     }
-    if (!res.is_not_found()) return res;
-    DCHECK(res.is_not_found());
+    if (res.ok()) {
+        block.buffer.copy_to(out, size, shift);
+        block.offset = block_offset;
+        _block_map[block_id] = block;
+        _stats.read_cache_count += 1;
+        _stats.read_cache_bytes += load_size;
+        _stats.read_mem_cache_bytes += options.stats.read_mem_bytes;
+        _stats.read_disk_cache_bytes += options.stats.read_disk_bytes;
+        _stats.read_cache_ns += read_cache_ns;
+        _cache->record_read_cache(load_size, read_cache_ns / 1000);
+        return Status::OK();
+    } else if (res.is_resource_busy()) {
+        _stats.skip_read_cache_count += 1;
+        _stats.skip_read_cache_bytes += load_size;
+    }
+    if (!res.is_not_found() && !res.is_resource_busy()) return res;
 
     // read remote
     char* src = nullptr;
@@ -134,13 +150,16 @@ Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bo
         }
     }
 
-    if (_enable_populate_cache) {
+    if (_enable_populate_cache && res.is_not_found()) {
         SCOPED_RAW_TIMER(&_stats.write_cache_ns);
-        Status r = cache->write_cache(_cache_key, block_offset, load_size, src);
+        WriteCacheOptions options;
+        Status r = _cache->write_cache(_cache_key, block_offset, load_size, src, &options);
         if (r.ok()) {
             _stats.write_cache_count += 1;
             _stats.write_cache_bytes += load_size;
-        } else {
+            _stats.write_mem_cache_bytes += options.stats.write_mem_bytes;
+            _stats.write_disk_cache_bytes += options.stats.write_disk_bytes;
+        } else if (!r.is_already_exist()) {
             _stats.write_cache_fail_count += 1;
             _stats.write_cache_fail_bytes += load_size;
             LOG(WARNING) << "write block cache failed, errmsg: " << r.get_error_msg();
@@ -250,10 +269,17 @@ void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int6
     p -= (offset - begin);
     auto f = [&](const char* buf, size_t offset, size_t size) {
         SCOPED_RAW_TIMER(&_stats.write_cache_ns);
-        Status r = cache->write_cache(_cache_key, offset, size, buf, 0, false);
+        WriteCacheOptions options;
+        options.overwrite = false;
+        Status r = cache->write_cache(_cache_key, offset, size, buf, &options);
         if (r.ok()) {
             _stats.write_cache_count += 1;
             _stats.write_cache_bytes += size;
+            _stats.write_mem_cache_bytes += options.stats.write_mem_bytes;
+            _stats.write_disk_cache_bytes += options.stats.write_disk_bytes;
+        } else if (r.is_cancelled()) {
+            _stats.skip_write_cache_count += 1;
+            _stats.skip_write_cache_bytes += size;
         } else if (!r.is_already_exist()) {
             _stats.write_cache_fail_count += 1;
             _stats.write_cache_fail_bytes += size;

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 
+#include "block_cache/block_cache.h"
 #include "block_cache/io_buffer.h"
 #include "io/shared_buffered_input_stream.h"
 
@@ -29,8 +30,16 @@ public:
         int64_t write_cache_ns = 0;
         int64_t read_cache_count = 0;
         int64_t write_cache_count = 0;
+        int64_t write_mem_cache_bytes = 0;
+        int64_t write_disk_cache_bytes = 0;
         int64_t read_cache_bytes = 0;
+        int64_t read_mem_cache_bytes = 0;
+        int64_t read_disk_cache_bytes = 0;
         int64_t write_cache_bytes = 0;
+        int64_t skip_read_cache_count = 0;
+        int64_t skip_read_cache_bytes = 0;
+        int64_t skip_write_cache_count = 0;
+        int64_t skip_write_cache_bytes = 0;
         int64_t write_cache_fail_count = 0;
         int64_t write_cache_fail_bytes = 0;
         int64_t read_block_buffer_bytes = 0;
@@ -40,7 +49,7 @@ public:
     explicit CacheInputStream(const std::shared_ptr<SharedBufferedInputStream>& stream, const std::string& filename,
                               size_t size, int64_t modification_time);
 
-    ~CacheInputStream() override = default;
+    ~CacheInputStream() override;
 
     StatusOr<int64_t> read(void* data, int64_t count) override;
 
@@ -83,6 +92,7 @@ private:
     Stats _stats;
     int64_t _size;
     bool _enable_populate_cache = false;
+    BlockCache* _cache = nullptr;
     int64_t _block_size = 0;
     std::unordered_map<int64_t, BlockBuffer> _block_map;
 };

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -108,6 +108,8 @@ Status init_datacache(GlobalEnv* global_env) {
         cache_options.max_concurrent_inserts = config::datacache_max_concurrent_inserts;
         cache_options.enable_checksum = config::datacache_checksum_enable;
         cache_options.enable_direct_io = config::datacache_direct_io_enable;
+        cache_options.enable_cache_adaptor = starrocks::config::datacache_adaptor_enable;
+        cache_options.skip_read_factor = starrocks::config::datacache_skip_read_factor;
         cache_options.engine = config::datacache_engine;
         return cache->init(cache_options);
     }

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -37,8 +37,6 @@
 #include <sys/file.h>
 #include <unistd.h>
 
-#include "block_cache/block_cache.h"
-
 #if defined(LEAK_SANITIZER)
 #include <sanitizer/lsan_interface.h>
 #endif

--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -209,8 +209,9 @@ TEST_F(BlockCacheTest, write_with_overwrite_option) {
     Status st = cache->write_cache(cache_key, 0, cache_size, value.c_str());
     ASSERT_TRUE(st.ok());
 
+    WriteCacheOptions write_options;
     std::string value2(cache_size, 'b');
-    st = cache->write_cache(cache_key, 0, cache_size, value2.c_str(), 0, true);
+    st = cache->write_cache(cache_key, 0, cache_size, value2.c_str(), &write_options);
     ASSERT_TRUE(st.ok());
 
     char rvalue[cache_size] = {0};
@@ -219,12 +220,79 @@ TEST_F(BlockCacheTest, write_with_overwrite_option) {
     std::string expect_value(cache_size, 'b');
     ASSERT_EQ(memcmp(rvalue, expect_value.c_str(), cache_size), 0);
 
+    write_options.overwrite = false;
     std::string value3(cache_size, 'c');
-    st = cache->write_cache(cache_key, 0, cache_size, value3.c_str(), 0, false);
+    st = cache->write_cache(cache_key, 0, cache_size, value3.c_str(), &write_options);
     ASSERT_TRUE(st.is_already_exist());
 
     cache->shutdown();
 }
+
+TEST_F(BlockCacheTest, read_cache_with_adaptor) {
+    std::unique_ptr<BlockCache> cache(new BlockCache);
+    const size_t block_size = 1024 * 1024;
+
+    CacheOptions options;
+    options.mem_space_size = 1024;
+    size_t quota = 500 * 1024 * 1024;
+    options.disk_spaces.push_back({.path = "./ut_dir/block_disk_cache", .size = quota});
+    options.block_size = block_size;
+    options.max_concurrent_inserts = 100000;
+    options.engine = "starcache";
+    options.enable_cache_adaptor = true;
+    options.skip_read_factor = 1;
+    Status status = cache->init(options);
+    ASSERT_TRUE(status.ok());
+
+    const size_t batch_size = block_size - 1234;
+    const size_t rounds = 20;
+    const std::string cache_key = "test_file";
+
+    // write cache
+    for (size_t i = 0; i < rounds; ++i) {
+        char ch = 'a' + i % 26;
+        std::string value(batch_size, ch);
+        Status st = cache->write_cache(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+        ASSERT_TRUE(st.ok());
+    }
+
+    const int kAdaptorWindowSize = 50;
+
+    // record read latencyr to ensure cache latency > remote latency
+    for (size_t i = 0; i < kAdaptorWindowSize; ++i) {
+        cache->record_read_cache(batch_size, 1000000000);
+        cache->record_read_remote(batch_size, 10);
+    }
+
+    // all reads will be reject by cache adaptor
+    for (size_t i = 0; i < rounds; ++i) {
+        char ch = 'a' + i % 26;
+        std::string expect_value(batch_size, ch);
+        char value[batch_size] = {0};
+        ReadCacheOptions opts;
+        auto res = cache->read_cache(cache_key + std::to_string(i), 0, batch_size, value, &opts);
+        ASSERT_TRUE(res.status().is_resource_busy());
+    }
+
+    // record read latencyr to ensure cache latency < remote latency
+    for (size_t i = 0; i < kAdaptorWindowSize; ++i) {
+        cache->record_read_cache(batch_size, 10);
+        cache->record_read_remote(batch_size, 1000000000);
+    }
+
+    // all reads will be accepted by cache adaptor
+    for (size_t i = 0; i < rounds; ++i) {
+        char ch = 'a' + i % 26;
+        std::string expect_value(batch_size, ch);
+        char value[batch_size] = {0};
+        ReadCacheOptions opts;
+        auto res = cache->read_cache(cache_key + std::to_string(i), 0, batch_size, value, &opts);
+        ASSERT_TRUE(res.status().ok());
+    }
+
+    cache->shutdown();
+}
+
 #endif
 
 #ifdef WITH_CACHELIB

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -49,7 +49,6 @@ public:
 protected:
     void _create_runtime_state(const std::string& timezone);
     void _create_runtime_profile();
-    HdfsScanProfile* _create_profile();
     Status _init_datacache(size_t mem_size, const std::string& engine);
     HdfsScannerParams* _create_param(const std::string& file, THdfsScanRange* range, const TupleDescriptor* tuple_desc);
     void build_hive_column_names(HdfsScannerParams* params, const TupleDescriptor* tuple_desc,
@@ -68,75 +67,6 @@ protected:
 void HdfsScannerTest::_create_runtime_profile() {
     _runtime_profile = _pool.add(new RuntimeProfile("test"));
     _runtime_profile->set_metadata(1);
-}
-
-HdfsScanProfile* HdfsScannerTest::_create_profile() {
-    if (!_runtime_profile) {
-        _create_runtime_profile();
-    }
-    HdfsScanProfile* profile = _pool.add(new HdfsScanProfile());
-    profile->runtime_profile = _runtime_profile;
-    profile->rows_read_counter = ADD_COUNTER(_runtime_profile, "RowsRead", TUnit::UNIT);
-    profile->rows_skip_counter = ADD_COUNTER(_runtime_profile, "RowsSkip", TUnit::UNIT);
-    profile->scan_ranges_counter = ADD_COUNTER(_runtime_profile, "ScanRanges", TUnit::UNIT);
-
-    profile->reader_init_timer = ADD_TIMER(_runtime_profile, "ReaderInit");
-    profile->open_file_timer = ADD_TIMER(_runtime_profile, "OpenFile");
-    profile->expr_filter_timer = ADD_TIMER(_runtime_profile, "ExprFilterTime");
-
-    profile->column_read_timer = ADD_TIMER(_runtime_profile, "ColumnReadTime");
-    profile->column_convert_timer = ADD_TIMER(_runtime_profile, "ColumnConvertTime");
-
-    {
-        static const char* prefix = "SharedBuffered";
-        ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
-        profile->shared_buffered_shared_io_bytes =
-                ADD_CHILD_COUNTER(_runtime_profile, "SharedIOBytes", TUnit::BYTES, prefix);
-        profile->shared_buffered_shared_io_count =
-                ADD_CHILD_COUNTER(_runtime_profile, "SharedIOCount", TUnit::UNIT, prefix);
-        profile->shared_buffered_shared_io_timer = ADD_CHILD_TIMER(_runtime_profile, "SharedIOTime", prefix);
-        profile->shared_buffered_direct_io_bytes =
-                ADD_CHILD_COUNTER(_runtime_profile, "DirectIOBytes", TUnit::BYTES, prefix);
-        profile->shared_buffered_direct_io_count =
-                ADD_CHILD_COUNTER(_runtime_profile, "DirectIOCount", TUnit::UNIT, prefix);
-        profile->shared_buffered_direct_io_timer = ADD_CHILD_TIMER(_runtime_profile, "DirectIOTime", prefix);
-    }
-
-    {
-        static const char* prefix = "DataCache";
-        ADD_COUNTER(_runtime_profile, prefix, TUnit::UNIT);
-        profile->datacache_read_counter =
-                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadCounter", TUnit::UNIT, prefix);
-        profile->datacache_read_bytes = ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBytes", TUnit::BYTES, prefix);
-        profile->datacache_read_timer = ADD_CHILD_TIMER(_runtime_profile, "DataCacheReadTimer", prefix);
-        profile->datacache_write_counter =
-                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteCounter", TUnit::UNIT, prefix);
-        profile->datacache_write_bytes =
-                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteBytes", TUnit::BYTES, prefix);
-        profile->datacache_write_timer = ADD_CHILD_TIMER(_runtime_profile, "DataCacheWriteTimer", prefix);
-        profile->datacache_write_fail_counter =
-                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteFailCounter", TUnit::UNIT, prefix);
-        profile->datacache_write_fail_bytes =
-                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheWriteFailBytes", TUnit::BYTES, prefix);
-        profile->datacache_read_block_buffer_counter =
-                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBlockBufferCounter", TUnit::UNIT, prefix);
-        profile->datacache_read_block_buffer_bytes =
-                ADD_CHILD_COUNTER(_runtime_profile, "DataCacheReadBlockBufferBytes", TUnit::BYTES, prefix);
-    }
-
-    {
-        static const char* prefix = "InputStream";
-        ADD_COUNTER(_runtime_profile, prefix, TUnit::NONE);
-        profile->app_io_bytes_read_counter =
-                ADD_CHILD_COUNTER(_runtime_profile, "AppIOBytesRead", TUnit::BYTES, prefix);
-        profile->app_io_timer = ADD_CHILD_TIMER(_runtime_profile, "AppIOTime", prefix);
-        profile->app_io_counter = ADD_CHILD_COUNTER(_runtime_profile, "AppIOCounter", TUnit::UNIT, prefix);
-        profile->fs_bytes_read_counter = ADD_CHILD_COUNTER(_runtime_profile, "FSIOBytesRead", TUnit::BYTES, prefix);
-        profile->fs_io_counter = ADD_CHILD_COUNTER(_runtime_profile, "FSIOCounter", TUnit::UNIT, prefix);
-        profile->fs_io_timer = ADD_CHILD_TIMER(_runtime_profile, "FSIOTime", prefix);
-    }
-
-    return profile;
 }
 
 void HdfsScannerTest::_create_runtime_state(const std::string& timezone) {
@@ -1674,7 +1604,6 @@ TEST_F(HdfsScannerTest, TestCSVWithoutEndDelemeter) {
         auto* range = _create_scan_range(small_file, 0, 0);
         auto* tuple_desc = _create_tuple_desc(csv_descs);
         auto* param = _create_param(small_file, range, tuple_desc);
-        param->profile = _create_profile();
 #if defined(WITH_STARCACHE)
         status = _init_datacache(50 * 1024 * 1024, "starcache"); // 50MB
         ASSERT_TRUE(status.ok()) << status.get_error_msg();


### PR DESCRIPTION
In some cases, such as the network performance of the machine is much better than disk, reading disk cache may cause some negative optimization.
To make full use of host resources, we implement a time-based cache adaptor in starcache to adjust the io traffic to network and disk according the resource overload. 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
