### PR TITLE
[Enhancement] adaptive choose execute nodes base on the volume of processed data

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2454,5 +2454,5 @@ public class Config extends ConfigBase {
     public static boolean replan_on_insert = false;
 
     @ConfField(mutable = true)
-    public static int adaptive_choose_nodes_threshold = 32;
+    public static int adaptive_choose_instances_threshold = 32;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2452,4 +2452,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static boolean replan_on_insert = false;
+
+    @ConfField(mutable = true)
+    public static int adaptive_choose_nodes_threshold = 32;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -499,7 +499,6 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         }
         str.append(outputBuilder);
         str.append("\n");
-        str.append("  Fragment cost: ").append(fragmentCost).append("\n");
         str.append("  Input Partition: ").append(dataPartition.getExplainString(TExplainLevel.NORMAL));
         if (sink != null) {
             str.append(sink.getVerboseExplain("  ")).append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -98,8 +98,6 @@ import java.util.stream.Stream;
  * fix that
  */
 public class PlanFragment extends TreeNode<PlanFragment> {
-    public static final int HOST_FACTOR_MAX = 1;
-
     // id for this plan fragment
     protected final PlanFragmentId fragmentId;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -112,8 +112,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.starrocks.qe.SessionVariableConstants.ChooseInstancesMode.enableDecreaseInstance;
-import static com.starrocks.qe.SessionVariableConstants.ChooseInstancesMode.enableIncreaseInstance;
 import static com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient.TINY_SCALE_ROWS_LIMIT;
 
 public class CoordinatorPreprocessor {
@@ -1484,8 +1482,9 @@ public class CoordinatorPreprocessor {
 
         long nodeNums = Math.min(amplifyFactor * baseNodeNums, candidates.size());
 
-        String mode = connectContext.getSessionVariable().getAdaptiveChooseExecuteInstancesMode();
-        if (enableIncreaseInstance(mode) && nodeNums > childUsedHosts.size()) {
+        SessionVariableConstants.ChooseInstancesMode mode = connectContext.getSessionVariable()
+                .getAdaptiveChooseExecuteInstancesMode();
+        if (mode.enableIncreaseInstance() && nodeNums > childUsedHosts.size()) {
             for (Map.Entry<Long, ComputeNode> entry : candidates.entrySet()) {
                 TNetworkAddress address = new TNetworkAddress(entry.getValue().getHost(), entry.getValue().getBePort());
                 if (!childUsedHosts.contains(address)) {
@@ -1496,7 +1495,7 @@ public class CoordinatorPreprocessor {
                 }
             }
             return childHosts;
-        } else if (enableDecreaseInstance(mode) && nodeNums < childUsedHosts.size()
+        } else if (mode.enableDecreaseInstance() && nodeNums < childUsedHosts.size()
                 && candidates.size() >= Config.adaptive_choose_instances_threshold) {
             Collections.shuffle(childHosts, random);
             return childHosts.stream().limit(nodeNums).collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -1483,7 +1483,7 @@ public class CoordinatorPreprocessor {
         long nodeNums = Math.min(amplifyFactor * baseNodeNums, candidates.size());
 
         SessionVariableConstants.ChooseInstancesMode mode = connectContext.getSessionVariable()
-                .getAdaptiveChooseExecuteInstancesMode();
+                .getChooseExecuteInstancesMode();
         if (mode.enableIncreaseInstance() && nodeNums > childUsedHosts.size()) {
             for (Map.Entry<Long, ComputeNode> entry : candidates.entrySet()) {
                 TNetworkAddress address = new TNetworkAddress(entry.getValue().getHost(), entry.getValue().getBePort());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -1485,7 +1485,6 @@ public class CoordinatorPreprocessor {
 
         long nodeNums = Math.min(amplifyFactor * baseNodeNums, candidates.size());
 
-        // only increase nodes when enable_adaptive_increase_execute_nodes = true
         String mode = connectContext.getSessionVariable().getAdaptiveChooseExecuteInstancesMode();
         if ((ADAPTIVE_INCREASE.equalsIgnoreCase(mode) || AUTO.equalsIgnoreCase(mode))
                 && nodeNums > childUsedHosts.size()) {
@@ -1502,7 +1501,6 @@ public class CoordinatorPreprocessor {
         } else if ((ADAPTIVE_DECREASE.equalsIgnoreCase(mode) || AUTO.equalsIgnoreCase(mode))
                 && nodeNums < childUsedHosts.size()
                 && candidates.size() >= Config.adaptive_choose_instances_threshold) {
-            // only decrease nodes when be nodes > = adaptive_choose_nodes_threshold
             Collections.shuffle(childHosts, random);
             return childHosts.stream().limit(nodeNums).collect(Collectors.toList());
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -1477,7 +1477,7 @@ public class CoordinatorPreprocessor {
 
         long nodeNums = Math.min(amplifyFactor * baseNodeNums, candidates.size());
 
-        // only increase nodes when enable_adaptive_execute_node_num = true
+        // only increase nodes when enable_adaptive_increase_execute_nodes = true
         if (connectContext.getSessionVariable().enableAdaptiveIncreaseExecuteNodes() && nodeNums > childUsedHosts.size()) {
             for (Map.Entry<Long, ComputeNode> entry : candidates.entrySet()) {
                 TNetworkAddress address = new TNetworkAddress(entry.getValue().getHost(), entry.getValue().getBePort());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -112,9 +112,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.starrocks.qe.SessionVariableConstants.ADAPTIVE_DECREASE;
-import static com.starrocks.qe.SessionVariableConstants.ADAPTIVE_INCREASE;
-import static com.starrocks.qe.SessionVariableConstants.AUTO;
+import static com.starrocks.qe.SessionVariableConstants.ChooseInstancesMode.enableDecreaseInstance;
+import static com.starrocks.qe.SessionVariableConstants.ChooseInstancesMode.enableIncreaseInstance;
 import static com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient.TINY_SCALE_ROWS_LIMIT;
 
 public class CoordinatorPreprocessor {
@@ -1486,8 +1485,7 @@ public class CoordinatorPreprocessor {
         long nodeNums = Math.min(amplifyFactor * baseNodeNums, candidates.size());
 
         String mode = connectContext.getSessionVariable().getAdaptiveChooseExecuteInstancesMode();
-        if ((ADAPTIVE_INCREASE.equalsIgnoreCase(mode) || AUTO.equalsIgnoreCase(mode))
-                && nodeNums > childUsedHosts.size()) {
+        if (enableIncreaseInstance(mode) && nodeNums > childUsedHosts.size()) {
             for (Map.Entry<Long, ComputeNode> entry : candidates.entrySet()) {
                 TNetworkAddress address = new TNetworkAddress(entry.getValue().getHost(), entry.getValue().getBePort());
                 if (!childUsedHosts.contains(address)) {
@@ -1498,8 +1496,7 @@ public class CoordinatorPreprocessor {
                 }
             }
             return childHosts;
-        } else if ((ADAPTIVE_DECREASE.equalsIgnoreCase(mode) || AUTO.equalsIgnoreCase(mode))
-                && nodeNums < childUsedHosts.size()
+        } else if (enableDecreaseInstance(mode) && nodeNums < childUsedHosts.size()
                 && candidates.size() >= Config.adaptive_choose_instances_threshold) {
             Collections.shuffle(childHosts, random);
             return childHosts.stream().limit(nodeNums).collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -1478,7 +1478,7 @@ public class CoordinatorPreprocessor {
         long nodeNums = Math.min(amplifyFactor * baseNodeNums, candidates.size());
 
         // only increase nodes when enable_adaptive_execute_node_num = true
-        if (connectContext.getSessionVariable().enableAdaptiveExecuteNodeNum() && nodeNums > childUsedHosts.size()) {
+        if (connectContext.getSessionVariable().enableAdaptiveIncreaseExecuteNodes() && nodeNums > childUsedHosts.size()) {
             for (Map.Entry<Long, ComputeNode> entry : candidates.entrySet()) {
                 TNetworkAddress address = new TNetworkAddress(entry.getValue().getHost(), entry.getValue().getBePort());
                 if (!childUsedHosts.contains(address)) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1333,8 +1333,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ADAPTIVE_CHOOSE_EXECUTE_INSTANCES_MODE)
     private String adaptiveChooseExecuteInstancesMode = ADAPTIVE_DECREASE.name();
 
-    public String getAdaptiveChooseExecuteInstancesMode() {
-        return adaptiveChooseExecuteInstancesMode;
+    public SessionVariableConstants.ChooseInstancesMode getAdaptiveChooseExecuteInstancesMode() {
+        return Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
+                        StringUtils.upperCase(adaptiveChooseExecuteInstancesMode))
+                .or(SessionVariableConstants.ChooseInstancesMode.LOCALITY);
     }
 
     public void setAdaptiveChooseExecuteInstancesMode(String mode) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -522,7 +522,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String CBO_PUSHDOWN_TOPN_LIMIT = "cbo_push_down_topn_limit";
 
-    public static final String ADAPTIVE_CHOOSE_EXECUTE_INSTANCES_MODE = "adaptive_choose_execute_instances_mode";
+    public static final String CHOOSE_EXECUTE_INSTANCES_MODE = "choose_execute_instances_mode";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -1330,24 +1330,24 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_DERIVE_RANGE_JOIN_PREDICATE)
     private boolean cboDeriveRangeJoinPredicate = false;
 
-    @VarAttr(name = ADAPTIVE_CHOOSE_EXECUTE_INSTANCES_MODE)
-    private String adaptiveChooseExecuteInstancesMode = ADAPTIVE_DECREASE.name();
+    @VarAttr(name = CHOOSE_EXECUTE_INSTANCES_MODE)
+    private String chooseExecuteInstancesMode = ADAPTIVE_DECREASE.name();
 
-    public SessionVariableConstants.ChooseInstancesMode getAdaptiveChooseExecuteInstancesMode() {
+    public SessionVariableConstants.ChooseInstancesMode getChooseExecuteInstancesMode() {
         return Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
-                        StringUtils.upperCase(adaptiveChooseExecuteInstancesMode))
+                        StringUtils.upperCase(chooseExecuteInstancesMode))
                 .or(SessionVariableConstants.ChooseInstancesMode.LOCALITY);
     }
 
-    public void setAdaptiveChooseExecuteInstancesMode(String mode) {
+    public void setChooseExecuteInstancesMode(String mode) {
         SessionVariableConstants.ChooseInstancesMode result =
                 Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class, StringUtils.upperCase(mode))
                         .orNull();
         if (result == null) {
             String legalValues = Joiner.on(" | ").join(SessionVariableConstants.ChooseInstancesMode.values());
-            throw new IllegalArgumentException("Legal values of adaptive_choose_execute_instances_mode are " + legalValues);
+            throw new IllegalArgumentException("Legal values of choose_execute_instances_mode are " + legalValues);
         }
-        this.adaptiveChooseExecuteInstancesMode = StringUtils.upperCase(mode);
+        this.chooseExecuteInstancesMode = StringUtils.upperCase(mode);
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -517,7 +517,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String CBO_PUSHDOWN_TOPN_LIMIT = "cbo_push_down_topn_limit";
 
-    public static final String ENABLE_ADAPTIVE_EXECUTE_NODE_NUM = "enable_adaptive_execute_node_num";
+    public static final String ENABLE_ADAPTIVE_INCREASE_EXECUTE_NODES = "enable_adaptive_increase_execute_nodes";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -1325,15 +1325,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_DERIVE_RANGE_JOIN_PREDICATE)
     private boolean cboDeriveRangeJoinPredicate = false;
 
-    @VarAttr(name = ENABLE_ADAPTIVE_EXECUTE_NODE_NUM)
-    private boolean enableAdaptiveExecuteNodeNum = false;
+    @VarAttr(name = ENABLE_ADAPTIVE_INCREASE_EXECUTE_NODES)
+    private boolean enableAdaptiveIncreaseExecuteNodes = false;
 
-    public boolean enableAdaptiveExecuteNodeNum() {
-        return enableAdaptiveExecuteNodeNum;
+    public boolean enableAdaptiveIncreaseExecuteNodes() {
+        return enableAdaptiveIncreaseExecuteNodes;
     }
 
-    public void setEnableAdaptiveExecuteNodeNum(boolean enableAdaptiveExecuteNodeNum) {
-        this.enableAdaptiveExecuteNodeNum = enableAdaptiveExecuteNodeNum;
+    public void setEnableAdaptiveIncreaseExecuteNodes(boolean enableAdaptiveIncreaseExecuteNodes) {
+        this.enableAdaptiveIncreaseExecuteNodes = enableAdaptiveIncreaseExecuteNodes;
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -34,6 +34,9 @@
 
 package com.starrocks.qe;
 
+import com.amazonaws.util.StringUtils;
+import com.google.common.base.Enums;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
@@ -65,6 +68,8 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import static com.starrocks.qe.SessionVariableConstants.ChooseInstancesMode.ADAPTIVE_DECREASE;
 
 // System variable
 @SuppressWarnings("FieldMayBeFinal")
@@ -1326,14 +1331,21 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean cboDeriveRangeJoinPredicate = false;
 
     @VarAttr(name = ADAPTIVE_CHOOSE_EXECUTE_INSTANCES_MODE)
-    private String adaptiveChooseExecuteInstancesMode = SessionVariableConstants.ADAPTIVE_DECREASE;
+    private String adaptiveChooseExecuteInstancesMode = ADAPTIVE_DECREASE.name();
 
     public String getAdaptiveChooseExecuteInstancesMode() {
         return adaptiveChooseExecuteInstancesMode;
     }
 
-    public void setAdaptiveChooseExecuteInstancesMode(String adaptiveChooseExecuteInstancesMode) {
-        this.adaptiveChooseExecuteInstancesMode = adaptiveChooseExecuteInstancesMode;
+    public void setAdaptiveChooseExecuteInstancesMode(String mode) {
+        SessionVariableConstants.ChooseInstancesMode result =
+                Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class, StringUtils.upperCase(mode))
+                        .orNull();
+        if (result == null) {
+            String legalValues = Joiner.on(" | ").join(SessionVariableConstants.ChooseInstancesMode.values());
+            throw new IllegalArgumentException("Legal values of adaptive_choose_execute_instances_mode are " + legalValues);
+        }
+        this.adaptiveChooseExecuteInstancesMode = StringUtils.upperCase(mode);
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -517,6 +517,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String CBO_PUSHDOWN_TOPN_LIMIT = "cbo_push_down_topn_limit";
 
+    public static final String ENABLE_ADAPTIVE_EXECUTE_NODE_NUM = "enable_adaptive_execute_node_num";
+
+    public static final String ADAPTIVE_EXECUTE_NODE_NUM_MIN_FACTOR = "adaptive_execute_node_num_min_factor";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1322,6 +1326,28 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_DERIVE_RANGE_JOIN_PREDICATE)
     private boolean cboDeriveRangeJoinPredicate = false;
+
+    @VarAttr(name = ENABLE_ADAPTIVE_EXECUTE_NODE_NUM)
+    private boolean enableAdaptiveExecuteNodeNum = false;
+
+    @VarAttr(name = ADAPTIVE_EXECUTE_NODE_NUM_MIN_FACTOR)
+    private double adaptiveExecuteNodeMinFactor = 0.5;
+
+    public boolean enableAdaptiveExecuteNodeNum() {
+        return enableAdaptiveExecuteNodeNum;
+    }
+
+    public void setEnableAdaptiveExecuteNodeNum(boolean enableAdaptiveExecuteNodeNum) {
+        this.enableAdaptiveExecuteNodeNum = enableAdaptiveExecuteNodeNum;
+    }
+
+    public double getAdaptiveExecuteNodeMinFactor() {
+        return adaptiveExecuteNodeMinFactor;
+    }
+
+    public void setAdaptiveExecuteNodeMinFactor(double adaptiveExecuteNodeMinFactor) {
+        this.adaptiveExecuteNodeMinFactor = adaptiveExecuteNodeMinFactor;
+    }
 
     public boolean enableCboDeriveRangeJoinPredicate() {
         return cboDeriveRangeJoinPredicate;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -519,8 +519,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_ADAPTIVE_EXECUTE_NODE_NUM = "enable_adaptive_execute_node_num";
 
-    public static final String ADAPTIVE_EXECUTE_NODE_NUM_MIN_FACTOR = "adaptive_execute_node_num_min_factor";
-
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1330,9 +1328,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = ENABLE_ADAPTIVE_EXECUTE_NODE_NUM)
     private boolean enableAdaptiveExecuteNodeNum = false;
 
-    @VarAttr(name = ADAPTIVE_EXECUTE_NODE_NUM_MIN_FACTOR)
-    private double adaptiveExecuteNodeMinFactor = 0.5;
-
     public boolean enableAdaptiveExecuteNodeNum() {
         return enableAdaptiveExecuteNodeNum;
     }
@@ -1341,13 +1336,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.enableAdaptiveExecuteNodeNum = enableAdaptiveExecuteNodeNum;
     }
 
-    public double getAdaptiveExecuteNodeMinFactor() {
-        return adaptiveExecuteNodeMinFactor;
-    }
-
-    public void setAdaptiveExecuteNodeMinFactor(double adaptiveExecuteNodeMinFactor) {
-        this.adaptiveExecuteNodeMinFactor = adaptiveExecuteNodeMinFactor;
-    }
 
     public boolean enableCboDeriveRangeJoinPredicate() {
         return cboDeriveRangeJoinPredicate;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -517,7 +517,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String CBO_PUSHDOWN_TOPN_LIMIT = "cbo_push_down_topn_limit";
 
-    public static final String ENABLE_ADAPTIVE_INCREASE_EXECUTE_NODES = "enable_adaptive_increase_execute_nodes";
+    public static final String ADAPTIVE_CHOOSE_EXECUTE_INSTANCES_MODE = "adaptive_choose_execute_instances_mode";
 
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
@@ -1325,15 +1325,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_DERIVE_RANGE_JOIN_PREDICATE)
     private boolean cboDeriveRangeJoinPredicate = false;
 
-    @VarAttr(name = ENABLE_ADAPTIVE_INCREASE_EXECUTE_NODES)
-    private boolean enableAdaptiveIncreaseExecuteNodes = false;
+    @VarAttr(name = ADAPTIVE_CHOOSE_EXECUTE_INSTANCES_MODE)
+    private String adaptiveChooseExecuteInstancesMode = SessionVariableConstants.ADAPTIVE_DECREASE;
 
-    public boolean enableAdaptiveIncreaseExecuteNodes() {
-        return enableAdaptiveIncreaseExecuteNodes;
+    public String getAdaptiveChooseExecuteInstancesMode() {
+        return adaptiveChooseExecuteInstancesMode;
     }
 
-    public void setEnableAdaptiveIncreaseExecuteNodes(boolean enableAdaptiveIncreaseExecuteNodes) {
-        this.enableAdaptiveIncreaseExecuteNodes = enableAdaptiveIncreaseExecuteNodes;
+    public void setAdaptiveChooseExecuteInstancesMode(String adaptiveChooseExecuteInstancesMode) {
+        this.adaptiveChooseExecuteInstancesMode = adaptiveChooseExecuteInstancesMode;
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -14,9 +14,6 @@
 
 package com.starrocks.qe;
 
-import com.google.common.base.Enums;
-import org.apache.commons.lang3.StringUtils;
-
 public class SessionVariableConstants {
 
     private SessionVariableConstants() {}
@@ -45,16 +42,12 @@ public class SessionVariableConstants {
         ADAPTIVE_INCREASE,
         ADAPTIVE_DECREASE;
 
-        public static boolean enableIncreaseInstance(String mode) {
-            ChooseInstancesMode chooseInstancesMode = Enums.getIfPresent(ChooseInstancesMode.class,
-                    StringUtils.upperCase(mode)).or(LOCALITY);
-            return chooseInstancesMode == AUTO || chooseInstancesMode == ADAPTIVE_INCREASE;
+        public boolean enableIncreaseInstance() {
+            return this == AUTO || this == ADAPTIVE_INCREASE;
         }
 
-        public static boolean enableDecreaseInstance(String mode) {
-            ChooseInstancesMode chooseInstancesMode = Enums.getIfPresent(ChooseInstancesMode.class,
-                    StringUtils.upperCase(mode)).or(LOCALITY);
-            return chooseInstancesMode == AUTO || chooseInstancesMode == ADAPTIVE_DECREASE;
+        public boolean enableDecreaseInstance() {
+            return this == AUTO || this == ADAPTIVE_DECREASE;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -31,4 +31,7 @@ public class SessionVariableConstants {
     public static final String DOUBLE = "double";
 
     public static final String DECIMAL = "decimal";
+
+    public static final String ADAPTIVE_INCREASE = "adaptive_increase";
+    public static final String ADAPTIVE_DECREASE = "adaptive_decrease";
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -14,6 +14,9 @@
 
 package com.starrocks.qe;
 
+import com.google.common.base.Enums;
+import org.apache.commons.lang3.StringUtils;
+
 public class SessionVariableConstants {
 
     private SessionVariableConstants() {}
@@ -34,4 +37,24 @@ public class SessionVariableConstants {
 
     public static final String ADAPTIVE_INCREASE = "adaptive_increase";
     public static final String ADAPTIVE_DECREASE = "adaptive_decrease";
+
+
+    public enum ChooseInstancesMode {
+        LOCALITY,
+        AUTO,
+        ADAPTIVE_INCREASE,
+        ADAPTIVE_DECREASE;
+
+        public static boolean enableIncreaseInstance(String mode) {
+            ChooseInstancesMode chooseInstancesMode = Enums.getIfPresent(ChooseInstancesMode.class,
+                    StringUtils.upperCase(mode)).or(LOCALITY);
+            return chooseInstancesMode == AUTO || chooseInstancesMode == ADAPTIVE_INCREASE;
+        }
+
+        public static boolean enableDecreaseInstance(String mode) {
+            ChooseInstancesMode chooseInstancesMode = Enums.getIfPresent(ChooseInstancesMode.class,
+                    StringUtils.upperCase(mode)).or(LOCALITY);
+            return chooseInstancesMode == AUTO || chooseInstancesMode == ADAPTIVE_DECREASE;
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.google.common.base.Enums;
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.CastExpr;
@@ -35,6 +37,7 @@ import com.starrocks.mysql.MysqlPassword;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.SessionVariableConstants;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.QueryStatement;
@@ -187,6 +190,16 @@ public class SetStmtAnalyzer {
 
         if (variable.equalsIgnoreCase(SessionVariable.ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ)) {
             checkRangeLongVariable(resolvedExpression, SessionVariable.ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ, 1L, null);
+        }
+
+        if (variable.equalsIgnoreCase(SessionVariable.ADAPTIVE_CHOOSE_EXECUTE_INSTANCES_MODE)) {
+            SessionVariableConstants.ChooseInstancesMode mode =
+                    Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
+                            StringUtils.upperCase(resolvedExpression.getStringValue())).orNull();
+            if (mode == null) {
+                String legalValues = Joiner.on(" | ").join(SessionVariableConstants.ChooseInstancesMode.values());
+                throw new IllegalArgumentException("Legal values of adaptive_choose_execute_instances_mode are " + legalValues);
+            }
         }
 
         var.setResolvedExpression(resolvedExpression);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -192,13 +192,13 @@ public class SetStmtAnalyzer {
             checkRangeLongVariable(resolvedExpression, SessionVariable.ADAPTIVE_DOP_MAX_BLOCK_ROWS_PER_DRIVER_SEQ, 1L, null);
         }
 
-        if (variable.equalsIgnoreCase(SessionVariable.ADAPTIVE_CHOOSE_EXECUTE_INSTANCES_MODE)) {
+        if (variable.equalsIgnoreCase(SessionVariable.CHOOSE_EXECUTE_INSTANCES_MODE)) {
             SessionVariableConstants.ChooseInstancesMode mode =
                     Enums.getIfPresent(SessionVariableConstants.ChooseInstancesMode.class,
                             StringUtils.upperCase(resolvedExpression.getStringValue())).orNull();
             if (mode == null) {
                 String legalValues = Joiner.on(" | ").join(SessionVariableConstants.ChooseInstancesMode.values());
-                throw new IllegalArgumentException("Legal values of adaptive_choose_execute_instances_mode are " + legalValues);
+                throw new IllegalArgumentException("Legal values of choose_execute_instances_mode are " + legalValues);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptExpression.java
@@ -206,4 +206,60 @@ public class OptExpression {
         }
         return sb.toString();
     }
+
+    public static Builder buildWithOpAndInputs(Operator op, List<OptExpression> inputs) {
+        return new Builder(op, inputs);
+    }
+
+    public static final class Builder {
+
+        private Operator op;
+
+        private List<OptExpression> inputs;
+
+        private LogicalProperty property;
+
+        private Statistics statistics;
+
+        private double cost = 0;
+
+        private List<PhysicalPropertySet> requiredProperties;
+
+
+        public Builder(Operator op, List<OptExpression> inputs) {
+            this.op = op;
+            this.inputs = inputs;
+        }
+
+        public Builder setLogicalProperty(LogicalProperty property) {
+            this.property = property;
+            return this;
+        }
+
+        public Builder setStatistics(Statistics statistics) {
+            this.statistics = statistics;
+            return this;
+        }
+
+        public Builder setCost(double cost) {
+            this.cost = cost;
+            return this;
+        }
+
+        public Builder setRequiredProperties(List<PhysicalPropertySet> requiredProperties) {
+            this.requiredProperties = requiredProperties;
+            return this;
+        }
+
+        public OptExpression build() {
+            Preconditions.checkState(op != null);
+            OptExpression result = OptExpression.create(op, inputs);
+            result.setStatistics(statistics);
+            result.setCost(cost);
+            result.setLogicalProperty(property);
+            result.setRequiredProperties(requiredProperties);
+            return result;
+        }
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -624,8 +624,6 @@ public class Optimizer {
         result = new ExtractAggregateColumn().rewrite(result, rootTaskContext);
         result = new PruneSubfieldsForComplexType().rewrite(result, rootTaskContext);
 
-        SessionVariable sessionVariable = rootTaskContext.getOptimizerContext().getSessionVariable();
-
         // This must be put at last of the optimization. Because wrapping reused ColumnRefOperator with CloneOperator
         // too early will prevent it from certain optimizations that depend on the equivalence of the ColumnRefOperator.
         result = new CloneDuplicateColRefRule().rewrite(result, rootTaskContext);
@@ -656,16 +654,17 @@ public class Optimizer {
             childPlans.add(childPlan);
         }
 
-        OptExpression expression = OptExpression.create(groupExpression.getOp(),
-                childPlans);
-        // record inputProperties at optExpression, used for planFragment builder to determine join type
-        expression.setRequiredProperties(inputProperties);
-        expression.setStatistics(groupExpression.getGroup().getStatistics());
-        expression.setCost(groupExpression.getCost(requiredProperty));
+        OptExpression.Builder builder = OptExpression.buildWithOpAndInputs(groupExpression.getOp(), childPlans);
 
-        // When build plan fragment, we need the output column of logical property
-        expression.setLogicalProperty(rootGroup.getLogicalProperty());
-        return expression;
+
+        // record inputProperties used to determine join type when building planFragment
+        // record logical property used to obtain output colRefSet when building planFragment
+        builder.setRequiredProperties(inputProperties)
+                .setStatistics(groupExpression.getGroup().getStatistics())
+                .setCost(groupExpression.getCost(requiredProperty))
+                .setLogicalProperty(rootGroup.getLogicalProperty());
+
+        return builder.build();
     }
 
     private void collectAllScanOperators(Memo memo, TaskContext rootTaskContext) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -50,6 +50,9 @@ public class StatisticsEstimateCoefficient {
     public static final double DEFAULT_ANTI_JOIN_SELECTIVITY_COEFFICIENT = 0.4;
     // default shuffle column row count limit
     public static final double DEFAULT_PRUNE_SHUFFLE_COLUMN_ROWS_LIMIT = 200000;
+
+    public static final long TINY_SCALE_ROWS_LIMIT = 100000;
+
     // a small scale rows, such as default push down aggregate row count limit, 100w
     public static final long SMALL_SCALE_ROWS_LIMIT = 1000000;
     // default or predicate limit

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -425,9 +425,46 @@ public class PlanFragmentBuilder {
         }
 
         public PlanFragment translate(OptExpression optExpression, ExecPlan context) {
-            return visit(optExpression, context);
+            PlanFragment fragment = visit(optExpression, context);
+            computeFragmentCost(context, fragment);
+            return fragment;
         }
 
+        /*
+         * Reduce the compute node when input data decreases, example:
+         *                      Agg(1 rows)                      5 be
+         *                         |                              ^
+         *                    Join(50 rows)                      10 be
+         *                   /             \                      ^
+         *      Join(200 rows)            Scan(100 rows)         10 be
+         *     /              \                                   ^
+         *  Scan(200 rows)    Scan(100 rows)                     10 be
+         */
+        private void computeFragmentCost(ExecPlan context, PlanFragment fragment) {
+            for (PlanFragment child : fragment.getChildren()) {
+                computeFragmentCost(context, child);
+            }
+            OptExpression output = getOptExpression(context, fragment.getPlanRoot());
+
+            // scan fragment
+            if (fragment.getLeftMostNode() instanceof ScanNode) {
+                fragment.setFragmentCost(output.getCost());
+                return;
+            }
+
+            List<OptExpression> inputs = fragment.getChildren().stream().map(PlanFragment::getPlanRoot)
+                    .map(p -> getOptExpression(context, p)).collect(Collectors.toList());
+
+            double childCost = inputs.stream().map(OptExpression::getCost).reduce(Double::sum).orElse(0D);
+            fragment.setFragmentCost(output.getCost() - childCost);
+        }
+
+        private OptExpression getOptExpression(ExecPlan context, PlanNode node) {
+            if (context.getOptExpression(node.getId().asInt()) == null && node instanceof ProjectNode) {
+                node = node.getChild(0);
+            }
+            return context.getOptExpression(node.getId().asInt());
+        }
         @Override
         public PlanFragment visit(OptExpression optExpression, ExecPlan context) {
             canUseLocalShuffleAgg &= optExpression.arity() <= 1;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -430,16 +430,6 @@ public class PlanFragmentBuilder {
             return fragment;
         }
 
-        /*
-         * Reduce the compute node when input data decreases, example:
-         *                      Agg(1 rows)                      5 be
-         *                         |                              ^
-         *                    Join(50 rows)                      10 be
-         *                   /             \                      ^
-         *      Join(200 rows)            Scan(100 rows)         10 be
-         *     /              \                                   ^
-         *  Scan(200 rows)    Scan(100 rows)                     10 be
-         */
         private void computeFragmentCost(ExecPlan context, PlanFragment fragment) {
             for (PlanFragment child : fragment.getChildren()) {
                 computeFragmentCost(context, child);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -46,22 +46,22 @@ public class SessionVariableTest {
     @Test
     public void testSetChooseMode() {
         SessionVariable sessionVariable = new SessionVariable();
-        sessionVariable.setAdaptiveChooseExecuteInstancesMode("adaptive_increase");
-        Assert.assertTrue(sessionVariable.getAdaptiveChooseExecuteInstancesMode().enableIncreaseInstance());
+        sessionVariable.setChooseExecuteInstancesMode("adaptive_increase");
+        Assert.assertTrue(sessionVariable.getChooseExecuteInstancesMode().enableIncreaseInstance());
 
-        sessionVariable.setAdaptiveChooseExecuteInstancesMode("adaptive_decrease");
-        Assert.assertTrue(sessionVariable.getAdaptiveChooseExecuteInstancesMode().enableDecreaseInstance());
+        sessionVariable.setChooseExecuteInstancesMode("adaptive_decrease");
+        Assert.assertTrue(sessionVariable.getChooseExecuteInstancesMode().enableDecreaseInstance());
 
-        sessionVariable.setAdaptiveChooseExecuteInstancesMode("auto");
-        Assert.assertTrue(sessionVariable.getAdaptiveChooseExecuteInstancesMode().enableIncreaseInstance());
-        Assert.assertTrue(sessionVariable.getAdaptiveChooseExecuteInstancesMode().enableDecreaseInstance());
+        sessionVariable.setChooseExecuteInstancesMode("auto");
+        Assert.assertTrue(sessionVariable.getChooseExecuteInstancesMode().enableIncreaseInstance());
+        Assert.assertTrue(sessionVariable.getChooseExecuteInstancesMode().enableDecreaseInstance());
 
         try {
-            sessionVariable.setAdaptiveChooseExecuteInstancesMode("xxx");
+            sessionVariable.setChooseExecuteInstancesMode("xxx");
             Assert.fail("cannot set a invalid value");
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage(),
-                    e.getMessage().contains("Legal values of adaptive_choose_execute_instances_mode are"));
+                    e.getMessage().contains("Legal values of choose_execute_instances_mode are"));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -47,18 +47,15 @@ public class SessionVariableTest {
     public void testSetChooseMode() {
         SessionVariable sessionVariable = new SessionVariable();
         sessionVariable.setAdaptiveChooseExecuteInstancesMode("adaptive_increase");
-        Assert.assertTrue(SessionVariableConstants.ChooseInstancesMode
-                .enableIncreaseInstance(sessionVariable.getAdaptiveChooseExecuteInstancesMode()));
+        Assert.assertTrue(sessionVariable.getAdaptiveChooseExecuteInstancesMode().enableIncreaseInstance());
 
         sessionVariable.setAdaptiveChooseExecuteInstancesMode("adaptive_decrease");
-        Assert.assertTrue(SessionVariableConstants.ChooseInstancesMode
-                .enableDecreaseInstance(sessionVariable.getAdaptiveChooseExecuteInstancesMode()));
+        Assert.assertTrue(sessionVariable.getAdaptiveChooseExecuteInstancesMode().enableDecreaseInstance());
 
         sessionVariable.setAdaptiveChooseExecuteInstancesMode("auto");
-        Assert.assertTrue(SessionVariableConstants.ChooseInstancesMode
-                .enableIncreaseInstance(sessionVariable.getAdaptiveChooseExecuteInstancesMode()));
-        Assert.assertTrue(SessionVariableConstants.ChooseInstancesMode
-                .enableDecreaseInstance(sessionVariable.getAdaptiveChooseExecuteInstancesMode()));
+        Assert.assertTrue(sessionVariable.getAdaptiveChooseExecuteInstancesMode().enableIncreaseInstance());
+        Assert.assertTrue(sessionVariable.getAdaptiveChooseExecuteInstancesMode().enableDecreaseInstance());
+
         try {
             sessionVariable.setAdaptiveChooseExecuteInstancesMode("xxx");
             Assert.fail("cannot set a invalid value");

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -42,4 +42,29 @@ public class SessionVariableTest {
         Assert.assertEquals(SessionVariable.DEFAULT_SESSION_VARIABLE.getPipelineProfileLevel(), kv.defaultValue);
         Assert.assertEquals(100, kv.actualValue);
     }
+
+    @Test
+    public void testSetChooseMode() {
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setAdaptiveChooseExecuteInstancesMode("adaptive_increase");
+        Assert.assertTrue(SessionVariableConstants.ChooseInstancesMode
+                .enableIncreaseInstance(sessionVariable.getAdaptiveChooseExecuteInstancesMode()));
+
+        sessionVariable.setAdaptiveChooseExecuteInstancesMode("adaptive_decrease");
+        Assert.assertTrue(SessionVariableConstants.ChooseInstancesMode
+                .enableDecreaseInstance(sessionVariable.getAdaptiveChooseExecuteInstancesMode()));
+
+        sessionVariable.setAdaptiveChooseExecuteInstancesMode("auto");
+        Assert.assertTrue(SessionVariableConstants.ChooseInstancesMode
+                .enableIncreaseInstance(sessionVariable.getAdaptiveChooseExecuteInstancesMode()));
+        Assert.assertTrue(SessionVariableConstants.ChooseInstancesMode
+                .enableDecreaseInstance(sessionVariable.getAdaptiveChooseExecuteInstancesMode()));
+        try {
+            sessionVariable.setAdaptiveChooseExecuteInstancesMode("xxx");
+            Assert.fail("cannot set a invalid value");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage(),
+                    e.getMessage().contains("Legal values of adaptive_choose_execute_instances_mode are"));
+        }
+    }
 }


### PR DESCRIPTION
Fixes #issue
 - adaptive choose execute nodes base on the volume of processed data. For now, we just decrease execute nodes when the cluster has enough nodes (more than 32 nodes by default) and the process data is in a relative small volumn. If you want increase execute nodes when the process data is large you need `set ENABLE_ADAPTIVE_INCREASE_EXECUTE_NODES = true`
 - ensure optExpression contains cost info after physical rule rewrite.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
