### PR TITLE
[BugFix] Fix string format bug in TabletSchedCtx.unprotectedFinishClone

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -941,7 +941,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         // We should discard the clone replica with stale version.
         TTabletInfo reportedTablet = request.getFinish_tablet_infos().get(0);
         if (reportedTablet.getVersion() < visibleVersion) {
-            String msg = String.format("the clone replica's version is stale. %d-%d, task visible version: %d",
+            String msg = String.format("the clone replica's version is stale. %d, task visible version: %d",
                     reportedTablet.getVersion(),
                     visibleVersion);
             throw new SchedException(Status.RUNNING_FAILED, msg);


### PR DESCRIPTION
Fixes 
```
2023-10-11 15:19:32,908 WARN (thrift-server-pool-6671314|19441251) [TabletScheduler.finishCloneTask():1311] got unexpected exception when finish clone task. tablet: 418571700
java.util.MissingFormatArgumentException: Format specifier '%d'
        at java.util.Formatter.format(Formatter.java:2519) ~[?:1.8.0_322]
        at java.util.Formatter.format(Formatter.java:2455) ~[?:1.8.0_322]
        at java.lang.String.format(String.java:2940) ~[?:1.8.0_322]
        at com.starrocks.clone.TabletSchedCtx.unprotectedFinishClone(TabletSchedCtx.java:944) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletSchedCtx.finishCloneTask(TabletSchedCtx.java:887) ~[starrocks-fe.jar:?]
        at com.starrocks.clone.TabletScheduler.finishCloneTask(TabletScheduler.java:1292) [starrocks-fe.jar:?]
        at com.starrocks.master.MasterImpl.finishClone(MasterImpl.java:826) [starrocks-fe.jar:?]
        at com.starrocks.master.MasterImpl.finishTask(MasterImpl.java:258) [starrocks-fe.jar:?]
        at com.starrocks.service.FrontendServiceImpl.finishTask(FrontendServiceImpl.java:546) [starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$finishTask.getResult(FrontendService.java:1851) [starrocks-fe.jar:?]
        at com.starrocks.thrift.FrontendService$Processor$finishTask.getResult(FrontendService.java:1831) [starrocks-fe.jar:?]
        at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38) [libthrift-0.13.0.jar:0.13.0]
        at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38) [libthrift-0.13.0.jar:0.13.0]
        at com.starrocks.common.SRTThreadPoolServer$WorkerProcess.run(SRTThreadPoolServer.java:310) [starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_322]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_322]
        at java.lang.Thread.run(Thread.java:750) [?:1.8.0_322]

```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
