### PR TITLE
[BugFix] Support compensate iceberg partition predicates in MV Rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -425,6 +425,7 @@ public class Optimizer {
         ruleRewriteOnlyOnce(tree, rootTaskContext, new GroupByCountDistinctRewriteRule());
 
         ruleRewriteOnlyOnce(tree, rootTaskContext, new DeriveRangeJoinPredicateRule());
+
         return tree.getInputs().get(0);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DeriveRangeJoinPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DeriveRangeJoinPredicateRule.java
@@ -18,7 +18,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.catalog.Type;
-import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
@@ -34,11 +33,9 @@ import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
-import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,6 +43,9 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import static com.starrocks.sql.optimizer.statistics.StatisticsCalcUtils.getStatistics;
+import static com.starrocks.sql.optimizer.statistics.StatisticsCalcUtils.replaceColRef;
 
 public class DeriveRangeJoinPredicateRule extends TransformationRule {
 
@@ -223,40 +223,5 @@ public class DeriveRangeJoinPredicateRule extends TransformationRule {
         }
 
         return null;
-    }
-
-    private Statistics getStatistics(OptExpression input, OptimizerContext context) {
-        deriveStatistics(input, context);
-        return input.getStatistics();
-    }
-
-
-    private void deriveStatistics(OptExpression optExpression, OptimizerContext context) {
-        if (optExpression.getStatistics() != null) {
-            return;
-        }
-
-        for (OptExpression child : optExpression.getInputs()) {
-            deriveStatistics(child, context);
-        }
-        ExpressionContext ec = new ExpressionContext(optExpression);
-        StatisticsCalculator sc = new StatisticsCalculator(ec, context.getColumnRefFactory(),
-                context.getTaskContext().getOptimizerContext());
-        sc.estimatorStats();
-        optExpression.setStatistics(ec.getStatistics());
-    }
-
-    private ScalarOperator replaceColRef(ScalarOperator scalarOperator, LogicalOperator op) {
-        if (op.getProjection() != null) {
-            ColumnRefSet outputCols = new ColumnRefSet(op.getProjection().getOutputColumns());
-            if (outputCols.isIntersect(scalarOperator.getUsedColumns())) {
-                // need use the original output cols from the operator to rewrite the scalarOperator
-                ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(
-                        op.getProjection().getColumnRefMap(), false);
-                return rewriter.rewrite(scalarOperator);
-            }
-        }
-
-        return scalarOperator;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -34,6 +34,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.OlapTable;
@@ -42,6 +43,7 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
@@ -60,6 +62,7 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.Optimizer;
 import com.starrocks.sql.optimizer.OptimizerConfig;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -70,6 +73,7 @@ import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalHiveScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
@@ -84,11 +88,14 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.parser.ParsingException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -101,6 +108,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static com.starrocks.sql.optimizer.statistics.StatisticsCalcUtils.getStatistics;
+import static com.starrocks.sql.optimizer.statistics.StatisticsCalcUtils.replaceColRef;
 
 public class MvUtils {
     private static final Logger LOG = LogManager.getLogger(MvUtils.class);
@@ -796,6 +806,58 @@ public class MvUtils {
         return true;
     }
 
+    public static List<ScalarOperator> compensatePartitionPredicateForIceberg(Statistics icebergStatics,
+                                                                              LogicalIcebergScanOperator scanOperator) {
+        List<ScalarOperator> partitionPredicates = Lists.newArrayList();
+        if (icebergStatics == null) {
+            return partitionPredicates;
+        }
+
+        Preconditions.checkState(scanOperator.getTable().isIcebergTable());
+        IcebergTable icebergTable = (IcebergTable) scanOperator.getTable();
+        if (icebergTable.isUnPartitioned()) {
+            return partitionPredicates;
+        }
+
+        // generate range predicate
+        Map<String, ColumnRefOperator> columnRefOperatorMap = scanOperator.getColumnNameToColRefMap();
+        List<Column> partitionColumns = icebergTable.getPartitionColumns();
+        for (Column partCol : partitionColumns) {
+            if (!columnRefOperatorMap.containsKey(partCol.getName())) {
+                continue;
+            }
+
+            if (!partCol.getType().isStringType()) {
+                continue;
+            }
+
+            ColumnRefOperator partColRef = columnRefOperatorMap.get(partCol.getName());
+            ColumnStatistic partColStatics = icebergStatics.getColumnStatistic(partColRef);
+
+            if (StringUtils.isEmpty(partColStatics.getMinString()) ||
+                    StringUtils.isEmpty(partColStatics.getMaxString())) {
+                LOG.debug("column minString value: {}, maxString value: {}",
+                        partColStatics.getMinString(),
+                        partColStatics.getMaxValue());
+                continue;
+            }
+
+            ScalarOperator lower = new ConstantOperator(partColStatics.getMinString(), Type.STRING);
+            ScalarOperator upper = new ConstantOperator(partColStatics.getMaxString(), Type.STRING);
+            ScalarOperator upperPred = new BinaryPredicateOperator(BinaryType.LE,
+                    replaceColRef(partColRef, scanOperator), upper);
+            upperPred.setIsPushdown(true);
+
+            ScalarOperator lowerPred = new BinaryPredicateOperator(BinaryType.GE,
+                    replaceColRef(partColRef, scanOperator), lower);
+            lowerPred.setIsPushdown(true);
+
+            partitionPredicates.add(upperPred);
+            partitionPredicates.add(lowerPred);
+        }
+        return partitionPredicates;
+    }
+
     public static List<ScalarOperator> compensatePartitionPredicateForHiveScan(LogicalHiveScanOperator scanOperator) {
         List<ScalarOperator> partitionPredicates = Lists.newArrayList();
         Preconditions.checkState(scanOperator.getTable().isHiveTable());
@@ -838,12 +900,17 @@ public class MvUtils {
         return partitionPredicates;
     }
 
-    public static ScalarOperator compensatePartitionPredicate(OptExpression plan,
+    public static ScalarOperator compensatePartitionPredicate(OptimizerContext context,
+                                                              OptExpression plan,
                                                               ColumnRefFactory columnRefFactory,
                                                               boolean isCompensate) {
         List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(plan);
         if (scanOperators.isEmpty()) {
             return ConstantOperator.createBoolean(true);
+        }
+        Statistics icebergStatics = null;
+        if (scanOperators.stream().anyMatch(x -> x instanceof LogicalIcebergScanOperator)) {
+            icebergStatics = getStatistics(plan, context);
         }
 
         List<ScalarOperator> partitionPredicates = Lists.newArrayList();
@@ -877,6 +944,9 @@ public class MvUtils {
                 }
             } else if (scanOperator instanceof LogicalHiveScanOperator) {
                 partitionPredicate = compensatePartitionPredicateForHiveScan((LogicalHiveScanOperator) scanOperator);
+            } else if (scanOperator instanceof LogicalIcebergScanOperator) {
+                partitionPredicate = compensatePartitionPredicateForIceberg(icebergStatics,
+                        (LogicalIcebergScanOperator) scanOperator);
             } else {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -161,7 +161,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         // sync mv always has the same partition with
         // Compensate partition predicates and add them into query predicate.
         final ScalarOperator queryPartitionPredicate =
-                MvUtils.compensatePartitionPredicate(queryExpression, queryColumnRefFactory, isCompensate);
+                MvUtils.compensatePartitionPredicate(context, queryExpression, queryColumnRefFactory, isCompensate);
         if (queryPartitionPredicate == null) {
             logMVRewrite(context, this, "Compensate query expression's partition predicates " +
                     "from pruned partitions failed.");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
@@ -19,12 +19,18 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.ExpressionContext;
+import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.statistic.BasicStatsMeta;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatsConstants;
@@ -156,4 +162,37 @@ public class StatisticsCalcUtils {
         return 1;
     }
 
+    public static Statistics getStatistics(OptExpression input, OptimizerContext context) {
+        deriveStatistics(input, context);
+        return input.getStatistics();
+    }
+
+    public static void deriveStatistics(OptExpression optExpression, OptimizerContext context) {
+        if (optExpression.getStatistics() != null) {
+            return;
+        }
+
+        for (OptExpression child : optExpression.getInputs()) {
+            deriveStatistics(child, context);
+        }
+        ExpressionContext ec = new ExpressionContext(optExpression);
+        StatisticsCalculator sc = new StatisticsCalculator(ec, context.getColumnRefFactory(),
+                context.getTaskContext().getOptimizerContext());
+        sc.estimatorStats();
+        optExpression.setStatistics(ec.getStatistics());
+    }
+
+    public static ScalarOperator replaceColRef(ScalarOperator scalarOperator, LogicalOperator op) {
+        if (op.getProjection() != null) {
+            ColumnRefSet outputCols = new ColumnRefSet(op.getProjection().getOutputColumns());
+            if (outputCols.isIntersect(scalarOperator.getUsedColumns())) {
+                // need use the original output cols from the operator to rewrite the scalarOperator
+                ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(
+                        op.getProjection().getColumnRefMap(), false);
+                return rewriter.rewrite(scalarOperator);
+            }
+        }
+
+        return scalarOperator;
+    }
 }


### PR DESCRIPTION
### Main
1. Why need to compensate iceberg partition predicates?

- If we don't compensate iceberg partition predicates, we can not know the base iceberg table's query partition range.
- then we cannot decide whether the associated materialized views are satisfied with the query.

2. How to compensate iceberg partition predicates?
- Now in the SR's optimizer, PartitionPruner only pruned OlapTable/HiveTable's partitions, and Iceberg table's partitions can be pruned in the runtime.
- Refer `DeriveRangeJoinPredicateRule` this class, we can derive the partition predicates in mv rewrite for string type.

### Limitation
1. Iceberg's `getRemoteFileInfos` can not prune all partition predicates(eg, str2date) which will cause the derived partition predicates is not useful.
```
        List<RemoteFileInfo> splits = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFileInfos(
                catalogName, icebergTable, null, snapshotId, icebergPredicate, null);
```
2. Iceberg's min/max are stored in the ColumnStatics: min/max is string for string type, others are double. String type is exactly right, but for other types `double` may be not exactly right.

### Further

- Like hive table, we should support partition prune for Iceberg Table in SR's optimizer.

### Examples

```
-- iceberg
CREATE TABLE if not exists iceberg_tbl_string_part_10 
(
    k1 int,
    v1 int, 
    v2 varchar(65535), 
    dt date,
    ds string
)
PARTITION BY (ds);

-- mv

CREATE MATERIALIZED VIEW if not exists mv_string_part_10 
PARTITION BY part_ds 
DISTRIBUTED BY hash(k1) BUCKETS 1 
REFRESH DEFERRED MANUAL
PROPERTIES (  "force_external_table_query_rewrite"="checked","replication_num"="1") AS select k1, v1, v2, dt, ds, str2date(ds, '%Y-%m-%d') as part_ds from iceberg.mv_iceberg.iceberg_tbl_string_part_10;
```

MV Rewrite
```
-- Case1:   ds  can be pruned, so the query can be rewritten.
mysql> explain SELECT `iceberg_tbl_string_part_10`.`k1`, `iceberg_tbl_string_part_10`.`v1`, `iceberg_tbl_string_part_10`.`v2`, `iceberg_tbl_string_part_10`.`dt`, `iceberg_tbl_string_part_10`.`ds`, str2date(`iceberg_tbl_string_part_10`.`ds`, '%Y-%m-%d') AS `part_ds`
    -> FROM `iceberg`.`mv_iceberg`.`iceberg_tbl_string_part_10` where ds >= '2010-01-02' and ds < '2010-01-03';
+-------------------------------------------------------------------+
| Explain String                                                    |
+-------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                   |
|  OUTPUT EXPRS:1: k1 | 2: v1 | 3: v2 | 4: dt | 5: ds | 6: str2date |
|   PARTITION: RANDOM                                               |
|                                                                   |
|   RESULT SINK                                                     |
|                                                                   |
|   1:Project                                                       |
|   |  <slot 1> : 7: k1                                             |
|   |  <slot 2> : 8: v1                                             |
|   |  <slot 3> : 9: v2                                             |
|   |  <slot 4> : 10: dt                                            |
|   |  <slot 5> : 11: ds                                            |
|   |  <slot 6> : 12: part_ds                                       |
|   |                                                               |
|   0:OlapScanNode                                                  |
|      TABLE: mv_string_part_10                                     |
|      PREAGGREGATION: ON                                           |
|      PREDICATES: 11: ds = '2010-01-02'                            |
|      partitions=1/1                                               |
|      rollup: mv_string_part_10                                    |
|      tabletRatio=1/1                                              |
|      tabletList=85024                                             |
|      cardinality=1                                                |
|      avgRowSize=72.0                                              |
|      numNodes=0                                                   |
|      MaterializedView: true                                       |
+-------------------------------------------------------------------+
26 rows in set (0.08 sec)

-- Case2:   cast(ds as date)  can be pruned, so the query can be rewritten.
mysql> explain SELECT `iceberg_tbl_string_part_10`.`k1`, `iceberg_tbl_string_part_10`.`v1`, `iceberg_tbl_string_part_10`.`v2`, `iceberg_tbl_string_part_10`.`dt`, `iceberg_tbl_string_part_10`.`ds`, str2date(`iceberg_tbl_string_part_10`.`ds`, '%Y-%m-%d') AS `part_ds` FROM `iceberg`.`mv_iceberg`.`iceberg_tbl_string_part_10` where cast(ds as date) >= '2010-01-02' and cast(ds as date) < '2010-01-03';
+-------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                    |
+-------------------------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                                   |
|  OUTPUT EXPRS:1: k1 | 2: v1 | 3: v2 | 4: dt | 5: ds | 6: str2date                                                 |
|   PARTITION: RANDOM                                                                                               |
|                                                                                                                   |
|   RESULT SINK                                                                                                     |
|                                                                                                                   |
|   1:Project                                                                                                       |
|   |  <slot 1> : 7: k1                                                                                             |
|   |  <slot 2> : 8: v1                                                                                             |
|   |  <slot 3> : 9: v2                                                                                             |
|   |  <slot 4> : 10: dt                                                                                            |
|   |  <slot 5> : 11: ds                                                                                            |
|   |  <slot 6> : 12: part_ds                                                                                       |
|   |                                                                                                               |
|   0:OlapScanNode                                                                                                  |
|      TABLE: mv_string_part_10                                                                                     |
|      PREAGGREGATION: ON                                                                                           |
|      PREDICATES: 11: ds = '2010-01-02', CAST(11: ds AS DATE) < '2010-01-03', CAST(11: ds AS DATE) >= '2010-01-02' |
|      partitions=1/1                                                                                               |
|      rollup: mv_string_part_10                                                                                    |
|      tabletRatio=1/1                                                                                              |
|      tabletList=85024                                                                                             |
|      cardinality=1                                                                                                |
|      avgRowSize=12.0                                                                                              |
|      numNodes=0                                                                                                   |
|      MaterializedView: true                                                                                       |
+-------------------------------------------------------------------------------------------------------------------+
26 rows in set (0.72 sec)

-- Case3:   str2date(ds, '%Y-%m-%d') can not be pruned, so the query can not be rewritten.
mysql> explain SELECT `iceberg_tbl_string_part_10`.`k1`, `iceberg_tbl_string_part_10`.`v1`, `iceberg_tbl_string_part_10`.`v2`, `iceberg_tbl_string_part_10`.`dt`, `iceberg_tbl_string_part_10`.`ds`, str2date(`iceberg_tbl_string_part_10`.`ds`, '%Y-%m-%d') AS `part_ds`
    -> FROM `iceberg`.`mv_iceberg`.`iceberg_tbl_string_part_10` where str2date(ds, '%Y-%m-%d') >= '2010-01-02' and str2date(ds, '%Y-%m-%d') < '2010-01-03';
+----------------------------------------------------------------------------------------------------------+
| Explain String                                                                                           |
+----------------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                          |
|  OUTPUT EXPRS:1: k1 | 2: v1 | 3: v2 | 4: dt | 5: ds | 6: str2date                                        |
|   PARTITION: UNPARTITIONED                                                                               |
|                                                                                                          |
|   RESULT SINK                                                                                            |
|                                                                                                          |
|   2:EXCHANGE                                                                                             |
|                                                                                                          |
| PLAN FRAGMENT 1                                                                                          |
|  OUTPUT EXPRS:                                                                                           |
|   PARTITION: RANDOM                                                                                      |
|                                                                                                          |
|   STREAM DATA SINK                                                                                       |
|     EXCHANGE ID: 02                                                                                      |
|     UNPARTITIONED                                                                                        |
|                                                                                                          |
|   1:Project                                                                                              |
|   |  <slot 1> : 1: k1                                                                                    |
|   |  <slot 2> : 2: v1                                                                                    |
|   |  <slot 3> : 3: v2                                                                                    |
|   |  <slot 4> : 4: dt                                                                                    |
|   |  <slot 5> : 5: ds                                                                                    |
|   |  <slot 6> : str2date(5: ds, '%Y-%m-%d')                                                              |
|   |                                                                                                      |
|   0:IcebergScanNode                                                                                      |
|      TABLE: iceberg.mv_iceberg.iceberg_tbl_string_part_10                                                |
|      PREDICATES: str2date(5: ds, '%Y-%m-%d') >= '2010-01-02', str2date(5: ds, '%Y-%m-%d') < '2010-01-03' |
|      cardinality=1                                                                                       |
|      avgRowSize=6.0                                                                                      |
|      numNodes=0                                                                                          |
+----------------------------------------------------------------------------------------------------------+
30 rows in set (0.10 sec)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
